### PR TITLE
_pickle/iterators: reducer_override=None, fast-mode cycle guard, getstate & zip/map fixes

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1838,9 +1838,17 @@ unsafe fn pull_iterator_tuple(
     // it is produced, then re-read the set at its (possibly relocated) address
     // before returning.
     let _roots = pyre_object::gc_roots::push_roots();
+    // Pin the iterator list itself: `next(it)` runs Python and can move it, and
+    // later iterations dereference it again — a raw local would go stale.
+    pyre_object::gc_roots::pin_root(w_iterators);
+    let iters_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let base = pyre_object::gc_roots::shadow_stack_len();
     for i in 0..n {
-        let it = pyre_object::w_list_getitem(w_iterators, i as i64).unwrap();
+        let it = pyre_object::w_list_getitem(
+            pyre_object::gc_roots::shadow_stack_get(iters_slot),
+            i as i64,
+        )
+        .unwrap();
         match next(it) {
             Ok(v) => pyre_object::gc_roots::pin_root(v),
             Err(e) if e.kind == PyErrorKind::StopIteration => {
@@ -1859,7 +1867,11 @@ unsafe fn pull_iterator_tuple(
                 if n == 2 {
                     // `functional.py:1047-1054` — the first ran dry; if the
                     // second still yields it is the longer one.
-                    let it1 = pyre_object::w_list_getitem(w_iterators, 1).unwrap();
+                    let it1 = pyre_object::w_list_getitem(
+                        pyre_object::gc_roots::shadow_stack_get(iters_slot),
+                        1,
+                    )
+                    .unwrap();
                     return match next(it1) {
                         Ok(_) => Err(strict_zip_error(func_name, 1, "longer")),
                         Err(e2) if e2.kind == PyErrorKind::StopIteration => Ok(None),
@@ -1872,7 +1884,11 @@ unsafe fn pull_iterator_tuple(
                 // re-`next`ing it is a wasted (and on a side-effectful iterator,
                 // observable) call.
                 for j in 1..n {
-                    let itj = pyre_object::w_list_getitem(w_iterators, j as i64).unwrap();
+                    let itj = pyre_object::w_list_getitem(
+                        pyre_object::gc_roots::shadow_stack_get(iters_slot),
+                        j as i64,
+                    )
+                    .unwrap();
                     match next(itj) {
                         Ok(_) => return Err(strict_zip_error(func_name, j, "longer")),
                         Err(e2) if e2.kind == PyErrorKind::StopIteration => {}

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -824,8 +824,10 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
     } else {
         save_object(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot))
     };
-    // `_fast_save_leave` — pop the path on the way out (success path; an error
-    // aborts the whole dump and discards the context).
+    // `_fast_save_leave` — pop the path on the way out. Runs for both an `Ok`
+    // and an `Err` dispatch result; the only path that skips it is the
+    // persistent_id hook above erroring (its `?`), which aborts the whole dump
+    // and discards the context.
     if let Some(h) = fast_tracked {
         ctx.fast_memo.remove(&h);
     }

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1,6 +1,6 @@
 //! `_pickle.Pickler` — `interp_pickle.py W_Pickler` (atom + container subset).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use malachite_bigint::BigInt;
 use pyre_object::PyObjectRef;
@@ -60,9 +60,16 @@ struct PickleCtx {
     pers_func: PyObjectRef,
     /// `buffer_callback` for proto-5 out-of-band buffers, or `None`/`PY_NULL`.
     buffer_callback: PyObjectRef,
-    /// `fast` mode — when set, memoization is skipped (no PUT/GET, no
-    /// recursion guard).
+    /// `fast` mode — when set, memoization is skipped (no PUT/GET); a
+    /// shallow cyclic-object guard (`fast_nesting` / `fast_memo`) still fires
+    /// past `FAST_NESTING_LIMIT`.
     fast: bool,
+    /// Live save recursion depth, for the fast-mode cyclic guard.
+    fast_nesting: i64,
+    /// Identity hashes of the objects on the active save path; populated only
+    /// past `FAST_NESTING_LIMIT` so fast mode raises `ValueError` on a cycle
+    /// instead of recursing into a stack overflow.
+    fast_memo: HashSet<usize>,
     /// Effective `dispatch_table` (the pickler's, else `copyreg.dispatch_table`)
     /// consulted by `type` for the reduce of an otherwise-unhandled object;
     /// `None`/`PY_NULL` when unavailable.
@@ -321,9 +328,10 @@ impl W_Pickler {
         // `persistent_id` resolves to a subclass method override or the
         // instance value set through the getter (its getter raises while
         // unset, so a base pickler resolves to `PY_NULL`); `reducer_override`
-        // is a subclass hook only.  An explicit `persistent_id = None` is kept
-        // as the hook: `dump` then calls `None(obj)` and raises `TypeError`,
-        // matching `_pickle` (only deleting/leaving it unset disables it).
+        // is a subclass hook only (absent on a base pickler).  An explicit
+        // `persistent_id = None` / `reducer_override = None` is kept as the
+        // hook: `dump` then calls `None(obj)` and raises `TypeError`, matching
+        // `_pickle` (only deleting/leaving it unset disables the hook).
         // `findattr_result` propagates a hook property's own error instead of
         // panicking; each resolved hook is pinned before the next lookup.
         let pers_func = crate::baseobjspace::findattr_result(self_ptr, "persistent_id")?
@@ -331,7 +339,6 @@ impl W_Pickler {
         pyre_object::gc_roots::pin_root(pers_func);
         let pers_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let reducer_override = crate::baseobjspace::findattr_result(self_ptr, "reducer_override")?
-            .filter(|&f| !unsafe { pyre_object::is_none(f) })
             .unwrap_or(pyre_object::PY_NULL);
         pyre_object::gc_roots::pin_root(reducer_override);
         let reducer_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -730,6 +737,8 @@ pub(crate) fn pickle_core(
         pers_func,
         buffer_callback,
         fast,
+        fast_nesting: 0,
+        fast_memo: HashSet::new(),
         dispatch_table,
         reducer_override,
     };
@@ -763,6 +772,10 @@ pub(crate) fn pickle_core(
     }
 }
 
+/// `interp_pickle.py W_Pickler._fast_save_enter` — the recursion depth past
+/// which fast mode starts tracking the active path to detect cycles.
+const FAST_NESTING_LIMIT: i64 = 50;
+
 /// `interp_pickle.py W_Pickler.save` with the persistent-id hook: every
 /// object is first offered to `persistent_id`; a non-None result is saved
 /// as a persistent reference instead of by value.
@@ -775,17 +788,51 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
     pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     buf.commit_frame(false)?;
-    if !ctx.pers_func.is_null() {
+    // Fast mode skips memoization, so a cyclic object would recurse until the
+    // stack overflows. Past `FAST_NESTING_LIMIT`, track the active path by
+    // identity hash and raise `ValueError` on a repeat (`_fast_save_enter`).
+    let fast_tracked = if ctx.fast {
+        ctx.fast_nesting += 1;
+        if ctx.fast_nesting >= FAST_NESTING_LIMIT {
+            let w_cur = pyre_object::gc_roots::shadow_stack_get(slot);
+            let h = pyre_object::gc_hook::gc_identity_hash(w_cur as usize);
+            if !ctx.fast_memo.insert(h) {
+                ctx.fast_nesting -= 1;
+                return Err(PyError::value_error(format!(
+                    "fast mode: can't pickle cyclic objects including object type {} at {:p}",
+                    crate::baseobjspace::object_functionstr_type_name(w_cur),
+                    w_cur as *const u8,
+                )));
+            }
+            Some(h)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    let result = if !ctx.pers_func.is_null() {
         let w_pid = call_fn(
             ctx.pers_func,
             &[pyre_object::gc_roots::shadow_stack_get(slot)],
         )?;
         if !unsafe { pyre_object::is_none(w_pid) } {
-            return save_pers(ctx, buf, w_pid);
+            save_pers(ctx, buf, w_pid)
+        } else {
+            save_object(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot))
         }
-        return save_object(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot));
+    } else {
+        save_object(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot))
+    };
+    // `_fast_save_leave` — pop the path on the way out (success path; an error
+    // aborts the whole dump and discards the context).
+    if let Some(h) = fast_tracked {
+        ctx.fast_memo.remove(&h);
     }
-    save_object(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot))
+    if ctx.fast {
+        ctx.fast_nesting -= 1;
+    }
+    result
 }
 
 /// `interp_pickle.py save_pers` — emit a persistent reference. The

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -64,9 +64,9 @@ struct PickleCtx {
     /// shallow cyclic-object guard (`fast_nesting` / `fast_memo`) still fires
     /// past `FAST_NESTING_LIMIT`.
     fast: bool,
-    /// Live save recursion depth, for the fast-mode cyclic guard.
+    /// Nested-container depth, for the fast-mode cyclic guard.
     fast_nesting: i64,
-    /// `gc_identity_hash` → shadow-stack slots of the objects on the active
+    /// `gc_identity_hash` → shadow-stack slots of the containers on the active
     /// save path sharing that hash, populated only past `FAST_NESTING_LIMIT`.
     /// A repeat — resolved by pointer identity against the pinned ancestors,
     /// like `memo_get`, since a shared hash is not move-stable-unique — means a
@@ -775,9 +775,65 @@ pub(crate) fn pickle_core(
     }
 }
 
-/// `interp_pickle.py W_Pickler._fast_save_enter` — the recursion depth past
-/// which fast mode starts tracking the active path to detect cycles.
+/// `_pickle.c FAST_NESTING_LIMIT` — the nested-container depth past which fast
+/// mode starts tracking active containers to detect a cycle.
 const FAST_NESTING_LIMIT: i64 = 50;
+
+/// `_pickle.c fast_save_enter`. Fast mode skips memoization, so a cyclic
+/// container would recurse until the stack overflows. Past `FAST_NESTING_LIMIT`
+/// nested containers, track the active container by identity and raise
+/// `ValueError` on a repeat. Only the container saves (`save_list` / `save_dict`
+/// / `save_set`) call this, so a reducer that re-enters the same custom object
+/// keeps the normal recursion behaviour (a `RecursionError`) rather than being
+/// misreported as a fast-mode container cycle. `obj_slot` is the container's
+/// pinned shadow-stack slot; a shared `gc_identity_hash` is disambiguated by
+/// pointer identity against the pinned ancestors, like `memo_get`. Returns the
+/// bucket key to hand back to `fast_save_leave`, or `None` when nothing was
+/// tracked.
+fn fast_save_enter(ctx: &mut PickleCtx, obj_slot: usize) -> Result<Option<usize>, PyError> {
+    if !ctx.fast {
+        return Ok(None);
+    }
+    ctx.fast_nesting += 1;
+    if ctx.fast_nesting < FAST_NESTING_LIMIT {
+        return Ok(None);
+    }
+    let w_cur = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let h = pyre_object::gc_hook::gc_identity_hash(w_cur as usize);
+    let is_cycle = ctx.fast_memo.get(&h).is_some_and(|slots| {
+        slots
+            .iter()
+            .any(|&anc| pyre_object::gc_roots::shadow_stack_get(anc) == w_cur)
+    });
+    if is_cycle {
+        ctx.fast_nesting -= 1;
+        return Err(PyError::value_error(format!(
+            "fast mode: can't pickle cyclic objects including object type {} at {:p}",
+            crate::baseobjspace::object_functionstr_type_name(w_cur),
+            w_cur as *const u8,
+        )));
+    }
+    ctx.fast_memo.entry(h).or_default().push(obj_slot);
+    Ok(Some(h))
+}
+
+/// `_pickle.c fast_save_leave` — drop the active container from the path on the
+/// way out. Must run for both an `Ok` and an `Err` member-save result so
+/// `fast_nesting` and `fast_memo` stay balanced.
+fn fast_save_leave(ctx: &mut PickleCtx, token: Option<usize>, obj_slot: usize) {
+    if !ctx.fast {
+        return;
+    }
+    if let Some(h) = token {
+        if let Some(slots) = ctx.fast_memo.get_mut(&h) {
+            slots.retain(|&anc| anc != obj_slot);
+            if slots.is_empty() {
+                ctx.fast_memo.remove(&h);
+            }
+        }
+    }
+    ctx.fast_nesting -= 1;
+}
 
 /// `interp_pickle.py W_Pickler.save` with the persistent-id hook: every
 /// object is first offered to `persistent_id`; a non-None result is saved
@@ -791,39 +847,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
     pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     buf.commit_frame(false)?;
-    // Fast mode skips memoization, so a cyclic object would recurse until the
-    // stack overflows. Past `FAST_NESTING_LIMIT`, track the active path by
-    // identity hash and raise `ValueError` on a repeat (`_fast_save_enter`).
-    let fast_tracked = if ctx.fast {
-        ctx.fast_nesting += 1;
-        if ctx.fast_nesting >= FAST_NESTING_LIMIT {
-            let w_cur = pyre_object::gc_roots::shadow_stack_get(slot);
-            let h = pyre_object::gc_hook::gc_identity_hash(w_cur as usize);
-            // A shared identity hash is not yet a cycle: disambiguate by pointer
-            // identity against the pinned ancestors on the path (mirrors
-            // `memo_get`) before declaring one.
-            let is_cycle = ctx.fast_memo.get(&h).is_some_and(|slots| {
-                slots
-                    .iter()
-                    .any(|&anc| pyre_object::gc_roots::shadow_stack_get(anc) == w_cur)
-            });
-            if is_cycle {
-                ctx.fast_nesting -= 1;
-                return Err(PyError::value_error(format!(
-                    "fast mode: can't pickle cyclic objects including object type {} at {:p}",
-                    crate::baseobjspace::object_functionstr_type_name(w_cur),
-                    w_cur as *const u8,
-                )));
-            }
-            ctx.fast_memo.entry(h).or_default().push(slot);
-            Some(h)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-    let result = if !ctx.pers_func.is_null() {
+    if !ctx.pers_func.is_null() {
         let w_pid = call_fn(
             ctx.pers_func,
             &[pyre_object::gc_roots::shadow_stack_get(slot)],
@@ -835,23 +859,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
         }
     } else {
         save_object(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot))
-    };
-    // `_fast_save_leave` — pop the path on the way out. Runs for both an `Ok`
-    // and an `Err` dispatch result; the only path that skips it is the
-    // persistent_id hook above erroring (its `?`), which aborts the whole dump
-    // and discards the context.
-    if let Some(h) = fast_tracked {
-        if let Some(slots) = ctx.fast_memo.get_mut(&h) {
-            slots.retain(|&anc| anc != slot);
-            if slots.is_empty() {
-                ctx.fast_memo.remove(&h);
-            }
-        }
     }
-    if ctx.fast {
-        ctx.fast_nesting -= 1;
-    }
-    result
 }
 
 /// `interp_pickle.py save_pers` — emit a persistent reference. The
@@ -1376,6 +1384,7 @@ fn save_list(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
     // observed instead of dereferencing a stale snapshot.
     pyre_object::gc_roots::pin_root(w_obj);
     let slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let fast_token = fast_save_enter(ctx, slot)?;
     if ctx.bin {
         buf.push(op::EMPTY_LIST);
     } else {
@@ -1383,7 +1392,9 @@ fn save_list(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
         buf.push(op::LIST);
     }
     memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(slot));
-    batch_appends(ctx, buf, slot)
+    let result = batch_appends(ctx, buf, slot);
+    fast_save_leave(ctx, fast_token, slot);
+    result
 }
 
 /// `interp_pickle.py save_dict`.
@@ -1394,6 +1405,7 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
     // `[k0, v0, …]` Python list (GC-walked), re-read per save.
     pyre_object::gc_roots::pin_root(w_obj);
     let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let fast_token = fast_save_enter(ctx, dict_slot)?;
     let items = unsafe {
         pyre_object::dictmultiobject::w_dict_items(pyre_object::gc_roots::shadow_stack_get(
             dict_slot,
@@ -1412,7 +1424,9 @@ fn save_dict(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Resul
         buf.push(op::DICT);
     }
     memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(dict_slot));
-    batch_setitems(ctx, buf, items_slot)
+    let result = batch_setitems(ctx, buf, items_slot);
+    fast_save_leave(ctx, fast_token, dict_slot);
+    result
 }
 
 /// `interp_pickle.py save_set`. Sets are unordered, so the wire bytes are
@@ -1434,29 +1448,38 @@ fn save_set(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(w_obj);
     let set_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let fast_token = fast_save_enter(ctx, set_slot)?;
     memoize(ctx, buf, pyre_object::gc_roots::shadow_stack_get(set_slot));
 
     let items = unsafe {
         pyre_object::setobject::w_set_items(pyre_object::gc_roots::shadow_stack_get(set_slot))
     };
-    let slot = pin_items(items);
-    let length = pinned_len(slot);
+    let items_slot = pin_items(items);
+    let result = save_set_items(ctx, buf, items_slot);
+    fast_save_leave(ctx, fast_token, set_slot);
+    result
+}
+
+/// Emit the ADDITEMS batches for the members of a proto >= 4 set already opened
+/// with EMPTY_SET. `items_slot` pins the member snapshot, re-read per save.
+fn save_set_items(ctx: &mut PickleCtx, buf: &mut Framer, items_slot: usize) -> Result<(), PyError> {
+    let length = pinned_len(items_slot);
     if length == 0 {
         return Ok(());
     }
     buf.push(op::MARK);
-    save(ctx, buf, pinned_get(slot, 0))?;
+    save(ctx, buf, pinned_get(items_slot, 0))?;
     let mut i = 1;
     while i + 1 < length {
         if i % BATCHSIZE == 0 {
             buf.push(op::ADDITEMS);
             buf.push(op::MARK);
         }
-        save(ctx, buf, pinned_get(slot, i))?;
+        save(ctx, buf, pinned_get(items_slot, i))?;
         i += 1;
     }
     if length > 1 {
-        save(ctx, buf, pinned_get(slot, length - 1))?;
+        save(ctx, buf, pinned_get(items_slot, length - 1))?;
     }
     buf.push(op::ADDITEMS);
     Ok(())

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1,6 +1,6 @@
 //! `_pickle.Pickler` — `interp_pickle.py W_Pickler` (atom + container subset).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use malachite_bigint::BigInt;
 use pyre_object::PyObjectRef;
@@ -66,10 +66,13 @@ struct PickleCtx {
     fast: bool,
     /// Live save recursion depth, for the fast-mode cyclic guard.
     fast_nesting: i64,
-    /// Identity hashes of the objects on the active save path; populated only
-    /// past `FAST_NESTING_LIMIT` so fast mode raises `ValueError` on a cycle
-    /// instead of recursing into a stack overflow.
-    fast_memo: HashSet<usize>,
+    /// `gc_identity_hash` → shadow-stack slots of the objects on the active
+    /// save path sharing that hash, populated only past `FAST_NESTING_LIMIT`.
+    /// A repeat — resolved by pointer identity against the pinned ancestors,
+    /// like `memo_get`, since a shared hash is not move-stable-unique — means a
+    /// cycle, so fast mode raises `ValueError` instead of recursing into a
+    /// stack overflow.
+    fast_memo: HashMap<usize, Vec<usize>>,
     /// Effective `dispatch_table` (the pickler's, else `copyreg.dispatch_table`)
     /// consulted by `type` for the reduce of an otherwise-unhandled object;
     /// `None`/`PY_NULL` when unavailable.
@@ -738,7 +741,7 @@ pub(crate) fn pickle_core(
         buffer_callback,
         fast,
         fast_nesting: 0,
-        fast_memo: HashSet::new(),
+        fast_memo: HashMap::new(),
         dispatch_table,
         reducer_override,
     };
@@ -796,7 +799,15 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
         if ctx.fast_nesting >= FAST_NESTING_LIMIT {
             let w_cur = pyre_object::gc_roots::shadow_stack_get(slot);
             let h = pyre_object::gc_hook::gc_identity_hash(w_cur as usize);
-            if !ctx.fast_memo.insert(h) {
+            // A shared identity hash is not yet a cycle: disambiguate by pointer
+            // identity against the pinned ancestors on the path (mirrors
+            // `memo_get`) before declaring one.
+            let is_cycle = ctx.fast_memo.get(&h).is_some_and(|slots| {
+                slots
+                    .iter()
+                    .any(|&anc| pyre_object::gc_roots::shadow_stack_get(anc) == w_cur)
+            });
+            if is_cycle {
                 ctx.fast_nesting -= 1;
                 return Err(PyError::value_error(format!(
                     "fast mode: can't pickle cyclic objects including object type {} at {:p}",
@@ -804,6 +815,7 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
                     w_cur as *const u8,
                 )));
             }
+            ctx.fast_memo.entry(h).or_default().push(slot);
             Some(h)
         } else {
             None
@@ -829,7 +841,12 @@ fn save(ctx: &mut PickleCtx, buf: &mut Framer, w_obj: PyObjectRef) -> Result<(),
     // persistent_id hook above erroring (its `?`), which aborts the whole dump
     // and discards the context.
     if let Some(h) = fast_tracked {
-        ctx.fast_memo.remove(&h);
+        if let Some(slots) = ctx.fast_memo.get_mut(&h) {
+            slots.retain(|&anc| anc != slot);
+            if slots.is_empty() {
+                ctx.fast_memo.remove(&h);
+            }
+        }
     }
     if ctx.fast {
         ctx.fast_nesting -= 1;

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -86,15 +86,21 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
     let w_objdict = crate::baseobjspace::findattr(w_obj, "__dict__");
     let mut w_ret = match w_objdict {
         Some(d) if crate::baseobjspace::len_w(d)? > 0 => {
-            // Copy `__dict__`, dropping the internal `__dict_data__` key that a
-            // dict subclass keeps its mapping payload under: that payload is
-            // reconstructed through `dictitems`, not the instance state, so an
-            // attribute-less dict subclass must yield `None` here (matching the
-            // empty instance `__dict__` of a built-in subclass).
+            // Copy `__dict__`. For a dict subclass, drop the internal
+            // `__dict_data__` key it keeps its mapping payload under: that
+            // payload is reconstructed through `dictitems`, not the instance
+            // state, so an attribute-less dict subclass yields `None` here
+            // (matching the empty instance `__dict__` of a built-in subclass).
+            // A non-dict instance keeps a user attribute of that name.
+            let is_dict_inst = {
+                let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+                unsafe { crate::baseobjspace::isinstance_w(w_obj, w_dict_type) }
+            };
             let w_copy = pyre_object::w_dict_new();
             let mut count = 0usize;
             for (k, v) in unsafe { pyre_object::w_dict_items(d) } {
-                if unsafe { pyre_object::is_str(k) }
+                if is_dict_inst
+                    && unsafe { pyre_object::is_str(k) }
                     && unsafe { pyre_object::w_str_get_value(k) } == "__dict_data__"
                 {
                     continue;


### PR DESCRIPTION
follow-up to resolve #163

## Summary

CPython 3.14 parity fixes for `_pickle` and the lazy `map`/`zip` iterators, found during code review on top of #207. Each change is validated byte-identical to CPython 3.14 on both JIT backends.

- **`object.__getstate__`: scope the `__dict_data__` drop to dict instances** (`reduce_protocol.rs`). `object_getstate_default` dropped the internal `__dict_data__` key from every instance's copied `__dict__`, but that key is only a dict subclass's mapping payload (reconstructed through `dictitems`, not the instance state). A non-dict instance with a user attribute of that name lost it on a pickle round-trip. It is now dropped only when the object is a dict instance/subclass.

- **`Pickler`: keep `reducer_override = None` as the hook; guard fast-mode cycles** (`pickler.rs`).
  - An explicit `reducer_override = None` on a `Pickler` subclass is the hook, like `persistent_id`: `dump()` calls `None(obj)` and raises `TypeError` for any object that reaches it. Built-ins are dispatched by exact type first, so the hook is never consulted for them (`dump([1, 2])` still succeeds). Previously `None` was filtered out and the invalid configuration silently fell back to normal reduction.
  - `fast` mode skips memoization, so a cyclic object recursed until the Rust stack overflowed. Past `FAST_NESTING_LIMIT` the active save path is tracked by identity hash and a repeat raises `ValueError: fast mode: can't pickle cyclic objects ...` (`_fast_save_enter` / `_fast_save_leave`).

- **`zip`/`map`: root the iterator list across `next()`** (`baseobjspace.rs`). `pull_iterator_tuple` pinned each pulled value but held the iterator list only in a raw local. A sub-iterator's `next()` can run Python and relocate the list under the moving GC, so a later loop iteration dereferenced a stale pointer. The list is now pinned and re-read from the shadow stack at every access.

Validation: `pyre/check.py` 131/131 on both backends (dynasm + cranelift); `cargo test` for `pyre-object` and `pyre-interpreter` green; behaviour probed byte-identical to CPython 3.14 (`reducer_override = None` reaching a custom object, fast-mode cyclic objects, dict-subclass round-trip with/without instance attrs, `zip`/`map`).

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved crashes in strict-mode unpacking for iterator-based operations (such as `map`/`zip` patterns).
  * Improved object serialization in fast mode by adding cycle detection to prevent recursion overflows for circular references.
  * Fixed object state copying so `__dict_data__` is preserved for non-dictionary instances while still being skipped appropriately for dictionaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->