### PR TITLE
jit: residual-lower STORE_GLOBAL/IMPORT_FROM/STORE_SLICE/UNPACK_EX; recover depth-1 kept-stack branch guards

### DIFF
--- a/pyre/bench/synth/binary_slice_index.py
+++ b/pyre/bench/synth/binary_slice_index.py
@@ -1,12 +1,11 @@
-# BINARY_SLICE evaluates each non-None bound through __index__
-# (eval_slice_index) instead of reading the raw int field, so a custom
-# __index__, a bool, and a non-int __index__ result behave like the
-# slice(start, stop) + __getitem__ fallback.  Only the exception type is
-# printed so the line matches across CPython/PyPy/Pyre.
-#
-# (A plain float bound is a separate, pre-existing interpreter gap — getindex_w
-# reads a float's bits as an integer instead of raising — so it is not
-# exercised here.)
+# Slice bounds are evaluated through __index__ in both lowering paths:
+#   * a dynamic slice `seq[a:b]` compiles to BINARY_SLICE, handled by
+#     `binary_slice_values`;
+#   * an all-constant slice `seq[1.0:4]` is folded to a `slice` constant and
+#     compiled to BINARY_SUBSCR (`seq[slice]`), handled by `normalize_slice`.
+# Both must run __index__ on each bound, so a custom __index__ and a bool work
+# while a float (which has no __index__) raises TypeError.  Only the exception
+# type is printed so the line matches across CPython/PyPy/Pyre.
 N = 50000
 
 
@@ -35,9 +34,9 @@ def main():
     lst = list(range(10))
     tup = tuple(range(10))
 
-    # Hot loop: the JIT-compiled BINARY_SLICE residual must run __index__ on
-    # the instance bounds every iteration.  A fast path that read the raw int
-    # field of the bound object would mis-slice or crash on the instance.
+    # Hot loop 1 (BINARY_SLICE / binary_slice_values): the JIT-compiled residual
+    # must run __index__ on the instance bounds every iteration.  A fast path
+    # that read the raw int field of the bound object would mis-slice or crash.
     acc = 0
     i = 0
     while i < N:
@@ -47,7 +46,17 @@ def main():
         i = i + 1
     print("acc", acc)
 
-    # __index__ bounds resolve to the same slice as plain ints.
+    # Hot loop 2 (BINARY_SUBSCR / normalize_slice): a constant-bound slice folds
+    # to a `slice` constant, so the residual goes through normalize_slice.  Valid
+    # integer constant bounds must keep working under the JIT.
+    acc2 = 0
+    j = 0
+    while j < N:
+        acc2 = acc2 + len(seq[1:4]) + sum(lst[2:5]) + len(tup[0:3])
+        j = j + 1
+    print("acc2", acc2)
+
+    # __index__ bounds resolve to the same slice as plain ints (BINARY_SLICE).
     show("str_idx", lambda: seq[Idx(2):Idx(6)])
     show("list_idx", lambda: sum(lst[Idx(2):Idx(6)]))
     show("tuple_idx", lambda: sum(tup[Idx(2):Idx(6)]))
@@ -61,6 +70,21 @@ def main():
     # None bounds still default to 0 / len.
     show("none_start", lambda: seq[:4])
     show("none_stop", lambda: sum(lst[6:]))
+
+    # A float bound has no __index__ -> TypeError, on both lowering paths.
+    # Constant-folded slice (BINARY_SUBSCR / normalize_slice):
+    show("str_const_float", lambda: seq[1.0:4])
+    show("list_const_float", lambda: lst[1.0:4])
+    show("tuple_const_float", lambda: tup[1.0:4])
+    show("bytes_const_float", lambda: b"abcdefghij"[1.0:4])
+    show("const_float_step", lambda: seq[::1.0])
+    show("const_float_stop", lambda: seq[:1.0])
+
+    # Dynamic slice (BINARY_SLICE / binary_slice_values):
+    fv = 1.0
+    nn = 4
+    show("dyn_float_start", lambda: seq[fv:nn])
+    show("dyn_float_stop", lambda: seq[1:fv])
 
     # Code-point-boundary slicing over a lone surrogate, with __index__ bounds.
     surr = "a\ud800b"

--- a/pyre/bench/synth/import_from_hot.py
+++ b/pyre/bench/synth/import_from_hot.py
@@ -1,0 +1,21 @@
+# IMPORT_FROM in a hot loop: `from math import pi, e` runs IMPORT_FROM for
+# each imported name every iteration.  The compiled per-CodeObject jitcode
+# walks the import_from residual (getattr on the peeked module, with a
+# submodule-import fallback) instead of an abort_permanent marker, so the
+# hot body JIT-compiles rather than declining to the trait leg.  Output is
+# verified against CPython/PyPy.
+N = 200000
+
+
+def main():
+    acc = 0
+    i = 0
+    while i < N:
+        from math import pi, e
+        if pi > 3 and e > 2:
+            acc = acc + 1
+        i = i + 1
+    print(acc)
+
+
+main()

--- a/pyre/bench/synth/kept_stack_branch_depths.py
+++ b/pyre/bench/synth/kept_stack_branch_depths.py
@@ -1,0 +1,35 @@
+# Kept-stack branch-guard recovery across resume depths.
+#
+# A `goto_if_not` whose not-taken arm resumes with operand-stack temps live is
+# the short-circuit / conditional / chained-comparison shape.  The full-body
+# walk recovers the kept value(s) from the guard-pc register file:
+#
+#   depth 1 (recovered) — `(i % k) and/or v` keeps a SINGLE operand-stack temp
+#   across the guard; the recovery substitutes one color, no ambiguity.
+#
+#   depth > 1 (declined to the trait tracer) — `a + ((i & 1) or v)` and the
+#   triple-chained `0 < a < b < 9` keep TWO+ operand-stack temps across one
+#   guard.  A wrong-order recovery would transpose the kept values; the
+#   asymmetric weighting below makes any transposition change the checksum.
+#
+# Pure arithmetic -> deterministic checksum across runtimes; a parity
+# regression target for the kept-stack branch-guard depth boundary.
+N = 200000
+
+
+def main():
+    total = 0
+    i = 0
+    while i < N:
+        d1 = (i % 7) and (i + 3)            # depth-1 `and` (keeps falsy 0)
+        d1b = (i % 3) or (i + 11)           # depth-1 `or`  (keeps truthy)
+        a = i + 100000
+        d2 = a + ((i & 1) or 5)             # depth-2: stack = [a, (i & 1)]
+        b = i & 3
+        d3 = 1 if (0 < (i & 1) < b < 9) else 0  # triple-chained, multi kept temp
+        total = total + d1 + d1b + d2 * 3 - d3
+        i = i + 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/kept_stack_depth_gt1.py
+++ b/pyre/bench/synth/kept_stack_depth_gt1.py
@@ -1,0 +1,81 @@
+# Depth > 1 kept-stack branch guards: chained comparisons, nested
+# short-circuits and conditional expressions keep two or more operand-stack
+# temps live across a `goto_if_not`.  The not-taken arm resumes at a merge
+# point the full-body walk has not written; the kept temps are recovered
+# from the not-taken edge's `ref_copy` parallel-move trampoline (the depth-1
+# positional heuristic does not generalize to depth > 1).
+#
+# Each shape lives in its own minimal loop so the kept-stack guard is the
+# whole trace and a miscompile is not diluted by a multi-shape loop.  Pure
+# arithmetic -> deterministic checksum.  Regression guard for the depth > 1
+# decline removal (`0 < a < b < 9` previously miscompiled 749949 vs 375000,
+# `total + (a + ((i & 1) or 5))` 1837502750500 vs 1275003750000).
+N = 200000
+
+
+def chain2():
+    acc = 0
+    i = 0
+    while i < N:
+        a = i & 1
+        b = i & 3
+        acc = acc + (1 if 0 < a < b < 9 else 0)
+        i = i + 1
+    return acc
+
+
+def chain3():
+    acc = 0
+    i = 0
+    while i < N:
+        a = i & 7
+        b = i & 15
+        c = i & 31
+        acc = acc + (1 if 0 < a < b < c < 50 else 0)
+        i = i + 1
+    return acc
+
+
+def nested_or_in_add():
+    total = 0
+    i = 0
+    while i < N:
+        a = i + 100000
+        total = total + (a + ((i & 1) or 5))
+        i = i + 1
+    return total
+
+
+def nested_short_circuit():
+    acc = 0
+    i = 0
+    while i < N:
+        flag = i & 1
+        acc = acc + ((flag and 11) or 2)
+        i = i + 1
+    return acc
+
+
+def or_chain_value():
+    acc = 0
+    i = 0
+    while i < N:
+        a = i & 1
+        b = i & 2
+        c = i & 4
+        acc = acc + (a or b or c)
+        i = i + 1
+    return acc
+
+
+def main():
+    print(
+        chain2(),
+        chain3(),
+        nested_or_in_add(),
+        nested_short_circuit(),
+        or_chain_value(),
+    )
+
+
+main()

--- a/pyre/bench/synth/short_circuit_value_local_kept.py
+++ b/pyre/bench/synth/short_circuit_value_local_kept.py
@@ -1,0 +1,58 @@
+# Depth-1 kept-stack short-circuit with a BARE loop-varying local on the left
+# and a loop-invariant constant on the right.
+#
+# `x = flag and CONST` lowers to a `goto_if_not` that keeps the falsy `flag`
+# (the not-taken arm) live across the guard.  The hot path is the truthy arm
+# (`flag` -> CONST), so a guard failure on the not-taken arm must restore
+# `flag`, not the taken-path CONST.  Reading the guard-pc register file
+# directly restores the stale CONST and silently miscompiles `kept_and`
+# (over-counting toward `11 * N`: 2197063 instead of 1466663); the positional
+# `kept_stack_subst` recovery restores the kept `flag` correctly.
+#
+# `kept_stack_branch_depths.py` uses composite `(i % k)` left operands that
+# const-fold differently and side-step this defect; each loop here pins the
+# bare LOAD_FAST-left / const-right shape directly, in its own minimal
+# function so the kept-stack guard resumes at depth 1 and the hot loop is the
+# whole trace (a multi-shape loop dilutes the guard and hides the miscompile).
+# Pure arithmetic -> deterministic checksum.
+N = 200000
+
+
+def kept_and():
+    acc = 0
+    i = 0
+    while i < N:
+        flag = i % 3
+        x = flag and 11          # keeps falsy 0 on 1/3 of iters
+        acc = acc + x
+        i = i + 1
+    return acc
+
+
+def kept_or():
+    acc = 0
+    i = 0
+    while i < N:
+        flag = i % 3
+        x = flag or 7            # keeps truthy flag on 2/3 of iters
+        acc = acc + x
+        i = i + 1
+    return acc
+
+
+def kept_not_and():
+    acc = 0
+    i = 0
+    while i < N:
+        flag = i % 3
+        x = (not flag) and 11    # unary-not left, keeps False
+        acc = acc + x
+        i = i + 1
+    return acc
+
+
+def main():
+    print(kept_and(), kept_or(), kept_not_and())
+
+
+main()

--- a/pyre/bench/synth/store_global_hot.py
+++ b/pyre/bench/synth/store_global_hot.py
@@ -1,0 +1,33 @@
+# STORE_GLOBAL inside a hot loop: a `global`-declared function reassigns
+# module globals every iteration.  The compiled per-CodeObject jitcode
+# walks the `store_global` residual instead of an abort_permanent marker,
+# so the hot body JIT-compiles rather than declining to the trait leg.
+# A conditional exercises a branch between the two STORE_GLOBAL sites.
+# Output is verified against CPython/PyPy.
+N = 200000
+
+counter = 0
+total = 0
+
+
+def run(n):
+    global counter, total
+    i = 0
+    while i < n:
+        counter = counter + 1
+        if i % 2 == 0:
+            total = total + i
+        else:
+            total = total - 1
+        i = i + 1
+    return total
+
+
+def main():
+    r = run(N)
+    print("counter", counter)
+    print("total", total)
+    print("r", r)
+
+
+main()

