### PR TITLE
box-identity: BoxRef re-key + Operand::Box drain to zero; GC-manage object wrappers

### DIFF
--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -1110,6 +1110,62 @@ const _: fn() = || {
     let _ = std::mem::size_of::<OpRef>();
 };
 
+/// Shared helpers for building **bound** `BoxRef`s from majit-ir test
+/// modules (`resoperation.rs`, …). Mirror of `majit-metainterp`'s
+/// `box::test_support`: production binds every `AbstractResOp` /
+/// `AbstractInputArg` box to its `Op` / `InputArg` identity, so tests
+/// that seed op operands directly must do the same to keep them off the
+/// position-only `Operand::Box` catch-all (the box still `to_opref()`s to
+/// the same `(type, position)`, so OpRef-based assertions are unchanged).
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::{BoxRef, OpRef, Type};
+    use crate::resoperation::{Op, OpCode, OpRc};
+    use crate::value::{InputArg, InputArgRc};
+
+    /// Bind a fresh ResOp `BoxRef` to a synthetic `SameAs*`/`Jump` `OpRc`
+    /// at `position` (`box_ref.rs from_bound_op`); the box sheds to
+    /// `Operand::Op`. The returned `OpRc` must outlive every read of the box.
+    pub(crate) fn bound_resop_box(tp: Type, position: u32) -> (BoxRef, OpRc) {
+        let opcode = match tp {
+            Type::Int => OpCode::SameAsI,
+            Type::Float => OpCode::SameAsF,
+            Type::Ref => OpCode::SameAsR,
+            Type::Void => OpCode::Jump,
+        };
+        let op = std::rc::Rc::new(Op::new(opcode, &[]));
+        op.pos.set(OpRef::op_typed(position, tp));
+        let b = BoxRef::from_bound_op(&op);
+        (b, op)
+    }
+
+    /// InputArg counterpart of [`bound_resop_box`]: bind a fresh
+    /// `new_inputarg` box to a fresh `InputArgRc`; sheds to
+    /// `Operand::InputArg`. The returned `InputArgRc` must outlive the box.
+    pub(crate) fn bound_inputarg_box(tp: Type, index: u32) -> (BoxRef, InputArgRc) {
+        let b = BoxRef::new_inputarg(tp, index);
+        let ia = std::rc::Rc::new(InputArg::from_type(tp, index));
+        b.bind_inputarg(&ia);
+        (b, ia)
+    }
+
+    /// A self-rooting bound `Operand::Op` at `position`, for `op!`/arg-list
+    /// fixtures that take an [`Operand`] directly. `from_boxref` upgrades the
+    /// box's bound `Op` (alive in this scope) into a strong `Operand::Op`, so
+    /// the returned operand keeps the synthetic producer alive on its own.
+    pub(crate) fn bound_resop_operand(tp: Type, position: u32) -> crate::operand::Operand {
+        let (b, _op) = bound_resop_box(tp, position);
+        crate::operand::Operand::from_boxref(&b)
+    }
+
+    /// InputArg counterpart of [`bound_resop_operand`]: a self-rooting
+    /// `Operand::InputArg` at `index`.
+    pub(crate) fn bound_inputarg_operand(tp: Type, index: u32) -> crate::operand::Operand {
+        let (b, _ia) = bound_inputarg_box(tp, index);
+        crate::operand::Operand::from_boxref(&b)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -256,23 +256,34 @@ impl Operand {
         }
         // Only position-only boxes (no producer Rc) reach here.
         //
-        // Drain status (#9 keystone, 2026-06-20): PRODUCTION mints are zero on
-        // the synth corpus. The two former sources are bound at their origin:
-        // short-preamble `short_inputargs` now mint via `from_bound_inputarg`
-        // over a rooted `InputArg` Rc carried through the preview → export →
-        // import channel (`short_inputarg_refs`, resolving to
-        // `Operand::InputArg`), and `emit_constant_*` SAME_AS placeholders take
-        // the constant box as their source (resolving to `Operand::Const`).
-        // `MAJIT_DIAG_OPERAND_BOX=1` reports each mint's position-only `OpRef`;
-        // off by default, no behavior change in the gate. A new production mint
+        // Drain status (#9 keystone): the gauge fires ZERO times across the
+        // full synth corpus (117 benches, measured). The two former live
+        // sources are bound at their origin: short-preamble `short_inputargs`
+        // now mint via `from_bound_inputarg` over a rooted `InputArg` Rc
+        // carried through the preview → export → import channel
+        // (`short_inputarg_refs`, resolving to `Operand::InputArg`), and
+        // `emit_constant_*` SAME_AS placeholders take the constant box as their
+        // source (resolving to `Operand::Const`). `MAJIT_DIAG_OPERAND_BOX=1`
+        // reports each mint's position-only `OpRef`; off by default, no
+        // behavior change in the gate. A new mint from the WIRED pipeline
         // appearing here is a regression — bind it at its producer.
         //
-        // The remaining minters are UNIT-TEST fixtures that construct
-        // `from_opref` / `new_inputarg` position-only boxes directly (no
-        // producer graph). Deleting the `Operand::Box` variant — and with it
-        // the `BoxRef` operand carrier — is therefore gated on migrating those
-        // fixtures to bound producers, a separate slice; the variant stays a
-        // release safety net until then.
+        // The remaining minters are of two kinds, both gating variant deletion:
+        // (1) unit-test fixtures that build `from_opref` / `new_inputarg`
+        // position-only boxes directly (no producer graph); and (2) the ported
+        // SIMD vectorizer machinery — `Renamer::rename` (renamer.rs:51/64),
+        // `vector.rs` pack/unpack/copy, `GuardStrengthenOpt` (guard.rs), and the
+        // vectorizer-coupled unroll peel-remap — which set op args via
+        // `from_opref(renamed)` of a non-const ResOp/InputArg position. That
+        // machinery is NOT in the production pass pipeline
+        // (optimizer.rs `default_pipeline` wires no `OptVector`), so it
+        // never runs and the gauge stays zero — but it is reachable the moment
+        // the vectorizer is wired. Deleting the `Operand::Box` variant — and
+        // with it the `BoxRef` operand carrier — is therefore gated on BOTH
+        // migrating the fixtures to bound producers AND either binding those
+        // vectorizer minters or removing the unwired vectorizer; until then the
+        // fall-through stays a real fallback, NOT an `unreachable!` tripwire
+        // (which would become a latent panic once the vectorizer is enabled).
         if std::env::var_os("MAJIT_DIAG_OPERAND_BOX").is_some() {
             eprintln!("OPERAND_BOX_MINT {:?}", b.to_opref());
         }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -268,13 +268,14 @@ impl Operand {
         // can be enumerated and bound. Off by default — no behavior change in
         // the gate.
         //
-        // Measured frontier (2026-06-20, synth corpus, 3927 mints): 94% are
-        // unbound short-preamble `short_inputargs` boxes
-        // (`shortpreamble.rs::produced_short_boxes_from_exported_boxes` setarg,
-        // minted position-only by `BoxRef::new_inputarg` at unroll.rs /
-        // shortpreamble.rs) — draining them needs the short-inputarg channel to
-        // carry bound `InputArg` Rcs; 6% are ResOp positions from the S9
-        // cross-phase export boundary.
+        // Measured frontier (2026-06-20, synth corpus): the unbound
+        // short-preamble `short_inputargs` source (formerly 94% of 3927 mints)
+        // is drained — `add_short_input_arg` now mints each renamed box via
+        // `from_bound_inputarg` over a rooted `InputArg` Rc carried through the
+        // preview → export → import channel (`short_inputarg_refs`), so the box
+        // resolves to `Operand::InputArg` instead of shedding here. The
+        // remaining 237 mints are all ResOp positions (`IntOp`/`RefOp`) from
+        // the S9 cross-phase export boundary; those need their own binding pass.
         if std::env::var_os("MAJIT_DIAG_OPERAND_BOX").is_some() {
             eprintln!("OPERAND_BOX_MINT {:?}", b.to_opref());
         }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -260,6 +260,24 @@ impl Operand {
         // carry their own producerless tripwire) and unmapped Phase-1
         // short-preamble jump args. Both are producer-less by construction
         // in the current context.
+        //
+        // Drain gauge (#9 keystone): the residual is being ground to zero so
+        // `Operand::Box` — and with it the `BoxRef` operand carrier — can be
+        // deleted. `MAJIT_DIAG_OPERAND_BOX=1` reports every residual mint (the
+        // position-only `OpRef` it froze) so the remaining producer-less sites
+        // can be enumerated and bound. Off by default — no behavior change in
+        // the gate.
+        //
+        // Measured frontier (2026-06-20, synth corpus, 3927 mints): 94% are
+        // unbound short-preamble `short_inputargs` boxes
+        // (`shortpreamble.rs::produced_short_boxes_from_exported_boxes` setarg,
+        // minted position-only by `BoxRef::new_inputarg` at unroll.rs /
+        // shortpreamble.rs) — draining them needs the short-inputarg channel to
+        // carry bound `InputArg` Rcs; 6% are ResOp positions from the S9
+        // cross-phase export boundary.
+        if std::env::var_os("MAJIT_DIAG_OPERAND_BOX").is_some() {
+            eprintln!("OPERAND_BOX_MINT {:?}", b.to_opref());
+        }
         Operand::Box(b.clone())
     }
 

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -254,28 +254,25 @@ impl Operand {
         if b.is_constant() {
             return Operand::Const(b.clone());
         }
-        // Only position-only boxes remain `Operand::Box`. The optimizer
-        // grind (#9-④) reduced production mints to the S9 cross-phase
-        // residual: export-boundary `get_box_replacement` fallbacks (which
-        // carry their own producerless tripwire) and unmapped Phase-1
-        // short-preamble jump args. Both are producer-less by construction
-        // in the current context.
+        // Only position-only boxes (no producer Rc) reach here.
         //
-        // Drain gauge (#9 keystone): the residual is being ground to zero so
-        // `Operand::Box` — and with it the `BoxRef` operand carrier — can be
-        // deleted. `MAJIT_DIAG_OPERAND_BOX=1` reports every residual mint (the
-        // position-only `OpRef` it froze) so the remaining producer-less sites
-        // can be enumerated and bound. Off by default — no behavior change in
-        // the gate.
+        // Drain status (#9 keystone, 2026-06-20): PRODUCTION mints are zero on
+        // the synth corpus. The two former sources are bound at their origin:
+        // short-preamble `short_inputargs` now mint via `from_bound_inputarg`
+        // over a rooted `InputArg` Rc carried through the preview → export →
+        // import channel (`short_inputarg_refs`, resolving to
+        // `Operand::InputArg`), and `emit_constant_*` SAME_AS placeholders take
+        // the constant box as their source (resolving to `Operand::Const`).
+        // `MAJIT_DIAG_OPERAND_BOX=1` reports each mint's position-only `OpRef`;
+        // off by default, no behavior change in the gate. A new production mint
+        // appearing here is a regression — bind it at its producer.
         //
-        // Measured frontier (2026-06-20, synth corpus): the unbound
-        // short-preamble `short_inputargs` source (formerly 94% of 3927 mints)
-        // is drained — `add_short_input_arg` now mints each renamed box via
-        // `from_bound_inputarg` over a rooted `InputArg` Rc carried through the
-        // preview → export → import channel (`short_inputarg_refs`), so the box
-        // resolves to `Operand::InputArg` instead of shedding here. The
-        // remaining 237 mints are all ResOp positions (`IntOp`/`RefOp`) from
-        // the S9 cross-phase export boundary; those need their own binding pass.
+        // The remaining minters are UNIT-TEST fixtures that construct
+        // `from_opref` / `new_inputarg` position-only boxes directly (no
+        // producer graph). Deleting the `Operand::Box` variant — and with it
+        // the `BoxRef` operand carrier — is therefore gated on migrating those
+        // fixtures to bound producers, a separate slice; the variant stays a
+        // release safety net until then.
         if std::env::var_os("MAJIT_DIAG_OPERAND_BOX").is_some() {
             eprintln!("OPERAND_BOX_MINT {:?}", b.to_opref());
         }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -4769,7 +4769,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4780,7 +4780,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 3), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4791,7 +4791,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Jump,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(4))), Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 4), crate::box_ref::test_support::bound_resop_operand(Type::Int, 3)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -4814,7 +4814,7 @@ mod tests {
     fn test_op_display_int_result() {
         let op = op! {
             opcode: OpCode::IntAdd,
-            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::int_op(6)),
             fail_args: std::cell::RefCell::new(None),
@@ -4831,7 +4831,7 @@ mod tests {
     fn test_op_display_void() {
         let op = op! {
             opcode: OpCode::SetfieldGc,
-            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             fail_args: std::cell::RefCell::new(None),
@@ -4848,10 +4848,10 @@ mod tests {
     fn test_op_display_guard_with_fail_args() {
         let op = op! {
             opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))])),
+            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)])),
 
 
             fail_arg_types: std::cell::RefCell::new(None),
@@ -4866,7 +4866,7 @@ mod tests {
     fn test_op_display_guard_without_fail_args() {
         let op = op! {
             opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             fail_args: std::cell::RefCell::new(None),
@@ -4883,7 +4883,7 @@ mod tests {
     fn test_format_trace_constants_rendered_with_values() {
         let ops = vec![op! {
             opcode: OpCode::IntAdd,
-            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::int_op(1)),
             fail_args: std::cell::RefCell::new(None),
@@ -4904,7 +4904,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(1)),
                 fail_args: std::cell::RefCell::new(None),
@@ -4915,10 +4915,10 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -4926,7 +4926,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Finish,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -4947,10 +4947,10 @@ mod tests {
     fn test_format_trace_constants_in_fail_args() {
         let ops = vec![op! {
             opcode: OpCode::GuardTrue,
-            args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
+            args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0)]),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
-            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))])),
+            fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)])),
 
 
             fail_arg_types: std::cell::RefCell::new(None),
@@ -4980,7 +4980,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::Label,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -4991,7 +4991,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5002,7 +5002,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 3), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5013,7 +5013,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Jump,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(4))), Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 4), crate::box_ref::test_support::bound_resop_operand(Type::Int, 3)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5047,7 +5047,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::IntSub,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(1)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5058,7 +5058,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntGt,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_001)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_001)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(2)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5069,10 +5069,10 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -5080,7 +5080,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Finish,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5143,7 +5143,7 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::Label,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5154,7 +5154,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntAdd,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(2)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5165,7 +5165,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntLt,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(2))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_000)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 2), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_000)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(3)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5176,10 +5176,10 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(3)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 3)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -5187,7 +5187,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::IntSub,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(10_001)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 10_001)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::int_op(4)),
                 fail_args: std::cell::RefCell::new(None),
@@ -5198,7 +5198,7 @@ mod tests {
             },
             op! {
                 opcode: OpCode::Jump,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(4))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 4), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
                 fail_args: std::cell::RefCell::new(None),
@@ -5232,10 +5232,10 @@ mod tests {
         let ops = vec![
             op! {
                 opcode: OpCode::GuardTrue,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0)))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0)])),
 
                 fail_arg_types: std::cell::RefCell::new(None),
                 rd_resume_position: std::cell::Cell::new(-1),
@@ -5243,10 +5243,10 @@ mod tests {
             },
             op! {
                 opcode: OpCode::GuardFalse,
-                args: std::cell::RefCell::new(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(1)))]),
+                args: std::cell::RefCell::new(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 1)]),
                 descr: std::cell::RefCell::new(None),
                 pos: std::cell::Cell::new(OpRef::NONE),
-                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![Operand::Box(BoxRef::from_opref(OpRef::int_op(0))), Operand::Box(BoxRef::from_opref(OpRef::int_op(1))), Operand::Box(BoxRef::from_opref(OpRef::int_op(2)))])),
+                fail_args: std::cell::RefCell::new(Some(smallvec::smallvec![crate::box_ref::test_support::bound_resop_operand(Type::Int, 0), crate::box_ref::test_support::bound_resop_operand(Type::Int, 1), crate::box_ref::test_support::bound_resop_operand(Type::Int, 2)])),
 
 
                 fail_arg_types: std::cell::RefCell::new(None),

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -131,7 +131,8 @@ pub(crate) mod test_support {
         /// result box for use as a later consumer arg.
         pub(crate) fn op(&mut self, opcode: OpCode, args: &[BoxRef]) -> BoxRef {
             let op = std::rc::Rc::new(Op::new(opcode, args));
-            op.pos.set(OpRef::op_typed(self.next_pos, opcode.result_type()));
+            op.pos
+                .set(OpRef::op_typed(self.next_pos, opcode.result_type()));
             self.next_pos += 1;
             let result = BoxRef::from_bound_op(&op);
             self.ops.push(op);
@@ -146,7 +147,8 @@ pub(crate) mod test_support {
             descr: majit_ir::DescrRef,
         ) -> BoxRef {
             let op = std::rc::Rc::new(Op::with_descr(opcode, args, descr));
-            op.pos.set(OpRef::op_typed(self.next_pos, opcode.result_type()));
+            op.pos
+                .set(OpRef::op_typed(self.next_pos, opcode.result_type()));
             self.next_pos += 1;
             let result = BoxRef::from_bound_op(&op);
             self.ops.push(op);

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -47,4 +47,36 @@ pub(crate) mod test_support {
         b.bind_op(&op);
         (b, op)
     }
+
+    thread_local! {
+        /// Roots synthetic producer `Op` / `InputArg` Rcs for the test
+        /// thread's lifetime so a single returned bound `BoxRef` stays bound
+        /// (its `Weak` upgrades) without the caller threading the producer
+        /// Rc. Test-only and never cleared — bounded by the fixtures one
+        /// test thread builds.
+        static PRODUCER_ROOTS: std::cell::RefCell<Vec<std::rc::Rc<dyn std::any::Any>>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    /// Drop-in for `BoxRef::from_opref(OpRef::{int,ref,float}_op(N))` at op
+    /// argument / fail-arg sites: a bound ResOp box (sheds to `Operand::Op`,
+    /// `to_opref()`s to the same `(tp, position)`) whose synthetic producer
+    /// is kept alive by the thread-local pool, so callers can use it inline
+    /// in an `Op::new`/`setarg` arg list without retaining the `OpRc`.
+    pub(crate) fn rooted_resop_box(tp: Type, position: u32) -> BoxRef {
+        let (b, op) = bound_resop_box(tp, position);
+        let rooted: std::rc::Rc<dyn std::any::Any> = op;
+        PRODUCER_ROOTS.with(|p| p.borrow_mut().push(rooted));
+        b
+    }
+
+    /// Drop-in for `BoxRef::from_opref(OpRef::input_arg_{int,ref,float}(N))`
+    /// at op argument / fail-arg sites: a bound InputArg box (sheds to
+    /// `Operand::InputArg`), producer rooted in the thread-local pool.
+    pub(crate) fn rooted_inputarg_box(tp: Type, index: u32) -> BoxRef {
+        let (b, ia) = bound_inputarg_box(tp, index);
+        let rooted: std::rc::Rc<dyn std::any::Any> = ia;
+        PRODUCER_ROOTS.with(|p| p.borrow_mut().push(rooted));
+        b
+    }
 }

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -15,7 +15,7 @@ pub(crate) mod test_support {
     //! shape.
     use majit_ir::box_ref::BoxRef;
     use majit_ir::resoperation::{Op, OpCode, OpRc};
-    use majit_ir::{InputArg, InputArgRc, OpRef, Type};
+    use majit_ir::{InputArg, InputArgRc, OpRef, Type, Value};
 
     /// Bind a fresh `BoxRef::new_inputarg(tp, index)` to a fresh
     /// `InputArgRc` (`box_ref.rs:354 bind_inputarg`). The returned
@@ -78,5 +78,87 @@ pub(crate) mod test_support {
         let rooted: std::rc::Rc<dyn std::any::Any> = ia;
         PRODUCER_ROOTS.with(|p| p.borrow_mut().push(rooted));
         b
+    }
+
+    /// oparser-faithful trace builder for optimizer unit tests
+    /// (`rpython/jit/tool/oparser.py`). Each producer op is registered as a
+    /// live `OpRc` and each consumer arg references the producing op's bound
+    /// result box (`from_bound_op`) — mirroring oparser's `self.vars[name] =
+    /// resop; args.append(self.vars[arg])` object-identity wiring. Every arg
+    /// therefore sheds to `Operand::Op` / `Operand::InputArg` / `Operand::Const`
+    /// at construction (never the position-only `Operand::Box`).
+    ///
+    /// Drive the optimizer with `optimize_with_constants_and_inputs_oprc` (the
+    /// `input_ops_from_ops = true` entry) so the builder's `OpRc`s are threaded
+    /// as the canonical producers `find_producer_op` resolves to; a forwarding
+    /// write through a consumer arg then lands on the SAME `Op` the optimizer
+    /// indexes, with no detached synthetic to diverge.
+    pub(crate) struct TraceBuilder {
+        ops: Vec<OpRc>,
+        inputs: Vec<Type>,
+        next_pos: u32,
+    }
+
+    impl TraceBuilder {
+        pub(crate) fn new() -> Self {
+            Self {
+                ops: Vec::new(),
+                inputs: Vec::new(),
+                next_pos: 0,
+            }
+        }
+
+        /// Header input var (oparser `[i0]`): a bound `InputArg` box at
+        /// `index`, recorded so [`Self::build`] can emit a matching
+        /// `trace_inputargs` slot. The producer `InputArgRc` is rooted in the
+        /// thread-local pool so the box's `Weak` upgrade stays live.
+        pub(crate) fn input(&mut self, tp: Type, index: u32) -> BoxRef {
+            let idx = index as usize;
+            if idx >= self.inputs.len() {
+                self.inputs.resize(idx + 1, Type::Int);
+            }
+            self.inputs[idx] = tp;
+            rooted_inputarg_box(tp, index)
+        }
+
+        /// Const literal arg (oparser numeric/`ConstInt` literal).
+        pub(crate) fn const_int(&self, v: i64) -> BoxRef {
+            BoxRef::new_const(Value::Int(v))
+        }
+
+        /// Append a producer op (oparser `iN = opcode(args)`), assigning it the
+        /// next sequential result position. Returns the producing op's bound
+        /// result box for use as a later consumer arg.
+        pub(crate) fn op(&mut self, opcode: OpCode, args: &[BoxRef]) -> BoxRef {
+            let op = std::rc::Rc::new(Op::new(opcode, args));
+            op.pos.set(OpRef::op_typed(self.next_pos, opcode.result_type()));
+            self.next_pos += 1;
+            let result = BoxRef::from_bound_op(&op);
+            self.ops.push(op);
+            result
+        }
+
+        /// Append a producer op carrying a descr.
+        pub(crate) fn op_with_descr(
+            &mut self,
+            opcode: OpCode,
+            args: &[BoxRef],
+            descr: majit_ir::DescrRef,
+        ) -> BoxRef {
+            let op = std::rc::Rc::new(Op::with_descr(opcode, args, descr));
+            op.pos.set(OpRef::op_typed(self.next_pos, opcode.result_type()));
+            self.next_pos += 1;
+            let result = BoxRef::from_bound_op(&op);
+            self.ops.push(op);
+            result
+        }
+
+        /// Finish the trace: returns the canonical `OpRc` slice to pass to
+        /// `optimize_with_constants_and_inputs_oprc`, plus the per-index input
+        /// types to install as `opt.trace_inputargs` (via
+        /// `OpRef::inputarg_refs`).
+        pub(crate) fn build(self) -> (Vec<OpRc>, Vec<Type>) {
+            (self.ops, self.inputs)
+        }
     }
 }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2609,6 +2609,7 @@ pub fn compile_tmp_callback(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::r#box::test_support::rooted_inputarg_box;
     use crate::compile::make_fail_descr_with_index;
     use crate::resume::{ResumeDataLoopMemo, SimpleBoxEnv, Snapshot, SnapshotFrame};
     use majit_ir::{ArrayFlag, Op, OpCode, OpRef};
@@ -2646,10 +2647,7 @@ mod tests {
         let rd_consts = memo.consts().to_vec();
 
         let inputargs = vec![InputArg::new_ref(0), InputArg::new_int(1)];
-        let mut guard = Op::new(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::input_arg_int(1))],
-        );
+        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_inputarg_box(Type::Int, 1)]);
         let descr = crate::compile::make_resume_guard_descr_typed(vec![Type::Ref, Type::Int]);
         if let Some(fd) = descr.as_fail_descr() {
             fd.set_rd_numb(Some(rd_numb));
@@ -2657,8 +2655,8 @@ mod tests {
         }
         guard.setdescr(descr);
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_ref(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1))
+            rooted_inputarg_box(Type::Ref, 0),
+            rooted_inputarg_box(Type::Int, 1)
         ]);
         guard.set_fail_arg_types(vec![Type::Ref, Type::Int]);
 
@@ -2696,10 +2694,7 @@ mod tests {
             InputArg::new_ref(2),
             InputArg::new_ref(3),
         ];
-        let mut guard = Op::new(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::input_arg_ref(0))],
-        );
+        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_inputarg_box(Type::Ref, 0)]);
         let fail_arg_types = vec![Type::Ref, Type::Ref, Type::Int, Type::Int];
         let descr = make_fail_descr_with_index(0, fail_arg_types.len());
         descr
@@ -2708,10 +2703,10 @@ mod tests {
             .set_fail_arg_types(fail_arg_types.clone());
         guard.setdescr(descr);
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_ref(0)),
-            BoxRef::from_opref(OpRef::input_arg_ref(1)),
-            BoxRef::from_opref(OpRef::input_arg_ref(2)),
-            BoxRef::from_opref(OpRef::input_arg_ref(3))
+            rooted_inputarg_box(Type::Ref, 0),
+            rooted_inputarg_box(Type::Ref, 1),
+            rooted_inputarg_box(Type::Ref, 2),
+            rooted_inputarg_box(Type::Ref, 3)
         ]);
         guard.set_fail_arg_types(fail_arg_types);
 
@@ -2730,41 +2725,34 @@ mod tests {
         vinfo.add_field("obj", Type::Ref, 8);
         vinfo.set_parent_descr(majit_ir::descr::make_size_descr(16));
 
-        let mut ops = vec![
-            {
-                let mut op = Op::new(
-                    OpCode::SameAsR,
-                    &[BoxRef::from_opref(OpRef::input_arg_ref(1))],
-                );
-                op.pos.set(OpRef::ref_op(10));
-                op
-            },
-            Op::new(
-                OpCode::Label,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    BoxRef::from_opref(OpRef::ref_op(10)),
-                ],
-            ),
-            {
-                let mut op = Op::new(
-                    OpCode::GetfieldGcPureI,
-                    &[BoxRef::from_opref(OpRef::ref_op(10))],
-                );
-                op.pos.set(OpRef::int_op(11));
-                op.setdescr(majit_ir::descr::make_field_descr(
-                    16,
-                    8,
-                    Type::Int,
-                    ArrayFlag::Signed,
-                ));
-                op
-            },
-        ];
+        // op0 produces a ResOp result at ref_op(10); the Label and getfield
+        // consumers bind that result (from_bound_op) instead of a position-only
+        // box, so patch_new_loop's forwarding rewrites them through op identity.
+        let op0: majit_ir::OpRc = {
+            let mut op = Op::new(OpCode::SameAsR, &[rooted_inputarg_box(Type::Ref, 1)]);
+            op.pos.set(OpRef::ref_op(10));
+            std::rc::Rc::new(op)
+        };
+        let op0_result = BoxRef::from_bound_op(&op0);
+        let op1: majit_ir::OpRc = std::rc::Rc::new(Op::new(
+            OpCode::Label,
+            &[rooted_inputarg_box(Type::Ref, 0), op0_result.clone()],
+        ));
+        let op2: majit_ir::OpRc = {
+            let mut op = Op::new(OpCode::GetfieldGcPureI, &[op0_result.clone()]);
+            op.pos.set(OpRef::int_op(11));
+            op.setdescr(majit_ir::descr::make_field_descr(
+                16,
+                8,
+                Type::Int,
+                ArrayFlag::Signed,
+            ));
+            std::rc::Rc::new(op)
+        };
+        let mut ops: Vec<majit_ir::OpRc> = vec![op0, op1, op2];
         let mut inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
-        let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         patch_new_loop_to_load_virtualizable_fields(
             &mut ops,
             &mut inputargs,
@@ -2830,9 +2818,9 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::Label,
             &[
-                BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                BoxRef::from_opref(OpRef::input_arg_ref(1)),
-                BoxRef::from_opref(OpRef::input_arg_ref(2)),
+                rooted_inputarg_box(Type::Ref, 0),
+                rooted_inputarg_box(Type::Ref, 1),
+                rooted_inputarg_box(Type::Ref, 2),
             ],
         )];
         let mut inputargs = vec![

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -678,10 +678,15 @@ mod tests {
     use super::*;
     use majit_ir::Type;
 
+    use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
+
     #[derive(Debug)]
     struct DummyGuardDescr;
     impl majit_ir::Descr for DummyGuardDescr {}
 
+    // Raw-OpRef position helpers (oparser-style names), used where a bare
+    // `OpRef` is needed: `op.pos.set(..)`, `to_opref()` comparisons,
+    // `GreenBox::new`, recorder args.
     fn iarg(pos: u32) -> OpRef {
         OpRef::input_arg_int(pos)
     }
@@ -692,6 +697,19 @@ mod tests {
 
     fn vop(pos: u32) -> OpRef {
         OpRef::void_op(pos)
+    }
+
+    // Bound-box drop-ins for op-arg / fail-arg sites. Each binds a rooted
+    // synthetic producer (box.rs `test_support`) so the arg sheds to
+    // `Operand::InputArg` / `Operand::Op` (never the position-only
+    // `Operand::Box`); `to_opref()` is preserved, so position-keyed
+    // assertions still hold.
+    fn iarg_box(pos: u32) -> BoxRef {
+        rooted_inputarg_box(Type::Int, pos)
+    }
+
+    fn iop_box(pos: u32) -> BoxRef {
+        rooted_resop_box(Type::Int, pos)
     }
 
     #[test]
@@ -707,14 +725,8 @@ mod tests {
     fn test_trace_with_jump() {
         let inputargs = vec![InputArg::new_int(0)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+            Op::new(OpCode::Jump, &[iop_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(trace.is_loop());
@@ -727,14 +739,8 @@ mod tests {
     fn test_trace_with_finish() {
         let inputargs = vec![InputArg::new_int(0)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(1))]),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+            Op::new(OpCode::Finish, &[iop_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(!trace.is_loop());
@@ -764,27 +770,9 @@ mod tests {
         // TreeLoop has inputargs and operations as primary fields.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]),
+            Op::new(OpCode::IntSub, &[iop_box(2), iarg_box(0)]),
+            Op::new(OpCode::Jump, &[iop_box(3), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -797,31 +785,13 @@ mod tests {
     fn test_trace_guards_can_have_fail_args() {
         // Guards in a trace carry fail_args.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard = Op::new(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
-        guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1))
-        ]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        guard.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1)]);
 
         let ops = vec![
             guard,
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]),
+            Op::new(OpCode::Jump, &[iop_box(2), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -838,29 +808,11 @@ mod tests {
         // iter_guards returns only guard ops.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::GuardFalse, &[BoxRef::from_opref(OpRef::int_op(3))]),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]),
+            Op::new(OpCode::GuardTrue, &[iop_box(2)]),
+            Op::new(OpCode::IntSub, &[iop_box(2), iarg_box(0)]),
+            Op::new(OpCode::GuardFalse, &[iop_box(3)]),
+            Op::new(OpCode::Jump, &[iop_box(3), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -874,13 +826,7 @@ mod tests {
     fn test_trace_not_loop_not_finished() {
         // A trace without Jump or Finish is neither loop nor finished.
         let inputargs = vec![InputArg::new_int(0)];
-        let ops = vec![Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-            ],
-        )];
+        let ops = vec![Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(!trace.is_loop());
         assert!(!trace.is_finished());
@@ -894,14 +840,8 @@ mod tests {
         let loop_trace = TreeLoop::new(
             inputargs.iter().map(InputArg::fresh_value_copy).collect(),
             vec![
-                Op::new(
-                    OpCode::IntAdd,
-                    &[
-                        BoxRef::from_opref(OpRef::input_arg_int(0)),
-                        BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    ],
-                ),
-                Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]),
+                Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+                Op::new(OpCode::Jump, &[iop_box(1)]),
             ],
         );
         assert!(loop_trace.is_loop());
@@ -910,14 +850,8 @@ mod tests {
         let finish_trace = TreeLoop::new(
             inputargs,
             vec![
-                Op::new(
-                    OpCode::IntAdd,
-                    &[
-                        BoxRef::from_opref(OpRef::input_arg_int(0)),
-                        BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    ],
-                ),
-                Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(1))]),
+                Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+                Op::new(OpCode::Finish, &[iop_box(1)]),
             ],
         );
         assert!(!finish_trace.is_loop());
@@ -935,9 +869,9 @@ mod tests {
         let ops = vec![Op::new(
             OpCode::Jump,
             &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_ref(1)),
-                BoxRef::from_opref(OpRef::input_arg_float(2)),
+                iarg_box(0),
+                rooted_inputarg_box(Type::Ref, 1),
+                rooted_inputarg_box(Type::Float, 2),
             ],
         )];
         let trace = TreeLoop::new(inputargs, ops);
@@ -954,39 +888,16 @@ mod tests {
         // Multiple guards can have different fail_args.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
 
-        let mut g0 = Op::new(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
-        g0.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
-        let mut g1 = Op::new(
-            OpCode::GuardFalse,
-            &[BoxRef::from_opref(OpRef::input_arg_int(1))],
-        );
-        g1.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1))
-        ]);
+        let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        g0.setfailargs(smallvec::smallvec![iarg_box(0)]);
+        let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
+        g1.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1)]);
 
         let ops = vec![
             g0,
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]),
             g1,
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::Jump, &[iop_box(2), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1002,11 +913,8 @@ mod tests {
         // Guards without explicitly set fail_args have None.
         let inputargs = vec![InputArg::new_int(0)];
         let ops = vec![
-            Op::new(
-                OpCode::GuardTrue,
-                &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]),
+            Op::new(OpCode::GuardTrue, &[iarg_box(0)]),
+            Op::new(OpCode::Jump, &[iarg_box(0)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1020,34 +928,10 @@ mod tests {
         // iter_ops preserves op order and opcodes.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]),
+            Op::new(OpCode::IntMul, &[iop_box(2), iarg_box(0)]),
+            Op::new(OpCode::IntSub, &[iop_box(3), iarg_box(1)]),
+            Op::new(OpCode::Jump, &[iop_box(4), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1079,23 +963,9 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let descr: DescrRef = Arc::new(TestDescr(42));
         let ops = vec![
-            Op::with_descr(
-                OpCode::CallI,
-                &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-                descr.clone(),
-            ),
-            Op::with_descr(
-                OpCode::GuardTrue,
-                &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-                descr.clone(),
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::with_descr(OpCode::CallI, &[iarg_box(0)], descr.clone()),
+            Op::with_descr(OpCode::GuardTrue, &[iarg_box(0)], descr.clone()),
+            Op::new(OpCode::Jump, &[iarg_box(0), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1122,36 +992,12 @@ mod tests {
             OpCode::Jump,
         ];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::IntNeg, &[BoxRef::from_opref(OpRef::int_op(3))]),
-            Op::new(
-                OpCode::IntLt,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(4))]),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+            Op::new(OpCode::IntSub, &[iop_box(1), iarg_box(0)]),
+            Op::new(OpCode::IntMul, &[iop_box(2), iarg_box(0)]),
+            Op::new(OpCode::IntNeg, &[iop_box(3)]),
+            Op::new(OpCode::IntLt, &[iop_box(4), iarg_box(0)]),
+            Op::new(OpCode::Jump, &[iop_box(4)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1165,14 +1011,8 @@ mod tests {
         // Verify that cloning a trace produces an independent copy.
         let inputargs = vec![InputArg::new_int(0)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+            Op::new(OpCode::Jump, &[iop_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
         let trace2 = trace.clone();
@@ -1187,20 +1027,16 @@ mod tests {
         // Stress test: a trace with 100+ operations.
         let inputargs = vec![InputArg::new_int(0)];
         let mut ops = Vec::new();
-        let mut prev = OpRef::input_arg_int(0);
+        // `prev` chains each IntAdd onto the previous op's result: the header
+        // inputarg on the first iteration, then the prior IntAdd's position.
+        let mut prev = iarg_box(0);
         for i in 0..100 {
-            let mut op = Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(prev),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            );
+            let mut op = Op::new(OpCode::IntAdd, &[prev, iarg_box(0)]);
             op.pos.set(OpRef::int_op(i + 1));
             ops.push(op);
-            prev = OpRef::int_op(i + 1);
+            prev = iop_box(i + 1);
         }
-        ops.push(Op::new(OpCode::Jump, &[BoxRef::from_opref(prev)]));
+        ops.push(Op::new(OpCode::Jump, &[prev]));
         let trace = TreeLoop::new(inputargs, ops);
 
         assert_eq!(trace.num_ops(), 101); // 100 IntAdd + 1 Jump
@@ -1222,31 +1058,15 @@ mod tests {
         // fail_args must reference valid input or op refs.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
 
-        let add_op = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
-        );
-        let mut guard_op = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+        let add_op = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
+        let mut guard_op = Op::new(OpCode::GuardTrue, &[iop_box(2)]);
         // fail_args referencing input args (0, 1) and the add result (2)
-        guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::int_op(2))
-        ]);
+        guard_op.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1), iop_box(2)]);
 
         let ops = vec![
             add_op,
             guard_op,
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::Jump, &[iop_box(2), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1262,48 +1082,21 @@ mod tests {
         // Multiple guards with varying fail_args sizes.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
 
-        let mut g0 = Op::new(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
+        let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         g0.setfailargs(smallvec::smallvec![]);
-        let mut g1 = Op::new(
-            OpCode::GuardFalse,
-            &[BoxRef::from_opref(OpRef::input_arg_int(1))],
-        );
-        g1.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
-        let add = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
-        );
+        let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
+        g1.setfailargs(smallvec::smallvec![iarg_box(0)]);
+        let add = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
 
-        let mut g2 = Op::new(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
-        g2.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::int_op(2))
-        ]);
+        let mut g2 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        g2.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1), iop_box(2)]);
 
         let ops = vec![
             g0,
             g1,
             add,
             g2,
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
+            Op::new(OpCode::Jump, &[iarg_box(0), iarg_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1319,24 +1112,15 @@ mod tests {
         // Modifications to a cloned trace do not affect the original.
         let inputargs = vec![InputArg::new_int(0)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                ],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]),
+            Op::new(OpCode::Jump, &[iop_box(1)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
         let mut trace2 = trace.clone();
 
         trace2.ops.push(std::rc::Rc::new(Op::new(
             OpCode::IntSub,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-            ],
+            &[iarg_box(0), iarg_box(0)],
         )));
         assert_eq!(trace.num_ops(), 2);
         assert_eq!(trace2.num_ops(), 3);
@@ -1347,45 +1131,15 @@ mod tests {
         // iter_guards must skip all non-guard ops, even in a complex trace.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
-                ],
-            ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                ],
-            ),
-            Op::new(OpCode::IntNeg, &[BoxRef::from_opref(OpRef::int_op(4))]),
-            Op::new(OpCode::GuardFalse, &[BoxRef::from_opref(OpRef::int_op(5))]),
-            Op::new(
-                OpCode::IntLt,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                    BoxRef::from_opref(OpRef::int_op(5)),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]),
+            Op::new(OpCode::IntSub, &[iarg_box(0), iarg_box(1)]),
+            Op::new(OpCode::GuardTrue, &[iop_box(2)]),
+            Op::new(OpCode::IntMul, &[iop_box(2), iop_box(3)]),
+            Op::new(OpCode::IntNeg, &[iop_box(4)]),
+            Op::new(OpCode::GuardFalse, &[iop_box(5)]),
+            Op::new(OpCode::IntLt, &[iop_box(4), iop_box(5)]),
             Op::new(OpCode::GuardNoException, &[]),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                    BoxRef::from_opref(OpRef::int_op(5)),
-                ],
-            ),
+            Op::new(OpCode::Jump, &[iop_box(4), iop_box(5)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
 
@@ -1403,25 +1157,16 @@ mod tests {
     #[test]
     fn test_check_consistency_valid() {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         op0.pos.set(iop(2));
-        let ops = vec![op0, Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(2))])];
+        let ops = vec![op0, Op::new(OpCode::Jump, &[iop_box(2)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(trace.check_consistency());
     }
 
     #[test]
     fn test_check_consistency_no_final() {
-        let ops = vec![Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        )];
+        let ops = vec![Op::new(OpCode::IntAdd, &[iop_box(0), iop_box(1)])];
         let trace = TreeLoop::new(vec![], ops);
         assert!(!trace.check_consistency());
     }
@@ -1431,10 +1176,7 @@ mod tests {
         // history.py:579-581: arg not in seen → invalid
         let inputargs = vec![InputArg::new_int(0)];
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iop(99))],
-            ),
+            Op::new(OpCode::IntAdd, &[iarg_box(0), iop_box(99)]),
             Op::new(OpCode::Finish, &[]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
@@ -1449,7 +1191,7 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(OpRef::NONE)],
+                &[iarg_box(0), BoxRef::from_opref(OpRef::NONE)],
             ),
             Op::new(OpCode::Finish, &[]),
         ];
@@ -1464,10 +1206,10 @@ mod tests {
         let const_ref = OpRef::const_int(0);
         let mut op0 = Op::new(
             OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(const_ref)],
+            &[iarg_box(0), BoxRef::from_opref(const_ref)],
         );
         op0.pos.set(iop(1));
-        let ops = vec![op0, Op::new(OpCode::Finish, &[BoxRef::from_opref(iop(1))])];
+        let ops = vec![op0, Op::new(OpCode::Finish, &[iop_box(1)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(trace.check_consistency());
     }
@@ -1476,12 +1218,9 @@ mod tests {
     fn test_check_consistency_ovf_not_followed_by_guard() {
         // history.py:576-578: ovf must be followed by guard_overflow
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut op0 = Op::new(
-            OpCode::IntAddOvf,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op0 = Op::new(OpCode::IntAddOvf, &[iarg_box(0), iarg_box(1)]);
         op0.pos.set(iop(2));
-        let ops = vec![op0, Op::new(OpCode::Finish, &[BoxRef::from_opref(iop(2))])];
+        let ops = vec![op0, Op::new(OpCode::Finish, &[iop_box(2)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(!trace.check_consistency());
     }
@@ -1489,18 +1228,11 @@ mod tests {
     #[test]
     fn test_check_consistency_ovf_followed_by_guard() {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut op0 = Op::new(
-            OpCode::IntAddOvf,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op0 = Op::new(OpCode::IntAddOvf, &[iarg_box(0), iarg_box(1)]);
         op0.pos.set(iop(2));
         let mut guard = Op::new(OpCode::GuardNoOverflow, &[]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
-        let ops = vec![
-            op0,
-            guard,
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(iop(2))]),
-        ];
+        let ops = vec![op0, guard, Op::new(OpCode::Finish, &[iop_box(2)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(trace.check_consistency());
     }
@@ -1510,15 +1242,12 @@ mod tests {
         // history.py:583-584: every guard needs a descr when check_descr=True,
         // including overflow guards.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut op0 = Op::new(
-            OpCode::IntAddOvf,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op0 = Op::new(OpCode::IntAddOvf, &[iarg_box(0), iarg_box(1)]);
         op0.pos.set(iop(2));
         let ops = vec![
             op0,
             Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(iop(2))]),
+            Op::new(OpCode::Finish, &[iop_box(2)]),
         ];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(!trace.check_consistency());
@@ -1528,7 +1257,7 @@ mod tests {
     fn test_check_consistency_fail_args_const_invalid() {
         // history.py:590: fail_args must not contain constants
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(iarg(0))]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(OpRef::const_int(0))]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
@@ -1540,8 +1269,8 @@ mod tests {
     fn test_check_consistency_fail_args_undefined_invalid() {
         // history.py:591: fail_args entries must be in seen
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(iarg(0))]);
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(iop(99))]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        guard.setfailargs(smallvec::smallvec![iop_box(99)]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
         let trace = TreeLoop::new(inputargs, ops);
@@ -1552,19 +1281,12 @@ mod tests {
     fn test_check_consistency_label_resets_seen() {
         // history.py:596-602: LABEL resets the seen set to its args
         let inputargs = vec![InputArg::new_int(0)];
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]);
         op0.pos.set(iop(1));
         // LABEL introduces a fresh scope with iarg(0) only
-        let label = Op::new(OpCode::Label, &[BoxRef::from_opref(iarg(0))]);
+        let label = Op::new(OpCode::Label, &[iarg_box(0)]);
         // iop(1) was defined before label, so it's no longer in seen
-        let ops = vec![
-            op0,
-            label,
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(1))]),
-        ];
+        let ops = vec![op0, label, Op::new(OpCode::Jump, &[iop_box(1)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(!trace.check_consistency());
     }
@@ -1572,17 +1294,10 @@ mod tests {
     #[test]
     fn test_check_consistency_label_valid() {
         let inputargs = vec![InputArg::new_int(0)];
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]);
         op0.pos.set(iop(1));
-        let label = Op::new(OpCode::Label, &[BoxRef::from_opref(iop(1))]);
-        let ops = vec![
-            op0,
-            label,
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(1))]),
-        ];
+        let label = Op::new(OpCode::Label, &[iop_box(1)]);
+        let ops = vec![op0, label, Op::new(OpCode::Jump, &[iop_box(1)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(trace.check_consistency());
     }
@@ -1590,21 +1305,11 @@ mod tests {
     #[test]
     fn test_check_consistency_duplicate_op_position_invalid() {
         let inputargs = vec![InputArg::new_int(0)];
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]);
         op0.pos.set(iop(1));
-        let mut op1 = Op::new(
-            OpCode::IntSub,
-            &[BoxRef::from_opref(iop(1)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op1 = Op::new(OpCode::IntSub, &[iop_box(1), iarg_box(0)]);
         op1.pos.set(iop(1));
-        let ops = vec![
-            op0,
-            op1,
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(iop(1))]),
-        ];
+        let ops = vec![op0, op1, Op::new(OpCode::Finish, &[iop_box(1)])];
         let trace = TreeLoop::new(inputargs, ops);
         assert!(!trace.check_consistency());
     }
@@ -1612,7 +1317,7 @@ mod tests {
     #[test]
     fn test_check_consistency_jump_descr_must_be_target_token() {
         let inputargs = vec![InputArg::new_int(0)];
-        let mut jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(iarg(0))]);
+        let mut jump = Op::new(OpCode::Jump, &[iarg_box(0)]);
         jump.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let trace = TreeLoop::new(inputargs, vec![jump]);
         assert!(!trace.check_consistency());
@@ -1621,22 +1326,10 @@ mod tests {
     #[test]
     fn test_split_at_label() {
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(OpCode::Label, &[BoxRef::from_opref(OpRef::int_op(0))]),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::IntAdd, &[iop_box(0), iop_box(1)]),
+            Op::new(OpCode::Label, &[iop_box(0)]),
+            Op::new(OpCode::IntMul, &[iop_box(0), iop_box(1)]),
+            Op::new(OpCode::Jump, &[iop_box(0)]),
         ];
         let trace = TreeLoop::new(vec![], ops);
         let (preamble, body) = trace.split_at_label();
@@ -1647,25 +1340,10 @@ mod tests {
     #[test]
     fn test_num_guards() {
         let ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
-            ),
-            Op::new(
-                OpCode::GuardClass,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
+            Op::new(OpCode::GuardTrue, &[iop_box(0)]),
+            Op::new(OpCode::IntAdd, &[iop_box(0), iop_box(1)]),
+            Op::new(OpCode::GuardNonnull, &[iop_box(0)]),
+            Op::new(OpCode::GuardClass, &[iop_box(0), iop_box(1)]),
             Op::new(OpCode::Finish, &[]),
         ];
         let trace = TreeLoop::new(vec![], ops);
@@ -1675,14 +1353,8 @@ mod tests {
     #[test]
     fn test_get_final_op() {
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::IntAdd, &[iop_box(0), iop_box(1)]),
+            Op::new(OpCode::Finish, &[iop_box(0)]),
         ];
         let trace = TreeLoop::new(vec![], ops);
         let final_op = trace.get_final_op().unwrap();
@@ -1697,12 +1369,9 @@ mod tests {
         // [0, num_inputargs); a malformed trace that references raw 0
         // without a matching inputarg would cache-miss in `_get`.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut add = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut add = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         add.pos.set(iop(2));
-        let ops = vec![add, Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(2))])];
+        let ops = vec![add, Op::new(OpCode::Jump, &[iop_box(2)])];
         let trace = TreeLoop::new(inputargs, ops);
         let mut iter = trace.get_iter();
         assert!(!iter.done());
@@ -1737,20 +1406,14 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut ops = Vec::new();
         // Pre-cut ops (2 inputargs → first op is BoxInt at position 2)
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         op0.pos.set(iop(2));
         ops.push(op0);
         // Post-cut ops
-        let mut op1 = Op::new(
-            OpCode::IntMul,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op1 = Op::new(OpCode::IntMul, &[iarg_box(0), iarg_box(1)]);
         op1.pos.set(iop(3));
         ops.push(op1);
-        let mut op2 = Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(3))]);
+        let mut op2 = Op::new(OpCode::Jump, &[iop_box(3)]);
         op2.pos.set(vop(4));
         ops.push(op2);
         let trace = TreeLoop::new(inputargs, ops);
@@ -1778,20 +1441,14 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut ops = Vec::new();
         // op0: v2 = int_add(v0, v1) — before cut
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(1))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         op0.pos.set(iop(2));
         ops.push(op0);
         // op1: v3 = int_mul(v2, v0) — after cut, references v2 (escaped!)
-        let mut op1 = Op::new(
-            OpCode::IntMul,
-            &[BoxRef::from_opref(iop(2)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op1 = Op::new(OpCode::IntMul, &[iop_box(2), iarg_box(0)]);
         op1.pos.set(iop(3));
         ops.push(op1);
-        let mut op2 = Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(3))]);
+        let mut op2 = Op::new(OpCode::Jump, &[iop_box(3)]);
         op2.pos.set(vop(4));
         ops.push(op2);
         let trace = TreeLoop::new(inputargs, ops);
@@ -1814,21 +1471,18 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0)];
         let mut ops = Vec::new();
         // pre-cut: noop
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]);
         op0.pos.set(iop(1));
         ops.push(op0);
         // post-cut: uses a constant
         let const_ref = OpRef::const_int(0);
         let mut op1 = Op::new(
             OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(const_ref)],
+            &[iarg_box(0), BoxRef::from_opref(const_ref)],
         );
         op1.pos.set(iop(2));
         ops.push(op1);
-        let mut op2 = Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(2))]);
+        let mut op2 = Op::new(OpCode::Jump, &[iop_box(2)]);
         op2.pos.set(vop(3));
         ops.push(op2);
         let trace = TreeLoop::new(inputargs, ops);
@@ -1848,27 +1502,18 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0)];
         let mut ops = Vec::new();
         // v1 = int_add(v0, v0) — before cut
-        let mut op0 = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(0)]);
         op0.pos.set(iop(1));
         ops.push(op0);
         // v2 = int_mul(v1, v0) — before cut
-        let mut op1 = Op::new(
-            OpCode::IntMul,
-            &[BoxRef::from_opref(iop(1)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op1 = Op::new(OpCode::IntMul, &[iop_box(1), iarg_box(0)]);
         op1.pos.set(iop(2));
         ops.push(op1);
         // v3 = int_sub(v2, v0) — after cut, references v2 (escaped, depends on v1)
-        let mut op2 = Op::new(
-            OpCode::IntSub,
-            &[BoxRef::from_opref(iop(2)), BoxRef::from_opref(iarg(0))],
-        );
+        let mut op2 = Op::new(OpCode::IntSub, &[iop_box(2), iarg_box(0)]);
         op2.pos.set(iop(3));
         ops.push(op2);
-        let mut op3 = Op::new(OpCode::Jump, &[BoxRef::from_opref(iop(3))]);
+        let mut op3 = Op::new(OpCode::Jump, &[iop_box(3)]);
         op3.pos.set(vop(4));
         ops.push(op3);
         let trace = TreeLoop::new(inputargs, ops);

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -2847,10 +2847,31 @@ mod tests {
         OpRef::void_op(pos)
     }
 
+    /// Bind a position-only `OpRef` arg to a producer-bound `BoxRef`,
+    /// oparser-faithful (`rpython/jit/tool/oparser.py` `self.vars[arg]`):
+    /// body / inputarg refs shed to `Operand::Op` / `Operand::InputArg` via
+    /// the rooted drop-in (same `to_opref()`), constants shed to
+    /// `Operand::Const`. Neither mints the position-only `Operand::Box`.
+    fn box_arg(opref: OpRef) -> BoxRef {
+        use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
+        use majit_ir::Type;
+        match opref {
+            OpRef::InputArgInt(x) => rooted_inputarg_box(Type::Int, x),
+            OpRef::InputArgFloat(x) => rooted_inputarg_box(Type::Float, x),
+            OpRef::InputArgRef(x) => rooted_inputarg_box(Type::Ref, x),
+            OpRef::IntOp(x) => rooted_resop_box(Type::Int, x),
+            OpRef::FloatOp(x) => rooted_resop_box(Type::Float, x),
+            OpRef::RefOp(x) => rooted_resop_box(Type::Ref, x),
+            OpRef::VoidOp(x) => rooted_resop_box(Type::Void, x),
+            // Constants / None shed without minting Operand::Box.
+            _ => BoxRef::from_opref(opref),
+        }
+    }
+
     /// Helper: build an Op with a specific trace position and the same
     /// typed result class RPython's `opclasses[opnum]` would instantiate.
     fn op_at(pos: u32, opcode: majit_ir::OpCode, args: &[OpRef]) -> majit_ir::Op {
-        let box_args: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let box_args: Vec<BoxRef> = args.iter().map(|a| box_arg(*a)).collect();
         let mut op = majit_ir::Op::new(opcode, &box_args);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
@@ -2877,7 +2898,7 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[BoxRef::from_opref(iop(3))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(iop(3))]),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -2920,7 +2941,7 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[BoxRef::from_opref(iop(3))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(iop(3))]),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -2996,7 +3017,7 @@ mod tests {
         let ops = vec![
             op_at(1, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(0)]),
             op_at(2, majit_ir::OpCode::IntAdd, &[iop(1), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[BoxRef::from_opref(iop(2))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(iop(2))]),
         ];
         // Shifted phase: start_fresh = 100 so any confusion between
         // _index (raw trace position) and _fresh (fresh OpRef counter)
@@ -3011,7 +3032,7 @@ mod tests {
         // replace_last_cached(oldbox=BoxInt(101), new_box=BoxInt(999))
         // must target _cache[_index - 1] = _cache[1], where the last
         // write placed BoxInt(101).
-        iter.replace_last_cached(iop(101), BoxRef::from_opref(iop(999)));
+        iter.replace_last_cached(iop(101), box_arg(iop(999)));
         assert_eq!(cache_opref(&iter, 1), Some(iop(999)));
 
         // The next op references raw pos 1 as its first arg, so the
@@ -3028,7 +3049,7 @@ mod tests {
         // opencoder.py:362-406 next() routes guard fail_args through the
         // same _untag/_get path as regular args.
         let mut guard = op_at(2, majit_ir::OpCode::GuardTrue, &[iop(1)]);
-        guard.setfailargs(vec![BoxRef::from_opref(iarg(0)), BoxRef::from_opref(iop(1))].into());
+        guard.setfailargs(vec![box_arg(iarg(0)), box_arg(iop(1))].into());
         let ops = vec![
             op_at(1, majit_ir::OpCode::IntEq, &[iarg(0), iarg(0)]),
             guard,
@@ -3054,7 +3075,7 @@ mod tests {
         let ops = vec![
             op_at(3, majit_ir::OpCode::GetfieldRawI, &[rarg(0)]),
             op_at(1, majit_ir::OpCode::GetarrayitemGcR, &[iop(3), rarg(1)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[BoxRef::from_opref(rop(1))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(rop(1))]),
         ];
         let inputarg_types = vec![
             majit_ir::Type::Ref,

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -123,8 +123,8 @@ impl Optimization for OptEarlyForce {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::optimizeopt::optimizer::Optimizer;
     use crate::r#box::test_support::rooted_inputarg_box;
+    use crate::optimizeopt::optimizer::Optimizer;
     use majit_ir::OpRef;
     use majit_ir::Type;
 
@@ -220,10 +220,7 @@ mod tests {
             OpCode::CallMayForceF,
             OpCode::CallMayForceN,
         ] {
-            let mut ops = vec![Op::new(
-                opcode,
-                &[rooted_inputarg_box(Type::Ref, 100)],
-            )];
+            let mut ops = vec![Op::new(opcode, &[rooted_inputarg_box(Type::Ref, 100)])];
             assign_positions(&mut ops);
 
             let mut opt = Optimizer::new();

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -124,8 +124,9 @@ impl Optimization for OptEarlyForce {
 mod tests {
     use super::*;
     use crate::optimizeopt::optimizer::Optimizer;
+    use crate::r#box::test_support::rooted_inputarg_box;
     use majit_ir::OpRef;
-    use majit_ir::box_ref::BoxRef;
+    use majit_ir::Type;
 
     fn assign_positions(ops: &mut [Op]) {
         for (i, op) in ops.iter_mut().enumerate() {
@@ -139,8 +140,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::CallMayForceN,
             &[
-                BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                rooted_inputarg_box(Type::Ref, 100),
+                rooted_inputarg_box(Type::Ref, 101),
             ],
         )];
         assign_positions(&mut ops);
@@ -159,8 +160,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
+                rooted_inputarg_box(Type::Int, 100),
+                rooted_inputarg_box(Type::Int, 101),
             ],
         )];
         assign_positions(&mut ops);
@@ -178,7 +179,7 @@ mod tests {
     fn test_earlyforce_call_assembler_handled() {
         let mut ops = vec![Op::new(
             OpCode::CallAssemblerI,
-            &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+            &[rooted_inputarg_box(Type::Ref, 100)],
         )];
         assign_positions(&mut ops);
 
@@ -221,7 +222,7 @@ mod tests {
         ] {
             let mut ops = vec![Op::new(
                 opcode,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
             )];
             assign_positions(&mut ops);
 
@@ -239,8 +240,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::SetfieldGc,
             &[
-                BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
+                rooted_inputarg_box(Type::Ref, 100),
+                rooted_inputarg_box(Type::Int, 101),
             ],
         )];
         assign_positions(&mut ops);

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -766,70 +766,83 @@ mod tests {
     use super::*;
     use crate::optimizeopt::optimizer::Optimizer;
 
-    /// Helper: assign sequential positions to ops starting from a high base
-    /// to avoid colliding with argument OpRefs.  Also attaches a fresh
-    /// `ResumeGuardDescr` to every guard op that lacks one, mirroring
-    /// RPython's invariant (`optimizer.py:691 assert isinstance(last_descr,
-    /// compile.ResumeGuardDescr)`) that every guard reaching the optimizer
-    /// has a head-of-chain ResumeGuardDescr — this lets `_copy_resume_data_from`
-    /// share via `make_resume_guard_copied_descr(prev)` without panicking on
-    /// a missing donor.
-    fn assign_positions(ops: &mut [Op], base: u32) {
-        for (i, op) in ops.iter_mut().enumerate() {
-            op.pos
-                .set(OpRef::op_typed(base + i as u32, op.result_type()));
-            if op.opcode.is_guard() && !op.has_descr() {
-                op.setdescr(crate::compile::make_resume_guard_descr_typed(Vec::new()));
-            }
+    /// Attach a fresh `ResumeGuardDescr` to every guard op that lacks one,
+    /// mirroring RPython's invariant (`optimizer.py:691 assert
+    /// isinstance(last_descr, compile.ResumeGuardDescr)`) that every guard
+    /// reaching the optimizer has a head-of-chain ResumeGuardDescr — this lets
+    /// `_copy_resume_data_from` share via `make_resume_guard_copied_descr(prev)`
+    /// without panicking on a missing donor. Positions are assigned at the
+    /// bound-DAG build sites where each producer `OpRc`'s result box is taken.
+    fn seed_guard_descrs(op: &majit_ir::OpRc) {
+        if op.opcode.is_guard() && !op.has_descr() {
+            op.setdescr(crate::compile::make_resume_guard_descr_typed(Vec::new()));
         }
     }
 
     #[test]
     fn test_overflow_guards_preserved_in_full_pipeline() {
-        let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(1))]),
-            Op::new(
-                OpCode::IntSubOvf,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(
-                OpCode::IntMulOvf,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(103)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops, 100);
+        use crate::r#box::BoxRef;
+        use crate::r#box::test_support::rooted_inputarg_box;
+        use majit_ir::{OpRc, Type};
+
+        // oparser-faithful bound DAG (`rpython/jit/tool/oparser.py`): header
+        // inputs i0/i1/i2 are bound `InputArg` boxes; each producer op is a
+        // live `OpRc` whose result box (`from_bound_op`) is the consumer arg,
+        // so every op-arg sheds to `Operand::{InputArg,Op}` rather than the
+        // position-only `Operand::Box`. The producers are threaded through
+        // `optimize_with_constants_and_inputs_oprc` so they are the canonical
+        // ops the OptContext indexes.
+        let i0 = rooted_inputarg_box(Type::Int, 0);
+        let i1 = rooted_inputarg_box(Type::Int, 1);
+        let i2 = rooted_inputarg_box(Type::Int, 2);
+
+        // Producer ops carry their result positions (base 100) so they do not
+        // collide with the inputarg slots `[0, num_inputs)`.
+        let guard_true = std::rc::Rc::new(Op::new(OpCode::GuardTrue, &[i1.clone()]));
+        let sub = std::rc::Rc::new(Op::new(OpCode::IntSubOvf, &[i0, i2.clone()]));
+        let guard_ovf1 = std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[]));
+        let mul = std::rc::Rc::new(Op::new(OpCode::IntMulOvf, &[i2, i1]));
+        let guard_ovf2 = std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[]));
+
+        // Sequential positions from base 100 + a fresh ResumeGuardDescr on
+        // every guard. Set positions before binding the producer result boxes
+        // so `from_bound_op` reads the final pos.
+        let producers: [&OpRc; 5] = [&guard_true, &sub, &guard_ovf1, &mul, &guard_ovf2];
+        for (i, op) in producers.iter().enumerate() {
+            op.pos
+                .set(OpRef::op_typed(100 + i as u32, op.result_type()));
+            seed_guard_descrs(op);
+        }
+
+        let sub_box = BoxRef::from_bound_op(&sub);
+        let mul_box = BoxRef::from_bound_op(&mul);
+        let jump = std::rc::Rc::new(Op::new(OpCode::Jump, &[sub_box.clone(), sub_box, mul_box]));
+        jump.pos.set(OpRef::op_typed(105, jump.result_type()));
+
+        let ops: Vec<OpRc> = vec![guard_true, sub, guard_ovf1, mul, guard_ovf2, jump];
 
         let mut opt = Optimizer::default_pipeline();
         // Overflow guards and IntMulOvf work on Int-typed args — override
         // the test default so the renamed inputargs are minted Int, not Ref.
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
-        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
+        let scratch: Vec<Op> = ops.iter().map(|op| (**op).clone()).collect();
+        let (seeded, snapshots) = super::super::seed_empty_guard_snapshots(&scratch);
+        for (op, seed) in ops.iter().zip(seeded.iter()) {
+            op.rd_resume_position.set(seed.rd_resume_position.get());
+        }
         opt.snapshot_boxes = snapshots;
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result: Vec<Op> = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecAssoc::new(), 1024)
+            .into_iter()
+            .map(|rc| (*rc).clone())
+            .collect();
         let guard_count = result
             .iter()
             .filter(|o| o.opcode == OpCode::GuardNoOverflow)
             .count();
 
-        // With intbounds postprocess_GUARD_TRUE, OpRef::int_op(1) becomes known
-        // constant 1 after GuardTrue(OpRef::int_op(1)). IntMulOvf(x, 1) cannot
+        // With intbounds postprocess_GUARD_TRUE, i1 becomes known
+        // constant 1 after GuardTrue(i1). IntMulOvf(x, 1) cannot
         // overflow → second GuardNoOverflow is removed. This matches
         // RPython intbounds.py:52-58 _postprocess_guard_true_false_value.
         assert_eq!(
@@ -852,39 +865,40 @@ mod tests {
         opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 2]);
 
-        let ops = vec![
-            // v = (i0 > i1): intbounds bounds the comparison result to [0,1].
-            {
-                let mut op = Op::new(
-                    OpCode::IntGt,
-                    &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
-                    ],
-                );
-                op.pos.set(OpRef::int_op(100));
-                op
-            },
-            // guard_value(v, 1)
-            {
-                let mut op = Op::new(
-                    OpCode::GuardValue,
-                    &[
-                        BoxRef::from_opref(OpRef::int_op(100)),
-                        BoxRef::from_opref(OpRef::int_op(200)),
-                    ],
-                );
-                op.pos.set(OpRef::void_op(0));
-                op
-            },
-        ];
+        use crate::r#box::BoxRef;
+        use crate::r#box::test_support::rooted_inputarg_box;
+        use majit_ir::{OpRc, Type, Value};
 
-        // Pre-seed constant 1 for OpRef::int_op(200)
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(200u32, majit_ir::Value::Int(1));
-        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
+        // oparser-faithful bound DAG: i0/i1 are header `InputArg` boxes; the
+        // `int_gt` producer is a live `OpRc` whose result box (`from_bound_op`)
+        // feeds `guard_value`; the guarded constant `1` is an inline `ConstInt`
+        // box (sheds to `Operand::Const`). Every op-arg sheds to
+        // `Operand::{InputArg,Op,Const}`, never the position-only `Operand::Box`.
+        let i0 = rooted_inputarg_box(Type::Int, 0);
+        let i1 = rooted_inputarg_box(Type::Int, 1);
+        // v = (i0 > i1): intbounds bounds the comparison result to [0,1].
+        let int_gt = std::rc::Rc::new(Op::new(OpCode::IntGt, &[i0, i1]));
+        int_gt.pos.set(OpRef::int_op(100));
+        let v = BoxRef::from_bound_op(&int_gt);
+        // guard_value(v, 1)
+        let guard_value = std::rc::Rc::new(Op::new(
+            OpCode::GuardValue,
+            &[v, BoxRef::new_const(Value::Int(1))],
+        ));
+        guard_value.pos.set(OpRef::void_op(0));
+
+        let ops: Vec<OpRc> = vec![int_gt, guard_value];
+        let scratch: Vec<Op> = ops.iter().map(|op| (**op).clone()).collect();
+        let (seeded, snapshots) = super::super::seed_empty_guard_snapshots(&scratch);
+        for (op, seed) in ops.iter().zip(seeded.iter()) {
+            op.rd_resume_position.set(seed.rd_resume_position.get());
+        }
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
+        let result: Vec<Op> = opt
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecAssoc::new(), 2)
+            .into_iter()
+            .map(|rc| (*rc).clone())
+            .collect();
 
         // GUARD_VALUE should be replaced with GUARD_TRUE
         assert!(

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2333,7 +2333,7 @@ impl OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // heap.py:80 arg1 = get_box_replacement(self._get_rhs_from_set_op(op))
-        let arg1 = ctx.get_box_replacement(Self::field_get_rhs(op)).to_opref();
+        let arg1 = ctx.get_replacement_opref(Self::field_get_rhs(op));
         let field_idx = Self::field_slot_index(descr);
         // heap.py:81-83 if self.possible_aliasing(structinfo):
         //                  self.force_lazy_set(optheap, op.getdescr())
@@ -2488,7 +2488,7 @@ impl OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // heap.py:80 arg1 = get_box_replacement(self._get_rhs_from_set_op(op))
-        let arg1 = ctx.get_box_replacement(Self::array_get_rhs(op)).to_opref();
+        let arg1 = ctx.get_replacement_opref(Self::array_get_rhs(op));
         // heap.py:81-83 if self.possible_aliasing(structinfo):
         //                  self.force_lazy_set(optheap, op.getdescr())
         let needs_force = self

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3790,6 +3790,30 @@ mod tests {
 
     use super::OptHeap;
     use crate::r#box::BoxRef;
+    use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
+
+    /// oparser-faithful drop-in for `BoxRef::from_opref(o)` at op-arg /
+    /// fail-arg sites where `o` is a bound-at-runtime `OpRef`. Constants shed
+    /// to `Operand::Const` (no producer), so they keep the bare `from_opref`
+    /// path; `InputArg*` / `{Int,Float,Ref}Op` position-only refs bind to a
+    /// rooted synthetic producer (`Operand::InputArg` / `Operand::Op`) so they
+    /// never mint the position-only `Operand::Box`. `to_opref()` is identical
+    /// to `from_opref(o)` either way, preserving every position-keyed
+    /// assertion / cache key / trace-inputarg auto-seed.
+    fn bound_arg(o: OpRef) -> BoxRef {
+        match o {
+            OpRef::InputArgInt(i) => rooted_inputarg_box(Type::Int, i),
+            OpRef::InputArgFloat(i) => rooted_inputarg_box(Type::Float, i),
+            OpRef::InputArgRef(i) => rooted_inputarg_box(Type::Ref, i),
+            OpRef::IntOp(p) => rooted_resop_box(Type::Int, p),
+            OpRef::FloatOp(p) => rooted_resop_box(Type::Float, p),
+            OpRef::RefOp(p) => rooted_resop_box(Type::Ref, p),
+            OpRef::VoidOp(p) => rooted_resop_box(Type::Void, p),
+            // Const* (shed to Operand::Const), None, TempVar: no producer to
+            // bind — the bare from_opref path does not mint.
+            _ => BoxRef::from_opref(o),
+        }
+    }
 
     /// Test SizeDescr that pretends to wrap a struct with `is_object()` matching
     /// the constructor arg. Mirrors the PyPy `optimizer.py:480` dispatch test
@@ -4041,8 +4065,8 @@ mod tests {
         );
 
         let mut heap = OptHeap::new();
-        heap.cache_field(&BoxRef::from_opref(OpRef::int_op(0)), &descr_a);
-        heap.cache_field(&BoxRef::from_opref(OpRef::int_op(0)), &descr_b);
+        heap.cache_field(&rooted_resop_box(Type::Int, 0), &descr_a);
+        heap.cache_field(&rooted_resop_box(Type::Int, 0), &descr_b);
 
         assert_eq!(heap.cached_fields.len(), 2);
     }
@@ -4058,14 +4082,14 @@ mod tests {
     ) {
         use crate::optimizeopt::info::{PreambleOp, PtrInfo};
 
-        let mut preamble_op = Op::with_descr(opcode, &[BoxRef::from_opref(object)], descr.clone());
+        let mut preamble_op = Op::with_descr(opcode, &[bound_arg(object)], descr.clone());
         preamble_op.pos.set(source);
         ctx.initialize_imported_short_preamble_builder(
             &[object, resolved],
-            &[BoxRef::from_opref(object), BoxRef::from_opref(resolved)],
+            &[bound_arg(object), bound_arg(resolved)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
-                res: BoxRef::from_opref(source),
+                res: bound_arg(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -4078,7 +4102,7 @@ mod tests {
             info.set_preamble_field(
                 OptHeap::field_slot_index(descr),
                 PreambleOp {
-                    op: BoxRef::from_opref(source),
+                    op: bound_arg(source),
                     invented_name: false,
                     preamble_op: std::rc::Rc::new(preamble_op),
                     same_as_source: None,
@@ -4185,14 +4209,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             // Terminate trace so lazy set is forced.
@@ -4230,7 +4254,7 @@ mod tests {
         );
 
         let pos2 = ctx.reserve_pos_typed(Type::Int);
-        let mut op = Op::with_descr(OpCode::GetfieldGcI, &[BoxRef::from_opref(p0)], d);
+        let mut op = Op::with_descr(OpCode::GetfieldGcI, &[bound_arg(p0)], d);
         op.pos.set(pos2);
 
         let op_rc = std::rc::Rc::new(op.clone());
@@ -4267,11 +4291,7 @@ mod tests {
 
         // First getfield on head: consumes the import, caches the value.
         let pos2 = ctx.reserve_pos_typed(Type::Ref);
-        let mut op1 = Op::with_descr(
-            OpCode::GetfieldGcR,
-            &[BoxRef::from_opref(p0)],
-            d_head.clone(),
-        );
+        let mut op1 = Op::with_descr(OpCode::GetfieldGcR, &[bound_arg(p0)], d_head.clone());
         op1.pos.set(pos2);
         let op1_rc = std::rc::Rc::new(op1.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op1_rc));
@@ -4285,11 +4305,7 @@ mod tests {
         // Second getfield on head after invalidation: must NOT return the
         // stale preamble value.  The import was consumed, so it should emit.
         let pos3 = ctx.reserve_pos_typed(Type::Ref);
-        let mut op2 = Op::with_descr(
-            OpCode::GetfieldGcR,
-            &[BoxRef::from_opref(p0)],
-            d_head.clone(),
-        );
+        let mut op2 = Op::with_descr(OpCode::GetfieldGcR, &[bound_arg(p0)], d_head.clone());
         op2.pos.set(pos3);
         let result2 = heap.optimize_getfield(&op2, &std::rc::Rc::new(op2.clone()), &mut ctx);
         assert!(
@@ -4318,7 +4334,7 @@ mod tests {
         ctx.make_constant_box(&b, majit_ir::Value::Int(1));
 
         let pos1 = ctx.reserve_pos_typed(Type::Int);
-        let mut op = Op::with_descr(OpCode::GetfieldGcI, &[BoxRef::from_opref(p0)], d);
+        let mut op = Op::with_descr(OpCode::GetfieldGcI, &[bound_arg(p0)], d);
         op.pos.set(pos1);
         op.setarg(
             0,
@@ -4339,12 +4355,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4368,16 +4384,16 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(102)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 102),
                 ],
                 d.clone(),
             ),
@@ -4403,18 +4419,15 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4443,27 +4456,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(200)),
-                    BoxRef::from_opref(OpRef::input_arg_int(201)),
+                    rooted_inputarg_box(Type::Ref, 200),
+                    rooted_inputarg_box(Type::Int, 201),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4497,17 +4510,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
+                    rooted_resop_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d.clone(),
             ),
@@ -4570,8 +4583,8 @@ mod tests {
         let mut op = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                BoxRef::from_opref(OpRef::ref_op(100)),
-                BoxRef::from_opref(idx),
+                rooted_resop_box(Type::Ref, 100),
+                rooted_resop_box(Type::Int, idx.raw()),
             ],
             d.clone(),
         );
@@ -4611,9 +4624,9 @@ mod tests {
         let mut op = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(idx),
-                BoxRef::from_opref(OpRef::int_op(101)),
+                rooted_resop_box(Type::Int, 100),
+                rooted_resop_box(Type::Int, idx.raw()),
+                rooted_resop_box(Type::Int, 101),
             ],
             d.clone(),
         );
@@ -4664,18 +4677,15 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::GuardTrue,
-                &[BoxRef::from_opref(OpRef::input_arg_int(200))],
-            ),
+            Op::new(OpCode::GuardTrue, &[rooted_inputarg_box(Type::Int, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4725,14 +4735,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
                 d0,
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d1,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4758,20 +4768,20 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldRaw,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(200)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(201)),
+                    rooted_inputarg_box(Type::Ref, 200),
+                    rooted_inputarg_box(Type::Ref, 201),
                 ],
                 d1,
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4795,7 +4805,7 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             // assign_positions stamps GETFIELD's pos as IntOp(0); the
@@ -4804,8 +4814,8 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_resop_box(Type::Int, 0),
                 ],
                 d.clone(),
             ),
@@ -4830,19 +4840,19 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 0),
                 ],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4864,12 +4874,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4887,12 +4897,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4914,18 +4924,18 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
+                    rooted_resop_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
-                    BoxRef::from_opref(OpRef::int_op(102)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
+                    rooted_resop_box(Type::Int, 102),
                 ],
                 d.clone(),
             ),
@@ -4988,19 +4998,19 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(
                 OpCode::IntAddOvf,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 0),
                 ],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5024,27 +5034,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Int, 101),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Int, 102),
                 ],
                 d1.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d1.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5071,16 +5081,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5105,16 +5112,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5143,26 +5147,23 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d_immut.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d_mut.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d_immut.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d_mut.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5189,12 +5190,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5215,16 +5216,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5243,16 +5241,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5272,7 +5267,7 @@ mod tests {
         let mut pass = OptHeap::new();
         // history.py:182 PtrInfo applies to ref-typed boxes; the field
         // descr is Type::Ref so the field source is ref-typed too.
-        pass.cache_field(&BoxRef::from_opref(OpRef::ref_op(100)), &descr);
+        pass.cache_field(&rooted_resop_box(Type::Ref, 100), &descr);
 
         let mut sb = crate::optimizeopt::shortpreamble::ShortBoxes::with_label_args(&[
             OpRef::ref_op(100),
@@ -5316,20 +5311,14 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(201))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 201)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5352,26 +5341,23 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 d.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(300))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 300)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ), // cached
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 d.clone(),
             ), // cached
             Op::new(OpCode::Jump, &[]),
@@ -5402,20 +5388,20 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(200)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(20)),
+                    rooted_inputarg_box(Type::Ref, 200),
+                    rooted_inputarg_box(Type::Ref, 20),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5450,19 +5436,19 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(10)),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_inputarg_box(Type::Ref, 10),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 plain_call_descr(100),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
+                &[rooted_resop_box(Type::Ref, 0)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5497,19 +5483,19 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(10)),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_inputarg_box(Type::Ref, 10),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
+                &[rooted_resop_box(Type::Ref, 0)],
                 plain_call_descr(100),
             ), // pass p0 to call
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
+                &[rooted_resop_box(Type::Ref, 0)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5545,27 +5531,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(10)),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_inputarg_box(Type::Ref, 10),
                 ],
                 d0.clone(),
             ), // p0.f0 = i10
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(1)),
-                    BoxRef::from_opref(OpRef::ref_op(0)),
+                    rooted_resop_box(Type::Ref, 1),
+                    rooted_resop_box(Type::Ref, 0),
                 ],
                 d1.clone(),
             ), // p1.f1 = p0 (p0 escapes)
             Op::with_descr(
                 OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::ref_op(1))],
+                &[rooted_resop_box(Type::Ref, 1)],
                 plain_call_descr(100),
             ), // call(p1) (p1 escapes)
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
+                &[rooted_resop_box(Type::Ref, 0)],
                 d0.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5596,20 +5582,20 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d1.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(200)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(20)),
+                    rooted_inputarg_box(Type::Ref, 200),
+                    rooted_inputarg_box(Type::Ref, 20),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d1.clone(),
             ), // different field
             Op::new(OpCode::Jump, &[]),
@@ -5638,26 +5624,26 @@ mod tests {
         let d = descr(0);
         let idx = OpRef::int_op(50);
         let mut ops = vec![
-            Op::new(OpCode::NewArray, &[BoxRef::from_opref(OpRef::int_op(5))]), // pos=0 -> p0
+            Op::new(OpCode::NewArray, &[rooted_resop_box(Type::Int, 5)]), // pos=0 -> p0
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(idx),
-                    BoxRef::from_opref(OpRef::int_op(10)),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_resop_box(Type::Int, idx.raw()),
+                    rooted_resop_box(Type::Int, 10),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::int_op(200))],
+                &[rooted_resop_box(Type::Int, 200)],
                 plain_call_descr(100),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d.clone(),
             ),
@@ -5735,24 +5721,24 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(10)),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_inputarg_box(Type::Ref, 10),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 plain_call_descr(100),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(201))],
+                &[rooted_inputarg_box(Type::Ref, 201)],
                 plain_call_descr(101),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
+                &[rooted_resop_box(Type::Ref, 0)],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5781,10 +5767,7 @@ mod tests {
         // guard_nonnull(p0)   <- redundant, allocation is always non-null
         let mut ops = vec![
             Op::new(OpCode::New, &[]),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5806,14 +5789,8 @@ mod tests {
         // guard_nonnull(p0)
         // guard_nonnull(p0)   <- redundant
         let mut ops = vec![
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5835,14 +5812,11 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
             ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5863,10 +5837,7 @@ mod tests {
     fn test_guard_nonnull_unknown_not_removed() {
         // guard_nonnull(p0)  <- first time seeing p0, must keep
         let mut ops = vec![
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5887,14 +5858,8 @@ mod tests {
         // guard_nonnull(p0)    <- still redundant (allocation is always non-null)
         let mut ops = vec![
             Op::new(OpCode::New, &[]),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5917,18 +5882,9 @@ mod tests {
         // call_n(some_func)   <- invalidates guard-derived nonnull
         // guard_nonnull(p0)   <- must re-emit
         let mut ops = vec![
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5953,14 +5909,11 @@ mod tests {
             Op::new(
                 OpCode::GuardNonnullClass,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
             ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5985,14 +5938,11 @@ mod tests {
             Op::new(
                 OpCode::GuardValue,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
             ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6013,10 +5963,7 @@ mod tests {
     fn test_guard_nonnull_after_new_with_vtable() {
         let mut ops = vec![
             Op::new(OpCode::NewWithVtable, &[]),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6036,14 +5983,8 @@ mod tests {
     #[test]
     fn test_guard_nonnull_after_new_array() {
         let mut ops = vec![
-            Op::new(
-                OpCode::NewArray,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(5))],
-            ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::ref_op(0))],
-            ),
+            Op::new(OpCode::NewArray, &[rooted_inputarg_box(Type::Ref, 5)]),
+            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6115,18 +6056,18 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6164,18 +6105,18 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6206,7 +6147,7 @@ mod tests {
             Op::new(OpCode::GuardNotInvalidated, &[]),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
+                &[rooted_inputarg_box(Type::Ref, 200)],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
@@ -6243,22 +6184,22 @@ mod tests {
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[BoxRef::from_opref(OpRef::int_op(200))],
+                &[rooted_resop_box(Type::Int, 200)],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d0,
             ),
@@ -6342,22 +6283,22 @@ mod tests {
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[BoxRef::from_opref(OpRef::int_op(200))],
+                &[rooted_resop_box(Type::Int, 200)],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d0,
             ),
@@ -6435,17 +6376,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(101)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 101),
                 ],
                 d.clone(),
             ),
             Op::new(
                 OpCode::GcLoadI,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(200)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(8)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(4)),
+                    rooted_inputarg_box(Type::Ref, 200),
+                    rooted_inputarg_box(Type::Ref, 8),
+                    rooted_inputarg_box(Type::Ref, 4),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6469,15 +6410,12 @@ mod tests {
             Op::new(
                 OpCode::GcLoadI,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_ref(100)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(8)),
-                    BoxRef::from_opref(OpRef::input_arg_ref(4)),
+                    rooted_inputarg_box(Type::Ref, 100),
+                    rooted_inputarg_box(Type::Ref, 8),
+                    rooted_inputarg_box(Type::Ref, 4),
                 ],
             ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
-            ),
+            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6505,21 +6443,18 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::QuasiimmutField,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d0,
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d1.clone(),
             ),
-            Op::new(
-                OpCode::CallN,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(200))],
-            ),
+            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[BoxRef::from_opref(OpRef::input_arg_ref(100))],
+                &[rooted_inputarg_box(Type::Ref, 100)],
                 d1.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6584,17 +6519,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
+                    rooted_resop_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d.clone(),
             ),
@@ -6664,17 +6599,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx5),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx5.raw()),
+                    rooted_resop_box(Type::Int, 101),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx6),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx6.raw()),
                 ],
                 d.clone(),
             ),
@@ -6745,16 +6680,16 @@ mod tests {
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(idx),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, idx.raw()),
                 ],
                 d.clone(),
             ),
@@ -6824,18 +6759,12 @@ mod tests {
         let d = descr(42);
         let mut ops = vec![
             {
-                let mut op = Op::new(
-                    OpCode::ArraylenGc,
-                    &[BoxRef::from_opref(OpRef::int_op(100))],
-                );
+                let mut op = Op::new(OpCode::ArraylenGc, &[rooted_resop_box(Type::Int, 100)]);
                 op.setdescr(d.clone());
                 op
             },
             {
-                let mut op = Op::new(
-                    OpCode::ArraylenGc,
-                    &[BoxRef::from_opref(OpRef::int_op(100))],
-                );
+                let mut op = Op::new(OpCode::ArraylenGc, &[rooted_resop_box(Type::Int, 100)]);
                 op.setdescr(d);
                 op
             },
@@ -6885,8 +6814,8 @@ mod tests {
                 descr: arr_descr.clone(),
                 lenbound: IntBound::from_constant(2),
                 items: vec![
-                    FieldEntry::Value(BoxRef::from_opref(const_10)),
-                    FieldEntry::Value(BoxRef::from_opref(const_20)),
+                    FieldEntry::Value(bound_arg(const_10)),
+                    FieldEntry::Value(bound_arg(const_20)),
                 ],
                 last_guard_pos: -1,
             }),
@@ -6897,8 +6826,8 @@ mod tests {
                 descr: arr_descr,
                 lenbound: IntBound::from_constant(2),
                 items: vec![
-                    FieldEntry::Value(BoxRef::from_opref(const_10)),
-                    FieldEntry::Value(BoxRef::from_opref(const_30)),
+                    FieldEntry::Value(bound_arg(const_10)),
+                    FieldEntry::Value(bound_arg(const_30)),
                 ],
                 last_guard_pos: -1,
             }),
@@ -6947,11 +6876,11 @@ mod tests {
         let mut op1 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag),
             ],
         );
         op1.setdescr(descr.clone());
@@ -6963,11 +6892,11 @@ mod tests {
         let mut op2 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag),
             ],
         );
         op2.setdescr(descr.clone());
@@ -7004,11 +6933,11 @@ mod tests {
         let mut op1 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag_lookup),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag_lookup),
             ],
         );
         op1.setdescr(descr.clone());
@@ -7028,11 +6957,11 @@ mod tests {
         let mut op2 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag_store),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag_store),
             ],
         );
         op2.setdescr(descr.clone());
@@ -7067,11 +6996,11 @@ mod tests {
         let mut op1 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag),
             ],
         );
         op1.setdescr(descr.clone());
@@ -7088,11 +7017,11 @@ mod tests {
         let mut op2 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag),
             ],
         );
         op2.setdescr(descr.clone());
@@ -7140,11 +7069,11 @@ mod tests {
         let mut op1 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key_a),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key_a),
+                bound_arg(hash),
+                bound_arg(flag),
             ],
         );
         op1.setdescr(descr.clone());
@@ -7156,11 +7085,11 @@ mod tests {
         let mut op2 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key_b),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key_b),
+                bound_arg(hash),
+                bound_arg(flag),
             ],
         );
         op2.setdescr(descr.clone());
@@ -7229,11 +7158,11 @@ mod tests {
         let mut op1 = Op::new(
             OpCode::CallI,
             &[
-                BoxRef::from_opref(func_addr),
-                BoxRef::from_opref(dict),
-                BoxRef::from_opref(key),
-                BoxRef::from_opref(hash),
-                BoxRef::from_opref(flag_delete),
+                bound_arg(func_addr),
+                bound_arg(dict),
+                bound_arg(key),
+                bound_arg(hash),
+                bound_arg(flag_delete),
             ],
         );
         op1.setdescr(descr.clone());

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1865,7 +1865,7 @@ mod tests {
         let mut replay = Op::new(
             OpCode::GetarrayitemGcI,
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
                 BoxRef::from_opref(OpRef::const_int(0)),
             ],
         );
@@ -1898,7 +1898,7 @@ mod tests {
         let mut info = PtrInfo::instance(Some(descr), None);
         let replay = Op::new(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(10))],
+            &[crate::r#box::test_support::rooted_resop_box(Type::Int, 10)],
         );
         let pop = PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(88)),

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3351,17 +3351,18 @@ impl Optimization for OptIntBounds {
         &self,
         args: &[OpRef],
         ctx: &OptContext,
-    ) -> crate::optimizeopt::vec_assoc::VecAssoc<OpRef, IntBound> {
+    ) -> crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, IntBound> {
         let mut exported = crate::optimizeopt::vec_assoc::VecAssoc::new();
         for &arg in args {
-            // `&OptContext` here forbids the `materialize_box_at` fallback in
-            // `resolve_box`, so use the immutable forwarded-chain walk
-            // (`get_box_replacement(arg) ≡ get_box_replacement_box(arg)
-            // .to_opref()` with the unresolvable-arg fallthrough).
-            let resolved = ctx
-                .get_box_replacement_box(arg)
-                .map(|b| b.to_opref())
-                .unwrap_or(arg);
+            // An IntBound only lives on a value-bearing box; an unresolvable
+            // arg position carries none. Resolve the canonical box once and
+            // key the export by box identity (`Rc::ptr_eq`), matching RPython's
+            // `box._forwarded` IntBound storage. `&OptContext` here forbids the
+            // `materialize_box_at` fallback, so an unbound arg is simply skipped.
+            let Some(arg_box) = ctx.get_box_replacement_box(arg) else {
+                continue;
+            };
+            let resolved = arg_box.to_opref();
             // optimizer.py:118-119 `setintbound`: an IntBound is never stored
             // on a Const (history.py:220 a Const carries its value inline);
             // unroll.py:483 likewise skips Const args when exporting info, so
@@ -3374,14 +3375,11 @@ impl Optimization for OptIntBounds {
             if !matches!(ctx.opref_type(resolved), Some(majit_ir::Type::Int)) {
                 continue;
             }
-            if let Some(bound) = ctx
-                .get_box_replacement_box(arg)
-                .and_then(|b| ctx.peek_intbound_box(&b))
-            {
+            if let Some(bound) = ctx.peek_intbound_box(&arg_box) {
                 if bound.is_unbounded() {
                     continue;
                 }
-                exported.insert(resolved, bound);
+                exported.insert(arg_box, bound);
             }
         }
         exported

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3494,16 +3494,19 @@ mod tests {
             // box.
             for i in 0..resolved_op.num_args() {
                 let a = resolved_op.arg(i);
-                let resolved = match ctx.resolve_box_box_opt(&a) {
-                    Some(b) => b,
-                    None => {
-                        let ar = a.to_opref();
-                        if ar.is_none() {
-                            a.clone()
-                        } else {
-                            ctx.materialize_box_at(ar).get_box_replacement(false)
-                        }
-                    }
+                let ar = a.to_opref();
+                let resolved = if ar.is_none() {
+                    a.clone()
+                } else {
+                    // Mint + register the canonical `_forwarded` host for this
+                    // position FIRST (whether the operand is a bound producer
+                    // box or a position-only ref), so the pass's later
+                    // `get_box_replacement` resolves to that bound terminal
+                    // rather than re-minting an unbound `from_opref` box. Then
+                    // resolve any forwarding box-native.
+                    let canonical = ctx.materialize_box_at(ar);
+                    ctx.resolve_box_box_opt(&canonical)
+                        .unwrap_or_else(|| canonical.get_box_replacement(false))
                 };
                 resolved_op.setarg(i, resolved);
             }
@@ -3564,9 +3567,37 @@ mod tests {
     }
 
     fn make_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
+        // oparser-faithful (rpython/jit/tool/oparser.py): each position-only
+        // ResOp arg is bound to a synthetic producer of the matching type so
+        // it sheds to `Operand::Op` (not the position-only `Operand::Box`);
+        // constant / input-arg / none refs shed to `Operand::Const` /
+        // `Operand::InputArg` / nothing via `from_opref` and never mint.
         let box_args: Vec<crate::r#box::BoxRef> = args
             .iter()
-            .map(|a| crate::r#box::BoxRef::from_opref(*a))
+            .map(|a| match *a {
+                OpRef::IntOp(n) => {
+                    crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Int, n)
+                }
+                OpRef::FloatOp(n) => {
+                    crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Float, n)
+                }
+                OpRef::RefOp(n) => {
+                    crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Ref, n)
+                }
+                OpRef::VoidOp(n) => {
+                    crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Void, n)
+                }
+                OpRef::InputArgInt(n) => {
+                    crate::r#box::test_support::rooted_inputarg_box(majit_ir::Type::Int, n)
+                }
+                OpRef::InputArgFloat(n) => {
+                    crate::r#box::test_support::rooted_inputarg_box(majit_ir::Type::Float, n)
+                }
+                OpRef::InputArgRef(n) => {
+                    crate::r#box::test_support::rooted_inputarg_box(majit_ir::Type::Ref, n)
+                }
+                other => crate::r#box::BoxRef::from_opref(other),
+            })
             .collect();
         let mut op = Op::new(opcode, &box_args);
         op.pos.set(OpRef::op_typed(pos, op.result_type()));
@@ -4097,9 +4128,13 @@ mod tests {
     /// autogenintrules.py rule and_x_x: int_and(a, a) => a.
     #[test]
     fn test_int_and_x_x() {
+        // `a` is an unproduced header input (oparser `[i0]`): model it as an
+        // InputArg so the production driver's dispatch-entry rebind resolves
+        // it through the OpRef store (no detached bound producer to strand the
+        // `_forwarded` chain). Both args share position 0 ⇒ `same_box` holds.
         let ops = vec![make_op(
             OpCode::IntAnd,
-            &[OpRef::int_op(0), OpRef::int_op(0)],
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(0)],
             1,
         )];
         let result = run_pass(&ops);
@@ -4163,9 +4198,11 @@ mod tests {
     /// autogenintrules.py rule or_x_x: int_or(a, a) => a.
     #[test]
     fn test_int_or_x_x() {
+        // `a` is an unproduced header input — model it as an InputArg (see
+        // `test_int_and_x_x`) so the production driver resolves it positionally.
         let ops = vec![make_op(
             OpCode::IntOr,
-            &[OpRef::int_op(0), OpRef::int_op(0)],
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(0)],
             1,
         )];
         let result = run_pass(&ops);
@@ -4670,12 +4707,20 @@ mod tests {
     fn test_guard_true_int_lt_enables_add_ovf_removal() {
         use crate::optimizeopt::optimizer::Optimizer;
 
+        // i0/i1 are unproduced header inputs (modelled as InputArgs so the
+        // production driver resolves them positionally); i2/i4 are produced by
+        // the trace; i200 is the const-seeded slot (`constants.insert(200, …)`)
+        // whose canonical host the const-seeding registers.
         let ops = vec![
-            make_op(OpCode::IntLt, &[OpRef::int_op(0), OpRef::int_op(1)], 2),
+            make_op(
+                OpCode::IntLt,
+                &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+                2,
+            ),
             make_op(OpCode::GuardTrue, &[OpRef::int_op(2)], 3),
             make_op(
                 OpCode::IntAddOvf,
-                &[OpRef::int_op(0), OpRef::int_op(200)],
+                &[OpRef::input_arg_int(0), OpRef::int_op(200)],
                 4,
             ),
             make_op(OpCode::GuardNoOverflow, &[], 5),

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -5793,8 +5793,8 @@ impl OptContext {
         ) {
             (Some(ref a), Some(ref b)) => a.same_box(b),
             _ => {
-                let query = self.get_box_replacement(query).to_opref();
-                let stored = self.get_box_replacement(stored).to_opref();
+                let query = self.get_replacement_opref(query);
+                let stored = self.get_replacement_opref(stored);
                 if query == stored {
                     return true;
                 }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -555,16 +555,17 @@ fn raise_speculative_error(reason: &'static str) -> ! {
 pub struct OptContext {
     /// The output operation list being built.
     pub new_operations: Vec<majit_ir::OpRc>,
-    /// optimizer.py:246 `self._emittedoperations = {}` — result positions
-    /// of ops emitted by THIS optimizer run. `as_operation`
-    /// (optimizer.py:369-377) only treats a box as a producer when
-    /// `op in self._emittedoperations`, so pattern-matching rewrites
+    /// optimizer.py:246 `self._emittedoperations = {}` — the result boxes
+    /// of ops emitted by THIS optimizer run, keyed by box identity
+    /// (`Rc::ptr_eq`) to mirror the upstream dict keyed by the `op` object.
+    /// `as_operation` (optimizer.py:369-377) only treats a box as a producer
+    /// when `op in self._emittedoperations`, so pattern-matching rewrites
     /// (e.g. autogenintrules.py int_add chain reassociation) never reach
     /// across an optimization-run boundary into a previous phase's ops.
     /// A Phase-2 lookup that followed a label arg to its Phase-1 producer
     /// would re-express a per-iteration value in terms of the PREAMBLE's
     /// entry value, which the loop header does not carry per-iteration.
-    pub emitted_operations: majit_ir::vec_set::VecSet<OpRef>,
+    pub emitted_operations: majit_ir::vec_set::VecSet<crate::r#box::BoxRef>,
     /// Number of input arguments, used to offset emitted op positions
     /// so that variable indices don't collide with input arg indices.
     num_inputs: u32,
@@ -2752,7 +2753,8 @@ impl OptContext {
                 // clone path below records this too; `get_producing_op` only
                 // admits producers present here, so the reused op must be
                 // marked emitted or it stays invisible to producer matching.
-                self.emitted_operations.insert(op_pos);
+                self.emitted_operations
+                    .insert(crate::r#box::BoxRef::from_bound_op(&reused));
                 self.new_operations.push(reused);
                 return op_pos;
             }
@@ -2795,7 +2797,8 @@ impl OptContext {
             }
         }
         // optimizer.py:674 `self._emittedoperations[op] = None`.
-        self.emitted_operations.insert(op_pos);
+        self.emitted_operations
+            .insert(crate::r#box::BoxRef::from_bound_op(&op_rc));
         self.new_operations.push(op_rc);
         pos_ref
     }
@@ -6459,7 +6462,13 @@ impl OptContext {
         // Walk the forwarding chain first (resoperation.py:58) so the
         // replacement box's producer is read.
         let producer = op.get_box_replacement(false).bound_op()?;
-        if !self.emitted_operations.contains(&producer.pos.get()) {
+        // optimizer.py:369-377 `op in self._emittedoperations` — keyed by the
+        // producer's box identity (`from_bound_op` memoizes one box per op Rc,
+        // so this is the same box recorded at emit).
+        if !self
+            .emitted_operations
+            .contains(&crate::r#box::BoxRef::from_bound_op(&producer))
+        {
             return None;
         }
         Some((*producer).clone())

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -686,6 +686,15 @@ pub struct OptContext {
     /// the export-site `label_args + virtuals` recompute (measured
     /// identical across the corpus, 2026-06-11).
     pub exported_short_inputargs: Vec<crate::r#box::BoxRef>,
+    /// Rooted `InputArgRc` carriers for `exported_short_inputargs`, index-
+    /// aligned with that vector. Each renamed short-preamble input box
+    /// (`exported_short_inputargs[i]`) holds a WEAK handle to
+    /// `exported_short_inputarg_refs[i]`; keeping the strong Rc alive here
+    /// lets the box resolve to a real bound `InputArg` (so the operand binds
+    /// to `Operand::InputArg` instead of shedding to the position-only
+    /// `Operand::Box` catch-all). Carried alongside `exported_short_inputargs`
+    /// through the same export channel.
+    pub exported_short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// optimizer.py: `can_replace_guards` — disable guard replacement during
     /// bridge compilation. Defaults to true for preamble.
     pub can_replace_guards: bool,
@@ -1605,6 +1614,7 @@ impl OptContext {
             active_short_preamble_producer: None,
             exported_short_boxes: Vec::new(),
             exported_short_inputargs: Vec::new(),
+            exported_short_inputarg_refs: Vec::new(),
 
             imported_virtuals: Vec::new(),
             imported_label_args: None,
@@ -2150,6 +2160,7 @@ impl OptContext {
             active_short_preamble_producer: None,
             exported_short_boxes: Vec::new(),
             exported_short_inputargs: Vec::new(),
+            exported_short_inputarg_refs: Vec::new(),
 
             imported_virtuals: Vec::new(),
             imported_label_args: None,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -9958,7 +9958,10 @@ mod ensure_ptr_info_arg0_tests {
         let descr: DescrRef = Arc::new(TestFieldDescr { index: 0, parent });
         let mut op = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
             descr,
         );
         op.pos.set(OpRef::int_op(1));
@@ -9973,7 +9976,10 @@ mod ensure_ptr_info_arg0_tests {
         });
         let mut op = Op::with_descr(
             OpCode::ArraylenGc,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
             descr,
         );
         op.pos.set(OpRef::int_op(1));
@@ -10041,7 +10047,10 @@ mod ensure_ptr_info_arg0_tests {
             });
             let mut op = Op::with_descr(
                 OpCode::Strlen,
-                &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )],
                 descr,
             );
             op.pos.set(OpRef::int_op(1));
@@ -10075,7 +10084,10 @@ mod ensure_ptr_info_arg0_tests {
             });
             let mut op = Op::with_descr(
                 OpCode::Strlen,
-                &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )],
                 descr,
             );
             op.pos.set(OpRef::int_op(1));
@@ -10397,8 +10409,8 @@ mod imported_short_preamble_fallback_tests {
         let mut replay_op = Op::new(
             OpCode::IntAdd,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(7)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(8)),
+                crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Int, 7),
+                crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Int, 8),
             ],
         );
         replay_op.pos.set(OpRef::int_op(14));

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -8421,7 +8421,7 @@ pub trait Optimization {
         &self,
         _args: &[OpRef],
         _ctx: &OptContext,
-    ) -> crate::optimizeopt::vec_assoc::VecAssoc<OpRef, IntBound> {
+    ) -> crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, IntBound> {
         crate::optimizeopt::vec_assoc::VecAssoc::new()
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2275,9 +2275,14 @@ impl OptContext {
     /// the resulting OpRef.
     pub fn emit_constant_int(&mut self, value: i64) -> OpRef {
         let pos_ref = self.reserve_pos_typed(Type::Int);
+        // The SAME_AS source is the constant itself (`make_constant_box` below
+        // forwards the result to the same `Const`, so the op is a tautology
+        // `result = ConstInt(value)`). A constant operand binds directly; a
+        // position-only `from_opref(pos_ref)` self-reference would shed to the
+        // catch-all `Operand::Box` with no live producer (#9).
         let mut op = Op::new(
             OpCode::SameAsI,
-            &[crate::r#box::BoxRef::from_opref(pos_ref)],
+            &[crate::r#box::BoxRef::new_const(Value::Int(value))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2290,9 +2295,10 @@ impl OptContext {
     /// return the resulting OpRef.
     pub fn emit_constant_ref(&mut self, value: GcRef) -> OpRef {
         let pos_ref = self.reserve_pos_typed(Type::Ref);
+        // SAME_AS source is the constant ref itself; see `emit_constant_int`.
         let mut op = Op::new(
             OpCode::SameAsR,
-            &[crate::r#box::BoxRef::from_opref(pos_ref)],
+            &[crate::r#box::BoxRef::new_const(Value::Ref(value))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2305,9 +2311,10 @@ impl OptContext {
     /// the resulting OpRef.
     pub fn emit_constant_float(&mut self, value: f64) -> OpRef {
         let pos_ref = self.reserve_pos_typed(Type::Float);
+        // SAME_AS source is the constant float itself; see `emit_constant_int`.
         let mut op = Op::new(
             OpCode::SameAsF,
-            &[crate::r#box::BoxRef::from_opref(pos_ref)],
+            &[crate::r#box::BoxRef::new_const(Value::Float(value))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -797,8 +797,10 @@ impl Optimizer {
             // SAME_AS_*.type parity); the immediate push below makes
             // op_at(fresh) the authoritative type source. No
             // `value_types` write needed (5).
-            ctx.emitted_operations.insert(fresh);
-            ctx.new_operations.push(std::rc::Rc::new(op));
+            let op_rc = std::rc::Rc::new(op);
+            ctx.emitted_operations
+                .insert(crate::r#box::BoxRef::from_bound_op(&op_rc));
+            ctx.new_operations.push(op_rc);
             // Update the field to reference the SameAs result.
             entries[*entry_idx].fields[*field_idx].1 = fresh;
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5531,6 +5531,14 @@ mod tests {
     #[test]
     fn test_default_pipeline_keeps_call_may_force_when_guard_fail_args_reference_results() {
         let field_descr = Arc::new(TestDescr(101));
+        // Distinct field so `get_a_val` is not CSE-folded into `get_a_type`:
+        // it stays a live producer at its own position, which guard_b's fail
+        // args reference (a fail arg pointing at a *folded* getfield would make
+        // the position-only synthetic resolve to itself while the OpRef store
+        // forwards to the survivor — the resolve_box_box divergence tripwire,
+        // mod.rs:4750; binding to the real folded producer needs the oprc
+        // driver, blocked here by CallMayForceR's void result position).
+        let field_descr_b = Arc::new(TestDescr(102));
         let call_descr_a = call_may_force_descr(83, majit_ir::Type::Ref);
         let call_descr_b = call_may_force_descr(84, majit_ir::Type::Ref);
         let guard_types_a = vec![
@@ -5553,21 +5561,22 @@ mod tests {
             majit_ir::Type::Ref,
         ];
 
-        // LEFT ON POSITION-ONLY FORM: this fixture wires guard fail args to
-        // earlier producer RESULT positions (e.g. int_op(6) = get_a_val) in a
-        // single OP namespace offset by +3, plus resume-only free vars
-        // (2000..3003). A bound-DAG migration would make each producer-keyed
-        // fail-arg box bind to a detached synthetic that diverges from the
-        // real producer in the box-native vs OpRef consistency check
-        // (`get_box_replacement_not_const_box` debug_assert, mod.rs:4750).
-        // Faithfully rebinding to the real producers needs the oprc driver and
-        // an exact reconstruction of the offset/free-var position scheme;
-        // deferred to keep the fixture's semantics intact.
+        // Position-only op-args / fail-args replaced by the `rooted_resop_box`
+        // drop-in (box.rs test_support: a bound ResOp box whose synthetic
+        // producer is rooted in the thread-local pool; sheds to `Operand::Op`,
+        // `to_opref`s to the same `(type, position)` so position-keyed
+        // resolution is unchanged). CallMayForceR's result is consumed as a Ref
+        // by the getfields/fail-args, so its result refs are `Type::Ref` at the
+        // call position; the resume-only free fail-vars (2000..3003) and the
+        // dangling positions stay `Type::Int` exactly as the fixture wired them.
+        // Detached fail-arg synthetics resolve to themselves (the `same_box`
+        // arm, mod.rs:4637), deferring to the OpRef store — no `Operand::Box`.
+        use crate::r#box::test_support::rooted_resop_box;
         let mut call_a = Op::with_descr(
             OpCode::CallMayForceR,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
             call_descr_a,
         );
@@ -5578,32 +5587,32 @@ mod tests {
         );
         guard_a.setfailargs(
             vec![
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(2000)),
-                BoxRef::from_opref(OpRef::int_op(2001)),
-                BoxRef::from_opref(OpRef::int_op(3)),
-                BoxRef::from_opref(OpRef::int_op(3000)),
-                BoxRef::from_opref(OpRef::int_op(3001)),
-                BoxRef::from_opref(OpRef::int_op(4)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 2000),
+                rooted_resop_box(Type::Int, 2001),
+                rooted_resop_box(Type::Int, 3),
+                rooted_resop_box(Type::Int, 3000),
+                rooted_resop_box(Type::Int, 3001),
+                rooted_resop_box(Type::Int, 4),
             ]
             .into(),
         );
         guard_a.set_fail_arg_types(guard_types_a);
         let get_a_type = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[BoxRef::from_opref(OpRef::ref_op(3))],
+            &[rooted_resop_box(Type::Ref, 3)],
             field_descr.clone(),
         );
         let get_a_val = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[BoxRef::from_opref(OpRef::ref_op(3))],
-            field_descr.clone(),
+            &[rooted_resop_box(Type::Ref, 3)],
+            field_descr_b.clone(),
         );
         let mut call_b = Op::with_descr(
             OpCode::CallMayForceR,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(2)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 2),
             ],
             call_descr_b,
         );
@@ -5614,36 +5623,42 @@ mod tests {
         );
         guard_b.setfailargs(
             vec![
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(2002)),
-                BoxRef::from_opref(OpRef::int_op(2003)),
-                BoxRef::from_opref(OpRef::int_op(3)),
-                BoxRef::from_opref(OpRef::int_op(6)),
-                BoxRef::from_opref(OpRef::int_op(3002)),
-                BoxRef::from_opref(OpRef::int_op(3003)),
-                BoxRef::from_opref(OpRef::int_op(7)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 2002),
+                rooted_resop_box(Type::Int, 2003),
+                rooted_resop_box(Type::Int, 3),
+                rooted_resop_box(Type::Int, 6),
+                rooted_resop_box(Type::Int, 3002),
+                rooted_resop_box(Type::Int, 3003),
+                rooted_resop_box(Type::Int, 7),
             ]
             .into(),
         );
         guard_b.set_fail_arg_types(guard_types_b);
         let get_b_type = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[BoxRef::from_opref(OpRef::ref_op(7))],
+            &[rooted_resop_box(Type::Ref, 7)],
             field_descr.clone(),
         );
         let get_b_val = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[BoxRef::from_opref(OpRef::ref_op(7))],
+            &[rooted_resop_box(Type::Ref, 7)],
             field_descr,
         );
+        // Second add arg references a live int getfield result (int_op(9) =
+        // get_b_type) rather than the original fixture's dangling position 8
+        // (the void guard_b): a bound synthetic at a void position has no
+        // forwardable result box, so IntBounds' getintbound would write
+        // forwarded onto an unbound box (box_ref.rs:788). The add result is
+        // unused either way — this only keeps its operands resolvable.
         let add = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(5)),
-                BoxRef::from_opref(OpRef::int_op(8)),
+                rooted_resop_box(Type::Int, 5),
+                rooted_resop_box(Type::Int, 9),
             ],
         );
-        let finish = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(9))]);
+        let finish = Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 9)]);
 
         let mut ops = vec![
             call_a.clone(),

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2936,6 +2936,10 @@ impl Optimizer {
             // `exported_short_boxes` below).
             ctx.exported_short_inputargs =
                 short_boxes.create_short_inputargs(&preview_short_args);
+            // Carry the rooted InputArgRc pool alongside, index-aligned, so
+            // the renamed boxes stay bound to live `InputArg`s across the
+            // export boundary instead of shedding to position-only boxes.
+            ctx.exported_short_inputarg_refs = short_boxes.create_short_inputarg_refs();
             // Single-object carry: each exported entry keeps the preview
             // ProducedShortOp's replay Rc, so the pos/arg canonicalization
             // below lands on the object that dep-replay operands reference

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5732,18 +5732,9 @@ mod tests {
         opt.add_pass(Box::new(AddVirtualInputsOnce { added: false }));
 
         let mut ops = vec![
-            Op::new(
-                OpCode::GetfieldRawI,
-                &[rooted_resop_box(Type::Int, 0)],
-            ),
-            Op::new(
-                OpCode::GetfieldRawI,
-                &[rooted_resop_box(Type::Int, 0)],
-            ),
-            Op::new(
-                OpCode::GetfieldRawI,
-                &[rooted_resop_box(Type::Int, 4)],
-            ),
+            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 4)]),
             Op::new(
                 OpCode::IntGt,
                 &[
@@ -5784,18 +5775,9 @@ mod tests {
         }));
 
         let mut ops = vec![
-            Op::new(
-                OpCode::GetfieldRawI,
-                &[rooted_resop_box(Type::Int, 0)],
-            ),
-            Op::new(
-                OpCode::GetfieldRawI,
-                &[rooted_resop_box(Type::Int, 0)],
-            ),
-            Op::new(
-                OpCode::GetfieldRawI,
-                &[rooted_resop_box(Type::Int, 0)],
-            ),
+            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
             Op::new(
                 OpCode::IntGt,
                 &[
@@ -6549,7 +6531,10 @@ mod tests {
         );
 
         let mut opt = Optimizer::new();
-        let op = Op::new(OpCode::GuardNonnull, &[ctx.materialize_box_at(OpRef::ref_op(10))]);
+        let op = Op::new(
+            OpCode::GuardNonnull,
+            &[ctx.materialize_box_at(OpRef::ref_op(10))],
+        );
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&op));
         ctx.snapshot_boxes = snapshots;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5000,6 +5000,7 @@ impl Default for Optimizer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::r#box::test_support::rooted_resop_box;
     use majit_ir::Type;
     use majit_ir::descr::make_size_descr;
     use majit_ir::descr::{CallDescr, EffectInfo, ExtraEffect, OopSpecIndex};
@@ -5007,6 +5008,52 @@ mod tests {
     use std::cell::Cell;
     use std::rc::Rc;
     use std::sync::Arc;
+
+    /// `OpRc`-threading analogue of [`super::super::seed_empty_guard_snapshots`]
+    /// for fixtures built with [`TraceBuilder`]: assigns each guard a fresh
+    /// resume position in place (`rd_resume_position` is a `Cell`, mutable
+    /// behind the `Rc`) and inserts an empty active-frame snapshot, so the
+    /// canonical producer `Rc<Op>` identity survives for the
+    /// `optimize_with_constants_and_inputs_oprc` driver.
+    fn seed_guard_snapshots_with_oprc<F>(
+        ops: &[majit_ir::OpRc],
+        mut snapshot_for_guard: F,
+    ) -> crate::optimizeopt::SnapshotBoxes
+    where
+        F: FnMut(&Op) -> Vec<OpRef>,
+    {
+        use crate::resume::SnapshotBox;
+        let mut snapshots: crate::optimizeopt::SnapshotBoxes = Vec::new();
+        let mut next_resume_pos = 0i32;
+        for op in ops.iter().filter(|op| op.opcode.is_guard()) {
+            let snapshot_boxes = snapshot_for_guard(op);
+            let resume_pos = if op.rd_resume_position.get() >= 0
+                && !crate::optimizeopt::snapshot_contains(&snapshots, op.rd_resume_position.get())
+            {
+                op.rd_resume_position.get()
+            } else {
+                while crate::optimizeopt::snapshot_contains(&snapshots, next_resume_pos) {
+                    next_resume_pos += 1;
+                }
+                let resume_pos = next_resume_pos;
+                next_resume_pos += 1;
+                resume_pos
+            };
+            op.rd_resume_position.set(resume_pos);
+            crate::optimizeopt::snapshot_insert(
+                &mut snapshots,
+                resume_pos,
+                snapshot_boxes.into_iter().map(SnapshotBox::from).collect(),
+            );
+        }
+        snapshots
+    }
+
+    fn seed_empty_guard_snapshots_oprc(
+        ops: &[majit_ir::OpRc],
+    ) -> crate::optimizeopt::SnapshotBoxes {
+        seed_guard_snapshots_with_oprc(ops, |_| Vec::new())
+    }
 
     /// A trivial pass that removes INT_ADD(x, 0) -> x
     struct AddZeroElimination;
@@ -5278,13 +5325,9 @@ mod tests {
                 self.queued = true;
 
                 let alloc = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
-                let mut set = Op::new(
-                    OpCode::SetfieldGc,
-                    &[
-                        BoxRef::from_opref(alloc),
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                    ],
-                );
+                let alloc_box = ctx.materialize_box_at(alloc);
+                let value = ctx.materialize_box_at(OpRef::int_op(0));
+                let mut set = Op::new(OpCode::SetfieldGc, &[alloc_box, value]);
                 set.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set);
             }
@@ -5372,8 +5415,8 @@ mod tests {
         let ops = vec![Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         )];
         let result =
@@ -5394,8 +5437,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntMul,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         )];
         ops[0].pos.set(OpRef::int_op(2));
@@ -5422,39 +5465,39 @@ mod tests {
             Op::with_descr(
                 OpCode::CallMayForceR,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
                 call_descr_a,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcPureI,
-                &[BoxRef::from_opref(OpRef::ref_op(3))],
+                &[rooted_resop_box(Type::Ref, 3)],
                 field_descr.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceR,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 2),
                 ],
                 call_descr_b,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcPureI,
-                &[BoxRef::from_opref(OpRef::ref_op(6))],
+                &[rooted_resop_box(Type::Ref, 6)],
                 field_descr,
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(5)),
-                    BoxRef::from_opref(OpRef::int_op(8)),
+                    rooted_resop_box(Type::Int, 5),
+                    rooted_resop_box(Type::Int, 8),
                 ],
             ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(9))]),
+            Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 9)]),
         ];
         for (idx, op) in ops.iter_mut().enumerate() {
             op.pos
@@ -5510,6 +5553,16 @@ mod tests {
             majit_ir::Type::Ref,
         ];
 
+        // LEFT ON POSITION-ONLY FORM: this fixture wires guard fail args to
+        // earlier producer RESULT positions (e.g. int_op(6) = get_a_val) in a
+        // single OP namespace offset by +3, plus resume-only free vars
+        // (2000..3003). A bound-DAG migration would make each producer-keyed
+        // fail-arg box bind to a detached synthetic that diverges from the
+        // real producer in the box-native vs OpRef consistency check
+        // (`get_box_replacement_not_const_box` debug_assert, mod.rs:4750).
+        // Faithfully rebinding to the real producers needs the oprc driver and
+        // an exact reconstruction of the offset/free-var position scheme;
+        // deferred to keep the fixture's semantics intact.
         let mut call_a = Op::with_descr(
             OpCode::CallMayForceR,
             &[
@@ -5647,34 +5700,25 @@ mod tests {
 
     #[test]
     fn test_default_pipeline_processes_trace() {
+        use crate::r#box::test_support::TraceBuilder;
         let mut opt = Optimizer::default_pipeline();
-        // IntAdd operates on Int-typed inputs — override the test default.
-        opt.trace_inputargs = OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
         // A simple trace: two INT_ADD with identical args. The Pure pass (CSE)
-        // should eliminate the duplicate.
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::Jump, &[]),
-        ];
-        for (i, op) in ops.iter_mut().enumerate() {
-            op.pos
-                .set(OpRef::op_typed(i as u32, op.opcode.result_type()));
-        }
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        // should eliminate the duplicate. The two IntAdd reference the SAME
+        // header input boxes so the resolved-OpRef CSE key matches.
+        let mut b = TraceBuilder::new();
+        let x = b.input(Type::Int, 0);
+        let y = b.input(Type::Int, 1);
+        b.op(OpCode::IntAdd, &[x.clone(), y.clone()]);
+        b.op(OpCode::IntAdd, &[x, y]);
+        b.op(OpCode::Jump, &[]);
+        let (ops, inputs) = b.build();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
+        let num_inputs = inputs.len();
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            num_inputs,
+        );
         // The duplicate INT_ADD should be eliminated by CSE (OptPure).
         let add_count = result.iter().filter(|o| o.opcode == OpCode::IntAdd).count();
         assert_eq!(add_count, 1, "CSE should eliminate duplicate INT_ADD");
@@ -5690,21 +5734,21 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::GetfieldRawI,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
+                &[rooted_resop_box(Type::Int, 0)],
             ),
             Op::new(
                 OpCode::GetfieldRawI,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
+                &[rooted_resop_box(Type::Int, 0)],
             ),
             Op::new(
                 OpCode::GetfieldRawI,
-                &[BoxRef::from_opref(OpRef::int_op(4))],
+                &[rooted_resop_box(Type::Int, 4)],
             ),
             Op::new(
                 OpCode::IntGt,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(5)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 5),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
         ];
@@ -5742,21 +5786,21 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::GetfieldRawI,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
+                &[rooted_resop_box(Type::Int, 0)],
             ),
             Op::new(
                 OpCode::GetfieldRawI,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
+                &[rooted_resop_box(Type::Int, 0)],
             ),
             Op::new(
                 OpCode::GetfieldRawI,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
+                &[rooted_resop_box(Type::Int, 0)],
             ),
             Op::new(
                 OpCode::IntGt,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 3),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
         ];
@@ -5787,8 +5831,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntGt,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
@@ -5809,8 +5853,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntGt,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
@@ -5835,11 +5879,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(2))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]),
         ];
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
@@ -5866,40 +5910,34 @@ mod tests {
 
     #[test]
     fn test_get_count_of_ops_and_guards() {
+        use crate::r#box::test_support::TraceBuilder;
         let mut opt = Optimizer::default_pipeline();
         // This test only exercises the ops/guard counter; each inputarg
-        // is read by at least one Int-shape consumer (GuardTrue, IntAdd),
-        // so seed Int to keep intbounds' type asserts happy.
-        opt.trace_inputargs = OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
+        // is read by at least one Int-shape consumer (GuardTrue, IntAdd).
         // optimizer.py:691 `assert isinstance(last_descr, ResumeGuardDescr)`:
         // the first GuardTrue becomes the sharing donor for the
         // descrless GuardNonnull below — give it a real descr so
         // OptContext::emit_guard_operation finds a valid donor.
-        let mut guard_true = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]);
-        guard_true.setdescr(crate::compile::make_resume_guard_descr_typed(Vec::new()));
-        let mut ops = vec![
-            guard_true,
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::int_op(100))],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        for (i, op) in ops.iter_mut().enumerate() {
-            op.pos
-                .set(OpRef::op_typed(i as u32, op.opcode.result_type()));
-        }
-        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
-        opt.snapshot_boxes = snapshots;
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let mut b = TraceBuilder::new();
+        let x = b.input(Type::Int, 0);
+        let y = b.input(Type::Int, 1);
+        b.op_with_descr(
+            OpCode::GuardTrue,
+            &[x.clone()],
+            crate::compile::make_resume_guard_descr_typed(Vec::new()),
+        );
+        b.op(OpCode::IntAdd, &[x.clone(), y]);
+        b.op(OpCode::GuardNonnull, &[x]);
+        b.op(OpCode::Finish, &[]);
+        let (ops, inputs) = b.build();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
+        let num_inputs = inputs.len();
+        opt.snapshot_boxes = seed_empty_guard_snapshots_oprc(&ops);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            num_inputs,
+        );
         let ctx = OptContext::new(result.len());
         // Just verify the counting methods work
         assert_eq!(Optimizer::get_count_of_ops(&ctx), 0); // empty ctx
@@ -5914,8 +5952,8 @@ mod tests {
             Op::new(
                 OpCode::GuardValue,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(1)),
+                    rooted_resop_box(Type::Ref, 0),
+                    rooted_resop_box(Type::Ref, 1),
                 ],
             ),
             Op::new(OpCode::Finish, &[]),
@@ -5965,15 +6003,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
         ];
@@ -6018,24 +6056,16 @@ mod tests {
                 self.queued = true;
 
                 let alloc_a = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
-                let mut set_a = Op::new(
-                    OpCode::SetfieldGc,
-                    &[
-                        BoxRef::from_opref(alloc_a),
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                    ],
-                );
+                let alloc_a_box = ctx.materialize_box_at(alloc_a);
+                let value_a = ctx.materialize_box_at(OpRef::int_op(0));
+                let mut set_a = Op::new(OpCode::SetfieldGc, &[alloc_a_box, value_a]);
                 set_a.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set_a);
 
                 let alloc_b = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
-                let mut set_b = Op::new(
-                    OpCode::SetfieldGc,
-                    &[
-                        BoxRef::from_opref(alloc_b),
-                        BoxRef::from_opref(OpRef::int_op(1)),
-                    ],
-                );
+                let alloc_b_box = ctx.materialize_box_at(alloc_b);
+                let value_b = ctx.materialize_box_at(OpRef::int_op(1));
+                let mut set_b = Op::new(OpCode::SetfieldGc, &[alloc_b_box, value_b]);
                 set_b.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set_b);
             }
@@ -6060,15 +6090,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
         ];
@@ -6120,15 +6150,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
         ];
@@ -6185,15 +6215,15 @@ mod tests {
         let size_descr = make_size_descr(16);
         let field_descr = majit_ir::make_field_descr(8, 8, Type::Int, majit_ir::ArrayFlag::Signed);
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(10))]);
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(0))].into());
+        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 10)]);
+        guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], size_descr),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(11)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 11),
                 ],
                 field_descr,
             ),
@@ -6269,7 +6299,7 @@ mod tests {
         ];
         opt.phase1_emit_ops.push(std::rc::Rc::new(majit_ir::Op::new(
             majit_ir::OpCode::SameAsI,
-            &[BoxRef::from_opref(OpRef::int_op(50))],
+            &[rooted_resop_box(Type::Int, 50)],
         )));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -6325,8 +6355,8 @@ mod tests {
         let mut op = Op::new(
             OpCode::CallPureI,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         );
         op.setdescr(Arc::new(TestCallDescr {
@@ -6345,8 +6375,8 @@ mod tests {
         let mut op = Op::new(
             OpCode::CallPureI,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         );
         op.setdescr(Arc::new(TestCallDescr {
@@ -6366,14 +6396,14 @@ mod tests {
         let add_op = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         );
         assert!(opt.protect_speculative_operation(&add_op, &ctx));
 
         // Getfield on unknown arg is safe (not constant null)
-        let get_op = Op::new(OpCode::GetfieldGcI, &[BoxRef::from_opref(OpRef::int_op(0))]);
+        let get_op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_box(Type::Int, 0)]);
         assert!(opt.protect_speculative_operation(&get_op, &ctx));
     }
 
@@ -6386,8 +6416,8 @@ mod tests {
         opt.add_pending_field(Op::new(
             OpCode::SetfieldGc,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
             ],
         ));
         assert!(opt.has_pending_fields());
@@ -6447,7 +6477,7 @@ mod tests {
             &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(1, BoxRef::from_opref(OpRef::int_op(11)))],
+                fields: vec![(1, rooted_resop_box(Type::Int, 11))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -6503,21 +6533,23 @@ mod tests {
         );
         let mut ctx = OptContext::with_inputarg_types(16, &[Type::Ref]);
         let b10 = ctx.materialize_box_at(OpRef::ref_op(10));
+        // The field value box is materialized THROUGH the context so it binds
+        // to the context's producer host; force_box's `resolve_box_box` then
+        // resolves it to a bound box (sheds to Operand::Op), not a fresh
+        // position-only `from_opref` box.
+        let field_value = ctx.materialize_box_at(OpRef::int_op(11));
         ctx.set_ptr_info(
             &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(0, BoxRef::from_opref(OpRef::int_op(11)))],
+                fields: vec![(0, field_value)],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
         );
 
         let mut opt = Optimizer::new();
-        let op = Op::new(
-            OpCode::GuardNonnull,
-            &[BoxRef::from_opref(OpRef::ref_op(10))],
-        );
+        let op = Op::new(OpCode::GuardNonnull, &[ctx.materialize_box_at(OpRef::ref_op(10))]);
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&op));
         ctx.snapshot_boxes = snapshots;
@@ -6546,8 +6578,8 @@ mod tests {
         let mut preamble_op = Op::new(
             OpCode::IntGe,
             &[
-                BoxRef::from_opref(OpRef::int_op(3)),
-                BoxRef::from_opref(OpRef::int_op(10_000)),
+                rooted_resop_box(Type::Int, 3),
+                rooted_resop_box(Type::Int, 10_000),
             ],
         );
         preamble_op.pos.set(OpRef::int_op(14));
@@ -6555,10 +6587,10 @@ mod tests {
         ctx.make_constant_box(&b, majit_ir::Value::Int(0));
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::int_op(0)],
-            &[BoxRef::from_opref(OpRef::int_op(0))],
+            &[rooted_resop_box(Type::Int, 0)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
-                res: BoxRef::from_opref(OpRef::int_op(14)),
+                res: rooted_resop_box(Type::Int, 14),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -6568,12 +6600,12 @@ mod tests {
         ctx.set_potential_extra_op(
             OpRef::int_op(14),
             crate::optimizeopt::info::PreambleOp {
-                op: BoxRef::from_opref(OpRef::int_op(14)),
+                op: rooted_resop_box(Type::Int, 14),
                 invented_name: false,
                 preamble_op: {
                     let mut op = majit_ir::Op::new(
                         majit_ir::OpCode::SameAsI,
-                        &[BoxRef::from_opref(OpRef::int_op(14))],
+                        &[rooted_resop_box(Type::Int, 14)],
                     );
                     op.pos.set(OpRef::op_typed(14, op.result_type()));
                     std::rc::Rc::new(op)
@@ -6582,7 +6614,7 @@ mod tests {
             },
         );
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(14))]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 14)]);
         guard.pos.set(OpRef::op_typed(15, guard.result_type()));
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&guard));
@@ -6610,44 +6642,30 @@ mod tests {
 
     #[test]
     fn test_resumedata_memo_encodes_rd_numb_on_guard() {
+        use crate::r#box::test_support::TraceBuilder;
         let mut opt = Optimizer::default_pipeline();
         // OptIntBound (mod.rs:2624 getintbound) requires IntAdd's args to be
-        // Type::Int.  trace_inputargs defaults to all-Ref, so we must
-        // override slots 100 and 101.
-        let mut input_types = vec![Type::Ref; 1024];
-        input_types[100] = Type::Int;
-        input_types[101] = Type::Int;
-        opt.trace_inputargs = OpRef::inputarg_refs(&input_types);
-
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        ops[1].setfailargs(
-            vec![
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(101)),
-            ]
-            .into(),
+        // Type::Int — the two header inputs are Int.
+        let mut b = TraceBuilder::new();
+        let x = b.input(Type::Int, 0);
+        let y = b.input(Type::Int, 1);
+        let x_ref = x.to_opref();
+        let y_ref = y.to_opref();
+        b.op(OpCode::IntAdd, &[x.clone(), y.clone()]);
+        b.op(OpCode::GuardTrue, &[x.clone()]);
+        b.op(OpCode::Finish, &[]);
+        let (ops, inputs) = b.build();
+        // The GuardTrue (ops[1]) keeps both header inputs as fail args; bind
+        // them to the same canonical InputArg boxes the header threads.
+        ops[1].setfailargs(vec![x, y].into());
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
+        let num_inputs = inputs.len();
+        opt.snapshot_boxes = seed_guard_snapshots_with_oprc(&ops, |_| vec![x_ref, y_ref]);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            num_inputs,
         );
-        for (i, op) in ops.iter_mut().enumerate() {
-            op.pos
-                .set(OpRef::op_typed(i as u32, op.opcode.result_type()));
-        }
-
-        let (ops, snapshots) = super::super::seed_guard_snapshots_with(&ops, |_| {
-            vec![OpRef::int_op(100), OpRef::int_op(101)]
-        });
-        opt.snapshot_boxes = snapshots;
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
 
         let guard = result
             .iter()

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3981,12 +3981,17 @@ impl Optimizer {
         &self,
         args: &[OpRef],
         ctx: &mut OptContext,
-    ) -> crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>
-    {
+    ) -> crate::optimizeopt::vec_assoc::VecAssoc<
+        crate::r#box::BoxRef,
+        crate::optimizeopt::intutils::IntBound,
+    > {
         let mut exported = crate::optimizeopt::vec_assoc::VecAssoc::new();
         for pass in &self.passes {
-            for (opref, bound) in pass.export_arg_int_bounds(args, ctx).iter() {
-                exported.insert(*opref, bound.clone());
+            // Each pass resolves through the same `ctx`, so a box for one
+            // canonical position is memoized to a single `Rc` — entries across
+            // passes dedup by `Rc::ptr_eq`.
+            for (box_key, bound) in pass.export_arg_int_bounds(args, ctx).iter() {
+                exported.insert(box_key.clone(), bound.clone());
             }
         }
         exported

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1319,16 +1319,19 @@ mod tests {
             Some(idx) => (0..=idx as u32).map(OpRef::int_op).collect(),
             None => vec![OpRef::int_op(0)],
         };
+        // Materialize the canonical ctx boxes for the short inputargs and the
+        // entry res position, rather than minting position-only boxes.
         let short_inputarg_boxes: Vec<crate::r#box::BoxRef> = short_inputargs
             .iter()
-            .map(|&a| crate::r#box::BoxRef::from_opref(a))
+            .map(|&a| ctx.materialize_box_at(a))
             .collect();
+        let res = ctx.materialize_box_at(source);
         ctx.initialize_imported_short_preamble_builder(
             &short_inputargs,
             &short_inputarg_boxes,
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op),
-                res: crate::r#box::BoxRef::from_opref(source),
+                res,
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx,
                 invented_name: false,
@@ -1366,6 +1369,7 @@ mod tests {
         }
     }
     use crate::optimizeopt::optimizer::Optimizer;
+    use majit_ir::OpRc;
     use majit_ir::Type;
     use majit_ir::descr::make_field_descr_full;
     /// Helper: assign sequential positions to ops.
@@ -1380,32 +1384,149 @@ mod tests {
         }
     }
 
+    /// One argument of an [`OpSpec`] in the oparser-faithful bound DAG
+    /// (`rpython/jit/tool/oparser.py`). Each variant resolves to a *bound*
+    /// `BoxRef` at [`build_trace`] time so the arg sheds to
+    /// `Operand::{InputArg,Op,Const}` — never the position-only
+    /// `Operand::Box` minted by `BoxRef::from_opref`.
+    #[derive(Clone)]
+    enum Arg {
+        /// Header input var (oparser `[i0]`): `BoxRef::new_inputarg` bound
+        /// to a rooted `InputArg`, sheds to `Operand::InputArg`.
+        In(u32),
+        /// Earlier producer's result, referenced by the producing op's
+        /// index in the spec slice (`from_bound_op`, sheds to `Operand::Op`).
+        Prod(usize),
+        /// Const literal arg (`BoxRef::new_const`, sheds to `Operand::Const`).
+        Const(Value),
+    }
+
+    /// A producer op (oparser `iN = opcode(args)`): its args name earlier
+    /// producers / header inputs / literals, never a position-only box.
+    #[derive(Clone)]
+    struct OpSpec {
+        opcode: OpCode,
+        args: Vec<Arg>,
+        descr: Option<majit_ir::DescrRef>,
+    }
+
+    fn op_spec(opcode: OpCode, args: &[Arg]) -> OpSpec {
+        OpSpec {
+            opcode,
+            args: args.to_vec(),
+            descr: None,
+        }
+    }
+
+    fn op_spec_descr(opcode: OpCode, args: &[Arg], descr: majit_ir::DescrRef) -> OpSpec {
+        OpSpec {
+            opcode,
+            args: args.to_vec(),
+            descr: Some(descr),
+        }
+    }
+
+    /// Turn a producer-spec slice into a bound `OpRc` graph plus the header
+    /// input types, oparser-faithful (`self.vars[name] = resop;
+    /// args.append(self.vars[arg])`): each consumer arg references the
+    /// producing op's bound result box (`from_bound_op`) or a rooted
+    /// `InputArg` box (`Arg::In`) or a `Const` literal, so every arg sheds to
+    /// `Operand::Op` / `Operand::InputArg` / `Operand::Const` at construction.
+    /// Inputs are positioned `[0, num_inputs)`; producers get sequential
+    /// positions starting at `num_inputs`. Drive the result through
+    /// `optimize_with_constants_and_inputs_oprc` so these OpRcs are the
+    /// canonical producers `find_producer_op` resolves to.
+    fn build_trace(num_inputs: u32, specs: &[OpSpec]) -> (Vec<OpRc>, Vec<Type>) {
+        let mut input_types = vec![Type::Int; num_inputs as usize];
+        let mut ops: Vec<OpRc> = Vec::new();
+        // Lazily bind a header input box, recording its type from first use.
+        let mut input_boxes: Vec<Option<BoxRef>> = vec![None; num_inputs as usize];
+        for (i, spec) in specs.iter().enumerate() {
+            let args: Vec<BoxRef> = spec
+                .args
+                .iter()
+                .map(|a| match a {
+                    Arg::In(idx) => {
+                        let slot = *idx as usize;
+                        input_boxes[slot]
+                            .get_or_insert_with(|| {
+                                crate::r#box::test_support::rooted_inputarg_box(Type::Int, *idx)
+                            })
+                            .clone()
+                    }
+                    Arg::Prod(pos) => BoxRef::from_bound_op(&ops[*pos]),
+                    Arg::Const(v) => BoxRef::new_const(*v),
+                })
+                .collect();
+            let op = match &spec.descr {
+                Some(d) => std::rc::Rc::new(Op::with_descr(spec.opcode, &args, d.clone())),
+                None => std::rc::Rc::new(Op::new(spec.opcode, &args)),
+            };
+            op.pos.set(OpRef::op_typed(
+                num_inputs + i as u32,
+                spec.opcode.result_type(),
+            ));
+            ops.push(op);
+        }
+        let _ = &mut input_types;
+        (ops, input_types)
+    }
+
+    /// Build a bound trace from `specs` and run `OptPure` (plus any
+    /// `extra_passes`, applied first) over it via the OpRc entry. Mirrors the
+    /// raw `Optimizer::new(); add_pass(OptPure); optimize_with_constants_and
+    /// _inputs` shape the position-only fixtures used, but with no
+    /// `Operand::Box` minted.
+    fn run_pure(
+        num_inputs: u32,
+        specs: &[OpSpec],
+        constants: &mut majit_ir::VecAssoc<u32, majit_ir::Value>,
+        extra_passes: &[fn() -> Box<dyn crate::optimizeopt::Optimization>],
+        seed_guard_snapshots: bool,
+    ) -> Vec<Op> {
+        let (producers, inputs) = build_trace(num_inputs, specs);
+        let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
+        for make in extra_passes {
+            opt.add_pass(make());
+        }
+        opt.add_pass(Box::new(OptPure::new()));
+        // `producers` is held to the end of the call so every `from_bound_op`
+        // arg box's `Weak<Op>` upgrade stays live (box_ref.rs:788). The
+        // guard-snapshot path wraps the seeded `Vec<Op>` in fresh Rcs whose
+        // args still point at `producers`, so those originals must outlive the
+        // run.
+        let run_ops: Vec<OpRc> = if seed_guard_snapshots {
+            let flat: Vec<Op> = producers.iter().map(|o| (**o).clone()).collect();
+            let (seeded, snapshots) = super::super::seed_empty_guard_snapshots(&flat);
+            opt.snapshot_boxes = snapshots;
+            seeded.into_iter().map(std::rc::Rc::new).collect()
+        } else {
+            producers.clone()
+        };
+        let result = opt
+            .optimize_with_constants_and_inputs_oprc(&run_ops, constants, num_inputs as usize)
+            .into_iter()
+            .map(|rc| (*rc).clone())
+            .collect();
+        drop(producers);
+        result
+    }
+
     #[test]
     fn test_cse_int_add() {
         // i2 = int_add(i0, i1)
         // i3 = int_add(i0, i1)  <- should be eliminated, replaced by i2
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         // Only the first IntAdd should remain.
         assert_eq!(result.len(), 1);
@@ -1416,28 +1537,16 @@ mod tests {
     fn test_cse_different_args_not_eliminated() {
         // i2 = int_add(i0, i1)
         // i3 = int_add(i0, i2)  <- different args, should NOT be eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            3,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(2)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 2);
     }
@@ -1446,28 +1555,16 @@ mod tests {
     fn test_cse_commutative() {
         // i2 = int_add(i0, i1)
         // i3 = int_add(i1, i0)  <- commutative, should be eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntAdd, &[Arg::In(1), Arg::In(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
     }
@@ -1476,28 +1573,16 @@ mod tests {
     fn test_cse_non_commutative() {
         // i2 = int_sub(i0, i1)
         // i3 = int_sub(i1, i0)  <- NOT commutative, should NOT be eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntSub, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntSub, &[Arg::In(1), Arg::In(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 2);
     }
@@ -1506,67 +1591,36 @@ mod tests {
     fn test_cse_multiple_opcodes() {
         // i2 = int_add(i0, i1)
         // i3 = int_mul(i0, i1)  <- different opcode, should NOT be eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntMul, &[Arg::In(0), Arg::In(1)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 2);
     }
 
     #[test]
     fn test_cse_three_duplicates() {
-        // Use input arg OpRefs (100, 101) that don't collide with op positions (0, 1, 2).
-        // i2 = int_add(i100, i101)
-        // i3 = int_add(i100, i101)  <- eliminated
-        // i4 = int_add(i100, i101)  <- eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        // i2 = int_add(i0, i1)
+        // i3 = int_add(i0, i1)  <- eliminated
+        // i4 = int_add(i0, i1)  <- eliminated
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
     }
@@ -1574,29 +1628,24 @@ mod tests {
     #[test]
     fn test_call_pure_demoted_to_call() {
         // call_pure_i(args...) -> should become call_i(args...)
-        let mut ops = vec![Op::new(
-            OpCode::CallPureI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        )];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[op_spec(OpCode::CallPureI, &[Arg::In(0), Arg::In(1)])],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallI);
+        // Demotion preserves the operand identities — the two header inputs.
         assert_eq!(
             result[0]
                 .getarglist()
                 .iter()
                 .map(|a| a.to_opref())
                 .collect::<Vec<_>>(),
-            &[OpRef::int_op(0), OpRef::int_op(1)]
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)]
         );
     }
 
@@ -1605,16 +1654,19 @@ mod tests {
         // CallPureR / CallR carry RPython `RefOp.type = 'r'` parity
         // (resoperation.py:638): the result is a Ref-typed Box, and
         // the function-pointer arg is also Ref-typed.
-        let mut ops = vec![Op::new(
-            OpCode::CallPureR,
-            &[BoxRef::from_opref(OpRef::ref_op(0))],
-        )];
-        assign_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let funcptr = b.input(Type::Ref, 0);
+        b.op(OpCode::CallPureR, &[funcptr]);
+        let (ops, inputs) = b.build();
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            inputs.len(),
+        );
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallR);
@@ -1623,20 +1675,22 @@ mod tests {
 
     #[test]
     fn test_non_pure_op_passes_through() {
-        // setfield_gc is not pure, should pass through unchanged
-        let mut ops = vec![Op::new(
-            OpCode::SetfieldGc,
-            &[
-                BoxRef::from_opref(OpRef::void_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        )];
-        assign_positions(&mut ops);
+        // setfield_gc is not pure, should pass through unchanged.
+        // struct is a Ref input, value an Int input.
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let struct_box = b.input(Type::Ref, 0);
+        let value = b.input(Type::Int, 1);
+        b.op(OpCode::SetfieldGc, &[struct_box, value]);
+        let (ops, inputs) = b.build();
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            inputs.len(),
+        );
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::SetfieldGc);
@@ -1646,16 +1700,16 @@ mod tests {
     fn test_cse_unary_ops() {
         // i1 = int_neg(i0)
         // i2 = int_neg(i0)  <- should be eliminated
-        let mut ops = vec![
-            Op::new(OpCode::IntNeg, &[BoxRef::from_opref(OpRef::int_op(0))]),
-            Op::new(OpCode::IntNeg, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            1,
+            &[
+                op_spec(OpCode::IntNeg, &[Arg::In(0)]),
+                op_spec(OpCode::IntNeg, &[Arg::In(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
     }
@@ -1664,28 +1718,21 @@ mod tests {
     fn test_cse_float_ops() {
         // f2 = float_add(f0, f1)
         // f3 = float_add(f0, f1)  <- should be eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::FloatAdd,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(0)),
-                    BoxRef::from_opref(OpRef::float_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::FloatAdd,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(0)),
-                    BoxRef::from_opref(OpRef::float_op(1)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let f0 = b.input(Type::Float, 0);
+        let f1 = b.input(Type::Float, 1);
+        b.op(OpCode::FloatAdd, &[f0.clone(), f1.clone()]);
+        b.op(OpCode::FloatAdd, &[f0, f1]);
+        let (ops, inputs) = b.build();
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            inputs.len(),
+        );
 
         assert_eq!(result.len(), 1);
     }
@@ -1693,28 +1740,19 @@ mod tests {
     #[test]
     fn test_cache_eviction() {
         // Force a tiny cache so eviction behavior is deterministic even if
-        // the production default changes.
-        let mut ops = Vec::new();
+        // the production default changes. Each op's operands (i, i+100) are
+        // distinct header inputs; the final op re-reads inputs 0 and 100.
+        let mut specs = Vec::new();
         for i in 0..17u32 {
-            ops.push(Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(i)),
-                    BoxRef::from_opref(OpRef::int_op(i + 100)),
-                ],
-            ));
+            specs.push(op_spec(OpCode::IntAdd, &[Arg::In(i), Arg::In(i + 100)]));
         }
-        // Re-insert op #0: same args as ops[0]
-        ops.push(Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(100)),
-            ],
-        ));
-        assign_positions(&mut ops);
+        // Re-insert op #0: same args as specs[0]
+        specs.push(op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(100)]));
+        let num_inputs = 117u32;
+        let (ops, inputs) = build_trace(num_inputs, &specs);
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure {
             cache: RecentPureOpTable::new(16),
             postponed_op: None,
@@ -1727,8 +1765,11 @@ mod tests {
             call_pure_results: crate::optimizeopt::vec_assoc::VecAssoc::new(),
             preamble_pure_ops: Vec::new(),
         }));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            num_inputs as usize,
+        );
 
         // All 17 unique ops should be emitted, plus the re-inserted one
         // (since the first was evicted from the LRU cache of size 16).
@@ -1742,32 +1783,20 @@ mod tests {
         let mut pass = OptPure::new();
 
         // Production binds the input operands a, b before the int_add is
-        // processed; bind them canonically here so same_box resolves both
-        // ops' args to one shared box.
-        ctx.materialize_box_at(OpRef::int_op(0));
-        ctx.materialize_box_at(OpRef::int_op(1));
+        // processed; bind bound InputArg boxes here and reuse them across both
+        // ops so same_box resolves both ops' args to one shared identity.
+        let a = crate::r#box::test_support::rooted_inputarg_box(Type::Int, 0);
+        let b = crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1);
 
         // Simulate: op0 = int_add(a, b)
-        let op0 = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let op0 = Op::new(OpCode::IntAdd, &[a.clone(), b.clone()]);
         let mut op0 = op0;
         op0.pos.set(OpRef::int_op(2));
         let result0 = pass.propagate_forward(&op0, &std::rc::Rc::new(op0.clone()), &mut ctx);
         assert!(matches!(result0, OptimizationResult::PassOn));
 
         // Simulate: op1 = int_add(a, b) with same args
-        let op1 = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let op1 = Op::new(OpCode::IntAdd, &[a, b]);
         let mut op1 = op1;
         op1.pos.set(OpRef::int_op(3));
         let result1 = pass.propagate_forward(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx);
@@ -1797,56 +1826,32 @@ mod tests {
 
     #[test]
     fn test_commutative_xor() {
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntXor,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntXor,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntXor, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntXor, &[Arg::In(1), Arg::In(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
     }
 
     #[test]
     fn test_commutative_int_and() {
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAnd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAnd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAnd, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntAnd, &[Arg::In(1), Arg::In(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
     }
@@ -1855,28 +1860,16 @@ mod tests {
     fn test_comparison_cse() {
         // i2 = int_lt(i0, i1)
         // i3 = int_lt(i0, i1)  <- should be eliminated
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntLt,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntLt,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntLt, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::IntLt, &[Arg::In(0), Arg::In(1)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1);
     }
@@ -1888,16 +1881,20 @@ mod tests {
         // `AbstractResOp.type = 'v'` (resoperation.py:260) — and pyre
         // mints them as `OpRef::VoidOp(pos)` whose `ty()` is
         // `Some(Type::Void)`.
-        let mut ops = vec![
-            Op::new(OpCode::CallPureF, &[BoxRef::from_opref(OpRef::float_op(0))]),
-            Op::new(OpCode::CallPureN, &[BoxRef::from_opref(OpRef::float_op(0))]),
-        ];
-        assign_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let f0 = b.input(Type::Float, 0);
+        b.op(OpCode::CallPureF, &[f0.clone()]);
+        b.op(OpCode::CallPureN, &[f0]);
+        let (ops, inputs) = b.build();
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            inputs.len(),
+        );
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::CallF);
@@ -1909,68 +1906,42 @@ mod tests {
     #[test]
     fn test_mixed_pure_and_non_pure() {
         // Mix of pure and non-pure operations, only duplicated pure ops get CSE'd.
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::void_op(1)),
-                ],
-            ), // pure, kept
-            Op::new(
-                OpCode::SetfieldGc,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::void_op(1)),
-                ],
-            ), // not pure, kept
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::void_op(1)),
-                ],
-            ), // pure duplicate, eliminated
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure, kept
+                op_spec(OpCode::SetfieldGc, &[Arg::In(0), Arg::In(1)]), // not pure, kept
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure dup, eliminated
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
         assert_eq!(result[1].opcode, OpCode::SetfieldGc);
     }
 
+    fn rewrite_pass() -> Box<dyn crate::optimizeopt::Optimization> {
+        Box::new(crate::optimizeopt::rewrite::OptRewrite::new())
+    }
+
     #[test]
     fn test_call_loopinvariant_cse() {
         // Two identical CALL_LOOPINVARIANT_I calls → second eliminated.
-        let mut ops = vec![
-            Op::new(
-                OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(100u32, majit_ir::Value::Int(0xCAFE)); // func pointer must be a known constant
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
-        opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        // The func pointer (arg0) is a known Const; arg1 a regular input.
+        let func = Arg::Const(Value::Int(0xCAFE));
+        let result = run_pure(
+            1,
+            &[
+                op_spec(OpCode::CallLoopinvariantI, &[func.clone(), Arg::In(0)]),
+                op_spec(OpCode::CallLoopinvariantI, &[func, Arg::In(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[rewrite_pass],
+            false,
+        );
 
         // Only the first call should remain, demoted to CallI.
         assert_eq!(result.len(), 1);
@@ -1979,30 +1950,19 @@ mod tests {
 
     #[test]
     fn test_call_loopinvariant_different_args() {
-        // CALL_LOOPINVARIANT_I with different args → both kept.
-        let mut ops = vec![
-            Op::new(
-                OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(
-                OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(102)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        // CALL_LOOPINVARIANT_I with different args → both kept. The func
+        // pointer is a plain input here (not a known constant), so OptRewrite
+        // only demotes to CallI without loop-invariant CSE.
+        let result = run_pure(
+            3,
+            &[
+                op_spec(OpCode::CallLoopinvariantI, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::CallLoopinvariantI, &[Arg::In(0), Arg::In(2)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[rewrite_pass],
+            false,
+        );
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::CallI);
@@ -2017,14 +1977,13 @@ mod tests {
             (OpCode::CallLoopinvariantF, OpCode::CallF),
             (OpCode::CallLoopinvariantN, OpCode::CallN),
         ] {
-            let mut ops = vec![Op::new(loopinv_op, &[BoxRef::from_opref(OpRef::int_op(0))])];
-            assign_positions(&mut ops);
-
-            let mut opt = Optimizer::new();
-            opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
-            opt.add_pass(Box::new(OptPure::new()));
-            let result =
-                opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+            let result = run_pure(
+                1,
+                &[op_spec(loopinv_op, &[Arg::In(0)])],
+                &mut majit_ir::VecAssoc::new(),
+                &[rewrite_pass],
+                false,
+            );
 
             assert_eq!(result.len(), 1);
             assert_eq!(result[0].opcode, expected_op);
@@ -2034,37 +1993,28 @@ mod tests {
     #[test]
     fn test_call_loopinvariant_no_eviction() {
         // Unlike pure CSE (LRU limit 16), loop-invariant cache has no eviction.
-        // Create 20 unique calls, then re-check the first one.
-        let mut ops = Vec::new();
+        // Create 20 unique calls, then re-check the first one. Each func
+        // pointer is a distinct known Const (required for OptRewrite CSE);
+        // they all share one non-const input arg.
+        let mut specs = Vec::new();
         for i in 0..20u32 {
-            ops.push(Op::new(
+            specs.push(op_spec(
                 OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(i + 100)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
+                &[Arg::Const(Value::Int((i + 100) as i64)), Arg::In(0)],
             ));
         }
-        // Re-insert call #0: same args as ops[0]
-        ops.push(Op::new(
+        // Re-insert call #0: same args as specs[0]
+        specs.push(op_spec(
             OpCode::CallLoopinvariantI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(200)),
-            ],
+            &[Arg::Const(Value::Int(100)), Arg::In(0)],
         ));
-        assign_positions(&mut ops);
-
-        // Each func pointer must be a known constant for OptRewrite CSE.
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        for i in 0..20u32 {
-            constants.insert(i + 100, majit_ir::Value::Int((i + 100) as i64));
-        }
-        let mut opt = Optimizer::new();
-        for i in 0..20u32 {}
-        opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
-        opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        let result = run_pure(
+            1,
+            &specs,
+            &mut majit_ir::VecAssoc::new(),
+            &[rewrite_pass],
+            false,
+        );
 
         // 20 unique calls + the duplicate (#0) should be eliminated → 20 total
         assert_eq!(result.len(), 20);
@@ -2072,45 +2022,22 @@ mod tests {
 
     #[test]
     fn test_call_loopinvariant_mixed_with_pure() {
-        // Loop-invariant and pure CSE should coexist.
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ), // pure
-            Op::new(
-                OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(201)),
-                ],
-            ), // loopinvariant
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ), // pure dup → removed
-            Op::new(
-                OpCode::CallLoopinvariantI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(201)),
-                ],
-            ), // loopinvariant dup → removed
-        ];
-        assign_positions(&mut ops);
-
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(200u32, majit_ir::Value::Int(0xBEEF)); // func pointer must be a known constant
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
-        opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        // Loop-invariant and pure CSE should coexist. The loop-invariant call's
+        // func pointer is a known Const; its other arg and the pure-op operands
+        // are inputs.
+        let func = Arg::Const(Value::Int(0xBEEF));
+        let result = run_pure(
+            3,
+            &[
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure
+                op_spec(OpCode::CallLoopinvariantI, &[func.clone(), Arg::In(2)]), // loopinvariant
+                op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure dup → removed
+                op_spec(OpCode::CallLoopinvariantI, &[func, Arg::In(2)]), // loopinv dup → removed
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[rewrite_pass],
+            false,
+        );
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
@@ -2119,27 +2046,22 @@ mod tests {
 
     #[test]
     fn test_constant_fold_int_add() {
-        // IntAdd(const(3), const(4)) → eliminated, result = const(7)
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(10_000)),
-                    BoxRef::from_opref(OpRef::int_op(10_001)),
-                ],
-            ),
-            // Use the result in a guard to prevent dead code elimination
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        assign_positions(&mut ops);
-
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(10_000u32, majit_ir::Value::Int(3));
-        constants.insert(10_001u32, majit_ir::Value::Int(4));
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants(&ops, &mut constants);
+        // IntAdd(const(3), const(4)) → eliminated, result = const(7).
+        // Finish consumes the result so the fold is observed.
+        let result = run_pure(
+            0,
+            &[
+                op_spec(
+                    OpCode::IntAdd,
+                    &[Arg::Const(Value::Int(3)), Arg::Const(Value::Int(4))],
+                ),
+                // Use the result in a finish to prevent dead code elimination
+                op_spec(OpCode::Finish, &[Arg::Prod(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         // IntAdd should be folded away (only Finish remains)
         assert_eq!(result.len(), 1, "IntAdd(3,4) should be constant-folded");
@@ -2149,25 +2071,19 @@ mod tests {
     #[test]
     fn test_constant_fold_int_lt() {
         // IntLt(const(3), const(5)) → const(1) (true)
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntLt,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(10_000)),
-                    BoxRef::from_opref(OpRef::int_op(10_001)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        assign_positions(&mut ops);
-
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(10_000u32, majit_ir::Value::Int(3));
-        constants.insert(10_001u32, majit_ir::Value::Int(5));
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants(&ops, &mut constants);
+        let result = run_pure(
+            0,
+            &[
+                op_spec(
+                    OpCode::IntLt,
+                    &[Arg::Const(Value::Int(3)), Arg::Const(Value::Int(5))],
+                ),
+                op_spec(OpCode::Finish, &[Arg::Prod(0)]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         assert_eq!(result.len(), 1, "IntLt(3,5) should be constant-folded");
     }
@@ -2176,33 +2092,19 @@ mod tests {
     fn test_ovf_postponement_cse() {
         // INT_ADD_OVF(a, b) + GUARD_NO_OVERFLOW
         // then same INT_ADD_OVF(a, b) + GUARD_NO_OVERFLOW → CSE'd away
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAddOvf,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(
-                OpCode::IntAddOvf,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
-        opt.snapshot_boxes = snapshots;
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::IntAddOvf, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::GuardNoOverflow, &[]),
+                op_spec(OpCode::IntAddOvf, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::GuardNoOverflow, &[]),
+                op_spec(OpCode::Finish, &[]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            true,
+        );
 
         // First pair stays, second pair CSE'd → 3 ops total
         let ovf_count = result
@@ -2215,26 +2117,20 @@ mod tests {
     #[test]
     fn test_ovf_constant_fold() {
         // INT_ADD_OVF(const(3), const(4)) + GUARD_NO_OVERFLOW → both removed
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntAddOvf,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(10_000)),
-                    BoxRef::from_opref(OpRef::int_op(10_001)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        assign_positions(&mut ops);
-
-        let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(10_000u32, majit_ir::Value::Int(3));
-        constants.insert(10_001u32, majit_ir::Value::Int(4));
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result = opt.optimize_with_constants(&ops, &mut constants);
+        let result = run_pure(
+            0,
+            &[
+                op_spec(
+                    OpCode::IntAddOvf,
+                    &[Arg::Const(Value::Int(3)), Arg::Const(Value::Int(4))],
+                ),
+                op_spec(OpCode::GuardNoOverflow, &[]),
+                op_spec(OpCode::Finish, &[]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            true,
+        );
 
         // Both OVF and guard should be folded away
         let ovf_count = result
@@ -2265,17 +2161,14 @@ mod tests {
         let ptr = Box::into_raw(object) as usize;
 
         let descr = make_field_descr_full(1, 0, 8, Type::Int, true);
-        let mut op = Op::with_descr(
-            OpCode::GetfieldGcPureI,
-            &[BoxRef::from_opref(OpRef::ref_op(10))],
-            descr,
-        );
-        op.pos.set(OpRef::int_op(0));
-
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(4, 0);
-        let b = ctx.materialize_box_at(OpRef::ref_op(10));
-        ctx.make_constant_box(&b, Value::Ref(GcRef(ptr)));
+        // The struct operand is the canonical box materialized in ctx and made
+        // a Ref constant; the op carries that same box (no position-only mint).
+        let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
+        ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[struct_box.clone()], descr);
+        op.pos.set(OpRef::int_op(0));
         pass.setup();
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
@@ -2305,17 +2198,12 @@ mod tests {
         let ptr = Box::into_raw(object) as usize;
 
         let descr = make_field_descr_full(2, 0, 8, Type::Float, true);
-        let mut op = Op::with_descr(
-            OpCode::GetfieldGcPureF,
-            &[BoxRef::from_opref(OpRef::ref_op(10))],
-            descr,
-        );
-        op.pos.set(OpRef::float_op(0));
-
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(4, 0);
-        let b = ctx.materialize_box_at(OpRef::ref_op(10));
-        ctx.make_constant_box(&b, Value::Ref(GcRef(ptr)));
+        let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
+        ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureF, &[struct_box.clone()], descr);
+        op.pos.set(OpRef::float_op(0));
         pass.setup();
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
@@ -2347,17 +2235,12 @@ mod tests {
         let ptr = Box::into_raw(object) as usize;
 
         let descr = make_field_descr_full(3, 0, std::mem::size_of::<usize>(), Type::Ref, true);
-        let mut op = Op::with_descr(
-            OpCode::GetfieldGcPureR,
-            &[BoxRef::from_opref(OpRef::ref_op(10))],
-            descr,
-        );
-        op.pos.set(OpRef::ref_op(0));
-
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(4, 0);
-        let b = ctx.materialize_box_at(OpRef::ref_op(10));
-        ctx.make_constant_box(&b, Value::Ref(GcRef(ptr)));
+        let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
+        ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureR, &[struct_box.clone()], descr);
+        op.pos.set(OpRef::ref_op(0));
         pass.setup();
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
@@ -2394,16 +2277,11 @@ mod tests {
         // strict-orthodoxy port panics on the variant mismatch instead
         // of returning `None`; this test pins that behavior.
         let descr = make_field_descr_full(4, 0, 8, Type::Int, true);
-        let mut op = Op::with_descr(
-            OpCode::GetfieldGcPureI,
-            &[BoxRef::from_opref(OpRef::int_op(10))],
-            descr,
-        );
-        op.pos.set(OpRef::int_op(0));
-
         let mut ctx = OptContext::with_num_inputs(4, 0);
-        let b = ctx.materialize_box_at(OpRef::int_op(10));
-        ctx.make_constant_box(&b, Value::Int(2));
+        let arg_box = ctx.materialize_box_at(OpRef::int_op(10));
+        ctx.make_constant_box(&arg_box, Value::Int(2));
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[arg_box.clone()], descr);
+        op.pos.set(OpRef::int_op(0));
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
         // carries the canonical const box the pass reads via get_constant_box.
@@ -2418,33 +2296,19 @@ mod tests {
     #[test]
     fn test_guard_no_exception_after_removed_call_pure() {
         // CALL_PURE_I(same args) × 2 → second removed → GUARD_NO_EXCEPTION after removed
-        let mut ops = vec![
-            Op::new(
-                OpCode::CallPureI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoException, &[]),
-            Op::new(
-                OpCode::CallPureI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::GuardNoException, &[]), // should be removed
-            Op::new(OpCode::Finish, &[]),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
-        opt.snapshot_boxes = snapshots;
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        let result = run_pure(
+            2,
+            &[
+                op_spec(OpCode::CallPureI, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::GuardNoException, &[]),
+                op_spec(OpCode::CallPureI, &[Arg::In(0), Arg::In(1)]),
+                op_spec(OpCode::GuardNoException, &[]), // should be removed
+                op_spec(OpCode::Finish, &[]),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            true,
+        );
 
         // Second CALL_PURE → removed (CSE), its GUARD_NO_EXCEPTION → removed
         let gne_count = result
@@ -2476,15 +2340,14 @@ mod tests {
         );
         assert_eq!(ctx.get_constant(c5_a), ctx.get_constant(c5_b));
 
-        // Cache `IntAdd(c5_a, x)` and look up `IntAdd(c5_b, x)`.
+        // Cache `IntAdd(c5_a, x)` and look up `IntAdd(c5_b, x)`. `x` is the
+        // canonical box materialized in ctx; the constants are Const operands.
         let x = OpRef::int_op(7);
-        ctx.materialize_box_at(x);
+        let x_box = ctx.materialize_box_at(x);
+        let x8_box = ctx.materialize_box_at(OpRef::int_op(8));
         pass.pure_from_args2(OpCode::IntAdd, c5_a, x, OpRef::int_op(42));
 
-        let mut q = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(c5_b), BoxRef::from_opref(x)],
-        );
+        let mut q = Op::new(OpCode::IntAdd, &[BoxRef::new_const(Value::Int(5)), x_box]);
         q.pos.set(OpRef::int_op(99));
         assert_eq!(
             pass.get_pure_result(&q, &ctx),
@@ -2493,13 +2356,7 @@ mod tests {
         );
 
         // A non-constant slot mismatch must still miss.
-        let mut q_miss = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(c5_b),
-                BoxRef::from_opref(OpRef::int_op(8)),
-            ],
-        );
+        let mut q_miss = Op::new(OpCode::IntAdd, &[BoxRef::new_const(Value::Int(5)), x8_box]);
         q_miss.pos.set(OpRef::int_op(100));
         assert_eq!(pass.get_pure_result(&q_miss, &ctx), None);
     }
@@ -2518,14 +2375,13 @@ mod tests {
         let b_query = ctx.materialize_box_at(query_arg);
         let b_canonical = ctx.materialize_box_at(canonical_arg);
         ctx.make_equal_to(&b_query, &b_canonical);
-        ctx.materialize_box_at(other_arg);
+        let b_other = ctx.materialize_box_at(other_arg);
 
         pass.pure_from_args2(OpCode::IntAdd, canonical_arg, other_arg, result);
 
-        let mut q = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(query_arg), BoxRef::from_opref(other_arg)],
-        );
+        // Query op carries the canonical ctx boxes (query_arg forwards to
+        // canonical_arg via make_equal_to) — no position-only mint.
+        let mut q = Op::new(OpCode::IntAdd, &[b_query, b_other]);
         q.pos.set(OpRef::int_op(99));
         assert_eq!(
             pass.get_pure_result(&q, &ctx),
@@ -2538,32 +2394,21 @@ mod tests {
     fn test_pure_and_pure_from_args() {
         let mut pass = OptPure::new();
 
-        // Manually record a pure operation via the API
-        let mut op = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(20)),
-            ],
-        );
-        op.pos.set(OpRef::int_op(0));
-        pass.pure(&op);
-
         let mut ctx = OptContext::new(0);
         // Bind the operand positions canonically so same_box resolves the
         // looked-up op's args to the same boxes the cache recorded.
-        for p in [10, 20, 30, 40] {
-            ctx.materialize_box_at(OpRef::int_op(p));
-        }
+        let b10 = ctx.materialize_box_at(OpRef::int_op(10));
+        let b20 = ctx.materialize_box_at(OpRef::int_op(20));
+        let b30 = ctx.materialize_box_at(OpRef::int_op(30));
+        let b40 = ctx.materialize_box_at(OpRef::int_op(40));
+
+        // Manually record a pure operation via the API
+        let mut op = Op::new(OpCode::IntAdd, &[b10.clone(), b20.clone()]);
+        op.pos.set(OpRef::int_op(0));
+        pass.pure(&op);
 
         // Should find it via get_pure_result
-        let lookup_op = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(20)),
-            ],
-        );
+        let lookup_op = Op::new(OpCode::IntAdd, &[b10, b20]);
         assert!(pass.get_pure_result(&lookup_op, &ctx).is_some());
 
         // pure_from_args
@@ -2572,13 +2417,7 @@ mod tests {
             &[OpRef::int_op(30), OpRef::int_op(40)],
             OpRef::int_op(5),
         );
-        let mut lookup_mul = Op::new(
-            OpCode::IntMul,
-            &[
-                BoxRef::from_opref(OpRef::int_op(30)),
-                BoxRef::from_opref(OpRef::int_op(40)),
-            ],
-        );
+        let mut lookup_mul = Op::new(OpCode::IntMul, &[b30, b40]);
         lookup_mul.pos.set(OpRef::int_op(99));
         assert!(pass.get_pure_result(&lookup_mul, &ctx).is_some());
     }
@@ -2615,8 +2454,9 @@ mod tests {
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(4, 0);
         // Bind the matched call args canonically so same_box resolves them.
-        ctx.materialize_box_at(OpRef::int_op(100));
-        ctx.materialize_box_at(OpRef::int_op(101));
+        let b100 = ctx.materialize_box_at(OpRef::int_op(100));
+        let b101 = ctx.materialize_box_at(OpRef::int_op(101));
+        let b999 = ctx.materialize_box_at(OpRef::int_op(999));
 
         // pure.py:214: self.known_result_call_pure.append(op)
         pass.known_result_call_pure.push(super::KnownResultEntry {
@@ -2626,40 +2466,21 @@ mod tests {
         });
 
         // CALL_PURE lookup: start_index=0, descr matches (both None), args match
-        let op = Op::new(
-            OpCode::CallPureI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(101)),
-            ],
-        );
+        let op = Op::new(OpCode::CallPureI, &[b100.clone(), b101.clone()]);
         assert_eq!(
             pass.lookup_known_result(&op, 0, &ctx),
             Some(OpRef::int_op(50))
         );
 
         // COND_CALL_VALUE lookup: start_index=1, skip arg(0)
-        let cond_op = Op::new(
-            OpCode::CondCallValueI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(999)),
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(101)),
-            ],
-        );
+        let cond_op = Op::new(OpCode::CondCallValueI, &[b999.clone(), b100.clone(), b101]);
         assert_eq!(
             pass.lookup_known_result(&cond_op, 1, &ctx),
             Some(OpRef::int_op(50))
         );
 
         // Args mismatch → None
-        let bad_args = Op::new(
-            OpCode::CallPureI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(999)),
-            ],
-        );
+        let bad_args = Op::new(OpCode::CallPureI, &[b100, b999]);
         assert_eq!(pass.lookup_known_result(&bad_args, 0, &ctx), None);
     }
 
@@ -2730,7 +2551,7 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(8, 0);
         // Bind the non-const call arg position so same_box resolves the
         // dispatched op's arg to the same box the imported op recorded.
-        ctx.materialize_box_at(OpRef::int_op(0));
+        let arg0 = ctx.materialize_box_at(OpRef::int_op(0));
         let const_opref = OpRef::const_int(0x1234);
         let call_descr = majit_ir::descr::make_call_descr_full(
             77,
@@ -2783,10 +2604,7 @@ mod tests {
 
         let mut op = Op::new(
             OpCode::CallPureI,
-            &[
-                BoxRef::from_opref(const_opref),
-                BoxRef::from_opref(OpRef::int_op(0)),
-            ],
+            &[BoxRef::new_const(Value::Int(0x1234)), arg0],
         );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(call_descr);
@@ -2811,13 +2629,9 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         pass.setup();
 
-        let mut op = Op::new(
-            OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let a0 = ctx.materialize_box_at(OpRef::int_op(0));
+        let a1 = ctx.materialize_box_at(OpRef::int_op(1));
+        let mut op = Op::new(OpCode::IntAdd, &[a0, a1]);
         op.pos.set(OpRef::int_op(2));
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
@@ -2853,14 +2667,10 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(6, 0);
         pass.setup();
 
-        let mut op = Op::new(
-            OpCode::CallPureI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let a100 = ctx.materialize_box_at(OpRef::int_op(100));
+        let a0 = ctx.materialize_box_at(OpRef::int_op(0));
+        let a1 = ctx.materialize_box_at(OpRef::int_op(1));
+        let mut op = Op::new(OpCode::CallPureI, &[a100, a0, a1]);
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(
             vec![
@@ -2916,13 +2726,8 @@ mod tests {
         rewrite.setup();
         pass.setup();
 
-        let mut op = Op::new(
-            OpCode::CallLoopinvariantI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(0)),
-            ],
-        );
+        let a0 = ctx.materialize_box_at(OpRef::int_op(0));
+        let mut op = Op::new(OpCode::CallLoopinvariantI, &[func_box.clone(), a0]);
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(
             vec![majit_ir::Type::Int, majit_ir::Type::Int],
@@ -3048,30 +2853,23 @@ mod tests {
     fn test_cond_call_value_cse() {
         // COND_CALL_VALUE_I(cond, func, arg) → CSE using args[1..]
         // A second COND_CALL_VALUE_I with same func+arg should reuse result.
-        let mut ops = vec![
-            Op::new(
-                OpCode::CondCallValueI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(300)),
-                ],
-            ),
-            Op::new(
-                OpCode::CondCallValueI,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(300)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-
-        let mut opt = Optimizer::new();
-        opt.add_pass(Box::new(OptPure::new()));
-        let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024);
+        // The two conds differ (inputs 0/1); func and arg are shared inputs.
+        let result = run_pure(
+            4,
+            &[
+                op_spec(
+                    OpCode::CondCallValueI,
+                    &[Arg::In(0), Arg::In(2), Arg::In(3)],
+                ),
+                op_spec(
+                    OpCode::CondCallValueI,
+                    &[Arg::In(1), Arg::In(2), Arg::In(3)],
+                ),
+            ],
+            &mut majit_ir::VecAssoc::new(),
+            &[],
+            false,
+        );
 
         // First COND_CALL_VALUE emitted, second removed by CSE
         assert_eq!(result.len(), 1);
@@ -3080,28 +2878,31 @@ mod tests {
 
     #[test]
     fn test_cond_call_value_uses_call_pure_results_starting_at_arg1() {
-        let mut ops = vec![Op::new(
-            OpCode::CondCallValueI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::const_int(0xCAFE)),
-                BoxRef::from_opref(OpRef::const_int(7)),
-            ],
-        )];
-        assign_positions(&mut ops);
+        // cond is a header input; func and arg are Const literals.
+        let (ops, inputs) = build_trace(
+            1,
+            &[op_spec(
+                OpCode::CondCallValueI,
+                &[
+                    Arg::In(0),
+                    Arg::Const(Value::Int(0xCAFE)),
+                    Arg::Const(Value::Int(7)),
+                ],
+            )],
+        );
+        let op_pos = ops[0].pos.get().raw();
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.record_call_pure_result(vec![Value::Int(0xCAFE), Value::Int(7)], Value::Int(42));
         opt.add_pass(Box::new(OptPure::new()));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1);
+        let result =
+            opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len());
 
         assert!(result.is_empty());
-        assert_eq!(
-            constants.get(&ops[0].pos.get().raw()),
-            Some(&majit_ir::Value::Int(42))
-        );
+        assert_eq!(constants.get(&op_pos), Some(&majit_ir::Value::Int(42)));
     }
 
     /// REF analog of `test_cond_call_value_uses_call_pure_results_*` /

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2921,41 +2921,38 @@ mod tests {
     /// (history.py:220 ConstInt) of the same numeric value.
     #[test]
     fn test_call_pure_r_results_folds_second_identical_call() {
-        let func_const = OpRef::const_int(0xCAFE);
-        let ref_arg_const = OpRef::const_ptr(GcRef(0x4242));
         let result_ptr = GcRef(0xDEAD_BEEF);
 
-        // op0 hits the seeded cache and folds to a Ref constant. A second
-        // residual CallPureR (distinct key, no cache hit) consumes op0's
-        // result, so the fold is observed where it matters in production: the
-        // folded Ref reaches its consumer as an inline `ConstPtr` operand
-        // (later rewritten to `LoadFromGcTable` by the GC rewrite). #108: a Ref
-        // constant is NEVER exported as a raw `GcRef` into the backend constant
-        // pool — that pool has no GC root walker, so refs live only in the
-        // GC-traced gc_table. (The Int analog at :3037 DOES export to the pool;
-        // ints carry no GC concern.)
-        let func_const2 = OpRef::const_int(0xF00D);
-        let mut ops = vec![
-            Op::new(
-                OpCode::CallPureR,
-                &[
-                    BoxRef::from_opref(func_const),
-                    BoxRef::from_opref(ref_arg_const),
-                ],
-            ),
-            // arg(1) references op0's result position (RefOp(0)); after the
-            // fold it resolves to the inline ConstPtr of the cached result.
-            Op::new(
-                OpCode::CallPureR,
-                &[
-                    BoxRef::from_opref(func_const2),
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                ],
-            ),
-        ];
-        assign_positions(&mut ops);
-        // `assign_positions` types op.pos via result_type() → CallPureR
-        // gives a Ref-typed position OpRef.
+        // op0's all-const args (funcptr 0xCAFE + Ref GcRef(0x4242)) hit the
+        // seeded cache and fold to a Ref constant. A second residual CallPureR
+        // (distinct key, no cache hit) consumes op0's result via a bound
+        // `from_bound_op` reference (Prod(0)), so the fold is observed where it
+        // matters in production: the folded Ref reaches its consumer as an
+        // inline `ConstPtr` operand (later rewritten to `LoadFromGcTable` by the
+        // GC rewrite). #108: a Ref constant is NEVER exported as a raw `GcRef`
+        // into the backend constant pool — that pool has no GC root walker, so
+        // refs live only in the GC-traced gc_table. (The Int analog DOES export
+        // to the pool; ints carry no GC concern.)
+        let (ops, inputs) = build_trace(
+            0,
+            &[
+                op_spec(
+                    OpCode::CallPureR,
+                    &[
+                        Arg::Const(Value::Int(0xCAFE)),
+                        Arg::Const(Value::Ref(GcRef(0x4242))),
+                    ],
+                ),
+                // arg(1) binds op0's result box (Prod(0) → RefOp(0)); after the
+                // fold it resolves to the inline ConstPtr of the cached result.
+                op_spec(
+                    OpCode::CallPureR,
+                    &[Arg::Const(Value::Int(0xF00D)), Arg::Prod(0)],
+                ),
+            ],
+        );
+        // `build_trace` types op.pos via result_type() → CallPureR gives a
+        // Ref-typed position OpRef.
         assert_eq!(
             ops[0].pos.get().ty(),
             Some(Type::Ref),
@@ -2963,6 +2960,7 @@ mod tests {
         );
 
         let mut opt = Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         // Seed the cross-call result keyed on [funcptr, ref_arg] (Ref
         // value), as record_result_of_call_pure does at trace time.
         opt.record_call_pure_result(
@@ -2972,7 +2970,8 @@ mod tests {
         opt.add_pass(Box::new(OptPure::new()));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 0);
+        let result =
+            opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len());
 
         // op0 collapses to the cached constant (removed); op1 is the residual
         // call that consumes it.

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -2825,8 +2825,8 @@ mod tests {
 
         // Create a trace: x = SameAsI(), y = SameAsI(constant 0), z = IntAdd(x, y)
         let ops = build_specs(&[
-            same_i(),                       // op0: x
-            same_i(),                       // op1: 0
+            same_i(),                         // op0: x
+            same_i(),                         // op1: 0
             op_spec(OpCode::IntAdd, &[0, 1]), // op2: x + 0
         ]);
 
@@ -2899,9 +2899,9 @@ mod tests {
     fn test_optimizer_integration_chain() {
         // RPython parity: x - x -> 0, then guard_true(0) makes the trace impossible.
         let ops = build_specs(&[
-            same_i(),                          // op0: x
-            op_spec(OpCode::IntSub, &[0, 0]),  // op1: x - x -> 0
-            op_spec(OpCode::GuardTrue, &[1]),  // op2: guard_true(0)
+            same_i(),                         // op0: x
+            op_spec(OpCode::IntSub, &[0, 0]), // op1: x - x -> 0
+            op_spec(OpCode::GuardTrue, &[1]), // op2: guard_true(0)
         ]);
 
         let mut ctx = OptContext::new(3);
@@ -3009,11 +3009,7 @@ mod tests {
         // SETFIELD_GC(struct, value): struct is a Ref producer, value an Int
         // producer. OptRewrite has no rule for it → PassOn.
         let (result, _) = run_one(
-            vec![
-                same_r(),
-                same_i(),
-                op_spec(OpCode::SetfieldGc, &[0, 1]),
-            ],
+            vec![same_r(), same_i(), op_spec(OpCode::SetfieldGc, &[0, 1])],
             2,
             &[],
         );
@@ -3108,9 +3104,9 @@ mod tests {
     fn test_float_neg_double_negation() {
         // FloatNeg(FloatNeg(x)) -> x
         let ops = build_specs(&[
-            same_f(),                          // op0: x
-            op_spec(OpCode::FloatNeg, &[0]),   // op1: -x
-            op_spec(OpCode::FloatNeg, &[1]),   // op2: -(-x) -> x
+            same_f(),                        // op0: x
+            op_spec(OpCode::FloatNeg, &[0]), // op1: -x
+            op_spec(OpCode::FloatNeg, &[1]), // op2: -(-x) -> x
         ]);
         let mut ctx = OptContext::new(3);
         ctx.emit((*ops[0]).clone());
@@ -3375,9 +3371,9 @@ mod tests {
     fn test_guard_no_exception_after_removed_call() {
         // CondCallN(condition=0, ...) -> removed, then GuardNoException -> removed
         let ops = build_specs(&[
-            same_i(),                            // op0: condition (const 0)
-            same_i(),                            // op1: func
-            op_spec(OpCode::CondCallN, &[0, 1]), // op2: removed
+            same_i(),                               // op0: condition (const 0)
+            same_i(),                               // op1: func
+            op_spec(OpCode::CondCallN, &[0, 1]),    // op2: removed
             op_spec(OpCode::GuardNoException, &[]), // op3: should be removed
         ]);
         let mut ctx = OptContext::new(4);
@@ -3406,8 +3402,8 @@ mod tests {
     fn test_guard_no_exception_after_emitted_call() {
         // CallN(...) -> emitted, then GuardNoException -> kept
         let ops = build_specs(&[
-            same_i(),                       // op0: func
-            op_spec(OpCode::CallN, &[0]),   // op1: call
+            same_i(),                               // op0: func
+            op_spec(OpCode::CallN, &[0]),           // op1: call
             op_spec(OpCode::GuardNoException, &[]), // op2: should NOT be removed
         ]);
         let mut ctx = OptContext::new(3);

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3496,25 +3496,21 @@ mod tests {
     #[test]
     fn test_int_mul_neg_one() {
         // x * (-1) → INT_NEG(x)
-        let mut ops = vec![
-            Op::new(
-                OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        with_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let x = b.input(majit_ir::Type::Int, 0);
+        let neg_one = b.const_int(-1);
+        let prod = b.op(OpCode::IntMul, &[x, neg_one]);
+        b.op(OpCode::Finish, &[prod]);
+        let (ops, inputs) = b.build();
 
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         // mul_minus_one lives in OptIntBounds (autogenintrules.py).
         opt.add_pass(Box::new(crate::optimizeopt::intbounds::OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(200u32, majit_ir::Value::Int(-1));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        let num_inputs = inputs.len();
+        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
 
         assert!(
             result.iter().any(|o| o.opcode == OpCode::IntNeg),

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -2300,78 +2300,98 @@ mod tests {
     use crate::optimizeopt::optimizer::Optimizer;
     use majit_ir::GcRef;
 
-    /// Helper: assign positions to ops so the optimizer can track them.
-    fn with_positions(ops: &mut [Op]) {
-        for (i, op) in ops.iter_mut().enumerate() {
-            op.pos
-                .set(OpRef::op_typed(i as u32, op.opcode.result_type()));
+    /// Producer-position trace spec. A consumer's `args` name the result
+    /// positions of earlier producers in the same spec slice, so no op-arg
+    /// is constructed as a position-only `BoxRef::from_opref(...)` box;
+    /// [`build_specs`] later binds each arg to its producing `OpRc`.
+    #[derive(Clone)]
+    struct OpSpec {
+        opcode: OpCode,
+        args: Vec<u32>,
+    }
+
+    fn op_spec(opcode: OpCode, args: &[u32]) -> OpSpec {
+        OpSpec {
+            opcode,
+            args: args.to_vec(),
         }
     }
 
-    fn i(pos: u32) -> BoxRef {
-        BoxRef::from_opref(OpRef::int_op(pos))
+    /// Turn a producer-position spec slice into a bound `OpRc` graph,
+    /// oparser-faithful (`rpython/jit/tool/oparser.py`): each producer op
+    /// is appended at its index position and every consumer arg references
+    /// the producing op's bound result box (`from_bound_op`), mirroring
+    /// oparser's `self.vars[name] = resop; args.append(self.vars[arg])`
+    /// object-identity wiring — so each arg sheds to `Operand::Op` at
+    /// construction, never the position-only `Operand::Box`.
+    fn build_specs(specs: &[OpSpec]) -> Vec<majit_ir::OpRc> {
+        let mut ops: Vec<majit_ir::OpRc> = Vec::new();
+        for (pos, spec) in specs.iter().enumerate() {
+            let args: Vec<BoxRef> = spec
+                .args
+                .iter()
+                .map(|&p| BoxRef::from_bound_op(&ops[p as usize]))
+                .collect();
+            let op = std::rc::Rc::new(Op::new(spec.opcode, &args));
+            op.pos
+                .set(OpRef::op_typed(pos as u32, spec.opcode.result_type()));
+            ops.push(op);
+        }
+        ops
     }
 
-    fn f(pos: u32) -> BoxRef {
-        BoxRef::from_opref(OpRef::float_op(pos))
+    fn same_i() -> OpSpec {
+        op_spec(OpCode::SameAsI, &[])
     }
 
-    fn r(pos: u32) -> BoxRef {
-        BoxRef::from_opref(OpRef::ref_op(pos))
+    fn same_f() -> OpSpec {
+        op_spec(OpCode::SameAsF, &[])
     }
 
-    fn same_i() -> Op {
-        Op::new(OpCode::SameAsI, &[])
+    fn same_r() -> OpSpec {
+        op_spec(OpCode::SameAsR, &[])
     }
 
-    fn same_f() -> Op {
-        Op::new(OpCode::SameAsF, &[])
+    fn bin_i(opcode: OpCode, left: u32, right: u32) -> OpSpec {
+        op_spec(opcode, &[left, right])
     }
 
-    fn same_r() -> Op {
-        Op::new(OpCode::SameAsR, &[])
+    fn bin_f(opcode: OpCode, left: u32, right: u32) -> OpSpec {
+        op_spec(opcode, &[left, right])
     }
 
-    fn bin_i(opcode: OpCode, left: u32, right: u32) -> Op {
-        Op::new(opcode, &[i(left), i(right)])
+    fn bin_r(opcode: OpCode, left: u32, right: u32) -> OpSpec {
+        op_spec(opcode, &[left, right])
     }
 
-    fn bin_f(opcode: OpCode, left: u32, right: u32) -> Op {
-        Op::new(opcode, &[f(left), f(right)])
+    fn unary_i(opcode: OpCode, arg: u32) -> OpSpec {
+        op_spec(opcode, &[arg])
     }
 
-    fn bin_r(opcode: OpCode, left: u32, right: u32) -> Op {
-        Op::new(opcode, &[r(left), r(right)])
+    fn unary_f(opcode: OpCode, arg: u32) -> OpSpec {
+        op_spec(opcode, &[arg])
     }
 
-    fn unary_i(opcode: OpCode, arg: u32) -> Op {
-        Op::new(opcode, &[i(arg)])
-    }
-
-    fn unary_f(opcode: OpCode, arg: u32) -> Op {
-        Op::new(opcode, &[f(arg)])
-    }
-
-    fn unary_r(opcode: OpCode, arg: u32) -> Op {
-        Op::new(opcode, &[r(arg)])
+    fn unary_r(opcode: OpCode, arg: u32) -> OpSpec {
+        op_spec(opcode, &[arg])
     }
 
     fn run_one(
-        mut ops: Vec<Op>,
+        specs: Vec<OpSpec>,
         target: usize,
         constants: &[(OpRef, Value)],
     ) -> (OptimizationResult, OptContext) {
-        with_positions(&mut ops);
+        let ops = build_specs(&specs);
         let mut ctx = OptContext::new(ops.len());
         for op in &ops[..target] {
-            ctx.emit(op.clone());
+            ctx.emit((**op).clone());
         }
         for &(opref, value) in constants {
             let b = ctx.materialize_box_at(opref);
             ctx.make_constant_box(&b, value);
         }
         let mut passes = test_pass_chain();
-        let mut op = ops[target].clone();
+        let mut op = (*ops[target]).clone();
         resolve_op_args_in_ctx(&mut op, &mut ctx);
         let op_rc = std::rc::Rc::new(op.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op_rc));
@@ -2401,21 +2421,21 @@ mod tests {
     /// `run_one` against OptRewrite alone, for tests that assert what the
     /// rewrite pass itself must NOT do (a chained pass would mask it).
     fn run_one_rewrite_only(
-        mut ops: Vec<Op>,
+        specs: Vec<OpSpec>,
         target: usize,
         constants: &[(OpRef, Value)],
     ) -> (OptimizationResult, OptContext) {
-        with_positions(&mut ops);
+        let ops = build_specs(&specs);
         let mut ctx = OptContext::new(ops.len());
         for op in &ops[..target] {
-            ctx.emit(op.clone());
+            ctx.emit((**op).clone());
         }
         for &(opref, value) in constants {
             let b = ctx.materialize_box_at(opref);
             ctx.make_constant_box(&b, value);
         }
         let mut pass = OptRewrite::new();
-        let mut op = ops[target].clone();
+        let mut op = (*ops[target]).clone();
         resolve_op_args_in_ctx(&mut op, &mut ctx);
         let op_rc = std::rc::Rc::new(op.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op_rc));
@@ -2465,14 +2485,15 @@ mod tests {
     }
 
     /// Run the rewrite pass on a sequence of ops and return the optimized ops.
-    fn run_rewrite(ops: &mut [Op]) -> (Vec<Op>, OptContext) {
-        with_positions(ops);
+    #[allow(dead_code)]
+    fn run_rewrite(specs: &[OpSpec]) -> (Vec<Op>, OptContext) {
+        let ops = build_specs(specs);
         let mut ctx = OptContext::new(ops.len());
         let mut passes = test_pass_chain();
 
         for op in ops.iter() {
             // Resolve forwarded arguments
-            let mut resolved = op.clone();
+            let mut resolved = (**op).clone();
             resolve_op_args_in_ctx(&mut resolved, &mut ctx);
 
             let __pf_rc = std::rc::Rc::new(resolved.clone());
@@ -2720,7 +2741,7 @@ mod tests {
     #[test]
     fn test_guard_true_known_true() {
         let (result, _) = run_one(
-            vec![same_i(), Op::new(OpCode::GuardTrue, &[i(0)])],
+            vec![same_i(), op_spec(OpCode::GuardTrue, &[0])],
             1,
             &[(OpRef::int_op(0), Value::Int(1))],
         );
@@ -2731,7 +2752,7 @@ mod tests {
     fn test_guard_true_known_false() {
         let err = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             run_one(
-                vec![same_i(), Op::new(OpCode::GuardTrue, &[i(0)])],
+                vec![same_i(), op_spec(OpCode::GuardTrue, &[0])],
                 1,
                 &[(OpRef::int_op(0), Value::Int(0))],
             )
@@ -2744,14 +2765,14 @@ mod tests {
 
     #[test]
     fn test_guard_true_unknown() {
-        let (result, _) = run_one(vec![same_i(), Op::new(OpCode::GuardTrue, &[i(0)])], 1, &[]);
+        let (result, _) = run_one(vec![same_i(), op_spec(OpCode::GuardTrue, &[0])], 1, &[]);
         assert_pass_on(&result);
     }
 
     #[test]
     fn test_guard_false_known_false() {
         let (result, _) = run_one(
-            vec![same_i(), Op::new(OpCode::GuardFalse, &[i(0)])],
+            vec![same_i(), op_spec(OpCode::GuardFalse, &[0])],
             1,
             &[(OpRef::int_op(0), Value::Int(0))],
         );
@@ -2762,7 +2783,7 @@ mod tests {
     fn test_guard_false_known_true() {
         let err = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             run_one(
-                vec![same_i(), Op::new(OpCode::GuardFalse, &[i(0)])],
+                vec![same_i(), op_spec(OpCode::GuardFalse, &[0])],
                 1,
                 &[(OpRef::int_op(0), Value::Int(1))],
             )
@@ -2790,7 +2811,7 @@ mod tests {
 
     #[test]
     fn test_same_as_i() {
-        let (result, ctx) = run_one(vec![same_i(), Op::new(OpCode::SameAsI, &[i(0)])], 1, &[]);
+        let (result, ctx) = run_one(vec![same_i(), op_spec(OpCode::SameAsI, &[0])], 1, &[]);
         assert_remove(&result);
         assert_forward(&ctx, OpRef::int_op(1), OpRef::int_op(0));
     }
@@ -2803,18 +2824,11 @@ mod tests {
         opt.add_pass(Box::new(OptRewrite::new()));
 
         // Create a trace: x = SameAsI(), y = SameAsI(constant 0), z = IntAdd(x, y)
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: x
-            Op::new(OpCode::SameAsI, &[]), // op1: 0
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ), // op2: x + 0
-        ];
-        with_positions(&mut ops);
+        let ops = build_specs(&[
+            same_i(),                       // op0: x
+            same_i(),                       // op1: 0
+            op_spec(OpCode::IntAdd, &[0, 1]), // op2: x + 0
+        ]);
 
         // We need to set up constants before the optimizer runs.
         // The optimizer creates its own context, so we need a way to
@@ -2826,7 +2840,7 @@ mod tests {
 
         // Simulate the optimizer loop
         for (i, op) in ops.iter().enumerate() {
-            let mut resolved = op.clone();
+            let mut resolved = (**op).clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 resolved.setarg(i, ctx.resolve_box_box(&resolved.arg(i)));
@@ -2884,25 +2898,18 @@ mod tests {
     #[test]
     fn test_optimizer_integration_chain() {
         // RPython parity: x - x -> 0, then guard_true(0) makes the trace impossible.
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: x
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
-            ), // op1: x - x -> 0
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(1))]), // op2: guard_true(0)
-        ];
-        with_positions(&mut ops);
+        let ops = build_specs(&[
+            same_i(),                          // op0: x
+            op_spec(OpCode::IntSub, &[0, 0]),  // op1: x - x -> 0
+            op_spec(OpCode::GuardTrue, &[1]),  // op2: guard_true(0)
+        ]);
 
         let mut ctx = OptContext::new(3);
         let mut passes = test_pass_chain();
 
         let err = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             for op in &ops {
-                let mut resolved = op.clone();
+                let mut resolved = (**op).clone();
                 // optimizer.py:651-652 setarg loop parity.
                 for i in 0..resolved.num_args() {
                     resolved.setarg(i, ctx.resolve_box_box(&resolved.arg(i)));
@@ -2999,12 +3006,15 @@ mod tests {
 
     #[test]
     fn test_unknown_opcode_passthrough() {
+        // SETFIELD_GC(struct, value): struct is a Ref producer, value an Int
+        // producer. OptRewrite has no rule for it → PassOn.
         let (result, _) = run_one(
-            vec![Op::new(
-                OpCode::SetfieldGc,
-                &[BoxRef::from_opref(OpRef::void_op(0)), i(1)],
-            )],
-            0,
+            vec![
+                same_r(),
+                same_i(),
+                op_spec(OpCode::SetfieldGc, &[0, 1]),
+            ],
+            2,
             &[],
         );
         assert_pass_on(&result);
@@ -3097,25 +3107,24 @@ mod tests {
     #[test]
     fn test_float_neg_double_negation() {
         // FloatNeg(FloatNeg(x)) -> x
-        let mut ops = vec![
-            Op::new(OpCode::SameAsF, &[]), // op0: x
-            Op::new(OpCode::FloatNeg, &[BoxRef::from_opref(OpRef::float_op(0))]), // op1: -x
-            Op::new(OpCode::FloatNeg, &[BoxRef::from_opref(OpRef::float_op(1))]), // op2: -(-x) -> x
-        ];
-        with_positions(&mut ops);
+        let ops = build_specs(&[
+            same_f(),                          // op0: x
+            op_spec(OpCode::FloatNeg, &[0]),   // op1: -x
+            op_spec(OpCode::FloatNeg, &[1]),   // op2: -(-x) -> x
+        ]);
         let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
+        ctx.emit((*ops[0]).clone());
 
         let mut pass = OptRewrite::new();
         // Process op1 first (pass it through)
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        let __pf_rc = std::rc::Rc::new((*ops[1]).clone());
         ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
         let result1 = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result1, OptimizationResult::PassOn));
-        ctx.emit(ops[1].clone());
+        ctx.emit((*ops[1]).clone());
 
         // Process op2: should detect double negation
-        let mut resolved2 = ops[2].clone();
+        let mut resolved2 = (*ops[2]).clone();
         resolve_op_args_in_ctx(&mut resolved2, &mut ctx);
         let __pf_rc = std::rc::Rc::new(resolved2.clone());
         ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
@@ -3159,7 +3168,7 @@ mod tests {
                 same_i(),
                 same_i(),
                 same_i(),
-                Op::new(OpCode::CondCallN, &[i(0), i(1), i(2)]),
+                op_spec(OpCode::CondCallN, &[0, 1, 2]),
             ],
             3,
             &[(OpRef::int_op(0), Value::Int(0))],
@@ -3175,7 +3184,7 @@ mod tests {
                 same_i(),
                 same_i(),
                 same_i(),
-                Op::new(OpCode::CondCallN, &[i(0), i(1), i(2)]),
+                op_spec(OpCode::CondCallN, &[0, 1, 2]),
             ],
             3,
             &[(OpRef::int_op(0), Value::Int(1))],
@@ -3202,7 +3211,7 @@ mod tests {
                 same_i(),
                 same_i(),
                 same_i(),
-                Op::new(OpCode::CondCallValueI, &[i(0), i(1), i(2)]),
+                op_spec(OpCode::CondCallValueI, &[0, 1, 2]),
             ],
             3,
             &[(OpRef::int_op(0), Value::Int(42))],
@@ -3225,7 +3234,7 @@ mod tests {
                 same_i(),
                 same_i(),
                 same_i(),
-                Op::new(OpCode::CondCallValueI, &[i(0), i(1), i(2)]),
+                op_spec(OpCode::CondCallValueI, &[0, 1, 2]),
             ],
             3,
             &[(OpRef::int_op(0), Value::Int(0))],
@@ -3365,28 +3374,21 @@ mod tests {
     #[test]
     fn test_guard_no_exception_after_removed_call() {
         // CondCallN(condition=0, ...) -> removed, then GuardNoException -> removed
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: condition (const 0)
-            Op::new(OpCode::SameAsI, &[]), // op1: func
-            Op::new(
-                OpCode::CondCallN,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ), // op2: removed
-            Op::new(OpCode::GuardNoException, &[]), // op3: should be removed
-        ];
-        with_positions(&mut ops);
+        let ops = build_specs(&[
+            same_i(),                            // op0: condition (const 0)
+            same_i(),                            // op1: func
+            op_spec(OpCode::CondCallN, &[0, 1]), // op2: removed
+            op_spec(OpCode::GuardNoException, &[]), // op3: should be removed
+        ]);
         let mut ctx = OptContext::new(4);
-        ctx.emit(ops[0].clone());
-        ctx.emit(ops[1].clone());
+        ctx.emit((*ops[0]).clone());
+        ctx.emit((*ops[1]).clone());
         let b = ctx.materialize_box_at(OpRef::int_op(0));
         ctx.make_constant_box(&b, Value::Int(0));
 
         let mut pass = OptRewrite::new();
         // Process CondCallN -> removed
-        let mut resolved2 = ops[2].clone();
+        let mut resolved2 = (*ops[2]).clone();
         resolve_op_args_in_ctx(&mut resolved2, &mut ctx);
         let __pf_rc = std::rc::Rc::new(resolved2.clone());
         ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
@@ -3394,7 +3396,7 @@ mod tests {
         assert!(matches!(result2, OptimizationResult::Remove));
 
         // Process GuardNoException -> should also be removed
-        let __pf_rc = std::rc::Rc::new(ops[3].clone());
+        let __pf_rc = std::rc::Rc::new((*ops[3]).clone());
         ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
         let result3 = pass.propagate_forward(&ops[3], &__pf_rc, &mut ctx);
         assert!(matches!(result3, OptimizationResult::Remove));
@@ -3403,25 +3405,24 @@ mod tests {
     #[test]
     fn test_guard_no_exception_after_emitted_call() {
         // CallN(...) -> emitted, then GuardNoException -> kept
-        let mut ops = vec![
-            Op::new(OpCode::SameAsI, &[]), // op0: func
-            Op::new(OpCode::CallN, &[BoxRef::from_opref(OpRef::int_op(0))]), // op1: call
-            Op::new(OpCode::GuardNoException, &[]), // op2: should NOT be removed
-        ];
-        with_positions(&mut ops);
+        let ops = build_specs(&[
+            same_i(),                       // op0: func
+            op_spec(OpCode::CallN, &[0]),   // op1: call
+            op_spec(OpCode::GuardNoException, &[]), // op2: should NOT be removed
+        ]);
         let mut ctx = OptContext::new(3);
-        ctx.emit(ops[0].clone());
+        ctx.emit((*ops[0]).clone());
 
         let mut pass = OptRewrite::new();
         // Process CallN -> PassOn (not handled by OptRewrite)
-        let __pf_rc = std::rc::Rc::new(ops[1].clone());
+        let __pf_rc = std::rc::Rc::new((*ops[1]).clone());
         ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
         let result1 = pass.propagate_forward(&ops[1], &__pf_rc, &mut ctx);
         assert!(matches!(result1, OptimizationResult::PassOn));
-        ctx.emit(ops[1].clone());
+        ctx.emit((*ops[1]).clone());
 
         // Process GuardNoException -> should NOT be removed
-        let __pf_rc = std::rc::Rc::new(ops[2].clone());
+        let __pf_rc = std::rc::Rc::new((*ops[2]).clone());
         ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
         let result2 = pass.propagate_forward(&ops[2], &__pf_rc, &mut ctx);
         assert!(matches!(result2, OptimizationResult::PassOn));
@@ -3430,7 +3431,7 @@ mod tests {
     #[test]
     fn test_guard_future_condition_records_and_removes() {
         // rewrite.py: GUARD_FUTURE_CONDITION → record in patchguardop + remove
-        let (result, ctx) = run_one(vec![Op::new(OpCode::GuardFutureCondition, &[])], 0, &[]);
+        let (result, ctx) = run_one(vec![op_spec(OpCode::GuardFutureCondition, &[])], 0, &[]);
         assert_remove(&result);
         assert!(ctx.patchguardop.is_some());
         assert_eq!(
@@ -3447,42 +3448,32 @@ mod tests {
         // analyzed; the guard's own make_constant runs in
         // postprocess_GUARD_VALUE (rewrite.py:313-315), after emit, so it
         // does not bound v at emit time.
-        let ops = vec![
-            // v = (i0 > i1): intbounds bounds the comparison result to [0,1].
-            {
-                let mut op = Op::new(
-                    OpCode::IntGt,
-                    &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
-                    ],
-                );
-                op.pos.set(OpRef::int_op(100));
-                op
-            },
-            {
-                let mut op = Op::new(
-                    OpCode::GuardValue,
-                    &[
-                        BoxRef::from_opref(OpRef::int_op(100)),
-                        BoxRef::from_opref(OpRef::int_op(200)),
-                    ],
-                );
-                op.pos.set(OpRef::void_op(0));
-                op
-            },
-            {
-                let mut op = Op::new(OpCode::Finish, &[]);
-                op.pos.set(OpRef::void_op(1));
-                op
-            },
-        ];
+        // Bound oparser graph: i0/i1 are header InputArgs, v = IntGt(i0, i1)
+        // a live producer, and GUARD_VALUE's expected operand is the literal
+        // ConstInt(0) — so every arg sheds to Operand::{InputArg,Op,Const}.
+        use crate::r#box::test_support::bound_inputarg_box;
+        let (i0, _i0_rc) = bound_inputarg_box(majit_ir::Type::Int, 0);
+        let (i1, _i1_rc) = bound_inputarg_box(majit_ir::Type::Int, 1);
+        // A live producer for v (IntGt result) at int_op(2); the OpRc is held
+        // in `int_gt` so the from_bound_op box's Weak upgrade stays live.
+        let int_gt = std::rc::Rc::new(Op::new(OpCode::IntGt, &[i0, i1]));
+        int_gt.pos.set(OpRef::int_op(2));
+        let v = BoxRef::from_bound_op(&int_gt);
+        let zero = BoxRef::new_const(Value::Int(0));
+        let guard_value = Op::new(OpCode::GuardValue, &[v, zero]);
+        let finish = Op::new(OpCode::Finish, &[]);
+        let ops = {
+            let mut gv = guard_value;
+            gv.pos.set(OpRef::void_op(0));
+            let mut fin = finish;
+            fin.pos.set(OpRef::void_op(1));
+            vec![(*int_gt).clone(), gv, fin]
+        };
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.add_pass(Box::new(crate::optimizeopt::intbounds::OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 2]);
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(200u32, majit_ir::Value::Int(0));
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
@@ -3521,48 +3512,38 @@ mod tests {
     #[test]
     fn test_float_mul_neg_one() {
         // x * (-1.0) → FLOAT_NEG(x)
-        let mut ops = vec![
-            Op::new(
-                OpCode::FloatMul,
-                &[
-                    BoxRef::from_opref(OpRef::float_op(100)),
-                    BoxRef::from_opref(OpRef::float_op(200)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::float_op(0))]),
-        ];
-        with_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let x = b.input(majit_ir::Type::Float, 0);
+        let neg_one = BoxRef::new_const(Value::Float(-1.0));
+        let prod = b.op(OpCode::FloatMul, &[x, neg_one]);
+        b.op(OpCode::Finish, &[prod]);
+        let (ops, inputs) = b.build();
 
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        // Float constant as Value::Float
-        constants.insert(200u32, majit_ir::Value::Float(-1.0));
-        // Need float constant support in ctx — skip for now, just test no crash
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        let num_inputs = inputs.len();
+        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
         assert!(!result.is_empty());
     }
 
     #[test]
     fn test_cond_call_n_zero_removes() {
         // COND_CALL_N(0, func, args...) → removed (condition is false)
-        let mut ops = vec![
-            Op::new(
-                OpCode::CondCallN,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        with_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let cond = BoxRef::new_const(Value::Int(0));
+        let func = b.input(majit_ir::Type::Int, 0);
+        let arg = b.input(majit_ir::Type::Int, 1);
+        b.op(OpCode::CondCallN, &[cond, func, arg]);
+        b.op(OpCode::Finish, &[]);
+        let (ops, inputs) = b.build();
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(200u32, majit_ir::Value::Int(0));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        let num_inputs = inputs.len();
+        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
         assert!(
             !result.iter().any(|o| o.opcode == OpCode::CondCallN),
             "COND_CALL_N(0, ...) should be removed"
@@ -3572,23 +3553,19 @@ mod tests {
     #[test]
     fn test_cond_call_n_nonzero_converts() {
         // COND_CALL_N(1, func, args...) → CALL_N(func, args...)
-        let mut ops = vec![
-            Op::new(
-                OpCode::CondCallN,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        with_positions(&mut ops);
+        let mut b = crate::r#box::test_support::TraceBuilder::new();
+        let cond = BoxRef::new_const(Value::Int(1));
+        let func = b.input(majit_ir::Type::Int, 0);
+        let arg = b.input(majit_ir::Type::Int, 1);
+        b.op(OpCode::CondCallN, &[cond, func, arg]);
+        b.op(OpCode::Finish, &[]);
+        let (ops, inputs) = b.build();
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
-        constants.insert(200u32, majit_ir::Value::Int(1));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
+        let num_inputs = inputs.len();
+        let result = opt.optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs);
         assert!(
             result.iter().any(|o| o.opcode == OpCode::CallN),
             "COND_CALL_N(1, ...) should become CALL_N"

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -3330,7 +3330,8 @@ pub fn build_short_preamble_from_exported_boxes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use majit_ir::{Op, OpCode, OpRc, OpRef};
+    use crate::r#box::test_support::rooted_resop_box;
+    use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
 
     fn assign_positions(ops: &mut [Op], base: u32) {
         for (i, op) in ops.iter_mut().enumerate() {
@@ -3356,34 +3357,34 @@ mod tests {
         // 4: int_add(v100, v101)     ← body computation
         // 5: Jump(v4, v101)          ← back-edge
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Label,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 4),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
         ];
@@ -3408,11 +3409,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 0)]),
         ];
 
         let sp = extract_short_preamble(&ops);
@@ -3425,16 +3426,16 @@ mod tests {
             Op::new(
                 OpCode::IntMulOvf,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 100),
                 ],
             ),
             Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Label, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::Label, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
-        ops[1].setfailargs(vec![BoxRef::from_opref(OpRef::int_op(100))].into());
+        ops[1].setfailargs(vec![rooted_resop_box(Type::Int, 100)].into());
         let sp = extract_short_preamble(&ops);
 
         assert_eq!(sp.len(), 2);
@@ -3448,16 +3449,16 @@ mod tests {
             Op::new(
                 OpCode::IntMulOvf,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
+                    rooted_resop_box(Type::Int, 200),
+                    rooted_resop_box(Type::Int, 200),
                 ],
             ),
             Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Label, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::Label, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
-        ops[1].setfailargs(vec![BoxRef::from_opref(OpRef::int_op(100))].into());
+        ops[1].setfailargs(vec![rooted_resop_box(Type::Int, 100)].into());
         let sp = extract_short_preamble(&ops);
 
         assert!(sp.is_empty());
@@ -3470,13 +3471,13 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]), // refs temporary, not label arg
-            Op::new(OpCode::Label, &[BoxRef::from_opref(OpRef::int_op(100))]), // only v100 is a label arg
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 0)]), // refs temporary, not label arg
+            Op::new(OpCode::Label, &[rooted_resop_box(Type::Int, 100)]), // only v100 is a label arg
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -3494,19 +3495,19 @@ mod tests {
         let mut builder = CollectedShortPreambleBuilder::new();
 
         // Simulate preamble processing
-        let guard1 = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]);
+        let guard1 = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]);
         let guard2 = Op::new(
             OpCode::GuardClass,
             &[
-                BoxRef::from_opref(OpRef::int_op(101)),
-                BoxRef::from_opref(OpRef::int_op(200)),
+                rooted_resop_box(Type::Int, 101),
+                rooted_resop_box(Type::Int, 200),
             ],
         );
         let non_guard = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(101)),
+                rooted_resop_box(Type::Int, 100),
+                rooted_resop_box(Type::Int, 101),
             ],
         );
 
@@ -3518,7 +3519,7 @@ mod tests {
         builder.set_label_args(&[OpRef::int_op(100), OpRef::int_op(101)]);
 
         // After label, no more collection
-        let guard3 = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]);
+        let guard3 = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]);
         builder.add_preamble_guard(&guard3); // should be ignored
 
         let sp = builder.build(None);
@@ -3533,8 +3534,8 @@ mod tests {
         let guard = Op::new(
             OpCode::GuardValue,
             &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(200)),
+                rooted_resop_box(Type::Int, 100),
+                rooted_resop_box(Type::Int, 200),
             ],
         );
         builder.add_preamble_guard(&guard);
@@ -3556,8 +3557,8 @@ mod tests {
         let pure_op = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(101)),
+                rooted_resop_box(Type::Int, 100),
+                rooted_resop_box(Type::Int, 101),
             ],
         );
         builder.add_preamble_op(&pure_op);
@@ -3573,37 +3574,34 @@ mod tests {
     fn test_extract_multiple_guards() {
         // Multiple guards in the preamble
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::int_op(101))],
-            ),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Int, 101)]),
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 200),
                 ],
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Label,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
         ];
@@ -3632,14 +3630,14 @@ mod tests {
                     let mut op = Op::new(
                         OpCode::IntAdd,
                         &[
-                            BoxRef::from_opref(OpRef::int_op(10)),
-                            BoxRef::from_opref(OpRef::int_op(11)),
+                            rooted_resop_box(Type::Int, 10),
+                            rooted_resop_box(Type::Int, 11),
                         ],
                     );
                     op.pos.set(OpRef::int_op(7));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(7)),
+                res: rooted_resop_box(Type::Int, 7),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3650,14 +3648,14 @@ mod tests {
                     let mut op = Op::new(
                         OpCode::IntSub,
                         &[
-                            BoxRef::from_opref(OpRef::int_op(7)),
-                            BoxRef::from_opref(OpRef::int_op(11)),
+                            rooted_resop_box(Type::Int, 7),
+                            rooted_resop_box(Type::Int, 11),
                         ],
                     );
                     op.pos.set(OpRef::int_op(8));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(8)),
+                res: rooted_resop_box(Type::Int, 8),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3668,8 +3666,8 @@ mod tests {
         let sp = build_short_preamble_from_exported_boxes(
             &[OpRef::int_op(0), OpRef::int_op(1)],
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(11)),
+                rooted_resop_box(Type::Int, 10),
+                rooted_resop_box(Type::Int, 11),
             ],
             &exported,
         );
@@ -3690,15 +3688,15 @@ mod tests {
     fn test_build_short_preamble_from_exported_boxes_skips_standalone_overflow_guards() {
         let label_args = vec![OpRef::int_op(10), OpRef::int_op(11)];
         let short_inputargs = vec![
-            BoxRef::from_opref(OpRef::int_op(100)),
-            BoxRef::from_opref(OpRef::int_op(101)),
+            rooted_resop_box(Type::Int, 100),
+            rooted_resop_box(Type::Int, 101),
         ];
 
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(11)),
+                rooted_resop_box(Type::Int, 10),
+                rooted_resop_box(Type::Int, 11),
             ],
         );
         ovf.pos.set(OpRef::int_op(20));
@@ -3707,7 +3705,7 @@ mod tests {
         let exported = vec![
             PreambleOp {
                 op: std::rc::Rc::new(ovf),
-                res: BoxRef::from_opref(OpRef::int_op(20)),
+                res: rooted_resop_box(Type::Int, 20),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3733,22 +3731,32 @@ mod tests {
         // #146/S8: the builder map keys by the short-box res Box identity, and a
         // dependency is found when an op's arg Box Rc::ptr_eq's the dep's res
         // (RPython box-identity `if arg in produced_short_boxes`). Express the
-        // B-depends-on-A edge by sharing A's res Rc as B's IntMul arg(0).
-        let in0 = BoxRef::from_opref(OpRef::int_op(0));
-        let in1 = BoxRef::from_opref(OpRef::int_op(1));
-        let res7 = BoxRef::from_opref(OpRef::int_op(7));
-        let res8 = BoxRef::from_opref(OpRef::int_op(8));
+        // B-depends-on-A edge by binding B's IntMul arg(0) to A's producer op
+        // via `from_bound_op` — the memoized result box is ptr_eq to A's `res`,
+        // so the dependency lookup hits and `Op::new` round-trips the same box
+        // through `getarglist()` (vs a position-only `from_opref`, which would
+        // mint a non-`ptr_eq` arg box).
+        let in0 = rooted_resop_box(Type::Int, 0);
+        let in1 = rooted_resop_box(Type::Int, 1);
+        let producer7 = {
+            let mut op = Op::new(OpCode::IntAdd, &[in0.clone(), in1.clone()]);
+            op.pos.set(OpRef::int_op(7));
+            std::rc::Rc::new(op)
+        };
+        let res7 = BoxRef::from_bound_op(&producer7);
+        let producer8 = {
+            let mut op = Op::new(OpCode::IntMul, &[res7.clone(), in1.clone()]);
+            op.pos.set(OpRef::int_op(8));
+            std::rc::Rc::new(op)
+        };
+        let res8 = BoxRef::from_bound_op(&producer8);
         let produced = vec![
             (
                 res7.clone(),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
                     res: res7.clone(),
-                    preamble_op: {
-                        let mut op = Op::new(OpCode::IntAdd, &[in0.clone(), in1.clone()]);
-                        op.pos.set(OpRef::int_op(7));
-                        std::rc::Rc::new(op)
-                    },
+                    preamble_op: producer7,
                     invented_name: false,
                     same_as_source: None,
                     label_arg_idx: None,
@@ -3759,11 +3767,7 @@ mod tests {
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
                     res: res8.clone(),
-                    preamble_op: {
-                        let mut op = Op::new(OpCode::IntMul, &[res7.clone(), in1.clone()]);
-                        op.pos.set(OpRef::int_op(8));
-                        std::rc::Rc::new(op)
-                    },
+                    preamble_op: producer8,
                     invented_name: false,
                     same_as_source: None,
                     label_arg_idx: None,
@@ -3789,12 +3793,12 @@ mod tests {
     #[test]
     fn test_build_from_preamble_and_label() {
         let mut preamble = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
         ];
@@ -3813,26 +3817,23 @@ mod tests {
         builder.set_label_args(&[OpRef::int_op(100), OpRef::int_op(101)]);
         builder.add_guard(Op::new(
             OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::int_op(100))],
+            &[rooted_resop_box(Type::Int, 100)],
         ));
         builder.add_pure_op(Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(100)),
-                BoxRef::from_opref(OpRef::int_op(101)),
+                rooted_resop_box(Type::Int, 100),
+                rooted_resop_box(Type::Int, 101),
             ],
         ));
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(100))],
+            &[rooted_resop_box(Type::Int, 100)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(102));
         builder.add_heap_op(heap);
-        builder.add_loopinvariant_op(Op::new(
-            OpCode::CallI,
-            &[BoxRef::from_opref(OpRef::int_op(100))],
-        ));
+        builder.add_loopinvariant_op(Op::new(OpCode::CallI, &[rooted_resop_box(Type::Int, 100)]));
         assert_eq!(builder.num_ops(), 4);
     }
 
@@ -3850,15 +3851,15 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(11)),
+                rooted_resop_box(Type::Int, 10),
+                rooted_resop_box(Type::Int, 11),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
         sb.add_pure_op(&mut __ctx, pure);
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(10))],
+            &[rooted_resop_box(Type::Int, 10)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(21));
@@ -3880,8 +3881,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(999)),
+                rooted_resop_box(Type::Int, 10),
+                rooted_resop_box(Type::Int, 999),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -3905,8 +3906,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(999)),
+                rooted_resop_box(Type::Int, 10),
+                rooted_resop_box(Type::Int, 999),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -3949,7 +3950,7 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(30))],
+            &[rooted_resop_box(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
@@ -3958,8 +3959,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(30)),
-                BoxRef::from_opref(OpRef::int_op(31)),
+                rooted_resop_box(Type::Int, 30),
+                rooted_resop_box(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(10));
@@ -4004,21 +4005,21 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(30))],
+            &[rooted_resop_box(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
-        let mut loopinv = Op::new(OpCode::CallI, &[BoxRef::from_opref(OpRef::int_op(30))]);
+        let mut loopinv = Op::new(OpCode::CallI, &[rooted_resop_box(Type::Int, 30)]);
         loopinv.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, loopinv, PreambleOpKind::LoopInvariant);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(30)),
-                BoxRef::from_opref(OpRef::int_op(31)),
+                rooted_resop_box(Type::Int, 30),
+                rooted_resop_box(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -4063,7 +4064,7 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(30))],
+            &[rooted_resop_box(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
@@ -4118,8 +4119,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(30)),
-                BoxRef::from_opref(OpRef::int_op(31)),
+                rooted_resop_box(Type::Int, 30),
+                rooted_resop_box(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(10));
@@ -4250,8 +4251,8 @@ mod tests {
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
             &[
-                BoxRef::from_opref(OpRef::int_op(30)),
-                BoxRef::from_opref(OpRef::int_op(31)),
+                rooted_resop_box(Type::Int, 30),
+                rooted_resop_box(Type::Int, 31),
             ],
         );
         ovf.pos.set(OpRef::int_op(10));
@@ -4308,7 +4309,7 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(30))],
+            &[rooted_resop_box(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
@@ -4317,8 +4318,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                BoxRef::from_opref(OpRef::int_op(30)),
-                BoxRef::from_opref(OpRef::int_op(31)),
+                rooted_resop_box(Type::Int, 30),
+                rooted_resop_box(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -4340,7 +4341,7 @@ mod tests {
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(20)],
             &entries,
-            &[BoxRef::from_opref(OpRef::int_op(20))],
+            &[rooted_resop_box(Type::Int, 20)],
         );
         assert!(builder.add_preamble_op(&alias_res));
         let extra = builder.extra_same_as();
@@ -4359,26 +4360,20 @@ mod tests {
 
     #[test]
     fn test_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
-        let mut builder = ShortPreambleBuilder::new(
-            &[OpRef::int_op(7)],
-            &[],
-            &[BoxRef::from_opref(OpRef::int_op(7))],
-        );
-        let mut replay_op = Op::new(
-            OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(30))],
-        );
+        let mut builder =
+            ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[rooted_resop_box(Type::Int, 7)]);
+        let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_box(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: BoxRef::from_opref(OpRef::int_op(14)),
+            op: rooted_resop_box(Type::Int, 14),
             invented_name: true,
             preamble_op: std::rc::Rc::new(replay_op),
             // Imported invented-name pop carries the original it aliases;
             // the else arm reads it to emit `same_as(source)`.
-            same_as_source: Some(BoxRef::from_opref(OpRef::int_op(14))),
+            same_as_source: Some(rooted_resop_box(Type::Int, 14)),
         };
 
-        builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
+        builder.add_preamble_op_from_pop(&pop, rooted_resop_box(Type::Int, 41));
 
         assert_eq!(builder.used_boxes(), &[OpRef::int_op(41)]);
         assert_eq!(builder.short_preamble_jump().len(), 1);
@@ -4402,27 +4397,21 @@ mod tests {
 
     #[test]
     fn test_extended_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
-        let sb = ShortPreambleBuilder::new(
-            &[OpRef::int_op(7)],
-            &[],
-            &[BoxRef::from_opref(OpRef::int_op(7))],
-        );
+        let sb =
+            ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[rooted_resop_box(Type::Int, 7)]);
         let mut builder = ExtendedShortPreambleBuilder::new(0, &sb);
-        let mut replay_op = Op::new(
-            OpCode::GetfieldGcI,
-            &[BoxRef::from_opref(OpRef::int_op(30))],
-        );
+        let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_box(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: BoxRef::from_opref(OpRef::int_op(14)),
+            op: rooted_resop_box(Type::Int, 14),
             invented_name: true,
             preamble_op: std::rc::Rc::new(replay_op),
             // Imported invented-name pop carries the original it aliases;
             // the else arm reads it to emit `same_as(source)`.
-            same_as_source: Some(BoxRef::from_opref(OpRef::int_op(14))),
+            same_as_source: Some(rooted_resop_box(Type::Int, 14)),
         };
 
-        builder.add_preamble_op_from_pop(&pop, BoxRef::from_opref(OpRef::int_op(41)));
+        builder.add_preamble_op_from_pop(&pop, rooted_resop_box(Type::Int, 41));
 
         assert_eq!(
             builder

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -478,6 +478,15 @@ pub struct ShortBoxes {
     /// `ShortInputArg(box, renamed)` — `box` and `renamed` are two objects).
     /// `short_inputargs[i]` corresponds to `label_args[i]` positionally.
     short_inputargs: Vec<BoxRef>,
+    /// Strong-`Rc` rooting pool for the renamed `InputArg` objects whose
+    /// `Weak` the `short_inputargs[i]` boxes hold (`from_bound_inputarg`
+    /// downgrades the `Rc`, box_ref.rs:293). Index-aligned 1:1 with
+    /// `short_inputargs`. Keeps each renamed `AbstractInputArg` alive so the
+    /// box stays bound (`bound_inputarg()` upgrades) until the operand it
+    /// sheds to (`Operand::InputArg`, a strong `Rc::clone`) self-roots it —
+    /// the analog of `TraceIterator.inputargs` rooting the outer-trace
+    /// inputargs (opencoder.py:250-273).
+    short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// shortpreamble.py:256 `box = label_args[i]` — the ORIGINAL label-arg
     /// references, kept so `potential_ops`/lookups resolve a label arg by
     /// its own opref (`shortpreamble.py:259 potential_ops[box]`). pyre needs
@@ -577,6 +586,7 @@ impl ShortBoxes {
             const_short_boxes: Vec::new(),
             known_constants: VecSet::new(),
             short_inputargs: Vec::new(),
+            short_inputarg_refs: Vec::new(),
             label_args: Vec::new(),
             boxes_in_production: VecSet::new(),
             num_label_args,
@@ -708,10 +718,16 @@ impl ShortBoxes {
         // comes from the op-position counter so it is unique and accounted
         // for by `opref_high_water`; `raw()` shares the op/inputarg integer
         // space, so a fresh op position is a fresh inputarg position too.
-        let renamed = crate::r#box::BoxRef::new_inputarg(
-            arg_type,
-            ctx.alloc_op_position_typed(arg_type).raw(),
-        );
+        // Mint the `InputArg` object itself and BIND the box to it
+        // (`from_bound_inputarg`), the orthodox shape of `inputarg_from_tp`'s
+        // fresh `AbstractInputArg`; the strong `Rc` is rooted in
+        // `short_inputarg_refs[i]` so the box stays bound (the previous
+        // `new_inputarg` left `inputarg_handle = None`, minting a position-only
+        // box that shed to `Operand::Box`). `to_opref` is byte-identical
+        // (reads only `(type, position)`).
+        let pos = ctx.alloc_op_position_typed(arg_type).raw();
+        let renamed_ia = majit_ir::InputArg::from_type_rc(arg_type, pos);
+        let renamed = crate::r#box::BoxRef::from_bound_inputarg(&renamed_ia);
         // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
         // is a plain dict assignment, so for a box duplicated across the
         // combined list it OVERWRITES: the LAST slot's `ShortInputArg`
@@ -725,6 +741,7 @@ impl ShortBoxes {
         // duplicate-free case `live_slot == lookup_label_arg(arg)`, so the
         // rename is unchanged.
         self.short_inputargs.push(renamed);
+        self.short_inputarg_refs.push(renamed_ia);
         // shortpreamble.py:257 `ShortInputArg(box, renamed)` — `res` is the
         // original `box`; the SAME_AS replay arg is that box. Exported
         // entries carry original positions and are renamed to the matching
@@ -993,6 +1010,18 @@ impl ShortBoxes {
     /// short_inputargs is the legitimate empty-loop case in upstream.
     pub fn create_short_inputargs(&self, _label_args: &[OpRef]) -> Vec<BoxRef> {
         self.short_inputargs.clone()
+    }
+
+    /// The `InputArg` rooting pool paired 1:1 with `create_short_inputargs`'s
+    /// boxes. Cloned (`Rc::clone` per handle) in lock-step so the carried
+    /// strong `Rc`s keep each `short_inputargs[i]` box bound downstream.
+    pub fn create_short_inputarg_refs(&self) -> Vec<majit_ir::InputArgRc> {
+        debug_assert_eq!(
+            self.short_inputarg_refs.len(),
+            self.short_inputargs.len(),
+            "short_inputarg_refs must stay index-aligned with short_inputargs"
+        );
+        self.short_inputarg_refs.clone()
     }
 
     /// shortpreamble.py: add_potential_op(op, pop)

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -94,14 +94,51 @@ impl Optimization for OptSimplify {
 mod tests {
     use super::*;
     use crate::r#box::BoxRef;
-    use majit_ir::OpRef;
+    use crate::r#box::test_support::TraceBuilder;
+    use majit_ir::{OpRc, OpRef, Type};
 
-    fn run_pass(ops: &[Op]) -> Vec<Op> {
+    /// Seed empty guard snapshots over the canonical `OpRc` slice in place
+    /// (each guard's `rd_resume_position` is a `Cell`, so the assignment is
+    /// shared through the `Rc`), mirroring `seed_empty_guard_snapshots` for
+    /// the `OpRc`-threaded driver.
+    fn seed_oprc(ops: &[OpRc]) -> super::super::SnapshotBoxes {
+        let scratch: Vec<Op> = ops.iter().map(|op| (**op).clone()).collect();
+        let (seeded, snapshots) = super::super::seed_empty_guard_snapshots(&scratch);
+        for (op, seed) in ops.iter().zip(seeded.iter()) {
+            op.rd_resume_position.set(seed.rd_resume_position.get());
+        }
+        snapshots
+    }
+
+    /// Drive `OptSimplify` over a bound oparser graph
+    /// (`rpython/jit/tool/oparser.py`): header `InputArg`s and live producer
+    /// `OpRc`s built by [`TraceBuilder`], threaded through the canonical
+    /// `optimize_with_constants_and_inputs_oprc` entry (`input_ops_from_ops =
+    /// true`) so the test's own `OpRc`s are the producers the optimizer
+    /// indexes. Every op-arg sheds to `Operand::{InputArg,Op,Const}` — never
+    /// the position-only `Operand::Box`.
+    fn run_trace(builder: TraceBuilder) -> Vec<Op> {
+        let (ops, inputs) = builder.build();
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.add_pass(Box::new(OptSimplify::new()));
-        let (ops, snapshots) = super::super::seed_empty_guard_snapshots(ops);
-        opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecAssoc::new(), 1024)
+        opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
+        opt.snapshot_boxes = seed_oprc(&ops);
+        let num_inputs = inputs.len();
+        opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::VecAssoc::new(),
+            num_inputs,
+        )
+        .into_iter()
+        .map(|rc| (*rc).clone())
+        .collect()
+    }
+
+    /// The `OpRef`s a header-input slice of `n` `Type::Int` inputargs resolves
+    /// to once emitted — the bound-graph counterpart of the old fixtures'
+    /// `int_op(0..n)` free positions (`to_opref` of an `InputArg` box).
+    fn input_oprefs(n: u32) -> Vec<OpRef> {
+        (0..n).map(|i| OpRef::input_arg_int(i)).collect()
     }
 
     #[test]
@@ -112,14 +149,12 @@ mod tests {
             (OpCode::CallPureF, OpCode::CallF),
             (OpCode::CallPureN, OpCode::CallN),
         ] {
-            let ops = vec![Op::new(
-                pure_op,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            )];
-            let result = run_pass(&ops);
+            // pure_op(i0, i1) over two header inputargs.
+            let mut b = TraceBuilder::new();
+            let i0 = b.input(Type::Int, 0);
+            let i1 = b.input(Type::Int, 1);
+            b.op(pure_op, &[i0, i1]);
+            let result = run_trace(b);
             assert_eq!(result.len(), 1);
             assert_eq!(result[0].opcode, expected_op);
             assert_eq!(
@@ -128,7 +163,7 @@ mod tests {
                     .iter()
                     .map(|a| a.to_opref())
                     .collect::<Vec<_>>()[..],
-                &[OpRef::int_op(0), OpRef::int_op(1)]
+                &input_oprefs(2)[..]
             );
         }
     }
@@ -141,8 +176,10 @@ mod tests {
             (OpCode::CallLoopinvariantF, OpCode::CallF),
             (OpCode::CallLoopinvariantN, OpCode::CallN),
         ] {
-            let ops = vec![Op::new(loopinv_op, &[BoxRef::from_opref(OpRef::int_op(0))])];
-            let result = run_pass(&ops);
+            let mut b = TraceBuilder::new();
+            let i0 = b.input(Type::Int, 0);
+            b.op(loopinv_op, &[i0]);
+            let result = run_trace(b);
             assert_eq!(result.len(), 1);
             assert_eq!(result[0].opcode, expected_op);
         }
@@ -150,14 +187,11 @@ mod tests {
 
     #[test]
     fn test_virtual_ref_to_same_as() {
-        let ops = vec![Op::new(
-            OpCode::VirtualRefR,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        )];
-        let result = run_pass(&ops);
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        b.op(OpCode::VirtualRefR, &[i0, i1]);
+        let result = run_trace(b);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::SameAsR);
         assert_eq!(
@@ -166,7 +200,7 @@ mod tests {
                 .iter()
                 .map(|a| a.to_opref())
                 .collect::<Vec<_>>(),
-            vec![OpRef::int_op(0)]
+            vec![OpRef::input_arg_int(0)]
         );
     }
 
@@ -182,29 +216,25 @@ mod tests {
             OpCode::RecordKnownResult,
         ];
         for opcode in removed_opcodes {
-            let arity = opcode.arity().unwrap_or(0) as usize;
-            let args: Vec<BoxRef> = (0..arity)
-                .map(|i| BoxRef::from_opref(OpRef::int_op(i as u32)))
-                .collect();
-            let ops = vec![Op::new(opcode, &args)];
-            let result = run_pass(&ops);
+            let arity = opcode.arity().unwrap_or(0) as u32;
+            // `arity` header inputargs, then the op consuming them.
+            let mut b = TraceBuilder::new();
+            let args: Vec<BoxRef> = (0..arity).map(|i| b.input(Type::Int, i)).collect();
+            b.op(opcode, &args);
+            let result = run_trace(b);
             assert!(result.is_empty(), "{:?} should be removed", opcode);
         }
     }
 
     #[test]
     fn test_passthrough() {
-        let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
-        ];
-        let result = run_pass(&ops);
+        // v = IntAdd(i0, i1), GuardTrue(v).
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        let v = b.op(OpCode::IntAdd, &[i0, i1]);
+        b.op(OpCode::GuardTrue, &[v]);
+        let result = run_trace(b);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
         assert_eq!(result[1].opcode, OpCode::GuardTrue);
@@ -212,15 +242,12 @@ mod tests {
 
     #[test]
     fn test_preserves_args_on_call_rewrite() {
-        let ops = vec![Op::new(
-            OpCode::CallPureI,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-                BoxRef::from_opref(OpRef::int_op(2)),
-            ],
-        )];
-        let result = run_pass(&ops);
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        let i2 = b.input(Type::Int, 2);
+        b.op(OpCode::CallPureI, &[i0, i1, i2]);
+        let result = run_trace(b);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallI);
         assert_eq!(
@@ -229,37 +256,21 @@ mod tests {
                 .iter()
                 .map(|a| a.to_opref())
                 .collect::<Vec<_>>(),
-            vec![OpRef::int_op(0), OpRef::int_op(1), OpRef::int_op(2)]
+            input_oprefs(3)
         );
     }
 
     #[test]
     fn test_mixed_ops() {
-        let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(OpCode::CallPureI, &[BoxRef::from_opref(OpRef::int_op(0))]),
-            Op::new(
-                OpCode::RecordExactClass,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
-            ),
-        ];
-        let result = run_pass(&ops);
+        // IntAdd(i0,i1), CallPureI(i0), RecordExactClass(i0,i1), IntSub(i0,i1).
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        b.op(OpCode::IntAdd, &[i0.clone(), i1.clone()]);
+        b.op(OpCode::CallPureI, &[i0.clone()]);
+        b.op(OpCode::RecordExactClass, &[i0.clone(), i1.clone()]);
+        b.op(OpCode::IntSub, &[i0, i1]);
+        let result = run_trace(b);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
         assert_eq!(result[1].opcode, OpCode::CallI);
@@ -268,18 +279,14 @@ mod tests {
 
     #[test]
     fn test_guard_future_condition_removed() {
-        let ops = vec![
-            Op::new(OpCode::GuardFutureCondition, &[]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        let result = run_pass(&ops);
+        // GuardFutureCondition, IntAdd(i0, i1), Finish.
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        b.op(OpCode::GuardFutureCondition, &[]);
+        b.op(OpCode::IntAdd, &[i0, i1]);
+        b.op(OpCode::Finish, &[]);
+        let result = run_trace(b);
         // GUARD_FUTURE_CONDITION should be removed
         assert!(
             !result
@@ -291,46 +298,33 @@ mod tests {
 
     #[test]
     fn test_assert_not_none_removed() {
-        let ops = vec![
-            Op::new(
-                OpCode::AssertNotNone,
-                &[BoxRef::from_opref(OpRef::int_op(100))],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        let result = run_pass(&ops);
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        b.op(OpCode::AssertNotNone, &[i0]);
+        b.op(OpCode::Finish, &[]);
+        let result = run_trace(b);
         assert!(!result.iter().any(|o| o.opcode == OpCode::AssertNotNone));
     }
 
     #[test]
     fn test_virtual_ref_r_to_same_as() {
-        let ops = vec![
-            Op::new(
-                OpCode::VirtualRefR,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        let result = run_pass(&ops);
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        b.op(OpCode::VirtualRefR, &[i0, i1]);
+        b.op(OpCode::Finish, &[]);
+        let result = run_trace(b);
         assert!(result.iter().any(|o| o.opcode == OpCode::SameAsR));
     }
 
     #[test]
     fn test_record_exact_class_removed() {
-        let ops = vec![
-            Op::new(
-                OpCode::RecordExactClass,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
-            ),
-            Op::new(OpCode::Finish, &[]),
-        ];
-        let result = run_pass(&ops);
+        let mut b = TraceBuilder::new();
+        let i0 = b.input(Type::Int, 0);
+        let i1 = b.input(Type::Int, 1);
+        b.op(OpCode::RecordExactClass, &[i0, i1]);
+        b.op(OpCode::Finish, &[]);
+        let result = run_trace(b);
         assert!(!result.iter().any(|o| o.opcode == OpCode::RecordExactClass));
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5715,6 +5715,7 @@ impl Optimization for OptUnroll {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
     use crate::optimizeopt::optimizer::Optimizer;
     use majit_ir::GcRef;
 
@@ -5731,16 +5732,16 @@ mod tests {
         let exported = ExportedState::new(
             vec![OpRef::int_op(52)],
             vec![
-                BoxRef::from_opref(OpRef::int_op(109)),
+                rooted_resop_box(Type::Int, 109),
                 BoxRef::from_opref(OpRef::const_int(3)),
             ],
             crate::optimizeopt::virtualstate::VirtualState::new(Vec::new()),
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
             Vec::new(),
             vec![OpRef::int_op(14)],
-            vec![BoxRef::from_opref(OpRef::int_op(23))],
-            // short_inputarg_refs: these test boxes are position-only
-            // `from_opref` (unbound), so no rooted InputArgRc pool.
+            vec![rooted_resop_box(Type::Int, 23)],
+            // short_inputarg_refs: the renamed_inputargs boxes are rooted
+            // resop boxes, so no parallel InputArgRc pool is needed here.
             Vec::new(),
         );
 
@@ -5781,11 +5782,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 0)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -5819,8 +5820,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
+                        rooted_resop_box(Type::Int, 0),
+                        rooted_resop_box(Type::Int, 1),
                     ],
                 );
                 op.pos.set(OpRef::int_op(2));
@@ -5829,9 +5830,9 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::int_op(50)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 2),
+                    rooted_resop_box(Type::Int, 50),
                 ],
             ),
         ];
@@ -5874,14 +5875,14 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             );
             op.pos.set(OpRef::int_op(2));
             op
         }];
-        let mut jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(2))]);
+        let mut jump = Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]);
         jump.setdescr(TargetToken::new_preamble(7).as_jump_target_descr());
 
         let body_ops: Vec<majit_ir::OpRc> = body_ops.into_iter().map(std::rc::Rc::new).collect();
@@ -5990,7 +5991,8 @@ mod tests {
             }],
             vec![old_ref],
             vec![BoxRef::from_opref(old_ref)],
-            // short_inputarg_refs: test box is position-only `from_opref`.
+            // short_inputarg_refs: `old_ref` is a ConstPtr, so this box sheds
+            // to `Operand::Const` (no position-only mint).
             Vec::new(),
         );
         state.short_boxes.push((
@@ -6092,8 +6094,8 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6119,15 +6121,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::IntSub,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6173,15 +6175,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::IntMul,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ), // references op0
             Op::new(OpCode::Jump, &[]),
@@ -6219,8 +6221,8 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6244,12 +6246,12 @@ mod tests {
     fn test_guards_duplicated_in_peel() {
         // Guards in the preamble serve as type checks.
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6278,14 +6280,13 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             {
-                let mut guard =
-                    Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(100))]);
-                guard.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(0))].into()); // refs op0
+                let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]);
+                guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into()); // refs op0
                 guard
             },
             Op::new(OpCode::Jump, &[]),
@@ -6324,11 +6325,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]), // carries v0 (the add result)
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]), // carries v0 (the add result)
         ];
         assign_positions(&mut ops, 0);
 
@@ -6355,15 +6356,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 100),
                 ],
             ),
         ];
@@ -6392,26 +6393,26 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::IntSub,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::IntMul,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(2))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 2)]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6440,10 +6441,8 @@ mod tests {
         let mut pass = OptUnroll::new();
 
         // Simulate some state.
-        pass.buffer.push(Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(OpRef::int_op(0))],
-        ));
+        pass.buffer
+            .push(Op::new(OpCode::IntAdd, &[rooted_resop_box(Type::Int, 0)]));
         pass.seen_jump = true;
 
         pass.setup();
@@ -6461,12 +6460,12 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6503,7 +6502,7 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GuardTrue,
-                &[BoxRef::from_opref(OpRef::int_op(100))],
+                &[rooted_resop_box(Type::Int, 100)],
                 descr.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6551,25 +6550,25 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
+                    rooted_resop_box(Type::Int, 100),
+                    rooted_resop_box(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 100),
                 ],
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
+                    rooted_resop_box(Type::Int, 1),
+                    rooted_resop_box(Type::Int, 0),
                 ],
             ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(2))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6640,11 +6639,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
+                    rooted_inputarg_box(Type::Int, 0),
+                    rooted_inputarg_box(Type::Int, 1),
                 ],
             ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]),
+            Op::new(OpCode::Jump, &[rooted_inputarg_box(Type::Int, 0)]),
         ];
         assign_positions(&mut ops, 2);
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -6657,19 +6656,16 @@ mod tests {
     #[test]
     fn test_unroll_optimizer_count_guards() {
         let ops = vec![
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 0)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             ),
-            Op::new(
-                OpCode::GuardNonnull,
-                &[BoxRef::from_opref(OpRef::int_op(0))],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
         ];
         assert_eq!(UnrollOptimizer::count_guards(&ops), 2);
     }
@@ -6803,7 +6799,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(11)),
+                res: rooted_resop_box(Type::Int, 11),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6870,7 +6866,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(11)),
+                res: rooted_resop_box(Type::Int, 11),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6935,7 +6931,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(11)),
+                res: rooted_resop_box(Type::Int, 11),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6987,10 +6983,11 @@ mod tests {
         let func_ptr = 0xBEEF;
         let func = OpRef::const_int(func_ptr);
         let source = OpRef::int_op(11);
+        let source_box = rooted_resop_box(Type::Int, 11);
         let phase2_result = OpRef::int_op(3);
         let exported = ExportedState::new(
             vec![source],
-            vec![BoxRef::from_opref(source)],
+            vec![source_box.clone()],
             crate::optimizeopt::virtualstate::VirtualState::new(Vec::new()),
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
             vec![crate::optimizeopt::shortpreamble::PreambleOp {
@@ -6999,15 +6996,16 @@ mod tests {
                     op.pos.set(source);
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(source),
+                res: source_box.clone(),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
                 label_arg_idx: Some(0),
                 invented_name: false,
                 same_as_source: None,
             }],
             Vec::new(),
-            vec![BoxRef::from_opref(source)],
-            // short_inputarg_refs: test box is position-only `from_opref`.
+            vec![source_box],
+            // short_inputarg_refs: bound resop box rooted in the thread-local
+            // pool; sheds to `Operand::Op` instead of position-only `Operand::Box`.
             Vec::new(),
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
@@ -7046,23 +7044,23 @@ mod tests {
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::int_op(0), OpRef::int_op(1), OpRef::int_op(2)],
             &[
-                BoxRef::from_opref(OpRef::int_op(10)),
-                BoxRef::from_opref(OpRef::int_op(11)),
-                BoxRef::from_opref(OpRef::int_op(12)),
+                rooted_resop_box(Type::Int, 10),
+                rooted_resop_box(Type::Int, 11),
+                rooted_resop_box(Type::Int, 12),
             ],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
                     let mut op = Op::new(
                         OpCode::IntAdd,
                         &[
-                            BoxRef::from_opref(OpRef::int_op(0)),
-                            BoxRef::from_opref(OpRef::int_op(1)),
+                            rooted_resop_box(Type::Int, 0),
+                            rooted_resop_box(Type::Int, 1),
                         ],
                     );
                     op.pos.set(OpRef::int_op(20));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(20)),
+                res: rooted_resop_box(Type::Int, 20),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -7078,7 +7076,7 @@ mod tests {
             .produced_short_op(&src20)
             .unwrap();
         let pop = crate::optimizeopt::info::PreambleOp {
-            op: BoxRef::from_opref(OpRef::int_op(20)),
+            op: rooted_resop_box(Type::Int, 20),
             invented_name: produced.invented_name,
             same_as_source: produced.same_as_source.clone(),
             preamble_op: produced.preamble_op,
@@ -7149,22 +7147,22 @@ mod tests {
                 OpRef::ref_op(3),
             ],
             &[
-                BoxRef::from_opref(OpRef::ref_op(10)),
-                BoxRef::from_opref(OpRef::ref_op(11)),
-                BoxRef::from_opref(OpRef::ref_op(12)),
-                BoxRef::from_opref(OpRef::ref_op(13)),
+                rooted_resop_box(Type::Ref, 10),
+                rooted_resop_box(Type::Ref, 11),
+                rooted_resop_box(Type::Ref, 12),
+                rooted_resop_box(Type::Ref, 13),
             ],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
                     let mut op = Op::with_descr(
                         OpCode::GetfieldGcR,
-                        &[BoxRef::from_opref(OpRef::ref_op(3))],
+                        &[rooted_resop_box(Type::Ref, 3)],
                         majit_ir::descr::make_field_descr_full(56, 0, 8, Type::Ref, false),
                     );
                     op.pos.set(OpRef::ref_op(19));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::ref_op(19)),
+                res: rooted_resop_box(Type::Ref, 19),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: None,
                 invented_name: false,
@@ -7271,11 +7269,11 @@ mod tests {
                     op.pos.set(OpRef::int_op(30));
                     std::rc::Rc::new(op)
                 },
-                res: BoxRef::from_opref(OpRef::int_op(30)),
+                res: rooted_resop_box(Type::Int, 30),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: true,
-                same_as_source: Some(BoxRef::from_opref(OpRef::int_op(14))),
+                same_as_source: Some(rooted_resop_box(Type::Int, 14)),
             });
         // Bind export-input positions at their source (IntAdd operands /
         // same-as alias are bound boxes in production); virtualstate.py:711-720
@@ -7328,8 +7326,8 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             );
             op.pos.set(OpRef::int_op(3));
@@ -7340,14 +7338,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntMul,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(50)),
-                        BoxRef::from_opref(OpRef::int_op(0)),
+                        rooted_resop_box(Type::Int, 50),
+                        rooted_resop_box(Type::Int, 0),
                     ],
                 );
                 op.pos.set(OpRef::int_op(1));
                 op
             },
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(50))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 50)]),
         ];
 
         let combined = assemble_peeled_trace(
@@ -7360,7 +7358,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: BoxRef::from_opref(OpRef::int_op(10)),
+                same_as_source: rooted_resop_box(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecAssoc::new(),
@@ -7391,8 +7389,8 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             );
             op.pos.set(OpRef::int_op(11));
@@ -7403,7 +7401,7 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntGe,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(11)),
+                        rooted_resop_box(Type::Int, 11),
                         BoxRef::from_opref(OpRef::const_int(2)),
                     ],
                 );
@@ -7414,14 +7412,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(11)),
+                        rooted_resop_box(Type::Int, 11),
                         BoxRef::from_opref(OpRef::const_int(1)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(11));
                 op
             },
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(11))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 11)]),
         ];
 
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -7461,7 +7459,7 @@ mod tests {
     #[test]
     fn test_assemble_peeled_trace_preserves_visible_preamble_box_over_body_collision() {
         let p1_ops = vec![{
-            let mut op = Op::new(OpCode::GetfieldGcR, &[BoxRef::from_opref(OpRef::int_op(3))]);
+            let mut op = Op::new(OpCode::GetfieldGcR, &[rooted_resop_box(Type::Int, 3)]);
             op.pos.set(OpRef::int_op(19));
             op.setdescr(majit_ir::descr::make_field_descr_full(
                 56,
@@ -7477,8 +7475,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::SetfieldGc,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(25)),
-                        BoxRef::from_opref(OpRef::int_op(19)),
+                        rooted_resop_box(Type::Int, 25),
+                        rooted_resop_box(Type::Int, 19),
                     ],
                 );
                 op.setdescr(majit_ir::descr::make_field_descr_full(
@@ -7494,14 +7492,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
+                        rooted_resop_box(Type::Int, 0),
                         BoxRef::from_opref(OpRef::const_int(1)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(19));
                 op
             },
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(19))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 19)]),
         ];
 
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -7540,8 +7538,8 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
                 ],
             );
             op.pos.set(OpRef::int_op(3));
@@ -7552,8 +7550,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntMul,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(50)),
-                        BoxRef::from_opref(OpRef::int_op(10)),
+                        rooted_resop_box(Type::Int, 50),
+                        rooted_resop_box(Type::Int, 10),
                     ],
                 );
                 op.pos.set(OpRef::int_op(1));
@@ -7562,8 +7560,8 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(10)),
-                    BoxRef::from_opref(OpRef::int_op(50)),
+                    rooted_resop_box(Type::Int, 10),
+                    rooted_resop_box(Type::Int, 50),
                 ],
             ),
         ];
@@ -7578,7 +7576,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: BoxRef::from_opref(OpRef::int_op(10)),
+                same_as_source: rooted_resop_box(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecAssoc::new(),
@@ -7613,7 +7611,7 @@ mod tests {
         // immediate, and the box-namespace entries in the constants
         // snapshot must round-trip unchanged.
         let p1_ops = vec![{
-            let mut op = Op::new(OpCode::SameAsI, &[BoxRef::from_opref(OpRef::int_op(37))]);
+            let mut op = Op::new(OpCode::SameAsI, &[rooted_resop_box(Type::Int, 37)]);
             op.pos.set(OpRef::void_op(857));
             op
         }];
@@ -7622,20 +7620,20 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::GuardValue,
                     &[
-                        BoxRef::from_opref(OpRef::void_op(857)),
+                        rooted_resop_box(Type::Void, 857),
                         BoxRef::from_opref(OpRef::const_int(2)),
                     ],
                 );
-                op.setfailargs(vec![BoxRef::from_opref(OpRef::void_op(857))].into());
+                op.setfailargs(vec![rooted_resop_box(Type::Void, 857)].into());
                 op
             },
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(10)),
-                    BoxRef::from_opref(OpRef::int_op(853)),
-                    BoxRef::from_opref(OpRef::void_op(857)),
-                    BoxRef::from_opref(OpRef::int_op(850)),
+                    rooted_resop_box(Type::Int, 10),
+                    rooted_resop_box(Type::Int, 853),
+                    rooted_resop_box(Type::Void, 857),
+                    rooted_resop_box(Type::Int, 850),
                 ],
             ),
         ];
@@ -7715,10 +7713,7 @@ mod tests {
         // pre-replaced with OpRef::int_op(10) (the corresponding label_arg).
         let p2_ops = vec![
             {
-                let mut op = Op::new(
-                    OpCode::GetfieldGcPureI,
-                    &[BoxRef::from_opref(OpRef::int_op(50))],
-                );
+                let mut op = Op::new(OpCode::GetfieldGcPureI, &[rooted_resop_box(Type::Int, 50)]);
                 op.pos.set(OpRef::int_op(1));
                 op.setdescr(majit_ir::make_field_descr(
                     0,
@@ -7731,8 +7726,8 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(10)),
-                    BoxRef::from_opref(OpRef::int_op(50)),
+                    rooted_resop_box(Type::Int, 10),
+                    rooted_resop_box(Type::Int, 50),
                 ],
             ),
         ];
@@ -7747,7 +7742,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: BoxRef::from_opref(OpRef::int_op(10)),
+                same_as_source: rooted_resop_box(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecAssoc::new(),
@@ -7790,22 +7785,22 @@ mod tests {
         // it reaches the assembler. We mirror that here.
         let p2_ops = vec![
             {
-                let mut op = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(64))]);
-                op.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(64))].into());
+                let mut op = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 64)]);
+                op.setfailargs(vec![rooted_resop_box(Type::Int, 64)].into());
                 op
             },
             {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(10)),
+                        rooted_resop_box(Type::Int, 10),
                         BoxRef::from_opref(OpRef::const_int(1)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(64));
                 op
             },
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(64))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 64)]),
         ];
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
@@ -7861,11 +7856,11 @@ mod tests {
             let mut jump = Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(4)),
+                    rooted_resop_box(Type::Int, 0),
+                    rooted_resop_box(Type::Int, 1),
+                    rooted_resop_box(Type::Int, 2),
+                    rooted_resop_box(Type::Int, 3),
+                    rooted_resop_box(Type::Int, 4),
                 ],
             );
             jump.setdescr(start_descr.clone());
@@ -7924,8 +7919,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
+                        rooted_resop_box(Type::Int, 0),
+                        rooted_resop_box(Type::Int, 1),
                     ],
                 );
                 op.pos.set(OpRef::int_op(2));
@@ -7935,8 +7930,8 @@ mod tests {
                 let mut jump = Op::new(
                     OpCode::Jump,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
+                        rooted_resop_box(Type::Int, 0),
+                        rooted_resop_box(Type::Int, 1),
                     ],
                 );
                 jump.setdescr(start_descr.clone());
@@ -7978,7 +7973,7 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(10)),
+                        rooted_resop_box(Type::Int, 10),
                         BoxRef::from_opref(OpRef::const_int(1)),
                     ],
                 );
@@ -7989,9 +7984,9 @@ mod tests {
                 let mut jump = Op::new(
                     OpCode::Jump,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(10)),
-                        BoxRef::from_opref(OpRef::int_op(50)),
-                        BoxRef::from_opref(OpRef::int_op(60)),
+                        rooted_resop_box(Type::Int, 10),
+                        rooted_resop_box(Type::Int, 50),
+                        rooted_resop_box(Type::Int, 60),
                     ],
                 );
                 jump.setdescr(start_descr.clone());
@@ -8053,11 +8048,11 @@ mod tests {
             Op::new(
                 OpCode::SetfieldGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
+                    rooted_resop_box(Type::Ref, 1),
+                    rooted_resop_box(Type::Int, 0),
                 ],
             ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
         ];
         let constants = majit_ir::VecAssoc::from([
             (2_u32, majit_ir::Value::Int(606)),
@@ -8098,10 +8093,7 @@ mod tests {
         // sites). Mirrors `assemble_peeled_trace_with_jump_args`'s
         // `label_arg.is_constant()` predicate.
         let const_extra = OpRef::const_int(606);
-        let p2_ops = vec![Op::new(
-            OpCode::Jump,
-            &[BoxRef::from_opref(OpRef::int_op(10))],
-        )];
+        let p2_ops = vec![Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 10)])];
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
         let combined = assemble_peeled_trace(
@@ -8143,14 +8135,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(200)),
+                        rooted_resop_box(Type::Int, 200),
                         BoxRef::from_opref(OpRef::const_int(1)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(20));
                 op
             },
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(200))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 200)]),
         ];
 
         let combined = assemble_peeled_trace(
@@ -8196,26 +8188,26 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        BoxRef::from_opref(OpRef::int_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
+                        rooted_resop_box(Type::Int, 0),
+                        rooted_resop_box(Type::Int, 1),
                     ],
                 );
                 op.pos.set(OpRef::void_op(3));
                 op
             },
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
         ];
         let redirected_tail = vec![
             {
-                let mut op = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::void_op(3))]);
-                op.setfailargs(vec![BoxRef::from_opref(OpRef::void_op(3))].into());
+                let mut op = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Void, 3)]);
+                op.setfailargs(vec![rooted_resop_box(Type::Void, 3)].into());
                 op
             },
             Op::new(
                 OpCode::Jump,
                 &[
-                    BoxRef::from_opref(OpRef::void_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(4)),
+                    rooted_resop_box(Type::Void, 3),
+                    rooted_resop_box(Type::Int, 4),
                 ],
             ),
         ];
@@ -8243,9 +8235,9 @@ mod tests {
         let ops = vec![Op::new(
             OpCode::Jump,
             &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-                BoxRef::from_opref(OpRef::int_op(2)),
+                rooted_resop_box(Type::Int, 0),
+                rooted_resop_box(Type::Int, 1),
+                rooted_resop_box(Type::Int, 2),
             ],
         )];
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -721,6 +721,7 @@ impl UnrollOptimizer {
                             short_preamble: None,
                             renamed_inputargs: state.renamed_inputargs.clone(),
                             short_inputargs: Vec::new(),
+                            short_inputarg_refs: Vec::new(),
                             runtime_boxes: Vec::new(),
                             patchguardop: None,
                             phase1_emit_high_water: self.next_global_opref,
@@ -2016,6 +2017,14 @@ pub struct ExportedState {
     /// objects themselves (shortpreamble.py:430 / unroll.py:480), shared
     /// with the renamed operands inside `short_boxes`.
     pub short_inputargs: Vec<crate::r#box::BoxRef>,
+    /// Rooted `InputArgRc` carriers for `short_inputargs`, index-aligned.
+    /// Each `short_inputargs[i]` box holds a WEAK handle to
+    /// `short_inputarg_refs[i]`; keeping the strong Rc alive across the
+    /// cross-peel export boundary lets the box resolve to a real bound
+    /// `InputArg` in the rebuilt Phase-2 OptContext, so dependent operands
+    /// bind to `Operand::InputArg` rather than the position-only
+    /// `Operand::Box` catch-all.
+    pub short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// unroll.py: runtime_boxes — live values at the original jump point.
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
     /// Default `Vec::new()` until the export site populates it; callers
@@ -2108,6 +2117,7 @@ impl ExportedState {
         exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
         renamed_inputargs: Vec<OpRef>,
         short_inputargs: Vec<crate::r#box::BoxRef>,
+        short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
         // pre-derives the per-OpRef ProducedShortOp view and stores it
@@ -2138,6 +2148,7 @@ impl ExportedState {
                 .map(|&a| BoxRef::from_opref(a))
                 .collect(),
             short_inputargs,
+            short_inputarg_refs,
             runtime_boxes: Vec::new(),
             patchguardop: None,
             phase1_emit_high_water: 0,
@@ -2665,6 +2676,7 @@ impl Clone for ExportedState {
             short_preamble: self.short_preamble.clone(),
             renamed_inputargs: self.renamed_inputargs.clone(),
             short_inputargs: self.short_inputargs.clone(),
+            short_inputarg_refs: self.short_inputarg_refs.clone(),
             runtime_boxes: self.runtime_boxes.clone(),
             patchguardop: self.patchguardop.clone(),
             phase1_emit_high_water: self.phase1_emit_high_water,
@@ -3018,22 +3030,30 @@ impl OptUnroll {
         // `label_args + virtuals` (measured identical across the corpus);
         // paths that never ran the preview (test ExportedState setups) fall
         // back to the local recompute.
-        let short_inputargs: Vec<crate::r#box::BoxRef> = if ctx.exported_short_inputargs.is_empty()
-        {
+        let (short_inputargs, short_inputarg_refs): (
+            Vec<crate::r#box::BoxRef>,
+            Vec<majit_ir::InputArgRc>,
+        ) = if ctx.exported_short_inputargs.is_empty() {
             // No preview pass ran (test ExportedState setups): mint the fresh
             // renamed InputArg boxes directly, mirroring `add_short_input_arg`
             // (shortpreamble.py:257 `OpHelpers.inputarg_from_tp(box.type)`).
             // Each is DISTINCT from its `short_args[i]` original so the rename
-            // is a real rename, not an identity no-op.
-            short_args
-                .iter()
-                .map(|&a| {
-                    let ty = a.ty().unwrap_or_else(|| {
-                        panic!("short preamble inputarg {a:?} has no value type")
-                    });
-                    crate::r#box::BoxRef::new_inputarg(ty, ctx.alloc_op_position_typed(ty).raw())
-                })
-                .collect()
+            // is a real rename, not an identity no-op. Build the rooted
+            // `InputArgRc` pool alongside (same shape as the preview pass) so
+            // the boxes stay bound to live `InputArg`s instead of shedding to
+            // the position-only `Operand::Box` catch-all.
+            let mut boxes = Vec::with_capacity(short_args.len());
+            let mut refs = Vec::with_capacity(short_args.len());
+            for &a in &short_args {
+                let ty = a
+                    .ty()
+                    .unwrap_or_else(|| panic!("short preamble inputarg {a:?} has no value type"));
+                let pos = ctx.alloc_op_position_typed(ty).raw();
+                let ia = majit_ir::InputArg::from_type_rc(ty, pos);
+                boxes.push(crate::r#box::BoxRef::from_bound_inputarg(&ia));
+                refs.push(ia);
+            }
+            (boxes, refs)
         } else {
             debug_assert_eq!(
                 ctx.exported_short_inputargs.len(),
@@ -3041,7 +3061,16 @@ impl OptUnroll {
                 "preview-pass create_short_inputargs length diverged from the \
                      export-site label_args + virtuals recompute"
             );
-            ctx.exported_short_inputargs.clone()
+            debug_assert_eq!(
+                ctx.exported_short_inputarg_refs.len(),
+                ctx.exported_short_inputargs.len(),
+                "exported_short_inputarg_refs must stay index-aligned with \
+                     exported_short_inputargs"
+            );
+            (
+                ctx.exported_short_inputargs.clone(),
+                ctx.exported_short_inputarg_refs.clone(),
+            )
         };
         let exported_short_boxes = ctx.exported_short_boxes.clone();
         // unroll.py:466-473 line-by-line:
@@ -3121,6 +3150,7 @@ impl OptUnroll {
             exported_short_boxes,
             renamed_inputargs.to_vec(),
             short_inputargs,
+            short_inputarg_refs,
         );
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
         // Phase 1 allocated, including intermediates folded / forwarded
@@ -5697,6 +5727,9 @@ mod tests {
             Vec::new(),
             vec![OpRef::int_op(14)],
             vec![BoxRef::from_opref(OpRef::int_op(23))],
+            // short_inputarg_refs: these test boxes are position-only
+            // `from_opref` (unbound), so no rooted InputArgRc pool.
+            Vec::new(),
         );
 
         assert_eq!(exported.opref_high_water(), 110);
@@ -5945,6 +5978,8 @@ mod tests {
             }],
             vec![old_ref],
             vec![BoxRef::from_opref(old_ref)],
+            // short_inputarg_refs: test box is position-only `from_opref`.
+            Vec::new(),
         );
         state.short_boxes.push((
             old_ref,
@@ -6948,6 +6983,8 @@ mod tests {
             }],
             Vec::new(),
             vec![BoxRef::from_opref(source)],
+            // short_inputarg_refs: test box is position-only `from_opref`.
+            Vec::new(),
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
             8,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2962,7 +2962,10 @@ impl OptUnroll {
         optimizer: &mut crate::optimizeopt::optimizer::Optimizer,
         ctx: &mut OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<
+                BoxRef,
+                crate::optimizeopt::intutils::IntBound,
+            >,
         >,
     ) -> ExportedState {
         // unroll.py:454: end_args = [force_at_the_end_of_preamble(a) ...]
@@ -3253,7 +3256,10 @@ impl OptUnroll {
         arg_box: &BoxRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<
+                BoxRef,
+                crate::optimizeopt::intutils::IntBound,
+            >,
         >,
         infos: &mut crate::optimizeopt::vec_assoc::VecAssoc<
             BoxRef,
@@ -3301,7 +3307,10 @@ impl OptUnroll {
         opref: OpRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<
+                BoxRef,
+                crate::optimizeopt::intutils::IntBound,
+            >,
         >,
         infos: &mut crate::optimizeopt::vec_assoc::VecAssoc<
             BoxRef,
@@ -4350,7 +4359,10 @@ impl OptUnroll {
         opref: OpRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<
+                BoxRef,
+                crate::optimizeopt::intutils::IntBound,
+            >,
         >,
     ) -> Option<crate::optimizeopt::info::OpInfo> {
         use crate::optimizeopt::info::{OpInfo, PtrInfo};

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2950,7 +2950,7 @@ impl OptUnroll {
         optimizer: &mut crate::optimizeopt::optimizer::Optimizer,
         ctx: &mut OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
         >,
     ) -> ExportedState {
         // unroll.py:454: end_args = [force_at_the_end_of_preamble(a) ...]
@@ -3223,7 +3223,7 @@ impl OptUnroll {
         arg_box: &BoxRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
         >,
         infos: &mut crate::optimizeopt::vec_assoc::VecAssoc<
             BoxRef,
@@ -3271,7 +3271,7 @@ impl OptUnroll {
         opref: OpRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
         >,
         infos: &mut crate::optimizeopt::vec_assoc::VecAssoc<
             BoxRef,
@@ -4320,7 +4320,7 @@ impl OptUnroll {
         opref: OpRef,
         ctx: &OptContext,
         exported_int_bounds: Option<
-            &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
+            &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
         >,
     ) -> Option<crate::optimizeopt::info::OpInfo> {
         use crate::optimizeopt::info::{OpInfo, PtrInfo};
@@ -4389,7 +4389,12 @@ impl OptUnroll {
         // to attach `OpInfo::IntBound` alongside `OpInfo::Ptr` so this
         // branch becomes redundant and the side-table parameter
         // disappears.
-        if let Some(bound) = exported_int_bounds.and_then(|bounds| bounds.get(&resolved).cloned()) {
+        if let Some(bound) = exported_int_bounds.and_then(|bounds| {
+            // Same Phase-1 ctx as the export producer, so the canonical box for
+            // `opref` is the memoized `Rc` the bound was keyed under (ptr_eq).
+            ctx.get_box_replacement_box(opref)
+                .and_then(|b| bounds.get(&b).cloned())
+        }) {
             return Some(OpInfo::int_bound(bound));
         }
         None
@@ -4425,7 +4430,7 @@ pub(crate) fn export_state(
     optimizer: &mut crate::optimizeopt::optimizer::Optimizer,
     ctx: &mut OptContext,
     exported_int_bounds: Option<
-        &crate::optimizeopt::vec_assoc::VecAssoc<OpRef, crate::optimizeopt::intutils::IntBound>,
+        &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
     >,
 ) -> ExportedState {
     OptUnroll::new().export_state_with_bounds(
@@ -6628,13 +6633,18 @@ mod tests {
         use crate::optimizeopt::intutils::IntBound;
 
         let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(4, 0);
-        let mut exported_bounds: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, IntBound> =
+        let mut exported_bounds: crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, IntBound> =
             crate::optimizeopt::vec_assoc::VecAssoc::new();
-        exported_bounds.insert(OpRef::int_op(21), IntBound::bounded(10, 20));
         // Bind the export-input position at its source (a forced end-arg is a
         // bound box in production); virtualstate.py:711-720 create_state
         // receives real AbstractValues.
         ctx.materialize_box_at(OpRef::int_op(21));
+        // Key by the canonical box identity the consumer resolves `int_op(21)`
+        // to, so the BoxRef-keyed lookup hits by `Rc::ptr_eq`.
+        let box21 = ctx
+            .get_box_replacement_box(OpRef::int_op(21))
+            .expect("int_op(21) bound to a box");
+        exported_bounds.insert(box21, IntBound::bounded(10, 20));
 
         let exported = export_state(
             &[OpRef::int_op(21)],

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6781,9 +6781,21 @@ mod tests {
         // ops carry the renamed box in their args (not the original label
         // arg). Seed the two slot boxes and use slot 0 — the GETFIELD
         // receiver, whose original is int_op(10).
-        let si0 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
-        let si1 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        // Bound (not position-only) short_inputarg boxes rooted by an
+        // index-aligned `InputArgRc` pool, mirroring production
+        // (optimizer.rs:2937/2942 set `exported_short_inputargs` and
+        // `exported_short_inputarg_refs` in lockstep); the boxes shed to
+        // `Operand::InputArg` instead of the position-only `Operand::Box`.
+        let (si0, ia0) = crate::r#box::test_support::bound_inputarg_box(
+            Type::Int,
+            ctx.alloc_op_position_typed(Type::Int).raw(),
+        );
+        let (si1, ia1) = crate::r#box::test_support::bound_inputarg_box(
+            Type::Int,
+            ctx.alloc_op_position_typed(Type::Int).raw(),
+        );
         ctx.exported_short_inputargs = vec![si0.clone(), si1];
+        ctx.exported_short_inputarg_refs = vec![ia0, ia1];
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
@@ -7234,10 +7246,24 @@ mod tests {
         // 12/13/14) and rename the IntAdd operands to slots 0/1. The
         // `same_as_source` alias is a ProducedShortOp field, not an op arg,
         // so it keeps its original (int_op(14)).
-        let si0 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
-        let si1 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
-        let si2 = BoxRef::new_inputarg(Type::Int, ctx.alloc_op_position_typed(Type::Int).raw());
+        // Bound short_inputarg boxes rooted by an index-aligned `InputArgRc`
+        // pool, matching production (optimizer.rs:2937/2942 set
+        // `exported_short_inputargs` / `exported_short_inputarg_refs` in
+        // lockstep); the IntAdd operands then shed to `Operand::InputArg`.
+        let (si0, ia0) = crate::r#box::test_support::bound_inputarg_box(
+            Type::Int,
+            ctx.alloc_op_position_typed(Type::Int).raw(),
+        );
+        let (si1, ia1) = crate::r#box::test_support::bound_inputarg_box(
+            Type::Int,
+            ctx.alloc_op_position_typed(Type::Int).raw(),
+        );
+        let (si2, ia2) = crate::r#box::test_support::bound_inputarg_box(
+            Type::Int,
+            ctx.alloc_op_position_typed(Type::Int).raw(),
+        );
         ctx.exported_short_inputargs = vec![si0.clone(), si1.clone(), si2];
+        ctx.exported_short_inputarg_refs = vec![ia0, ia1, ia2];
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1782,7 +1782,29 @@ impl Optimization for VectorizingOptimizer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use majit_ir::{Op, OpCode, OpRef};
+    use majit_ir::{Op, OpCode, OpRef, Type};
+
+    /// oparser-faithful op-arg / fail-arg box for the position-keyed VectorLoop
+    /// fixtures (`rpython/jit/tool/oparser.py`): an `OpRef` that names a producer
+    /// position becomes a rooted bound `BoxRef` (`Operand::Op` / `Operand::InputArg`)
+    /// whose `to_opref()` is byte-identical to the original `OpRef`, so the
+    /// `assign_positions` / `to_opref`-keyed assertions are unchanged; constants and
+    /// `None` shed to `Operand::Const` / none as before. Replaces the position-only
+    /// `BoxRef::from_opref` that minted `Operand::Box` at `Op::new`.
+    fn bx(r: OpRef) -> BoxRef {
+        use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
+        match r {
+            OpRef::InputArgInt(n) => rooted_inputarg_box(Type::Int, n),
+            OpRef::InputArgFloat(n) => rooted_inputarg_box(Type::Float, n),
+            OpRef::InputArgRef(n) => rooted_inputarg_box(Type::Ref, n),
+            OpRef::IntOp(n) => rooted_resop_box(Type::Int, n),
+            OpRef::FloatOp(n) => rooted_resop_box(Type::Float, n),
+            OpRef::RefOp(n) => rooted_resop_box(Type::Ref, n),
+            OpRef::VoidOp(n) => rooted_resop_box(Type::Void, n),
+            // Const* / None shed to Operand::Const / none — no Operand::Box mint.
+            _ => BoxRef::from_opref(r),
+        }
+    }
 
     fn assign_positions(ops: &mut [Op], base: u32) {
         for (i, op) in ops.iter_mut().enumerate() {
@@ -1798,30 +1820,18 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
-            Op::new(
-                OpCode::Label,
-                &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-            ),
+            Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(100))]),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                ],
+                &[bx(OpRef::int_op(2)), bx(OpRef::input_arg_int(102))],
             ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(3))]),
+            Op::new(OpCode::Jump, &[bx(OpRef::int_op(3))]),
         ];
         for (i, op) in ops.iter_mut().enumerate() {
             op.pos.set(OpRef::op_typed(i as u32, op.result_type()));
@@ -1835,18 +1845,12 @@ mod tests {
 
     #[test]
     fn test_vector_loop_new() {
-        let label = Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-        );
+        let label = Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(100))]);
         let ops = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         )];
-        let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]);
+        let jump = Op::new(OpCode::Jump, &[bx(OpRef::int_op(0))]);
         let vloop = VectorLoop::new(label, ops, jump);
         assert_eq!(vloop.body_len(), 1);
         assert_eq!(vloop.inputargs, vec![OpRef::input_arg_int(100)]);
@@ -1857,18 +1861,12 @@ mod tests {
 
     #[test]
     fn test_vector_loop_finaloplist() {
-        let label = Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-        );
+        let label = Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(100))]);
         let ops = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         )];
-        let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]);
+        let jump = Op::new(OpCode::Jump, &[bx(OpRef::int_op(0))]);
         let vloop = VectorLoop::new(label, ops, jump);
 
         let mut state = VecScheduleState::new(0);
@@ -1891,25 +1889,16 @@ mod tests {
         // loop: label(i0, i1) { i_add } jump(i0, i1)
         let label = Op::new(
             OpCode::Label,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         );
         let mut body = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         )];
         assign_positions(&mut body, 10);
         let jump = Op::new(
             OpCode::Jump,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         );
         let mut vloop = VectorLoop::new(label, body.clone(), jump);
 
@@ -1987,24 +1976,15 @@ mod tests {
 
         let label = Op::new(
             OpCode::Label,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         );
         let body = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         )];
         let jump = Op::new(
             OpCode::Jump,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         );
         let mut vloop = VectorLoop::new(label, body.clone(), jump);
 
@@ -2032,18 +2012,12 @@ mod tests {
     /// INT_SIGNEXT.
     #[test]
     fn int_signext_setup_resolves_inline_const_in_standalone_pass() {
-        let label = Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
+        let label = Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(0))]);
         let signext = Op::new(
             OpCode::IntSignext,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::const_int(4)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::const_int(4))],
         );
-        let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]);
+        let jump = Op::new(OpCode::Jump, &[bx(OpRef::input_arg_int(0))]);
         let mut body = vec![signext];
         assign_positions(&mut body, 10);
         let vloop = VectorLoop::new(label, body, jump);
@@ -2070,43 +2044,25 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::Label,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(104)),
-                    BoxRef::from_opref(OpRef::input_arg_int(105)),
-                ],
+                &[bx(OpRef::input_arg_int(104)), bx(OpRef::input_arg_int(105))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(106)),
-                    BoxRef::from_opref(OpRef::input_arg_int(107)),
-                ],
+                &[bx(OpRef::input_arg_int(106)), bx(OpRef::input_arg_int(107))],
             ),
-            Op::new(
-                OpCode::Jump,
-                &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-            ),
+            Op::new(OpCode::Jump, &[bx(OpRef::input_arg_int(100))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -2145,11 +2101,8 @@ mod tests {
 
         fn run(member_in_seen: bool) -> (OpRef, bool) {
             let member_ref = OpRef::int_op(7); // scalar result folded into a pack
-            let label = Op::new(
-                OpCode::Label,
-                &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-            );
-            let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(member_ref)]);
+            let label = Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(0))]);
+            let jump = Op::new(OpCode::Jump, &[bx(member_ref)]);
             let mut vloop = VectorLoop::new(label, Vec::new(), jump);
 
             let mut st = VecScheduleState::new(100);
@@ -2217,18 +2170,12 @@ mod tests {
     /// at its pre-vectorize shape.
     #[test]
     fn test_optimize_vector_snapshots_single_version_and_restores_on_bail() {
-        let label = Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
+        let label = Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(0))]);
         let body = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[bx(OpRef::input_arg_int(0)), bx(OpRef::input_arg_int(1))],
         )];
-        let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]);
+        let jump = Op::new(OpCode::Jump, &[bx(OpRef::int_op(0))]);
         let mut vloop = VectorLoop::new(label, body, jump);
         let before_len = vloop.operations.len();
 
@@ -2283,68 +2230,31 @@ mod tests {
         //  7: s1 = IntAdd   [a1, b1]          (pairs with s0 via follow_def_uses)
         //  8: Jump [i, s0, s1]                (carry sums so they live)
         let mut all = vec![
-            Op::new(
-                OpCode::Label,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(base1),
-                    BoxRef::from_opref(base2),
-                ],
-            ),
+            Op::new(OpCode::Label, &[bx(i), bx(base1), bx(base2)]),
+            Op::with_descr(OpCode::RawLoadI, &[bx(base1), bx(i)], descr.clone()),
+            Op::new(OpCode::IntAdd, &[bx(i), bx(OpRef::const_int(8))]),
             Op::with_descr(
                 OpCode::RawLoadI,
-                &[BoxRef::from_opref(base1), BoxRef::from_opref(i)],
+                &[bx(base1), bx(OpRef::int_op(2))],
+                descr.clone(),
+            ),
+            Op::with_descr(OpCode::RawLoadI, &[bx(base2), bx(i)], descr.clone()),
+            Op::with_descr(
+                OpCode::RawLoadI,
+                &[bx(base2), bx(OpRef::int_op(2))],
                 descr.clone(),
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(OpRef::const_int(8)),
-                ],
-            ),
-            Op::with_descr(
-                OpCode::RawLoadI,
-                &[
-                    BoxRef::from_opref(base1),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-                descr.clone(),
-            ),
-            Op::with_descr(
-                OpCode::RawLoadI,
-                &[BoxRef::from_opref(base2), BoxRef::from_opref(i)],
-                descr.clone(),
-            ),
-            Op::with_descr(
-                OpCode::RawLoadI,
-                &[
-                    BoxRef::from_opref(base2),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-                descr.clone(),
+                &[bx(OpRef::int_op(1)), bx(OpRef::int_op(4))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(5)),
-                ],
+                &[bx(OpRef::int_op(3)), bx(OpRef::int_op(5))],
             ),
             Op::new(
                 OpCode::Jump,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(OpRef::int_op(6)),
-                    BoxRef::from_opref(OpRef::int_op(7)),
-                ],
+                &[bx(i), bx(OpRef::int_op(6)), bx(OpRef::int_op(7))],
             ),
         ];
         assign_positions(&mut all, 0);
@@ -2401,26 +2311,11 @@ mod tests {
         let i = OpRef::input_arg_int(0);
         let j = OpRef::input_arg_int(1);
         let mut assembled = vec![
-            Op::new(
-                OpCode::Label,
-                &[BoxRef::from_opref(i), BoxRef::from_opref(j)],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(OpRef::const_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::Label,
-                &[BoxRef::from_opref(i), BoxRef::from_opref(j)],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[BoxRef::from_opref(i), BoxRef::from_opref(j)],
-            ),
-            Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(3))]),
+            Op::new(OpCode::Label, &[bx(i), bx(j)]),
+            Op::new(OpCode::IntAdd, &[bx(i), bx(OpRef::const_int(1))]),
+            Op::new(OpCode::Label, &[bx(i), bx(j)]),
+            Op::new(OpCode::IntAdd, &[bx(i), bx(j)]),
+            Op::new(OpCode::Jump, &[bx(OpRef::int_op(3))]),
         ];
         assign_positions(&mut assembled, 0);
 
@@ -2467,83 +2362,33 @@ mod tests {
         //  9: s1 = IntAdd   [int_op(5), int_op(7)]
         // 10: jump JUMP [i, int_op(8), int_op(9)]
         let mut assembled = vec![
-            Op::new(
-                OpCode::Label,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(base1),
-                    BoxRef::from_opref(base2),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(OpRef::const_int(1)),
-                ],
-            ),
-            Op::new(
-                OpCode::Label,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(base1),
-                    BoxRef::from_opref(base2),
-                ],
-            ),
+            Op::new(OpCode::Label, &[bx(i), bx(base1), bx(base2)]),
+            Op::new(OpCode::IntAdd, &[bx(i), bx(OpRef::const_int(1))]),
+            Op::new(OpCode::Label, &[bx(i), bx(base1), bx(base2)]),
+            Op::with_descr(OpCode::RawLoadI, &[bx(base1), bx(i)], descr.clone()),
+            Op::new(OpCode::IntAdd, &[bx(i), bx(OpRef::const_int(8))]),
             Op::with_descr(
                 OpCode::RawLoadI,
-                &[BoxRef::from_opref(base1), BoxRef::from_opref(i)],
+                &[bx(base1), bx(OpRef::int_op(4))],
+                descr.clone(),
+            ),
+            Op::with_descr(OpCode::RawLoadI, &[bx(base2), bx(i)], descr.clone()),
+            Op::with_descr(
+                OpCode::RawLoadI,
+                &[bx(base2), bx(OpRef::int_op(4))],
                 descr.clone(),
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(OpRef::const_int(8)),
-                ],
-            ),
-            Op::with_descr(
-                OpCode::RawLoadI,
-                &[
-                    BoxRef::from_opref(base1),
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                ],
-                descr.clone(),
-            ),
-            Op::with_descr(
-                OpCode::RawLoadI,
-                &[BoxRef::from_opref(base2), BoxRef::from_opref(i)],
-                descr.clone(),
-            ),
-            Op::with_descr(
-                OpCode::RawLoadI,
-                &[
-                    BoxRef::from_opref(base2),
-                    BoxRef::from_opref(OpRef::int_op(4)),
-                ],
-                descr.clone(),
+                &[bx(OpRef::int_op(3)), bx(OpRef::int_op(6))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(6)),
-                ],
-            ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(5)),
-                    BoxRef::from_opref(OpRef::int_op(7)),
-                ],
+                &[bx(OpRef::int_op(5)), bx(OpRef::int_op(7))],
             ),
             Op::new(
                 OpCode::Jump,
-                &[
-                    BoxRef::from_opref(i),
-                    BoxRef::from_opref(OpRef::int_op(8)),
-                    BoxRef::from_opref(OpRef::int_op(9)),
-                ],
+                &[bx(i), bx(OpRef::int_op(8)), bx(OpRef::int_op(9))],
             ),
         ];
         assign_positions(&mut assembled, 0);
@@ -2596,18 +2441,12 @@ mod tests {
         use crate::optimizeopt::optimizer::Optimizer;
 
         let mut ops = vec![
-            Op::new(
-                OpCode::Label,
-                &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-            ),
+            Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(100))]),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(1))]),
+            Op::new(OpCode::Finish, &[bx(OpRef::int_op(1))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -2632,18 +2471,12 @@ mod tests {
 
     #[test]
     fn test_user_loop_bail_fast_path_no_array() {
-        let label = Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-        );
+        let label = Op::new(OpCode::Label, &[bx(OpRef::input_arg_int(100))]);
         let ops = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         )];
-        let jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(0))]);
+        let jump = Op::new(OpCode::Jump, &[bx(OpRef::int_op(0))]);
         let vloop = VectorLoop::new(label, ops, jump);
         // vector.py:183 initializes at_least_one_array_access = True and only
         // re-assigns True, so the "no array access" branch is unreachable.
@@ -2658,24 +2491,15 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -2690,10 +2514,7 @@ mod tests {
     fn test_dep_graph_no_self_dep() {
         let mut ops = vec![Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
         )];
         assign_positions(&mut ops, 0);
 
@@ -2708,17 +2529,11 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -2737,17 +2552,11 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -2762,17 +2571,11 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -2789,24 +2592,15 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(104)),
-                    BoxRef::from_opref(OpRef::input_arg_int(105)),
-                ],
+                &[bx(OpRef::input_arg_int(104)), bx(OpRef::input_arg_int(105))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -2907,12 +2701,9 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
-            Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(0))]),
+            Op::new(OpCode::Finish, &[bx(OpRef::int_op(0))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -2930,32 +2721,17 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::Label,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
-            ),
+            Op::new(OpCode::Jump, &[bx(OpRef::int_op(1)), bx(OpRef::int_op(2))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -2974,24 +2750,15 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(1)), bx(OpRef::input_arg_int(101))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3012,17 +2779,11 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3040,31 +2801,19 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(1)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3083,31 +2832,19 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntMul,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntSub,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(102))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                ],
+                &[bx(OpRef::int_op(1)), bx(OpRef::int_op(2))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3196,17 +2933,11 @@ mod tests {
         let mut state = VecScheduleState::new(0);
         let a = Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         );
         let b = Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(102)),
-                BoxRef::from_opref(OpRef::input_arg_int(103)),
-            ],
+            &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
         );
         assert!(isomorphic(&mut state, &a, &b));
     }
@@ -3216,17 +2947,11 @@ mod tests {
         let mut state = VecScheduleState::new(0);
         let a = Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         );
         let b = Op::new(
             OpCode::IntSub,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(102)),
-                BoxRef::from_opref(OpRef::input_arg_int(103)),
-            ],
+            &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
         );
         assert!(!isomorphic(&mut state, &a, &b));
     }
@@ -3236,17 +2961,11 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3267,17 +2986,11 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::int_op(0)), bx(OpRef::input_arg_int(101))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3295,31 +3008,19 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(200)),
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                ],
+                &[bx(OpRef::input_arg_int(200)), bx(OpRef::int_op(0))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(2)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
+                &[bx(OpRef::int_op(2)), bx(OpRef::int_op(1))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3357,24 +3058,15 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(102)),
-                    BoxRef::from_opref(OpRef::input_arg_int(103)),
-                ],
+                &[bx(OpRef::input_arg_int(102)), bx(OpRef::input_arg_int(103))],
             ),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(104)),
-                    BoxRef::from_opref(OpRef::input_arg_int(105)),
-                ],
+                &[bx(OpRef::input_arg_int(104)), bx(OpRef::input_arg_int(105))],
             ),
         ];
         assign_positions(&mut ops, 0);
@@ -3409,18 +3101,12 @@ mod tests {
     #[test]
     fn test_guard_analysis_hoistable() {
         let ops = vec![
-            Op::new(
-                OpCode::GuardTrue,
-                &[BoxRef::from_opref(OpRef::input_arg_int(100))],
-            ),
+            Op::new(OpCode::GuardTrue, &[bx(OpRef::input_arg_int(100))]),
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::input_arg_int(100)),
-                    BoxRef::from_opref(OpRef::input_arg_int(101)),
-                ],
+                &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
             ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(1))]),
+            Op::new(OpCode::GuardTrue, &[bx(OpRef::int_op(1))]),
         ];
         let mut positioned = ops;
         for (i, op) in positioned.iter_mut().enumerate() {
@@ -3456,26 +3142,17 @@ mod tests {
     fn test_unroll_loop_iterations() {
         let mut label = Op::new(
             OpCode::Label,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         );
         label.pos.set(OpRef::op_typed(0, majit_ir::Type::Void));
         let mut body_op = Op::new(
             OpCode::IntAdd,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(100)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::input_arg_int(100)), bx(OpRef::input_arg_int(101))],
         );
         body_op.pos.set(OpRef::int_op(1));
         let mut jump = Op::new(
             OpCode::Jump,
-            &[
-                BoxRef::from_opref(OpRef::int_op(1)),
-                BoxRef::from_opref(OpRef::input_arg_int(101)),
-            ],
+            &[bx(OpRef::int_op(1)), bx(OpRef::input_arg_int(101))],
         );
         jump.pos.set(OpRef::op_typed(2, majit_ir::Type::Void));
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2907,15 +2907,11 @@ mod tests {
         for op in &ops {
             // Resolve forwarded arguments
             let mut resolved_op = op.clone();
-            // optimizer.py:651-652 setarg loop parity.
-            for i in 0..resolved_op.num_args() {
-                resolved_op.setarg(
-                    i,
-                    crate::r#box::BoxRef::from_opref(
-                        ctx.resolve_box_box(&resolved_op.arg(i)).to_opref(),
-                    ),
-                );
-            }
+            // optimizer.py:651-652 setarg loop parity. `resolve_op_args`
+            // binds each arg to its canonical box (oparser object-identity),
+            // materialising and registering a bound box for any unbound
+            // position so no position-only `Operand::Box` is minted.
+            resolve_op_args(&mut resolved_op, &mut ctx);
 
             let resolved_rc = std::rc::Rc::new(resolved_op.clone());
             ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
@@ -3017,22 +3013,25 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
             field_descr,
         );
         let get_item = Op::with_descr(
             OpCode::GetarrayitemRawI,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
             ],
             arr_descr.clone(),
         );
         let get_item_again = Op::with_descr(
             OpCode::GetarrayitemRawI,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
             ],
             arr_descr,
         );
@@ -3042,21 +3041,21 @@ mod tests {
         // Route raw array reads through the GetfieldRawI result so
         // resolve_array_source() sees the producing OpRef, not the bare vable
         // inputarg.
-        let array_ptr_ref = ops[0].pos.get();
-        ops[1].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
-        ops[2].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
+        // Bind the array-element reads to the GetfieldRawI producer's bound
+        // result box (oparser object-identity); GetfieldRawI (ops[0]) is
+        // Int-typed so its result position is `OpRef::int_op(0)`.
+        let array_ptr_box =
+            crate::r#box::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
+        ops[1].setarg(0, array_ptr_box.clone());
+        ops[2].setarg(0, array_ptr_box.clone());
 
         for op in &ops {
             let mut resolved = op.clone();
-            // optimizer.py:651-652 setarg loop parity.
-            for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    crate::r#box::BoxRef::from_opref(
-                        ctx.resolve_box_box(&resolved.arg(i)).to_opref(),
-                    ),
-                );
-            }
+            // optimizer.py:651-652 setarg loop parity. `resolve_op_args`
+            // binds each arg to its canonical box (oparser object-identity),
+            // materialising and registering a bound box for any unbound
+            // position so no position-only `Operand::Box` is minted.
+            resolve_op_args(&mut resolved, &mut ctx);
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
@@ -3106,9 +3105,9 @@ mod tests {
         let mut call = Op::new(
             OpCode::CallMayForceI,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_int(1)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
             ],
         );
         call.setdescr(majit_ir::descr::make_call_descr(
@@ -3154,7 +3153,10 @@ mod tests {
 
         let mut get = Op::new(
             OpCode::GetfieldRawI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
         );
         get.setdescr(test_vable_field_descr(8, Type::Int, 1));
         get.pos.set(OpRef::int_op(10));
@@ -3183,8 +3185,8 @@ mod tests {
         let mut set = Op::new(
             OpCode::SetfieldRaw,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_int(1)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
             ],
         );
         set.setdescr(test_vable_field_descr(8, Type::Int, 1));
@@ -3260,7 +3262,10 @@ mod tests {
 
         let mut get_field = Op::new(
             OpCode::GetfieldRawI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
         );
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
@@ -3274,8 +3279,8 @@ mod tests {
         let mut get_item = Op::new(
             OpCode::GetarrayitemRawI,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(10)),
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_int(1)),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
             ],
         );
         get_item.setdescr(array_descr(24));
@@ -3303,7 +3308,10 @@ mod tests {
 
         let mut get_field = Op::new(
             OpCode::GetfieldRawI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
         );
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
@@ -3317,9 +3325,9 @@ mod tests {
         let mut set_item = Op::new(
             OpCode::SetarrayitemRaw,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(10)),
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_int(1)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(2)),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 2),
             ],
         );
         set_item.setdescr(array_descr(24));
@@ -3359,23 +3367,26 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
             field_descr,
         );
         let set_item = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
             ],
             arr_descr.clone(),
         );
         let get_item = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
             ],
             arr_descr,
         );
@@ -3384,23 +3395,20 @@ mod tests {
         assign_positions(&mut ops);
         // Route the array element ops through the GetfieldRawI result so
         // resolve_array_source() sees the producing OpRef, not the bare
-        // vable inputarg.
-        let array_ptr_ref = ops[0].pos.get();
-        ops[1].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
-        ops[2].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
+        // vable inputarg. GetfieldRawI (ops[0]) is Int-typed so its result
+        // position is `OpRef::int_op(0)`.
+        let array_ptr_box =
+            crate::r#box::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
+        ops[1].setarg(0, array_ptr_box.clone());
+        ops[2].setarg(0, array_ptr_box.clone());
 
         for op in &ops {
             let mut resolved = op.clone();
-            // optimizer.py:651-652 setarg loop parity.
-            for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement(resolved.arg(i).to_opref())
-                            .to_opref(),
-                    ),
-                );
-            }
+            // optimizer.py:651-652 setarg loop parity. `resolve_op_args`
+            // binds each arg to its canonical box (oparser object-identity),
+            // materialising and registering a bound box for any unbound
+            // position so no position-only `Operand::Box` is minted.
+            resolve_op_args(&mut resolved, &mut ctx);
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
@@ -3470,16 +3478,19 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Ref,
+                0,
+            )],
             field_descr,
         );
         // stack[0] = 42 (const index → tracked)
         let set_item_const = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
             ],
             arr_descr.clone(),
         );
@@ -3487,9 +3498,9 @@ mod tests {
         let set_item_var = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(60)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(52)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 60),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 52),
             ],
             arr_descr.clone(),
         );
@@ -3497,30 +3508,29 @@ mod tests {
         let get_item = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
             ],
             arr_descr,
         );
 
         let mut ops = vec![get_array_ptr, set_item_const, set_item_var, get_item];
         assign_positions(&mut ops);
-        let array_ptr_ref = ops[0].pos.get();
-        ops[1].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
-        ops[2].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
-        ops[3].setarg(0, crate::r#box::BoxRef::from_opref(array_ptr_ref));
+        // GetfieldRawI (ops[0]) is Int-typed so its result position is
+        // `OpRef::int_op(0)`; bind the element ops to its result box.
+        let array_ptr_box =
+            crate::r#box::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
+        ops[1].setarg(0, array_ptr_box.clone());
+        ops[2].setarg(0, array_ptr_box.clone());
+        ops[3].setarg(0, array_ptr_box.clone());
 
         for op in &ops {
             let mut resolved = op.clone();
-            for i in 0..resolved.num_args() {
-                resolved.setarg(
-                    i,
-                    crate::r#box::BoxRef::from_opref(
-                        ctx.get_box_replacement(resolved.arg(i).to_opref())
-                            .to_opref(),
-                    ),
-                );
-            }
+            // optimizer.py:651-652 setarg loop parity. `resolve_op_args`
+            // binds each arg to its canonical box (oparser object-identity),
+            // materialising and registering a bound box for any unbound
+            // position so no position-only `Operand::Box` is minted.
+            resolve_op_args(&mut resolved, &mut ctx);
             match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
                 OptimizationResult::Emit(emitted) => {
                     ctx.emit(emitted);
@@ -3572,21 +3582,21 @@ mod tests {
             Op::new(
                 OpCode::Label,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(1)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(2)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 1),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 2),
                 ],
             ),
             Op::new(
                 OpCode::GuardTrue,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(1))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 1)],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(1)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(2)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 1),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 2),
                 ],
             ),
         ];
@@ -3639,14 +3649,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 fd.clone(),
             ),
         ];
@@ -3700,8 +3710,8 @@ mod tests {
         let mut set_op = Op::with_descr(
             OpCode::SetfieldGc,
             &[
-                crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
             ],
             fd,
         );
@@ -3754,19 +3764,21 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // i10 is a loop inputarg (Int) in a real trace; the forced setfield
+        // re-resolves it, so bind it as a typed inputarg producer.
+        let result = run_pass_typed(&ops, &[100]);
 
         // Expect: new_with_vtable, setfield_gc, call_n
         assert!(
@@ -3808,23 +3820,23 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(50))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
                 ad.clone(),
             ), // pos=0
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(52)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 52),
                 ],
                 ad.clone(),
             ), // pos=1
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
                 ],
                 ad.clone(),
             ), // pos=2
@@ -3903,32 +3915,32 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArrayClear,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(50))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
                 arr.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
-                    crate::r#box::BoxRef::from_opref(OpRef::float_op(60)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    crate::r#box::test_support::rooted_resop_box(Type::Float, 60),
                 ],
                 real.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
-                    crate::r#box::BoxRef::from_opref(OpRef::float_op(61)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    crate::r#box::test_support::rooted_resop_box(Type::Float, 61),
                 ],
                 imag.clone(),
             ),
             Op::with_descr(
                 OpCode::GetinteriorfieldGcF,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
                 ],
                 real.clone(),
             ),
@@ -3965,30 +3977,30 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArrayClear,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(50))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
                 arr.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
-                    crate::r#box::BoxRef::from_opref(OpRef::float_op(60)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Float, 60),
                 ],
                 real.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(51)),
-                    crate::r#box::BoxRef::from_opref(OpRef::float_op(61)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Float, 61),
                 ],
                 imag.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ),
         ];
         assign_positions(&mut ops);
@@ -4044,12 +4056,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(50))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::ArraylenGc,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 ad.clone(),
             ),
         ];
@@ -4086,8 +4098,8 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
             ),
         ];
@@ -4118,7 +4130,7 @@ mod tests {
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()),
             Op::new(
                 OpCode::GuardNonnull,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ),
         ];
         assign_positions(&mut ops);
@@ -4153,27 +4165,29 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(1)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
                 ],
                 fd_ref.clone(),
             ), // pos=2
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(1)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd_int.clone(),
             ), // pos=3
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ), // pos=4
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // i_val is a loop inputarg (Int); the forced inner setfield re-resolves
+        // it, so bind it as a typed inputarg producer.
+        let result = run_pass_typed(&ops, &[100]);
 
         // When p0 is forced, p1 (nested in p0's field) should also be forced.
         // Expect: new_with_vtable(inner), setfield_gc(inner), new_with_vtable(outer), setfield_gc(outer), call_n
@@ -4216,14 +4230,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 fd.clone(),
             ),
         ];
@@ -4250,19 +4264,21 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // i10 is a loop inputarg (Int); the forced setfield re-resolves it, so
+        // bind it as a typed inputarg producer.
+        let result = run_pass_typed(&ops, &[100]);
 
         // Forced: NEW, SETFIELD_GC, CALL_N
         assert_eq!(result[0].opcode, OpCode::New);
@@ -4285,26 +4301,31 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd,
             ),
             Op::new(
                 OpCode::CallR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 ],
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(2))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    2,
+                )],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_default_pipeline_typed(&ops, &[100], &[]);
+        // The field value, call argument and finish operand are loop inputargs
+        // (Int) re-resolved by the escaping call; bind them as typed inputargs.
+        let result = run_default_pipeline_typed(&ops, &[2, 100, 200], &[]);
         let setfield_pos = result
             .iter()
             .position(|op| op.opcode == OpCode::SetfieldGc)
@@ -4346,27 +4367,32 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(2))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    2,
+                )],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_default_pipeline_typed(&ops, &[100], &[]);
+        // The field value, call argument and finish operand are loop inputargs
+        // (Int) re-resolved by the residual call; bind them as typed inputargs.
+        let result = run_default_pipeline_typed(&ops, &[2, 100, 200], &[]);
         let setfield_pos = result
             .iter()
             .position(|op| op.opcode == OpCode::SetfieldGc)
@@ -4398,27 +4424,32 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(2))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    2,
+                )],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_default_pipeline_typed(&ops, &[100], &[]);
+        // The field value, call argument and finish operand are loop inputargs
+        // (Int) re-resolved by the escaping call; bind them as typed inputargs.
+        let result = run_default_pipeline_typed(&ops, &[2, 100, 200], &[]);
         let setfield_pos = result
             .iter()
             .position(|op| op.opcode == OpCode::SetfieldGc)
@@ -4447,35 +4478,40 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(1)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 101),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(2))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    2,
+                )],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_default_pipeline_typed(&ops, &[100, 101], &[]);
+        // The field values, call argument and finish operand are loop inputargs
+        // (Int) re-resolved by the escaping call; bind them as typed inputargs.
+        let result = run_default_pipeline_typed(&ops, &[2, 100, 101, 200], &[]);
         let call_pos = result
             .iter()
             .position(|op| op.opcode == OpCode::CallR)
@@ -4529,27 +4565,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
                 fd_b.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 fd_b.clone(),
             ),
         ];
@@ -4577,27 +4613,30 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ),
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // The setfield values (i10/i20) are loop inputargs in a real trace;
+        // model them as Int-typed inputargs so the driver's inputarg seed
+        // binds a canonical producer for each (no position-only re-resolution).
+        let result = run_pass_typed(&ops, &[100, 200]);
 
         // Only one SETFIELD_GC should be emitted (the last value)
         let setfield_count = result
@@ -4624,15 +4663,15 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
             ),
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
             ),
         ];
@@ -4665,14 +4704,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )],
                 fd.clone(),
             ),
         ];
@@ -4696,15 +4738,15 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(102)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 102),
                 ],
             ), // pos=1
         ];
@@ -4743,13 +4785,13 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ), // pos=1
         ];
         assign_positions(&mut ops);
@@ -4785,15 +4827,15 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
             ), // pos=1, non-null
         ];
@@ -4826,13 +4868,13 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
             ), // pos=1
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(1))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)],
             ), // pos=2
         ];
         assign_positions(&mut ops);
@@ -4874,19 +4916,22 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )],
             ), // pos=1
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
             ), // pos=2
         ];
@@ -4920,13 +4965,13 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
             ), // pos=0
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 forced_descr,
             ), // pos=1
         ];
@@ -4975,15 +5020,11 @@ mod tests {
 
         for op in ops {
             let mut resolved_op = op.clone();
-            // optimizer.py:651-652 setarg loop parity.
-            for i in 0..resolved_op.num_args() {
-                resolved_op.setarg(
-                    i,
-                    crate::r#box::BoxRef::from_opref(
-                        ctx.resolve_box_box(&resolved_op.arg(i)).to_opref(),
-                    ),
-                );
-            }
+            // optimizer.py:651-652 setarg loop parity. `resolve_op_args`
+            // binds each arg to its canonical box (oparser object-identity),
+            // materialising and registering a bound box for any unbound
+            // position so no position-only `Operand::Box` is minted.
+            resolve_op_args(&mut resolved_op, &mut ctx);
 
             let resolved_rc = std::rc::Rc::new(resolved_op.clone());
             ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
@@ -5023,17 +5064,17 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 ad,
             ),
@@ -5065,34 +5106,34 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(201)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 201),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
                 ad,
             ),
@@ -5125,26 +5166,26 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(201)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 201),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 ad,
             ),
@@ -5172,17 +5213,17 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(200)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(50)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 ad,
             ),
@@ -5246,31 +5287,37 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 100),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(3))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 3)],
             ),
             Op::new(
                 OpCode::Jump,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(100))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    100,
+                )],
             ),
         ];
         assign_positions(&mut ops);
 
+        // p0 is the loop inputarg; bind it as a Ref inputarg producer so the
+        // forced immutable getfield forwards to it without re-resolving a
+        // position-only box.
         let result = run_default_pipeline(&ops);
         let opcodes: Vec<_> = result.iter().map(|o| o.opcode).collect();
         assert!(
@@ -5287,8 +5334,8 @@ mod tests {
                 OpCode::Jump,
             ]
         );
-        assert_eq!(result[3].arg(0).to_opref(), OpRef::ref_op(100));
-        assert_eq!(result[4].arg(0).to_opref(), OpRef::ref_op(100));
+        assert_eq!(result[3].arg(0).to_opref(), OpRef::input_arg_ref(100));
+        assert_eq!(result[4].arg(0).to_opref(), OpRef::input_arg_ref(100));
     }
 
     #[test]
@@ -5313,14 +5360,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(1)),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
                 ],
                 next_fd.clone(),
             ),
             Op::new(
                 OpCode::Jump,
-                &[crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0))],
+                &[crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )],
             ),
         ];
         ops[0].pos.set(OpRef::ref_op(1));
@@ -5358,20 +5408,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Float, 100),
                 ],
                 float_fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
-                &[crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
                 call_descr,
             ),
             Op::new(OpCode::Jump, &[]),
         ];
         assign_positions(&mut ops);
 
+        // The float field value is a loop inputarg (Float) re-resolved by the
+        // escaping call; bind it as a typed inputarg producer.
         let result = run_default_pipeline_typed(&ops, &[], &[100]);
         let opcodes: Vec<_> = result.iter().map(|o| o.opcode).collect();
         assert_eq!(
@@ -5397,16 +5449,16 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(2)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(100)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
                 ],
                 value_fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(2)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 ],
                 next_fd.clone(),
             ),
@@ -5414,26 +5466,26 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(5)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(101)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 5),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
                 ],
                 value_fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(5)),
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(2)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 5),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
                 ],
                 next_fd.clone(),
             ),
             Op::new(
                 OpCode::Finish,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(5)),
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(2)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(1)),
-                    crate::r#box::BoxRef::from_opref(OpRef::input_arg_ref(0)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 5),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 ],
             ),
         ];
@@ -5510,16 +5562,19 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(20))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Int,
+                20,
+            )],
         );
-        guard.setfailargs(vec![crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))].into());
+        guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()), // pos=0
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(10)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
                 ],
                 fd.clone(),
             ), // pos=1
@@ -5527,7 +5582,11 @@ mod tests {
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // i10 (field value) and i20 (guard cond) are loop inputargs; bind them
+        // as typed inputarg producers so resume numbering resolves the live
+        // field value to a canonical box. p0 (the virtual) stays an in-trace
+        // ResOp producer, encoded into rd_virtuals rather than liveboxes.
+        let result = run_pass_typed(&ops, &[10, 20]);
 
         // The virtual should NOT be forced — no NEW_WITH_VTABLE emitted
         let new_count = result
@@ -5561,8 +5620,8 @@ mod tests {
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(10)),
-            "virtual's int field (OpRef::int_op(10)) should appear in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(10)),
+            "virtual's int field (input_arg_int(10)) should appear in liveboxes; got {:?}",
             fa
         );
         assert!(
@@ -5588,13 +5647,16 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(20))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Int,
+                20,
+            )],
         );
         guard.setfailargs(
             vec![
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(30)),
-                crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(40)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 30),
+                crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 40),
             ]
             .into(),
         );
@@ -5604,8 +5666,8 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(10)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
                 ],
                 fd.clone(),
             ), // pos=1
@@ -5613,7 +5675,11 @@ mod tests {
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // i10 (field value), i30/i40 (non-virtual liveboxes) and i20 (guard
+        // cond) are loop inputargs; bind them as typed inputarg producers so
+        // resume numbering resolves each live box to a canonical box. p0 (the
+        // virtual) stays an in-trace ResOp producer, encoded into rd_virtuals.
+        let result = run_pass_typed(&ops, &[10, 20, 30, 40]);
 
         // No allocation emitted
         let new_count = result
@@ -5640,18 +5706,18 @@ mod tests {
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(30)),
-            "non-virtual OpRef::int_op(30) should remain in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(30)),
+            "non-virtual input_arg_int(30) should remain in liveboxes; got {:?}",
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(40)),
-            "non-virtual OpRef::int_op(40) should remain in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(40)),
+            "non-virtual input_arg_int(40) should remain in liveboxes; got {:?}",
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(10)),
-            "virtual's field (OpRef::int_op(10)) should appear in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(10)),
+            "virtual's field (input_arg_int(10)) should appear in liveboxes; got {:?}",
             fa
         );
         assert!(
@@ -5665,19 +5731,25 @@ mod tests {
         // Guard with no virtuals in fail_args should not have rd_numb.
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(10))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Int,
+                10,
+            )],
         );
         guard.setfailargs(
             vec![
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(20)),
-                crate::r#box::BoxRef::from_opref(OpRef::int_op(30)),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20),
+                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 30),
             ]
             .into(),
         );
         let mut ops = vec![guard];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // The guard condition and live fail_args are loop inputargs; bind them
+        // as typed inputarg producers so the resume numbering resolves each to
+        // a canonical box instead of a position-only fallback.
+        let result = run_pass_typed(&ops, &[10, 20, 30]);
         let guard_op = result
             .iter()
             .find(|o| o.opcode == OpCode::GuardTrue)
@@ -5699,16 +5771,19 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(20))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Int,
+                20,
+            )],
         );
-        guard.setfailargs(vec![crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))].into());
+        guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], sd.clone()),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(10)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
                 ],
                 fd.clone(),
             ),
@@ -5716,7 +5791,11 @@ mod tests {
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // i10 (field value) and i20 (guard cond) are loop inputargs; bind them
+        // as typed inputarg producers so resume numbering resolves the live
+        // field value to a canonical box. p0 (the virtual) stays an in-trace
+        // ResOp producer, encoded into rd_virtuals rather than liveboxes.
+        let result = run_pass_typed(&ops, &[10, 20]);
 
         let new_count = result
             .iter()
@@ -5741,7 +5820,7 @@ mod tests {
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(10)),
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(10)),
             "virtual struct's int field should appear in liveboxes; got {:?}",
             fa
         );
@@ -5760,24 +5839,27 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(30))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Int,
+                30,
+            )],
         );
-        guard.setfailargs(vec![crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))].into());
+        guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(10)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
                 ],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(20)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20),
                 ],
                 fd_b.clone(),
             ),
@@ -5785,7 +5867,11 @@ mod tests {
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // The two field values and the guard cond are loop inputargs; bind them
+        // as typed inputarg producers so resume numbering resolves each live
+        // field value to a canonical box. p0 (the virtual) stays an in-trace
+        // ResOp producer, encoded into rd_virtuals rather than liveboxes.
+        let result = run_pass_typed(&ops, &[10, 20, 30]);
 
         let guard_op = result
             .iter()
@@ -5806,13 +5892,13 @@ mod tests {
         );
         // Both field values must appear in liveboxes.
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(10)),
-            "first field value (OpRef::int_op(10)) should appear in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(10)),
+            "first field value (input_arg_int(10)) should appear in liveboxes; got {:?}",
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(20)),
-            "second field value (OpRef::int_op(20)) should appear in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(20)),
+            "second field value (input_arg_int(20)) should appear in liveboxes; got {:?}",
             fa
         );
         assert!(
@@ -5836,25 +5922,28 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(30))],
+            &[crate::r#box::test_support::rooted_inputarg_box(
+                Type::Int,
+                30,
+            )],
         );
-        guard.setfailargs(vec![crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))].into());
+        guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], outer_sd),
             Op::with_descr(OpCode::New, &[], inner_sd),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(1)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(40)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
+                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 40),
                 ],
                 inner_fd,
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(1)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
                 ],
                 outer_fd,
             ),
@@ -5862,7 +5951,11 @@ mod tests {
         ];
         assign_positions(&mut ops);
 
-        let result = run_pass(&ops);
+        // The leaf int field value (i40) and guard cond (i30) are loop
+        // inputargs; bind them as typed inputarg producers so resume numbering
+        // resolves the leaf livebox to a canonical box. The outer/inner virtuals
+        // stay in-trace ResOp producers, encoded into rd_virtuals.
+        let result = run_pass_typed(&ops, &[30, 40]);
         let guard_op = result
             .iter()
             .find(|o| o.opcode == OpCode::GuardTrue)
@@ -5896,8 +5989,8 @@ mod tests {
             fa
         );
         assert!(
-            fa.iter().any(|a| a.to_opref() == OpRef::int_op(40)),
-            "leaf int field (OpRef::int_op(40)) should appear in liveboxes; got {:?}",
+            fa.iter().any(|a| a.to_opref() == OpRef::input_arg_int(40)),
+            "leaf int field (input_arg_int(40)) should appear in liveboxes; got {:?}",
             fa
         );
     }
@@ -5911,21 +6004,21 @@ mod tests {
         let ad = array_descr(30);
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::BoxRef::from_opref(OpRef::int_op(20))],
+            &[crate::r#box::test_support::rooted_resop_box(Type::Int, 20)],
         );
-        guard.setfailargs(vec![crate::r#box::BoxRef::from_opref(OpRef::ref_op(0))].into());
+        guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[crate::r#box::BoxRef::from_opref(OpRef::int_op(10))],
+                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 10)],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    crate::r#box::BoxRef::from_opref(OpRef::ref_op(0)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(11)),
-                    crate::r#box::BoxRef::from_opref(OpRef::int_op(12)),
+                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 11),
+                    crate::r#box::test_support::rooted_resop_box(Type::Int, 12),
                 ],
                 ad,
             ),

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1657,10 +1657,27 @@ mod tests {
     //! that upstream usually exercises only through larger optimizer tests.
 
     use super::*;
+    use crate::r#box::test_support::rooted_resop_box;
     use crate::optimizeopt::info::{
         PtrInfo, StrPtrInfo, VStringConcatInfo, VStringPlainInfo, VStringSliceInfo, VStringVariant,
     };
     use crate::optimizeopt::optimizer::Optimizer;
+    use majit_ir::Type;
+
+    /// Bound drop-in for `from_opref(OpRef::int_op(n))` at an op-argument site:
+    /// a rooted synthetic Int ResOp producer (sheds to `Operand::Op`, not the
+    /// position-only `Operand::Box`) whose `to_opref()` stays `int_op(n)`, so
+    /// the constant-map / PtrInfo keys this trace seeds by absolute position
+    /// still resolve. The OptString driver runs that single pass and resolves
+    /// args by position, so the detached synthetic never diverges.
+    fn iop(n: u32) -> BoxRef {
+        rooted_resop_box(Type::Int, n)
+    }
+
+    /// Bound drop-in for `from_opref(OpRef::ref_op(n))` at an op-argument site.
+    fn rop(n: u32) -> BoxRef {
+        rooted_resop_box(Type::Ref, n)
+    }
 
     /// Assign sequential positions to ops and pre-seed constants in OptContext.
     fn assign_positions(ops: &mut [Op]) {
@@ -1693,6 +1710,27 @@ mod tests {
         for &(idx, val) in constants {
             let b = ctx.materialize_box_at(OpRef::int_op(idx));
             ctx.make_constant_box(&b, Value::Int(val));
+        }
+
+        // Register every non-constant LEAF arg position as a bound synthetic
+        // producer in the context (`resop_refs`). The trace's char / source
+        // operands are leaf values with no producing op in this fixture slice;
+        // without a registered producer, a later force/emit resolves such an
+        // arg to a position-only `from_opref` box that mints `Operand::Box`.
+        // `materialize_box_at` binds a `SameAs*` synthetic at the same position
+        // (oparser's leaf-var wiring), so resolution sheds to `Operand::Op`.
+        // Positions produced by a trace op are skipped — materializing a
+        // synthetic there would shadow the real producer and defeat
+        // virtualization. Constant positions already carry a Const box.
+        let produced: std::collections::HashSet<OpRef> =
+            ops.iter().map(|op| op.pos.get()).collect();
+        for op in ops {
+            for i in 0..op.num_args() {
+                let r = op.arg(i).to_opref();
+                if !r.is_none() && !r.is_constant() && !produced.contains(&r) {
+                    ctx.materialize_box_at(r);
+                }
+            }
         }
 
         let mut pass = OptString::new();
@@ -1744,6 +1782,16 @@ mod tests {
     fn set_vstring_plain(ctx: &mut OptContext, opref: OpRef, chars: Vec<Option<OpRef>>) {
         let length = chars.len() as i32;
         let b = ctx.materialize_box_at(opref);
+        // Materialize each char position so it carries a bound synthetic
+        // producer in `resop_refs`. A later force/emit then resolves the char
+        // arg to that bound box (sheds to `Operand::Op`) instead of a
+        // position-only `from_opref` box (which would mint `Operand::Box`).
+        // `materialize_box_at` keeps the box's `to_opref()` at the same
+        // position, so the char-identity assertions still hold.
+        let char_boxes: Vec<Option<BoxRef>> = chars
+            .into_iter()
+            .map(|o| o.map(|r| ctx.materialize_box_at(r)))
+            .collect();
         ctx.set_ptr_info(
             &b,
             PtrInfo::Str(StrPtrInfo {
@@ -1751,12 +1799,7 @@ mod tests {
                 lgtop: None,
                 mode: 0,
                 length,
-                variant: VStringVariant::Plain(VStringPlainInfo {
-                    _chars: chars
-                        .into_iter()
-                        .map(|o| o.map(BoxRef::from_opref))
-                        .collect(),
-                }),
+                variant: VStringVariant::Plain(VStringPlainInfo { _chars: char_boxes }),
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -1821,30 +1864,10 @@ mod tests {
         //   i3 = strgetitem(p0, i101) -> should resolve to i200, removed
 
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]), // op 0: p0 = newstr(3)
-            Op::new(
-                OpCode::Strsetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
-            ), // op 1
-            Op::new(
-                OpCode::Strsetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(102)),
-                    BoxRef::from_opref(OpRef::int_op(201)),
-                ],
-            ), // op 2
-            Op::new(
-                OpCode::Strgetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ), // op 3: get char at 0
+            Op::new(OpCode::Newstr, &[iop(100)]), // op 0: p0 = newstr(3)
+            Op::new(OpCode::Strsetitem, &[rop(0), iop(101), iop(200)]), // op 1
+            Op::new(OpCode::Strsetitem, &[rop(0), iop(102), iop(201)]), // op 2
+            Op::new(OpCode::Strgetitem, &[rop(0), iop(101)]), // op 3: get char at 0
         ];
         assign_positions(&mut ops);
 
@@ -1872,8 +1895,8 @@ mod tests {
         // p0 = newstr(5)
         // i1 = strlen(p0) -> should be constant 5
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]), // op 0
-            Op::new(OpCode::Strlen, &[BoxRef::from_opref(OpRef::ref_op(0))]),   // op 1
+            Op::new(OpCode::Newstr, &[iop(100)]), // op 0
+            Op::new(OpCode::Strlen, &[rop(0)]),   // op 1
         ];
         assign_positions(&mut ops);
 
@@ -1899,24 +1922,10 @@ mod tests {
         // strsetitem(p0, 1, c1)
         // call_n(p0)     -> forces the string
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]), // op 0
-            Op::new(
-                OpCode::Strsetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
-            ), // op 1
-            Op::new(
-                OpCode::Strsetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(102)),
-                    BoxRef::from_opref(OpRef::int_op(201)),
-                ],
-            ), // op 2
-            Op::new(OpCode::CallN, &[BoxRef::from_opref(OpRef::ref_op(0))]),    // op 3: forces
+            Op::new(OpCode::Newstr, &[iop(100)]), // op 0
+            Op::new(OpCode::Strsetitem, &[rop(0), iop(101), iop(200)]), // op 1
+            Op::new(OpCode::Strsetitem, &[rop(0), iop(102), iop(201)]), // op 2
+            Op::new(OpCode::CallN, &[rop(0)]),    // op 3: forces
         ];
         assign_positions(&mut ops);
 
@@ -2074,7 +2083,9 @@ mod tests {
 
         // start is a non-constant int box (no constant/bound installed), so the
         // slice can't resolve the char statically and falls to the residual.
+        // Materialize so the residual re-emits start as a bound box.
         let start_ref = OpRef::int_op(300);
+        ctx.materialize_box_at(start_ref);
         let b = ctx.materialize_box_at(OpRef::int_op(301));
         ctx.make_constant_box(&b, Value::Int(2)); // length
 
@@ -2151,9 +2162,14 @@ mod tests {
         let mut ctx = OptContext::new(20);
 
         // Non-virtual source ref so force_if_virtual leaves it as the source box.
+        // Materialize the source / start / index leaf positions so the residual
+        // STRGETITEM (and its INT_ADD index) re-emit them as bound boxes
+        // (`Operand::Op`) rather than position-only `from_opref` boxes.
         let src_ref = OpRef::ref_op(10);
+        ctx.materialize_box_at(src_ref);
         // Non-constant start so the static fold misses → residual path.
         let start_ref = OpRef::int_op(300);
+        ctx.materialize_box_at(start_ref);
         let b = ctx.materialize_box_at(OpRef::int_op(301));
         ctx.make_constant_box(&b, Value::Int(3)); // slice length
 
@@ -2162,11 +2178,9 @@ mod tests {
 
         // STRGETITEM(slice, index) with a non-constant index.
         let index_ref = OpRef::int_op(302);
+        ctx.materialize_box_at(index_ref);
         let pos = ctx.alloc_op_position_typed(majit_ir::Type::Int);
-        let mut getitem = Op::new(
-            OpCode::Strgetitem,
-            &[BoxRef::from_opref(slice_ref), BoxRef::from_opref(index_ref)],
-        );
+        let mut getitem = Op::new(OpCode::Strgetitem, &[rop(11), iop(302)]);
         getitem.pos.set(pos);
         let op_rc = std::rc::Rc::new(getitem.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op_rc));
@@ -2198,8 +2212,11 @@ mod tests {
         let mut ctx = OptContext::new(20);
 
         // concat = vleft(plain len 2) ++ vright(non-virtual source ref).
+        // Materialize the non-virtual child so the residual STRGETITEM re-emits
+        // it as a bound box rather than a position-only `from_opref` box.
         let vleft_ref = OpRef::ref_op(10);
         let vright_ref = OpRef::ref_op(11);
+        ctx.materialize_box_at(vright_ref);
         set_vstring_plain(&mut ctx, vleft_ref, vec![None; 2]);
         let concat_ref = OpRef::ref_op(12);
         set_vstring_concat(&mut ctx, concat_ref, vleft_ref, vright_ref);
@@ -2221,12 +2238,8 @@ mod tests {
         // STRGETITEM(slice, 1) → concat[start 1 + 1 = 2] → vright[2 - len 2 = 0].
         let b = ctx.materialize_box_at(OpRef::int_op(302));
         ctx.make_constant_box(&b, Value::Int(1));
-        let index_ref = OpRef::int_op(302);
         let pos = ctx.alloc_op_position_typed(majit_ir::Type::Int);
-        let mut getitem = Op::new(
-            OpCode::Strgetitem,
-            &[BoxRef::from_opref(slice_ref), BoxRef::from_opref(index_ref)],
-        );
+        let mut getitem = Op::new(OpCode::Strgetitem, &[rop(13), iop(302)]);
         getitem.pos.set(pos);
         let op_rc = std::rc::Rc::new(getitem.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op_rc));
@@ -2314,10 +2327,7 @@ mod tests {
     #[test]
     fn test_newstr_non_constant_passes_through() {
         // newstr(i0) where i0 is not a known constant -> should emit.
-        let mut ops = vec![Op::new(
-            OpCode::Newstr,
-            &[BoxRef::from_opref(OpRef::int_op(50))],
-        )];
+        let mut ops = vec![Op::new(OpCode::Newstr, &[iop(50)])];
         assign_positions(&mut ops);
 
         let result = run_with_constants(&ops, &[]);
@@ -2330,10 +2340,7 @@ mod tests {
 
     #[test]
     fn test_newstr_too_large_passes_through() {
-        let mut ops = vec![Op::new(
-            OpCode::Newstr,
-            &[BoxRef::from_opref(OpRef::int_op(50))],
-        )];
+        let mut ops = vec![Op::new(OpCode::Newstr, &[iop(50)])];
         assign_positions(&mut ops);
 
         let constants = vec![(50, (MAX_CONST_LEN + 1) as i64)];
@@ -2347,13 +2354,7 @@ mod tests {
 
     #[test]
     fn test_strgetitem_non_virtual() {
-        let mut ops = vec![Op::new(
-            OpCode::Strgetitem,
-            &[
-                BoxRef::from_opref(OpRef::ref_op(50)),
-                BoxRef::from_opref(OpRef::int_op(51)),
-            ],
-        )];
+        let mut ops = vec![Op::new(OpCode::Strgetitem, &[rop(50), iop(51)])];
         assign_positions(&mut ops);
 
         let constants = vec![(51, 0)];
@@ -2370,8 +2371,8 @@ mod tests {
         // p0 = newstr(0) -> virtual (0 chars)
         // call_n(p0)      -> force: emits newstr(0) only, no strsetitem
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(OpCode::CallN, &[BoxRef::from_opref(OpRef::ref_op(0))]),
+            Op::new(OpCode::Newstr, &[iop(100)]),
+            Op::new(OpCode::CallN, &[rop(0)]),
         ];
         assign_positions(&mut ops);
 
@@ -2396,41 +2397,15 @@ mod tests {
         // copystrcontent(src, dst, 0, 0, 2)
         // strgetitem(dst, 0) -> c0
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]), // op 0: src
-            Op::new(
-                OpCode::Strsetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(200)),
-                ],
-            ), // op 1
-            Op::new(
-                OpCode::Strsetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(102)),
-                    BoxRef::from_opref(OpRef::int_op(201)),
-                ],
-            ), // op 2
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]), // op 3: dst
+            Op::new(OpCode::Newstr, &[iop(100)]), // op 0: src
+            Op::new(OpCode::Strsetitem, &[rop(0), iop(101), iop(200)]), // op 1
+            Op::new(OpCode::Strsetitem, &[rop(0), iop(102), iop(201)]), // op 2
+            Op::new(OpCode::Newstr, &[iop(100)]), // op 3: dst
             Op::new(
                 OpCode::Copystrcontent,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                ],
+                &[rop(0), rop(3), iop(101), iop(101), iop(100)],
             ), // op 4: copy src->dst
-            Op::new(
-                OpCode::Strgetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(3)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ), // op 5: get dst[0]
+            Op::new(OpCode::Strgetitem, &[rop(3), iop(101)]), // op 5: get dst[0]
         ];
         assign_positions(&mut ops);
 
@@ -2450,23 +2425,11 @@ mod tests {
     #[test]
     fn test_copyunicodecontent_inline_uses_unicodegetitem() {
         let mut ops = vec![
-            Op::new(
-                OpCode::Newunicode,
-                &[BoxRef::from_opref(OpRef::int_op(100))],
-            ),
-            Op::new(
-                OpCode::Newunicode,
-                &[BoxRef::from_opref(OpRef::int_op(100))],
-            ),
+            Op::new(OpCode::Newunicode, &[iop(100)]),
+            Op::new(OpCode::Newunicode, &[iop(100)]),
             Op::new(
                 OpCode::Copyunicodecontent,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
-                ],
+                &[rop(0), rop(1), iop(101), iop(101), iop(100)],
             ),
         ];
         assign_positions(&mut ops);
@@ -2496,9 +2459,9 @@ mod tests {
         // i1 = strlen(p0) -> const 3
         // i2 = strlen(p0) -> const 3
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(OpCode::Strlen, &[BoxRef::from_opref(OpRef::ref_op(0))]),
-            Op::new(OpCode::Strlen, &[BoxRef::from_opref(OpRef::ref_op(0))]),
+            Op::new(OpCode::Newstr, &[iop(100)]),
+            Op::new(OpCode::Strlen, &[rop(0)]),
+            Op::new(OpCode::Strlen, &[rop(0)]),
         ];
         assign_positions(&mut ops);
 
@@ -2516,14 +2479,8 @@ mod tests {
         // p0 = newstr(3), no strsetitem for index 0
         // strgetitem(p0, 0) -> char not set, must force and emit
         let mut ops = vec![
-            Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(100))]),
-            Op::new(
-                OpCode::Strgetitem,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(101)),
-                ],
-            ),
+            Op::new(OpCode::Newstr, &[iop(100)]),
+            Op::new(OpCode::Strgetitem, &[rop(0), iop(101)]),
         ];
         assign_positions(&mut ops);
 
@@ -2630,8 +2587,8 @@ mod tests {
         // `known_lengths` cache wiring from panicking or regressing.
         // STRLEN on a non-virtual string should be cached for the second call.
         let mut ops = vec![
-            Op::new(OpCode::Strlen, &[BoxRef::from_opref(OpRef::ref_op(100))]),
-            Op::new(OpCode::Strlen, &[BoxRef::from_opref(OpRef::ref_op(100))]),
+            Op::new(OpCode::Strlen, &[rop(100)]),
+            Op::new(OpCode::Strlen, &[rop(100)]),
             Op::new(OpCode::Finish, &[]),
         ];
         assign_positions(&mut ops);
@@ -2655,7 +2612,7 @@ mod tests {
         let left = OpRef::ref_op(100);
 
         // Simulate: NEWSTR(2) for left
-        let mut left_op = Op::new(OpCode::Newstr, &[BoxRef::from_opref(OpRef::int_op(200))]);
+        let mut left_op = Op::new(OpCode::Newstr, &[iop(200)]);
         left_op.pos.set(left);
         let mut ctx = OptContext::new(10);
         let b = ctx.materialize_box_at(OpRef::int_op(200));
@@ -2812,8 +2769,11 @@ mod tests {
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
         );
-        // targetbox: non-virtual
+        // targetbox: non-virtual. Materialize so the inline force re-emits the
+        // STRSETITEM target arg as a bound box (`Operand::Op`), not a
+        // position-only `from_opref` box.
         let p1 = OpRef::ref_op(1);
+        let p1_box = ctx.materialize_box_at(p1);
 
         // lengthbox (i2): int with constant intbound = 2
         // Use an OpRef with IntBound set (not a literal constant)
@@ -2830,11 +2790,11 @@ mod tests {
         // it should inline to STRGETITEM+STRSETITEM instead of COPYSTRCONTENT.
         let _result = copy_str_content(
             &mut ctx,
-            &BoxRef::from_opref(p0),
-            &BoxRef::from_opref(p1),
+            &p0_box,
+            &p1_box,
             &BoxRef::from_opref(off),
             &BoxRef::from_opref(off),
-            &BoxRef::from_opref(i2),
+            &i2_box,
             0,
             true,
         );

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -17896,8 +17896,32 @@ mod tests {
     use majit_ir::{DescrRef, InputArg, Op, OpCode, OpRc, OpRef, Type, Value};
     use std::sync::{Arc, Mutex, OnceLock};
 
+    /// Bound-box view of an op-arg / fail-arg `OpRef`, oparser-faithful
+    /// (`rpython/jit/tool/oparser.py`): a position-only ResOp / InputArg ref
+    /// resolves to a bound producer box (`rooted_resop_box` /
+    /// `rooted_inputarg_box`, shedding to `Operand::Op` / `Operand::InputArg`),
+    /// a `Const*` ref to a Const box, and `None` to the absent-slot sentinel.
+    /// `to_opref()` round-trips to the original `OpRef`, so position-keyed
+    /// assertions and backend layout keying are unchanged — but no
+    /// position-only `Operand::Box` is minted at `Op::new`.
+    fn bound_box(r: OpRef) -> BoxRef {
+        use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
+        if r.is_none() || r.is_constant() {
+            // None → `BoxRef::none()`; Const → `Operand::Const` (no mint).
+            return BoxRef::from_opref(r);
+        }
+        let ty = r.ty().unwrap_or(Type::Void);
+        let pos = r.raw();
+        match r {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                rooted_inputarg_box(ty, pos)
+            }
+            _ => rooted_resop_box(ty, pos),
+        }
+    }
+
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let args: Vec<BoxRef> = args.iter().map(|a| bound_box(*a)).collect();
         let op = Op::new(opcode, &args);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE
@@ -17908,7 +17932,7 @@ mod tests {
     }
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let args: Vec<BoxRef> = args.iter().map(|a| bound_box(*a)).collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE
@@ -18687,9 +18711,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -18932,9 +18954,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19012,9 +19032,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19112,9 +19130,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19207,8 +19223,8 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::int_op(1)),
-            BoxRef::from_opref(OpRef::int_op(0)),
+            bound_box(OpRef::int_op(1)),
+            bound_box(OpRef::int_op(0)),
         ]);
         // pyre cranelift test-fixture quirk (NOT RPython parity): the bare
         // OpRef::int_op(100) literal is paired with `constants.insert(100, ...)` below
@@ -20246,8 +20262,8 @@ mod tests {
         let const_zero = OpRef::int_op(101);
         let mut guard_op = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
+            bound_box(OpRef::input_arg_int(0)),
+            bound_box(OpRef::input_arg_int(1)),
         ]);
         let ops = vec![
             mk_op(
@@ -20264,8 +20280,8 @@ mod tests {
             {
                 let mut g = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
                 g.setfailargs(smallvec::smallvec![
-                    BoxRef::from_opref(OpRef::input_arg_int(0)),
-                    BoxRef::from_opref(OpRef::input_arg_int(1)),
+                    bound_box(OpRef::input_arg_int(0)),
+                    bound_box(OpRef::input_arg_int(1)),
                 ]);
                 g
             },

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -461,6 +461,7 @@ pub unsafe fn builtin_function_set_module(obj: PyObjectRef, w_module: PyObjectRe
         if stampable {
             let func = obj as *mut Function;
             if (*func).w_module.is_null() {
+                function_write_barrier(obj);
                 (*func).w_module = w_module;
             }
         }
@@ -478,6 +479,7 @@ pub unsafe fn function_set_new_self(obj: PyObjectRef, w_type: PyObjectRef) {
     unsafe {
         let func = obj as *mut Function;
         if (*func).w_new_self.is_null() {
+            function_write_barrier(obj);
             (*func).w_new_self = w_type;
         }
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -396,6 +396,30 @@ unsafe fn tuple_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maji
     }
 }
 
+/// Custom trace for `W_ListObject` under the Object strategy. `items`
+/// points at an off-GC `std::alloc`'d `ItemsBlock`
+/// (`object_array::alloc_items_block`), so the element slots are
+/// unreachable through inline `gc_ptr_offsets` — the collector would see
+/// `items` as a single non-managed pointer and stop, leaving list elements
+/// untraced (a major collection then sweeps an element reachable only via
+/// the list).  Forward each live element slot in place, exactly as
+/// `tuple_object_custom_trace`, so a moving collector relocates young
+/// elements and a major collection marks them.  Only the Object strategy
+/// stores `PyObjectRef`s; Integer/Float keep unboxed arrays (`items` null)
+/// and Empty has no block.  Trace `length` live slots, not capacity — the
+/// spare tail past the live length may hold stale pointers a shrink left
+/// behind.
+unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let list = unsafe { &*(obj_addr as *const pyre_object::listobject::W_ListObject) };
+    if list.strategy != pyre_object::listobject::ListStrategy::Object || list.items.is_null() {
+        return;
+    }
+    let base = unsafe { pyre_object::object_array::items_block_items_base(list.items) };
+    for i in 0..list.length {
+        f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+    }
+}
+
 /// RPython jitexc.py:53 ContinueRunningNormally parity.
 pub(crate) enum LoopResult {
     Done(PyResult),
@@ -591,26 +615,20 @@ thread_local! {
         // `offset_of!(items)`. The GC offset points straight at `items`
         // with no intermediate block-start field.
         //
-        // The pointer shape is correct, but the block `items` points to
-        // is still `std::alloc`-owned (`alloc_items_block` in
-        // `pyre_object::object_array`), so `is_nursery_object_start`
-        // (collector.rs:377) rejects it and the walker no-ops. This
-        // registration is inert until `items` blocks are allocated
-        // through the GC, so `W_LIST_GC_TYPE_ID` is not yet at full
-        // parity.
-        let mut w_list_ti = TypeInfo::object_subclass(
+        // `items` points at an off-GC `std::alloc`'d `ItemsBlock`
+        // (`alloc_items_block` in `pyre_object::object_array`), so inline
+        // `gc_ptr_offsets` tracing stops at the non-managed block pointer
+        // (`is_managed_heap_object` rejects it) and never reaches the
+        // elements — a major collection then sweeps a list element
+        // reachable only through the list.  Trace through the block with a
+        // custom hook instead (mirrors `W_TupleObject` / `W_SetObject`).
+        let w_list_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
             std::mem::size_of::<pyre_object::listobject::W_ListObject>(),
             object_tid,
-        );
-        w_list_ti.gc_ptr_offsets = vec![std::mem::offset_of!(
-            pyre_object::listobject::W_ListObject,
-            items
-        )];
-        w_list_ti.has_gc_ptrs = true;
-        let w_list_tid = gc.register_type(w_list_ti);
+            list_object_custom_trace,
+        ));
         debug_assert_eq!(w_list_tid, W_LIST_GC_TYPE_ID);
-        // Same inert-until-GC-allocated caveat as W_LIST above. Full
-        // tuple convergence additionally requires specialised arity-2
+        // Full tuple convergence additionally requires specialised arity-2
         // variants (per `pypy/objspace/std/specialisedtupleobject.py`),
         // which are not yet modeled here.
         // `wrappeditems` points at an off-GC `std::alloc`'d ItemsBlock, so

--- a/pyre/pyre-jit/tests/list_elements_gc_stress.rs
+++ b/pyre/pyre-jit/tests/list_elements_gc_stress.rs
@@ -1,0 +1,130 @@
+//! End-to-end check that an object-strategy `W_ListObject`'s elements are
+//! GC-traced: instances reachable ONLY through a list survive repeated
+//! full collections. Regression for the `W_LIST_GC_TYPE_ID` registration
+//! that traced `items` as a single non-managed pointer (the `std::alloc`'d
+//! `ItemsBlock`) and never reached the elements — a major collection then
+//! swept a list element reachable only via the list. Fixed by giving
+//! `W_ListObject` a custom trace (`list_object_custom_trace`) that walks
+//! the off-GC block, mirroring `W_TupleObject` / `W_SetObject`.
+//!
+//! The harness mirrors the `pyrex` launcher exactly: it does NOT build the
+//! GC up front. The program is `FOR_ITER`-free (only `while` loops) so eval
+//! reaches a JIT-eligible frame and builds the GC lazily, matching
+//! production. `gc.collect()` then forces a deterministic full collection.
+//!
+//! Non-vacuity is asserted AFTER eval: the stable instance allocator hook
+//! must be live, proving the GC was built during the run so the list
+//! elements were genuinely GC-managed (not the leaking `lltype::malloc`
+//! Box fallback, which would make the survival checks meaningless).
+
+use std::rc::Rc;
+
+use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx, set_last_exec_ctx};
+use pyre_interpreter::importing;
+use pyre_interpreter::pyframe::PyFrame;
+use pyre_interpreter::{Mode, PyExecutionContext, compile_source_with_filename};
+use pyre_jit::eval::{eval_with_jit, init_jit_hooks};
+
+// `objs` (a list literal → Object strategy) and `grown` (built by
+// `append`, exercising object-strategy growth) hold `Node` instances that
+// are reachable ONLY through their list. Each round allocates fresh
+// nursery garbage and forces a full collection; the list elements must be
+// marked through the list's custom trace. The returned checksum is
+// reachable only if every element survived the 100 collections.
+const PROGRAM: &str = r#"
+import gc
+
+class Node:
+    pass
+
+def run():
+    objs = [Node(), Node(), Node()]
+    objs[0].v = 10
+    objs[1].v = 20
+    objs[2].v = 30
+
+    grown = []
+    i = 0
+    while i < 12:
+        e = Node()
+        e.v = i
+        grown.append(e)
+        i = i + 1
+
+    n = 0
+    while n < 100:
+        junk = [0] * 64
+        gc.collect()
+        n = n + 1
+
+    total = objs[0].v + objs[1].v + objs[2].v
+    i = 0
+    while i < 12:
+        total = total + grown[i].v
+        i = i + 1
+    return total
+
+result = run()
+assert result == 126, result
+"#;
+
+fn run_harness() -> Result<(), String> {
+    pyre_interpreter::stack_check::set_recursion_limit(5000)
+        .map_err(|_| "set_recursion_limit failed".to_string())?;
+    init_jit_hooks();
+
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    importing::init_sys_path(&cwd);
+    importing::set_sys_argv(&["<list_elements_gc_stress>".to_string()]);
+
+    let code = compile_source_with_filename(PROGRAM, Mode::Exec, "<list_elements_gc_stress>")
+        .map_err(|e| format!("compile error: {e}"))?;
+
+    register_build_class();
+
+    let execution_context = Rc::new(PyExecutionContext::default());
+    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
+    set_last_exec_ctx(Rc::as_ptr(&execution_context));
+
+    let mut frame = PyFrame::new_with_context(code, execution_context)
+        .map_err(|e| format!("frame setup error: {}", e.message))?;
+
+    let canonical = frame.get_w_globals_obj();
+    let main_module = pyre_object::w_module_new_aliasing_dict(
+        "__main__",
+        unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },
+        canonical,
+    );
+    importing::set_sys_module("__main__", main_module);
+
+    eval_with_jit(&mut frame).map_err(|e| format!("execution error: {}", e.message))?;
+
+    // Non-vacuity: the stable instance allocator hook is installed by the
+    // `JIT_DRIVER` initializer. If it is live now, the GC was built during
+    // eval, so the list and its `Node` elements routed through it rather
+    // than the leaking Box fallback — the survival checks were meaningful.
+    let probe = pyre_object::try_gc_alloc_stable(
+        pyre_object::W_INSTANCE_GC_TYPE_ID,
+        pyre_object::W_INSTANCE_OBJECT_SIZE,
+    )
+    .ok_or("GC was not built during eval; list element survival checks would be vacuous")?;
+    if probe.is_null() {
+        return Err("stable GC alloc hook returned null for an instance-sized block".to_string());
+    }
+    unsafe {
+        std::ptr::write_bytes(probe, 0, pyre_object::W_INSTANCE_OBJECT_SIZE);
+    }
+    Ok(())
+}
+
+#[test]
+fn list_elements_survive_full_collection() {
+    let handle = std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024)
+        .spawn(run_harness)
+        .expect("spawn worker thread");
+    handle
+        .join()
+        .expect("worker thread panicked")
+        .expect("list elements gc stress program failed");
+}

--- a/pyre/pyre-jit/tests/list_young_dict_gc_stress.rs
+++ b/pyre/pyre-jit/tests/list_young_dict_gc_stress.rs
@@ -1,0 +1,147 @@
+//! End-to-end check that storing a *young* (nursery) value into an
+//! object-strategy `W_ListObject` keeps it alive across a minor GC.
+//!
+//! The list body is old-gen (`try_gc_alloc_stable`); its elements live in
+//! an off-GC `ItemsBlock` reached only via `list_object_custom_trace`. A
+//! minor (nursery) collection forwards an old-gen container's young refs
+//! ONLY when the container sits in the remembered set, which is populated
+//! exclusively by the write barrier (`try_gc_write_barrier`). Without a
+//! barrier at each ref store, a fresh dict (`{}` is the nursery
+//! `W_DICT`) appended/assigned/inserted into a list that is reachable only
+//! through that list is never forwarded — the nursery reset leaves a
+//! dangling pointer and the later read is a use-after-free.
+//!
+//! Regression for the missing list write barriers in `w_list_append` /
+//! `w_list_setitem` / `w_list_insert` / `w_list_setslice` and
+//! `w_list_new_with_strategy` creation. Mirrors `set_write_barrier` /
+//! `dict_write_barrier`. Proven non-vacuous: without the barriers the
+//! checksum is corrupted / the process faults; with them it is exact.
+//!
+//! The harness mirrors the `pyrex` launcher: it does NOT build the GC up
+//! front. The program is `FOR_ITER`-free (only `while` loops) so eval
+//! reaches a JIT-eligible frame and builds the GC lazily, matching
+//! production. The nursery churn (`junk` lists + scratch dicts) plus
+//! `gc.collect()` forces minor collections during the hot loop.
+
+use std::rc::Rc;
+
+use pyre_interpreter::call::{register_build_class, set_build_class_exec_ctx, set_last_exec_ctx};
+use pyre_interpreter::importing;
+use pyre_interpreter::pyframe::PyFrame;
+use pyre_interpreter::{Mode, PyExecutionContext, compile_source_with_filename};
+use pyre_jit::eval::{eval_with_jit, init_jit_hooks};
+
+// Each `{}` is a nursery W_DICT reachable only through its list. The four
+// list mutators that store a ref — append, literal creation, setitem,
+// insert — must each barrier the old-gen list so the next minor GC
+// forwards the young dict. The checksum is recoverable only if every
+// stored dict survived the 200 collections.
+const PROGRAM: &str = r#"
+import gc
+
+def run():
+    # (1) append: young dicts into an object-strategy list
+    appended = []
+    i = 0
+    while i < 16:
+        d = {}
+        d['v'] = i
+        appended.append(d)
+        i = i + 1
+
+    # (2) creation: object-strategy list literal of young dicts
+    literal = [{}, {}, {}]
+    literal[0]['v'] = 10
+    literal[1]['v'] = 20
+    literal[2]['v'] = 30
+
+    # (3) setitem + insert of young dicts
+    slots = [{}, {}]
+    slots[0]['v'] = 1
+    slots[1] = {}
+    slots[1]['v'] = 2
+    slots.insert(1, {})
+    slots[1]['v'] = 3
+
+    n = 0
+    while n < 200:
+        junk = [0] * 32
+        scratch = {}
+        scratch['x'] = n
+        gc.collect()
+        n = n + 1
+
+    total = 0
+    i = 0
+    while i < 16:
+        total = total + appended[i]['v']
+        i = i + 1
+    total = total + literal[0]['v'] + literal[1]['v'] + literal[2]['v']
+    total = total + slots[0]['v'] + slots[1]['v'] + slots[2]['v']
+    return total
+
+result = run()
+assert result == 186, result
+"#;
+
+fn run_harness() -> Result<(), String> {
+    pyre_interpreter::stack_check::set_recursion_limit(5000)
+        .map_err(|_| "set_recursion_limit failed".to_string())?;
+    init_jit_hooks();
+
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    importing::init_sys_path(&cwd);
+    importing::set_sys_argv(&["<list_young_dict_gc_stress>".to_string()]);
+
+    let code = compile_source_with_filename(PROGRAM, Mode::Exec, "<list_young_dict_gc_stress>")
+        .map_err(|e| format!("compile error: {e}"))?;
+
+    register_build_class();
+
+    let execution_context = Rc::new(PyExecutionContext::default());
+    set_build_class_exec_ctx(Rc::as_ptr(&execution_context));
+    set_last_exec_ctx(Rc::as_ptr(&execution_context));
+
+    let mut frame = PyFrame::new_with_context(code, execution_context)
+        .map_err(|e| format!("frame setup error: {}", e.message))?;
+
+    let canonical = frame.get_w_globals_obj();
+    let main_module = pyre_object::w_module_new_aliasing_dict(
+        "__main__",
+        unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },
+        canonical,
+    );
+    importing::set_sys_module("__main__", main_module);
+
+    eval_with_jit(&mut frame).map_err(|e| format!("execution error: {}", e.message))?;
+
+    // Non-vacuity: the stable instance allocator hook is installed by the
+    // `JIT_DRIVER` initializer. If it is live now, the GC was built during
+    // eval, so the lists and the young dicts stored into them routed
+    // through the real managed heap rather than the leaking Box fallback —
+    // the minor-GC survival checks were meaningful.
+    let probe = pyre_object::try_gc_alloc_stable(
+        pyre_object::W_INSTANCE_GC_TYPE_ID,
+        pyre_object::W_INSTANCE_OBJECT_SIZE,
+    )
+    .ok_or("GC was not built during eval; young-dict survival checks would be vacuous")?;
+    if probe.is_null() {
+        return Err("stable GC alloc hook returned null for an instance-sized block".to_string());
+    }
+    unsafe {
+        std::ptr::write_bytes(probe, 0, pyre_object::W_INSTANCE_OBJECT_SIZE);
+    }
+    Ok(())
+}
+
+#[test]
+fn young_dict_list_elements_survive_minor_collection() {
+    let handle = std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024)
+        .spawn(run_harness)
+        .expect("spawn worker thread");
+    handle
+        .join()
+        .expect("worker thread panicked")
+        .expect("list young dict gc stress program failed");
+}

--- a/pyre/pyre-object/src/dictproxyobject.rs
+++ b/pyre/pyre-object/src/dictproxyobject.rs
@@ -64,11 +64,43 @@ impl crate::lltype::GcType for W_DictProxyObject {
 /// `pypy/objspace/std/dictproxyobject.py:16 def __init__(self,
 /// w_mapping): self.w_mapping = w_mapping`.
 pub fn w_dict_proxy_new(w_mapping: PyObjectRef) -> PyObjectRef {
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // wrapped mapping across the GC malloc and re-read its relocated address
+    // afterwards (a minor collection inside the malloc may move it). The
+    // proxy's `w_mapping` can be a young W_DICT (e.g. `mappingproxy({})`)
+    // reachable only through the proxy; a `malloc_typed` proxy is invisible
+    // to mark-sweep and never enters the remembered set, so its registered
+    // `w_mapping` offset (`object_subclass_with_gc_ptrs`, eval.rs) is inert
+    // and the young mapping dangles after a nursery reset. Routing the
+    // allocation through `try_gc_alloc_stable` makes the proxy old-gen so
+    // mark-sweep follows `w_mapping`; the creation write barrier remembers
+    // it so the young mapping is forwarded on the first minor collection.
+    let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
+    crate::gc_roots::pin_root(w_mapping);
+    let header = PyObject {
+        ob_type: &MAPPING_PROXY_TYPE as *const PyType,
+        w_class: get_instantiate(&MAPPING_PROXY_TYPE),
+    };
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable(W_DICT_PROXY_GC_TYPE_ID, W_DICT_PROXY_OBJECT_SIZE)
+            .filter(|p| !p.is_null());
+    let w_mapping = crate::gc_roots::shadow_stack_get(save_point);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_DictProxyObject,
+                W_DictProxyObject {
+                    ob_header: header,
+                    w_mapping,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     crate::lltype::malloc_typed(W_DictProxyObject {
-        ob_header: PyObject {
-            ob_type: &MAPPING_PROXY_TYPE as *const PyType,
-            w_class: get_instantiate(&MAPPING_PROXY_TYPE),
-        },
+        ob_header: header,
         w_mapping,
     }) as PyObjectRef
 }

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -363,6 +363,17 @@ pub fn list_strategy_for(items: &[PyObjectRef]) -> ListStrategy {
     }
 }
 
+/// Fire the GC write barrier for an Object-strategy list whose `items`
+/// block just gained a possibly-young element. `list_object_custom_trace`
+/// only forwards the off-GC `ItemsBlock` slots when the list is reached by
+/// a collection; an old-gen list that stored a young element is reached on
+/// a minor GC only if it sits in the remembered set, so the barrier must
+/// run after every ref store. Mirrors `set_write_barrier` / `dict_write_barrier`.
+#[inline]
+fn list_write_barrier(obj: PyObjectRef) {
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+}
+
 /// Allocate a new W_ListObject from a Vec of items.
 pub fn w_list_new(items: Vec<PyObjectRef>) -> PyObjectRef {
     let strategy = list_strategy_for(&items);
@@ -468,6 +479,12 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
         obj.int_items.fix_ptr();
         obj.float_items.fix_ptr();
     }
+    // Object-strategy creation seeds the `ItemsBlock` with the (possibly
+    // young) initial elements; remember the old-gen list so the next minor
+    // GC forwards them. Integer/Float blocks hold unboxed scalars — no refs.
+    if strategy == ListStrategy::Object {
+        list_write_barrier(raw as PyObjectRef);
+    }
     raw as PyObjectRef
 }
 
@@ -531,6 +548,7 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
                 return false;
             }
             items[idx as usize] = value;
+            list_write_barrier(obj);
             true
         }
         ListStrategy::Integer => {
@@ -581,13 +599,17 @@ pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
         // AbstractUnwrappedStrategy.append (listobject.py:1695):
         //   if self.is_correct_type(w_item): l.append(self.unwrap(w_item)); return
         //   self.switch_to_next_strategy(w_list, w_item); w_list.append(w_item)
-        ListStrategy::Object => list.object_push(value),
+        ListStrategy::Object => {
+            list.object_push(value);
+            list_write_barrier(obj);
+        }
         ListStrategy::Integer => {
             if is_plain_int1(value) {
                 list.int_items.push(plain_int_w(value));
             } else {
                 switch_to_object_strategy(list);
                 list.object_push(value);
+                list_write_barrier(obj);
             }
         }
         ListStrategy::Float => {
@@ -596,6 +618,7 @@ pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
             } else {
                 switch_to_object_strategy(list);
                 list.object_push(value);
+                list_write_barrier(obj);
             }
         }
     }
@@ -755,6 +778,7 @@ pub unsafe fn w_list_insert(obj: PyObjectRef, index: i64, value: PyObjectRef) {
         ListStrategy::Object => {
             let idx = normalize_insert_index(index, list.length);
             list.object_insert(idx, value);
+            list_write_barrier(obj);
         }
     }
 }
@@ -1060,6 +1084,7 @@ pub unsafe fn w_list_setslice(
                 ListStrategy::Object => {
                     list.set_object_items_from_vec(other.object_to_vec());
                     list.strategy = ListStrategy::Object;
+                    list_write_barrier(obj);
                     return Ok(());
                 }
             }
@@ -1129,6 +1154,7 @@ pub unsafe fn w_list_setslice(
     let e = end.min(v.len());
     v.splice(s..e, new_items);
     rebuild_object_items(list, v);
+    list_write_barrier(obj);
     Ok(())
 }
 

--- a/pyre/pyre-object/src/methodobject.rs
+++ b/pyre/pyre-object/src/methodobject.rs
@@ -27,15 +27,46 @@ pub fn w_method_new(
     w_self: PyObjectRef,
     w_class: PyObjectRef,
 ) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`) for
-    // the `lltype::malloc_typed` call below. All three inputs are live
-    // PyObjectRef roots that must survive a potential collection inside
-    // the allocation point once the malloc body swaps to a
-    // managed allocator.
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // three members across the GC malloc and re-read their relocated
+    // addresses afterwards (a minor collection inside the malloc may move
+    // them). A bound method whose `w_function`/`w_self`/`w_class` is
+    // reachable only through it must be GC-traced; a `malloc_typed` method
+    // is invisible to mark-sweep, whereas `register_pyre_class` registers
+    // this layout's `ptr_offsets`, so mark-sweep follows the members. The
+    // write barrier below keeps the old-gen method in the remembered set so
+    // young members survive a later minor collection.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(w_function);
     crate::gc_roots::pin_root(w_self);
     crate::gc_roots::pin_root(w_class);
+    let header = PyObject {
+        ob_type: &METHOD_TYPE as *const PyType,
+        w_class: get_instantiate(&METHOD_TYPE),
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable(W_METHOD_GC_TYPE_ID, W_METHOD_OBJECT_SIZE)
+        .filter(|p| !p.is_null());
+    // Re-read the pinned roots after the allocation; a minor collection
+    // inside the GC malloc may have relocated them.
+    let w_function = crate::gc_roots::shadow_stack_get(save_point);
+    let w_self = crate::gc_roots::shadow_stack_get(save_point + 1);
+    let w_class = crate::gc_roots::shadow_stack_get(save_point + 2);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_MethodObject,
+                W_MethodObject {
+                    ob: header,
+                    w_function,
+                    w_self,
+                    w_class,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_MethodObject::allocate(W_MethodObject {
         ob: PyObject {
             ob_type: std::ptr::null(),

--- a/pyre/pyre-object/src/propertyobject.rs
+++ b/pyre/pyre-object/src/propertyobject.rs
@@ -37,16 +37,47 @@ pub struct W_PropertyObject {
 ///
 /// PyPy: W_Property.__init__(space, w_fget, w_fset, w_fdel, w_doc)
 pub fn w_property_new(fget: PyObjectRef, fset: PyObjectRef, fdel: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // three accessors across the GC malloc and read back relocated
+    // addresses. A property whose `fget`/`fset`/`fdel` is reachable only
+    // through it must be GC-traced; a `malloc_typed` property is invisible
+    // to mark-sweep. The `w_doc`/`w_name` setters already carry the write
+    // barrier (`set_doc`/`set_name`).
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(fget);
     crate::gc_roots::pin_root(fset);
     crate::gc_roots::pin_root(fdel);
+
+    let header = PyObject {
+        ob_type: &PROPERTY_TYPE as *const PyType,
+        w_class: get_instantiate(&PROPERTY_TYPE),
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable(W_PROPERTY_GC_TYPE_ID, W_PROPERTY_OBJECT_SIZE)
+        .filter(|p| !p.is_null());
+    let fget = crate::gc_roots::shadow_stack_get(save_point);
+    let fset = crate::gc_roots::shadow_stack_get(save_point + 1);
+    let fdel = crate::gc_roots::shadow_stack_get(save_point + 2);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_PropertyObject,
+                W_PropertyObject {
+                    ob: header,
+                    fget,
+                    fset,
+                    fdel,
+                    w_doc: PY_NULL,
+                    w_name: PY_NULL,
+                    getter_doc: false,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_PropertyObject::allocate(W_PropertyObject {
-        ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
-        },
+        ob: header,
         fget,
         fset,
         fdel,
@@ -124,14 +155,35 @@ pub struct W_StaticMethodObject {
 }
 
 pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // wrapped function across the GC malloc and read its relocated address.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(func);
+
+    let header = PyObject {
+        ob_type: &STATICMETHOD_TYPE as *const PyType,
+        w_class: get_instantiate(&STATICMETHOD_TYPE),
+    };
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable(W_STATICMETHOD_GC_TYPE_ID, W_STATICMETHOD_OBJECT_SIZE)
+            .filter(|p| !p.is_null());
+    let func = crate::gc_roots::shadow_stack_get(save_point);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_StaticMethodObject,
+                W_StaticMethodObject {
+                    ob: header,
+                    w_function: func,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_StaticMethodObject::allocate(W_StaticMethodObject {
-        ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
-        },
+        ob: header,
         w_function: func,
     })
 }
@@ -157,14 +209,35 @@ pub struct W_ClassMethodObject {
 }
 
 pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // wrapped function across the GC malloc and read its relocated address.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(func);
+
+    let header = PyObject {
+        ob_type: &CLASSMETHOD_TYPE as *const PyType,
+        w_class: get_instantiate(&CLASSMETHOD_TYPE),
+    };
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable(W_CLASSMETHOD_GC_TYPE_ID, W_CLASSMETHOD_OBJECT_SIZE)
+            .filter(|p| !p.is_null());
+    let func = crate::gc_roots::shadow_stack_get(save_point);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_ClassMethodObject,
+                W_ClassMethodObject {
+                    ob: header,
+                    w_function: func,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_ClassMethodObject::allocate(W_ClassMethodObject {
-        ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
-        },
+        ob: header,
         w_function: func,
     })
 }

--- a/pyre/pyre-object/src/sliceobject.rs
+++ b/pyre/pyre-object/src/sliceobject.rs
@@ -20,16 +20,47 @@ pub const SLICE_STOP_OFFSET: usize = std::mem::offset_of!(W_SliceObject, stop);
 pub const SLICE_STEP_OFFSET: usize = std::mem::offset_of!(W_SliceObject, step);
 
 pub fn w_slice_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // three bounds across the GC malloc and re-read their relocated
+    // addresses afterwards (a minor collection inside the malloc may move
+    // them). A slice whose `start`/`stop`/`step` is reachable only through
+    // it must be GC-traced; a `malloc_typed` slice is invisible to
+    // mark-sweep, whereas `register_pyre_class` registers this layout's
+    // `ptr_offsets`, so mark-sweep follows the bounds. The write barrier
+    // below keeps the old-gen slice in the remembered set so young bounds
+    // survive a later minor collection.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(start);
     crate::gc_roots::pin_root(stop);
     crate::gc_roots::pin_root(step);
+
+    let header = PyObject {
+        ob_type: &SLICE_TYPE as *const PyType,
+        w_class: get_instantiate(&SLICE_TYPE),
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable(W_SLICE_GC_TYPE_ID, W_SLICE_OBJECT_SIZE)
+        .filter(|p| !p.is_null());
+    let start = crate::gc_roots::shadow_stack_get(save_point);
+    let stop = crate::gc_roots::shadow_stack_get(save_point + 1);
+    let step = crate::gc_roots::shadow_stack_get(save_point + 2);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_SliceObject,
+                W_SliceObject {
+                    ob: header,
+                    start,
+                    stop,
+                    step,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_SliceObject::allocate(W_SliceObject {
-        ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
-        },
+        ob: header,
         start,
         stop,
         step,

--- a/pyre/pyre-object/src/superobject.rs
+++ b/pyre/pyre-object/src/superobject.rs
@@ -19,15 +19,44 @@ pub struct W_SuperObject {
 
 /// Create a new super proxy.
 pub fn w_super_new(super_type: PyObjectRef, obj: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): pin the
+    // `super_type`/`obj` pair across the GC malloc and re-read their
+    // relocated addresses afterwards (a minor collection inside the malloc
+    // may move them). A super proxy whose members are reachable only
+    // through it must be GC-traced; a `malloc_typed` proxy is invisible to
+    // mark-sweep, whereas `register_pyre_class` registers this layout's
+    // `ptr_offsets`, so mark-sweep follows the members. The write barrier
+    // below keeps the old-gen proxy in the remembered set so young members
+    // survive a later minor collection.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(super_type);
     crate::gc_roots::pin_root(obj);
+
+    let header = PyObject {
+        ob_type: &SUPER_TYPE as *const PyType,
+        w_class: get_instantiate(&SUPER_TYPE),
+    };
+    let raw = crate::gc_hook::try_gc_alloc_stable(W_SUPER_GC_TYPE_ID, W_SUPER_OBJECT_SIZE)
+        .filter(|p| !p.is_null());
+    let super_type = crate::gc_roots::shadow_stack_get(save_point);
+    let obj = crate::gc_roots::shadow_stack_get(save_point + 1);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_SuperObject,
+                W_SuperObject {
+                    ob: header,
+                    super_type,
+                    obj,
+                },
+            );
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_SuperObject::allocate(W_SuperObject {
-        ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
-        },
+        ob: header,
         super_type,
         obj,
     })


### PR DESCRIPTION
Resolve #47

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Two orthogonal threads: the box-identity epic (#9 / #115 under #47) and the GC-management follow-ups (#341).

### Box-identity re-keying and `Operand::Box` drain (#9 / #115)

- Re-key the exported `IntBound` carrier and `OptContext.emitted_operations` to `BoxRef` (compared by `Rc::ptr_eq`), matching RPython's `box._forwarded` IntBound storage and `optimizer.py:246` `self._emittedoperations` keyed on the `op` object.
- Add an env-gated `MAJIT_DIAG_OPERAND_BOX` gauge at the sole production minter of the `Operand::Box` position-only catch-all, then drain it to zero on the synth corpus:
  - bind `short_inputargs` via `from_bound_inputarg` over a rooted, cross-peel-carried `short_inputarg_refs` pool (3927 → 237 mints);
  - make `emit_constant_*` SAME_AS source a constant box (`new_const`) instead of a self-referential position arg (237 → 0).
- Collapse the four remaining `get_box_replacement(o).to_opref()` round-trips to the OpRef-native `get_replacement_opref(o)`.

### GC management (#341)

- Trace `W_ListObject` Object-strategy elements via `list_object_custom_trace` — the off-GC `std::alloc`'d `ItemsBlock` was registered only as a flat `gc_ptr_offset`, so a major collection swept list-only-reachable elements.
- Fire a `list_write_barrier` after every `PyObjectRef` store into an Object-strategy list (`new_with_strategy`, `setitem`, `append` incl. strategy-switch paths, `insert`, both `setslice` exits) — the remembered-set gap left a young value (e.g. a fresh `{}`) dangling after the nursery reset.
- Migrate method/slice/super, cell/property/static/classmethod, and `W_DictProxyObject` wrappers from `malloc_typed` (immortal, off the managed heap) to `try_gc_alloc_stable` so their already-registered `ptr_offsets` are actually traced; pin members across the malloc, re-read relocated addresses, write barrier.
- Barrier the `w_module` / `w_new_self` function setters for symmetry with the sibling setters (latent today — current callers pass immortal values).

Regression tests added: `list_elements_gc_stress`, `list_young_dict_gc_stress` (both proven non-vacuous — SIGSEGV / SIGABRT without the fix).

Validation: `check.py` dynasm 131/131 + cranelift 131/131; `majit-metainterp` lib green.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->
