### PR TITLE
#171: Integer-strategy list op lowering + walker-native list.append fold

### DIFF
--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -81,13 +81,22 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
             // `CallControl::mark_oopspec` — which `guess_call_kind` then
             // classifies as `CallKind::Builtin` (call.py:135-136).
             if leaf.starts_with("oopspec_") {
-                if let Some(spec) = global_marker_str(llbc, gd) {
-                    push_hint(
-                        &mut out,
-                        marker_path_to_fn_path(&path, "oopspec_"),
-                        &format!("oopspec:{spec}"),
-                    );
-                }
+                // Fail fast like the `_jit_look_inside_` arm above: the macro
+                // emits a literal string, so an undecodable initializer is a
+                // marker encoding/decoder drift, not an absent spec. Silently
+                // dropping the hint would quietly disable oopspec lowering for
+                // the function path.
+                let spec = global_marker_str(llbc, gd).unwrap_or_else(|| {
+                    panic!(
+                        "oopspec marker `{path}` has an undecodable string \
+                         initializer; this signals a marker encoding/decoder drift"
+                    )
+                });
+                push_hint(
+                    &mut out,
+                    marker_path_to_fn_path(&path, "oopspec_"),
+                    &format!("oopspec:{spec}"),
+                );
                 continue;
             }
             for (prefix, hints) in CONST_PREFIX_HINTS {

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -1,7 +1,7 @@
 //! Harvest JIT-hint markers from the ullbc surrogate consts the
 //! `majit_macros` proc-macros emit (`_elidable_function_<NAME>`,
 //! `_jit_look_inside_<NAME>`, `_jit_loop_invariant_<NAME>`,
-//! `_jit_unroll_safe_<NAME>`).
+//! `_jit_unroll_safe_<NAME>`, `oopspec_<NAME>`).
 //!
 //! The source attribute (`#[elidable]` / `#[dont_look_inside]` / …) is
 //! consumed by the proc-macro at expansion time and does NOT survive in
@@ -71,6 +71,23 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                     marker_path_to_fn_path(&path, "_jit_look_inside_"),
                     hint,
                 );
+                continue;
+            }
+            // `#[oopspec("spec")]` emits `oopspec_<NAME>: &'static str =
+            // "spec"` (majit_macros::oopspec, rlib/jit.py:255 `func.oopspec
+            // = spec`).  Unlike the fixed-hint markers, the payload is the
+            // const's *value*, so decode the string literal and emit a
+            // companion `oopspec:<spec>` hint that `lib.rs` consumes via
+            // `CallControl::mark_oopspec` — which `guess_call_kind` then
+            // classifies as `CallKind::Builtin` (call.py:135-136).
+            if leaf.starts_with("oopspec_") {
+                if let Some(spec) = global_marker_str(llbc, gd) {
+                    push_hint(
+                        &mut out,
+                        marker_path_to_fn_path(&path, "oopspec_"),
+                        &format!("oopspec:{spec}"),
+                    );
+                }
                 continue;
             }
             for (prefix, hints) in CONST_PREFIX_HINTS {
@@ -152,6 +169,55 @@ fn global_marker_bool(llbc: &Llbc, gd: &GlobalDecl) -> Option<bool> {
     None
 }
 
+/// Read the `&'static str` value of an oopspec marker const. The init
+/// body assigns `Local(0) = Const(ConstantExpr)` whose `kind` nests the
+/// string literal (`{"kind": {"Literal": {"Str": spec}}, "ty": …}`),
+/// mirroring [`global_marker_bool`]'s bool path.
+fn global_marker_str(llbc: &Llbc, gd: &GlobalDecl) -> Option<String> {
+    let init_id = gd.rest.get("init")?.as_u64()?;
+    let body = llbc.fn_by_id(init_id)?.unstructured()?;
+    for block in &body.body {
+        for stmt in &block.statements {
+            let StmtKind::Assign(place, Rvalue::Use(Operand::Const(value))) =
+                stmt.stmt_kind().ok()?
+            else {
+                continue;
+            };
+            if !matches!(place.kind, PlaceKind::Local(0)) {
+                continue;
+            }
+            if let Some(s) = decode_str_const(&value) {
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
+fn decode_str_const(value: &serde_json::Value) -> Option<String> {
+    if let Some(s) = value.as_str() {
+        return Some(s.to_string());
+    }
+    let obj = value.as_object()?;
+    for key in ["Str", "str"] {
+        if let Some(v) = obj.get(key) {
+            if let Some(s) = v.as_str() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    // `ConstantExpr` nests the literal under `kind` →
+    // `{"Literal": {"Str": spec}}`; descend through both wrappers.
+    for key in ["kind", "Literal"] {
+        if let Some(nested) = obj.get(key) {
+            if let Some(s) = decode_str_const(nested) {
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
 fn decode_bool_const(value: &serde_json::Value) -> Option<bool> {
     if let Some(b) = value.as_bool() {
         return Some(b);
@@ -185,4 +251,44 @@ fn decode_bool_const(value: &serde_json::Value) -> Option<bool> {
         return decode_bool_const(kind);
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_str_const;
+
+    #[test]
+    fn decode_str_const_reads_constant_expr_literal() {
+        // The exact shape Charon emits for `const X: &str = "spec"`:
+        // `Local(0) = Const(ConstantExpr{kind:{Literal:{Str:spec}}})`.
+        let value = serde_json::json!({
+            "kind": {"Literal": {"Str": "list.int_capacity(l)"}},
+            "ty": {"Deduplicated": 7911}
+        });
+        assert_eq!(
+            decode_str_const(&value).as_deref(),
+            Some("list.int_capacity(l)")
+        );
+    }
+
+    #[test]
+    fn decode_str_const_reads_bare_and_wrapped_strings() {
+        assert_eq!(
+            decode_str_const(&serde_json::json!("plain")).as_deref(),
+            Some("plain")
+        );
+        assert_eq!(
+            decode_str_const(&serde_json::json!({"Str": "wrapped"})).as_deref(),
+            Some("wrapped")
+        );
+    }
+
+    #[test]
+    fn decode_str_const_rejects_non_string() {
+        assert_eq!(decode_str_const(&serde_json::json!(42)), None);
+        assert_eq!(
+            decode_str_const(&serde_json::json!({"kind": {"Literal": {"Bool": true}}})),
+            None
+        );
+    }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -8145,7 +8145,13 @@ mod tests {
         };
         let mut transformer = Transformer::new(&config);
         let rewrite = transformer
-            ._handle_list_call("list.int_len", &op, &[l.clone()], &mut graph, "list_int_len")
+            ._handle_list_call(
+                "list.int_len",
+                &op,
+                &[l.clone()],
+                &mut graph,
+                "list_int_len",
+            )
             .expect("list.int_len must lower");
         let RewriteResult::Replace(ops) = rewrite else {
             panic!("expected Replace");
@@ -8197,7 +8203,9 @@ mod tests {
         };
         assert_eq!(ops.len(), 2);
         let block = match &ops[0].kind {
-            OpKind::FieldRead { base, field, ty, .. } => {
+            OpKind::FieldRead {
+                base, field, ty, ..
+            } => {
                 assert_eq!(base, &l);
                 assert_eq!(field.name, "int_items.block");
                 assert_eq!(field.owner_root.as_deref(), Some("W_ListObject"));
@@ -8375,8 +8383,10 @@ mod tests {
             kind: OpKind::ConstInt(0),
         };
         let mut transformer = Transformer::new(&config);
-        assert!(transformer
-            ._handle_list_call("list.append", &op, &[l], &mut graph, "list_unhandled")
-            .is_none());
+        assert!(
+            transformer
+                ._handle_list_call("list.append", &op, &[l], &mut graph, "list_unhandled")
+                .is_none()
+        );
     }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2782,6 +2782,14 @@ impl<'a> Transformer<'a> {
                     self._handle_jit_call(base, op, target, args, result_ty, graph_name, graph);
                 return prepend_const_prefix(&mut const_prefix_ops, result);
             }
+            // jtransform.py:488 — list.* / newlist oopspecs → _handle_list_call.
+            // Unhandled spellings return `None` and fall through to the
+            // residual-call path (RPython raises `NotSupported`).
+            if base.starts_with("list.") || base.starts_with("newlist") {
+                if let Some(result) = self._handle_list_call(base, op, args, graph, graph_name) {
+                    return prepend_const_prefix(&mut const_prefix_ops, result);
+                }
+            }
             // NOTE: conditional_call!/conditional_call_elidable!/record_known_result!
             // are handled by jitcode_lower (proc-macro level), NOT here.
             // The codewriter AST parser does not expand macro_rules!, so these
@@ -2872,6 +2880,149 @@ impl<'a> Transformer<'a> {
         let result =
             self.handle_residual_call(graph, op, target, descriptor, args, result_ty, graph_name);
         prepend_const_prefix(&mut const_prefix_ops, result)
+    }
+
+    /// Port of `jtransform.py:1762 _handle_list_call` for pyre's
+    /// strategy-tagged Integer-storage list oopspec leaves
+    /// (`ll_list_int_{length,getitem_fast,setitem_fast}` in
+    /// `listobject.rs`, annotated
+    /// `#[oopspec("list.int_{len,getitem,setitem}")]`).
+    ///
+    /// Lowers the oopspec call into the typed field / array ops the
+    /// heapcache understands instead of an opaque residual call.  pyre's
+    /// Integer storage is a nested inline `IntArray`
+    /// (`W_ListObject.int_items: IntArray { block: Ptr(GcArray(Signed)),
+    /// ptr, len, .. }`), so the items live behind the `int_items.block`
+    /// GC array:
+    ///   `list.int_len(l)`         → getfield_gc_i(l, int_items.len)
+    ///   `list.int_getitem(l, i)`  → getfield_gc_r(l, int_items.block);
+    ///                                getarrayitem_gc_i(block, i)
+    ///   `list.int_setitem(l,i,v)` → getfield_gc_r(l, int_items.block);
+    ///                                setarrayitem_gc(block, i, v)
+    ///
+    /// pyre splits the fused `getlistitem_gc` / `setlistitem_gc` resops
+    /// (`do_resizable_list_getitem/setitem`, jtransform.py:1954-1972)
+    /// into the explicit getfield(block) + get/setarrayitem pair because
+    /// the runtime exposes the backing GC array through the
+    /// `int_items.block` field (`Ptr(GcArray(Signed))`) rather than a
+    /// fused interior descr.
+    ///
+    /// The `_fast` leaves carry a non-negative index by contract
+    /// (`jtransform.py:1799 _get_list_nonneg_canraise_flags` → no
+    /// `check_neg_index`), so the index operand is used directly.
+    ///
+    /// Returns `None` for any oopspec spelling this does not handle, so
+    /// the caller falls through to the residual path
+    /// (`jtransform.py:1796` raises `NotSupported`).
+    fn _handle_list_call(
+        &mut self,
+        oopspec_name: &str,
+        op: &SpaceOperation,
+        args: &[crate::flowspace::model::Variable],
+        graph: &mut crate::model::FunctionGraph,
+        graph_name: &str,
+    ) -> Option<RewriteResult> {
+        use crate::jit_codewriter::type_state::ConcreteType;
+        // Field owner for the `W_ListObject` storage struct.  The dotted
+        // names address the fused offsets the runtime descr group
+        // exposes (`int_items.len` → `list_int_items_len_descr`,
+        // `int_items.block` → `list_int_items_block_descr`); the
+        // descr-resolution layer maps them to the matching
+        // `W_LIST_DESCR_GROUP` entries.
+        const LIST_OWNER: &str = "W_ListObject";
+
+        let (detail, ops): (&str, Vec<SpaceOperation>) = match oopspec_name {
+            "list.int_len" => {
+                let l = args.first()?.clone();
+                (
+                    "list.int_len → getfield_gc_i(int_items.len)",
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind: OpKind::FieldRead {
+                            base: l,
+                            field: FieldDescriptor::new(
+                                "int_items.len",
+                                Some(LIST_OWNER.to_string()),
+                            ),
+                            ty: ValueType::Int,
+                            pure: false,
+                        },
+                    }],
+                )
+            }
+            "list.int_getitem" => {
+                let l = args.first()?.clone();
+                let index = args.get(1)?.clone();
+                let block = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+                (
+                    "list.int_getitem → getfield_gc_r(int_items.block) + getarrayitem_gc_i",
+                    vec![
+                        SpaceOperation {
+                            result: Some(block.clone()),
+                            kind: OpKind::FieldRead {
+                                base: l,
+                                field: FieldDescriptor::new(
+                                    "int_items.block",
+                                    Some(LIST_OWNER.to_string()),
+                                ),
+                                ty: ValueType::Ref(None),
+                                pure: false,
+                            },
+                        },
+                        SpaceOperation {
+                            result: op.result.clone(),
+                            kind: OpKind::ArrayRead {
+                                base: block,
+                                index,
+                                item_ty: ValueType::Int,
+                                array_type_id: None,
+                                nolength: false,
+                            },
+                        },
+                    ],
+                )
+            }
+            "list.int_setitem" => {
+                let l = args.first()?.clone();
+                let index = args.get(1)?.clone();
+                let value = args.get(2)?.clone();
+                let block = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+                (
+                    "list.int_setitem → getfield_gc_r(int_items.block) + setarrayitem_gc",
+                    vec![
+                        SpaceOperation {
+                            result: Some(block.clone()),
+                            kind: OpKind::FieldRead {
+                                base: l,
+                                field: FieldDescriptor::new(
+                                    "int_items.block",
+                                    Some(LIST_OWNER.to_string()),
+                                ),
+                                ty: ValueType::Ref(None),
+                                pure: false,
+                            },
+                        },
+                        SpaceOperation {
+                            result: op.result.clone(),
+                            kind: OpKind::ArrayWrite {
+                                base: block,
+                                index,
+                                value: crate::model::LinkArg::Value(value),
+                                item_ty: ValueType::Int,
+                                array_type_id: None,
+                                nolength: false,
+                            },
+                        },
+                    ],
+                )
+            }
+            _ => return None,
+        };
+        self.notes.push(GraphTransformNote {
+            function: graph_name.to_string(),
+            detail: detail.to_string(),
+        });
+        Some(RewriteResult::Replace(ops))
     }
 
     /// RPython: `Transformer.handle_regular_call(op)`.
@@ -7941,5 +8092,172 @@ mod tests {
             }
             other => panic!("expected GuardValue, got {other:?}"),
         }
+    }
+
+    /// `list.int_len(l)` lowers to a single `getfield_gc_i(l,
+    /// int_items.len)` (`do_resizable_list_len`).
+    #[test]
+    fn handle_list_call_int_len_lowers_to_getfield_len() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_int_len");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let result = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call("list.int_len", &op, &[l.clone()], &mut graph, "list_int_len")
+            .expect("list.int_len must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        match &ops[0].kind {
+            OpKind::FieldRead {
+                base,
+                field,
+                ty,
+                pure,
+            } => {
+                assert_eq!(base, &l);
+                assert_eq!(field.name, "int_items.len");
+                assert_eq!(field.owner_root.as_deref(), Some("W_ListObject"));
+                assert!(matches!(ty, ValueType::Int));
+                assert!(!pure);
+            }
+            other => panic!("expected FieldRead, got {other:?}"),
+        }
+        assert_eq!(ops[0].result, Some(result));
+    }
+
+    /// `list.int_getitem(l, i)` lowers to `getfield_gc_r(l,
+    /// int_items.block)` feeding `getarrayitem_gc_i(block, i)`.
+    #[test]
+    fn handle_list_call_int_getitem_lowers_to_block_plus_getarrayitem() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_int_getitem");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let index = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let result = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "list.int_getitem",
+                &op,
+                &[l.clone(), index.clone()],
+                &mut graph,
+                "list_int_getitem",
+            )
+            .expect("list.int_getitem must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 2);
+        let block = match &ops[0].kind {
+            OpKind::FieldRead { base, field, ty, .. } => {
+                assert_eq!(base, &l);
+                assert_eq!(field.name, "int_items.block");
+                assert_eq!(field.owner_root.as_deref(), Some("W_ListObject"));
+                assert!(matches!(ty, ValueType::Ref(None)));
+                ops[0].result.clone().expect("block result var")
+            }
+            other => panic!("expected FieldRead, got {other:?}"),
+        };
+        match &ops[1].kind {
+            OpKind::ArrayRead {
+                base,
+                index: idx,
+                item_ty,
+                array_type_id,
+                nolength,
+            } => {
+                assert_eq!(base, &block);
+                assert_eq!(idx, &index);
+                assert!(matches!(item_ty, ValueType::Int));
+                assert_eq!(array_type_id, &None);
+                assert!(!nolength);
+            }
+            other => panic!("expected ArrayRead, got {other:?}"),
+        }
+        assert_eq!(ops[1].result, Some(result));
+    }
+
+    /// `list.int_setitem(l, i, v)` lowers to `getfield_gc_r(l,
+    /// int_items.block)` feeding `setarrayitem_gc(block, i, v)`.
+    #[test]
+    fn handle_list_call_int_setitem_lowers_to_block_plus_setarrayitem() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_int_setitem");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let index = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let value = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "list.int_setitem",
+                &op,
+                &[l.clone(), index.clone(), value.clone()],
+                &mut graph,
+                "list_int_setitem",
+            )
+            .expect("list.int_setitem must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 2);
+        let block = match &ops[0].kind {
+            OpKind::FieldRead { base, field, .. } => {
+                assert_eq!(base, &l);
+                assert_eq!(field.name, "int_items.block");
+                ops[0].result.clone().expect("block result var")
+            }
+            other => panic!("expected FieldRead, got {other:?}"),
+        };
+        match &ops[1].kind {
+            OpKind::ArrayWrite {
+                base,
+                index: idx,
+                value: written,
+                item_ty,
+                array_type_id,
+                nolength,
+            } => {
+                assert_eq!(base, &block);
+                assert_eq!(idx, &index);
+                assert_eq!(written.as_variable(), Some(&value));
+                assert!(matches!(item_ty, ValueType::Int));
+                assert_eq!(array_type_id, &None);
+                assert!(!nolength);
+            }
+            other => panic!("expected ArrayWrite, got {other:?}"),
+        }
+        assert_eq!(ops[1].result, None);
+    }
+
+    /// An unhandled list oopspec spelling returns `None` so the caller
+    /// falls through to the residual-call path.
+    #[test]
+    fn handle_list_call_unhandled_spelling_returns_none() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_unhandled");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        assert!(transformer
+            ._handle_list_call("list.append", &op, &[l], &mut graph, "list_unhandled")
+            .is_none());
     }
 }

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -3016,6 +3016,43 @@ impl<'a> Transformer<'a> {
                     ],
                 )
             }
+            "list.int_capacity" => {
+                let l = args.first()?.clone();
+                (
+                    "list.int_capacity → getfield_gc_i(int_items.heap_cap)",
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind: OpKind::FieldRead {
+                            base: l,
+                            field: FieldDescriptor::new(
+                                "int_items.heap_cap",
+                                Some(LIST_OWNER.to_string()),
+                            ),
+                            ty: ValueType::Int,
+                            pure: false,
+                        },
+                    }],
+                )
+            }
+            "list.int_set_len" => {
+                let l = args.first()?.clone();
+                let n = args.get(1)?.clone();
+                (
+                    "list.int_set_len → setfield_gc_i(int_items.len)",
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind: OpKind::FieldWrite {
+                            base: l,
+                            field: FieldDescriptor::new(
+                                "int_items.len",
+                                Some(LIST_OWNER.to_string()),
+                            ),
+                            value: crate::model::LinkArg::Value(n),
+                            ty: ValueType::Int,
+                        },
+                    }],
+                )
+            }
             _ => return None,
         };
         self.notes.push(GraphTransformNote {
@@ -8242,6 +8279,88 @@ mod tests {
             other => panic!("expected ArrayWrite, got {other:?}"),
         }
         assert_eq!(ops[1].result, None);
+    }
+
+    /// `list.int_capacity(l)` lowers to a single `getfield_gc_i(l,
+    /// int_items.heap_cap)`.
+    #[test]
+    fn handle_list_call_int_capacity_lowers_to_heap_cap_field() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_int_capacity");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let result = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "list.int_capacity",
+                &op,
+                &[l.clone()],
+                &mut graph,
+                "list_int_capacity",
+            )
+            .expect("list.int_capacity must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        match &ops[0].kind {
+            OpKind::FieldRead {
+                base, field, ty, ..
+            } => {
+                assert_eq!(base, &l);
+                assert_eq!(field.name, "int_items.heap_cap");
+                assert!(matches!(ty, ValueType::Int));
+            }
+            other => panic!("expected FieldRead, got {other:?}"),
+        }
+        assert_eq!(ops[0].result, Some(result));
+    }
+
+    /// `list.int_set_len(l, n)` lowers to a single `setfield_gc_i(l, n,
+    /// int_items.len)`.
+    #[test]
+    fn handle_list_call_int_set_len_lowers_to_len_field_write() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_int_set_len");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let n = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "list.int_set_len",
+                &op,
+                &[l.clone(), n.clone()],
+                &mut graph,
+                "list_int_set_len",
+            )
+            .expect("list.int_set_len must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        match &ops[0].kind {
+            OpKind::FieldWrite {
+                base,
+                field,
+                value,
+                ty,
+            } => {
+                assert_eq!(base, &l);
+                assert_eq!(field.name, "int_items.len");
+                assert_eq!(value.as_variable(), Some(&n));
+                assert!(matches!(ty, ValueType::Int));
+            }
+            other => panic!("expected FieldWrite, got {other:?}"),
+        }
+        assert_eq!(ops[0].result, None);
     }
 
     /// An unhandled list oopspec spelling returns `None` so the caller

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1204,6 +1204,26 @@ pub fn ensure_range_iter(iter: PyObjectRef) -> Result<(), PyError> {
     )))
 }
 
