### PR TITLE
JIT: closure/cell opcodes, code-constant interning, and flatten free-coloring groundwork

### DIFF
--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -6191,9 +6191,22 @@ impl<'a> ResumeDataDirectReader<'a> {
 
     /// `resume.py:1509-1518 setfield(struct, fieldnum, descr)` dispatcher:
     /// forwards to `bh_setfield_gc_r` / `bh_setfield_gc_f` /
-    /// `bh_setfield_gc_i` based on `descr.is_pointer_field()` /
-    /// `is_float_field()`.  `fieldnum` is the resume.py-tagged value
-    /// to decode (decode_ref / decode_float / decode_int per kind).
+    /// `bh_setfield_gc_i` based on the field's value kind.  `fieldnum` is
+    /// the resume.py-tagged value to decode (decode_ref / decode_float /
+    /// decode_int per kind).
+    ///
+    /// Routes on `field_type()` (the value kind the optimizer numbered the
+    /// stored box as) rather than `is_pointer_field()`.  In RPython these
+    /// coincide — `FLAG_POINTER` is set iff the field is a GC `Ptr`, so
+    /// `is_pointer_field()` ⟺ `field_type == Ref`.  Pyre overloads the
+    /// flag for the write barrier: `ExecutionContext.sys_exc_value`
+    /// (`pyre-jit-trace/src/descr.rs`) carries `field_type = Ref` (so the
+    /// optimizer tracks and numbers the value as a GC ref) but a
+    /// non-pointer flag (so `rewrite.rs handle_write_barrier_setfield`
+    /// emits no barrier into the non-GC EC root).  The resume decode must
+    /// match how the value was numbered — by `field_type` — or a Ref value
+    /// (here a virtual exception object) is mis-decoded via `decode_int`
+    /// → `getvirtual_int` on a non-raw virtual.
     pub fn setfield(&mut self, struct_ptr: i64, fieldnum: i16, descr: &majit_ir::DescrRef) {
         let fd = descr
             .as_field_descr()
@@ -6204,7 +6217,7 @@ impl<'a> ResumeDataDirectReader<'a> {
             field_type: fd.field_type(),
             field_size: fd.field_size(),
         };
-        if fd.is_pointer_field() {
+        if fd.field_type() == majit_ir::Type::Ref {
             // resume.py:1511 newvalue = self.decode_ref(fieldnum)
             // resume.py:1512 self.cpu.bh_setfield_gc_r(struct, newvalue, descr)
             let value = self.decode_ref(fieldnum);

--- a/pyre/bench/synth/closure_per_call.py
+++ b/pyre/bench/synth/closure_per_call.py
@@ -1,0 +1,33 @@
+# Regression guard for the per-call-created nested closure JIT hang.
+#
+# `add` is defined fresh on every `make` call, and `make` is driven from a
+# hot outer loop.  Each nested code constant must realize to one shared code
+# object (stable `__code__` identity / JIT green key), so the trace give-up
+# counter accumulates and the JIT stops re-tracing the dead closure.  When the
+# code object is re-materialized per call instead, every closure instance gets
+# a fresh green key, the give-up never sticks, and tracing thrashes
+# super-linearly until this bench times out.
+N = 40000
+
+
+def make(n):
+    acc = [0]
+
+    def add(x):
+        acc[0] += x
+        return acc[0]
+
+    r = 0
+    for i in range(n):
+        r = add(i)
+    return r
+
+
+def main():
+    s = 0
+    for k in range(N):
+        s += make(k % 12)
+    print(s)
+
+
+main()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -13,7 +13,7 @@ use crate::{
     build_list_from_refs, build_map_from_refs, build_tuple_from_refs,
     decode_instruction_for_dispatch, dict_storage_load, dict_storage_store, ensure_range_iter,
     execute_opcode_step, range_iter_continues, range_iter_next_or_null, stack_underflow_error,
-    unpack_sequence_exact, w_code_new,
+    unpack_sequence_exact,
 };
 use pyre_object::*;
 
@@ -2099,8 +2099,7 @@ impl ConstantOpcodeHandler for PyFrame {
         &mut self,
         code: &crate::bytecode::CodeObject,
     ) -> Result<Self::Value, PyError> {
-        let code_ptr = Box::into_raw(Box::new(code.clone())) as *const ();
-        Ok(w_code_new(code_ptr))
+        Ok(crate::pycode::intern_code_constant(code))
     }
 
     fn none_constant(&mut self) -> Result<Self::Value, PyError> {

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -251,6 +251,41 @@ pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     w_code_new(code_ptr)
 }
 
+thread_local! {
+    /// Realized `W_CodeObject` for each nested code constant, keyed by
+    /// the frozen `CodeObject`'s address.  `pycode.py` realizes a nested
+    /// code constant into one `PyCode` at enclosing-code construction and
+    /// shares it through `co_consts`; pyre realizes lazily on `LOAD_CONST`,
+    /// so this table reproduces the sharing.  The frozen `CodeObject` lives
+    /// in the enclosing code's `constants` array, and that enclosing code is
+    /// Box-immortal (`w_code_new` → `Box::into_raw`), so the key address is
+    /// stable for the process and never reused.  The cached wrappers are
+    /// likewise Box-immortal, so the raw pointers never dangle and need no
+    /// GC tracing (same rationale as `MAPDICT_METHOD_CACHE_CODES`).
+    static CODE_CONSTANT_INTERN: std::cell::RefCell<std::collections::HashMap<usize, PyObjectRef>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Realize a nested code constant into its shared `W_CodeObject`,
+/// reproducing `co_consts` holding one realized code object per nested
+/// code.  `code` must be the frozen constant embedded in an enclosing
+/// (Box-immortal) `CodeObject`'s `constants` array — its address is the
+/// stable identity key.  Repeated `LOAD_CONST` of the same nested code
+/// returns the same wrapper, giving stable `__code__` identity and a
+/// stable JIT green key (`greens = [..., 'pycode']`).  Without this the
+/// per-`LOAD_CONST` wrapper differs every call, so a closure defined in a
+/// hot-loop-called function gets a fresh green key each iteration and the
+/// trace give-up counter never accumulates.
+pub fn intern_code_constant(code: &crate::CodeObject) -> PyObjectRef {
+    let key = code as *const crate::CodeObject as usize;
+    if let Some(w) = CODE_CONSTANT_INTERN.with(|c| c.borrow().get(&key).copied()) {
+        return w;
+    }
+    let w = box_code_constant(code);
+    CODE_CONSTANT_INTERN.with(|c| c.borrow_mut().insert(key, w));
+    w
+}
+
 /// pypy/module/__pypy__/interp_magic.py:79
 /// `func.getcode().hidden_applevel = True` — explicit setter for the
 /// `__pypy__.hidden_applevel(func)` builtin marker, plus the

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2663,8 +2663,10 @@ fn pyobject_from_constant(constant: &crate::bytecode::ConstantData) -> PyObjectR
         ConstantData::Str { value } => pyre_object::strobject::box_str_constant(value),
         // `eval.rs:1321-1323 bytes_constant`.
         ConstantData::Bytes { value } => pyre_object::bytesobject::w_bytes_from_bytes(value),
-        // `eval.rs:1325-1331 code_constant` — same pointer-cast helper.
-        ConstantData::Code { code } => crate::pycode::box_code_constant(code),
+        // `eval.rs:1325-1331 code_constant` — intern so the blackhole
+        // reifies the same shared `W_CodeObject` the interpreter
+        // `LOAD_CONST` does (stable `__code__` identity + JIT green key).
+        ConstantData::Code { code } => crate::pycode::intern_code_constant(code),
         // `eval.rs:1333-1335 none_constant`.
         ConstantData::None => pyre_object::w_none(),
         // `eval.rs:1337-1339 ellipsis_constant`.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5374,48 +5374,37 @@ fn collect_outer_active_boxes(
                         }
                     }
                 }
-                // Under the canonical splice a single `-live-` marker is
-                // SHARED across a range of Python PCs at different
-                // stack depths, and its liveness banks carry the UNION of
-                // those PCs' live frame colors.  Resuming at a shallower
-                // PC therefore sees a Ref color that names a stack slot
-                // BEYOND this resume's live window (`semantic_ref_slot_for_
-                // reg_color` is `None` because the slot sits past
-                // `valid_stack_only`) — a frame slot that is dead here and
-                // was never populated in `registers_r`.  Both decode paths
-                // already tolerate this: the blackhole rebuild
+                // `semantic_idx` is `None`: this Ref color names no live
+                // frame slot at the resume PC.  Under the canonical splice a
+                // single `-live-` marker is SHARED across a range of Python
+                // PCs at different stack depths, and its liveness banks carry
+                // the UNION of those PCs' live colors.  Resuming at a
+                // shallower PC therefore sees colors that are dead here:
+                //   - a mapped frame stack slot BEYOND this resume's live
+                //     window (`semantic_ref_slot_for_reg_color` is `None`
+                //     because the slot sits past `valid_stack_only`), or
+                //   - under free (non-identity) coloring, a NON-frame SSA
+                //     temp (in neither the local nor the stack color map)
+                //     that is live only at another PC the marker spans.
+                // Both are dead at this PC: the trace produced no box for a
+                // dead value, so `registers_r[color]` is NONE.  Both decode
+                // paths already tolerate this — the blackhole rebuild
                 // (`state.rs` ref-bank loop) and the bridge decoder drop a
                 // Ref color whose semantic slot is `None`.  Keep encode
-                // symmetric — substitute `CONST_NULL` (history.py:361) so
-                // the positional snapshot/liveness count stays aligned
-                // rather than failing loud on the unsourceable dead slot.
-                // Only colors that name a real frame slot (present in the
-                // stack/local color maps) qualify; a color with no frame
-                // correspondence still falls through to the fail-loud
-                // `registers_r` read so genuine liveness-coverage bugs
-                // surface.  Under the walker (gate-off) each PC owns a
-                // depth-narrowed marker, so this arm never fires.
-                None if stack_color_map.contains(&(color as u16))
-                    || local_color_map.contains(&(color as u16)) =>
-                {
-                    // Splice block reordering can hoist an op (e.g. the
-                    // bumped-counter `int_add_ovf` result) ahead of the
-                    // `-live-` marker its consumer block resumes at; the
-                    // color is then live-in at the resume marker while the
-                    // static color→slot map still names a stack slot beyond
-                    // this pc's depth window.  The walk register bank holds
-                    // the actual live value — supply it (matching the trait
-                    // `get_list_of_active_boxes`'s direct `registers_r`
-                    // read) so the blackhole / bridge seeds the real box
-                    // instead of NULL-corrupting the slot it is stored to.
-                    // Only a genuinely never-written color (dead-beyond-
-                    // depth union slot of a shared marker) falls back to
-                    // CONST_NULL to keep the positional snapshot aligned.
-                    match regs_r.get(color).copied() {
-                        Some(v) if v != OpRef::NONE => v,
-                        _ => OpRef::const_ptr(majit_ir::GcRef(0)),
-                    }
-                }
+                // symmetric: substitute `CONST_NULL` (history.py:361) so the
+                // positional snapshot/liveness count stays aligned rather
+                // than failing loud on the unsourceable dead slot.  A color
+                // the trace DID produce here (e.g. an op hoisted ahead of its
+                // consumer block's marker so it is live-in at the resume
+                // marker) carries its real `registers_r` box — `regs_r[color]`
+                // is non-NONE precisely when the value is genuinely live, so
+                // this read is the same `get_list_of_active_boxes` parity the
+                // mapped arm above uses.  Under the walker (gate-off) each PC
+                // owns a depth-narrowed marker, so this arm never fires.
+                None => match regs_r.get(color).copied() {
+                    Some(v) if v != OpRef::NONE => v,
+                    _ => OpRef::const_ptr(majit_ir::GcRef(0)),
+                },
                 _ => fallback(),
             }
         } else {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1463,6 +1463,62 @@ impl Drop for VableRollbackRoots {
     }
 }
 