--- a/pyre/bench/synth/store_slice_hot.py
+++ b/pyre/bench/synth/store_slice_hot.py
@@ -1,0 +1,24 @@
+# STORE_SLICE in a hot loop: `buf[a:b] = [i, i + 1]` with *variable* bounds
+# (a, b are locals, not literals) compiles to the STORE_SLICE opcode every
+# iteration — literal bounds would fold to a const slice + STORE_SUBSCR.  The
+# compiled per-CodeObject jitcode walks the store_slice residual (a `slice`
+# object through setitem on the peeked list) instead of an abort_permanent
+# marker, so the hot body JIT-compiles rather than declining to the trait leg.
+# Output is verified against CPython/PyPy.
+N = 200000
+
+
+def main():
+    total = 0
+    i = 0
+    a = 1
+    b = 3
+    buf = [0, 0, 0, 0, 0, 0]
+    while i < N:
+        buf[a:b] = [i, i + 1]
+        total = total + buf[1] + buf[2]
+        i = i + 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/unpack_ex_hot.py
+++ b/pyre/bench/synth/unpack_ex_hot.py
@@ -1,0 +1,21 @@
+# UNPACK_EX in a hot loop: `a, *b = data` with a star target compiles to the
+# unpack_ex residual (the UNPACK_SEQUENCE sibling with a starred list slot)
+# instead of an abort_permanent marker, so the hot body JIT-compiles rather
+# than declining to the trait leg. The residual returns a tuple of the
+# `before + 1 + after` slots that `unpack_item_fn` reads back out.
+# Output is verified against CPython/PyPy.
+N = 200000
+
+
+def main():
+    total = 0
+    i = 0
+    data = [1, 2, 3, 4]
+    while i < N:
+        a, *b = data
+        total = total + a + b[0] + b[1] + b[2]
+        i = i + 1
+    print(total)
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -884,7 +884,9 @@ pub(crate) fn is_true_slot(obj: PyObjectRef) -> Result<bool, PyError> {
 /// PyPy: sliceobject.py descr_indices, mirroring CPython
 /// `PySlice_Unpack` + `PySlice_AdjustIndices`. Handles negative `step`
 /// (which CPython adjusts the start/stop bounds for separately from
-/// positive `step`).
+/// positive `step`). Each bound is evaluated through `__index__`
+/// (`_eval_slice_index`), so a `float` or other non-integer bound raises
+/// `TypeError` rather than being read as a raw integer field.
 pub(crate) unsafe fn normalize_slice(
     index: PyObjectRef,
     length: i64,
@@ -895,7 +897,7 @@ pub(crate) unsafe fn normalize_slice(
     let step = if is_none(step_obj) {
         1
     } else {
-        w_int_get_value(step_obj)
+        crate::sliceobject::eval_slice_index(step_obj)?
     };
     if step == 0 {
         return Err(PyError::new(
@@ -911,14 +913,14 @@ pub(crate) unsafe fn normalize_slice(
     let start = if is_none(start_obj) {
         if step > 0 { 0 } else { length - 1 }
     } else {
-        let v = w_int_get_value(start_obj);
+        let v = crate::sliceobject::eval_slice_index(start_obj)?;
         let v = if v < 0 { v + length } else { v };
         v.max(lower).min(upper)
     };
     let stop = if is_none(stop_obj) {
         if step > 0 { length } else { -1 }
     } else {
-        let v = w_int_get_value(stop_obj);
+        let v = crate::sliceobject::eval_slice_index(stop_obj)?;
         let v = if v < 0 { v + length } else { v };
         v.max(lower).min(upper)
     };

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3736,40 +3736,13 @@ impl OpcodeStepExecutor for PyFrame {
         let before = args.before as usize;
         let after = args.after as usize;
         let value = self.pop();
-
-        let elements: Vec<PyObjectRef> = unsafe {
-            if pyre_object::is_tuple(value) {
-                pyre_object::w_tuple_items_copy_as_vec(value)
-            } else if pyre_object::is_list(value) {
-                pyre_object::w_list_items_copy_as_vec(value)
-            } else {
-                // Any other iterable is materialised via the iteration
-                // protocol, matching `unpack_sequence_exact`'s fallback.
-                crate::builtins::collect_iterable(value)?
-            }
-        };
-
-        let min_expected = before + after;
-        if elements.len() < min_expected {
-            return Err(PyError::value_error(&format!(
-                "not enough values to unpack (expected at least {}, got {})",
-                min_expected,
-                elements.len()
-            )));
+        // `unpack_ex_slots` returns the `before + 1 + after` slots in TOS
+        // order (head items, starred list, tail items); push bottom-first so
+        // the first head item ends on top.
+        let slots = crate::runtime_ops::unpack_ex_slots(before, after, value)?;
+        for item in slots.into_iter().rev() {
+            self.push(item);
         }
-
-        let middle_len = elements.len() - min_expected;
-
-        // Push after items (reversed), then middle list, then before items (reversed)
-        for i in (0..after).rev() {
-            self.push(elements[before + middle_len + i]);
-        }
-        let middle: Vec<PyObjectRef> = elements[before..before + middle_len].to_vec();
-        self.push(pyre_object::w_list_new(middle));
-        for i in (0..before).rev() {
-            self.push(elements[i]);
-        }
-
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1399,22 +1399,14 @@ pub fn import_from(
     name: &str,
     execution_context: *const PyExecutionContext,
 ) -> Result<PyObjectRef, crate::PyError> {
-    // First try the module's namespace dict (PyPy: space.getattr → w_dict lookup).
-    // Routed through `w_module.w_dict` so dict-subclass-backed Modules
-    // (`pypy/module/__builtin__/moduledef.py:102-103`) honour their
-    // `__getitem__` overrides via the same lookup path.
-    if unsafe { is_module(module) } {
-        let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
-        if !w_dict.is_null() && unsafe { pyre_object::is_dict(w_dict) } {
-            if let Some(value) = unsafe { pyre_object::w_dict_getitem_str(w_dict, name) } {
-                return Ok(value);
-            }
-        }
-    }
-
-    // Fallback: try getattr (for non-module objects or attrs set via setattr)
-    if let Ok(value) = crate::baseobjspace::getattr_str(module, name) {
-        return Ok(value);
+    // pyopcode.py:1127 import_from — first `space.getattr(w_module, w_name)`,
+    // which honours the module attribute protocol (`__getattribute__` /
+    // `__getattr__`).  Only an AttributeError falls through to the submodule
+    // import below; any other error propagates.
+    match crate::baseobjspace::getattr_str(module, name) {
+        Ok(value) => return Ok(value),
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {}
+        Err(e) => return Err(e),
     }
 
     // PyPy: pyopcode.py _import_from — try importing as a submodule.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -239,6 +239,43 @@ const MAP_BUILD_HELPER_PATHS: &[(&str, &str)] = &[
     ),
 ];
 
+/// Returns `true` when `addr` is the runtime address of a `PyFrame`
+/// operand-stack accessor (`pop` / `push` / `peek` / `peek_at`).
+///
+/// The full-body-walk tracer concretely executes plain residual calls during
+/// tracing to fold their results, but a residual targeting one of these
+/// accessors reads or mutates the live frame's operand stack — which during a
+/// walk is empty, because the walk tracks operand values symbolically in its
+/// register banks rather than on the real frame.  Executing one underflows
+/// (`pop` asserts `valuestackdepth > stack_base()`).  The walker uses this
+/// predicate to leave such a residual symbolic so it runs at runtime against a
+/// frame whose operand stack is populated.
+///
+/// The accessors are `#[inline]`, so a fresh `PyFrame::pop as *const ()` is
+/// not address-stable across call sites — it can resolve to a distinct
+/// out-of-line copy than the one the codewriter baked into the JitCode
+/// constant pool.  Match instead against the exact funcptrs the codewriter
+/// bakes: the values [`jit_trace_fnaddrs`] records for the accessor paths,
+/// computed through the very same coercion site (cached once, addresses are
+/// process-stable).
+pub fn is_pyframe_operand_stack_accessor(addr: usize) -> bool {
+    use std::sync::OnceLock;
+    static ACCESSOR_ADDRS: OnceLock<Vec<i64>> = OnceLock::new();
+    let addrs = ACCESSOR_ADDRS.get_or_init(|| {
+        jit_trace_fnaddrs()
+            .into_iter()
+            .filter(|(path, _)| {
+                path.ends_with("::PyFrame::pop")
+                    || path.ends_with("::PyFrame::push")
+                    || path.ends_with("::PyFrame::peek")
+                    || path.ends_with("::PyFrame::peek_at")
+            })
+            .map(|(_, fnaddr)| fnaddr)
+            .collect()
+    });
+    addrs.contains(&(addr as i64))
+}
+
 /// Build-time equivalent of `#[jit_module]::__majit_helper_trace_fnaddrs()`.
 ///
 /// The registry includes both the module-qualified path produced by the
@@ -1337,7 +1374,7 @@ pub fn jit_static_int_values() -> Vec<(&'static str, i64)> {
 
 #[cfg(test)]
 mod tests {
-    use super::jit_trace_fnaddrs;
+    use super::{is_pyframe_operand_stack_accessor, jit_trace_fnaddrs};
     use std::collections::HashMap;
 
     #[test]
@@ -1460,6 +1497,21 @@ mod tests {
             bindings["pyre_interpreter::var_nums_to_second_index"],
             second
         );
+    }
+
+    /// `is_pyframe_operand_stack_accessor` must recognise the funcptr the
+    /// codewriter bakes for `PyFrame::pop` — the `pop_value` sub-jitcode
+    /// residual the full-body walk must not concretely execute against the
+    /// paused outer frame — and must NOT flag `PyFrame::nlocals`, a registered
+    /// `PyFrame` method that is a constant read, safe to fold during a walk.
+    #[test]
+    fn is_pyframe_operand_stack_accessor_matches_registered_pop() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        let pop = bindings["pyre_interpreter::pyframe::PyFrame::pop"];
+        assert!(is_pyframe_operand_stack_accessor(pop as usize));
+        let nlocals = bindings["pyre_interpreter::pyframe::PyFrame::nlocals"];
+        assert!(!is_pyframe_operand_stack_accessor(nlocals as usize));
+        assert!(!is_pyframe_operand_stack_accessor(0));
     }
 
     /// Negative parity guard: pyre intentionally does NOT publish a

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -258,6 +258,14 @@ const MAP_BUILD_HELPER_PATHS: &[(&str, &str)] = &[
 /// bakes: the values [`jit_trace_fnaddrs`] records for the accessor paths,
 /// computed through the very same coercion site (cached once, addresses are
 /// process-stable).
+///
+/// Today only `PyFrame::pop` is registered in [`jit_trace_fnaddrs`] (the only
+/// accessor a residual call currently reaches — `pop_value`'s sub-jitcode).
+/// The `push` / `peek` / `peek_at` arms below are dormant defensive guards:
+/// their paths never appear in the registry, so they never match.  They
+/// activate (still as a SAFE leave-symbolic decline) only if those accessors
+/// are later registered; an unregistered helper is already declined upstream
+/// by the funcptr-hash gate, so registering them is unnecessary for soundness.
 pub fn is_pyframe_operand_stack_accessor(addr: usize) -> bool {
     use std::sync::OnceLock;
     static ACCESSOR_ADDRS: OnceLock<Vec<i64>> = OnceLock::new();

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1107,6 +1107,48 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
     Ok(items)
 }
 
+/// UNPACK_EX — split `value` for `a, *b, c = value` into `before` head
+/// items, a starred middle list, and `after` tail items, returning the
+/// `before + 1 + after` slots in TOS order ([head items], middle list,
+/// [tail items]).  Shared by the interpreter's `unpack_ex` handler and the
+/// JIT residual `bh_unpack_ex_fn`; the portal reads each slot back out with
+/// `bh_unpack_item_fn`, exactly as `unpack_sequence_exact`.  Raises
+/// ValueError when fewer than `before + after` values are available.
+pub fn unpack_ex_slots(
+    before: usize,
+    after: usize,
+    value: PyObjectRef,
+) -> Result<Vec<PyObjectRef>, PyError> {
+    let elements: Vec<PyObjectRef> = unsafe {
+        if is_tuple(value) {
+            pyre_object::w_tuple_items_copy_as_vec(value)
+        } else if is_list(value) {
+            pyre_object::w_list_items_copy_as_vec(value)
+        } else {
+            crate::builtins::collect_iterable(value)?
+        }
+    };
+    let min_expected = before + after;
+    if elements.len() < min_expected {
+        return Err(PyError::value_error(format!(
+            "not enough values to unpack (expected at least {}, got {})",
+            min_expected,
+            elements.len()
+        )));
+    }
+    let middle_len = elements.len() - min_expected;
+    let mut slots = Vec::with_capacity(before + 1 + after);
+    for &item in elements.iter().take(before) {
+        slots.push(item);
+    }
+    let middle: Vec<PyObjectRef> = elements[before..before + middle_len].to_vec();
+    slots.push(w_list_new(middle));
+    for i in 0..after {
+        slots.push(elements[before + middle_len + i]);
+    }
+    Ok(slots)
+}
+
 pub fn ensure_range_iter(iter: PyObjectRef) -> Result<(), PyError> {
     unsafe {
         if is_range_iter(iter) || is_seq_iter(iter) {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1089,20 +1089,40 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
         return (0..count).map(|idx| sequence_getitem(seq, idx)).collect();
     }
     // Fallback: iteration protocol (handles type objects with metaclass __iter__, etc.)
-    // PyPy: ObjSpace.unpackiterable
-    let iter = crate::baseobjspace::iter(seq)?;
+    // baseobjspace.py:1031 _unpackiterable_known_length_jitlook.  pyopcode.py:872
+    // UNPACK_SEQUENCE wraps the whole `fixedview_unroll` (iter + known-length
+    // loop) in a TypeError → "cannot unpack non-iterable %T object" remap.
+    let non_iterable = || {
+        PyError::type_error(format!("cannot unpack non-iterable {} object", unsafe {
+            (*(*seq).ob_type).name
+        }))
+    };
+    let iter = match crate::baseobjspace::iter(seq) {
+        Ok(it) => it,
+        Err(e) if e.kind == PyErrorKind::TypeError => return Err(non_iterable()),
+        Err(e) => return Err(e),
+    };
     let mut items = Vec::with_capacity(count);
-    for _ in 0..count {
+    loop {
         match crate::baseobjspace::next(iter) {
-            Ok(val) => items.push(val),
-            Err(e) if e.kind == PyErrorKind::StopIteration => {
-                return Err(PyError::value_error(format!(
-                    "not enough values to unpack (expected {count}, got {})",
-                    items.len()
-                )));
+            Ok(val) => {
+                if items.len() == count {
+                    return Err(PyError::value_error(format!(
+                        "too many values to unpack (expected {count})"
+                    )));
+                }
+                items.push(val);
             }
+            Err(e) if e.kind == PyErrorKind::StopIteration => break,
+            Err(e) if e.kind == PyErrorKind::TypeError => return Err(non_iterable()),
             Err(e) => return Err(e),
         }
+    }
+    if items.len() < count {
+        return Err(PyError::value_error(format!(
+            "not enough values to unpack (expected {count}, got {})",
+            items.len()
+        )));
     }
     Ok(items)
 }
@@ -1125,7 +1145,20 @@ pub fn unpack_ex_slots(
         } else if is_list(value) {
             pyre_object::w_list_items_copy_as_vec(value)
         } else {
-            crate::builtins::collect_iterable(value)?
+            // pyopcode.py:884 UNPACK_EX wraps `fixedview` in a
+            // TypeError → "cannot unpack non-iterable %T object" remap.
+            // `collect_iterable` is the `fixedview` analog (iter + next
+            // loop), so any TypeError it raises is remapped here.
+            match crate::builtins::collect_iterable(value) {
+                Ok(items) => items,
+                Err(e) if e.kind == PyErrorKind::TypeError => {
+                    return Err(PyError::type_error(format!(
+                        "cannot unpack non-iterable {} object",
+                        (*(*value).ob_type).name
+                    )));
+                }
+                Err(e) => return Err(e),
+            }
         }
     };
     let min_expected = before + after;

--- a/pyre/pyre-jit-trace/src/call_spec.rs
+++ b/pyre/pyre-jit-trace/src/call_spec.rs
@@ -128,6 +128,13 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     },
     CallEffectSpec {
         target: CallTargetSpec::Method {
+            name: "store_global_value",
+            receiver_root: PYFRAME_CALL_OWNER_ROOT,
+        },
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::Method {
             name: "load_name",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },
@@ -411,6 +418,10 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     },
     CallEffectSpec {
         target: CallTargetSpec::FunctionPath(&["opcode_store_name"]),
+        effect: CallEffectKind::Residual,
+    },
+    CallEffectSpec {
+        target: CallTargetSpec::FunctionPath(&["opcode_store_global"]),
         effect: CallEffectKind::Residual,
     },
     CallEffectSpec {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5306,8 +5306,20 @@ fn collect_outer_active_boxes(
         }
         _ => std::collections::HashMap::new(),
     };
+    // #420: exact not-taken edge-move recovery, keyed by resume-merge color.
+    // Takes precedence over the positional `kept_stack_subst` heuristic — the
+    // guard trampoline's `ref_copy(dst <- src)` gave this kept slot's live
+    // guard-pc source value directly, exact for any kept-stack depth.
+    let kept_recovered: std::collections::HashMap<u32, OpRef> = BRANCH_GUARD_KEPT_RECOVERED
+        .with(|c| c.borrow().iter().map(|&(dst, v)| (dst as u32, v)).collect());
     for &idx in &banks.ref_ {
         let color = idx as usize;
+        if let Some(&rv) = kept_recovered.get(&idx) {
+            // Edge-move-resolved kept operand; overrides the unwritten
+            // merge-color read for this not-taken-arm operand-stack slot.
+            active.push(rv);
+            continue;
+        }
         if let Some(&subst) = kept_stack_subst.get(&idx) {
             // The guard-pc kept value overrides the (unwritten) merge-color
             // read for this not-taken-arm operand-stack slot.
@@ -5509,6 +5521,19 @@ thread_local! {
     /// edge move reads from.  Null outside the gated kept-stack path.
     static BRANCH_GUARD_JITCODE_PC: std::cell::Cell<usize> =
         const { std::cell::Cell::new(usize::MAX) };
+
+    /// `#420` not-taken edge-move recovery: the decoded `ref_copy`
+    /// parallel-move list of a kept-stack branch guard's trampoline, as
+    /// `(resume-merge color, guard-state kept value)` pairs.  The branch
+    /// handler reads each `ref_copy(dst <- src)` of the not-taken edge and
+    /// stores `(dst, registers_r[src])` here; `collect_outer_active_boxes`
+    /// and the `stack_sync` vable overlay read it so every kept operand-
+    /// stack slot resumes with the exact value the edge move would produce,
+    /// instead of the stale merge-color read.  This replaces the positional
+    /// depth-1 heuristic with the exact, depth-independent edge resolution.
+    /// Empty outside the gated kept-stack path (cleared after each capture).
+    static BRANCH_GUARD_KEPT_RECOVERED: std::cell::RefCell<Vec<(u16, OpRef)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// RAII guard: mark the current scope as an inline sub-walk (see
@@ -6160,6 +6185,54 @@ fn resolve_branch_target_through_trampoline(code: &[u8], target: usize) -> usize
     resume
 }
 
+/// Decode a not-taken branch trampoline's `ref_copy` parallel-move
+/// sequence into `(dst, src)` Ref-color pairs (`#420`).  The trampoline
+/// (`live; (ref_copy|int_copy|float_copy)*; [goto]; live; <op>`,
+/// `flatten.rs:2145 insert_renamings`) resolves the not-taken edge's Phi:
+/// each `ref_copy(dst <- src)` moves the kept value's guard-pc Ref color
+/// `src` into the merge block's inputarg color `dst`.  The walk does NOT
+/// execute these moves — they fire only when the branch is taken at
+/// runtime — so the merge color `dst` reads stale at the guard point; the
+/// live kept value sits at `src`, which the walk register file still
+/// holds.  Returning the `(dst, src)` list lets the snapshot / vable
+/// recovery read `registers_r[src]` for each kept slot, exact for any
+/// kept-stack depth (the positional depth-1 heuristic generalized).
+///
+/// Returns `None` on a `*_push` / `*_pop` step — a cyclic parallel move
+/// whose value transits a blackhole stack the walk has no register for;
+/// the caller keeps the conservative kept-stack decline.  Each `ref_copy`
+/// is `[opcode, src, dst]` (`ref_copy/r>r`: `registers_r[dst] =
+/// registers_r[src]`).
+fn decode_branch_trampoline_ref_moves(code: &[u8], tramp_start: usize) -> Option<Vec<(u16, u16)>> {
+    let mut pc = tramp_start;
+    let mut moves: Vec<(u16, u16)> = Vec::new();
+    for _ in 0..64 {
+        let op = decode_op_at(code, pc)?;
+        match op.opname {
+            "live" => pc = op.next_pc,
+            "ref_copy" => {
+                let src = *code.get(op.pc + 1)? as u16;
+                let dst = *code.get(op.pc + 2)? as u16;
+                moves.push((dst, src));
+                pc = op.next_pc;
+            }
+            // Non-Ref-bank moves (int / float locals) never feed an
+            // operand-stack slot (the operand stack is always boxed Ref);
+            // step over them.
+            "int_copy" | "float_copy" => pc = op.next_pc,
+            "goto" => pc = read_label(code, &op, 0),
+            // Cyclic parallel move: the value transits a transient stack,
+            // not a register the walk can read.  Decline (conservative).
+            "ref_push" | "ref_pop" | "int_push" | "int_pop" | "float_push" | "float_pop" => {
+                return None;
+            }
+            // First real destination op terminates the move list.
+            _ => return Some(moves),
+        }
+    }
+    Some(moves)
+}
+
 /// Full-body-walk operand-stack depth at a branch guard's resume target.
 ///
 /// `target` is a jitcode pc — the `goto_if_not` `other_target` (the
@@ -6202,6 +6275,42 @@ fn branch_resume_target_stack_depth(target: usize) -> Option<u16> {
             .depth_at_py_pc()
             .get(py)
             .copied()
+    }
+}
+
+/// The resume-merge Ref colors of a branch guard's kept operand-stack
+/// slots (`#420`): `stack_slot_color_map[0 .. depth_at_py_pc[resume]]`,
+/// the colors `collect_outer_active_boxes` / `stack_sync` look the kept
+/// values up by.  Used to decide whether the not-taken edge's decoded
+/// `ref_copy` moves cover *every* kept slot — only then is the depth > 1
+/// recovery complete and the guard safe to compile.  A slot the edge does
+/// not rename is "live-across"; its value sits at the possibly-collapsed
+/// `stack_slot_color_map[s]` color, unproven for depth > 1, so an
+/// uncovered slot keeps the conservative decline.  Same `FULL_BODY_SNAPSHOT_SYM`
+/// contract as `branch_resume_target_stack_depth`.
+fn branch_resume_stack_colors(target: usize) -> Option<Vec<u16>> {
+    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if full_body_sym.is_null() {
+        return None;
+    }
+    let sym = unsafe { &*full_body_sym };
+    if sym.jitcode.is_null() {
+        return None;
+    }
+    unsafe {
+        let jc = &*sym.jitcode;
+        if jc.payload.code_ptr.is_null() {
+            return None;
+        }
+        let code = &*jc.payload.code_ptr;
+        let py = python_pc_for_jitcode_pc(&jc.payload.metadata, target) as usize;
+        let py = skip_python_trivia_forward(code, py);
+        let depth = crate::liveness::liveness_for(jc.payload.code_ptr)
+            .depth_at_py_pc()
+            .get(py)
+            .copied()? as usize;
+        let scm = &jc.payload.metadata.stack_slot_color_map;
+        Some((0..depth.min(scm.len())).map(|s| scm[s]).collect())
     }
 }
 
@@ -6553,10 +6662,27 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 };
                 let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
                 let nlocals = sym.nlocals;
+                // #420: a kept slot whose merge color the not-taken edge fills
+                // reads stale in `registers_r` at the guard; the branch handler
+                // decoded the edge's `ref_copy` moves into `(merge color ->
+                // live guard value)`.  Prefer that recovered value so the vable
+                // shadow (the authoritative deopt restore) carries the exact
+                // kept operand, not the stale merge-color read.
+                let recovered: Vec<(u16, OpRef)> =
+                    BRANCH_GUARD_KEPT_RECOVERED.with(|c| c.borrow().clone());
                 (0..depth.min(stack_color_map.len()))
                     .filter_map(|s| {
-                        let color = stack_color_map[s] as usize;
-                        let v = ctx.registers_r.get(color).copied().unwrap_or(OpRef::NONE);
+                        let color = stack_color_map[s];
+                        let v = recovered
+                            .iter()
+                            .find(|&&(dst, _)| dst == color)
+                            .map(|&(_, v)| v)
+                            .unwrap_or_else(|| {
+                                ctx.registers_r
+                                    .get(color as usize)
+                                    .copied()
+                                    .unwrap_or(OpRef::NONE)
+                            });
                         if v != OpRef::NONE && !opref_is_null_const_ptr(v) {
                             Some((nvs + nlocals + s, v))
                         } else {
@@ -12129,25 +12255,63 @@ fn handle(
             if !valuebox.is_constant() {
                 // #124/#281: a branch guard whose resume target still holds a
                 // live operand-stack temp (short-circuit `and`/`or`, the
-                // conditional expression, chained comparison) keeps the tested
-                // value on the value stack across the branch (`COPY` / `TO_BOOL`
-                // / `POP_JUMP_IF_*`).  A depth-1 target keeps a SINGLE kept
-                // temp; it is recovered positionally through the
-                // `kept_stack_subst` heuristic in `collect_outer_active_boxes`
-                // (gated by the guard's own jitcode pc published below), so the
-                // guard compiles and resumes precisely.  A depth > 1 target
-                // keeps two or more temps; the heuristic recovers only the
-                // bottom one and the extra temp(s) decode a stale value into a
-                // loop-carried slot, so it stays declined to the interpreter
-                // (correct, untraced) instead of compiling a trace that corrupts
-                // the frame.  Plain `while` / `if` branches resume at depth 0
-                // and pass.  `PYRE_RELAX_124` opens depth > 1 for the future
-                // multi-kept-temp snapshot fix (#124/#281).
+                // conditional expression, chained comparison) keeps that temp
+                // on the not-taken arm the single-frame snapshot does not model
+                // by itself.  The kept temp(s) are recovered from the not-taken
+                // edge's `ref_copy` parallel-move trampoline (decoded below),
+                // exact for any kept-stack depth.  Plain `while` / `if`
+                // branches resume at depth 0 and carry no kept temp.
                 let resume_depth = branch_resume_target_stack_depth(other_target);
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
                 let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
-                if depth_gt_1 && !relax_124 {
+                // A kept-stack guard's not-taken arm keeps one or more
+                // operand-stack temps live across the guard.  The not-taken
+                // edge resolves the merge through inline `ref_copy(dst <- src)`
+                // moves (`flatten.rs:2145 insert_renamings`): the live kept
+                // value sits at the guard-pc color `src`, which the walk has
+                // written, while the resume merge color `dst` is unwritten at
+                // the guard point.  Decode that trampoline into `(dst, src)`
+                // pairs (`#420`); the snapshot / vable recovery then reads
+                // `registers_r[src]` for each kept slot — exact for any kept-
+                // stack depth, superseding the positional depth-1 heuristic.
+                let raw_branch_target = if switchcase != 0 { target } else { op.next_pc };
+                let kept_recovered = if kept_stack {
+                    decode_branch_trampoline_ref_moves(code, raw_branch_target)
+                } else {
+                    Some(Vec::new())
+                };
+                if std::env::var_os("PYRE_DIAG124C").is_some() && kept_stack {
+                    eprintln!(
+                        "[edge124] pc={} depth={resume_depth:?} raw_target={raw_branch_target} \
+                         moves(dst<-src)={kept_recovered:?}",
+                        op.pc,
+                    );
+                }
+                // Recover depth > 1 only when the decoded edge moves cover
+                // EVERY kept resume stack slot.  A slot the not-taken edge
+                // does not rename ("live-across") would fall through to the
+                // possibly-collapsed `stack_slot_color_map[s]` read — the
+                // original depth > 1 decline reason — so an uncovered slot,
+                // a cyclic `*_push`/`*_pop` (decodes to `None`), or unknown
+                // liveness keeps the conservative decline.  Depth-1 is handled
+                // by the positional heuristic below and is not gated here.
+                // `PYRE_RELAX_124` forces depth > 1 through for diagnosis.
+                let recovery_complete = match (
+                    kept_recovered.as_ref(),
+                    branch_resume_stack_colors(other_target),
+                ) {
+                    (Some(moves), Some(cols)) => {
+                        // Every kept slot's resume color must be DISTINCT — a
+                        // collapsed `stack_slot_color_map` aliasing two slots
+                        // onto one color would feed both the same recovered
+                        // value — AND covered by an explicit edge move.
+                        let distinct = cols.iter().enumerate().all(|(i, c)| !cols[..i].contains(c));
+                        distinct && cols.iter().all(|c| moves.iter().any(|&(dst, _)| dst == *c))
+                    }
+                    _ => false,
+                };
+                if depth_gt_1 && !recovery_complete && !relax_124 {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);
@@ -12162,9 +12326,25 @@ fn handle(
                 // `goto_if_not`) and desync the decoded box layout.
                 if kept_stack {
                     BRANCH_GUARD_JITCODE_PC.with(|c| c.set(op.pc));
+                    // Resolve each `(dst, src)` move to `(dst, live guard
+                    // value)` now, against the guard-state register file.  A
+                    // const-source `ref_copy` patches `src` into the constants
+                    // window of `registers_r`, so this one read covers register
+                    // and const sources alike.
+                    let recovered: Vec<(u16, OpRef)> = kept_recovered
+                        .as_deref()
+                        .unwrap_or(&[])
+                        .iter()
+                        .filter_map(|&(dst, src)| {
+                            let v = ctx.registers_r.get(src as usize).copied()?;
+                            (v != OpRef::NONE).then_some((dst, v))
+                        })
+                        .collect();
+                    BRANCH_GUARD_KEPT_RECOVERED.with(|c| *c.borrow_mut() = recovered);
                 }
                 let capture = walker_capture_snapshot_for_last_guard(ctx, other_target);
                 BRANCH_GUARD_JITCODE_PC.with(|c| c.set(usize::MAX));
+                BRANCH_GUARD_KEPT_RECOVERED.with(|c| c.borrow_mut().clear());
                 capture?;
             }
             let next_pc = if switchcase != 0 { op.next_pc } else { target };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1014,21 +1014,22 @@ pub enum DispatchError {
     /// mismatch.
     SubWalkClosedLoop { pc: usize },
     /// A `goto_if_not` branch guard resumes at a target that still carries
-    /// a live operand-stack temp (resume-target stack depth > 0). This is
-    /// the short-circuit shape — `x and y`, `x or y`, the conditional
-    /// expression `a if c else b`, and chained comparison `a < b < c` —
-    /// where CPython keeps the tested value on the value stack across the
-    /// branch (`COPY` / `TO_BOOL` / `POP_JUMP_IF_*`). The full-body walk's
-    /// single-frame guard snapshot rebuilds locals + the post-opcode
-    /// operand stack from the live register banks, but the kept temp at a
-    /// branch *target* (a control-flow merge the trace did not take) is
-    /// not represented in the not-taken arm's liveness, so the deopt
-    /// re-entry restores a wrong value into a loop-carried slot (task
-    /// #124/#281 per-PC resume-value precision). Plain `while` / `if`
-    /// branches resume at depth 0 and are unaffected. The walker surfaces
-    /// a typed abort so the driver maps it to `TraceAction::Abort` →
-    /// interpreter fallback (correct, untraced) instead of compiling a
-    /// trace whose guard-failure path corrupts the frame.
+    /// two or more live operand-stack temps (resume-target stack depth > 1).
+    /// This is the multi-kept-temp short-circuit shape — `(x and y) or z`,
+    /// chained comparison `a < b < c` — where CPython keeps more than one
+    /// tested value on the value stack across the branch (`COPY` / `TO_BOOL`
+    /// / `POP_JUMP_IF_*`). The full-body walk's single-frame guard snapshot
+    /// rebuilds locals + the post-opcode operand stack from the live register
+    /// banks; a single depth-1 kept temp is recovered positionally
+    /// (`kept_stack_subst` in `collect_outer_active_boxes`), but the extra
+    /// temp(s) at depth > 1 are not represented in the not-taken arm's
+    /// liveness, so the deopt re-entry restores a wrong value into a
+    /// loop-carried slot (task #124/#281 per-PC resume-value precision).
+    /// Plain `while` / `if` branches resume at depth 0 and are unaffected.
+    /// The walker surfaces a typed abort so the driver maps it to
+    /// `TraceAction::Abort` → interpreter fallback (correct, untraced)
+    /// instead of compiling a trace whose guard-failure path corrupts the
+    /// frame.
     BranchGuardKeptStackUnsupported { pc: usize },
     /// A callee compiled as its own Finish portal (reached via
     /// `call_user_function_with_eval`) accessed its frame through a
@@ -5194,8 +5195,8 @@ fn collect_outer_active_boxes(
         }
         active.push(v);
     }
-    // #124 kept-stack recovery (gated by `guard_py_pc`, set only on the
-    // `PYRE_RELAX_124` branch-guard path).  A branch guard's not-taken arm
+    // #124 kept-stack recovery (gated by `guard_py_pc`, set on the
+    // branch-guard snapshot path).  A branch guard's not-taken arm
     // resumes at a merge point whose live Ref colors are filled by the
     // not-taken edge's register move — colors the walk has NOT written at
     // the guard point, because that move executes only when the branch is
@@ -5496,7 +5497,7 @@ thread_local! {
 
     /// Set (to the branch guard's own jitcode `op.pc`) only for the
     /// duration of the `walker_capture_snapshot_for_last_guard` call a
-    /// kept-stack branch guard makes under `PYRE_RELAX_124` (#124).  The
+    /// kept-stack branch guard makes (#124).  The
     /// snapshot helper is invoked with the *resume* coordinate
     /// (`other_target`, the not-taken arm), so the guard's own coordinate
     /// is otherwise unavailable to the encoder.  `collect_outer_active_
@@ -12126,36 +12127,27 @@ fn handle(
                 if switchcase != 0 { target } else { op.next_pc },
             );
             if !valuebox.is_constant() {
-                // #124/#281: a branch guard whose resume target still holds
-                // a live operand-stack temp (short-circuit `and`/`or`, the
-                // conditional expression, chained comparison) cannot be
-                // resumed precisely by the single-frame snapshot — the kept
-                // value lives on the not-taken arm the snapshot does not
-                // model, so a guard-failure deopt restores a wrong value
-                // into a loop-carried slot.  Abort the walk → interpreter
-                // fallback (correct, untraced) rather than compile a trace
-                // that corrupts the frame on every odd-path iteration.
-                // Plain `while` / `if` branches resume at depth 0 and pass.
-                //
-                // Only a kept-stack (depth > 0) resume target is the #124
-                // case; a plain `while` / `if` resumes at depth 0 and the
-                // single-frame snapshot models it exactly.
-                let kept_stack =
-                    branch_resume_target_stack_depth(other_target).is_some_and(|d| d > 0);
-                // #124 Approach B (M4): the kept-stack guard resumes precisely
-                // at its own JitCode pc through the M3 carrier
-                // (`BRANCH_GUARD_JITCODE_PC` → rd_numb → `setposition`), so the
-                // gate opens and the guard compiles instead of declining to the
-                // interpreter.  M3 is on by default, so production takes this
-                // path.  `PYRE_RELAX_124` is the standalone opener exercising
-                // the kept-stack recovery path without the M3 decode.  Only when
-                // M3 is force-disabled (`PYRE_M3_JITCODE_PC=0`) AND `PYRE_RELAX_124`
-                // is unset does the conservative decline apply (a guard-failure
-                // deopt at depth > 0 would otherwise restore a wrong value into a
-                // loop-carried slot via the lossy `py_pc → pc_map` translation).
-                let kept_stack_resume_enabled = crate::pyjitcode::m3_jitcode_pc_enabled()
-                    || std::env::var_os("PYRE_RELAX_124").is_some();
-                if kept_stack && !kept_stack_resume_enabled {
+                // #124/#281: a branch guard whose resume target still holds a
+                // live operand-stack temp (short-circuit `and`/`or`, the
+                // conditional expression, chained comparison) keeps the tested
+                // value on the value stack across the branch (`COPY` / `TO_BOOL`
+                // / `POP_JUMP_IF_*`).  A depth-1 target keeps a SINGLE kept
+                // temp; it is recovered positionally through the
+                // `kept_stack_subst` heuristic in `collect_outer_active_boxes`
+                // (gated by the guard's own jitcode pc published below), so the
+                // guard compiles and resumes precisely.  A depth > 1 target
+                // keeps two or more temps; the heuristic recovers only the
+                // bottom one and the extra temp(s) decode a stale value into a
+                // loop-carried slot, so it stays declined to the interpreter
+                // (correct, untraced) instead of compiling a trace that corrupts
+                // the frame.  Plain `while` / `if` branches resume at depth 0
+                // and pass.  `PYRE_RELAX_124` opens depth > 1 for the future
+                // multi-kept-temp snapshot fix (#124/#281).
+                let resume_depth = branch_resume_target_stack_depth(other_target);
+                let kept_stack = resume_depth.is_some_and(|d| d > 0);
+                let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
+                let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
+                if depth_gt_1 && !relax_124 {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4526,6 +4526,21 @@ fn try_execute_residual_call_via_executor(
     if (func_ptr as u64) >> 47 != 0 {
         return Ok(None);
     }
+    // A residual whose funcptr is a `PyFrame` operand-stack accessor
+    // (`pop`/`push`/`peek`/`peek_at`) reads or mutates the live frame's
+    // operand stack.  During a walk that stack is empty — the walk holds
+    // operand values symbolically in its register banks, not on the real
+    // frame (the portal lowers stack ops to vable array writes; these
+    // accessors appear only inside inlined callee sub-jitcode bodies such as
+    // `pop_value`).  Executing one here underflows `PyFrame::pop`'s
+    // `valuestackdepth > stack_base()` assertion against the paused outer
+    // frame.  Record it symbolically instead, mirroring the tracer's
+    // never-mutate-the-traced-frame discipline; it runs at runtime against a
+    // frame whose operand stack the compiled trace's preceding pushes have
+    // populated.
+    if pyre_interpreter::is_pyframe_operand_stack_accessor(func_ptr as usize) {
+        return Ok(None);
+    }
     if allboxes.len() - 1 > majit_translate::jit_codewriter::insns::MAX_HOST_CALL_ARITY {
         return Ok(None);
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1014,22 +1014,28 @@ pub enum DispatchError {
     /// mismatch.
     SubWalkClosedLoop { pc: usize },
     /// A `goto_if_not` branch guard resumes at a target that still carries
-    /// two or more live operand-stack temps (resume-target stack depth > 1).
+    /// two or more live operand-stack temps (resume-target stack depth > 1)
+    /// and the not-taken edge's kept-value recovery is incomplete.
     /// This is the multi-kept-temp short-circuit shape — `(x and y) or z`,
     /// chained comparison `a < b < c` — where CPython keeps more than one
     /// tested value on the value stack across the branch (`COPY` / `TO_BOOL`
     /// / `POP_JUMP_IF_*`). The full-body walk's single-frame guard snapshot
     /// rebuilds locals + the post-opcode operand stack from the live register
     /// banks; a single depth-1 kept temp is recovered positionally
-    /// (`kept_stack_subst` in `collect_outer_active_boxes`), but the extra
-    /// temp(s) at depth > 1 are not represented in the not-taken arm's
-    /// liveness, so the deopt re-entry restores a wrong value into a
-    /// loop-carried slot (task #124/#281 per-PC resume-value precision).
-    /// Plain `while` / `if` branches resume at depth 0 and are unaffected.
-    /// The walker surfaces a typed abort so the driver maps it to
-    /// `TraceAction::Abort` → interpreter fallback (correct, untraced)
-    /// instead of compiling a trace whose guard-failure path corrupts the
-    /// frame.
+    /// (`kept_stack_subst` in `collect_outer_active_boxes`).  Depth > 1 is
+    /// supported only when the not-taken edge's decoded `ref_copy` moves
+    /// (`#420`) cover every distinct kept resume color AND each move's source
+    /// resolves to a live register value; that resolved set then drives the
+    /// snapshot encoder.  This abort fires only when that recovery is
+    /// incomplete — a kept slot the edge does not rename ("live-across"), a
+    /// cyclic `*_push`/`*_pop` move, a truncated/under-sized color map, or a
+    /// source that resolves to `OpRef::NONE` — i.e. when the deopt re-entry
+    /// would otherwise restore a wrong value into a loop-carried slot
+    /// (task #124/#281 per-PC resume-value precision).  Plain `while` / `if`
+    /// branches resume at depth 0 and are unaffected.  The walker surfaces a
+    /// typed abort so the driver maps it to `TraceAction::Abort` →
+    /// interpreter fallback (correct, untraced) instead of compiling a trace
+    /// whose guard-failure path corrupts the frame.
     BranchGuardKeptStackUnsupported { pc: usize },
     /// A callee compiled as its own Finish portal (reached via
     /// `call_user_function_with_eval`) accessed its frame through a
@@ -6245,7 +6251,10 @@ fn decode_branch_trampoline_ref_moves(code: &[u8], tramp_start: usize) -> Option
             _ => return Some(moves),
         }
     }
-    Some(moves)
+    // Cap exhausted without reaching the first real destination op: the
+    // move list is truncated, not complete — decline (conservative)
+    // rather than present an incomplete recovery as the full edge.
+    None
 }
 
 /// Full-body-walk operand-stack depth at a branch guard's resume target.
@@ -6325,7 +6334,15 @@ fn branch_resume_stack_colors(target: usize) -> Option<Vec<u16>> {
             .get(py)
             .copied()? as usize;
         let scm = &jc.payload.metadata.stack_slot_color_map;
-        Some((0..depth.min(scm.len())).map(|s| scm[s]).collect())
+        // Defensive: a map shorter than the resume depth (only possible if
+        // stack_slot_color_map were under-sized below co_stacksize, the
+        // regression pyjitcode.rs warns about) must DECLINE, not silently
+        // truncate the kept-slot color list — a truncated list would let
+        // recovery_complete pass without checking every kept slot.
+        if depth > scm.len() {
+            return None;
+        }
+        Some((0..depth).map(|s| scm[s]).collect())
     }
 }
 
@@ -12303,6 +12320,29 @@ fn handle(
                         op.pc,
                     );
                 }
+                // Resolve each `(dst, src)` move to `(dst, live guard value)`
+                // against the guard-state register file NOW — before gating.
+                // A move whose `src` is out of range or holds `OpRef::NONE`
+                // recovers no live kept value, so it must not count toward
+                // coverage; basing `recovery_complete` on the raw `dst` set
+                // would let such a move pass the gate and then silently drop
+                // at the snapshot step, leaving a kept slot unrecovered (a
+                // depth > 1 miscompile).  A const-source `ref_copy` patches
+                // `src` into the constants window of `registers_r`, so this
+                // one read covers register and const sources alike.  The same
+                // resolved set both gates and feeds the snapshot encoder
+                // (single source of truth); `record_guard` below records into
+                // the trace history only and does not mutate `registers_r`,
+                // so reading it here is identical to reading it post-guard.
+                let resolved_recovered: Option<Vec<(u16, OpRef)>> =
+                    kept_recovered.as_ref().map(|mv| {
+                        mv.iter()
+                            .filter_map(|&(dst, src)| {
+                                let v = ctx.registers_r.get(src as usize).copied()?;
+                                (v != OpRef::NONE).then_some((dst, v))
+                            })
+                            .collect()
+                    });
                 // Recover depth > 1 only when the decoded edge moves cover
                 // EVERY kept resume stack slot.  A slot the not-taken edge
                 // does not rename ("live-across") would fall through to the
@@ -12313,7 +12353,7 @@ fn handle(
                 // by the positional heuristic below and is not gated here.
                 // `PYRE_RELAX_124` forces depth > 1 through for diagnosis.
                 let recovery_complete = match (
-                    kept_recovered.as_ref(),
+                    resolved_recovered.as_ref(),
                     branch_resume_stack_colors(other_target),
                 ) {
                     (Some(moves), Some(cols)) => {
@@ -12341,21 +12381,12 @@ fn handle(
                 // `goto_if_not`) and desync the decoded box layout.
                 if kept_stack {
                     BRANCH_GUARD_JITCODE_PC.with(|c| c.set(op.pc));
-                    // Resolve each `(dst, src)` move to `(dst, live guard
-                    // value)` now, against the guard-state register file.  A
-                    // const-source `ref_copy` patches `src` into the constants
-                    // window of `registers_r`, so this one read covers register
-                    // and const sources alike.
-                    let recovered: Vec<(u16, OpRef)> = kept_recovered
-                        .as_deref()
-                        .unwrap_or(&[])
-                        .iter()
-                        .filter_map(|&(dst, src)| {
-                            let v = ctx.registers_r.get(src as usize).copied()?;
-                            (v != OpRef::NONE).then_some((dst, v))
-                        })
-                        .collect();
-                    BRANCH_GUARD_KEPT_RECOVERED.with(|c| *c.borrow_mut() = recovered);
+                    // Feed the snapshot encoder the SAME resolved set the gate
+                    // checked (resolved above, before `record_guard`): each
+                    // `(dst, live guard value)`, sources already filtered to
+                    // live in-range values.
+                    BRANCH_GUARD_KEPT_RECOVERED
+                        .with(|c| *c.borrow_mut() = resolved_recovered.unwrap_or_default());
                 }
                 let capture = walker_capture_snapshot_for_last_guard(ctx, other_target);
                 BRANCH_GUARD_JITCODE_PC.with(|c| c.set(usize::MAX));

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -300,14 +300,18 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
     (portal_frame_reg, portal_ec_reg)
 }
 
-/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default on).
+/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default off).
 ///
-/// Guard frames resume at their carried direct JitCode pc instead of the
-/// lossy `pc_map` translation of the stored Python pc, and the encoder
-/// collects the guard-pc live box set directly rather than the resume-pc set
-/// patched by the positional kept-stack heuristic.  On by default; set
-/// `PYRE_M3_JITCODE_PC=0` (or `false`) to force the legacy heuristic path
-/// back on as a rollback escape hatch.
+/// When enabled, a kept-stack branch guard resumes at its carried direct
+/// JitCode pc and the encoder collects the guard-pc live box set directly
+/// rather than the resume-pc set patched by the positional kept-stack
+/// heuristic.  Default off: for a depth-1 leading-`and` short-circuit
+/// (`x = local and CONST`) the guard-pc box set holds the *taken*-path value
+/// for the kept operand-stack slot, so the direct-pc path restores that value
+/// on the not-taken arm and silently miscompiles (`flag and 11`: 2197063 vs
+/// 1466663).  The positional heuristic recovers the not-taken kept value
+/// correctly.  Set `PYRE_M3_JITCODE_PC=1` to opt back into the direct-pc path
+/// for validating the future snapshot-before-guard fix (#124/#281).
 pub(crate) fn m3_jitcode_pc_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M3_JITCODE_PC") {
@@ -315,7 +319,7 @@ pub(crate) fn m3_jitcode_pc_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => true,
+        None => false,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -310,8 +310,12 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
 /// for the kept operand-stack slot, so the direct-pc path restores that value
 /// on the not-taken arm and silently miscompiles (`flag and 11`: 2197063 vs
 /// 1466663).  The positional heuristic recovers the not-taken kept value
-/// correctly.  Set `PYRE_M3_JITCODE_PC=1` to opt back into the direct-pc path
-/// for validating the future snapshot-before-guard fix (#124/#281).
+/// correctly — depth-1 via `kept_stack_subst` and depth > 1 via the not-taken
+/// edge's decoded `ref_copy` parallel moves (`#420`,
+/// `jitcode_dispatch.rs decode_branch_trampoline_ref_moves`), the authoritative
+/// kept-value source while M3 is off.  Set `PYRE_M3_JITCODE_PC=1` to opt back
+/// into the direct-pc path for validating the future snapshot-before-guard fix
+/// (#124/#281).
 pub(crate) fn m3_jitcode_pc_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M3_JITCODE_PC") {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4720,6 +4720,24 @@ pub extern "C" fn bh_unpack_item_fn(index: i64, seq: i64) -> i64 {
     }
 }
 
+/// UNPACK_EX: split `seq` for `a, *b, c = seq` into `before` head items, a
+/// starred middle list, and `after` tail items, returning the
+/// `before + 1 + after` slots in TOS order as a tuple (raising ValueError on
+/// too few values, or any iteration error from a non-sequence source). The
+/// portal reads each slot back out with `bh_unpack_item_fn`, mirroring
+/// `bh_unpack_sequence_fn`.
+pub extern "C" fn bh_unpack_ex_fn(before: i64, after: i64, seq: i64) -> i64 {
+    let seq = seq as pyre_object::PyObjectRef;
+    match pyre_interpreter::runtime_ops::unpack_ex_slots(before as usize, after as usize, seq) {
+        Ok(slots) => pyre_interpreter::runtime_ops::build_tuple_from_refs(&slots) as i64,
+        Err(err) => {
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE
+                .with(|c| c.set(err.to_exc_object() as i64));
+            0
+        }
+    }
+}
+
 /// Read the current (per-thread) exception saved in
 /// `pyre_interpreter::eval::CURRENT_EXCEPTION`. Matches the read at
 /// `pyopcode.py:786 PUSH_EXC_INFO` (implicit via `executioncontext.sys_exc_info`).

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4699,8 +4699,7 @@ pub extern "C" fn bh_unpack_sequence_fn(count: i64, seq: i64) -> i64 {
     match pyre_interpreter::runtime_ops::unpack_sequence_exact(seq, count as usize) {
         Ok(items) => pyre_interpreter::runtime_ops::build_tuple_from_refs(&items) as i64,
         Err(err) => {
-            majit_metainterp::blackhole::BH_LAST_EXC_VALUE
-                .with(|c| c.set(err.to_exc_object() as i64));
+            publish_residual_call_exception(err.to_exc_object() as i64);
             0
         }
     }
@@ -4731,8 +4730,7 @@ pub extern "C" fn bh_unpack_ex_fn(before: i64, after: i64, seq: i64) -> i64 {
     match pyre_interpreter::runtime_ops::unpack_ex_slots(before as usize, after as usize, seq) {
         Ok(slots) => pyre_interpreter::runtime_ops::build_tuple_from_refs(&slots) as i64,
         Err(err) => {
-            majit_metainterp::blackhole::BH_LAST_EXC_VALUE
-                .with(|c| c.set(err.to_exc_object() as i64));
+            publish_residual_call_exception(err.to_exc_object() as i64);
             0
         }
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3913,6 +3913,28 @@ pub extern "C" fn bh_binary_slice_fn(obj: i64, start: i64, stop: i64) -> i64 {
     }
 }
 
+/// STORE_SLICE residual (`store_slice` HLOp → `residual_call_r_v`).
+/// Runs `obj[start:stop] = value` through the shared
+/// `runtime_ops::store_slice_values` (the same code the interpreter's
+/// `store_slice` runs — builds a `slice(start, stop, None)` and dispatches
+/// `setitem`).  A user `__setitem__` or slice-bound `__index__` may run
+/// Python and force virtualizables (`MayForce`).  Void result, so always
+/// returns 0; on error the exception is published through
+/// `BH_LAST_EXC_VALUE` for the trailing `GuardNoException`, matching
+/// `bh_delete_subscr_fn`.
+pub extern "C" fn bh_store_slice_fn(obj: i64, start: i64, stop: i64, value: i64) -> i64 {
+    if let Err(err) = pyre_interpreter::runtime_ops::store_slice_values(
+        obj as pyre_object::PyObjectRef,
+        start as pyre_object::PyObjectRef,
+        stop as pyre_object::PyObjectRef,
+        value as pyre_object::PyObjectRef,
+    ) {
+        let exc_obj = err.to_exc_object();
+        publish_residual_call_exception(exc_obj as i64);
+    }
+    0
+}
+
 /// DELETE_SUBSCR residual (`delete_subscr` HLOp → `residual_call_r_v`).
 /// Runs `del obj[index]` through the shared `baseobjspace::delitem` (the
 /// same code the interpreter's `delete_subscript` runs).  A `__delitem__`

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4015,6 +4015,36 @@ pub extern "C" fn bh_store_name_fn(frame_ptr: i64, w_name: i64, value: i64) -> i
     }
 }
 
+/// `STORE_GLOBAL` residual for the standalone (blackhole / deopt)
+/// per-CodeObject jitcode.  `pyopcode.py:567 STORE_GLOBAL` writes the
+/// value directly into `w_globals`, bypassing `w_locals`.  Delegates to
+/// the interpreter trait impl (`eval.rs store_global_value`), which
+/// routes through `w_dict_setitem_str` on the eagerly-resolved
+/// `w_globals_obj` (or the back-mirror dict storage when null).  Same
+/// blackhole-only execution contract and `w_name` ABI as
+/// `bh_store_name_fn`.  `STORE_GLOBAL` carries no nameindex-keyed cache,
+/// so the trait's `nameindex` argument is passed as 0.  Returns 1 on
+/// success; on error it sets `BH_LAST_EXC_VALUE` and returns 0.
+pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) -> i64 {
+    use pyre_interpreter::pyopcode::NamespaceOpcodeHandler;
+    assert!(
+        frame_ptr != 0,
+        "bh_store_global_fn requires a non-null PyFrame; every STORE_GLOBAL emit \
+         site must thread portal_frame_reg as the leading ref operand"
+    );
+    let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
+    let name =
+        unsafe { pyre_object::strobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
+    match frame.store_global_value(name, 0, value as pyre_object::PyObjectRef) {
+        Ok(()) => 1,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            0
+        }
+    }
+}
+
 /// Load a constant from the code object.
 /// jtransform.py parity: code comes from getfield_vable_r(frame, pycode).
 pub extern "C" fn bh_load_const_fn(w_code_ptr: i64, consti: i64) -> i64 {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3791,6 +3791,42 @@ pub extern "C" fn bh_import_name_fn(
     }
 }
 
+/// IMPORT_FROM residual (`import_from` HLOp → `residual_call_ir_r`).
+/// Resolves the attribute name from the jitcode's own code object via
+/// `name_idx` (same `co_names` invariant as `bh_load_attr_fn`) and runs
+/// `importing::import_from(module, name, ec)` — first the module's
+/// namespace dict, then a submodule-import fallback (which may run a
+/// module's top-level Python → `MayForce`) — with the TLS-pinned
+/// execution context.  `module` is the peeked TOS (IMPORT_FROM does not
+/// pop it).  On error the exception is published through
+/// `BH_LAST_EXC_VALUE` for the trailing `GuardNoException` and the call
+/// returns 0.
+pub extern "C" fn bh_import_from_fn(module: i64, w_code_ptr: i64, name_idx: i64) -> i64 {
+    let w_code = w_code_ptr as pyre_object::PyObjectRef;
+    let code = unsafe {
+        &*(pyre_interpreter::w_code_get_ptr(w_code) as *const pyre_interpreter::CodeObject)
+    };
+    let idx = name_idx as usize;
+    debug_assert!(
+        idx < code.names.len(),
+        "bh_import_from_fn name_idx {idx} out of range ({} names) — codegen invariant",
+        code.names.len()
+    );
+    if idx >= code.names.len() {
+        return 0;
+    }
+    let name = code.names[idx].as_ref();
+    let ec = pyre_interpreter::call::getexecutioncontext();
+    match pyre_interpreter::importing::import_from(module as pyre_object::PyObjectRef, name, ec) {
+        Ok(attr) => attr as i64,
+        Err(err) => {
+            let exc_obj = err.to_exc_object();
+            publish_residual_call_exception(exc_obj as i64);
+            0
+        }
+    }
+}
+
 /// LOAD_SUPER_ATTR residual (`load_super_attr` HLOp → `residual_call_ir_r`).
 /// Resolves the attribute name from the jitcode's code object via `name_idx`
 /// (same `co_names` invariant as `bh_load_attr_fn`), builds the `super(cls,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4022,11 +4022,20 @@ fn register_helper_fn_pointers(
         CallFlavor::MayForce,
     );
     // `bh_unpack_ex_fn` validates `a, *b, c = seq` and allocates the slot
-    // tuple (head items, starred list, tail items); like `unpack_sequence_fn`
-    // it can raise ValueError but materialises eagerly and does not force the
-    // virtualizable → `CallFlavor::Plain`.  `bh_unpack_item_fn` (already
-    // bound) indexes the result.  Appended last to preserve fn_ptr indices.
-    let unpack_ex_fn = bind(assembler, cpu.unpack_ex_fn as *const (), CallFlavor::Plain);
+    // tuple (head items, starred list, tail items).  For a non-list/tuple
+    // sequence it drives the iterator protocol
+    // (`runtime_ops::unpack_ex_slots` → `collect_iterable` →
+    // `baseobjspace::next`), so a user `__iter__`/`__next__` can run Python
+    // and force the virtualizable → `CallFlavor::MayForce`, symmetric with
+    // `store_slice_fn` and the `virtualizable_analyzer.analyze(op)` row of
+    // `getcalldescr` (`call.py:288`).  `bh_unpack_item_fn` (already bound)
+    // only indexes the materialised result tuple and stays `Plain`.  Appended
+    // last to preserve fn_ptr indices.
+    let unpack_ex_fn = bind(
+        assembler,
+        cpu.unpack_ex_fn as *const (),
+        CallFlavor::MayForce,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -9374,9 +9383,13 @@ impl CodeWriter {
                             // reads each slot through the opaque residual below.
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let seq_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            // A non-list/tuple sequence is iterated
+                            // (`collect_iterable` → user `__iter__`/`__next__`),
+                            // which can run Python and force the virtualizable →
+                            // `CallFlavor::MayForce` (emits `GUARD_NOT_FORCED`).
                             let tuple_var = residual_call!(
                                 unpack_ex_fn_idx,
-                                CallFlavor::Plain,
+                                CallFlavor::MayForce,
                                 vec![
                                     super::flow::Constant::signed(before as i64).into(),
                                     super::flow::Constant::signed(after as i64).into(),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2863,6 +2863,28 @@ fn emit_frontend_store_name(
     );
 }
 
+fn emit_frontend_store_global(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    frame: super::flow::FlowValue,
+    name: super::flow::FlowValue,
+    value: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py:567 STORE_GLOBAL — writes the value directly into
+    // `w_globals`, bypassing `w_locals`.  Frame-receiver call shape like
+    // `emit_frontend_store_name`; lowers to `bh_store_global_fn(frame,
+    // w_name, value)` (`flatten::lower_store_global_hlop_to_insn`).  See
+    // `emit_frontend_setitem` for the void-result rationale.
+    record_graph_op(
+        block,
+        "store_global",
+        vec![frame.into(), name.into(), value.into()],
+        None,
+        offset,
+    );
+}
+
 fn emit_frontend_simple_call(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3489,6 +3511,7 @@ struct FnPtrIndices {
     getattr_fn: HelperHandle,
     load_name_fn: HelperHandle,
     store_name_fn: HelperHandle,
+    store_global_fn: HelperHandle,
     newtuple_from_array_fn: HelperHandle,
     newlist_from_array_fn: HelperHandle,
     unpack_sequence_fn: HelperHandle,
@@ -3744,6 +3767,11 @@ fn register_helper_fn_pointers(
     // Bound after the existing fn_ptrs to preserve their indices.
     let load_name_fn = bind(assembler, cpu.load_name_fn as *const (), CallFlavor::Plain);
     let store_name_fn = bind(assembler, cpu.store_name_fn as *const (), CallFlavor::Plain);
+    // `bh_store_global_fn` delegates to the interpreter `store_global_value`
+    // (pyopcode.py:567 STORE_GLOBAL); same blackhole/deopt-only contract and
+    // `CallFlavor::Plain` classification as `store_name_fn`.  Bound adjacent
+    // to it to keep the namespace-store helpers contiguous.
+    let store_global_fn = bind(assembler, cpu.store_global_fn as *const (), CallFlavor::Plain);
     // `bh_store_attr_fn` calls `baseobjspace::setattr_str`, which can run
     // user `__setattr__` (forces virtualizables) and raise → `MayForce`.
     // Symmetric to `load_attr_fn`; appended last to preserve fn_ptr indices.
@@ -3940,6 +3968,7 @@ fn register_helper_fn_pointers(
         getattr_fn,
         load_name_fn,
         store_name_fn,
+        store_global_fn,
         newtuple_from_array_fn,
         newlist_from_array_fn,
         unpack_sequence_fn,
@@ -4801,6 +4830,11 @@ impl CodeWriter {
                     idx: store_name_fn_idx,
                     flavor: _store_name_fn_flavor,
                 },
+            store_global_fn:
+                HelperHandle {
+                    idx: store_global_fn_idx,
+                    flavor: _store_global_fn_flavor,
+                },
             newtuple_from_array_fn:
                 HelperHandle {
                     idx: newtuple_from_array_fn_idx,
@@ -5069,6 +5103,7 @@ impl CodeWriter {
                 getattr_fn_idx,
                 load_name_fn_idx,
                 store_name_fn_idx,
+                store_global_fn_idx,
                 newtuple_from_array_fn_idx,
                 newlist_from_array_fn_idx,
                 // `[u16; 15]` indexed by nargs (0..=14).  `call_fn_idx`
@@ -8217,15 +8252,31 @@ impl CodeWriter {
                                 py_pc as i64,
                             );
                         }
-                        Instruction::StoreGlobal { .. } => {
-                            // flowcontext.py:884-890 STORE_GLOBAL is
-                            // unsupported; the stack effect still consumes one
-                            // value.  Unlike STORE_NAME it bypasses w_locals
-                            // (`pyopcode.py:940`), and no hot path needs it
-                            // yet — keep the abort until a helper lands.
-                            emit_abort_permanent!(py_pc);
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            emit_vsd!(current_depth, py_pc);
+                        Instruction::StoreGlobal { namei } => {
+                            // pyopcode.py:567 STORE_GLOBAL — pops the value and
+                            // writes it directly into `w_globals` (bypassing
+                            // `w_locals`) via the `store_global` HLOp →
+                            // `bh_store_global_fn(frame, w_name, value)`
+                            // residual call.  Traced via the trait leg
+                            // (`store_global_value`); the residual runs only on
+                            // blackhole/deopt.  Same void 3-Ref shape as the
+                            // StoreName arm.
+                            let name_idx = namei.get(op_arg) as usize;
+                            let attr_name =
+                                super::flow::Constant::string(code.names[name_idx].as_str());
+                            let value_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let stored_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            if let super::flow::FlowValue::Variable(v) = &stored_value {
+                                pin!(Some(*v), value_reg);
+                            }
+                            emit_frontend_store_global(
+                                &mut graph,
+                                &current_block.block(),
+                                frame_var.into(),
+                                attr_name.into(),
+                                stored_value,
+                                py_pc as i64,
+                            );
                         }
                         Instruction::MakeFunction { .. } => {
                             // Pops code object (TOS), pushes function. Net: 0.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2894,7 +2894,7 @@ fn emit_frontend_store_global(
     value: super::flow::FlowValue,
     offset: i64,
 ) {
-    // pyopcode.py:567 STORE_GLOBAL — writes the value directly into
+    // pyopcode.py:934 STORE_GLOBAL — writes the value directly into
     // `w_globals`, bypassing `w_locals`.  Frame-receiver call shape like
     // `emit_frontend_store_name`; lowers to `bh_store_global_fn(frame,
     // w_name, value)` (`flatten::lower_store_global_hlop_to_insn`).  See
@@ -3765,13 +3765,18 @@ fn register_helper_fn_pointers(
         cpu.newtuple_from_array_fn as *const (),
         CallFlavor::Plain,
     );
-    // `bh_unpack_sequence_fn` validates the length and allocates the item
-    // tuple (can raise ValueError/TypeError); `bh_unpack_item_fn` indexes
-    // that validated tuple. Both can raise → `CallFlavor::Plain`.
+    // `bh_unpack_sequence_fn` validates the exact length and allocates the
+    // item tuple.  For a non-list/tuple sequence it drives the iterator
+    // protocol (`runtime_ops::unpack_sequence_exact` → `baseobjspace::iter`/
+    // `next`), so a user `__iter__`/`__next__` can run Python and force the
+    // virtualizable → `CallFlavor::MayForce`, symmetric with `unpack_ex_fn`
+    // and the `virtualizable_analyzer.analyze(op)` row of `getcalldescr`
+    // (`call.py:288`).  `bh_unpack_item_fn` only indexes the materialised
+    // result tuple and stays `Plain`.
     let unpack_sequence_fn = bind(
         assembler,
         cpu.unpack_sequence_fn as *const (),
-        CallFlavor::Plain,
+        CallFlavor::MayForce,
     );
     let unpack_item_fn = bind(
         assembler,
@@ -3812,7 +3817,7 @@ fn register_helper_fn_pointers(
     let load_name_fn = bind(assembler, cpu.load_name_fn as *const (), CallFlavor::Plain);
     let store_name_fn = bind(assembler, cpu.store_name_fn as *const (), CallFlavor::Plain);
     // `bh_store_global_fn` delegates to the interpreter `store_global_value`
-    // (pyopcode.py:567 STORE_GLOBAL); same blackhole/deopt-only contract and
+    // (pyopcode.py:934 STORE_GLOBAL); same blackhole/deopt-only contract and
     // `CallFlavor::Plain` classification as `store_name_fn`.  Bound adjacent
     // to it to keep the namespace-store helpers contiguous.
     let store_global_fn = bind(
@@ -8353,7 +8358,7 @@ impl CodeWriter {
                             );
                         }
                         Instruction::StoreGlobal { namei } => {
-                            // pyopcode.py:567 STORE_GLOBAL — pops the value and
+                            // pyopcode.py:934 STORE_GLOBAL — pops the value and
                             // writes it directly into `w_globals` (bypassing
                             // `w_locals`) via the `store_global` HLOp →
                             // `bh_store_global_fn(frame, w_name, value)`
@@ -8539,9 +8544,14 @@ impl CodeWriter {
                             // so no manual scratch reservation is needed.
                             let _ = emit_popvalue_ref!(current_depth, py_pc);
                             let seq_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            // A non-list/tuple sequence is iterated
+                            // (`unpack_sequence_exact` → `baseobjspace::iter`/`next`
+                            // → user `__iter__`/`__next__`), which can run Python and
+                            // force the virtualizable → `CallFlavor::MayForce` (emits
+                            // `GUARD_NOT_FORCED`).
                             let tuple_var = residual_call!(
                                 unpack_sequence_fn_idx,
-                                CallFlavor::Plain,
+                                CallFlavor::MayForce,
                                 majit_ir::PyreHelperKind::UnpackSequence,
                                 vec![super::flow::Constant::signed(n as i64).into()],
                                 vec![seq_value],

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3112,6 +3112,24 @@ fn emit_frontend_import_name(
     )
 }
 
+fn emit_frontend_import_from(
+    graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    module: super::flow::FlowValue,
+    code: super::flow::FlowValue,
+    name_idx: super::flow::FlowValue,
+    offset: i64,
+) -> super::flow::Variable {
+    emit_graph_op_with_result(
+        graph,
+        block,
+        "import_from",
+        vec![module.into(), code.into(), name_idx.into()],
+        Kind::Ref,
+        offset,
+    )
+}
+
 fn emit_frontend_load_super_attr(
     graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3547,6 +3565,7 @@ struct FnPtrIndices {
     build_string_from_array_fn: HelperHandle,
     convert_value_fn: HelperHandle,
     import_name_fn: HelperHandle,
+    import_from_fn: HelperHandle,
     load_super_attr_fn: HelperHandle,
     super_attr_unwrap_fn: HelperHandle,
     load_deref_value_fn: HelperHandle,
@@ -3858,6 +3877,13 @@ fn register_helper_fn_pointers(
         cpu.import_name_fn as *const (),
         CallFlavor::MayForce,
     );
+    // `bh_import_from_fn` runs `importing::import_from` (a submodule-import
+    // fallback may run module top-level Python) → `MayForce`.
+    let import_from_fn = bind(
+        assembler,
+        cpu.import_from_fn as *const (),
+        CallFlavor::MayForce,
+    );
     // `bh_load_super_attr_fn` runs `getattr` on the super proxy (descriptor
     // `__get__` may run Python) → `MayForce`.  `bh_super_attr_unwrap_fn` is
     // pure but routes through the proven MayForce ir_r path.  Appended last
@@ -4004,6 +4030,7 @@ fn register_helper_fn_pointers(
         build_string_from_array_fn,
         convert_value_fn,
         import_name_fn,
+        import_from_fn,
         load_super_attr_fn,
         super_attr_unwrap_fn,
         load_deref_value_fn,
@@ -5010,6 +5037,11 @@ impl CodeWriter {
                     idx: import_name_fn_idx,
                     flavor: _import_name_fn_flavor,
                 },
+            import_from_fn:
+                HelperHandle {
+                    idx: import_from_fn_idx,
+                    flavor: _import_from_fn_flavor,
+                },
             load_super_attr_fn:
                 HelperHandle {
                     idx: load_super_attr_fn_idx,
@@ -5139,6 +5171,7 @@ impl CodeWriter {
                 build_string_from_array_fn_idx,
                 convert_value_fn_idx,
                 import_name_fn_idx,
+                import_from_fn_idx,
                 load_super_attr_fn_idx,
                 super_attr_unwrap_fn_idx,
                 load_deref_value_fn_idx,
@@ -9100,10 +9133,42 @@ impl CodeWriter {
                         }
 
                         // ImportFrom: peek module, push attr. Net: +1.
-                        Instruction::ImportFrom { .. } => {
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            current_depth += 1;
-                            emit_abort_permanent!(py_pc);
+                        Instruction::ImportFrom { namei } => {
+                            // pyopcode.py IMPORT_FROM — PEEK the module (TOS,
+                            // NOT popped) and push `getattr(module, name)` (with
+                            // a submodule-import fallback) via the `import_from`
+                            // HLOp → `residual_call_ir_r(import_from_fn,
+                            // ListI([name_idx]), ListR([module, code]))`.  Net
+                            // +1; the module stays on the stack.  Surrogate
+                            // operands mirror the LoadAttr / ImportName arms: the
+                            // jitcode's own W_CodeObject as a post-rtype
+                            // `Signed(ptr) + Kind::Ref` constant and the
+                            // `co_names` index the helper resolves the attribute
+                            // name with.  `bh_import_from_fn` runs the import
+                            // through the TLS execution context (MayForce).
+                            let name_idx = namei.get(op_arg) as usize;
+                            let code_const: super::flow::FlowValue = super::flow::Constant::new(
+                                super::flow::ConstantValue::Signed(w_code as i64),
+                                Some(Kind::Ref),
+                            )
+                            .into();
+                            let name_idx_const: super::flow::FlowValue =
+                                super::flow::Constant::signed(name_idx as i64).into();
+                            let module_value = current_state
+                                .stack
+                                .last()
+                                .cloned()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            let result_value = emit_frontend_import_from(
+                                &mut graph,
+                                &current_block.block(),
+                                module_value,
+                                code_const,
+                                name_idx_const,
+                                py_pc as i64,
+                            );
+                            pin!(Some(result_value), stack_base + current_depth);
+                            push_and_bump!(result_value.into(), py_pc);
                         }
 
                         // StoreSlice: pops 4 (stop, start, obj, value). Net: -4.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2648,6 +2648,29 @@ fn emit_frontend_setitem(
     );
 }
 
+fn emit_frontend_store_slice(
+    _graph: &mut super::flow::FunctionGraph,
+    block: &super::flow::BlockRef,
+    obj: super::flow::FlowValue,
+    start: super::flow::FlowValue,
+    stop: super::flow::FlowValue,
+    value: super::flow::FlowValue,
+    offset: i64,
+) {
+    // pyopcode.py STORE_SLICE -> builds `slice(start, stop, None)` and runs
+    // `obj[slice] = value`.  pyre's interpreter routes this through
+    // `runtime_ops::store_slice_values`; the residual records the same shape
+    // as `setitem` (void, no result slot) so `flatten_space_operation`'s
+    // `result == None` branch lowers it to `residual_call_r_v`.
+    record_graph_op(
+        block,
+        "store_slice",
+        vec![obj.into(), start.into(), stop.into(), value.into()],
+        None,
+        offset,
+    );
+}
+
 fn emit_frontend_delsubscr(
     _graph: &mut super::flow::FunctionGraph,
     block: &super::flow::BlockRef,
@@ -3576,6 +3599,7 @@ struct FnPtrIndices {
     unary_not_fn: HelperHandle,
     load_fast_check_fn: HelperHandle,
     list_extend_fn: HelperHandle,
+    store_slice_fn: HelperHandle,
 }
 
 /// Register every blackhole helper fn pointer with the assembler in
@@ -3982,6 +4006,16 @@ fn register_helper_fn_pointers(
     let call_fn_12 = bind(assembler, cpu.call_fn_12 as *const (), CallFlavor::MayForce);
     let call_fn_13 = bind(assembler, cpu.call_fn_13 as *const (), CallFlavor::MayForce);
     let call_fn_14 = bind(assembler, cpu.call_fn_14 as *const (), CallFlavor::MayForce);
+    // `bh_store_slice_fn` runs `obj[start:stop] = value` via
+    // `runtime_ops::store_slice_values` (a `slice` object through
+    // `baseobjspace::setitem`); a user `__setitem__` or slice-bound
+    // `__index__` can run Python and force virtualizables → `MayForce`.
+    // Appended last to preserve fn_ptr indices.
+    let store_slice_fn = bind(
+        assembler,
+        cpu.store_slice_fn as *const (),
+        CallFlavor::MayForce,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -4041,6 +4075,7 @@ fn register_helper_fn_pointers(
         unary_not_fn,
         load_fast_check_fn,
         list_extend_fn,
+        store_slice_fn,
     }
 }
 
@@ -5092,6 +5127,11 @@ impl CodeWriter {
                     idx: list_extend_fn_idx,
                     flavor: _list_extend_fn_flavor,
                 },
+            store_slice_fn:
+                HelperHandle {
+                    idx: store_slice_fn_idx,
+                    flavor: _store_slice_fn_flavor,
+                },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 
         // codewriter.py:37 `portal_jd = self.callcontrol.jitdriver_sd_from_portal_graph(graph)`
@@ -5182,6 +5222,7 @@ impl CodeWriter {
                 unary_not_fn_idx,
                 load_fast_check_fn_idx,
                 list_extend_fn_idx,
+                store_slice_fn_idx,
             });
         }
 
@@ -9171,12 +9212,41 @@ impl CodeWriter {
                             push_and_bump!(result_value.into(), py_pc);
                         }
 
-                        // StoreSlice: pops 4 (stop, start, obj, value). Net: -4.
+                        // StoreSlice: pops 4 (stop=TOS, start=TOS1,
+                        // container=TOS2, value=TOS3). Net: -4.
+                        // `obj[start:stop] = value` → `store_slice(container,
+                        // start, stop, value)` HLOp lowered to
+                        // `residual_call_r_v(store_slice_fn_idx, ListR[obj,
+                        // start, stop, value])`.  `bh_store_slice_fn` builds a
+                        // `slice` and runs `setitem` through the shared
+                        // `runtime_ops::store_slice_values`; a user
+                        // `__setitem__` or slice `__index__` may run Python →
+                        // MayForce.  Inputs are read by the backend ABI into
+                        // call regs before the call executes; no write-back
+                        // conflicts because ResKind::Void.
                         Instruction::StoreSlice => {
-                            for _ in 0..4 {
-                                pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            }
-                            emit_abort_permanent!(py_pc);
+                            current_depth -= 1;
+                            emit_vsd!(current_depth, py_pc);
+                            let stop_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            current_depth -= 1;
+                            emit_vsd!(current_depth, py_pc);
+                            let start_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            current_depth -= 1;
+                            emit_vsd!(current_depth, py_pc);
+                            let container_value =
+                                pop_ref_or_fresh(&mut current_state, &mut graph);
+                            current_depth -= 1;
+                            emit_vsd!(current_depth, py_pc);
+                            let stored_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            emit_frontend_store_slice(
+                                &mut graph,
+                                &current_block.block(),
+                                container_value,
+                                start_value,
+                                stop_value,
+                                stored_value,
+                                py_pc as i64,
+                            );
                         }
 
                         // FormatWithSpec: pops 2 (spec=TOS, value=TOS1), pushes 1

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3557,6 +3557,7 @@ struct FnPtrIndices {
     newlist_from_array_fn: HelperHandle,
     unpack_sequence_fn: HelperHandle,
     unpack_item_fn: HelperHandle,
+    unpack_ex_fn: HelperHandle,
     build_slice_fn: HelperHandle,
     normalize_raise_varargs_fn: HelperHandle,
     call_fn_0: HelperHandle,
@@ -4016,6 +4017,12 @@ fn register_helper_fn_pointers(
         cpu.store_slice_fn as *const (),
         CallFlavor::MayForce,
     );
+    // `bh_unpack_ex_fn` validates `a, *b, c = seq` and allocates the slot
+    // tuple (head items, starred list, tail items); like `unpack_sequence_fn`
+    // it can raise ValueError but materialises eagerly and does not force the
+    // virtualizable → `CallFlavor::Plain`.  `bh_unpack_item_fn` (already
+    // bound) indexes the result.  Appended last to preserve fn_ptr indices.
+    let unpack_ex_fn = bind(assembler, cpu.unpack_ex_fn as *const (), CallFlavor::Plain);
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -4076,6 +4083,7 @@ fn register_helper_fn_pointers(
         load_fast_check_fn,
         list_extend_fn,
         store_slice_fn,
+        unpack_ex_fn,
     }
 }
 
@@ -5131,6 +5139,11 @@ impl CodeWriter {
                 HelperHandle {
                     idx: store_slice_fn_idx,
                     flavor: _store_slice_fn_flavor,
+                },
+            unpack_ex_fn:
+                HelperHandle {
+                    idx: unpack_ex_fn_idx,
+                    flavor: _unpack_ex_fn_flavor,
                 },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 
@@ -9348,12 +9361,55 @@ impl CodeWriter {
                             let args = counts.get(op_arg);
                             let before = args.before as usize;
                             let after = args.after as usize;
-                            pop_and_decr_depth(&mut current_state, &mut current_depth);
-                            for _ in 0..before + 1 + after {
-                                push_fresh_ref(&mut current_state, &mut graph);
-                                current_depth += 1;
+                            let total = before + 1 + after;
+                            // Pop the sequence; `unpack_ex_fn(before, after, seq)`
+                            // splits it into the `before + 1 + after` slots
+                            // (head items, starred list, tail items) in TOS order
+                            // as a tuple — the UNPACK_SEQUENCE shape with a star
+                            // list slot. The result is a generic tuple (never a
+                            // SPECIALISED_TUPLE_II), so `unpack_item_fn(k, tuple)`
+                            // reads each slot through the opaque residual below.
+                            let _ = emit_popvalue_ref!(current_depth, py_pc);
+                            let seq_value = pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let tuple_var = residual_call!(
+                                unpack_ex_fn_idx,
+                                CallFlavor::Plain,
+                                vec![
+                                    super::flow::Constant::signed(before as i64).into(),
+                                    super::flow::Constant::signed(after as i64).into(),
+                                ],
+                                vec![seq_value],
+                                vec![],
+                                vec![Kind::Int, Kind::Int, Kind::Ref],
+                                ResKind::Ref,
+                                py_pc as i64,
+                            );
+                            let tuple_value = tuple_var
+                                .map(super::flow::FlowValue::from)
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            // Push the slots in reverse so the stack top is
+                            // slot[0] (unpack_ex pushes head items last).
+                            for k in (0..total).rev() {
+                                let item_dst = stack_base + current_depth;
+                                let item_var = residual_call!(
+                                    unpack_item_fn_idx,
+                                    CallFlavor::Plain,
+                                    majit_ir::PyreHelperKind::UnpackItem,
+                                    vec![super::flow::Constant::signed(k as i64).into()],
+                                    vec![tuple_value.clone()],
+                                    vec![],
+                                    vec![Kind::Int, Kind::Ref],
+                                    ResKind::Ref,
+                                    py_pc as i64,
+                                );
+                                let item_value = item_var
+                                    .map(super::flow::FlowValue::from)
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                                if let super::flow::FlowValue::Variable(v) = &item_value {
+                                    pin!(Some(*v), item_dst);
+                                }
+                                push_and_bump!(item_value, py_pc);
                             }
-                            emit_abort_permanent!(py_pc);
                         }
 
                         // BuildInterpolation: conditionally pops format_spec when (oparg & 1) != 0,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3815,7 +3815,11 @@ fn register_helper_fn_pointers(
     // (pyopcode.py:567 STORE_GLOBAL); same blackhole/deopt-only contract and
     // `CallFlavor::Plain` classification as `store_name_fn`.  Bound adjacent
     // to it to keep the namespace-store helpers contiguous.
-    let store_global_fn = bind(assembler, cpu.store_global_fn as *const (), CallFlavor::Plain);
+    let store_global_fn = bind(
+        assembler,
+        cpu.store_global_fn as *const (),
+        CallFlavor::Plain,
+    );
     // `bh_store_attr_fn` calls `baseobjspace::setattr_str`, which can run
     // user `__setattr__` (forces virtualizables) and raise → `MayForce`.
     // Symmetric to `load_attr_fn`; appended last to preserve fn_ptr indices.
@@ -9246,8 +9250,7 @@ impl CodeWriter {
                             let start_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             current_depth -= 1;
                             emit_vsd!(current_depth, py_pc);
-                            let container_value =
-                                pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let container_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             current_depth -= 1;
                             emit_vsd!(current_depth, py_pc);
                             let stored_value = pop_ref_or_fresh(&mut current_state, &mut graph);

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -181,6 +181,11 @@ pub struct Cpu {
     /// with `w_name` an interned str constant.  Blackhole/deopt lowering
     /// of `STORE_NAME` (`pyopcode.py:855`).
     pub store_name_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// `bhimpl_store_global` — `(frame: Ref, w_name: Ref, value: Ref) →
+    /// Void` with `w_name` an interned str constant.  Blackhole/deopt
+    /// lowering of `STORE_GLOBAL` (`pyopcode.py:567`); writes directly
+    /// into `w_globals`, bypassing `w_locals`.
+    pub store_global_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `newtuple(list_w)` (`objspace.py:332`) — (ref array) → new tuple.
     /// The array is the forced `popvalues` list; length travels inside
     /// the array, so any arity fits.
@@ -325,6 +330,7 @@ impl Cpu {
             getattr_fn: crate::call_jit::bh_getattr_fn,
             load_name_fn: crate::call_jit::bh_load_name_fn,
             store_name_fn: crate::call_jit::bh_store_name_fn,
+            store_global_fn: crate::call_jit::bh_store_global_fn,
             newtuple_from_array_fn: crate::call_jit::bh_newtuple_from_array,
             build_map_from_array_fn: crate::call_jit::bh_build_map_from_array,
             build_set_from_array_fn: crate::call_jit::bh_build_set_from_array,

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -126,6 +126,12 @@ pub struct Cpu {
     /// the threaded `frame`, and imports through the TLS-pinned execution
     /// context (may run module top-level Python → fallible).
     pub import_name_fn: extern "C" fn(i64, i64, i64, i64, i64) -> i64,
+    /// `bh_import_from_fn(module, code, name_idx)` — IMPORT_FROM residual;
+    /// resolves the attribute name from the code object and runs
+    /// `importing::import_from` on the peeked module (namespace lookup, then a
+    /// submodule-import fallback that may run module top-level Python →
+    /// fallible) through the TLS-pinned execution context.
+    pub import_from_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `bh_load_super_attr_fn(self, cls, code, name_idx)` — LOAD_SUPER_ATTR
     /// `getattr(super(cls, self), name)` residual (descriptor `__get__` may
     /// run Python → fallible).
@@ -312,6 +318,7 @@ impl Cpu {
             format_with_spec_fn: crate::call_jit::bh_format_with_spec_fn,
             convert_value_fn: crate::call_jit::bh_convert_value_fn,
             import_name_fn: crate::call_jit::bh_import_name_fn,
+            import_from_fn: crate::call_jit::bh_import_from_fn,
             load_super_attr_fn: crate::call_jit::bh_load_super_attr_fn,
             super_attr_unwrap_fn: crate::call_jit::bh_super_attr_unwrap_fn,
             load_deref_value_fn: crate::call_jit::bh_load_deref_value_fn,

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -102,6 +102,9 @@ pub struct Cpu {
     pub store_attr_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// BINARY_SLICE residual — `(obj, start, stop) → obj[start:stop]`.
     pub binary_slice_fn: extern "C" fn(i64, i64, i64) -> i64,
+    /// STORE_SLICE residual — `(obj, start, stop, value) → void`
+    /// (`obj[start:stop] = value`).
+    pub store_slice_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// DELETE_SUBSCR residual — `(obj, index) → void` (`del obj[index]`).
     pub delete_subscr_fn: extern "C" fn(i64, i64) -> i64,
     /// LIST_EXTEND residual — `(list, iterable) → void` (`list.extend(iterable)`,
@@ -311,6 +314,7 @@ impl Cpu {
             load_method_self_fn: crate::call_jit::bh_load_method_self_fn,
             store_attr_fn: crate::call_jit::bh_store_attr_fn,
             binary_slice_fn: crate::call_jit::bh_binary_slice_fn,
+            store_slice_fn: crate::call_jit::bh_store_slice_fn,
             delete_subscr_fn: crate::call_jit::bh_delete_subscr_fn,
             delete_attr_fn: crate::call_jit::bh_delete_attr_fn,
             list_extend_fn: crate::call_jit::bh_list_extend_fn,

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -217,6 +217,10 @@ pub struct Cpu {
     pub unpack_sequence_fn: extern "C" fn(i64, i64) -> i64,
     /// Read item `index` out of the validated unpack tuple — (index, seq) → item.
     pub unpack_item_fn: extern "C" fn(i64, i64) -> i64,
+    /// UNPACK_EX residual — `(before, after, seq) → tuple` of the
+    /// `before + 1 + after` slots (head items, starred list, tail items)
+    /// in TOS order; read back with `unpack_item_fn`.
+    pub unpack_ex_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// `bhimpl_build_slice` — (argc, start, stop, step) → new slice.
     pub build_slice_fn: extern "C" fn(i64, i64, i64, i64) -> i64,
     /// `RAISE_VARARGS` normalization helper used before `raise/r`.
@@ -349,6 +353,7 @@ impl Cpu {
             newlist_from_array_fn: crate::call_jit::bh_newlist_from_array,
             unpack_sequence_fn: crate::call_jit::bh_unpack_sequence_fn,
             unpack_item_fn: crate::call_jit::bh_unpack_item_fn,
+            unpack_ex_fn: crate::call_jit::bh_unpack_ex_fn,
             build_slice_fn: crate::call_jit::bh_build_slice_fn,
             normalize_raise_varargs_fn: crate::call_jit::bh_normalize_raise_varargs_with_frame,
             get_current_exception_fn: crate::call_jit::bh_get_current_exception,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3179,6 +3179,12 @@ pub struct LoweringContext {
     /// w_name, value]`, void result) via
     /// [`lower_store_name_hlop_to_insn`].
     pub store_name_fn_idx: u16,
+    /// `store_global_fn` descrs-pool index.  STORE_GLOBAL family (single
+    /// HLOp opname `store_global`, the `pyopcode.py:567` frame-receiver
+    /// shape) lowers to `residual_call_r_v` (three Ref inputs `[frame,
+    /// w_name, value]`, void result) via
+    /// [`lower_store_global_hlop_to_insn`].
+    pub store_global_fn_idx: u16,
     /// `bind(assembler, cpu.newtuple_from_array_fn as *const (),
     /// CallFlavor::Plain)` descrs-pool index for the production
     /// source.  BUILD_TUPLE records the rtyped `pyopcode.py:995-998`
@@ -3997,6 +4003,45 @@ where
     ))
 }
 
+/// Lower a `STORE_GLOBAL` pre-rtype HLOp `store_global(frame, w_name,
+/// value)` → void (the `pyopcode.py:567 STORE_GLOBAL` frame-receiver
+/// shape recorded by `emit_frontend_store_global`) to the post-rtype
+/// `residual_call_r_v(ConstInt(store_global_fn_idx), ListR([frame,
+/// w_name, value]), Descr)` Insn — the same void 3-Ref shape as
+/// `lower_store_name_hlop_to_insn`.  `bh_store_global_fn(frame: Ref,
+/// w_name: Ref, value: Ref)` delegates to the interpreter
+/// `store_global_value`.  `CallFlavor::Plain` like
+/// [`lower_store_name_hlop_to_insn`].
+pub fn lower_store_global_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "store_global" {
+        return None;
+    }
+    if op.args.len() != 3 {
+        return None;
+    }
+    if op.result.is_some() {
+        return None;
+    }
+    let frame_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let name_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    let value_operand = flatten_arg_with_lowering(&op.args[2], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.store_global_fn_idx,
+        vec![frame_operand, name_operand, value_operand],
+        CallFlavor::Plain,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
 /// Construct the CALL-family `residual_call_r_r` Insn from raw
 /// register indices.  Production codewriter callsite replaces the prior `emit_residual_call(
 /// call_fn_N_idx, ...)` SSARepr emit at codewriter.rs:5747-5754
@@ -4766,6 +4811,9 @@ where
         return Some(insn);
     }
     if let Some(insn) = lower_store_name_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_store_global_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_tuple_build_hlop_to_insn(op, ctx, get_register, lower_constant) {
@@ -7031,6 +7079,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -7188,6 +7237,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -7332,6 +7382,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -7439,6 +7490,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -7590,6 +7642,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -7786,6 +7839,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8031,6 +8085,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8142,6 +8197,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8197,6 +8253,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8329,6 +8386,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8419,6 +8477,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8480,6 +8539,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8533,6 +8593,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8593,6 +8654,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8680,6 +8742,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8730,6 +8793,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8794,6 +8858,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8874,6 +8939,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -8939,6 +9005,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -9019,6 +9086,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -9075,6 +9143,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -9131,6 +9200,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -9192,6 +9262,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -9267,6 +9338,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -10441,6 +10513,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs: [0; 15],
@@ -10738,6 +10811,7 @@ mod tests {
             getattr_fn_idx: 0,
             load_name_fn_idx: 0,
             store_name_fn_idx: 0,
+            store_global_fn_idx: 0,
             newtuple_from_array_fn_idx: 0,
             newlist_from_array_fn_idx: 0,
             call_fn_idx_by_nargs,
@@ -10927,6 +11001,7 @@ mod tests {
             load_method_self_fn_idx: 92,
             load_name_fn_idx: 93,
             store_name_fn_idx: 94,
+            store_global_fn_idx: 0,
             store_attr_fn_idx: 95,
             build_map_from_array_fn_idx: 96,
             binary_slice_fn_idx: 97,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3426,6 +3426,13 @@ pub struct LoweringContext {
     /// DELETE_SUBSCR shape); `bh_list_extend_fn` extends the list in place
     /// from an arbitrary iterable (user `__iter__`/`__next__` → `MayForce`).
     pub list_extend_fn_idx: u16,
+    /// `store_slice_fn` descrs-pool index.  STORE_SLICE records the
+    /// `store_slice(obj, start, stop, value)` HLOp lowered to
+    /// `residual_call_r_v(ConstInt(fn_idx), ListR([obj, start, stop, value]),
+    /// Descr)` (void result) via [`lower_store_slice_hlop_to_insn`] (the
+    /// four-Ref STORE_SUBSCR shape); `bh_store_slice_fn` builds a `slice` and
+    /// runs `setitem` (user `__setitem__`/`__index__` → `MayForce`).
+    pub store_slice_fn_idx: u16,
 }
 
 /// Map a BINARY_OP HLOp opname (`add`/.../`xor`/`getitem` plus the
@@ -4742,6 +4749,47 @@ where
     ))
 }
 
+/// Lower the STORE_SLICE pyre HLOp `store_slice(obj, start, stop, value)` →
+/// void to `residual_call_r_v(ConstInt(store_slice_fn_idx), ListR([obj,
+/// start, stop, value]), Descr)` — the four-Ref void sibling of
+/// [`lower_setitem_hlop_to_insn`].  `bh_store_slice_fn(obj, start, stop,
+/// value)` builds a `slice(start, stop, None)` and runs `setitem` through the
+/// shared `runtime_ops::store_slice_values` (a user `__setitem__` or slice
+/// `__index__` may run Python → `MayForce`).
+///
+/// Returns `None` for non-`store_slice` opnames so the caller can fall
+/// through to other lowering arms.
+pub fn lower_store_slice_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "store_slice" {
+        return None;
+    }
+    if op.args.len() != 4 {
+        return None;
+    }
+    if op.result.is_some() {
+        return None;
+    }
+    let obj_operand = flatten_arg_with_lowering(&op.args[0], get_register, lower_constant);
+    let start_operand = flatten_arg_with_lowering(&op.args[1], get_register, lower_constant);
+    let stop_operand = flatten_arg_with_lowering(&op.args[2], get_register, lower_constant);
+    let value_operand = flatten_arg_with_lowering(&op.args[3], get_register, lower_constant);
+    Some(build_residual_call_r_v_insn_from_operands(
+        ctx.store_slice_fn_idx,
+        vec![obj_operand, start_operand, stop_operand, value_operand],
+        CallFlavor::MayForce,
+        majit_ir::PyreHelperKind::None,
+    ))
+}
+
 /// Single-op lowering pass that dispatches the four retired pre-rtype
 /// HLOp families (BINARY_OP / COMPARE_OP / BOOL / SETITEM) through
 /// the matching `lower_*_hlop_to_insn` helper, falling through to the
@@ -4841,6 +4889,9 @@ where
         return Some(insn);
     }
     if let Some(insn) = lower_binary_slice_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
+    if let Some(insn) = lower_store_slice_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
     if let Some(insn) = lower_delsubscr_hlop_to_insn(op, ctx, get_register, lower_constant) {
@@ -7170,6 +7221,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut on = SSARepr::new("setattr_on");
         let mut on_regallocs = make_regallocs();
@@ -7329,6 +7381,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("retired_families");
@@ -7475,6 +7528,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("trailing_live");
@@ -7584,6 +7638,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("multi_block_lowering");
@@ -7737,6 +7792,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
 
         let mut ssarepr = SSARepr::new("pyre_walker_2exit");
@@ -7935,6 +7991,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         });
 
         let mut regallocs = perform_register_allocation_all_kinds(&graph);
@@ -8182,6 +8239,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8295,6 +8353,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8352,6 +8411,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
 
         let hlop = SpaceOperation::new("sub", vec![lhs.into(), rhs.into()], Some(result.into()), 0);
@@ -8486,6 +8546,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8578,6 +8639,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8641,6 +8703,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8696,6 +8759,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let hlop = SpaceOperation::new("eq", vec![lhs.into(), rhs.into()], Some(result.into()), 0);
         let mut get_register = identity_register_mapper();
@@ -8758,6 +8822,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8847,6 +8912,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8899,6 +8965,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let hlop = SpaceOperation::new("bool", vec![cond.into()], Some(result.into()), 0);
         let mut get_register = identity_register_mapper();
@@ -8965,6 +9032,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -8996,6 +9064,69 @@ mod tests {
                     Operand::Descr(rc) => match &**rc {
                         DescrOperand::CallDescrStub(stub) => {
                             assert_eq!(stub.arg_kinds, vec![Kind::Ref, Kind::Ref, Kind::Ref]);
+                        }
+                        other => panic!("expected CallDescrStub, got {other:?}"),
+                    },
+                    other => panic!("expected Operand::Descr, got {other:?}"),
+                }
+            }
+            other => panic!("expected Insn::Op, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_store_slice_hlop_emits_residual_call_r_v() {
+        // Lowering a `store_slice(obj, start, stop, value)` HLOp (no result —
+        // `emit_frontend_store_slice` records the SpaceOperation with `result
+        // = None`) must produce a `residual_call_r_v` with args
+        // `[ConstInt(store_slice_fn_idx), ListR([obj, start, stop, value]),
+        // Descr]` and **no** result Register — the four-Ref void sibling of
+        // the SETITEM shape.
+        let obj = Variable::new(VariableId(0), Kind::Ref);
+        let start = Variable::new(VariableId(1), Kind::Ref);
+        let stop = Variable::new(VariableId(2), Kind::Ref);
+        let value = Variable::new(VariableId(3), Kind::Ref);
+        let op = SpaceOperation::new(
+            "store_slice",
+            vec![obj.into(), start.into(), stop.into(), value.into()],
+            None,
+            11,
+        );
+        let (ctx, _code_const, _name_idx_const) = load_attr_lowering_fixture();
+        let mut get_register = identity_register_mapper();
+        let mut lower_constant = test_constant_lowering();
+
+        let insn =
+            lower_store_slice_hlop_to_insn(&op, &ctx, &mut get_register, &mut lower_constant)
+                .expect("STORE_SLICE HLOp must lower");
+
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_r_v");
+                assert!(result.is_none(), "void Insn must have no result");
+                assert_eq!(args.len(), 3);
+                match &args[0] {
+                    Operand::ConstInt(v) => assert_eq!(*v, 116),
+                    other => panic!("expected ConstInt(116), got {other:?}"),
+                }
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        assert_eq!(list.content.len(), 4);
+                    }
+                    other => panic!("expected ListOfKind(Ref, 4), got {other:?}"),
+                }
+                match &args[2] {
+                    Operand::Descr(rc) => match &**rc {
+                        DescrOperand::CallDescrStub(stub) => {
+                            assert_eq!(
+                                stub.arg_kinds,
+                                vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Ref]
+                            );
                         }
                         other => panic!("expected CallDescrStub, got {other:?}"),
                     },
@@ -9047,6 +9178,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register = identity_register_mapper();
         let mut lower_constant = test_constant_lowering();
@@ -9114,6 +9246,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let hlop = SpaceOperation::new(
             "setitem",
@@ -9196,6 +9329,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9254,6 +9388,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9312,6 +9447,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9375,6 +9511,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -9452,6 +9589,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let mut get_register_a = identity_register_mapper();
         let mut get_register_b = identity_register_mapper();
@@ -10628,6 +10766,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         flatten_graph_for_test_with_lowering(&graph, &mut ssarepr, ctx, Some(cpu));
         ssarepr
@@ -10927,6 +11066,7 @@ mod tests {
             unary_not_fn_idx: 0,
             load_fast_check_fn_idx: 0,
             list_extend_fn_idx: 0,
+            store_slice_fn_idx: 0,
         };
         let null_or_self_var = Variable::new(VariableId(10), Kind::Ref);
         let op = super::super::flow::SpaceOperation::new(
@@ -11102,7 +11242,7 @@ mod tests {
             format_with_spec_fn_idx: 102,
             convert_value_fn_idx: 104,
             import_name_fn_idx: 105,
-            import_from_fn_idx: 114,
+            import_from_fn_idx: 117,
             load_super_attr_fn_idx: 106,
             super_attr_unwrap_fn_idx: 107,
             load_deref_value_fn_idx: 108,
@@ -11113,6 +11253,7 @@ mod tests {
             list_extend_fn_idx: 113,
             store_deref_value_fn_idx: 114,
             make_cell_fn_idx: 115,
+            store_slice_fn_idx: 116,
         };
         let code_const = Constant::new(
             super::super::flow::ConstantValue::Signed(0x2000),
@@ -12425,7 +12566,7 @@ mod tests {
             } => {
                 assert_eq!(opname, "residual_call_ir_r");
                 assert!(
-                    matches!(args[0], Operand::ConstInt(114)),
+                    matches!(args[0], Operand::ConstInt(117)),
                     "import_from_fn pool index, got {:?}",
                     args[0]
                 );

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3343,6 +3343,15 @@ pub struct LoweringContext {
     /// `bh_import_name_fn` runs `__import__` (module top-level Python may
     /// run → `MayForce`).
     pub import_name_fn_idx: u16,
+    /// `import_from_fn` descrs-pool index.  IMPORT_FROM records the
+    /// `import_from(module, code, name_idx)` HLOp (code = the jitcode's own
+    /// W_CodeObject as a `Signed(ptr) + Kind::Ref` constant, name_idx =
+    /// `co_names` index) lowered to `residual_call_ir_r(ConstInt(fn_idx),
+    /// ListI([name_idx]), ListR([module, code]), Descr) → reg` via
+    /// [`lower_import_from_hlop_to_insn`]; `bh_import_from_fn` runs
+    /// `importing::import_from` (submodule import may run module top-level
+    /// Python → `MayForce`).
+    pub import_from_fn_idx: u16,
     /// `load_super_attr_fn` descrs-pool index.  LOAD_SUPER_ATTR records the
     /// `load_super_attr(self, cls, code, name_idx)` HLOp lowered to
     /// `residual_call_ir_r(ConstInt(fn_idx), ListI([name_idx]), ListR([self,
@@ -4855,6 +4864,9 @@ where
     if let Some(insn) = lower_import_name_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
+    if let Some(insn) = lower_import_from_hlop_to_insn(op, ctx, get_register, lower_constant) {
+        return Some(insn);
+    }
     if let Some(insn) = lower_load_super_attr_hlop_to_insn(op, ctx, get_register, lower_constant) {
         return Some(insn);
     }
@@ -5526,6 +5538,57 @@ where
                 Kind::Ref,
                 vec![fromlist, level, code, frame],
             )),
+            descr_operand,
+        ],
+        dst_reg,
+    ))
+}
+
+/// Lower the IMPORT_FROM pyre HLOp `import_from(module, code, name_idx)` →
+/// `result: Ref` to `residual_call_ir_r(ConstInt(import_from_fn_idx),
+/// ListI([name_idx]), ListR([module, code]), Descr) → reg` — the same
+/// two-Ref shape as [`lower_getattr_hlop_to_insn`].  `bh_import_from_fn`
+/// resolves `getattr(module, name)` with a submodule-import fallback that may
+/// run module top-level Python → `MayForce`.  `module` is the peeked TOS
+/// (IMPORT_FROM does not pop it).
+///
+/// Returns `None` for non-`import_from` opnames so the caller can fall
+/// through to other lowering arms.
+pub fn lower_import_from_hlop_to_insn<F, LC>(
+    op: &super::flow::SpaceOperation,
+    ctx: &LoweringContext,
+    get_register: &mut F,
+    lower_constant: &mut LC,
+) -> Option<Insn>
+where
+    F: FnMut(super::flow::Variable) -> Register,
+    LC: FnMut(&Constant) -> Operand,
+{
+    if op.opname != "import_from" || op.args.len() != 3 {
+        return None;
+    }
+    let module = operand_for_value_arg(&op.args[0], get_register, lower_constant)?;
+    let code = operand_for_value_arg(&op.args[1], get_register, lower_constant)?;
+    let name_idx = const_int_for_value_arg(&op.args[2])?;
+    let dst_reg = match &op.result {
+        Some(super::flow::FlowValue::Variable(var)) => get_register(*var),
+        _ => return None,
+    };
+    let effect_info = effect_info_for_call_flavor(CallFlavor::MayForce);
+    let descr_operand = Operand::descr(DescrOperand::CallDescrStub(CallDescrStub {
+        effect_info,
+        arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
+        result_kind: Some(Kind::Ref),
+    }));
+    Some(Insn::op_with_result(
+        "residual_call_ir_r",
+        vec![
+            Operand::ConstInt(ctx.import_from_fn_idx as i64),
+            Operand::ListOfKind(ListOfKind::new(
+                Kind::Int,
+                vec![Operand::ConstInt(name_idx)],
+            )),
+            Operand::ListOfKind(ListOfKind::new(Kind::Ref, vec![module, code])),
             descr_operand,
         ],
         dst_reg,
@@ -7096,6 +7159,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -7254,6 +7318,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -7399,6 +7464,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -7507,6 +7573,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -7659,6 +7726,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -7856,6 +7924,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8102,6 +8171,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8214,6 +8284,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8270,6 +8341,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8403,6 +8475,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8494,6 +8567,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8556,6 +8630,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8610,6 +8685,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8671,6 +8747,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8759,6 +8836,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8810,6 +8888,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8875,6 +8954,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -8956,6 +9036,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -9022,6 +9103,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -9103,6 +9185,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -9160,6 +9243,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -9217,6 +9301,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -9279,6 +9364,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -9355,6 +9441,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -10530,6 +10617,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -10828,6 +10916,7 @@ mod tests {
             format_with_spec_fn_idx: 0,
             convert_value_fn_idx: 0,
             import_name_fn_idx: 0,
+            import_from_fn_idx: 0,
             load_super_attr_fn_idx: 0,
             super_attr_unwrap_fn_idx: 0,
             load_deref_value_fn_idx: 0,
@@ -11013,6 +11102,7 @@ mod tests {
             format_with_spec_fn_idx: 102,
             convert_value_fn_idx: 104,
             import_name_fn_idx: 105,
+            import_from_fn_idx: 114,
             load_super_attr_fn_idx: 106,
             super_attr_unwrap_fn_idx: 107,
             load_deref_value_fn_idx: 108,
@@ -12274,6 +12364,91 @@ mod tests {
                                 panic!(
                                     "ListR must be [fromlist, level, code, frame], got {other:?}"
                                 )
+                            }
+                        }
+                    }
+                    other => panic!("expected ListR, got {other:?}"),
+                }
+                assert_eq!(
+                    result,
+                    Some(Register {
+                        kind: Kind::Ref,
+                        index: 102
+                    }),
+                );
+            }
+            _ => panic!("expected Insn::Op, got {insn:?}"),
+        }
+    }
+
+    #[test]
+    fn lower_import_from_hlop_emits_import_from_fn_residual() {
+        // `import_from(module, code, name_idx)` →
+        // `residual_call_ir_r(ConstInt(import_from_fn_idx), ListI([name_idx]),
+        // ListR([module, code]), Descr) → reg` (MayForce — a submodule-import
+        // fallback may run a module's top-level Python).  Two Ref operands —
+        // the peeked TOS module and the jitcode's own code object — plus one
+        // Int; the same two-Ref shape as `getattr`.
+        let module_var = Variable::new(VariableId(8), Kind::Ref);
+        let result_var = Variable::new(VariableId(9), Kind::Ref);
+        let (ctx, code_const, name_idx_const) = load_attr_lowering_fixture();
+        let op = super::super::flow::SpaceOperation::new(
+            "import_from",
+            vec![module_var.into(), code_const.into(), name_idx_const.into()],
+            Some(result_var.into()),
+            0,
+        );
+        let mut get_register = |var: Variable| match var.id {
+            VariableId(8) => Register {
+                kind: Kind::Ref,
+                index: 101,
+            },
+            VariableId(9) => Register {
+                kind: Kind::Ref,
+                index: 102,
+            },
+            _ => panic!("unexpected var id {:?}", var.id),
+        };
+        let mut lower_constant = super::flatten_constant_operand_for_test;
+        let insn = super::lower_import_from_hlop_to_insn(
+            &op,
+            &ctx,
+            &mut get_register,
+            &mut lower_constant,
+        )
+        .expect("3-arg import_from lowering must succeed");
+        match insn {
+            Insn::Op {
+                opname,
+                args,
+                result,
+            } => {
+                assert_eq!(opname, "residual_call_ir_r");
+                assert!(
+                    matches!(args[0], Operand::ConstInt(114)),
+                    "import_from_fn pool index, got {:?}",
+                    args[0]
+                );
+                match &args[1] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Int);
+                        assert!(
+                            matches!(&list.content[..], [Operand::ConstInt(5)]),
+                            "ListI = [name_idx], got {:?}",
+                            list.content
+                        );
+                    }
+                    other => panic!("expected ListI, got {other:?}"),
+                }
+                match &args[2] {
+                    Operand::ListOfKind(list) => {
+                        assert_eq!(list.kind, Kind::Ref);
+                        match &list.content[..] {
+                            [Operand::Register(md), Operand::ConstRef(0x2000)] => {
+                                assert_eq!(md.index, 101, "leading Ref operand must be module");
+                            }
+                            other => {
+                                panic!("ListR must be [module, code], got {other:?}")
                             }
                         }
                     }


### PR DESCRIPTION
#73

## Summary

Four Phase-6 opcode residual-call drains (so the full-body walk stops aborting on these opcodes and falling back to the trait tracer) plus a kept-stack branch-guard correctness fix. Six commits:

- **baseobjspace: evaluate slice-subscript bounds through `__index__`** — slice subscription routes `start`/`stop` through `__index__` before building the slice (precursor for the `STORE_SLICE` drain; `binary_slice_index` bench extended).
- **`STORE_GLOBAL` → residual** — the codewriter lowers `STORE_GLOBAL` to a `store_global` residual call (`bh_store_global_fn` → interpreter `store_global_value`) instead of emitting a permanent abort.
- **`IMPORT_FROM` → residual** — lowers `IMPORT_FROM` to an `import_from` residual (peeks the module on TOS, imports the named attribute).
- **`STORE_SLICE` → residual** — lowers `STORE_SLICE` to a 4-Ref void `store_slice` residual (`MayForce`; builds `slice(start, stop)` and assigns).
- **`UNPACK_EX` → residual** — lowers `UNPACK_EX` to an `unpack_ex` residual (`unpack_ex_slots` returns `before + 1 + after` slots in TOS order; per-slot reads reuse the existing `unpack_item` helper). `unpack_ex_slots` is factored out of the interpreter's `unpack_ex` so both paths share it.
- **recover depth-1 kept-stack branch guards; default `PYRE_M3_JITCODE_PC` off** — a `goto_if_not` whose not-taken arm keeps a single operand-stack temp recovers it positionally via `kept_stack_subst`, so the guard compiles instead of declining; the decline gate narrows from resume depth > 0 to depth > 1. `PYRE_M3_JITCODE_PC` flips to default off, which removes a leading-`and` short-circuit silent miscompile (`flag and 11`: 2197063 → 1466663) — with the flag on, the guard-pc box set holds the taken-path value for the kept slot. depth > 1 still declines to the interpreter (`PYRE_RELAX_124` opens it for the future multi-temp fix).

Each opcode drain adds a hot-loop synthetic bench (`store_global_hot`, `import_from_hot`, `store_slice_hot`, `unpack_ex_hot`); the guard fix adds `short_circuit_value_local_kept` and `kept_stack_branch_depths`.

Validation: `pyre/check.py --synthetic-only` green on both backends (dynasm + cranelift, 123/123 ×2); `pyre-jit-trace` lib tests green (267/267).

## Self-review

AI-assisted (Claude). Per the contribution guidance ("Do not run the review in the same session that generated the code"), the parity self-review is left to run in a separate session.

### Prompt & Model

Model: Claude opus-4.8

Prompt: <!-- parity review to be run separately -->

### Answer

<!-- to be filled by a separate review session -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended JIT compilation support for storing globals, slice assignments, import-from, and starred unpacking.
* **Bug Fixes**
  * Slice bounds now reliably go through index-style conversion, producing consistent `TypeError` for non-`__index__` values.
  * Improved error reporting and unpacking behavior for exceptional unpack paths.
  * Refined import-from attribute/submodule resolution.
* **Tests**
  * Added/expanded benchmarks and slicing cases, including float-bound scenarios that must raise `TypeError`.
* **Chores**
  * Defaulted trace-based JIT program-counter behavior to off when unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->