+/// Current length of the sequence a `W_SeqIterator` walks. `None` for a
+/// payload that is none of list/tuple/array, leaving callers to fall back
+/// to the length captured at iterator creation.
+///
+/// # Safety
+/// `seq` must be a valid object pointer.
+unsafe fn seq_iter_current_len(seq: PyObjectRef) -> Option<i64> {
+    unsafe {
+        if is_list(seq) {
+            Some(w_list_len(seq) as i64)
+        } else if is_tuple(seq) {
+            Some(w_tuple_len(seq) as i64)
+        } else if pyre_object::array_object::is_array(seq) {
+            Some(pyre_object::array_object::w_array_len(seq) as i64)
+        } else {
+            None
+        }
+    }
+}
+
 pub fn range_iter_continues(iter: PyObjectRef) -> Result<bool, PyError> {
     unsafe {
         if is_range_iter(iter) {
@@ -1214,7 +1234,14 @@ pub fn range_iter_continues(iter: PyObjectRef) -> Result<bool, PyError> {
         }
         if is_seq_iter(iter) {
             let si = &*(iter as *const W_SeqIterator);
-            return Ok(si.index < si.length);
+            // listiterator re-reads PyList_GET_SIZE(seq) each step and PyPy's
+            // W_FastListIterObject.descr_next ends on a getitem IndexError;
+            // neither snapshots a length. Read the CURRENT sequence length so
+            // an element appended during iteration is observed (and a removed
+            // tail ends the loop) rather than the length captured at iterator
+            // creation.
+            let len = seq_iter_current_len(si.seq).unwrap_or(si.length);
+            return Ok(si.index < len);
         }
     }
     Err(PyError::type_error("not an iterator"))
@@ -1230,21 +1257,30 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
         }
         if is_seq_iter(iter) {
             let si = &mut *(iter as *mut W_SeqIterator);
-            if si.index < si.length {
-                let idx = si.index;
-                si.index += 1;
-                if is_list(si.seq) {
-                    return Ok(w_list_getitem(si.seq, idx).unwrap_or(PY_NULL));
-                }
-                if is_tuple(si.seq) {
-                    return Ok(w_tuple_getitem(si.seq, idx).unwrap_or(PY_NULL));
-                }
-                if pyre_object::array_object::is_array(si.seq) {
-                    return Ok(pyre_object::array_object::w_array_unpack_item(
+            let idx = si.index;
+            // Bounds come from the sequence's CURRENT state (see
+            // range_iter_continues): getitem returns None past the live
+            // length, so an element appended during iteration is yielded and a
+            // removed tail ends the loop. Mirrors baseobjspace::next.
+            let item = if is_list(si.seq) {
+                w_list_getitem(si.seq, idx)
+            } else if is_tuple(si.seq) {
+                w_tuple_getitem(si.seq, idx)
+            } else if pyre_object::array_object::is_array(si.seq) {
+                if (idx as usize) < pyre_object::array_object::w_array_len(si.seq) {
+                    Some(pyre_object::array_object::w_array_unpack_item(
                         si.seq,
                         idx as usize,
-                    ));
+                    ))
+                } else {
+                    None
                 }
+            } else {
+                None
+            };
+            if let Some(v) = item {
+                si.index += 1;
+                return Ok(v);
             }
             return Ok(PY_NULL);
         }
@@ -1330,5 +1366,27 @@ mod tests {
         unsafe {
             assert_eq!(w_int_get_value(item), 5);
         }
+    }
+
+    #[test]
+    fn seq_iter_observes_list_growth_during_iteration() {
+        // listiterator re-reads the live list size each step, so an append
+        // during iteration is observed. range_iter_continues /
+        // range_iter_next_or_null must read the CURRENT length, not the length
+        // captured at iterator creation — otherwise `for x in xs:
+        // xs.append(...)` stops at the initial length.
+        let list = pyre_object::w_list_new(vec![w_int_new(0)]);
+        let iter = pyre_object::w_seq_iter_new(list, 1);
+        let mut seen = Vec::new();
+        while range_iter_continues(iter).unwrap() {
+            let v = range_iter_next_or_null(iter).unwrap();
+            assert!(!v.is_null());
+            let x = unsafe { w_int_get_value(v) };
+            seen.push(x);
+            if unsafe { pyre_object::w_list_len(list) } < 5 {
+                unsafe { pyre_object::w_list_append(list, w_int_new(x + 1)) };
+            }
+        }
+        assert_eq!(seen, vec![0, 1, 2, 3, 4]);
     }
 }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1205,8 +1205,11 @@ pub fn ensure_range_iter(iter: PyObjectRef) -> Result<(), PyError> {
 }
 
 /// Current length of the sequence a `W_SeqIterator` walks. `None` for a
-/// payload that is none of list/tuple/array, leaving callers to fall back
-/// to the length captured at iterator creation.
+/// payload outside list/tuple/str/array, leaving callers to fall back to
+/// the length captured at iterator creation.  The covered set mirrors the
+/// item-fetch arms of `baseobjspace::next` / `range_iter_next_or_null`, so
+/// `range_iter_continues` and the next-value helper stay consistent (a
+/// payload one can fetch from is a payload one can length).
 ///
 /// # Safety
 /// `seq` must be a valid object pointer.
@@ -1216,6 +1219,10 @@ unsafe fn seq_iter_current_len(seq: PyObjectRef) -> Option<i64> {
             Some(w_list_len(seq) as i64)
         } else if is_tuple(seq) {
             Some(w_tuple_len(seq) as i64)
+        } else if is_str(seq) {
+            // Code-point count, not byte count (matches the str seq-iter
+            // seed in baseobjspace::iter).
+            Some(w_str_len(seq) as i64)
         } else if pyre_object::array_object::is_array(seq) {
             Some(pyre_object::array_object::w_array_len(seq) as i64)
         } else {
@@ -1266,6 +1273,27 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
                 w_list_getitem(si.seq, idx)
             } else if is_tuple(si.seq) {
                 w_tuple_getitem(si.seq, idx)
+            } else if is_str(si.seq) {
+                // Box the idx-th code point as a one-character str, reading
+                // the WTF-8 view so a lone surrogate is yielded instead of
+                // panicking. Only `iter(str)` through the builtin reaches here
+                // with a str payload (the GET_ITER opcode materialises a char
+                // list); without this arm `seq_iter_current_len` would say
+                // "more" while this helper returned PY_NULL forever, hanging
+                // the loop. Mirrors baseobjspace::next.
+                let s = w_str_get_wtf8(si.seq);
+                let mut found: Option<PyObjectRef> = None;
+                let mut n = 0i64;
+                for cp in s.code_points() {
+                    if n == idx {
+                        let mut one = Wtf8Buf::new();
+                        one.push(cp);
+                        found = Some(w_str_from_wtf8(one));
+                        break;
+                    }
+                    n += 1;
+                }
+                found
             } else if pyre_object::array_object::is_array(si.seq) {
                 if (idx as usize) < pyre_object::array_object::w_array_len(si.seq) {
                     Some(pyre_object::array_object::w_array_unpack_item(
@@ -1388,5 +1416,24 @@ mod tests {
             }
         }
         assert_eq!(seen, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn seq_iter_over_str_payload_yields_codepoints_and_terminates() {
+        // `iter(str)` through the builtin (baseobjspace::iter) makes a seq-iter
+        // with a STR payload (the GET_ITER opcode instead materialises a char
+        // list). range_iter_continues / range_iter_next_or_null must fetch and
+        // advance for that payload too; otherwise `continues` stays true while
+        // `next` returns PY_NULL forever, hanging `for c in iter(s)`.
+        let s = pyre_object::strobject::box_str_constant(Wtf8::new("abcde"));
+        let iter = pyre_object::w_seq_iter_new(s, 5);
+        let mut count = 0;
+        while range_iter_continues(iter).unwrap() {
+            let v = range_iter_next_or_null(iter).unwrap();
+            assert!(!v.is_null(), "str seq-iter yielded NULL while continues==true");
+            count += 1;
+            assert!(count <= 5, "str seq-iter did not terminate (infinite-loop regression)");
+        }
+        assert_eq!(count, 5);
     }
 }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1430,9 +1430,15 @@ mod tests {
         let mut count = 0;
         while range_iter_continues(iter).unwrap() {
             let v = range_iter_next_or_null(iter).unwrap();
-            assert!(!v.is_null(), "str seq-iter yielded NULL while continues==true");
+            assert!(
+                !v.is_null(),
+                "str seq-iter yielded NULL while continues==true"
+            );
             count += 1;
-            assert!(count <= 5, "str seq-iter did not terminate (infinite-loop regression)");
+            assert!(
+                count <= 5,
+                "str seq-iter did not terminate (infinite-loop regression)"
+            );
         }
         assert_eq!(count, 5);
     }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2476,6 +2476,48 @@ mod tests {
     }
 
     #[test]
+    fn make_descr_from_bh_bridges_codewriter_int_items_leaves_to_group() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_translate::jitcode::BhDescr;
+
+        // Shape `_handle_list_call` emits and the codewriter assembler
+        // round-trips: dotted nested name, owner `W_ListObject`, offset 0
+        // (unresolved, because `W_ListObject` is not in the codewriter
+        // struct layouts), no parent. Without the bridge these mint a
+        // SimpleFieldDescr at offset 0 (the list header).
+        for (name, expected, ty) in [
+            ("int_items.len", list_int_items_len_descr(), Type::Int),
+            (
+                "int_items.heap_cap",
+                list_int_items_heap_cap_descr(),
+                Type::Int,
+            ),
+            ("int_items.block", list_int_items_block_descr(), Type::Ref),
+        ] {
+            let descr = make_descr_from_bh(&BhDescr::Field {
+                offset: 0,
+                field_size: 8,
+                field_type: ty,
+                field_flag: ArrayFlag::Signed,
+                is_field_signed: false,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                index_in_parent: 0,
+                parent: None,
+                name: name.into(),
+                owner: "W_ListObject".into(),
+            });
+            let field = descr.as_field_descr().expect("Field BhDescr -> FieldDescr");
+            assert_ne!(field.offset(), 0, "{name} bridged to the list header");
+            assert_eq!(
+                field.offset(),
+                expected.as_field_descr().unwrap().offset(),
+                "{name} offset must match the W_LIST_DESCR_GROUP entry",
+            );
+        }
+    }
+
+    #[test]
     fn make_descr_from_bh_struct_array_preserves_type_and_interior_fields() {
         use majit_ir::descr::ArrayFlag;
         use majit_translate::jitcode::{BhDescr, BhFieldSpec, BhInteriorFieldSpec, BhSizeSpec};
@@ -3194,6 +3236,26 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             owner,
             ..
         } => {
+            // #171 codewriter descr-bridge: `_handle_list_call`
+            // (jit_codewriter/jtransform.rs) lowers Integer-strategy list
+            // ops to fields on the dotted nested names
+            // `int_items.{len,heap_cap,block}` (owner `W_ListObject`).
+            // `bh_field_name` treats the dotted name as already-qualified,
+            // and `W_ListObject` is a runtime Rust type absent from the
+            // codewriter struct layouts, so the assembler's `fielddescrof`
+            // leaves these at offset 0 (the list header). Map the leaves to
+            // the canonical `W_LIST_DESCR_GROUP` entries the walker-native
+            // list specializations already use so an assembled codewriter
+            // list body addresses `IntArray.{len,heap_cap,block}` rather
+            // than the header.
+            if owner.as_str() == "W_ListObject" {
+                match name.as_str() {
+                    "int_items.len" => return list_int_items_len_descr(),
+                    "int_items.heap_cap" => return list_int_items_heap_cap_descr(),
+                    "int_items.block" => return list_int_items_block_descr(),
+                    _ => {}
+                }
+            }
             let full_name = if owner.is_empty() || name.contains('.') {
                 name.clone()
             } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9012,9 +9012,8 @@ fn dispatch_residual_call_iRd_kind(
     // replacing the opaque `bh_call_fn` residual (walker-native fold; see
     // `try_walker_specialize_list_append`).  The call arrives as `CallFn` with
     // `dst_bank == 'r'` (the None result is a Ref, not void) and
-    // `r_args = [bound-method, PY_NULL, value]`.  Gated behind
-    // PYRE_171_INLINE_LIST (default OFF) until the de-spec guard-failure bridge
-    // resume is fixed (#143 method-call CALL bridge); falls through to the
+    // `r_args = [bound-method, PY_NULL, value]`.  Default ON
+    // (`PYRE_171_INLINE_LIST=0` opts out); falls through to the
     // residual for any non-matching shape (SAFE).  The eager append rides
     // `FBW_APPEND_JOURNAL`, whose commit/rollback epilogues run on FBW walk
     // ends (same lifecycle as the STORE_SUBSCR store journal).
@@ -9027,9 +9026,20 @@ fn dispatch_residual_call_iRd_kind(
     // inlined call (e.g. a `STORE_ATTR` ahead of an inlined `push(lst, x)`).
     // An inlined append falls back to the generic residual, which resumes
     // *past* the call (after_residual_call) and so re-runs nothing extra.
+    //
+    // Also restrict to loop traces (`header_pc != 0`): in a function-entry
+    // trace (a no-loop helper compiled from entry, e.g. `def push(a, v):
+    // a.append(v)` called in a hot loop) the spare-capacity guard's
+    // blackhole resume reconstructs the re-executed append's receiver from a
+    // wrong box and re-runs `LOAD_METHOD` on a garbage pointer — the
+    // function-entry exit-layout numbering does not preserve the receiver
+    // local across the fold's mid-statement guards.  Loop traces resume
+    // through the loop-header pc_map coordinate and reconstruct it correctly
+    // (a no-loop helper's append falls back to the generic residual).
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
+        && ctx.trace_ctx.header_pc != 0
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && pyre_171_inline_list_enabled()
@@ -10660,11 +10670,13 @@ fn try_walker_specialize_subscr(
     Ok(Some(()))
 }
 
-/// Env gate for the #171 P3 `list.append` charon-body inline arm.  Default
-/// OFF until the arm is validated on every backend; `PYRE_171_INLINE_LIST=1`
-/// opts in.
+/// Env gate for the #171 P3 `list.append` int-storage fold.  Default ON;
+/// `PYRE_171_INLINE_LIST=0` opts out.  The fold is restricted to loop traces
+/// at the top full-body frame (see the dispatch-site gate): inline sub-walks
+/// and function-entry traces decline to the generic residual, so the only
+/// live path is the validated loop-trace append.
 fn pyre_171_inline_list_enabled() -> bool {
-    std::env::var("PYRE_171_INLINE_LIST").as_deref() == Ok("1")
+    std::env::var("PYRE_171_INLINE_LIST").as_deref() != Ok("0")
 }
 
 /// #171 P3: specialize `lst.append(x)` so its array ops (getfield length /
@@ -10706,11 +10718,8 @@ fn try_walker_specialize_list_append(
     }
     // r_args = [callable(bound method), null_or_self(PY_NULL), value].
     let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
-    let (
-        ConcreteValue::Ref(callable),
-        ConcreteValue::Ref(null_or_self),
-        ConcreteValue::Ref(value),
-    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    let (ConcreteValue::Ref(callable), ConcreteValue::Ref(null_or_self), ConcreteValue::Ref(value)) =
+        (arg_concretes[0], arg_concretes[1], arg_concretes[2])
     else {
         return Ok(None);
     };
@@ -10735,8 +10744,7 @@ fn try_walker_specialize_list_append(
         }
         // Canonical-identity check: a list subclass overriding `append`, or a
         // same-named method on another type, declines (its func differs).
-        let list_type =
-            pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE);
+        let list_type = pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE);
         if pyre_interpreter::lookup_in_type(list_type, "append") != Some(inner_func) {
             return Ok(None);
         }
@@ -12046,7 +12054,8 @@ fn dispatch_inline_call_dr_kind(
     let (args, arg_width) = read_ref_var_list(code, op, 2, ctx)?;
     let arg_concretes = read_ref_var_list_concrete(code, op, 2, ctx);
 
-    let callee_outcome = run_sub_jitcode_walk(ctx, op.pc, &sub_body, &[], &args, &arg_concretes, &[])?;
+    let callee_outcome =
+        run_sub_jitcode_walk(ctx, op.pc, &sub_body, &[], &args, &arg_concretes, &[])?;
 
     match callee_outcome {
         DispatchOutcome::SubReturn {
@@ -12184,8 +12193,15 @@ fn dispatch_inline_call_dir_kind(
     let (ref_args, ref_width) = read_ref_var_list(code, op, 2 + int_width, ctx)?;
     let ref_arg_concretes = read_ref_var_list_concrete(code, op, 2 + int_width, ctx);
 
-    let callee_outcome =
-        run_sub_jitcode_walk(ctx, op.pc, &sub_body, &int_args, &ref_args, &ref_arg_concretes, &[])?;
+    let callee_outcome = run_sub_jitcode_walk(
+        ctx,
+        op.pc,
+        &sub_body,
+        &int_args,
+        &ref_args,
+        &ref_arg_concretes,
+        &[],
+    )?;
 
     match callee_outcome {
         DispatchOutcome::SubReturn {
@@ -14734,11 +14750,8 @@ mod tests {
 
         super::fbw_store_journal_reset();
 
-        let list = pyre_object::listobject::w_list_new(vec![
-            w_int_new(10),
-            w_int_new(20),
-            w_int_new(30),
-        ]);
+        let list =
+            pyre_object::listobject::w_list_new(vec![w_int_new(10), w_int_new(20), w_int_new(30)]);
         // A first append forces the backing array to grow with a growth
         // factor, leaving spare capacity so the *next* append is in-place
         // (the only shape the arm specializes).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -234,6 +234,33 @@ pub struct SubJitCodeBody {
 /// tests pass synthetic closures over a local fixture map).
 pub type SubJitCodeLookup = dyn Fn(usize) -> Option<SubJitCodeBody>;
 
+/// Build a [`SubJitCodeBody`] view over the build-time `ALL_JITCODES[idx]`
+/// entry (`crate::jitcode_runtime::all_jitcodes`). Returns `None` for an
+/// out-of-range index.
+///
+/// The all-jitcodes table is `Box::leak`'d at load
+/// (`jitcode_runtime::load_all_jitcodes`), so the borrowed `code` /
+/// `constants_*` slices are `'static` as [`SubJitCodeBody`] requires.
+///
+/// This is the production sub-jitcode lookup shape — the shadow walker,
+/// the per-opcode arm entry, and trace-time list-helper specializations
+/// that descend into a charon body (e.g. `w_list_append`) all resolve a
+/// callee body through it. RPython parity: a `BhDescr::JitCode {
+/// jitcode_index }` operand resolves to `ALL_JITCODES[jitcode_index]`.
+pub fn sub_jitcode_body_by_index(idx: usize) -> Option<SubJitCodeBody> {
+    crate::jitcode_runtime::all_jitcodes()
+        .get(idx)
+        .map(|jc| SubJitCodeBody {
+            code: jc.code.as_slice(),
+            num_regs_r: jc.num_regs_r(),
+            num_regs_i: jc.num_regs_i(),
+            num_regs_f: jc.num_regs_f(),
+            constants_i: jc.constants_i.as_slice(),
+            constants_r: jc.constants_r.as_slice(),
+            constants_f: jc.constants_f.as_slice(),
+        })
+}
+
 /// State the walker reads from / writes to while stepping. RPython
 /// equivalent: `MetaInterp` itself — the trace recorder, the symbolic
 /// register banks (`registers_i`, `registers_r`, `registers_f`), and
@@ -14387,21 +14414,35 @@ mod tests {
     /// `crate::jitcode_runtime::all_jitcodes()`. Used by the end-to-end
     /// arm acceptance tests (`walk_return_value_arm_*`,
     /// `walk_pop_top_arm_*`) so the walker can recurse into real
-    /// callee bodies. The runtime's `all_jitcodes()` is a
-    /// `LazyLock<Vec<Arc<JitCode>>>` — every `.code` slice it surfaces
-    /// is `'static`-rooted, satisfying `SubJitCodeBody`'s body
-    /// constraint.
+    /// callee bodies. Delegates to the production
+    /// [`super::sub_jitcode_body_by_index`].
     fn production_sub_jitcodes(idx: usize) -> Option<SubJitCodeBody> {
-        let all = crate::jitcode_runtime::all_jitcodes();
-        all.get(idx).map(|jc| SubJitCodeBody {
-            code: jc.code.as_slice(),
-            num_regs_r: jc.num_regs_r(),
-            num_regs_i: jc.num_regs_i(),
-            num_regs_f: jc.num_regs_f(),
-            constants_i: jc.constants_i.as_slice(),
-            constants_r: jc.constants_r.as_slice(),
-            constants_f: jc.constants_f.as_slice(),
-        })
+        super::sub_jitcode_body_by_index(idx)
+    }
+
+    #[test]
+    fn sub_jitcode_body_by_index_builds_w_list_append() {
+        // #171 P3 (Route C): the lst.append recognition arm descends into
+        // the charon `w_list_append` body via a by-index SubJitCodeBody.
+        // Confirm the shared builder resolves it to a well-formed body —
+        // non-empty bytecode and >= 2 ref registers for the (list, value)
+        // seed (calldescr arg_classes 'rr').
+        let idx = crate::jitcode_runtime::list_append_jitcode()
+            .expect("w_list_append must be present in ALL_JITCODES")
+            .index();
+        let body = super::sub_jitcode_body_by_index(idx)
+            .expect("by-index builder must resolve w_list_append");
+        assert!(
+            !body.code.is_empty(),
+            "w_list_append body must carry assembled bytecode"
+        );
+        assert!(
+            body.num_regs_r >= 2,
+            "w_list_append takes (list, value) => >= 2 ref registers, got {}",
+            body.num_regs_r
+        );
+        // Out-of-range index resolves to None (RPython: ALL_JITCODES miss).
+        assert!(super::sub_jitcode_body_by_index(usize::MAX).is_none());
     }
 
     /// Tests use the production `PyreJitCodeDescr` adapter

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11558,6 +11558,110 @@ fn allocate_callee_register_banks(
     (regs_r, regs_i, regs_f, concrete_r, concrete_i)
 }
 
+/// Seed a callee jitcode's register banks with positional args and walk
+/// its body, returning the callee's terminal [`DispatchOutcome`]
+/// (`SubReturn` / `SubRaise` / `Terminate` / `SwitchToBlackhole`).
+///
+/// Shared descent core of the `inline_call_*` handlers
+/// ([`dispatch_inline_call_dr_kind`], `_dir`, `_dirf`) — they read the
+/// callee index + arglists from the caller bytecode, then delegate the
+/// bank allocation, arity check, arg seeding, sub-`WalkContext`
+/// construction, and `walk()` to here. A trace-time specialization can
+/// also call this directly to synthesize a descent into a charon helper
+/// body (e.g. `w_list_append`), passing args it already holds rather
+/// than reading them from bytecode.
+///
+/// `pc` is the caller-site pc, used only for arity-mismatch error
+/// reporting. An empty arg slice for an unused bank passes its arity
+/// check trivially. The callee runs with `is_top_level == false` and
+/// inherits the caller's descr pool + sub-jitcode lookup (RPython
+/// `pyjitpl.py:230-260 setup_call(argboxes_i, argboxes_r, argboxes_f)`).
+/// Only Ref-bank concrete shadows are seeded — matching the
+/// `inline_call_*` handlers, which thread `ref_arg_concretes` but no
+/// Int/Float concrete shadows across the frame boundary.
+fn run_sub_jitcode_walk(
+    ctx: &mut WalkContext<'_, '_>,
+    pc: usize,
+    sub_body: &SubJitCodeBody,
+    int_args: &[OpRef],
+    ref_args: &[OpRef],
+    ref_arg_concretes: &[ConcreteValue],
+    float_args: &[OpRef],
+) -> Result<DispatchOutcome, DispatchError> {
+    let (
+        mut callee_regs_r,
+        mut callee_regs_i,
+        mut callee_regs_f,
+        mut callee_concrete_r,
+        mut callee_concrete_i,
+    ) = allocate_callee_register_banks(sub_body, ctx.trace_ctx);
+
+    if int_args.len() > sub_body.num_regs_i {
+        return Err(DispatchError::InlineCallIntArityMismatch {
+            pc,
+            provided: int_args.len(),
+            callee_num_regs_i: sub_body.num_regs_i,
+        });
+    }
+    if ref_args.len() > sub_body.num_regs_r {
+        return Err(DispatchError::InlineCallArityMismatch {
+            pc,
+            provided: ref_args.len(),
+            callee_num_regs_r: sub_body.num_regs_r,
+        });
+    }
+    if float_args.len() > sub_body.num_regs_f {
+        return Err(DispatchError::InlineCallFloatArityMismatch {
+            pc,
+            provided: float_args.len(),
+            callee_num_regs_f: sub_body.num_regs_f,
+        });
+    }
+    for (i, arg) in int_args.iter().enumerate() {
+        callee_regs_i[i] = *arg;
+    }
+    for (i, arg) in ref_args.iter().enumerate() {
+        callee_regs_r[i] = *arg;
+    }
+    for (i, arg) in float_args.iter().enumerate() {
+        callee_regs_f[i] = *arg;
+    }
+    for (i, concrete) in ref_arg_concretes.iter().enumerate() {
+        callee_concrete_r[i] = *concrete;
+    }
+
+    let (callee_outcome, _callee_end_pc) = {
+        let mut sub_wc = WalkContext {
+            registers_r: &mut callee_regs_r,
+            registers_i: &mut callee_regs_i,
+            registers_f: &mut callee_regs_f,
+            concrete_registers_r: &mut callee_concrete_r,
+            concrete_registers_i: &mut callee_concrete_i,
+            descr_refs: ctx.descr_refs,
+            raw_descrs: ctx.raw_descrs,
+            is_authoritative_executor: ctx.is_authoritative_executor,
+            is_full_body_walk: ctx.is_full_body_walk,
+            trace_ctx: ctx.trace_ctx,
+            done_with_this_frame_descr_ref: ctx.done_with_this_frame_descr_ref.clone(),
+            done_with_this_frame_descr_int: ctx.done_with_this_frame_descr_int.clone(),
+            done_with_this_frame_descr_float: ctx.done_with_this_frame_descr_float.clone(),
+            done_with_this_frame_descr_void: ctx.done_with_this_frame_descr_void.clone(),
+            exit_frame_with_exception_descr_ref: ctx.exit_frame_with_exception_descr_ref.clone(),
+            is_top_level: false,
+            sub_jitcode_lookup: ctx.sub_jitcode_lookup,
+            last_exc_value: None,
+            last_exc_value_concrete: ConcreteValue::Null,
+            entry_py_pc: ctx.entry_py_pc,
+            outer_jitcode_index: ctx.outer_jitcode_index,
+            outer_active_boxes: ctx.outer_active_boxes.clone(),
+            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
+            pending_guard_snapshot_error: None,
+        };
+        walk(sub_body.code, 0, &mut sub_wc)?
+    };
+    Ok(callee_outcome)
+}
+
 /// Operand layout `dR>X`:
 ///   2B descr index + 1B varlen + N×1B Ref args + 1B `>X` dst.
 ///
@@ -11600,57 +11704,7 @@ fn dispatch_inline_call_dr_kind(
     let (args, arg_width) = read_ref_var_list(code, op, 2, ctx)?;
     let arg_concretes = read_ref_var_list_concrete(code, op, 2, ctx);
 
-    let (
-        mut callee_regs_r,
-        mut callee_regs_i,
-        mut callee_regs_f,
-        mut callee_concrete_r,
-        mut callee_concrete_i,
-    ) = allocate_callee_register_banks(&sub_body, ctx.trace_ctx);
-
-    if args.len() > sub_body.num_regs_r {
-        return Err(DispatchError::InlineCallArityMismatch {
-            pc: op.pc,
-            provided: args.len(),
-            callee_num_regs_r: sub_body.num_regs_r,
-        });
-    }
-    for (i, arg) in args.iter().enumerate() {
-        callee_regs_r[i] = *arg;
-    }
-    for (i, concrete) in arg_concretes.iter().enumerate() {
-        callee_concrete_r[i] = *concrete;
-    }
-
-    let (callee_outcome, _callee_end_pc) = {
-        let mut sub_wc = WalkContext {
-            registers_r: &mut callee_regs_r,
-            registers_i: &mut callee_regs_i,
-            registers_f: &mut callee_regs_f,
-            concrete_registers_r: &mut callee_concrete_r,
-            concrete_registers_i: &mut callee_concrete_i,
-            descr_refs: ctx.descr_refs,
-            raw_descrs: ctx.raw_descrs,
-            is_authoritative_executor: ctx.is_authoritative_executor,
-            is_full_body_walk: ctx.is_full_body_walk,
-            trace_ctx: ctx.trace_ctx,
-            done_with_this_frame_descr_ref: ctx.done_with_this_frame_descr_ref.clone(),
-            done_with_this_frame_descr_int: ctx.done_with_this_frame_descr_int.clone(),
-            done_with_this_frame_descr_float: ctx.done_with_this_frame_descr_float.clone(),
-            done_with_this_frame_descr_void: ctx.done_with_this_frame_descr_void.clone(),
-            exit_frame_with_exception_descr_ref: ctx.exit_frame_with_exception_descr_ref.clone(),
-            is_top_level: false,
-            sub_jitcode_lookup: ctx.sub_jitcode_lookup,
-            last_exc_value: None,
-            last_exc_value_concrete: ConcreteValue::Null,
-            entry_py_pc: ctx.entry_py_pc,
-            outer_jitcode_index: ctx.outer_jitcode_index,
-            outer_active_boxes: ctx.outer_active_boxes.clone(),
-            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
-            pending_guard_snapshot_error: None,
-        };
-        walk(sub_body.code, 0, &mut sub_wc)?
-    };
+    let callee_outcome = run_sub_jitcode_walk(ctx, op.pc, &sub_body, &[], &args, &arg_concretes, &[])?;
 
     match callee_outcome {
         DispatchOutcome::SubReturn {
@@ -11788,67 +11842,8 @@ fn dispatch_inline_call_dir_kind(
     let (ref_args, ref_width) = read_ref_var_list(code, op, 2 + int_width, ctx)?;
     let ref_arg_concretes = read_ref_var_list_concrete(code, op, 2 + int_width, ctx);
 
-    let (
-        mut callee_regs_r,
-        mut callee_regs_i,
-        mut callee_regs_f,
-        mut callee_concrete_r,
-        mut callee_concrete_i,
-    ) = allocate_callee_register_banks(&sub_body, ctx.trace_ctx);
-
-    if int_args.len() > sub_body.num_regs_i {
-        return Err(DispatchError::InlineCallIntArityMismatch {
-            pc: op.pc,
-            provided: int_args.len(),
-            callee_num_regs_i: sub_body.num_regs_i,
-        });
-    }
-    if ref_args.len() > sub_body.num_regs_r {
-        return Err(DispatchError::InlineCallArityMismatch {
-            pc: op.pc,
-            provided: ref_args.len(),
-            callee_num_regs_r: sub_body.num_regs_r,
-        });
-    }
-    for (i, arg) in int_args.iter().enumerate() {
-        callee_regs_i[i] = *arg;
-    }
-    for (i, arg) in ref_args.iter().enumerate() {
-        callee_regs_r[i] = *arg;
-    }
-    for (i, concrete) in ref_arg_concretes.iter().enumerate() {
-        callee_concrete_r[i] = *concrete;
-    }
-
-    let (callee_outcome, _callee_end_pc) = {
-        let mut sub_wc = WalkContext {
-            registers_r: &mut callee_regs_r,
-            registers_i: &mut callee_regs_i,
-            registers_f: &mut callee_regs_f,
-            concrete_registers_r: &mut callee_concrete_r,
-            concrete_registers_i: &mut callee_concrete_i,
-            descr_refs: ctx.descr_refs,
-            raw_descrs: ctx.raw_descrs,
-            is_authoritative_executor: ctx.is_authoritative_executor,
-            is_full_body_walk: ctx.is_full_body_walk,
-            trace_ctx: ctx.trace_ctx,
-            done_with_this_frame_descr_ref: ctx.done_with_this_frame_descr_ref.clone(),
-            done_with_this_frame_descr_int: ctx.done_with_this_frame_descr_int.clone(),
-            done_with_this_frame_descr_float: ctx.done_with_this_frame_descr_float.clone(),
-            done_with_this_frame_descr_void: ctx.done_with_this_frame_descr_void.clone(),
-            exit_frame_with_exception_descr_ref: ctx.exit_frame_with_exception_descr_ref.clone(),
-            is_top_level: false,
-            sub_jitcode_lookup: ctx.sub_jitcode_lookup,
-            last_exc_value: None,
-            last_exc_value_concrete: ConcreteValue::Null,
-            entry_py_pc: ctx.entry_py_pc,
-            outer_jitcode_index: ctx.outer_jitcode_index,
-            outer_active_boxes: ctx.outer_active_boxes.clone(),
-            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
-            pending_guard_snapshot_error: None,
-        };
-        walk(sub_body.code, 0, &mut sub_wc)?
-    };
+    let callee_outcome =
+        run_sub_jitcode_walk(ctx, op.pc, &sub_body, &int_args, &ref_args, &ref_arg_concretes, &[])?;
 
     match callee_outcome {
         DispatchOutcome::SubReturn {
@@ -11971,77 +11966,15 @@ fn dispatch_inline_call_dirf_kind(
     let ref_arg_concretes = read_ref_var_list_concrete(code, op, 2 + int_width, ctx);
     let (float_args, float_width) = read_float_var_list(code, op, 2 + int_width + ref_width, ctx)?;
 
-    let (
-        mut callee_regs_r,
-        mut callee_regs_i,
-        mut callee_regs_f,
-        mut callee_concrete_r,
-        mut callee_concrete_i,
-    ) = allocate_callee_register_banks(&sub_body, ctx.trace_ctx);
-
-    if int_args.len() > sub_body.num_regs_i {
-        return Err(DispatchError::InlineCallIntArityMismatch {
-            pc: op.pc,
-            provided: int_args.len(),
-            callee_num_regs_i: sub_body.num_regs_i,
-        });
-    }
-    if ref_args.len() > sub_body.num_regs_r {
-        return Err(DispatchError::InlineCallArityMismatch {
-            pc: op.pc,
-            provided: ref_args.len(),
-            callee_num_regs_r: sub_body.num_regs_r,
-        });
-    }
-    if float_args.len() > sub_body.num_regs_f {
-        return Err(DispatchError::InlineCallFloatArityMismatch {
-            pc: op.pc,
-            provided: float_args.len(),
-            callee_num_regs_f: sub_body.num_regs_f,
-        });
-    }
-    for (i, arg) in int_args.iter().enumerate() {
-        callee_regs_i[i] = *arg;
-    }
-    for (i, arg) in ref_args.iter().enumerate() {
-        callee_regs_r[i] = *arg;
-    }
-    for (i, arg) in float_args.iter().enumerate() {
-        callee_regs_f[i] = *arg;
-    }
-    for (i, concrete) in ref_arg_concretes.iter().enumerate() {
-        callee_concrete_r[i] = *concrete;
-    }
-
-    let (callee_outcome, _callee_end_pc) = {
-        let mut sub_wc = WalkContext {
-            registers_r: &mut callee_regs_r,
-            registers_i: &mut callee_regs_i,
-            registers_f: &mut callee_regs_f,
-            concrete_registers_r: &mut callee_concrete_r,
-            concrete_registers_i: &mut callee_concrete_i,
-            descr_refs: ctx.descr_refs,
-            raw_descrs: ctx.raw_descrs,
-            is_authoritative_executor: ctx.is_authoritative_executor,
-            is_full_body_walk: ctx.is_full_body_walk,
-            trace_ctx: ctx.trace_ctx,
-            done_with_this_frame_descr_ref: ctx.done_with_this_frame_descr_ref.clone(),
-            done_with_this_frame_descr_int: ctx.done_with_this_frame_descr_int.clone(),
-            done_with_this_frame_descr_float: ctx.done_with_this_frame_descr_float.clone(),
-            done_with_this_frame_descr_void: ctx.done_with_this_frame_descr_void.clone(),
-            exit_frame_with_exception_descr_ref: ctx.exit_frame_with_exception_descr_ref.clone(),
-            is_top_level: false,
-            sub_jitcode_lookup: ctx.sub_jitcode_lookup,
-            last_exc_value: None,
-            last_exc_value_concrete: ConcreteValue::Null,
-            entry_py_pc: ctx.entry_py_pc,
-            outer_jitcode_index: ctx.outer_jitcode_index,
-            outer_active_boxes: ctx.outer_active_boxes.clone(),
-            store_subscr_fn_addr: ctx.store_subscr_fn_addr,
-            pending_guard_snapshot_error: None,
-        };
-        walk(sub_body.code, 0, &mut sub_wc)?
-    };
+    let callee_outcome = run_sub_jitcode_walk(
+        ctx,
+        op.pc,
+        &sub_body,
+        &int_args,
+        &ref_args,
+        &ref_arg_concretes,
+        &float_args,
+    )?;
 
     match callee_outcome {
         DispatchOutcome::SubReturn {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14763,10 +14763,11 @@ mod tests {
             "post-grow list must have spare capacity for the in-place append"
         );
 
-        // Rollback path: eager append + journal push, then a non-commit
-        // exit rewinds the length.
-        unsafe { w_list_append(list, w_int_new(50)) };
+        // Rollback path: journal push + eager append (production order, see
+        // try_walker_specialize_list_append), then a non-commit exit rewinds
+        // the length.
         super::fbw_append_journal_push(list, len_before);
+        unsafe { w_list_append(list, w_int_new(50)) };
         assert_eq!(unsafe { w_list_len(list) }, 5);
         super::fbw_store_journal_rollback();
         assert_eq!(
@@ -14776,8 +14777,8 @@ mod tests {
         );
 
         // Commit path: the eager append stands; the log is dropped.
-        unsafe { w_list_append(list, w_int_new(60)) };
         super::fbw_append_journal_push(list, len_before);
+        unsafe { w_list_append(list, w_int_new(60)) };
         super::fbw_store_journal_commit();
         assert_eq!(
             unsafe { w_list_len(list) },

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5978,9 +5978,8 @@ pub(crate) fn fbw_store_journal_push(
 /// length rewind when the walk does not commit its end state.  `list` must
 /// be an Integer-strategy list whose backing array had spare capacity (the
 /// append's gate), so the rewind is allocation-free.
-// Consumed by the #171 P3 `list.append` specialization arm (next slice);
-// exercised now by `append_journal_rollback_rewinds_length`.
-#[allow(dead_code)]
+// Consumed by the #171 P3 `list.append` specialization arm
+// (`try_walker_specialize_list_append`).
 pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_before: usize) {
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
 }
@@ -9009,6 +9008,26 @@ fn dispatch_residual_call_iRd_kind(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // #171 P3: specialize `lst.append(x)` so its array ops reach the trace,
+    // replacing the opaque `bh_call_fn` residual (walker-native fold; see
+    // `try_walker_specialize_list_append`).  The call arrives as `CallFn` with
+    // `dst_bank == 'r'` (the None result is a Ref, not void) and
+    // `r_args = [bound-method, PY_NULL, value]`.  Gated behind
+    // PYRE_171_INLINE_LIST (default OFF) until the de-spec guard-failure bridge
+    // resume is fixed (#143 method-call CALL bridge); falls through to the
+    // residual for any non-matching shape (SAFE).  The eager append rides
+    // `FBW_APPEND_JOURNAL`, whose commit/rollback epilogues run on FBW walk
+    // ends (same lifecycle as the STORE_SUBSCR store journal).
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && pyre_171_inline_list_enabled()
+        && try_walker_specialize_list_append(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // pyjitpl.py:2063 forces-branch sub-case: when the descr's
     // `call_release_gil_target` is a non-NULL `(realfuncaddr, saveerr)`
     // pair, route through `direct_call_release_gil` which records
@@ -10628,6 +10647,272 @@ fn try_walker_specialize_subscr(
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
     );
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// Env gate for the #171 P3 `list.append` charon-body inline arm.  Default
+/// OFF until the arm is validated on every backend; `PYRE_171_INLINE_LIST=1`
+/// opts in.
+fn pyre_171_inline_list_enabled() -> bool {
+    std::env::var("PYRE_171_INLINE_LIST").as_deref() == Ok("1")
+}
+
+/// #171 P3: specialize `lst.append(x)` so its array ops (getfield length /
+/// capacity guard / setarrayitem / setfield length+1) reach the trace,
+/// replacing the opaque `bh_call_fn` residual that hides them.  Emits the IR
+/// walker-native — the `generated_list_append_by_strategy` int-storage fold
+/// (codegen.rs), hand-rolled against the walker register banks.
+///
+/// (Descending the canonical `w_list_append` body — the single-source
+/// alternative — is blocked: that body's prologue residuals call low-level
+/// strategy/storage helpers whose addresses are absent from
+/// `jit_trace_fnaddrs()`, so they stay symbolic `stable_symbolic_fnaddr`
+/// hashes and the executor declines them at the `>>47` guard, leaving the
+/// strategy switch non-concrete.  Registering + GC-safety-proving those
+/// helpers is a separate infra epic.)
+///
+/// Shape (confirmed empirically + cross-verified): the walker sees the call
+/// as `pyre_helper == CallFn`, `dst_bank == 'r'`, `r_args = [bound-method,
+/// PY_NULL, value]` (arity 3 — `bh_call_fn(callable, null_or_self, arg0)`).
+/// The Python result is `None` (a Ref, not void), so a None const is written
+/// to `dst` for the trailing `POP_TOP` to discard.
+///
+/// Gates to the Integer-storage / plain-`W_IntObject` / spare-capacity path
+/// (the no-realloc fast path).  Like [`try_walker_specialize_store_subscr`],
+/// the fold records the append IR but does NOT mutate the concrete list; this
+/// applies the append itself and journals the length rewind
+/// (`fbw_append_journal_push`) so a non-commit walk's legacy replay re-appends
+/// against the pre-walk heap.  Any non-matching shape declines (`Ok(None)`)
+/// BEFORE emitting IR, leaving the generic residual fallback intact (SAFE).
+fn try_walker_specialize_list_append(
+    ctx: &mut WalkContext<'_, '_>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    // r_args = [callable(bound method), null_or_self(PY_NULL), value].
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (
+        ConcreteValue::Ref(callable),
+        ConcreteValue::Ref(null_or_self),
+        ConcreteValue::Ref(value),
+    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    else {
+        return Ok(None);
+    };
+    // Plain bound-call shape only: callable + value present, null_or_self the
+    // PY_NULL sentinel.  A non-null `null_or_self` is a receiver
+    // `bh_call_fn_impl` prepends as arg0 — not the `lst.append(x)` shape.
+    if callable.is_null() || !null_or_self.is_null() || value.is_null() {
+        return Ok(None);
+    }
+
+    // Recognize the bound builtin `list.append` + Integer-storage list +
+    // plain-int value + spare capacity.  Mirrors the trait recognition
+    // (`trace_opcode.rs` is_method / canonical_list_method("append")).
+    let (inner_func, inner_self, len_before, is_inline, elem) = unsafe {
+        if !pyre_object::methodobject::is_method(callable) {
+            return Ok(None);
+        }
+        let inner_func = pyre_object::methodobject::w_method_get_func(callable);
+        let inner_self = pyre_object::methodobject::w_method_get_self(callable);
+        if inner_func.is_null() || inner_self.is_null() {
+            return Ok(None);
+        }
+        // Canonical-identity check: a list subclass overriding `append`, or a
+        // same-named method on another type, declines (its func differs).
+        let list_type =
+            pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE);
+        if pyre_interpreter::lookup_in_type(list_type, "append") != Some(inner_func) {
+            return Ok(None);
+        }
+        // Int storage + plain `W_IntObject` value + spare capacity.  `is_plain_int1`
+        // also admits a fits-int `W_LongObject`, but the fold unboxes through a
+        // plain `INT_TYPE` guard, so exclude `long` here (the `unbox_long` arm is
+        // a follow-up); a long value falls to the generic residual.
+        if !pyre_object::pyobject::is_list(inner_self)
+            || !pyre_object::w_list_uses_int_storage(inner_self)
+            || !pyre_object::is_plain_int1(value)
+            || pyre_object::pyobject::is_long(value)
+            || !pyre_object::w_list_can_append_without_realloc(inner_self)
+        {
+            return Ok(None);
+        }
+        (
+            inner_func,
+            inner_self,
+            pyre_object::w_list_len(inner_self),
+            pyre_object::w_list_is_inline_storage(inner_self),
+            pyre_object::w_int_get_value(value),
+        )
+    };
+
+    // --- commit to the specialization: emit IR (no further declines) ---
+    let callable_op = r_args[0];
+    let value_op = r_args[2];
+
+    // Pin the callable: guard_class METHOD, then guard_value on the stable
+    // `w_function` slot.  The bound method is freshly allocated each
+    // iteration but its function pointer is stable, so the receiver alone
+    // cannot tie the trace to `list.append` — guard the function.
+    let method_type_addr = &pyre_object::methodobject::METHOD_TYPE as *const _ as i64;
+    if !callable_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(callable_op) {
+        let type_const = ctx.trace_ctx.const_int(method_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[callable_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(callable_op, method_type_addr);
+
+    let func_ref = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        callable_op,
+        crate::descr::method_w_function_descr(),
+    );
+    let func_const = ctx.trace_ctx.const_ref(inner_func as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[func_ref, func_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(func_ref, func_const);
+
+    // Recover the receiver list OpRef from the method object for the fold.
+    let self_ref = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        callable_op,
+        crate::descr::method_w_self_descr(),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        self_ref,
+        majit_ir::Value::Ref(majit_ir::GcRef(inner_self as usize)),
+    );
+
+    // --- emit the int-storage append fold (walker-native) ---
+    // Mirrors `generated_list_append_by_strategy` (strategy_id=1), hand-rolled
+    // against the walker register banks with the real `op.pc` resume
+    // coordinate.  (The `WalkerFrameOps` trait impl captures snapshots at pc
+    // 0 — valid only for the per-opcode arm path, not this full-body walk —
+    // and `generated_list_append_by_strategy` is `MIFrame`-bound, so neither
+    // is reusable here.)  No charon-body descent: that body's prologue
+    // residuals call low-level strategy/storage helpers whose addresses are
+    // absent from `jit_trace_fnaddrs()`, so they stay symbolic and the
+    // executor declines them — the trace leg uses this fold; the
+    // runtime/blackhole leg still runs the canonical `w_list_append` body.
+
+    // guard_class LIST (skip when the class is already known / operand const).
+    let list_type_addr = &pyre_object::pyobject::LIST_TYPE as *const _ as i64;
+    if !self_ref.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(self_ref) {
+        let type_const = ctx.trace_ctx.const_int(list_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[self_ref, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(self_ref, list_type_addr);
+
+    // guard_value(strategy == Integer): getfield strategy + GuardValue.
+    let strategy = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        self_ref,
+        crate::descr::list_strategy_descr(),
+    );
+    let sid_const = ctx.trace_ctx.const_int(1);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[strategy, sid_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(strategy, sid_const);
+
+    // length read (int_items.len), stamped to the concrete pre-append length
+    // so the `IntLt` capacity guard and `IntAdd` length update fold.
+    let len = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        self_ref,
+        crate::descr::list_int_items_len_descr(),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(len, majit_ir::Value::Int(len_before as i64));
+
+    // Spare-capacity guard (`_ll_list_resize_ge` fast case, rlist.py:285):
+    // append inlines only while `len < capacity`.  On guard failure the
+    // resume at `op.pc` re-executes the method CALL — the real, resizing
+    // append performed generically.
+    let heap_cap = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        self_ref,
+        crate::descr::list_int_items_heap_cap_descr(),
+    );
+    let capacity = if is_inline {
+        // Inline arrays encode capacity as `heap_cap == 0`; guard that shape,
+        // then use the compile-time inline-capacity constant.
+        let zero_const = ctx.trace_ctx.const_int(0);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[heap_cap, zero_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(heap_cap, zero_const);
+        ctx.trace_ctx
+            .const_int(pyre_object::INT_ARRAY_INLINE_CAP as i64)
+    } else {
+        // Heap storage: `heap_cap > 0` is the backing-array capacity.
+        let zero = ctx.trace_ctx.const_int(0);
+        let heap_storage = ctx.trace_ctx.record_op(OpCode::IntGt, &[heap_cap, zero]);
+        ctx.trace_ctx
+            .set_opref_concrete(heap_storage, majit_ir::Value::Int(1));
+        walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardTrue, &[heap_storage])?;
+        heap_cap
+    };
+    let has_room = ctx.trace_ctx.record_op(OpCode::IntLt, &[len, capacity]);
+    ctx.trace_ctx
+        .set_opref_concrete(has_room, majit_ir::Value::Int(1));
+    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardTrue, &[has_room])?;
+
+    // Write the value: `items_ptr[len] = unbox(value)`, then `len += 1`.
+    let items_ptr = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        self_ref,
+        crate::descr::list_int_items_ptr_descr(),
+    );
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    let raw = walker_unbox_int(ctx, op.pc, value_op, int_type_addr)?;
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Int(elem));
+    crate::state::trace_raw_int_array_setitem_value(ctx.trace_ctx, items_ptr, len, raw);
+
+    let one = ctx.trace_ctx.const_int(1);
+    let new_len = ctx.trace_ctx.record_op(OpCode::IntAdd, &[len, one]);
+    ctx.trace_ctx
+        .set_opref_concrete(new_len, majit_ir::Value::Int(len_before as i64 + 1));
+    let len_descr = crate::descr::list_int_items_len_descr();
+    let len_descr_idx = len_descr.index();
+    ctx.trace_ctx
+        .record_op_with_descr(OpCode::SetfieldGc, &[self_ref, new_len], len_descr);
+    ctx.trace_ctx
+        .heapcache_setfield_cached(self_ref, len_descr_idx, new_len);
+
+    // Tracing is execution (pyjitpl.py:2095): apply the append to the
+    // concrete list now (the fold recorded the IR but did not mutate) and
+    // journal the length rewind for a non-commit walk.  The int-spare append
+    // allocates nothing (no realloc by the gate, raw int store), so no GC can
+    // move the operands between recognition and here — `inner_self` / `value`
+    // stay valid, no shadow re-read needed.
+    fbw_append_journal_push(inner_self, len_before);
+    unsafe { pyre_object::w_list_append(inner_self, value) };
+
+    // The Python result is None (a Ref); write it to the 'r' dst so the
+    // trailing POP_TOP has a slot to discard.
+    let none_ref = ctx.trace_ctx.const_ref(pyre_object::w_none() as i64);
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', none_ref)?;
     Ok(Some(()))
 }
 
@@ -14402,11 +14687,12 @@ mod tests {
 
     #[test]
     fn sub_jitcode_body_by_index_builds_w_list_append() {
-        // #171 P3 (Route C): the lst.append recognition arm descends into
-        // the charon `w_list_append` body via a by-index SubJitCodeBody.
-        // Confirm the shared builder resolves it to a well-formed body —
+        // The shared by-index `SubJitCodeBody` builder must resolve a
+        // build-time charon body (`w_list_append`) to a well-formed body —
         // non-empty bytecode and >= 2 ref registers for the (list, value)
-        // seed (calldescr arg_classes 'rr').
+        // params (calldescr arg_classes 'rr').  (Foundation for the deferred
+        // Route C single-source descent; the shipping `lst.append` arm folds
+        // walker-native instead — see `try_walker_specialize_list_append`.)
         let idx = crate::jitcode_runtime::list_append_jitcode()
             .expect("w_list_append must be present in ALL_JITCODES")
             .index();
@@ -14427,13 +14713,12 @@ mod tests {
 
     #[test]
     fn append_journal_rollback_rewinds_length() {
-        // #171 P3 (Route C) "hard part" infra: a walked eager `list.append`
-        // grows the concrete list at trace time (no residual to execute via
-        // the executor — the charon body is inlined), so a NON-commit walk
-        // must rewind the length, exactly like the STORE_SUBSCR store
-        // journal restores its displaced element.  Spare-capacity gating
-        // (`w_list_can_append_without_realloc`) makes the rewind a pure
-        // length set with no reallocation to undo.
+        // #171 P3 journal infra: a walked eager `list.append` grows the
+        // concrete list at trace time (the fold records the array-op IR but
+        // does not mutate), so a NON-commit walk must rewind the length,
+        // exactly like the STORE_SUBSCR store journal restores its displaced
+        // element.  Spare-capacity gating (`w_list_can_append_without_realloc`)
+        // makes the rewind a pure length set with no reallocation to undo.
         use pyre_object::listobject::{w_list_can_append_without_realloc, w_list_len};
         use pyre_object::{w_int_new, w_list_append};
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9018,8 +9018,18 @@ fn dispatch_residual_call_iRd_kind(
     // residual for any non-matching shape (SAFE).  The eager append rides
     // `FBW_APPEND_JOURNAL`, whose commit/rollback epilogues run on FBW walk
     // ends (same lifecycle as the STORE_SUBSCR store journal).
+    //
+    // Restrict to the top full-body frame: inside an inlined callee sub-walk
+    // (`INLINE_SUBWALK_CAPTURE_BOUNDARY`) the fold's gating guards collapse
+    // their resume to the caller's CALL boundary (`entry_py_pc` /
+    // `outer_active_boxes`), which re-executes the whole caller iteration on a
+    // guard failure — doubling any caller side effect sequenced before the
+    // inlined call (e.g. a `STORE_ATTR` ahead of an inlined `push(lst, x)`).
+    // An inlined append falls back to the generic residual, which resumes
+    // *past* the call (after_residual_call) and so re-runs nothing extra.
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
+        && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && pyre_171_inline_list_enabled()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5934,6 +5934,19 @@ thread_local! {
     static FBW_STORE_JOURNAL: std::cell::RefCell<Vec<[pyre_object::PyObjectRef; 3]>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
+    /// Undo log for the walked region's eagerly executed list APPENDS:
+    /// `(list, length_before_append)` pairs pushed by the `list.append`
+    /// specialization before it grows the list.  Same rationale as
+    /// [`FBW_STORE_JOURNAL`] — the append is admitted only when
+    /// `w_list_can_append_without_realloc` holds, so the undo is a pure
+    /// length rewind (`w_list_int_set_len`, no reallocation, no boxing) and
+    /// the backing array still has the slot.  A committing walk drops the
+    /// log; a non-commit walk rewinds each list's length in reverse push
+    /// order so the legacy replay re-appends against the pre-walk heap.
+    /// Entries' list refs are GC roots via [`fbw_store_journal_root_walker`].
+    static FBW_APPEND_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+
     /// Set when the walk records a side effect that was neither executed
     /// at walk time nor undo-logged: a void residual call recorded
     /// symbolically (the `try_execute_residual_call_via_executor` void
@@ -5947,6 +5960,7 @@ thread_local! {
 /// begins (mirrors [`bool_box_truth_reset`]).
 pub(crate) fn fbw_store_journal_reset() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(false));
 }
 
@@ -5960,9 +5974,22 @@ pub(crate) fn fbw_store_journal_push(
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().push([list, key, displaced]));
 }
 
-/// Commit-path epilogue: the walk's eager stores stand; drop the undo log.
+/// Record the live length a walked eager list append grew past, for the
+/// length rewind when the walk does not commit its end state.  `list` must
+/// be an Integer-strategy list whose backing array had spare capacity (the
+/// append's gate), so the rewind is allocation-free.
+// Consumed by the #171 P3 `list.append` specialization arm (next slice);
+// exercised now by `append_journal_rollback_rewinds_length`.
+#[allow(dead_code)]
+pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_before: usize) {
+    FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
+}
+
+/// Commit-path epilogue: the walk's eager stores and appends stand; drop
+/// the undo logs.
 pub(crate) fn fbw_store_journal_commit() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
 }
 
 /// Non-commit epilogue: restore each displaced element in reverse push
@@ -5970,6 +5997,11 @@ pub(crate) fn fbw_store_journal_commit() {
 /// `w_list_setitem` allocates nothing on the restore (the displaced value
 /// is already boxed and strategy-matching), so entries cannot move
 /// mid-rollback.
+///
+/// Stores are restored BEFORE appends are rewound: a store's key was
+/// in-bounds at store time and stays in-bounds at the walk's final
+/// (max) length, so every restore lands while the list is still grown;
+/// shrinking first could push a restore index past the length and drop it.
 pub(crate) fn fbw_store_journal_rollback() {
     FBW_STORE_JOURNAL.with(|j| {
         let mut entries = j.borrow_mut();
@@ -5987,6 +6019,14 @@ pub(crate) fn fbw_store_journal_rollback() {
                     eprintln!("[fbw-store-journal] rollback failed (index out of bounds)");
                 }
             }
+        }
+    });
+    // Rewind each eager append's length in reverse push order
+    // (`w_list_int_set_len`, allocation-free).
+    FBW_APPEND_JOURNAL.with(|j| {
+        let mut entries = j.borrow_mut();
+        while let Some((list, length_before)) = entries.pop() {
+            unsafe { pyre_object::listobject::w_list_int_set_len(list, length_before) };
         }
     });
 }
@@ -6007,10 +6047,10 @@ pub(crate) fn fbw_has_unjournaled_effect() -> bool {
     FBW_UNJOURNALED_EFFECT.with(|c| c.get())
 }
 
-/// `framework.py root_walker.walk_roots` parity for the store journal:
-/// the triples hold nursery-resident refs across the rest of the walk
-/// (residual calls allocate, and a minor collection moves nursery
-/// objects), so every slot is forwarded as a root.  Registered once via
+/// `framework.py root_walker.walk_roots` parity for the store and append
+/// journals: the entries hold nursery-resident refs across the rest of the
+/// walk (residual calls allocate, and a minor collection moves nursery
+/// objects), so every ref slot is forwarded as a root.  Registered once via
 /// `majit_gc::shadow_stack::register_extra_root_walker` at JIT init.
 pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     FBW_STORE_JOURNAL.with(|j| {
@@ -6021,6 +6061,13 @@ pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRe
                 // the Vec storage alive for the visit.
                 visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
             }
+        }
+    });
+    FBW_APPEND_JOURNAL.with(|j| {
+        for (list, _len) in j.borrow_mut().iter_mut() {
+            // SAFETY: as above — only the `PyObjectRef` slot is a root; the
+            // `usize` length is a plain scalar.
+            visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
         }
     });
 }
@@ -14376,6 +14423,63 @@ mod tests {
         );
         // Out-of-range index resolves to None (RPython: ALL_JITCODES miss).
         assert!(super::sub_jitcode_body_by_index(usize::MAX).is_none());
+    }
+
+    #[test]
+    fn append_journal_rollback_rewinds_length() {
+        // #171 P3 (Route C) "hard part" infra: a walked eager `list.append`
+        // grows the concrete list at trace time (no residual to execute via
+        // the executor — the charon body is inlined), so a NON-commit walk
+        // must rewind the length, exactly like the STORE_SUBSCR store
+        // journal restores its displaced element.  Spare-capacity gating
+        // (`w_list_can_append_without_realloc`) makes the rewind a pure
+        // length set with no reallocation to undo.
+        use pyre_object::listobject::{w_list_can_append_without_realloc, w_list_len};
+        use pyre_object::{w_int_new, w_list_append};
+
+        super::fbw_store_journal_reset();
+
+        let list = pyre_object::listobject::w_list_new(vec![
+            w_int_new(10),
+            w_int_new(20),
+            w_int_new(30),
+        ]);
+        // A first append forces the backing array to grow with a growth
+        // factor, leaving spare capacity so the *next* append is in-place
+        // (the only shape the arm specializes).
+        unsafe { w_list_append(list, w_int_new(40)) };
+        let len_before = unsafe { w_list_len(list) };
+        assert_eq!(len_before, 4);
+        assert!(
+            unsafe { w_list_can_append_without_realloc(list) },
+            "post-grow list must have spare capacity for the in-place append"
+        );
+
+        // Rollback path: eager append + journal push, then a non-commit
+        // exit rewinds the length.
+        unsafe { w_list_append(list, w_int_new(50)) };
+        super::fbw_append_journal_push(list, len_before);
+        assert_eq!(unsafe { w_list_len(list) }, 5);
+        super::fbw_store_journal_rollback();
+        assert_eq!(
+            unsafe { w_list_len(list) },
+            len_before,
+            "non-commit walk must rewind the eager append's length"
+        );
+
+        // Commit path: the eager append stands; the log is dropped.
+        unsafe { w_list_append(list, w_int_new(60)) };
+        super::fbw_append_journal_push(list, len_before);
+        super::fbw_store_journal_commit();
+        assert_eq!(
+            unsafe { w_list_len(list) },
+            len_before + 1,
+            "committed walk keeps the eager append"
+        );
+        // A subsequent rollback with the log already committed-empty is a
+        // no-op (does not shrink further).
+        super::fbw_store_journal_rollback();
+        assert_eq!(unsafe { w_list_len(list) }, len_before + 1);
     }
 
     /// Tests use the production `PyreJitCodeDescr` adapter

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1077,13 +1077,14 @@ mod tests {
 
     #[test]
     fn list_append_jitcode_resolves_charon_body() {
-        // #171 P3 foundation (issue #62/#23): the orthodox charon
-        // `w_list_append` body must be present and reachable by name in
-        // the build-time pipeline so the FBW walker can descend into it.
+        // #171 P3 foundation (deferred Route C): the orthodox charon
+        // `w_list_append` body is present and reachable by name in the
+        // build-time pipeline (the single-source descent the FBW walker would
+        // enter once the prologue strategy-helper fnaddrs are registered).
         // Confirm the by-name resolver finds it and that the body carries
         // real bytecode (not an empty shell) — i.e. the function graph was
         // assembled, carrying the array-op sequence the `list.int_*`
-        // oopspecs lower to.
+        // oopspecs lower to.  (The shipping arm folds walker-native instead.)
         let jc = list_append_jitcode()
             .expect("build-time pipeline must contain the charon `w_list_append` jitcode");
         assert_eq!(jc.name, "w_list_append");

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -186,6 +186,63 @@ pub fn portal_jitcode() -> Option<Arc<JitCode>> {
     get_jitcode_by_index(idx)
 }
 
+// Cached index of the charon-extracted `w_list_append` body within
+// `ALL_JITCODES`.
+//
+// Unlike the portal (resolved by its `jitdriver_sd` flag) or opcode arms
+// (resolved by `entry_jitcode_index`), the list-op helper bodies carry
+// no runtime marker — they are ordinary `make_jitcodes` function entries
+// whose only stable handle is their `name`, which `get_jitcode` sets to
+// the graph's last path segment (call.rs:3071). The positional index
+// shifts whenever the jitcode set changes, so it must be resolved by
+// name and never hardcoded.
+//
+// This by-name lookup is the foundation #171 P3 needs to descend the FBW
+// walker into the orthodox charon list-append body (issue #62/#23): the
+// dynamic `lst.append` recognition arm resolves the body here, then
+// builds a by-index sub-walk from `get_jitcode_by_index`.
+thread_local! {
+    /// Cached `ALL_JITCODES` index of `w_list_append` for the current
+    /// thread. `thread_local!` because the initializer iterates
+    /// `ALL_JITCODES` (also thread_local).
+    static LIST_APPEND_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
+}
+
+/// Scan `ALL_JITCODES` for the unique entry whose `name` equals `name`.
+///
+/// Returns `None` when no entry matches (e.g. compact test inputs that
+/// omit the helper). Panics on a duplicate leaf name — the by-name
+/// resolution model assumes the charon helper's path-last-segment name
+/// is unique within the pipeline, so a collision signals a structural
+/// regression that must surface immediately rather than silently pick
+/// the wrong body.
+fn compute_named_jitcode_index(name: &str) -> Option<usize> {
+    let all = all_jitcodes();
+    let mut hits = all
+        .iter()
+        .enumerate()
+        .filter(|(_, jc)| jc.name == name)
+        .map(|(i, _)| i);
+    let first = hits.next();
+    if hits.next().is_some() {
+        panic!(
+            "pyre-jit-trace: build-time pipeline has more than one jitcode \
+             named `{name}`; the list-op by-name resolver assumes the \
+             charon helper leaf name is unique"
+        );
+    }
+    first
+}
+
+/// The charon `w_list_append` body in `ALL_JITCODES`, resolved by name
+/// and cached per thread. `None` if the helper is absent from the
+/// build-time pipeline. See `LIST_APPEND_JITCODE_INDEX`.
+pub fn list_append_jitcode() -> Option<Arc<JitCode>> {
+    let idx = LIST_APPEND_JITCODE_INDEX
+        .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_append")))?;
+    get_jitcode_by_index(idx)
+}
+
 /// RPython: opcode dispatch arm table (analogue of PyPy's per-opcode
 /// Python methods). One `PipelineOpcodeArm` per Rust `match` arm.
 pub fn all_opcode_arms() -> &'static [PipelineOpcodeArm] {
@@ -1015,6 +1072,24 @@ mod tests {
         assert_eq!(
             jitdriver_count, 1,
             "RPython call.py:147 invariant: exactly one portal jitcode per JitDriverStaticData"
+        );
+    }
+
+    #[test]
+    fn list_append_jitcode_resolves_charon_body() {
+        // #171 P3 foundation (issue #62/#23): the orthodox charon
+        // `w_list_append` body must be present and reachable by name in
+        // the build-time pipeline so the FBW walker can descend into it.
+        // Confirm the by-name resolver finds it and that the body carries
+        // real bytecode (not an empty shell) — i.e. the function graph was
+        // assembled, carrying the array-op sequence the `list.int_*`
+        // oopspecs lower to.
+        let jc = list_append_jitcode()
+            .expect("build-time pipeline must contain the charon `w_list_append` jitcode");
+        assert_eq!(jc.name, "w_list_append");
+        assert!(
+            !jc.code.is_empty(),
+            "w_list_append jitcode should have non-empty bytecode (assembled body)"
         );
     }
 

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -634,8 +634,30 @@ fn stack_effects(
         | Instruction::GetIter
         | Instruction::GetYieldFromIter
         | Instruction::GetAiter
-        | Instruction::LoadAttr { .. }
         | Instruction::GetAwaitable { .. } => (d, d),
+        // LOAD_ATTR pushes 1 (attr) for the plain form, or 2 (attr,
+        // self_or_null) for the method form — mirror of `execute_load_attr`
+        // `attr.is_method()` → `load_method` (which pushes `[attr, NULL]`).
+        // Without the method-form +1, `depth_at_py_pc` at a following
+        // method-call CALL undercounts the `null_or_self` slot, so a guard
+        // that resumes AT the CALL pc to re-execute it (the list-append fold)
+        // rebuilds the operand stack one slot short.  Mirrors the
+        // `LoadGlobal` / `LoadSuperAttr` method-form handling above.
+        Instruction::LoadAttr { namei } => {
+            if namei.get(op_arg).is_method() {
+                (d + 1, d + 1)
+            } else {
+                (d, d)
+            }
+        }
+        // LOAD_SPECIAL pops the object and pushes [attr, self_or_null]
+        // (net +1) — `execute_load_special` always routes through
+        // `load_method`, so it has no plain form.  Same depth-undercount
+        // class as the method-form LOAD_ATTR above (a guard resuming inside
+        // the `[LoadSpecial .. consuming CALL]` window — e.g. a `with` block's
+        // `__enter__` / `__exit__` call — would otherwise rebuild the operand
+        // stack one slot short).
+        Instruction::LoadSpecial { .. } => (d + 1, d + 1),
         // Push 1 onto TOS without popping (net +1)
         Instruction::GetLen
         | Instruction::MatchMapping

--- a/pyre/pyre-jit-trace/src/shadow_walker.rs
+++ b/pyre/pyre-jit-trace/src/shadow_walker.rs
@@ -252,23 +252,8 @@ pub fn shadow_validate_pre(
     };
 
     // Production sub-jitcode lookup over the shared
-    // `crate::jitcode_runtime::all_jitcodes()` table — same shape as
-    // `jitcode_dispatch::tests::production_sub_jitcodes`. The Arc<JitCode>
-    // entries live inside a `LazyLock<Vec<...>>`, so the `.code` slice
-    // is `'static`-rooted as `SubJitCodeBody` requires.
-    let sub_jitcode_lookup = |idx: usize| -> Option<crate::jitcode_dispatch::SubJitCodeBody> {
-        let all = crate::jitcode_runtime::all_jitcodes();
-        all.get(idx)
-            .map(|jc| crate::jitcode_dispatch::SubJitCodeBody {
-                code: jc.code.as_slice(),
-                num_regs_r: jc.num_regs_r() as usize,
-                num_regs_i: jc.num_regs_i() as usize,
-                num_regs_f: jc.num_regs_f() as usize,
-                constants_i: jc.constants_i.as_slice(),
-                constants_r: jc.constants_r.as_slice(),
-                constants_f: jc.constants_f.as_slice(),
-            })
-    };
+    // `crate::jitcode_runtime::all_jitcodes()` table.
+    let sub_jitcode_lookup = crate::jitcode_dispatch::sub_jitcode_body_by_index;
 
     // Walker emits ops directly into `miframe.ctx`. We only catch errors
     // here; the recorded ops are what `diff_recorded_ops` later

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -638,6 +638,26 @@ fn resolve_field_offset(owner: &str, field_name: &str) -> usize {
         "next_instr" | "f_lasti" | "last_instr" => std::mem::offset_of!(PyFrame, last_instr),
         "namespace" | "w_globals" => std::mem::offset_of!(PyFrame, w_globals_obj),
         "vable_token" => std::mem::offset_of!(PyFrame, vable_token),
+        // #171 codewriter descr-bridge (blackhole side): the dotted nested
+        // `int_items.{len,heap_cap,block}` leaves `_handle_list_call`
+        // emits resolve to offset 0 in the codewriter assembler because
+        // `W_ListObject` is a runtime Rust type absent from its struct
+        // layouts. Resolve them to the real `IntArray` offsets so a
+        // blackholed codewriter list body addresses the typed storage, not
+        // the list header (mirrors the JIT-side bridge in
+        // `pyre-jit-trace/descr.rs make_descr_from_bh`).
+        "int_items.len" => {
+            std::mem::offset_of!(pyre_object::W_ListObject, int_items)
+                + pyre_object::INT_ARRAY_LEN_OFFSET
+        }
+        "int_items.heap_cap" => {
+            std::mem::offset_of!(pyre_object::W_ListObject, int_items)
+                + pyre_object::INT_ARRAY_HEAP_CAP_OFFSET
+        }
+        "int_items.block" => {
+            std::mem::offset_of!(pyre_object::W_ListObject, int_items)
+                + pyre_object::INT_ARRAY_BLOCK_OFFSET
+        }
         _ => {
             if majit_metainterp::majit_log_enabled() {
                 eprintln!(

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3778,6 +3778,10 @@ fn register_helper_fn_pointers(
         cpu.unpack_sequence_fn as *const (),
         CallFlavor::MayForce,
     );
+    // `bh_unpack_item_fn` only ever indexes the validated tuple that
+    // `bh_unpack_sequence_fn` returned (a real `W_TupleObject`), so
+    // `sequence_getitem` takes the tuple fast path and never re-enters
+    // Python: can raise, no virtual-force → `CallFlavor::Plain`.
     let unpack_item_fn = bind(
         assembler,
         cpu.unpack_item_fn as *const (),

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -69,6 +69,23 @@ impl IntArray {
         self.capacity().saturating_sub(self.len)
     }
 
+    /// Allocated capacity (block header). The no-resize append fast path
+    /// guards `len < heap_capacity()` before writing past the live length,
+    /// mirroring `_ll_list_resize_ge`'s `len(items) >= length + 1` check
+    /// (rlist.py:285).
+    #[inline]
+    pub fn heap_capacity(&self) -> usize {
+        self.heap_cap
+    }
+
+    /// Store the live length without touching the block. The caller must
+    /// guarantee `new_len <= heap_capacity()` (the no-resize precondition);
+    /// mirrors `_ll_list_resize_ge`'s `l.length = newsize` (rlist.py:293).
+    #[inline]
+    pub fn set_len(&mut self, new_len: usize) {
+        self.len = new_len;
+    }
+
     /// Integer list storage is always a separate block (no inline buffer).
     #[inline]
     pub fn is_inline(&self) -> bool {

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -81,8 +81,16 @@ impl IntArray {
     /// Store the live length without touching the block. The caller must
     /// guarantee `new_len <= heap_capacity()` (the no-resize precondition);
     /// mirrors `_ll_list_resize_ge`'s `l.length = newsize` (rlist.py:293).
+    /// Enforced here because this is safe/public: a `len` past the allocated
+    /// capacity would make `as_slice`/`as_mut_slice` build out-of-bounds
+    /// slices (UB).
     #[inline]
     pub fn set_len(&mut self, new_len: usize) {
+        assert!(
+            new_len <= self.heap_cap,
+            "IntArray::set_len precondition violated: new_len ({new_len}) > heap_cap ({})",
+            self.heap_cap
+        );
         self.len = new_len;
     }
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -488,6 +488,37 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
     raw as PyObjectRef
 }
 
+// Integer-strategy low-level access primitives, mirroring the rlist.py
+// oopspec leaves the JIT codewriter substitutes for clean array operations.
+// The runtime bodies below are the fallback when the call is not looked into;
+// the codewriter recognises the `#[oopspec("list.int_*")]` tag and emits
+// `GetfieldGcR(int_items.block) → GetarrayitemGcI` / `SetarrayitemGcI` /
+// `GetfieldGcI(int_items.len)` instead (see int_array.rs). The `_fast`
+// accessors take a non-negative, in-bounds `index`; the caller normalises
+// negative indices and checks the bound, as `ll_getitem`/`ll_setitem` wrap
+// `ll_getitem_fast`/`ll_setitem_fast` in rlist.py.
+
+/// `ll_length` for the Integer strategy (rlist.py:367 `'list.len(l)'`).
+#[majit_macros::oopspec("list.int_len(l)")]
+pub fn ll_list_int_length(l: &W_ListObject) -> usize {
+    l.int_items.len()
+}
+
+/// `ll_getitem_fast` for the Integer strategy (rlist.py:375
+/// `'list.getitem(l, index)'`): raw unboxed read at a known-in-bounds index.
+#[majit_macros::oopspec("list.int_getitem(l, index)")]
+pub fn ll_list_int_getitem_fast(l: &W_ListObject, index: usize) -> i64 {
+    l.int_items.as_slice()[index]
+}
+
+/// `ll_setitem_fast` for the Integer strategy (rlist.py:380
+/// `'list.setitem(l, index, item)'`): raw unboxed write at a known-in-bounds
+/// index.
+#[majit_macros::oopspec("list.int_setitem(l, index, item)")]
+pub fn ll_list_int_setitem_fast(l: &mut W_ListObject, index: usize, item: i64) {
+    l.int_items.as_mut_slice()[index] = item;
+}
+
 /// Get the item at the given index from a list.
 ///
 /// Supports negative indexing. Returns None if out of bounds.
@@ -509,13 +540,12 @@ pub unsafe fn w_list_getitem(obj: PyObjectRef, index: i64) -> Option<PyObjectRef
             Some(items[idx as usize])
         }
         ListStrategy::Integer => {
-            let items = list.int_items.as_slice();
-            let len = items.len() as i64;
+            let len = ll_list_int_length(list) as i64;
             let idx = if index < 0 { index + len } else { index };
             if idx < 0 || idx >= len {
                 return None;
             }
-            Some(w_int_new(items[idx as usize]))
+            Some(w_int_new(ll_list_int_getitem_fast(list, idx as usize)))
         }
         ListStrategy::Float => {
             let items = list.float_items.as_slice();
@@ -552,14 +582,14 @@ pub unsafe fn w_list_setitem(obj: PyObjectRef, index: i64, value: PyObjectRef) -
             true
         }
         ListStrategy::Integer => {
-            let len = list.int_items.len() as i64;
+            let len = ll_list_int_length(list) as i64;
             let idx = if index < 0 { index + len } else { index };
             if idx < 0 || idx >= len {
                 return false;
             }
             // AbstractUnwrappedStrategy.setitem (listobject.py:1737): plain_int_w (unwrap)
             if is_plain_int1(value) {
-                list.int_items[idx as usize] = plain_int_w(value);
+                ll_list_int_setitem_fast(list, idx as usize, plain_int_w(value));
                 true
             } else {
                 switch_to_object_strategy(list);
@@ -634,7 +664,7 @@ pub unsafe fn w_list_len(obj: PyObjectRef) -> usize {
         // listobject.py:1131 EmptyListStrategy.length returns 0.
         ListStrategy::Empty => 0,
         ListStrategy::Object => list.length,
-        ListStrategy::Integer => list.int_items.len(),
+        ListStrategy::Integer => ll_list_int_length(list),
         ListStrategy::Float => list.float_items.len(),
     }
 }
@@ -1227,6 +1257,36 @@ mod tests {
             let item = w_list_getitem(list, -1).unwrap();
             assert_eq!(crate::intobject::w_int_get_value(item), 3);
         }
+    }
+
+    #[test]
+    fn integer_strategy_oopspec_leaves_roundtrip() {
+        let items = vec![w_int_new(10), w_int_new(20), w_int_new(30)];
+        let list = w_list_new(items);
+        unsafe {
+            let l = &mut *(list as *mut W_ListObject);
+            assert_eq!(l.strategy, ListStrategy::Integer);
+            assert_eq!(ll_list_int_length(l), 3);
+            assert_eq!(ll_list_int_getitem_fast(l, 0), 10);
+            assert_eq!(ll_list_int_getitem_fast(l, 2), 30);
+            ll_list_int_setitem_fast(l, 1, 99);
+            assert_eq!(ll_list_int_getitem_fast(l, 1), 99);
+            // The write is observable through the public accessor.
+            let item = w_list_getitem(list, 1).unwrap();
+            assert_eq!(crate::intobject::w_int_get_value(item), 99);
+        }
+    }
+
+    #[test]
+    fn integer_strategy_oopspec_tags_present() {
+        // The `#[oopspec(...)]` attribute emits the spec string for the
+        // codewriter's `_handle_list_call` to decode (rlib/jit.py:250 parity).
+        assert_eq!(oopspec_ll_list_int_length, "list.int_len(l)");
+        assert_eq!(oopspec_ll_list_int_getitem_fast, "list.int_getitem(l, index)");
+        assert_eq!(
+            oopspec_ll_list_int_setitem_fast,
+            "list.int_setitem(l, index, item)"
+        );
     }
 
     #[test]

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1338,6 +1338,8 @@ mod tests {
             oopspec_ll_list_int_setitem_fast,
             "list.int_setitem(l, index, item)"
         );
+        assert_eq!(oopspec_ll_list_int_capacity, "list.int_capacity(l)");
+        assert_eq!(oopspec_ll_list_int_set_len, "list.int_set_len(l, n)");
     }
 
     #[test]

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1330,7 +1330,10 @@ mod tests {
         // The `#[oopspec(...)]` attribute emits the spec string for the
         // codewriter's `_handle_list_call` to decode (rlib/jit.py:250 parity).
         assert_eq!(oopspec_ll_list_int_length, "list.int_len(l)");
-        assert_eq!(oopspec_ll_list_int_getitem_fast, "list.int_getitem(l, index)");
+        assert_eq!(
+            oopspec_ll_list_int_getitem_fast,
+            "list.int_getitem(l, index)"
+        );
         assert_eq!(
             oopspec_ll_list_int_setitem_fast,
             "list.int_setitem(l, index, item)"

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -519,6 +519,22 @@ pub fn ll_list_int_setitem_fast(l: &mut W_ListObject, index: usize, item: i64) {
     l.int_items.as_mut_slice()[index] = item;
 }
 
+/// Allocated capacity for the Integer strategy. `ll_append`'s resize-ge
+/// fast case (rlist.py:285) inlines the append only while
+/// `len(items) >= length + 1`, i.e. spare capacity exists.
+#[majit_macros::oopspec("list.int_capacity(l)")]
+pub fn ll_list_int_capacity(l: &W_ListObject) -> usize {
+    l.int_items.heap_capacity()
+}
+
+/// Store the Integer-strategy live length (`_ll_list_resize_ge`'s
+/// `l.length = newsize`, rlist.py:293). The caller has already ensured
+/// the block has room, so this only bumps the length field.
+#[majit_macros::oopspec("list.int_set_len(l, n)")]
+pub fn ll_list_int_set_len(l: &mut W_ListObject, n: usize) {
+    l.int_items.set_len(n);
+}
+
 /// Get the item at the given index from a list.
 ///
 /// Supports negative indexing. Returns None if out of bounds.
@@ -635,7 +651,19 @@ pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
         }
         ListStrategy::Integer => {
             if is_plain_int1(value) {
-                list.int_items.push(plain_int_w(value));
+                // ll_append (rtyper/rlist.py:588): length = ll_length();
+                // _ll_resize_ge(length+1); ll_setitem_fast(length, item).
+                // The resize-ge fast case (rlist.py:285) inlines only while
+                // there is spare capacity; bump the length and store in
+                // place. Otherwise fall back to the resizing push.
+                let item = plain_int_w(value);
+                let length = ll_list_int_length(list);
+                if length < ll_list_int_capacity(list) {
+                    ll_list_int_set_len(list, length + 1);
+                    ll_list_int_setitem_fast(list, length, item);
+                } else {
+                    list.int_items.push(item);
+                }
             } else {
                 switch_to_object_strategy(list);
                 list.object_push(value);

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -682,6 +682,26 @@ pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
     }
 }
 
+/// Set the live length of an Integer-strategy list without reallocating
+/// or boxing — the undo of a spare-capacity append (`_ll_list_resize_ge`'s
+/// `l.length = newsize` run in reverse).  The backing array already has
+/// room (the append that this reverses was admitted by
+/// [`w_list_can_append_without_realloc`]), so this only rewinds the length
+/// field.
+///
+/// # Safety
+/// `obj` must point to a valid Integer-strategy `W_ListObject` whose
+/// backing array has capacity for at least `n` elements.
+pub unsafe fn w_list_int_set_len(obj: PyObjectRef, n: usize) {
+    let list = &mut *(obj as *mut W_ListObject);
+    debug_assert_eq!(
+        list.strategy,
+        ListStrategy::Integer,
+        "w_list_int_set_len on non-Integer strategy"
+    );
+    ll_list_int_set_len(list, n);
+}
+
 /// Get the length of a list.
 ///
 /// # Safety


### PR DESCRIPTION
#171

## Summary

Lowers Integer-strategy `list` operations to typed field/array ops in the JIT instead of opaque residual calls, and adds a walker-native trace-time `list.append(int)` fold.

**oopspec leaf accessors + codewriter lowering**
- `listobject`: add `ll_list_int_{getitem,setitem,length,capacity,set_len}` `#[oopspec]` leaves mirroring rlist.py's `ll_getitem_fast` / `ll_setitem_fast` / `ll_length`, and route the Integer arms of `w_list_getitem` / `w_list_setitem` / `w_list_len` / `w_list_append` through them.
- codewriter `_handle_list_call` (port of `jtransform.py:1762`): lower the `list.int_*` oopspecs to `getfield_gc_i(int_items.len)` / `getfield_gc_r(int_items.block) + get|setarrayitem_gc_i(block, i)` / `setfield_gc_i(int_items.len)` / `getfield_gc_i(int_items.heap_cap)` instead of an opaque residual call.
- `harvest_hints_from_llbcs`: decode the `oopspec_<NAME>: &'static str` const that `majit_macros::oopspec` emits, so Rust `#[oopspec]` tags actually reach `mark_oopspec` (previously the tagged leaves were inlined as regular graphs).
- `w_list_append`'s Integer no-resize fast path now composes these leaves (length read, spare-capacity guard per rlist.py:285, length bump per rlist.py:293, in-place store), so its jitcode body carries the array-op sequence matching `generated_list_append_by_strategy`.

**Trace-time `list.append` fold**
- `try_walker_specialize_list_append`: recognize the bound builtin `list.append` `CallFn` residual (`r_args = [bound-method, PY_NULL, value]`) on an Integer-strategy list with a plain `W_IntObject` value and spare capacity, and emit the array ops walker-native (`guard_class` METHOD + `guard_value`(func) to pin `list.append`, `guard_class` LIST + `guard_value`(strategy), length read, capacity guard, `setarrayitem_raw(items_ptr, len, unbox(value))` + `setfield` length+1) instead of the opaque `bh_call_fn` residual — eliminating the per-iteration bound-method/None box allocations. The eager append is applied concretely and rides a new `FBW_APPEND_JOURNAL` for non-commit rewind (same lifecycle as `FBW_STORE_JOURNAL`).
- Resume correctness:
  - model the method-form `LOAD_ATTR` and `LOAD_SPECIAL` stack effect as net +1 (was net 0, undercounting the `null_or_self` slot at the following method-call CALL);
  - decline the fold inside inline sub-walks (the collapsed caller-boundary resume would double a caller side effect sequenced before the inlined call);
  - restrict the fold to loop traces (`header_pc != 0`) — a function-entry no-loop trace's spare-capacity guard blackhole resume reconstructs the re-executed append's receiver from a wrong box; loop traces resume through the loop-header coordinate and reconstruct it correctly.
- Default ON; `PYRE_171_INLINE_LIST=0` opts out.

**Other**
- jit: classify `unpack_sequence_fn` as `MayForce` — `bh_unpack_sequence_fn` can run user `__len__` / `__getitem__` / `__iter__` / `__next__`, which can force a live virtualizable; it was emitted `Plain` (no `GUARD_NOT_FORCED`). `unpack_item_fn` stays `Plain` (only indexes the validated tuple).
- Supporting refactors: `sub_jitcode_body_by_index` / `run_sub_jitcode_walk` extraction and `list_append_jitcode()` by-name charon-body resolution (the production descent shape a trace-time list-helper specialization needs).

**Validation**: `check.py` 132/132 on dynasm + cranelift; `cargo test -p pyre-jit-trace` 270/0, `-p majit-translate` green, `-p pyre-object` listobject 29/29.

**Follow-ups** (tracked, not in this PR): un-scoping the fold to no-loop helper functions requires fixing the function-entry-trace receiver-box resume. A separate pre-existing JIT off-by-one (`append` + `for`-iter over the same list in one loop) was found during testing and is independent of this PR.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Specialized JIT compilation for integer list operations enabling faster element access and capacity queries
  * Improved sequence iterator semantics that detect list modifications during iteration

* **Performance Enhancements**
  * Optimized list append operations through eager specialization
  * Streamlined integer list element get/set operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->