+/// RAII guard registering each `Ref`-typed slot of the resume `deadframe`
+/// copy as a GC root for the duration of `blackhole_from_resumedata`.
+///
+/// `deadframe` is an off-heap copy of the guard-failure values
+/// (`result.values`).  The collector is moving, so a minor collection
+/// triggered while `blackhole_from_resumedata` lazily materializes virtuals
+/// (`getvirtual_ptr` → allocator) relocates the boxed objects and leaves the
+/// copy holding from-space pointers; `decode_ref` (resume.rs:1575) then reads
+/// a stale pointer for a box-sourced slot and the blackhole dereferences
+/// freed memory.  Resume *constants* are already forwarded by
+/// `rd_consts_root_walker`, but the box-sourced slots here are not.
+/// Registering each `Ref` element slot makes the root walker forward it in
+/// place, mirroring `VableRollbackRoots` (#326).
+///
+/// Only `Ref`-typed slots are registered: `Int`/`Float` slots hold raw
+/// scalars (`decode_ref` boxes those lazily via `box_int`/`box_float`), and a
+/// scalar that happened to alias a managed address must never be treated as a
+/// root.  `deadframe_types[idx]` is parallel to `deadframe[idx]` (resume.rs
+/// `decode_ref` keys the same index), so the type gate is exact.
+struct ResumeDeadframeRoots {
+    slots: Vec<*mut *mut u8>,
+}
+
+impl ResumeDeadframeRoots {
+    fn register(deadframe: &mut [i64], deadframe_types: Option<&[majit_ir::Type]>) -> Self {
+        let mut slots = Vec::new();
+        if let Some(types) = deadframe_types {
+            for (idx, ty) in types.iter().enumerate() {
+                if !matches!(ty, majit_ir::Type::Ref) {
+                    continue;
+                }
+                let Some(cell) = deadframe.get_mut(idx) else {
+                    break;
+                };
+                // Null / `NULLREF` slots carry no object to forward.
+                if *cell == 0 {
+                    continue;
+                }
+                let slot = cell as *mut i64 as *mut *mut u8;
+                if unsafe { pyre_object::gc_hook::try_gc_add_root(slot) } {
+                    slots.push(slot);
+                }
+            }
+        }
+        Self { slots }
+    }
+}
+
+impl Drop for ResumeDeadframeRoots {
+    fn drop(&mut self) {
+        for &slot in &self.slots {
+            pyre_object::gc_hook::try_gc_remove_root(slot);
+        }
+    }
+}
+
 /// resume.py:1312 blackhole_from_resumedata parity:
 /// Decode rd_numb via ResumeDataDirectReader, build blackhole chain,
 /// run _run_forever.
@@ -1521,6 +1577,17 @@ pub fn blackhole_resume_via_rd_numb(
                     .with_virtualizable_stack_base(pyjitcode.metadata.stack_base),
             )
         };
+
+    // Own the guard-failure values in host memory so the box-sourced `Ref`
+    // slots can be registered as GC roots: `blackhole_from_resumedata` below
+    // lazily materializes virtuals, and a minor collection during that work
+    // would relocate the boxed objects out from under the off-heap copy.
+    // Rooting forwards each `Ref` slot in place; `decode_ref` then reads the
+    // live (to-space) pointer rather than a dangling from-space one.  The
+    // `to_vec` uses the host allocator, so it cannot itself trigger a GC.
+    let mut deadframe_buf: Vec<i64> = deadframe.to_vec();
+    let _deadframe_roots = ResumeDeadframeRoots::register(&mut deadframe_buf, deadframe_types);
+    let deadframe: &[i64] = &deadframe_buf;
 
     // resume.py:983-991 _prepare_virtuals: convert RdVirtualInfo → VirtualInfo
     // for lazy materialization in getvirtual_ptr/getvirtual_int.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4435,6 +4435,43 @@ pub extern "C" fn bh_load_deref_value_fn(cell: i64, w_code_ptr: i64, deref_idx: 
     value as i64
 }
 
+/// STORE_DEREF residual (`store_deref_value` HLOp → `residual_call_r_r`).
+/// `cell` is the slot read from `locals_cells_stack_w`; `value` is the
+/// popped stack operand.  Mirrors `store_deref`: when the slot holds a
+/// cell, mutate the cell's contents in place (`w_cell_set`, incminimark
+/// write barrier inside) and return the unchanged cell so the caller
+/// re-stores the same pointer into the slot; otherwise return the raw
+/// `value` so the caller writes it into the slot directly.  Runs no user
+/// code and never raises (`CallFlavor::Plain`).
+pub extern "C" fn bh_store_deref_value_fn(cell: i64, value: i64) -> i64 {
+    let slot = cell as pyre_object::PyObjectRef;
+    if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
+        unsafe { pyre_object::w_cell_set(slot, value as pyre_object::PyObjectRef) };
+        cell
+    } else {
+        value
+    }
+}
+
+/// MAKE_CELL residual (`make_cell_value` HLOp → `residual_call_r_r`).
+/// `current` is the slot read from `locals_cells_stack_w`.  Mirrors
+/// `make_cell`: wrap the value in a fresh cell when the slot does not
+/// already hold one (`initialize_frame_scopes` installs cells for pure
+/// cellvars, so only an argument slot promoted to a cellvar still holds a
+/// raw value here), and return the cell the caller stores back into the
+/// slot.  A slot already holding a cell is returned unchanged so a
+/// never-reassigned cellvar does not become a cell wrapping a cell.
+/// Allocates (may trigger a minor GC) but runs no user code and never
+/// raises (`CallFlavor::Plain`).
+pub extern "C" fn bh_make_cell_fn(current: i64) -> i64 {
+    let cur = current as pyre_object::PyObjectRef;
+    if cur.is_null() || !unsafe { pyre_object::is_cell(cur) } {
+        pyre_object::w_cell_new(cur) as i64
+    } else {
+        current
+    }
+}
+
 /// UNARY_NEGATIVE residual (`unary_negative` HLOp → `residual_call_r_r`).
 /// Computes `-value` through `opcode_ops::unary_negative_value` (`neg`); a
 /// user `__neg__` may run Python (`MayForce`).  On error the exception

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3141,11 +3141,13 @@ fn frontend_load_const_flow_value(code: &CodeObject, idx: usize) -> super::flow:
     pyobject_const_ref_value(pyre_interpreter::pyframe::load_const_from_code(code, idx))
 }
 
-fn frontend_global_flow_value(w_code: *const (), name: &str) -> Option<super::flow::FlowValue> {
-    // `flowcontext.py:845-858 find_global` resolves globals during flow
-    // analysis and pushes a Constant.  Do the same when the current
-    // W_CodeObject exposes its globals/builtins; callers fall back to a
-    // fresh Ref only when pyre cannot reproduce the static lookup.
+/// Resolve `name` the way `flowcontext.py:845-858 find_global` does —
+/// module globals first, then `__builtins__` — returning the raw resolved
+/// object (or `None` when pyre cannot reproduce the static lookup).
+/// `frontend_global_flow_value` wraps the result in a const `FlowValue`;
+/// the `LOAD_GLOBAL` walker uses it to classify the FINAL resolved value
+/// (globals OR builtins) before deciding whether const-folding is GC-safe.
+fn frontend_global_object(w_code: *const (), name: &str) -> Option<pyre_object::PyObjectRef> {
     let w_code = w_code as pyre_object::PyObjectRef;
     if w_code.is_null() {
         return None;
@@ -3156,11 +3158,9 @@ fn frontend_global_flow_value(w_code: *const (), name: &str) -> Option<super::fl
     }
     let globals = unsafe { &*w_globals };
     if let Some(w_value) = pyre_interpreter::dict_storage_get(globals, name) {
-        return Some(pyobject_const_ref_value(w_value));
+        return Some(w_value);
     }
-    let Some(w_builtin) = pyre_interpreter::dict_storage_get(globals, "__builtins__") else {
-        return None;
-    };
+    let w_builtin = pyre_interpreter::dict_storage_get(globals, "__builtins__")?;
     let lookup_obj = if unsafe { pyre_object::is_module(w_builtin) } {
         unsafe { pyre_object::w_module_get_w_dict(w_builtin) }
     } else if unsafe { pyre_object::is_dict(w_builtin) } {
@@ -3174,7 +3174,14 @@ fn frontend_global_flow_value(w_code: *const (), name: &str) -> Option<super::fl
     pyre_interpreter::baseobjspace::finditem_str(lookup_obj, name)
         .ok()
         .flatten()
-        .map(pyobject_const_ref_value)
+}
+
+fn frontend_global_flow_value(w_code: *const (), name: &str) -> Option<super::flow::FlowValue> {
+    // `flowcontext.py:845-858 find_global` resolves globals during flow
+    // analysis and pushes a Constant.  Do the same when the current
+    // W_CodeObject exposes its globals/builtins; callers fall back to a
+    // fresh Ref only when pyre cannot reproduce the static lookup.
+    frontend_global_object(w_code, name).map(pyobject_const_ref_value)
 }
 
 fn set_last_bool_exitcase(block: &super::flow::BlockRef, branch_taken: bool) {
@@ -7273,22 +7280,21 @@ impl CodeWriter {
                                         w_code as pyre_object::PyObjectRef,
                                     )
                                 };
-                                // Classify the resolved global: a globals-only
-                                // lookup suffices since builtins are never the
-                                // user-mutated containers this gate targets.
-                                let global_is_relocatable_container = !w_globals.is_null()
-                                    && name
-                                        .and_then(|nm| {
-                                            pyre_interpreter::dict_storage_get(
-                                                unsafe { &*w_globals },
-                                                nm,
-                                            )
-                                        })
-                                        .is_some_and(|obj| unsafe {
-                                            pyre_object::is_dict(obj)
-                                                || pyre_object::is_list(obj)
-                                                || pyre_object::is_set(obj)
-                                        });
+                                // Classify the FINAL resolved global — module
+                                // globals OR `__builtins__`, the same lookup
+                                // `frontend_global_flow_value` const-folds.  A
+                                // custom / mutated builtins dict can supply a
+                                // mutable container, so a globals-only gate would
+                                // const-fold a relocating builtin container and
+                                // reintroduce the moving-GC dangling pointer the
+                                // residual avoids.
+                                let global_is_relocatable_container = name
+                                    .and_then(|nm| frontend_global_object(w_code, nm))
+                                    .is_some_and(|obj| unsafe {
+                                        pyre_object::is_dict(obj)
+                                            || pyre_object::is_list(obj)
+                                            || pyre_object::is_set(obj)
+                                    });
                                 if global_is_relocatable_container {
                                     // The namespace operand is the callee's
                                     // module dict OBJECT.  `PyFrame.__init__`

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3527,6 +3527,8 @@ struct FnPtrIndices {
     load_super_attr_fn: HelperHandle,
     super_attr_unwrap_fn: HelperHandle,
     load_deref_value_fn: HelperHandle,
+    store_deref_value_fn: HelperHandle,
+    make_cell_fn: HelperHandle,
     unary_negative_fn: HelperHandle,
     unary_invert_fn: HelperHandle,
     unary_not_fn: HelperHandle,
@@ -3851,6 +3853,18 @@ fn register_helper_fn_pointers(
         cpu.load_deref_value_fn as *const (),
         CallFlavor::Plain,
     );
+    // `bh_store_deref_value_fn` mutates a cell's contents (or returns the raw
+    // slot value); it runs no user code and never raises → `Plain`.  Appended
+    // last to preserve fn_ptr indices.
+    let store_deref_value_fn = bind(
+        assembler,
+        cpu.store_deref_value_fn as *const (),
+        CallFlavor::Plain,
+    );
+    // `bh_make_cell_fn` allocates a fresh cell (or returns the existing one);
+    // it runs no user code and never raises → `Plain`.  Appended last to
+    // preserve fn_ptr indices.
+    let make_cell_fn = bind(assembler, cpu.make_cell_fn as *const (), CallFlavor::Plain);
     // `bh_unary_invert_fn` computes `~value`; a user `__invert__` may run
     // Python → `MayForce`.  Appended last to preserve fn_ptr indices.
     let unary_invert_fn = bind(
@@ -3964,6 +3978,8 @@ fn register_helper_fn_pointers(
         load_super_attr_fn,
         super_attr_unwrap_fn,
         load_deref_value_fn,
+        store_deref_value_fn,
+        make_cell_fn,
         unary_negative_fn,
         unary_invert_fn,
         unary_not_fn,
@@ -4975,6 +4991,16 @@ impl CodeWriter {
                     idx: load_deref_value_fn_idx,
                     flavor: _load_deref_value_fn_flavor,
                 },
+            store_deref_value_fn:
+                HelperHandle {
+                    idx: store_deref_value_fn_idx,
+                    flavor: _store_deref_value_fn_flavor,
+                },
+            make_cell_fn:
+                HelperHandle {
+                    idx: make_cell_fn_idx,
+                    flavor: _make_cell_fn_flavor,
+                },
             unary_negative_fn:
                 HelperHandle {
                     idx: unary_negative_fn_idx,
@@ -5081,6 +5107,8 @@ impl CodeWriter {
                 load_super_attr_fn_idx,
                 super_attr_unwrap_fn_idx,
                 load_deref_value_fn_idx,
+                store_deref_value_fn_idx,
+                make_cell_fn_idx,
                 unary_negative_fn_idx,
                 unary_invert_fn_idx,
                 unary_not_fn_idx,
@@ -9453,10 +9481,108 @@ impl CodeWriter {
                             emit_abort_permanent!(py_pc);
                         }
 
-                        // StoreDeref: pops 1 value. Net: -1.
-                        Instruction::StoreDeref { .. } => {
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            emit_abort_permanent!(py_pc);
+                        // STORE_DEREF: pops the value and writes it into the
+                        // cell slot. Net: -1. The slot in
+                        // `locals_cells_stack_w` holds a cell object
+                        // (`initialize_frame_scopes` / MAKE_CELL / the closure
+                        // tuple install one), so `i` is the unified localsplus
+                        // index read like LOAD_FAST. The cell is read FIRST so
+                        // it lands above the value on the symbolic stack and
+                        // the two pinned slots stay distinct. The
+                        // `store_deref_value(cell, value)` HLOp →
+                        // `residual_call_r_r(store_deref_value_fn,
+                        // ListR[cell, value])` mutates the cell's contents in
+                        // place (`bh_store_deref_value_fn`, Plain — writes
+                        // heap, runs no user code) and returns the slot value:
+                        // the unchanged cell for a cell slot, or the raw
+                        // `value` for a non-cell slot. The result is stored
+                        // back into the slot via `setarrayitem_vable_r`
+                        // (jtransform.py:1898 `do_fixed_list_setitem`),
+                        // mirroring the STORE_FAST shadow write.
+                        Instruction::StoreDeref { i } => {
+                            let idx = i.get(op_arg).as_usize() as u16;
+                            emit_load_fast_ref!(current_depth, idx, py_pc);
+                            let cell_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let cell_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            if let super::flow::FlowValue::Variable(v) = &cell_value {
+                                pin!(Some(*v), cell_reg);
+                            }
+                            let value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let value_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            if let super::flow::FlowValue::Variable(v) = &value_value {
+                                pin!(Some(*v), value_reg);
+                            }
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "store_deref_value",
+                                vec![cell_value.into(), value_value.into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            if is_portal {
+                                let local_slot = local_to_vable_slot(idx as usize) as i64;
+                                let v_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(local_slot).into();
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "setarrayitem_vable_r",
+                                    vable_setarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_idx.into(),
+                                        super::flow::FlowValue::from(result_value).into(),
+                                    ),
+                                    None,
+                                    py_pc as i64,
+                                );
+                            }
+                            current_state.store_local_value(idx as usize, result_value.into());
+                        }
+
+                        // MAKE_CELL: wraps the slot value in a cell. Touches
+                        // only the localsplus slot (no operand-stack effect);
+                        // `i` is the unified localsplus index read like
+                        // LOAD_FAST. The `make_cell_value(current)` HLOp →
+                        // `residual_call_r_r(make_cell_fn, ListR[current])`
+                        // returns the cell to install: a fresh cell wrapping
+                        // the raw argument value, or the existing cell
+                        // unchanged (`bh_make_cell_fn`, Plain — allocates,
+                        // runs no user code). The result is stored into the
+                        // slot via `setarrayitem_vable_r`, mirroring the
+                        // STORE_FAST shadow write.
+                        Instruction::MakeCell { i } => {
+                            let idx = i.get(op_arg).as_usize() as u16;
+                            emit_load_fast_ref!(current_depth, idx, py_pc);
+                            let current_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let current_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            if let super::flow::FlowValue::Variable(v) = &current_value {
+                                pin!(Some(*v), current_reg);
+                            }
+                            let result_value = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "make_cell_value",
+                                vec![current_value.into()],
+                                Kind::Ref,
+                                py_pc as i64,
+                            );
+                            if is_portal {
+                                let local_slot = local_to_vable_slot(idx as usize) as i64;
+                                let v_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(local_slot).into();
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "setarrayitem_vable_r",
+                                    vable_setarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_idx.into(),
+                                        super::flow::FlowValue::from(result_value).into(),
+                                    ),
+                                    None,
+                                    py_pc as i64,
+                                );
+                            }
+                            current_state.store_local_value(idx as usize, result_value.into());
                         }
 
                         // Instructions that don't touch the operand stack (locals/cells only).
@@ -9464,7 +9590,6 @@ impl CodeWriter {
                         | Instruction::DeleteDeref { .. }
                         | Instruction::DeleteGlobal { .. }
                         | Instruction::DeleteName { .. }
-                        | Instruction::MakeCell { .. }
                         | Instruction::SetupAnnotations => {
                             emit_abort_permanent!(py_pc);
                         }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -6624,6 +6624,7 @@ impl CodeWriter {
                         | Instruction::Nop
                         | Instruction::Cache
                         | Instruction::NotTaken
+                        | Instruction::CopyFreeVars { .. }
                         | Instruction::ExtendedArg => {
                             // RPython: no-op operations produce no jitcode output
                         }
@@ -9463,7 +9464,6 @@ impl CodeWriter {
                         | Instruction::DeleteDeref { .. }
                         | Instruction::DeleteGlobal { .. }
                         | Instruction::DeleteName { .. }
-                        | Instruction::CopyFreeVars { .. }
                         | Instruction::MakeCell { .. }
                         | Instruction::SetupAnnotations => {
                             emit_abort_permanent!(py_pc);

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8063,6 +8063,20 @@ impl CodeWriter {
                             // reshapes the POP_EXCEPT-mutated source stack
                             // to the handler try-level, so the landing no
                             // longer mismatches the explicit-raise shape.
+                            //
+                            // No-catch arm (`catch_for_pc[py_pc]` None): this is
+                            // a `finally` cleanup RERAISE, which CPython 3.11+
+                            // reaches WITHOUT a `PUSH_EXC_INFO`, so the source
+                            // FrameState carries no live `last_exception` pair.
+                            // `flatten.py:163-174 make_exception_link` emits the
+                            // `reraise/` coding only when the edge args ARE that
+                            // pair; absent it, the orthodox coding is the explicit
+                            // `raise/r` of the in-flight exception value — exactly
+                            // what `emit_raise!`'s `exceptblock` arm builds via
+                            // `explicit_raise_state(exc_value)`.  Routing this
+                            // through `emit_reraise!` instead would hit its
+                            // materialized-pair assertion, so the explicit raise
+                            // is the parity-correct port here, not a deviation.
                             emit_raise!(exc_reg, exc_value, py_pc as i64, true);
                         }
 

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -137,6 +137,13 @@ pub struct Cpu {
     /// dereference residual (cell contents, raising the named unbound-variable
     /// `NameError` resolved via `code` + `deref_idx`).
     pub load_deref_value_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bh_store_deref_value_fn(cell, value)` — STORE_DEREF residual: mutate
+    /// the cell's contents (returning the unchanged cell) or return the raw
+    /// `value` for a non-cell slot; infallible.
+    pub store_deref_value_fn: extern "C" fn(i64, i64) -> i64,
+    /// `bh_make_cell_fn(current)` — MAKE_CELL residual: wrap a raw slot value
+    /// in a fresh cell (or return an existing cell unchanged); infallible.
+    pub make_cell_fn: extern "C" fn(i64) -> i64,
     /// `bh_unary_negative_fn(value)` — UNARY_NEGATIVE `-value` residual
     /// (a user `__neg__` may run Python → fallible).
     pub unary_negative_fn: extern "C" fn(i64) -> i64,
@@ -303,6 +310,8 @@ impl Cpu {
             load_super_attr_fn: crate::call_jit::bh_load_super_attr_fn,
             super_attr_unwrap_fn: crate::call_jit::bh_super_attr_unwrap_fn,
             load_deref_value_fn: crate::call_jit::bh_load_deref_value_fn,
+            store_deref_value_fn: crate::call_jit::bh_store_deref_value_fn,
+            make_cell_fn: crate::call_jit::bh_make_cell_fn,
             unary_negative_fn: crate::call_jit::bh_unary_negative_fn,
             unary_invert_fn: crate::call_jit::bh_unary_invert_fn,
             unary_not_fn: crate::call_jit::bh_unary_not_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2488,13 +2488,27 @@ impl<'a> GraphFlattener<'a> {
                 }
             }
         }
+        // Each kind reserves at most ONE fresh "dead" color shared by all
+        // its leaked placeholders.  The placeholders are value-dead (an
+        // `abort_permanent` Ref in the unreachable bail-out region, or an
+        // uncaught-`finally` lasti Int the jitcode never reads), so they
+        // only need a *valid* color, never a *distinct* one — sharing one
+        // color per kind keeps the coloring dense (a unique color each
+        // would blow the u8 liveness encoding / Ref-bank size on graphs
+        // with hundreds of `abort_permanent` placeholders).  The shared
+        // color is `num_colors` (one past every live color), so it cannot
+        // alias any live value.
+        let mut dead_color: [Option<u16>; 3] = [None; 3];
         for v in leaked {
             let kind = v.kind.unwrap_or(Kind::Ref);
             let alloc = &mut self.regallocs[kind.index()];
             if !alloc.coloring.contains_key(&v.id) {
-                let color = alloc.num_colors;
+                let color = *dead_color[kind.index()].get_or_insert_with(|| {
+                    let c = alloc.num_colors;
+                    alloc.num_colors += 1;
+                    c
+                });
                 alloc.coloring.insert(v.id, color);
-                alloc.num_colors += 1;
             }
         }
     }
@@ -4803,7 +4817,8 @@ where
     if let Some(insn) = lower_load_deref_value_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
-    if let Some(insn) = lower_store_deref_value_hlop_to_insn(op, ctx, get_register, lower_constant) {
+    if let Some(insn) = lower_store_deref_value_hlop_to_insn(op, ctx, get_register, lower_constant)
+    {
         return Some(insn);
     }
     if let Some(insn) = lower_make_cell_hlop_to_insn(op, ctx, get_register, lower_constant) {

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3344,6 +3344,22 @@ pub struct LoweringContext {
     /// (`Plain` — reads heap, raises on an unbound free variable, runs no
     /// user code).
     pub load_deref_value_fn_idx: u16,
+    /// `store_deref_value_fn` descrs-pool index.  STORE_DEREF records the
+    /// `store_deref_value(cell, value)` HLOp lowered to `residual_call_r_r(
+    /// ConstInt(fn_idx), ListR([cell, value]), Descr) → reg` via
+    /// [`lower_store_deref_value_hlop_to_insn`] (the two-Ref shape); the result
+    /// is the slot value the codewriter re-stores via `setarrayitem_vable_r`.
+    /// `bh_store_deref_value_fn` mutates the cell's contents (`Plain` — writes
+    /// heap, runs no user code, never raises).
+    pub store_deref_value_fn_idx: u16,
+    /// `make_cell_fn` descrs-pool index.  MAKE_CELL records the
+    /// `make_cell_value(current)` HLOp lowered to `residual_call_r_r(ConstInt(
+    /// fn_idx), ListR([current]), Descr) → reg` via
+    /// [`lower_make_cell_hlop_to_insn`] (the single-Ref shape); the result is
+    /// the cell the codewriter stores via `setarrayitem_vable_r`.
+    /// `bh_make_cell_fn` allocates a fresh cell (`Plain` — runs no user code,
+    /// never raises).
+    pub make_cell_fn_idx: u16,
     /// `unary_negative_fn` descrs-pool index.  UNARY_NEGATIVE records the
     /// flowspace `neg(value)` op (operation.py:466) lowered to
     /// `residual_call_r_r(ConstInt(fn_idx), ListR([value]), Descr) → reg` via
@@ -4787,6 +4803,12 @@ where
     if let Some(insn) = lower_load_deref_value_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_store_deref_value_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_make_cell_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     if let Some(insn) = lower_unary_negative_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
@@ -5117,6 +5139,81 @@ where
             Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![cell, code])),
             descr_operand,
         ],
+        dst_reg,
+    ))
+}
+
+/// Lower the STORE_DEREF pyre HLOp `store_deref_value(cell, value)` →
+/// `result: Ref` to `residual_call_r_r(ConstInt(store_deref_value_fn_idx),
+/// ListR([cell, value]), Descr) → reg`, the two-Ref shape.  `cell` is the
+/// slot read from `locals_cells_stack_w`; `value` is the popped stack
+/// operand.  The result is the slot value the codewriter re-stores via
+/// `setarrayitem_vable_r`: the unchanged cell after the in-place `w_cell_set`,
+/// or the raw `value` for a non-cell slot.  Writes mutable heap but runs no
+/// user code and never raises → `Plain`.
+///
+/// Returns `None` for a non-`store_deref_value` opname or unexpected arity so
+/// the caller can fall through to other lowering arms.
+pub fn lower_store_deref_value_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "store_deref_value" || op.args.len() != 2 {
+        return None;
+    }
+    let cell = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let value = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_r_r_insn_from_operands(
+        ctx.store_deref_value_fn_idx,
+        vec![cell, value],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+        dst_reg,
+    ))
+}
+
+/// Lower the MAKE_CELL pyre HLOp `make_cell_value(current)` → `result: Ref`
+/// to `residual_call_r_r(ConstInt(make_cell_fn_idx), ListR([current]),
+/// Descr) → reg`, the single-Ref shape.  `current` is the slot read from
+/// `locals_cells_stack_w`; the result is the cell the codewriter stores via
+/// `setarrayitem_vable_r`.  Allocates a fresh cell but runs no user code and
+/// never raises → `Plain`.
+///
+/// Returns `None` for a non-`make_cell_value` opname or unexpected arity so
+/// the caller can fall through to other lowering arms.
+pub fn lower_make_cell_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "make_cell_value" || op.args.len() != 1 {
+        return None;
+    }
+    let current = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    Some(build_residual_call_r_r_insn_from_operands(
+        ctx.make_cell_fn_idx,
+        vec![current],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
         dst_reg,
     ))
 }
@@ -6938,6 +7035,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -7093,6 +7192,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -7235,6 +7336,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -7340,6 +7443,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -7489,6 +7594,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -7683,6 +7790,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -7926,6 +8035,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8035,6 +8146,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8088,6 +8201,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8218,6 +8333,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8306,6 +8423,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8365,6 +8484,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8416,6 +8537,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8474,6 +8597,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8559,6 +8684,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8607,6 +8734,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8669,6 +8798,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8747,6 +8878,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8810,6 +8943,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8888,6 +9023,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8942,6 +9079,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -8996,6 +9135,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -9055,6 +9196,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -9128,6 +9271,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -10300,6 +10445,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -10595,6 +10742,8 @@ mod tests {
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
+            store_deref_value_fn_idx: 0,
+            make_cell_fn_idx: 0,
             unary_negative_fn_idx: 0,
             unary_invert_fn_idx: 0,
             unary_not_fn_idx: 0,
@@ -10782,6 +10931,8 @@ mod tests {
             load_fast_check_fn_idx: 111,
             unary_negative_fn_idx: 112,
             list_extend_fn_idx: 113,
+            store_deref_value_fn_idx: 114,
+            make_cell_fn_idx: 115,
         };
         let code_const = Constant::new(
             super::super::flow::ConstantValue::Signed(0x2000),
@@ -11400,6 +11551,147 @@ mod tests {
                         assert!(
                             matches!(&list.content[..], [Operand::Register(r)] if r.index == 101),
                             "ListR = [value], got {:?}",
+                            list.content
+                        );
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 102
+                    }),
+                );
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_store_deref_value_hlop_emits_store_deref_value_fn_residual() {
+        // `store_deref_value(cell, value)` →
+        // `residual_call_r_r(ConstInt(store_deref_value_fn_idx),
+        // ListR([cell, value]), Descr) → reg` (Plain — mutates the cell's
+        // heap contents, runs no user code, never raises).
+        let cell_var = Variable::new(VariableId(8), Kind::Ref);
+        let value_var = Variable::new(VariableId(9), Kind::Ref);
+        let result_var = Variable::new(VariableId(10), Kind::Ref);
+        let (ctx, _, _) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "store_deref_value",
+            vec![cell_var.into(), value_var.into()],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(8) => Register {
+                kind: Kind::Ref,
+                index: 101,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 103,
+            },
+            VariableId(10) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn = super::lower_store_deref_value_hlop_to_insn(
+            &op,
+            &ctx,
+            &mut get_register,
+            &mut lower_constant,
+        )
+        .expect("2-arg store_deref_value lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_r_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(114)),
+                    "store_deref_value_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        match &list.content[..] {
+                            [Operand::Register(cell), Operand::Register(value)] => {
+                                assert_eq!(cell.index, 101, "ListR[0] must be cell");
+                                assert_eq!(value.index, 103, "ListR[1] must be value");
+                            }
+                            other => panic!("ListR must be [cell, value], got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 102
+                    }),
+                );
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_make_cell_hlop_emits_make_cell_fn_residual() {
+        // `make_cell_value(current)` →
+        // `residual_call_r_r(ConstInt(make_cell_fn_idx), ListR([current]),
+        // Descr) → reg` (Plain — allocates a fresh cell, runs no user code,
+        // never raises).
+        let current_var = Variable::new(VariableId(8), Kind::Ref);
+        let result_var = Variable::new(VariableId(9), Kind::Ref);
+        let (ctx, _, _) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "make_cell_value",
+            vec![current_var.into()],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(8) => Register {
+                kind: Kind::Ref,
+                index: 101,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn =
+            super::lower_make_cell_hlop_to_insn(&op, &ctx, &mut get_register, &mut lower_constant)
+                .expect("1-arg make_cell_value lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_r_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(115)),
+                    "make_cell_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        assert!(
+                            matches!(&list.content[..], [Operand::Register(r)] if r.index == 101),
+                            "ListR = [current], got {:?}",
                             list.content
                         );
                     }

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2434,46 +2434,67 @@ impl<'a> GraphFlattener<'a> {
         regalloc_color(&*self.regallocs, v)
     }
 
-    /// pyre-only: give a distinct fresh color to every Variable referenced
-    /// as a graph-op argument that the regalloc left uncolored.  No
+    /// pyre-only: give a distinct fresh color to every Variable the walker
+    /// leaves uncolored — referenced as a graph-op argument, an outgoing
+    /// link argument, or a block inputarg without a regalloc color.  No
     /// upstream counterpart — upstream flowgraphs are always well-formed
     /// (every operand is a block inputarg or an earlier op's result), so
     /// `make_dependencies`, which registers interference nodes only for
     /// inputargs and op results, colors every operand.
     ///
-    /// pyre's walker emits `abort_permanent` for opcodes the JIT does not
-    /// support (`CONTAINS_OP`, `UNPACK_SEQUENCE`, …) and pushes fresh
-    /// symbolic Refs onto the operand stack so the rest of the block's
-    /// symbolic execution stays stack-balanced.  Those Refs have no graph
-    /// producer, so `make_dependencies` never colors them, and a later op
-    /// that consumes one (`bool`, `setarrayitem_vable_r`) would hit the
-    /// `regalloc_color` missing-color panic when this driver serializes
-    /// it.
+    /// Two pyre walker shapes leak never-defined placeholders:
     ///
-    /// `abort_permanent` sets `needs_fallthrough = false`, severing the
-    /// block's CFG successor, so any instruction that consumes such a Ref
-    /// sits in the dead region after the bail-out: the compiled trace
-    /// returns to the interpreter before reaching it.  The instruction is
-    /// still serialized to keep the byte stream well-formed, but never
-    /// executes, so its register operand only has to be a *valid* color —
-    /// never a *value-correct* one.  A distinct fresh color satisfies that
-    /// and cannot alias any live value's color.
+    /// - `abort_permanent` for opcodes the JIT does not support
+    ///   (`CONTAINS_OP`, `UNPACK_SEQUENCE`, …) pushes fresh symbolic Refs
+    ///   onto the operand stack so the rest of the block's symbolic
+    ///   execution stays stack-balanced.  Those Refs have no graph
+    ///   producer, so `make_dependencies` never colors them, and a later
+    ///   op that consumes one (`bool`, `setarrayitem_vable_r`) would hit
+    ///   the `regalloc_color` missing-color panic.  `abort_permanent` sets
+    ///   `needs_fallthrough = false`, so the consuming instruction sits in
+    ///   the dead region after the bail-out.
+    ///
+    /// - an uncaught `finally` RERAISE leaves the 3.11 lasti slot
+    ///   (`int_w(peekvalue(oparg))`) on the stack as a never-defined Int
+    ///   placeholder that the exception edge threads as a link argument and
+    ///   the landing block names as an inputarg.  The lasti restore is
+    ///   runtime PyError state, not modeled in the jitcode, so no operation
+    ///   ever reads the placeholder.
+    ///
+    /// In both cases the placeholder is value-dead: the serialized byte
+    /// stream must stay well-formed, but the register operand only has to
+    /// be a *valid* color — never a *value-correct* one.  A distinct fresh
+    /// color satisfies that and cannot alias any live value's color.
     fn color_leaked_arg_variables(&mut self) {
         let graph: &super::flow::FunctionGraph = self.graph;
+        let mut leaked: Vec<Variable> = Vec::new();
         for block in graph.iterblocks() {
             let block_borrow = block.borrow();
+            for inputarg in &block_borrow.inputargs {
+                if let Some(v) = inputarg.as_variable() {
+                    leaked.push(v);
+                }
+            }
             for op in &block_borrow.operations {
                 for arg in &op.args {
-                    for v in arg.variables() {
-                        let kind = v.kind.unwrap_or(Kind::Ref);
-                        let alloc = &mut self.regallocs[kind.index()];
-                        if !alloc.coloring.contains_key(&v.id) {
-                            let color = alloc.num_colors;
-                            alloc.coloring.insert(v.id, color);
-                            alloc.num_colors += 1;
-                        }
+                    leaked.extend(arg.variables());
+                }
+            }
+            for link in &block_borrow.exits {
+                for arg in &link.borrow().args {
+                    if let Some(v) = arg.as_ref().and_then(FlowValue::as_variable) {
+                        leaked.push(v);
                     }
                 }
+            }
+        }
+        for v in leaked {
+            let kind = v.kind.unwrap_or(Kind::Ref);
+            let alloc = &mut self.regallocs[kind.index()];
+            if !alloc.coloring.contains_key(&v.id) {
+                let color = alloc.num_colors;
+                alloc.coloring.insert(v.id, color);
+                alloc.num_colors += 1;
             }
         }
     }

--- a/pyre/pyre-object/src/cellobject.rs
+++ b/pyre/pyre-object/src/cellobject.rs
@@ -19,18 +19,46 @@ pub struct W_CellObject {
 /// Allocate a new cell wrapping `value`.
 /// Pass `PY_NULL` for an empty cell.
 pub fn w_cell_new(value: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`) for
-    // the `lltype::malloc_typed` call below. `value` is a live
-    // PyObjectRef root that must survive a potential collection inside
-    // the allocation point once the malloc body swaps to a
-    // managed allocator.
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`): `value`
+    // is a live GC pointer that must survive — and be relocated by — the
+    // collection the GC malloc below may trigger. `pin_root` records it in
+    // the shadow stack so the moving collector keeps it alive and rewrites
+    // the slot; we read the relocated address back after the malloc.
     let _roots = crate::gc_roots::push_roots();
+    let save_point = crate::gc_roots::shadow_stack_len();
     crate::gc_roots::pin_root(value);
+
+    let header = PyObject {
+        ob_type: &CELL_TYPE as *const PyType,
+        w_class: get_instantiate(&CELL_TYPE),
+    };
+    // Route through the managed allocator like `w_list_new`/`w_tuple_new`.
+    // A cell whose `contents` is reachable only through this cell (e.g. a
+    // closure cellvar) must itself be GC-traced; a `malloc_typed`
+    // (`std::alloc`) cell is invisible to `is_managed_heap_object`, so the
+    // mark-sweep skips it and the only-reachable-via-cell value is swept.
+    let raw = crate::gc_hook::try_gc_alloc_stable(W_CELL_GC_TYPE_ID, W_CELL_OBJECT_SIZE)
+        .filter(|p| !p.is_null());
+    let value = crate::gc_roots::shadow_stack_get(save_point);
+    if let Some(raw) = raw {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_CellObject,
+                W_CellObject {
+                    ob: header,
+                    contents: value,
+                },
+            );
+        }
+        // The cell lives in old-gen (`try_gc_alloc_stable`); `contents` may
+        // still be a nursery object. Register the cell so the next minor
+        // collection scans it (incminimark.py:1495 write_barrier) and
+        // relocates a young value held only by `contents`.
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
     W_CellObject::allocate(W_CellObject {
-        ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
-        },
+        ob: header,
         contents: value,
     })
 }
@@ -60,6 +88,11 @@ pub unsafe fn w_cell_get(obj: PyObjectRef) -> PyObjectRef {
 #[inline]
 pub unsafe fn w_cell_set(obj: PyObjectRef, value: PyObjectRef) {
     unsafe { (*(obj as *mut W_CellObject)).contents = value }
+    // The cell is an old-gen (`try_gc_alloc_stable`) object; storing a
+    // possibly-nursery `value` into it needs the incminimark write barrier
+    // (incminimark.py:1495) so the next minor collection scans the cell and
+    // relocates the young value held only by `contents`.
+    crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#27

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Work on the `flatten-graph` branch toward #27 (align `flatten_graph` to upstream). On top of `main` this carries:

**Closure / cell opcodes in the JIT (retire `abort_permanent`)**
- `COPY_FREE_VARS` lowered to a walker no-op.
- `MAKE_CELL` and `STORE_DEREF` lowered to cell residual calls.
- `W_CellObject` GC-allocated so closure cellvars stay traced.

**Nested code-constant interning**
- Realized nested code constants are interned by frozen-constant address (`pycode.rs`), so a function defined inside a hot-called function no longer mints a fresh code object — and thus a fresh JIT green key — on every call. Adds `synth/closure_per_call.py`.

**Free-coloring groundwork (`flatten` / resume coloring)**
- `color_leaked_arg_variables` now shares one dead color per kind for value-dead leaked placeholders instead of minting a unique escalating color each (the latter overflows the register-index space under non-identity coloring), and colors leaked link-arg / inputarg variables, not just op args.
- `collect_outer_active_boxes` tolerates non-frame-temp colors (substitutes `CONST_NULL` for a color whose `registers_r` slot is `NONE`) instead of failing loud on union-marker artifacts that are dead at the resume PC.
- Blackhole `setfield` decode is routed by `field_type` rather than `is_pointer_field()`, so a `Ref` field carrying a non-GC/`Unsigned` flag (e.g. `ExecutionContext.sys_exc_value`) is decoded as a ref, not an int.

**Resume / blackhole robustness**
- Box-sourced `Ref` slots of the resume deadframe are rooted during blackhole.

**Other**
- Non-portal `LOAD_GLOBAL` classifies its container by globals-or-builtins resolution.
- Documents why the `RERAISE` no-catch arm emits `raise/r` rather than `reraise/`.

`pyre/check.py` is green on both backends (dynasm + cranelift) at the branch tip. The free-coloring items are production-inert at present (the non-identity-color harness is not committed); they are prerequisites for the #238 Path-4 endgame that retires the identity-color (`walker_slot`) machinery.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized code constant caching and JIT code generation for improved performance
  * Enhanced garbage collection handling for cell objects and resume data
  * Improved trace dispatch and bytecode compilation efficiency
  * Added regression benchmark for nested closure behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->