### PR TITLE
rtyper: resized ListRepr rtyping + per-instantiation enum ClassDefs

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -434,6 +434,23 @@ pub fn canonical_struct_name(name: &str) -> String {
     }
 }
 
+/// Drop a trailing generic-argument suffix (`Foo<bar>` → `Foo`,
+/// `m::Foo<a, b>` → `m::Foo`), returning the ungeneric root.
+/// Truncates at the first `<`, so a nested argument's own `::` / `<`
+/// never leaks into the root; a name with no `<` is returned unchanged.
+///
+/// A per-instantiation enum receiver is spelled `Result<bool>`, but the
+/// discriminant→variant table is keyed by the bare template root
+/// `Result` (one template per generic ADT).  The narrowing resolver
+/// strips the suffix for that table lookup while the variant `ClassDef`
+/// key keeps it.
+pub fn strip_instantiation_suffix(name: &str) -> &str {
+    match name.find('<') {
+        Some(i) => &name[..i],
+        None => name,
+    }
+}
+
 impl LLType {
     /// descr.py:665: get_call_descr key tuple.
     pub fn func_key(
@@ -4815,6 +4832,22 @@ impl FailDescr for SimpleFailDescr {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_instantiation_suffix_drops_generic_args() {
+        // `<…>` is truncated at the first `<`, keeping any module
+        // qualifier and dropping a nested argument's own `::` / `<`.
+        assert_eq!(strip_instantiation_suffix("Result<bool>"), "Result");
+        assert_eq!(strip_instantiation_suffix("m::Result<bool, E>"), "m::Result");
+        assert_eq!(
+            strip_instantiation_suffix("Result<core::option::Option<i32>>"),
+            "Result"
+        );
+        // No `<` → unchanged (the behaviour every existing bare-keyed
+        // caller relies on).
+        assert_eq!(strip_instantiation_suffix("Color"), "Color");
+        assert_eq!(strip_instantiation_suffix("module::Color"), "module::Color");
+    }
 
     // ── FFI call surface parity tests (rpython/jit/metainterp/test/test_fficall.py) ──
 

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -422,6 +422,16 @@ pub fn register_struct_origins(origins: std::collections::HashMap<String, String
 /// `use foo::bar::Baz` path expansion that yields `foo::bar::Baz`
 /// in the AST).
 pub fn canonical_struct_name(name: &str) -> String {
+    // A per-instantiation name carries a `<…>` argument suffix
+    // (`Result<Tuple>`).  Canonicalize the bare base and reattach the
+    // suffix verbatim so a leaf (`Result<Tuple>`) and a qualified
+    // (`core::result::Result<Tuple>`) spelling normalise to one key,
+    // exactly as their bare bases reconcile — the base never contains a
+    // `<`, so the recursion bottoms out in the ungeneric path below.
+    if let Some(lt) = name.find('<') {
+        let (base, suffix) = name.split_at(lt);
+        return format!("{}{}", canonical_struct_name(base), suffix);
+    }
     if name.contains("::") {
         return name.to_string();
     }
@@ -448,6 +458,46 @@ pub fn strip_instantiation_suffix(name: &str) -> &str {
     match name.find('<') {
         Some(i) => &name[..i],
         None => name,
+    }
+}
+
+/// Remove the first balanced generic-argument group from a (possibly
+/// variant-qualified) name, preserving any trailing path segment:
+/// `Result<Tuple>::Ok` → `Result::Ok`, `Result<Tuple>` → `Result`,
+/// `m::Result<core::option::Option<i32>>::Ok` → `m::Result::Ok`.  A name
+/// with no `<` is borrowed unchanged (no allocation).
+///
+/// Unlike [`strip_instantiation_suffix`] (which truncates at the first
+/// `<`), this keeps the `::variant` tail a per-instantiation enum variant
+/// key carries, so a `Result<Tuple>::Ok` field lookup resolves through the
+/// bare `Result::Ok` rows the template registered.
+pub fn strip_generic_args(name: &str) -> std::borrow::Cow<'_, str> {
+    let Some(start) = name.find('<') else {
+        return std::borrow::Cow::Borrowed(name);
+    };
+    let mut depth = 0usize;
+    let mut end = None;
+    for (i, b) in name.bytes().enumerate().skip(start) {
+        match b {
+            b'<' => depth += 1,
+            b'>' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    match end {
+        Some(e) => {
+            let mut out = String::with_capacity(name.len() - (e + 1 - start));
+            out.push_str(&name[..start]);
+            out.push_str(&name[e + 1..]);
+            std::borrow::Cow::Owned(out)
+        }
+        None => std::borrow::Cow::Borrowed(name),
     }
 }
 
@@ -4838,7 +4888,10 @@ mod tests {
         // `<…>` is truncated at the first `<`, keeping any module
         // qualifier and dropping a nested argument's own `::` / `<`.
         assert_eq!(strip_instantiation_suffix("Result<bool>"), "Result");
-        assert_eq!(strip_instantiation_suffix("m::Result<bool, E>"), "m::Result");
+        assert_eq!(
+            strip_instantiation_suffix("m::Result<bool, E>"),
+            "m::Result"
+        );
         assert_eq!(
             strip_instantiation_suffix("Result<core::option::Option<i32>>"),
             "Result"
@@ -4847,6 +4900,45 @@ mod tests {
         // caller relies on).
         assert_eq!(strip_instantiation_suffix("Color"), "Color");
         assert_eq!(strip_instantiation_suffix("module::Color"), "module::Color");
+    }
+
+    #[test]
+    fn strip_generic_args_keeps_variant_tail() {
+        // The balanced `<…>` group is removed, the trailing `::variant`
+        // segment kept — the spelling a per-instantiation variant key
+        // (`Result<Tuple>::Ok`) must resolve under the bare template rows.
+        assert_eq!(strip_generic_args("Result<Tuple>::Ok"), "Result::Ok");
+        assert_eq!(strip_generic_args("Result<Tuple>"), "Result");
+        assert_eq!(
+            strip_generic_args("m::Result<core::option::Option<i32>>::Ok"),
+            "m::Result::Ok"
+        );
+        // No `<` → borrowed unchanged.
+        assert_eq!(strip_generic_args("Result::Ok"), "Result::Ok");
+        assert!(matches!(
+            strip_generic_args("Result::Ok"),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn canonical_struct_name_reattaches_generic_suffix() {
+        // A leaf with no origin-registry entry reattaches its suffix
+        // verbatim (the recursion bottoms out in the ungeneric path).
+        // `Tuple` has no `::`, so the leaf stays bare and the `<…>` is
+        // preserved exactly — the constructor and the prologue pre-mint
+        // pass the identical string and resolve one classdef.
+        assert_eq!(canonical_struct_name("Result<Tuple>"), "Result<Tuple>");
+        // Already-qualified base passes through verbatim under the suffix.
+        assert_eq!(
+            canonical_struct_name("core::result::Result<Tuple>"),
+            "core::result::Result<Tuple>"
+        );
+        // Idempotent.
+        assert_eq!(
+            canonical_struct_name(&canonical_struct_name("Result<Tuple>")),
+            canonical_struct_name("Result<Tuple>")
+        );
     }
 
     // ── FFI call surface parity tests (rpython/jit/metainterp/test/test_fficall.py) ──

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2122,13 +2122,14 @@ impl Bookkeeper {
             "f32" => return SomeValue::SingleFloat(super::model::SomeSingleFloat::new()),
             "f64" => return SomeValue::Float(super::model::SomeFloat::new()),
             "bool" => return super::model::s_bool(),
-            // Rust strings are UTF-8 text; literals lower through
-            // `__str_const` into `UniStr` constants (UnicodeString
-            // annotation, `UnicodeRepr::convert_const`), so the field
-            // projection must be the unicode string type or attr-cell
-            // unions degrade to the byte `StringRepr` ("not a str:
-            // UniStr(..)" at convert_const).
-            "String" | "str" => return super::model::s_unicode0(),
+            // Rust `String`/`str` fields are byte string values: string
+            // literals lower through `__str_const` into
+            // `ConstValue::ByteStr` constants (stamped `Ptr(STR)`, the
+            // rtyper's byte `StringRepr`), so the field projection must
+            // meet the same `SomeString` — projecting `s_unicode0` here
+            // raised `str ∪ unicode` where a literal merged into a
+            // String-typed attr cell.
+            "String" | "str" => return super::model::s_str0(),
             "char" => return SomeValue::Char(super::model::SomeChar::new(false)),
             "()" => return super::model::s_none(),
             _ => {}

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -648,7 +648,12 @@ impl Bookkeeper {
             };
             variants
                 .iter()
-                .filter(|(root, _)| root.contains("::"))
+                // A `::`-qualified template root (`module::Enum`) or a
+                // per-instantiation root (`Result<Tuple>`, #100) — both
+                // name a real enum base.  The bare leaf duplicate
+                // (`Enum`) is the other key the registration publishes,
+                // skipped here so the subtree numbers once.
+                .filter(|(root, _)| root.contains("::") || root.contains('<'))
                 .filter_map(|(root, by_discr)| {
                     let leaf = root.rsplit("::").next().unwrap_or(root);
                     reg.is_enum_base(leaf).then(|| {
@@ -1843,7 +1848,12 @@ impl Bookkeeper {
             let guard = self.pyre_enum_variant_by_discriminant.borrow();
             let map = guard.as_ref()?;
             map.get(lookup_root)
-                .or_else(|| lookup_root.rsplit("::").next().and_then(|leaf| map.get(leaf)))
+                .or_else(|| {
+                    lookup_root
+                        .rsplit("::")
+                        .next()
+                        .and_then(|leaf| map.get(leaf))
+                })
                 .cloned()?
         };
         let mut ktd = super::model::KnownTypeData::new();

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1834,10 +1834,16 @@ impl Bookkeeper {
         receiver: &Rc<crate::flowspace::model::Variable>,
     ) -> Option<super::model::KnownTypeData> {
         let by_discr = {
+            // The discriminant→variant table is keyed by the bare
+            // charon-template root (one template per generic ADT), so a
+            // per-instantiation receiver name (`Result<bool>`) must drop
+            // its `<…>` suffix to resolve.  Bare names pass through
+            // unchanged.
+            let lookup_root = majit_ir::descr::strip_instantiation_suffix(enum_root);
             let guard = self.pyre_enum_variant_by_discriminant.borrow();
             let map = guard.as_ref()?;
-            map.get(enum_root)
-                .or_else(|| enum_root.rsplit("::").next().and_then(|leaf| map.get(leaf)))
+            map.get(lookup_root)
+                .or_else(|| lookup_root.rsplit("::").next().and_then(|leaf| map.get(leaf)))
                 .cloned()?
         };
         let mut ktd = super::model::KnownTypeData::new();

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -8870,22 +8870,32 @@ fn render_adt_type_args(
         .unwrap_or_default()
 }
 
-/// A type-argument is "reference-shaped" when it is NOT an unboxed
-/// primitive.  In the RPython-erased model every non-primitive payload —
-/// a heap class (`Tuple`, `W_Object`), a nested generic enum
-/// (`StepResult<…>`, `Option<…>`), or a tuple of references — is stored
-/// as a single word-sized GC pointer in its variant field, so the
-/// per-instantiation variant class computes the same one-word payload
-/// layout regardless of the Rust inline size.  Per-instantiation
-/// projection is scoped to these args; a primitive (`bool`, `usize`,
-/// `f64`) is unboxed and stays on the bare variant class, which unifies
-/// its integer/float payloads without a `UnionError`.
-fn type_arg_is_ref_shaped(arg: &str) -> bool {
-    const PRIMITIVE: &[&str] = &[
-        "bool", "char", "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
-        "i128", "isize", "f32", "f64", "()", "",
-    ];
-    !PRIMITIVE.contains(&arg)
+/// A type-argument drives a per-instantiation variant-class split unless
+/// it is in the deferred-or-degenerate set below.  A split mints a
+/// distinct `<…>`-suffixed variant classdef (`Result<bool>::Ok` vs
+/// `Result<i64>::Ok` vs `Result<Tuple>::Ok`) whose payload field sees only
+/// that one concrete type, so the field annotates to that type's own repr
+/// (`BoolRepr`, `IntegerRepr`, the GC-pointer `InstanceRepr`).  Without the
+/// split every instantiation collapses onto one bare variant class whose
+/// `__pos_0` unions the whole program — a cross-category `int ∪ float ∪
+/// char ∪ ()` merge that generalises to a generic `InstanceRepr` and walls
+/// the rtyper on the materialised store.
+///
+/// Reference payloads (a heap class `Tuple`/`W_Object`/`str`, a nested
+/// generic enum `Option<…>`, a tuple of references) are one word-sized GC
+/// pointer; the scalar integer/bool/char primitives are unboxed but each
+/// carries a well-defined int-banked repr, so all of these split.
+/// Excluded:
+///   - `f32`/`f64` — float bank; deferred until the codewriter field-descr
+///     carries the concrete bank (a suffixed-owner `setfield_gc_f`
+///     otherwise falls back to a GC-word descr).
+///   - `()` — the unit-`Ok` return widens to a genuine void return
+///     (`widen_unit_return_to_void`) and never materialises a payload field.
+///   - `""` — a degenerate/absent type-arg that would render a malformed
+///     `<>` suffix.
+fn type_arg_splits_per_instantiation(arg: &str) -> bool {
+    const DEFERRED: &[&str] = &["f32", "f64", "()", ""];
+    !DEFERRED.contains(&arg)
 }
 
 /// The `<…>` generic-argument suffix of an `AggregateKind::Adt` /
@@ -8893,9 +8903,9 @@ fn type_arg_is_ref_shaped(arg: &str) -> bool {
 /// instantiation), or `None` when the head is not a reference-payload
 /// `enum` instantiation.  Returned `Some` only when the head names an
 /// `enum` (struct generics keep collapsing to their flat classdef) whose
-/// every type-argument is [`type_arg_is_ref_shaped`] — the scope under
-/// which the per-instantiation variant class shares the bare variant's
-/// word-slot layout soundly.  Every projection site (receiver type,
+/// every type-argument [`type_arg_splits_per_instantiation`] — the scope
+/// under which the per-instantiation variant class carries a sound payload
+/// repr.  Every projection site (receiver type,
 /// variant constructor, variant field read, numbering pre-scan) routes
 /// through this one predicate so they all agree on which instantiations
 /// split and how they spell the suffix.
@@ -8916,7 +8926,11 @@ pub(crate) fn adt_head_instantiation_suffix(
         return None;
     }
     let type_args = render_adt_type_args(adt, llbc, 0);
-    if type_args.is_empty() || !type_args.iter().all(|a| type_arg_is_ref_shaped(a)) {
+    if type_args.is_empty()
+        || !type_args
+            .iter()
+            .all(|a| type_arg_splits_per_instantiation(a))
+    {
         return None;
     }
     Some(format!("<{}>", type_args.join(",")))
@@ -10575,22 +10589,29 @@ mod tests {
     use majit_charon_reader::Llbc;
 
     #[test]
-    fn type_arg_is_ref_shaped_excludes_only_primitives() {
-        use super::type_arg_is_ref_shaped;
+    fn type_arg_splits_per_instantiation_defers_only_float_unit_empty() {
+        use super::type_arg_splits_per_instantiation;
         // Bare named heap classes split (1-word GC pointer in the
-        // erased model → share the template's word-slot layout).
-        assert!(type_arg_is_ref_shaped("Tuple"));
-        assert!(type_arg_is_ref_shaped("W_Object"));
-        assert!(type_arg_is_ref_shaped("str"));
+        // erased model).
+        assert!(type_arg_splits_per_instantiation("Tuple"));
+        assert!(type_arg_splits_per_instantiation("W_Object"));
+        assert!(type_arg_splits_per_instantiation("str"));
         // Nested generics and tuples are also 1-word GC pointers in the
-        // erased model — they share the same word-slot layout, so they
-        // split too (`Result<StepResult<…>, PyError>` etc.).
-        assert!(type_arg_is_ref_shaped("Option<i32>"));
-        assert!(type_arg_is_ref_shaped("(A,B)"));
-        // Unboxed primitives stay on the bare variant (own layout;
-        // union cleanly as integers).
-        for p in ["bool", "u32", "usize", "i64", "f64", "char", "()", ""] {
-            assert!(!type_arg_is_ref_shaped(p), "{p} must not split");
+        // erased model (`Result<StepResult<…>, PyError>` etc.).
+        assert!(type_arg_splits_per_instantiation("Option<i32>"));
+        assert!(type_arg_splits_per_instantiation("(A,B)"));
+        // Scalar integer/bool/char primitives split too: each carries a
+        // well-defined int-banked repr, so the per-instantiation `__pos_0`
+        // annotates to that repr instead of a program-wide union.
+        for p in [
+            "bool", "char", "u8", "u32", "u64", "u128", "usize", "i8", "i64", "i128", "isize",
+        ] {
+            assert!(type_arg_splits_per_instantiation(p), "{p} must split");
+        }
+        // Deferred: floats (float bank, codewriter descr not yet bank-aware)
+        // and the unit/degenerate atoms (no materialised payload field).
+        for p in ["f32", "f64", "()", ""] {
+            assert!(!type_arg_splits_per_instantiation(p), "{p} must not split");
         }
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -302,6 +302,54 @@ fn is_known_lowering_gap(msg: &str) -> bool {
     msg.contains("no rewritable returns")
 }
 
+/// Collect every reference-payload generic-enum CONSTRUCTOR
+/// instantiation in the program as `(name_path, "<…>")` pairs (`Result`,
+/// `<Tuple>`).  Every `Result::Ok` / `Option::Some` payload `UnionError`
+/// is a `setattr("__pos_0")` at a variant constructor, so scanning
+/// `Rvalue::Aggregate(AggregateKind::Adt, …)` heads — where the head
+/// carries the concrete generics inline — finds exactly the
+/// instantiations whose variant subclasses must be split and pre-minted.
+/// Filtered through [`adt_head_instantiation_suffix`] so the discovered
+/// set agrees with what the constructor / field-read sites project.
+fn collect_ref_enum_instantiations(llbc: &Llbc) -> Vec<(String, String)> {
+    let mut found: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    for fd in llbc.iter_local_fns() {
+        let Some(u) = fd.unstructured() else {
+            continue;
+        };
+        for bb in &u.body {
+            for st in &bb.statements {
+                let Ok(StmtKind::Assign(_, Rvalue::Aggregate(kind, _))) = st.stmt_kind() else {
+                    continue;
+                };
+                let Some(head) = kind
+                    .get("Adt")
+                    .and_then(serde_json::Value::as_array)
+                    .and_then(|adt| adt.first())
+                    .and_then(serde_json::Value::as_object)
+                else {
+                    continue;
+                };
+                let Some(suffix) = adt_head_instantiation_suffix(head, llbc) else {
+                    continue;
+                };
+                let Some(name_path) = head
+                    .get("id")
+                    .and_then(serde_json::Value::as_object)
+                    .and_then(|id| id.get("Adt"))
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|def_id| llbc.type_by_id(def_id))
+                    .map(|td| td.item_meta.name_path())
+                else {
+                    continue;
+                };
+                found.insert((name_path, suffix));
+            }
+        }
+    }
+    found.into_iter().collect()
+}
+
 pub fn build_semantic_program_from_llbc(
     llbc: &Llbc,
 ) -> Result<crate::front::semantic::SemanticProgram, LowerError> {
@@ -328,6 +376,30 @@ pub fn build_semantic_program_from_llbc_with_static_addrs(
         &mut struct_origins,
         &mut enum_variant_by_discriminant,
     );
+
+    // Per-instantiation enum-variant pre-registration source (#100): a
+    // reference-payload generic enum constructor (`Result<Tuple>::Ok`)
+    // projects a per-instantiation variant class so its payload does not
+    // union across instantiations.  Publish a discriminant-table entry
+    // per such instantiation, keyed by the LEAF-suffixed `{leaf}{suffix}`
+    // — the exact spelling the constructor carries as its owner tail
+    // (`resolve_aggregate_adt`) — so the prologue pre-mint and the
+    // constructor pass the identical string to `canonical_struct_name`
+    // and resolve ONE variant classdef regardless of what
+    // `STRUCT_ORIGIN_REGISTRY` maps the base to.  The cloned tag→variant
+    // map is instantiation-invariant.  `pre_register_enum_variant_classes`
+    // accepts the `<`-bearing key (its filter admits `::`-qualified OR
+    // per-instantiation roots) and numbers the variant subclasses before
+    // `assign_inheritance_ids`, so the split classes drain rather than
+    // landing unnumbered (per-graph Skip).
+    for (name_path, suffix) in collect_ref_enum_instantiations(llbc) {
+        if let Some(bare) = enum_variant_by_discriminant.get(&name_path).cloned() {
+            let leaf = name_path.rsplit("::").next().unwrap_or(&name_path);
+            enum_variant_by_discriminant
+                .entry(format!("{leaf}{suffix}"))
+                .or_insert(bare);
+        }
+    }
 
     // ── Pass 2: lower every function body and build SemanticFunctions ─
     let mut functions = Vec::new();
@@ -1374,8 +1446,10 @@ struct Lowering<'a> {
     /// heads a `Try::branch` diamond that
     /// [`crate::front::result_exc::rewire_result_exc_call_sites`]
     /// rewires into `ExitSwitch::LastException` exits after the body
-    /// lowering completes.
-    result_exc_call_results: Vec<Variable>,
+    /// lowering completes.  The paired `Option<String>` is the callee's
+    /// per-instantiation `<…>` suffix (Ref-shaped payloads only) keying
+    /// the rebuilt `Ok`/`Err` shells' ClassDef per instantiation.
+    result_exc_call_results: Vec<(Variable, Option<String>)>,
 }
 
 impl<'a> Lowering<'a> {
@@ -3531,7 +3605,21 @@ impl<'a> Lowering<'a> {
             (TypeDeclKind::Enum(variants), Some(idx)) => {
                 let v = variants.get(idx as usize)?;
                 let mut variant_owner = owner_path;
-                variant_owner.push(type_leaf);
+                // A reference-payload workspace enum instantiation
+                // constructs into its per-instantiation variant class
+                // (`Result<Tuple>::Ok`), the same spelling the receiver
+                // type projects and the discriminant narrowing mints, so
+                // the constructor's `setattr` and the narrowing land on
+                // one classdef per instantiation (no cross-instantiation
+                // payload union).
+                let leaf = match head
+                    .as_object()
+                    .and_then(|h| adt_head_instantiation_suffix(h, self.llbc))
+                {
+                    Some(suffix) => format!("{type_leaf}{suffix}"),
+                    None => type_leaf,
+                };
+                variant_owner.push(leaf);
                 let field_names: Vec<String> = v
                     .fields
                     .iter()
@@ -3561,7 +3649,17 @@ impl<'a> Lowering<'a> {
         }
         let container = arr[0].as_object()?;
         let adt = container.get("Adt")?.as_array()?;
-        let type_id = adt.first()?.as_u64()?;
+        // The projection container head is either a bare `type_id` u64 or
+        // the full `TypeDeclRef` object a generic-instantiated downcast
+        // carries — the same two shapes `resolve_aggregate_adt` decodes.
+        // The bare-u64 read alone returned `None` for every generic
+        // variant field read, so the per-instantiation variant class the
+        // constructor and receiver project had no matching field read.
+        let head = adt.first()?;
+        let type_id = match head.as_u64() {
+            Some(id) => id,
+            None => head.get("id")?.get("Adt")?.as_u64()?,
+        };
         let variant_idx = adt.get(1).and_then(serde_json::Value::as_u64);
         let field_idx = arr[1].as_u64()? as usize;
         let td = self.llbc.type_by_id(type_id)?;
@@ -3572,7 +3670,22 @@ impl<'a> Lowering<'a> {
         // bare leaf its non-layout consumers expect; `owner_id` carries
         // the collision-free identity for the layout layer.
         let name_path = td.item_meta.name_path();
-        let owner_root = name_path.rsplit("::").next().unwrap_or("").to_string();
+        // `owner_root` is the annotation-side classdef key: a
+        // reference-payload workspace enum instantiation reads its field
+        // off the per-instantiation variant class (`Result<Tuple>::Ok`),
+        // matching the receiver / constructor projection.  `owner_id`
+        // (the layout-side `StructId` minted below) stays on the bare
+        // template name so every instantiation shares the one template
+        // variant layout — sound because the split is scoped to
+        // reference payloads, which all share that word-slot layout.
+        let owner_leaf = name_path.rsplit("::").next().unwrap_or("").to_string();
+        let owner_root = match head
+            .as_object()
+            .and_then(|h| adt_head_instantiation_suffix(h, self.llbc))
+        {
+            Some(suffix) => format!("{owner_leaf}{suffix}"),
+            None => owner_leaf,
+        };
         match (&td.kind, variant_idx) {
             (TypeDeclKind::Struct(fields), None) => {
                 let f = fields.get(field_idx)?;
@@ -4713,7 +4826,16 @@ impl<'a> Lowering<'a> {
             && crate::front::result_exc::call_target_in_scope(target)
             && crate::front::result_exc::tyref_is_result_of_pyerror(&call.dest.ty, self.llbc)
         {
-            self.result_exc_call_results.push(result_var.clone());
+            // The per-instantiation suffix of the callee's `Result<T,
+            // PyError>` keys the shells `result_exc` rebuilds at the
+            // rewrap site, matching the front aggregate path's suffix so
+            // both writers share one ClassDef per instantiation.
+            let suffix = crate::front::result_exc::tyref_result_instantiation_suffix(
+                &call.dest.ty,
+                self.llbc,
+            );
+            self.result_exc_call_results
+                .push((result_var.clone(), suffix));
         }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var),
@@ -7991,7 +8113,19 @@ fn adt_node_class_root(node: &serde_json::Value, llbc: &Llbc) -> Option<String> 
             return None;
         }
     }
-    Some(name.rsplit("::").next().unwrap_or(&name).to_string())
+    let leaf = name.rsplit("::").next().unwrap_or(&name).to_string();
+    // A reference-payload workspace enum instantiation projects to a
+    // per-instantiation base class (`Result<Tuple>`) so its variant
+    // payloads do not union across instantiations.  The discriminant
+    // narrowing reads this base class name back to mint the matching
+    // `Result<Tuple>::Ok` variant subclass, so the suffix here and the
+    // constructor / field-read sites must agree — they share
+    // `adt_head_instantiation_suffix`.  Non-enum and primitive-payload
+    // heads return `None` and keep collapsing to the bare leaf.
+    if let Some(suffix) = adt_head_instantiation_suffix(adt, llbc) {
+        return Some(format!("{leaf}{suffix}"));
+    }
+    Some(leaf)
 }
 
 /// The pointee's monomorphic-ADT class root for a `*const T` /
@@ -8710,6 +8844,84 @@ fn charon_int_kind_to_rust(kind: &str, signed: bool) -> String {
     }
 }
 
+/// Render an ADT head's generic type-arguments (`generics.types[]`) to
+/// their AST strings, dropping the default allocator / hasher type-args
+/// Charon makes explicit (`Vec<T, Global>`, `HashMap<K, V, RandomState,
+/// Global>`).  Empty when the head carries no type-arguments.  Shared by
+/// [`charon_adt_to_ast_string`] (full type printer) and
+/// [`adt_head_instantiation_suffix`] (variant-class projection) so a
+/// rendered type and its `<…>` class suffix spell one instantiation
+/// identically.
+fn render_adt_type_args(
+    adt: &serde_json::Map<String, serde_json::Value>,
+    llbc: &Llbc,
+    depth: usize,
+) -> Vec<String> {
+    adt.get("generics")
+        .and_then(|g| g.as_object())
+        .and_then(|g| g.get("types"))
+        .and_then(|t| t.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|t| charon_type_value_to_ast_string(t, llbc, depth + 1))
+                .filter(|s| s != "Global" && s != "RandomState")
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A type-argument is "reference-shaped" when it is NOT an unboxed
+/// primitive.  In the RPython-erased model every non-primitive payload —
+/// a heap class (`Tuple`, `W_Object`), a nested generic enum
+/// (`StepResult<…>`, `Option<…>`), or a tuple of references — is stored
+/// as a single word-sized GC pointer in its variant field, so the
+/// per-instantiation variant class computes the same one-word payload
+/// layout regardless of the Rust inline size.  Per-instantiation
+/// projection is scoped to these args; a primitive (`bool`, `usize`,
+/// `f64`) is unboxed and stays on the bare variant class, which unifies
+/// its integer/float payloads without a `UnionError`.
+fn type_arg_is_ref_shaped(arg: &str) -> bool {
+    const PRIMITIVE: &[&str] = &[
+        "bool", "char", "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
+        "i128", "isize", "f32", "f64", "()", "",
+    ];
+    !PRIMITIVE.contains(&arg)
+}
+
+/// The `<…>` generic-argument suffix of an `AggregateKind::Adt` /
+/// type-node head (`<Tuple>` for a `Result<Tuple, PyError>`
+/// instantiation), or `None` when the head is not a reference-payload
+/// `enum` instantiation.  Returned `Some` only when the head names an
+/// `enum` (struct generics keep collapsing to their flat classdef) whose
+/// every type-argument is [`type_arg_is_ref_shaped`] — the scope under
+/// which the per-instantiation variant class shares the bare variant's
+/// word-slot layout soundly.  Every projection site (receiver type,
+/// variant constructor, variant field read, numbering pre-scan) routes
+/// through this one predicate so they all agree on which instantiations
+/// split and how they spell the suffix.
+///
+/// `core`/`std`/`alloc` is NOT excluded here: the variant classes that
+/// collide are `Result::Ok` / `Option::Some`, minted by the constructor
+/// path, so the split must reach `core::result::Result` /
+/// `core::option::Option`.  The receiver-type projection
+/// [`adt_node_class_root`] keeps its own container exclusion so
+/// `Vec<T>` / `Box<T>` still map to their annotator models.
+pub(crate) fn adt_head_instantiation_suffix(
+    adt: &serde_json::Map<String, serde_json::Value>,
+    llbc: &Llbc,
+) -> Option<String> {
+    let def_id = adt.get("id")?.as_object()?.get("Adt")?.as_u64()?;
+    let td = llbc.type_by_id(def_id)?;
+    if !matches!(td.kind, TypeDeclKind::Enum(_)) {
+        return None;
+    }
+    let type_args = render_adt_type_args(adt, llbc, 0);
+    if type_args.is_empty() || !type_args.iter().all(|a| type_arg_is_ref_shaped(a)) {
+        return None;
+    }
+    Some(format!("<{}>", type_args.join(",")))
+}
+
 /// Format a Charon `Adt` type body (`{"id": …, "generics": {"types": […]}}`).
 fn charon_adt_to_ast_string(
     adt: &serde_json::Map<String, serde_json::Value>,
@@ -8717,22 +8929,7 @@ fn charon_adt_to_ast_string(
     depth: usize,
 ) -> String {
     let id = adt.get("id");
-    let type_args: Vec<String> = adt
-        .get("generics")
-        .and_then(|g| g.as_object())
-        .and_then(|g| g.get("types"))
-        .and_then(|t| t.as_array())
-        .map(|arr| {
-            arr.iter()
-                .map(|t| charon_type_value_to_ast_string(t, llbc, depth + 1))
-                // Drop the default allocator / hasher type-args Charon
-                // makes explicit (`Vec<T, Global>`, `HashMap<K, V,
-                // RandomState, Global>`) so the rendered string elides
-                // them.
-                .filter(|s| s != "Global" && s != "RandomState")
-                .collect()
-        })
-        .unwrap_or_default();
+    let type_args: Vec<String> = render_adt_type_args(adt, llbc, depth);
     // `id` is either a string atom (`"Tuple"`), or an object
     // (`{"Adt": <def_id>}`, `{"Builtin": "Box"|"Slice"|"Str"|"Array"}`).
     if let Some(atom) = id.and_then(serde_json::Value::as_str) {
@@ -10376,6 +10573,26 @@ mod tests {
     use super::harden_duplicate_leaf_metadata;
     use super::{cast_kind_is_raw_ptr, cast_pointer_marker_op, charon_type_value_to_ast_string};
     use majit_charon_reader::Llbc;
+
+    #[test]
+    fn type_arg_is_ref_shaped_excludes_only_primitives() {
+        use super::type_arg_is_ref_shaped;
+        // Bare named heap classes split (1-word GC pointer in the
+        // erased model → share the template's word-slot layout).
+        assert!(type_arg_is_ref_shaped("Tuple"));
+        assert!(type_arg_is_ref_shaped("W_Object"));
+        assert!(type_arg_is_ref_shaped("str"));
+        // Nested generics and tuples are also 1-word GC pointers in the
+        // erased model — they share the same word-slot layout, so they
+        // split too (`Result<StepResult<…>, PyError>` etc.).
+        assert!(type_arg_is_ref_shaped("Option<i32>"));
+        assert!(type_arg_is_ref_shaped("(A,B)"));
+        // Unboxed primitives stay on the bare variant (own layout;
+        // union cleanly as integers).
+        for p in ["bool", "u32", "usize", "i64", "f64", "char", "()", ""] {
+            assert!(!type_arg_is_ref_shaped(p), "{p} must not split");
+        }
+    }
 
     #[test]
     fn resolve_to_producer_op_follows_cross_block_inputarg_link() {

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -172,6 +172,26 @@ pub(crate) fn tyref_is_result_of_pyerror(ty: &TyRef, llbc: &Llbc) -> bool {
     adt_path_of(err_body, llbc).is_some_and(|p| p == "pyre_interpreter::error::PyError")
 }
 
+/// The per-instantiation `<…>` suffix for a scoped callee's
+/// `Result<T, PyError>` return type, or `None` when the instantiation is
+/// not Ref-shaped (bool/int payloads stay on the bare `Result::Ok`
+/// classdef).  The suffix keys the rebuilt shell's ClassDef per
+/// instantiation — `Result<StepResult,PyError>::Ok` distinct from
+/// `Result<Tuple,PyError>::Ok` — matching the suffix the front aggregate
+/// path (`resolve_aggregate_adt`) computes for the same instantiation, so
+/// both writers agree on one ClassDef and the `__pos_0` payload no longer
+/// unions across instantiations.  Both the `Ok` and `Err` shells of one
+/// callee share this suffix so the two variants share one base ClassDef.
+pub(crate) fn tyref_result_instantiation_suffix(ty: &TyRef, llbc: &Llbc) -> Option<String> {
+    let body = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => llbc.dedup_body(*id)?,
+    };
+    let adt = body.get("Adt")?.as_object()?;
+    crate::front::mir::adt_head_instantiation_suffix(adt, llbc)
+}
+
 /// True when `ty` is `Result<(), PyError>` — the Ok payload is the unit
 /// type.  Such a callee returns void after the exception-link lowering
 /// (`exceptiontransform.py` widens the value-encoded result to the inner
@@ -228,17 +248,20 @@ pub(crate) fn widen_unit_return_to_void(graph: &mut FunctionGraph) {
 }
 
 /// Is `target` the `Result::Ok` / `Result::Err` transparent ctor?
+///
+/// The owner's final segment may carry a per-instantiation `<…>` suffix
+/// (`Result<Tuple,PyError>`) minted by the generic-ADT projection; strip
+/// it before the bare-path compare so suffixed and bare Result ctors are
+/// recognised alike.
 fn result_ctor_kind(target: &CallTarget) -> Option<bool> {
     let CallTarget::SyntheticTransparentCtor { name, owner_path } = target else {
         return None;
     };
-    if owner_path
-        != &[
-            "core".to_string(),
-            "result".to_string(),
-            "Result".to_string(),
-        ]
-    {
+    let [head @ .., tail] = owner_path.as_slice() else {
+        return None;
+    };
+    let tail_base = tail.split_once('<').map_or(tail.as_str(), |(b, _)| b);
+    if head != ["core".to_string(), "result".to_string()] || tail_base != "Result" {
         return None;
     }
     match name.as_str() {
@@ -790,7 +813,7 @@ enum SiteOutcome {
 /// custom `match` consumer that gets the catch-and-rewrap treatment.
 pub(crate) fn rewire_result_exc_call_sites(
     graph: &mut FunctionGraph,
-    results: &[Variable],
+    results: &[(Variable, Option<String>)],
     enclosing_scoped: bool,
 ) -> Result<RewireOutcome, String> {
     let mut outcome = RewireOutcome {
@@ -798,8 +821,8 @@ pub(crate) fn rewire_result_exc_call_sites(
         tail_forwards: 0,
         rewrapped: 0,
     };
-    for r in results {
-        match rewire_one_call_site(graph, r, enclosing_scoped)? {
+    for (r, suffix) in results {
+        match rewire_one_call_site(graph, r, suffix.as_deref().unwrap_or(""), enclosing_scoped)? {
             SiteOutcome::Diamond => outcome.diamonds += 1,
             SiteOutcome::TailForward => outcome.tail_forwards += 1,
             SiteOutcome::Rewrapped => outcome.rewrapped += 1,
@@ -811,6 +834,7 @@ pub(crate) fn rewire_result_exc_call_sites(
 fn rewire_one_call_site(
     graph: &mut FunctionGraph,
     r: &Variable,
+    suffix: &str,
     enclosing_scoped: bool,
 ) -> Result<SiteOutcome, String> {
     let name = graph.name.clone();
@@ -846,7 +870,7 @@ fn rewire_one_call_site(
         )
     });
     let Some(branch_op_idx) = branch_op_idx else {
-        catch_and_rewrap(graph, a, r)?;
+        catch_and_rewrap(graph, a, r, suffix)?;
         return Ok(SiteOutcome::Rewrapped);
     };
     assert_single_pred(graph, b, &name)?;
@@ -984,7 +1008,12 @@ fn rewire_one_call_site(
 /// rebuilt shells sit in the CALLER's graph next to the sibling shells
 /// the caller already builds for its own returns, so no new shell
 /// exposure is introduced on walked paths.
-fn catch_and_rewrap(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result<(), String> {
+fn catch_and_rewrap(
+    graph: &mut FunctionGraph,
+    a: usize,
+    r: &Variable,
+    suffix: &str,
+) -> Result<(), String> {
     use crate::model::BlockId;
     let name = graph.name.clone();
     if graph.blocks[a].exitswitch.is_some() {
@@ -1021,7 +1050,7 @@ fn catch_and_rewrap(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result
             .position(|a| is_r(a))
             .expect("has_r implies a Value position");
         let payload = n_inputs[r_value_idx].clone();
-        Some(build_shell(graph, n_id, "Ok", payload))
+        Some(build_shell(graph, n_id, "Ok", payload, suffix))
     } else {
         None
     };
@@ -1090,7 +1119,7 @@ fn catch_and_rewrap(graph: &mut FunctionGraph, a: usize, r: &Variable) -> Result
                 true,
             )
             .expect("from_exc_object must produce a value");
-        Some(build_shell(graph, e_id, "Err", v_err))
+        Some(build_shell(graph, e_id, "Err", v_err, suffix))
     } else {
         None
     };
@@ -1143,18 +1172,23 @@ fn build_shell(
     block: crate::model::BlockId,
     variant: &str,
     payload: Variable,
+    suffix: &str,
 ) -> Variable {
     use crate::model::FieldDescriptor;
-    let owner = format!("core::result::Result::{variant}");
+    // `suffix` (`<Tuple,PyError>` or empty) keys the shell's ClassDef per
+    // instantiation, matching the front aggregate path; both the `Ok` and
+    // `Err` shells of one callee carry it so the variants share one base.
+    let owner = format!("core::result::Result{suffix}::{variant}");
     let shell = graph
         .push_op_var(
             block,
             OpKind::Call {
                 target: CallTarget::synthetic_transparent_ctor_with_owner(
-                    ["core", "result", "Result"]
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect(),
+                    vec![
+                        "core".to_string(),
+                        "result".to_string(),
+                        format!("Result{suffix}"),
+                    ],
                     variant,
                 ),
                 args: Vec::new(),

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -154,6 +154,15 @@ impl StructFieldRegistry {
     }
 
     fn lookup_fields(&self, owner: &str) -> Option<&[(String, String)]> {
+        // A per-instantiation enum spelling (`Result<Tuple>`,
+        // `Result<Tuple>::Ok`) shares the bare template's rows: the
+        // reference-payload split exists only to separate annotator attr
+        // unification across instantiations, not to give each one its own
+        // row layout.  Drop the `<…>` argument span (keeping any trailing
+        // `::variant`) so the lookup resolves under the bare key the
+        // template registered.
+        let stripped = majit_ir::descr::strip_generic_args(owner);
+        let owner = stripped.as_ref();
         if let Some(fields) = self.fields.get(owner) {
             return Some(fields.as_slice());
         }

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -1196,14 +1196,23 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::LoopHeader { .. }
         | OpKind::Live
         | OpKind::VableForce { .. }
-        // `LoweredBlackholeOp` carries register-shaped blackhole insns
-        // (`strlen`/`strgetitem`/`strsetitem`/`newstr`) whose side-effect
-        // class is opname-dependent (the `newstr` malloc + `strsetitem`
-        // store mutate).  Conservatively side-effecting so the dead-op
-        // sweep never drops a store or an allocation.
-        | OpKind::LoweredBlackholeOp { .. }
         | OpKind::Hint { .. }
         | OpKind::Abort { .. } => false,
+
+        // `LoweredBlackholeOp` carries register-shaped blackhole insns whose
+        // side-effect class is opname-dependent — the same split `op_can_raise`
+        // (`call.rs`) and upstream `lloperation.py:382-383` (sideeffects /
+        // canfold) make.  The read family
+        // (`strlen`/`unicodelen`/`strgetitem`/`unicodegetitem`) is
+        // pure/removable; the alloc/store/copy family
+        // (`newstr`/`newunicode`/`strsetitem`/`unicodesetitem`/
+        // `copystrcontent`/`copyunicodecontent`) mutates.  Any unlisted opname
+        // falls through to side-effecting, so the dead-op sweep never drops a
+        // store or an allocation by default.
+        OpKind::LoweredBlackholeOp { opname, .. } => matches!(
+            opname.as_str(),
+            "strlen" | "unicodelen" | "strgetitem" | "unicodegetitem"
+        ),
     }
 }
 
@@ -1456,6 +1465,31 @@ mod tests {
     use crate::call::CallControl;
     use crate::model::{CallTarget, FunctionGraph, OpKind, ValueType};
     use crate::parse::CallPath;
+
+    #[test]
+    fn lowered_blackhole_op_purity_is_opname_aware() {
+        let pure = |name: &str| {
+            is_pure_op(&OpKind::LoweredBlackholeOp {
+                opname: name.to_string(),
+                args: vec![],
+            })
+        };
+        // Read family: pure/removable when the result is dead.
+        for name in ["strlen", "unicodelen", "strgetitem", "unicodegetitem"] {
+            assert!(pure(name), "{name} is a pure read");
+        }
+        // Alloc / store / copy family: side-effecting, must never be dropped.
+        for name in [
+            "newstr",
+            "newunicode",
+            "strsetitem",
+            "unicodesetitem",
+            "copystrcontent",
+            "copyunicodecontent",
+        ] {
+            assert!(!pure(name), "{name} mutates and must be kept");
+        }
+    }
 
     fn make_simple_callee() -> FunctionGraph {
         // Callee: fn callee(base) -> value { ArrayRead(base, const(0)) }

--- a/majit/majit-translate/src/jit_codewriter/call.rs
+++ b/majit/majit-translate/src/jit_codewriter/call.rs
@@ -743,6 +743,14 @@ pub struct CallControl {
     /// `take_opname_graph` consumes the entry during the drain so the
     /// graph is lowered exactly once.
     opname_graphs: HashMap<CallPath, crate::flowspace::model::FunctionGraph>,
+    /// Persistent set of paths registered as opname-dispatch helpers.
+    /// Unlike [`Self::opname_graphs`] (drained by `take_opname_graph` once
+    /// the body is lowered), this survives the drain so a caller's
+    /// `direct_call` to the helper still resolves as a regular callee after
+    /// the helper itself has been assembled — the resolution twin of the
+    /// `function_graphs`/`candidate_graphs` registration a rich-`OpKind`
+    /// graph gets.
+    opname_helper_paths: HashSet<CallPath>,
 
     /// `call.py:22 virtualref_info = None` — class-level default,
     /// populated by `CodeWriter.setup_vrefinfo`
@@ -1225,6 +1233,7 @@ impl CallControl {
             finished_jitcodes: Vec::new(),
             unfinished_graphs: Vec::new(),
             opname_graphs: HashMap::new(),
+            opname_helper_paths: HashSet::new(),
             virtualref_info: None,
             callinfocollection: majit_ir::CallInfoCollection::new(),
             descr_indices: DescrIndexRegistry::default(),
@@ -3101,6 +3110,16 @@ impl CallControl {
         graph: crate::flowspace::model::FunctionGraph,
     ) -> std::sync::Arc<crate::jitcode::JitCode> {
         self.opname_graphs.insert(path.clone(), graph);
+        // Make the helper resolvable as a regular callee: record its path
+        // persistently (for `target_to_path`) and mark it a candidate (for
+        // `graphs_from`), mirroring the `function_graphs` + `candidate_graphs`
+        // pair a rich-`OpKind` helper receives via `find_all_graphs_bfs`.
+        // Without this, a `direct_call` to the helper misses both gates and
+        // `guess_call_kind` classifies it `Residual` — the caller would emit a
+        // residual call for a synthetic low-level helper instead of using the
+        // generated JitCode.
+        self.opname_helper_paths.insert(path.clone());
+        self.candidate_graphs.insert(path.clone());
         self.get_jitcode(&path)
     }
 
@@ -3477,7 +3496,12 @@ impl CallControl {
         match target {
             CallTarget::FunctionPath { segments } => {
                 let path = CallPath::from_segments(segments.iter().map(String::as_str));
-                if self.function_graphs.contains_key(&path) {
+                // A rich-`OpKind` graph resolves via `function_graphs`; an
+                // opname-dispatch helper has no rich twin there, so it is
+                // recognised by its persistent registration instead.
+                if self.function_graphs.contains_key(&path)
+                    || self.opname_helper_paths.contains(&path)
+                {
                     return Some(path);
                 }
                 // Cross-module reference fallback.  `front::mir` resolves

--- a/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform_opname.rs
@@ -699,6 +699,38 @@ mod tests {
         assert_eq!(jitcode.try_index(), Some(0));
     }
 
+    /// A `direct_call` to a registered opname helper must resolve as a
+    /// *regular* callee (it owns a generated JitCode), not a residual call to
+    /// a synthetic low-level helper.  Pre-fix the helper was visible only in
+    /// `opname_graphs`, so `target_to_path`/`graphs_from` missed it and
+    /// `guess_call_kind` returned `Residual`.
+    #[test]
+    fn registered_opname_helper_resolves_as_regular_callee() {
+        use crate::jit_codewriter::call::{CallControl, CallKind};
+        use crate::model::{CallTarget, OpKind, SpaceOperation, ValueType};
+        use crate::parse::CallPath;
+
+        let flow = build_fusable_str_helper();
+        let path = CallPath::from_segments(["ll_test_fusable_str_helper"]);
+
+        let mut callcontrol = CallControl::new();
+        callcontrol.register_opname_helper_graph(path.clone(), flow);
+
+        let target = CallTarget::function_path(["ll_test_fusable_str_helper"]);
+        assert_eq!(callcontrol.target_to_path(&target), Some(path.clone()));
+
+        let call_op = SpaceOperation {
+            result: None,
+            kind: OpKind::Call {
+                target,
+                args: vec![],
+                result_ty: ValueType::Void,
+            },
+        };
+        assert_eq!(callcontrol.graphs_from(&call_op), Some(vec![path]));
+        assert_eq!(callcontrol.guess_call_kind(&call_op), CallKind::Regular);
+    }
+
     /// End-to-end: the restructured production `ll_strconcat` helper lowers
     /// cleanly through Spine B.  The two `copystrcontent` ops become void
     /// `LoweredBlackholeOp`s, the source-length reads fuse to `strlen`, and

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1077,8 +1077,10 @@ pub enum OpKind {
     /// keyed on (`blackhole.rs`).
     ///
     /// Only for opnames whose lowering is a single register-shaped insn with
-    /// no descriptor and no special effect classification; descriptor-bearing
-    /// ops (getfield/getarrayitem/…) keep their dedicated rich `OpKind`s.
+    /// no descriptor operand; effect classification remains opname-driven
+    /// (e.g. `newstr`/`newunicode` are `MemoryErrorOnly` in
+    /// `jit_codewriter::call::op_can_raise`).  Descriptor-bearing ops
+    /// (getfield/getarrayitem/…) keep their dedicated rich `OpKind`s.
     LoweredBlackholeOp {
         opname: String,
         args: Vec<crate::flowspace::model::Variable>,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2268,17 +2268,21 @@ pub(crate) fn derive_subject_inputcells(
             // (`description.py:283-305 FunctionDesc.pycall`).
             if matches!(ty, crate::model::ValueType::Ref(_)) {
                 // String-typed params are string values, not class
-                // instances: `String` and `str` both map to the single
-                // unicode string type (`project_pyre_field_type` —
-                // `s_unicode0`; string literals lower to `UniStr`
-                // constants).  The foreign
-                // `alloc::string::String` TypeDecl also registers
-                // struct-field rows, so the registry path below would
-                // otherwise seed a `SomeInstance(String)` shell whose
+                // instances: `String` and `str` both map to the byte
+                // string type (`s_str0` = `SomeString(no_nul=True)`,
+                // matching `project_pyre_field_type`).  String literals
+                // lower through `__str_const` to `ConstValue::ByteStr`
+                // (flowspace_adapter, stamped `Ptr(STR)`/`StringRepr`),
+                // so a literal flowing into a `&str`/`String` param must
+                // meet the same byte `SomeString` — seeding `s_unicode0`
+                // here instead raised `str ∪ unicode` at `mergeinputargs`.
+                // The foreign `alloc::string::String` TypeDecl also
+                // registers struct-field rows, so the registry path below
+                // would otherwise seed a `SomeInstance(String)` shell whose
                 // field writes poison classdef attr cells with
                 // instance-annotated strings.
                 if class_root.as_deref() == Some("String") || class_root.as_deref() == Some("str") {
-                    cells.push(crate::annotator::model::s_unicode0());
+                    cells.push(crate::annotator::model::s_str0());
                     continue;
                 }
                 if let (Some(root), Some(bk)) = (class_root.as_ref(), bookkeeper) {

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -652,6 +652,23 @@ fn nonraising_core_bridge_opname(segments: &[String], arg_count: usize) -> Optio
     }
 }
 
+/// `true` iff `segments` is the `core::slice::<Impl>::reverse` FunctionPath
+/// that `front::mir` emits for a Rust `slice.reverse()` call (which has no
+/// source body to register).  Unlike the bridge ops above, `reverse` has no
+/// rtyper *operator* arm, so it is routed in [`translate_op`] to the
+/// `getattr` + `simple_call` *method* shape that reaches
+/// `FixedSizeListRepr.rtype_method("reverse")` (`rlist.py:138-143`
+/// `rtype_method_reverse` → `ll_reverse`).  Shared with [`op_canraise`],
+/// which classifies the originating Call non-raising
+/// (`rlist.py:142 hop.exception_cannot_occur()`).
+fn is_slice_reverse_segments(segments: &[String]) -> bool {
+    segments.len() == 4
+        && segments[0] == "core"
+        && segments[1] == "slice"
+        && segments[2] == "<Impl>"
+        && segments[3] == "reverse"
+}
+
 /// `true` iff the flowspace op(s) this `OpKind` lowers to carry a
 /// non-empty `canraise` (`operation.py`).
 ///
@@ -711,6 +728,17 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
             args,
             ..
         } if nonraising_core_bridge_opname(segments, args.len()).is_some() => false,
+        // `core::slice::<Impl>::reverse` lowers (in `translate_op`) to a
+        // `getattr` + `simple_call` method shape whose `rtype_method_reverse`
+        // does `hop.exception_cannot_occur()` (`rlist.py:142`); classify the
+        // originating Call non-raising so a `?` tail op installs no exception
+        // edge the lowered op cannot take.  (`reverse` returns `()`, so it is
+        // never actually a `?` operand — this keeps the table faithful.)
+        // Matched before the general `Call` arm.
+        OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath { segments },
+            ..
+        } if is_slice_reverse_segments(segments) => false,
         // simple_call -> `CallOp.canraise` is `[Exception]` for a
         // non-builtin callable (operation.py:648-661).  Constant builtin
         // callables (int / float / chr / unicode) carry the narrower
@@ -1349,6 +1377,46 @@ pub fn translate_op(
                             TyperError::message("len operation requires a receiver arg".to_string())
                         })?;
                         return Ok(vec![FlowspaceOp::new("len", vec![arg], result)]);
+                    }
+                    // `slice.reverse()` lowers (in Rust MIR) to a call to
+                    // `core::slice::<Impl>::reverse`, arriving as the
+                    // FunctionPath with no source body to register.  Unlike
+                    // `len`/`iter`, `reverse` has no rtyper operator arm, so
+                    // emit the *method* shape — `getattr(recv, "reverse")` +
+                    // `simple_call(bound_method)` — that the annotator's
+                    // `find_method("reverse")` (`unaryop.rs`) and
+                    // `BuiltinMethodRepr::rtype_simple_call` →
+                    // `rtype_method("reverse")` consume, identical to the
+                    // `CallTarget::Method` arm below.  `rtype_method_reverse`
+                    // (`rlist.py:138-143`) `gendirectcall`s `ll_reverse`
+                    // (`rlist.py:677-686`).
+                    if is_slice_reverse_segments(segments) {
+                        if arg_hls.len() != 1 {
+                            return Err(TyperError::message(format!(
+                                "slice.reverse requires exactly one receiver arg, got {}",
+                                arg_hls.len()
+                            )));
+                        }
+                        let mut iter = arg_hls.into_iter();
+                        let receiver = iter.next().ok_or_else(|| {
+                            TyperError::message(
+                                "slice.reverse requires a receiver arg".to_string(),
+                            )
+                        })?;
+                        let bound_method = Hlvalue::Variable(Variable::new());
+                        return Ok(vec![
+                            FlowspaceOp::new(
+                                "getattr",
+                                vec![
+                                    receiver,
+                                    Hlvalue::Constant(Constant::new(ConstValue::byte_str(
+                                        "reverse",
+                                    ))),
+                                ],
+                                bound_method.clone(),
+                            ),
+                            FlowspaceOp::new("simple_call", vec![bound_method], result),
+                        ]);
                     }
                     let key =
                         crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments(

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1399,9 +1399,7 @@ pub fn translate_op(
                         }
                         let mut iter = arg_hls.into_iter();
                         let receiver = iter.next().ok_or_else(|| {
-                            TyperError::message(
-                                "slice.reverse requires a receiver arg".to_string(),
-                            )
+                            TyperError::message("slice.reverse requires a receiver arg".to_string())
                         })?;
                         let bound_method = Hlvalue::Variable(Variable::new());
                         return Ok(vec![

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -506,6 +506,10 @@ fn dispatch_rtype_op(
         // checkidx=False branch (bare getarrayitem); the negative-index and
         // checkidx branches surface a TyperError until those helpers land.
         (FixedSizeListRepr, IntegerRepr, "getitem") => committed(r1.rtype_getitem(hop)),
+        // rlist.py:245-267 — the resized ListRepr shares the dispatch but
+        // reads through the `items` array out of its `length`/`items`
+        // header struct (getfield "items" → getarrayitem).
+        (ListRepr, IntegerRepr, "getitem") => committed(r1.rtype_getitem(hop)),
         // rrange.py:34-50 — pair(AbstractRangeRepr, IntegerRepr).rtype_getitem.
         // RangeRepr handles the constant-step + nonneg + dum_nocheck branch
         // (start + index*step); the checkidx, negative-index, and
@@ -599,6 +603,10 @@ fn dispatch_rtype_op(
         // setarrayitem); the checkidx (IndexError) and negative-index
         // branches surface a TyperError until those helpers land.
         (FixedSizeListRepr, IntegerRepr, "setitem") => committed(r1.rtype_setitem(hop)),
+        // rlist.py:272-284 — the resized ListRepr shares the dispatch but
+        // reads through the `items` array out of its `length`/`items`
+        // header struct (getfield "items" → setarrayitem).
+        (ListRepr, IntegerRepr, "setitem") => committed(r1.rtype_setitem(hop)),
 
         // rptr.py:165-184 — pointer comparison accepts any repr on the
         // other side and coerces both args to the pointer repr.

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -301,6 +301,50 @@ impl Repr for FixedSizeListRepr {
         )?;
         hop.gendirectcall(&helper, args)
     }
+
+    /// RPython `AbstractBaseListRepr.rtype_method_reverse(self, hop)`
+    /// (`rlist.py:138-143`):
+    ///
+    /// ```python
+    /// def rtype_method_reverse(self, hop):
+    ///     v_lst, = hop.inputargs(self)
+    ///     hop.exception_cannot_occur()
+    ///     hop.gendirectcall(ll_reverse, v_lst)
+    /// ```
+    ///
+    /// `ll_reverse` (`rlist.py:677-686`) is an in-place swap loop over the
+    /// `FixedSizeListRepr` receiver (the bare `Ptr(GcArray)`): it reads both
+    /// endpoints, writes them crossed, and walks `i` up / `length_1_i` down
+    /// toward the middle. The lowered body is the multi-block CFG built by
+    /// [`build_ll_reverse_helper_graph`]. `reverse` returns `None` (void).
+    fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
+        match method_name {
+            "reverse" => {
+                let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+                hop.exception_cannot_occur()?;
+                let item_lltype = self.item_repr.lowleveltype().clone();
+                let ptr_lltype = self.lltype.clone();
+                let ptr_for_builder = ptr_lltype.clone();
+                let item_for_builder = item_lltype.clone();
+                let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+                    "ll_reverse".to_string(),
+                    vec![ptr_lltype],
+                    LowLevelType::Void,
+                    move |_rtyper, _args, _result| {
+                        build_ll_reverse_helper_graph(
+                            "ll_reverse",
+                            ptr_for_builder.clone(),
+                            item_for_builder.clone(),
+                        )
+                    },
+                )?;
+                hop.gendirectcall(&helper, vlist)
+            }
+            _ => Err(TyperError::message(format!(
+                "missing FixedSizeListRepr.rtype_method_{method_name}"
+            ))),
+        }
+    }
 }
 
 /// Synthesise `LLHelpers`-style `ll_fixed_length`
@@ -904,6 +948,236 @@ pub(crate) fn build_ll_setitem_fast_helper_graph(
         vec!["l".to_string(), "index".to_string(), "item".to_string()],
         func,
     ))
+}
+
+/// Synthesise `ll_reverse` (`rlist.py:677-686`):
+///
+/// ```python
+/// def ll_reverse(l):
+///     length = l.ll_length()
+///     i = 0
+///     length_1_i = length-1-i
+///     while i < length_1_i:
+///         tmp = l.ll_getitem_fast(i)
+///         l.ll_setitem_fast(i, l.ll_getitem_fast(length_1_i))
+///         l.ll_setitem_fast(length_1_i, tmp)
+///         i += 1
+///         length_1_i -= 1
+/// ```
+///
+/// In-place swap loop over the `FixedSizeListRepr` receiver (the bare
+/// `Ptr(GcArray)`): `ll_length` / `ll_getitem_fast` / `ll_setitem_fast` each
+/// collapse to a single `getarraysize` / `getarrayitem` / `setarrayitem` op
+/// (no `items` header indirection, unlike the resized list). Four-block CFG:
+/// - **startblock**: `getarraysize(l) -> length`, `int_sub(length, 1) ->
+///   length_1_i` (the `length - 1 - i` initial folds `- i` against the
+///   loop-seeding constant `i = 0`); links to `block_loop_cond(l, 0,
+///   length_1_i)`.
+/// - **block_loop_cond**: `int_lt(i, length_1_i) -> cond`. `True` →
+///   `block_loop_body`; `False` → returnblock (`None`). The strict `<` leaves
+///   an odd-length list's middle element in place.
+/// - **block_loop_body**: read BOTH endpoints before writing either (so the
+///   swap captures pre-swap values) — `getarrayitem(l, i) -> tmp`,
+///   `getarrayitem(l, length_1_i) -> v`, `setarrayitem(l, i, v)`,
+///   `setarrayitem(l, length_1_i, tmp)` — then `int_add(i, 1)`,
+///   `int_sub(length_1_i, 1)`, back to `block_loop_cond`.
+pub(crate) fn build_ll_reverse_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let signed_const = |n: i64| {
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::Int(n),
+            LowLevelType::Signed,
+        ))
+    };
+    let bool_const = |b: bool| {
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::Bool(b),
+            LowLevelType::Bool,
+        ))
+    };
+
+    let l_arg = variable_with_lltype("l", ptr_lltype.clone());
+    let startblock = Block::shared(vec![Hlvalue::Variable(l_arg.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // The loop blocks carry (l, i, length_1_i) as their own fresh inputargs.
+    let l_cond = variable_with_lltype("l", ptr_lltype.clone());
+    let i_cond = variable_with_lltype("i", LowLevelType::Signed);
+    let j_cond = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    let block_loop_cond = Block::shared(vec![
+        Hlvalue::Variable(l_cond.clone()),
+        Hlvalue::Variable(i_cond.clone()),
+        Hlvalue::Variable(j_cond.clone()),
+    ]);
+
+    let l_body = variable_with_lltype("l", ptr_lltype);
+    let i_body = variable_with_lltype("i", LowLevelType::Signed);
+    let j_body = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    let block_loop_body = Block::shared(vec![
+        Hlvalue::Variable(l_body.clone()),
+        Hlvalue::Variable(i_body.clone()),
+        Hlvalue::Variable(j_body.clone()),
+    ]);
+
+    // ---- startblock: length = getarraysize(l); length_1_i = length - 1.
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarraysize",
+        vec![Hlvalue::Variable(l_arg.clone())],
+        Hlvalue::Variable(length.clone()),
+    ));
+    let length_1_i = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(length), signed_const(1)],
+        Hlvalue::Variable(length_1_i.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_arg),
+                signed_const(0),
+                Hlvalue::Variable(length_1_i),
+            ],
+            Some(block_loop_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_loop_cond: int_lt(i, length_1_i). True -> body; False -> return None.
+    let cond = variable_with_lltype("cond", LowLevelType::Bool);
+    block_loop_cond
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_lt",
+            vec![
+                Hlvalue::Variable(i_cond.clone()),
+                Hlvalue::Variable(j_cond.clone()),
+            ],
+            Hlvalue::Variable(cond.clone()),
+        ));
+    block_loop_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+    let none_const = Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::None,
+        LowLevelType::Void,
+    ));
+    block_loop_cond.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_cond),
+                Hlvalue::Variable(i_cond),
+                Hlvalue::Variable(j_cond),
+            ],
+            Some(block_loop_body.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![none_const],
+            Some(graph.returnblock.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_loop_body: read both endpoints, write them crossed, step indices.
+    let tmp = variable_with_lltype("tmp", item_lltype.clone());
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getarrayitem",
+            vec![
+                Hlvalue::Variable(l_body.clone()),
+                Hlvalue::Variable(i_body.clone()),
+            ],
+            Hlvalue::Variable(tmp.clone()),
+        ));
+    let v = variable_with_lltype("v", item_lltype);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getarrayitem",
+            vec![
+                Hlvalue::Variable(l_body.clone()),
+                Hlvalue::Variable(j_body.clone()),
+            ],
+            Hlvalue::Variable(v.clone()),
+        ));
+    let w_i = variable_with_lltype("v", LowLevelType::Void);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(l_body.clone()),
+                Hlvalue::Variable(i_body.clone()),
+                Hlvalue::Variable(v),
+            ],
+            Hlvalue::Variable(w_i),
+        ));
+    let w_j = variable_with_lltype("v", LowLevelType::Void);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(l_body.clone()),
+                Hlvalue::Variable(j_body.clone()),
+                Hlvalue::Variable(tmp),
+            ],
+            Hlvalue::Variable(w_j),
+        ));
+    let i_next = variable_with_lltype("i", LowLevelType::Signed);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(i_body.clone()), signed_const(1)],
+            Hlvalue::Variable(i_next.clone()),
+        ));
+    let j_next = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_sub",
+            vec![Hlvalue::Variable(j_body.clone()), signed_const(1)],
+            Hlvalue::Variable(j_next.clone()),
+        ));
+    block_loop_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_body),
+                Hlvalue::Variable(i_next),
+                Hlvalue::Variable(j_next),
+            ],
+            Some(block_loop_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, vec!["l".to_string()], func))
 }
 
 #[cfg(test)]
@@ -1545,5 +1819,155 @@ mod tests {
             .map(|op| op.opname.clone())
             .collect();
         assert_eq!(ops, vec!["getfield", "setarrayitem"]);
+    }
+
+    /// `slice.reverse()` rtypes through `rtype_method("reverse")` to a
+    /// `direct_call(ll_reverse, v_lst)` (`rlist.py:138-143`); `reverse`
+    /// returns `None` (void), and the path calls
+    /// `hop.exception_cannot_occur()`.
+    #[test]
+    fn fixed_size_list_reverse_emits_direct_call_to_ll_reverse() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Void));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "simple_call".to_string(),
+                vec![Hlvalue::Variable(v_list)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .extend([SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ true,
+                /* resized */ false,
+            )))]);
+        hop.args_r
+            .borrow_mut()
+            .extend([Some(list_repr.clone() as Arc<dyn Repr>)]);
+
+        let result = list_repr
+            .rtype_method("reverse", &hop)
+            .unwrap_or_else(|err| panic!("list reverse: {err:?}"));
+        assert!(result.is_some());
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "rtype_method_reverse must call hop.exception_cannot_occur()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(dbg.contains("ll_reverse"), "expected 'll_reverse' in {dbg}");
+    }
+
+    /// An unknown method name surfaces a `TyperError` so the subject stays
+    /// on the legacy walker rather than miscompiling.
+    #[test]
+    fn fixed_size_list_unknown_method_is_deferred() {
+        let rtyper = fresh_rtyper_live();
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_repr.lowleveltype().clone()));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Void));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "simple_call".to_string(),
+                vec![Hlvalue::Variable(v_list)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops,
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_r
+            .borrow_mut()
+            .extend([Some(list_repr.clone() as Arc<dyn Repr>)]);
+        assert!(list_repr.rtype_method("sort", &hop).is_err());
+    }
+
+    /// The `ll_reverse` helper is a four-block swap loop: `startblock`
+    /// (`getarraysize` + `int_sub`) → `block_loop_cond` (`int_lt`) →
+    /// `block_loop_body` (two `getarrayitem` reads BEFORE two `setarrayitem`
+    /// writes, then `int_add` / `int_sub`) → back to the cond block.
+    #[test]
+    fn build_ll_reverse_helper_has_swap_loop_blocks() {
+        let rtyper = fresh_rtyper();
+        let repr = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let pygraph = build_ll_reverse_helper_graph(
+            "ll_reverse",
+            repr.lowleveltype().clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build_ll_reverse_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let block_op_seqs: Vec<Vec<String>> = graph
+            .iterblocks()
+            .iter()
+            .map(|b| {
+                b.borrow()
+                    .operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .collect()
+            })
+            .collect();
+        // The startblock signature distinguishes reverse from get/setitem.
+        assert!(
+            block_op_seqs.contains(&vec!["getarraysize".to_string(), "int_sub".to_string()]),
+            "startblock must be getarraysize + int_sub, got {block_op_seqs:?}"
+        );
+        // The loop-condition block.
+        assert!(
+            block_op_seqs.contains(&vec!["int_lt".to_string()]),
+            "expected an int_lt condition block, got {block_op_seqs:?}"
+        );
+        // The swap body: both reads precede both writes, then the two steps.
+        assert!(
+            block_op_seqs.contains(&vec![
+                "getarrayitem".to_string(),
+                "getarrayitem".to_string(),
+                "setarrayitem".to_string(),
+                "setarrayitem".to_string(),
+                "int_add".to_string(),
+                "int_sub".to_string(),
+            ]),
+            "expected the read-both-before-write swap body, got {block_op_seqs:?}"
+        );
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -158,8 +158,20 @@ impl Repr for FixedSizeListRepr {
     /// `getarrayitem` on the `Ptr(GcArray)` receiver. The negative-index
     /// (`ll_getitem`) and `checkidx` (IndexError-raising) branches surface
     /// a `TyperError` until those helpers land — Rust slice indexing never
-    /// produces them. `recast` is a no-op here (the item lltype is already
-    /// the array element type).
+    /// produces them.
+    ///
+    /// The upstream result `recast` (`rlist.py:266`
+    /// `return r_lst.recast(hop.llops, v_res)` → `convertvar(v, item_repr,
+    /// external_item_repr)`) is omitted: `FixedSizeListRepr::new` keeps only
+    /// the internal `item_repr` and drops the `external_item_repr` half of
+    /// `externalvsinternal`, so getitem returns the internal repr directly.
+    /// That is correct for every list a live subject builds today — a
+    /// primitive item has `external == internal`, making recast an identity —
+    /// but a GC-instance list (`external != internal`) would return the
+    /// internal/root repr instead of the concrete external repr. Deferred to
+    /// the #305 slice that models `external_item_repr`: pyre's `convertvar`
+    /// keys identity on `Arc::ptr_eq`, so a same-lltype-different-`Arc`
+    /// recast added now would `TyperError` every currently-green getitem.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::annotator::model::SomeValue;
         let s1 = hop

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -1177,7 +1177,11 @@ pub(crate) fn build_ll_reverse_helper_graph(
         Constant::new(ConstValue::Dict(Default::default())),
     );
     graph.func = Some(func.clone());
-    Ok(helper_pygraph_from_graph(graph, vec!["l".to_string()], func))
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string()],
+        func,
+    ))
 }
 
 #[cfg(test)]

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -174,6 +174,11 @@ impl Repr for FixedSizeListRepr {
     /// recast added now would `TyperError` every currently-green getitem.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::annotator::model::SomeValue;
+        if hop.has_implicit_exception("IndexError") {
+            return Err(TyperError::message(
+                "list rtype_getitem: checkidx IndexError branch not yet ported",
+            ));
+        }
         let s1 = hop
             .args_s
             .borrow()
@@ -845,6 +850,78 @@ mod tests {
             Some(signed_repr() as Arc<dyn Repr>),
         ]);
         assert!(list_repr.rtype_getitem(&hop).is_err());
+    }
+
+    /// A caught `IndexError` (`hop.has_implicit_exception("IndexError")`)
+    /// requires the `checkidx` path (`ll_getitem`), which is not yet
+    /// ported — `rtype_getitem` must surface a `TyperError` rather than
+    /// silently dropping the bounds check via the `dum_nocheck` fast path.
+    /// Mirrors the `rtype_setitem` checkidx guard.
+    #[test]
+    fn fixed_size_list_getitem_checkidx_indexerror_is_deferred() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        // A caught IndexError exitcase on this getitem.
+        let exitblock = std::rc::Rc::new(std::cell::RefCell::new(Block::new(vec![])));
+        let cls_index = crate::flowspace::model::HOST_ENV
+            .lookup_exception_class("IndexError")
+            .expect("IndexError class");
+        let link_index = std::rc::Rc::new(std::cell::RefCell::new(Link::new(
+            vec![],
+            Some(exitblock),
+            Some(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                cls_index,
+            )))),
+        )));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_list), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            vec![link_index],
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ false,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+        let err = list_repr
+            .rtype_getitem(&hop)
+            .expect_err("checkidx IndexError must defer to a TyperError");
+        assert!(
+            format!("{err}").contains("checkidx IndexError"),
+            "expected checkidx IndexError deferral message, got {err}"
+        );
     }
 
     /// rlist.py:272-284 nonneg + dum_nocheck branch — `setitem` on a

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -387,7 +387,6 @@ pub struct ListRepr {
     lltype: LowLevelType,
     /// `self.item_repr` (`rlist.py:111`) — the internal (gcref-wrapped)
     /// element repr.
-    #[allow(dead_code)]
     item_repr: Arc<dyn Repr>,
 }
 
@@ -462,6 +461,134 @@ impl Repr for ListRepr {
             },
         )?;
         hop.gendirectcall(&helper, vlist)
+    }
+
+    /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_getitem`
+    /// (`rlist.py:247-267`) for the resized list. Shares the dispatch with
+    /// [`FixedSizeListRepr::rtype_getitem`] (nonneg + `dum_nocheck` fast
+    /// path, `ll_getitem_nonneg` → `l.ll_getitem_fast(index)`), but the
+    /// resized receiver is the `Ptr(GcStruct("list", length, items))`
+    /// header, so `ll_getitem_fast` (`lltypesystem/rlist.py:259-262`) reads
+    /// the `items` array out of the struct first
+    /// (`l.ll_items()[index]` = `getfield(l, "items")` then
+    /// `getarrayitem`). The negative-index (`ll_getitem`) and `checkidx`
+    /// (IndexError-raising) branches surface a `TyperError` until those
+    /// helpers land.
+    ///
+    /// The upstream result `recast` (`rlist.py:266`) is omitted for the
+    /// same reason as `FixedSizeListRepr`: `ListRepr::new` keeps only the
+    /// internal `item_repr`, an identity recast for the primitive items a
+    /// live subject builds today. A GC-instance list (`external !=
+    /// internal`) is deferred to the #305 `external_item_repr` slice.
+    fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::annotator::model::SomeValue;
+        if hop.has_implicit_exception("IndexError") {
+            return Err(TyperError::message(
+                "list rtype_getitem: checkidx IndexError branch not yet ported",
+            ));
+        }
+        let s1 = hop
+            .args_s
+            .borrow()
+            .get(1)
+            .cloned()
+            .ok_or_else(|| TyperError::message("list rtype_getitem: args_s[1] missing"))?;
+        let nonneg = match &s1 {
+            SomeValue::Integer(i) => i.nonneg,
+            other => {
+                return Err(TyperError::message(format!(
+                    "list rtype_getitem: args_s[1] must be SomeInteger, got {other:?}"
+                )));
+            }
+        };
+        if !nonneg {
+            return Err(TyperError::message(
+                "list rtype_getitem: negative-index ll_getitem branch not yet ported",
+            ));
+        }
+        let args = hop.inputargs(vec![
+            ConvertedTo::Repr(self),
+            ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ])?;
+        hop.exception_cannot_occur()?;
+        let item_lltype = self.item_repr.lowleveltype().clone();
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let item_for_builder = item_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_getitem_fast".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed],
+            item_lltype,
+            move |_rtyper, _args, _result| {
+                build_ll_getitem_fast_helper_graph(
+                    "ll_getitem_fast",
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, args)
+    }
+
+    /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
+    /// (`rlist.py:272-284`) for the resized list. Shares the dispatch with
+    /// [`FixedSizeListRepr::rtype_setitem`] (nonneg + `dum_nocheck`,
+    /// `ll_setitem_nonneg` → `l.ll_setitem_fast(index, item)`), but the
+    /// resized receiver reads the `items` array out of the
+    /// `Ptr(GcStruct("list", length, items))` header first
+    /// (`lltypesystem/rlist.py:264-267` `l.ll_items()[index] = item` =
+    /// `getfield(l, "items")` then `setarrayitem`). The `checkidx`
+    /// (implicit-IndexError) and negative-index (`ll_setitem`) branches
+    /// surface a `TyperError` until those helpers land.
+    fn rtype_setitem(&self, hop: &HighLevelOp) -> RTypeResult {
+        use crate::annotator::model::SomeValue;
+        if hop.has_implicit_exception("IndexError") {
+            return Err(TyperError::message(
+                "list rtype_setitem: checkidx IndexError branch not yet ported",
+            ));
+        }
+        let s1 = hop
+            .args_s
+            .borrow()
+            .get(1)
+            .cloned()
+            .ok_or_else(|| TyperError::message("list rtype_setitem: args_s[1] missing"))?;
+        let nonneg = match &s1 {
+            SomeValue::Integer(i) => i.nonneg,
+            other => {
+                return Err(TyperError::message(format!(
+                    "list rtype_setitem: args_s[1] must be SomeInteger, got {other:?}"
+                )));
+            }
+        };
+        if !nonneg {
+            return Err(TyperError::message(
+                "list rtype_setitem: negative-index ll_setitem branch not yet ported",
+            ));
+        }
+        let args = hop.inputargs(vec![
+            ConvertedTo::Repr(self),
+            ConvertedTo::LowLevelType(&LowLevelType::Signed),
+            ConvertedTo::Repr(self.item_repr.as_ref()),
+        ])?;
+        hop.exception_is_here()?;
+        let item_lltype = self.item_repr.lowleveltype().clone();
+        let ptr_lltype = self.lltype.clone();
+        let ptr_for_builder = ptr_lltype.clone();
+        let item_for_builder = item_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_setitem_fast".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed, item_lltype],
+            LowLevelType::Void,
+            move |_rtyper, _args, _result| {
+                build_ll_setitem_fast_helper_graph(
+                    "ll_setitem_fast",
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, args)
     }
 }
 
@@ -611,6 +738,149 @@ pub(crate) fn build_ll_fixed_setitem_fast_helper_graph(
         "setarrayitem",
         vec![
             Hlvalue::Variable(l_arg),
+            Hlvalue::Variable(index_arg),
+            Hlvalue::Variable(item_arg),
+        ],
+        Hlvalue::Variable(v_void),
+    ));
+    let none_const = Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::None,
+        LowLevelType::Void,
+    ));
+    startblock.closeblock(vec![
+        Link::new(vec![none_const], Some(graph.returnblock.clone()), None).into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise the resized-list `ll_getitem_fast`
+/// (`lltypesystem/rlist.py:259-262`):
+///
+/// ```python
+/// def ll_getitem_fast(l, index):
+///     ll_assert(index < l.ll_length(), "getitem out of bounds")
+///     return l.ll_items()[index]
+/// ```
+///
+/// The `ll_assert` is a debug-only bound check (no production op). Unlike
+/// [`build_ll_fixed_getitem_fast_helper_graph`] (whose receiver IS the
+/// `Ptr(GcArray)`), the resized receiver is the
+/// `Ptr(GcStruct("list", length, items))` header, so the body reads the
+/// `items` array out of the struct first: `getfield(l, "items")` →
+/// `getarrayitem(items, index) -> ITEM`.
+pub(crate) fn build_ll_getitem_fast_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let index_arg = variable_with_lltype("index", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(index_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let items_ptr_lltype = LowLevelType::Ptr(Box::new(Ptr {
+        TO: PtrTarget::Array(ArrayType::gc(item_lltype.clone())),
+    }));
+    let v_items = variable_with_lltype("items", items_ptr_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l_arg), void_field_const("items")],
+        Hlvalue::Variable(v_items.clone()),
+    ));
+    let v_item = variable_with_lltype("item", item_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarrayitem",
+        vec![Hlvalue::Variable(v_items), Hlvalue::Variable(index_arg)],
+        Hlvalue::Variable(v_item.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_item)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise the resized-list `ll_setitem_fast`
+/// (`lltypesystem/rlist.py:264-267`):
+///
+/// ```python
+/// def ll_setitem_fast(l, index, item):
+///     ll_assert(index < l.ll_length(), "setitem out of bounds")
+///     l.ll_items()[index] = item
+/// ```
+///
+/// The `ll_assert` is a debug-only bound check (no production op). The
+/// resized receiver reads the `items` array out of the
+/// `Ptr(GcStruct("list", length, items))` header first:
+/// `getfield(l, "items")` → `setarrayitem(items, index, item)`. The
+/// function falls off the end (`return None`), so the returnblock receives
+/// the `Void` `None` constant.
+pub(crate) fn build_ll_setitem_fast_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let index_arg = variable_with_lltype("index", LowLevelType::Signed);
+    let item_arg = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(index_arg.clone()),
+        Hlvalue::Variable(item_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let items_ptr_lltype = LowLevelType::Ptr(Box::new(Ptr {
+        TO: PtrTarget::Array(ArrayType::gc(item_lltype)),
+    }));
+    let v_items = variable_with_lltype("items", items_ptr_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l_arg), void_field_const("items")],
+        Hlvalue::Variable(v_items.clone()),
+    ));
+    let v_void = variable_with_lltype("v", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(v_items),
             Hlvalue::Variable(index_arg),
             Hlvalue::Variable(item_arg),
         ],
@@ -1071,5 +1341,209 @@ mod tests {
             Some(item_repr),
         ]);
         assert!(list_repr.rtype_setitem(&hop).is_err());
+    }
+
+    /// rlist.py:247-267 nonneg + checkidx=False branch — `getitem` on a
+    /// resized `ListRepr` lowers to a `direct_call` of `ll_getitem_fast`
+    /// (the resized helper, distinct from `FixedSizeListRepr`'s
+    /// `ll_fixed_getitem_fast`), preceded by `hop.exception_cannot_occur()`.
+    #[test]
+    fn resized_list_getitem_nonneg_emits_direct_call_to_ll_getitem_fast() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let list_repr: Arc<ListRepr> = Arc::new(
+            ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_list), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ false,
+                /* resized */ true,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+
+        let result = list_repr
+            .rtype_getitem(&hop)
+            .unwrap_or_else(|err| panic!("resized list getitem nonneg: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "checkidx=False path must call hop.exception_cannot_occur()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_getitem_fast"),
+            "expected 'll_getitem_fast' in {dbg}"
+        );
+    }
+
+    /// rlist.py:272-284 nonneg + dum_nocheck branch — `setitem` on a
+    /// resized `ListRepr` lowers to a `direct_call` of `ll_setitem_fast`
+    /// (the resized helper, distinct from `FixedSizeListRepr`'s
+    /// `ll_fixed_setitem_fast`), preceded by `hop.exception_is_here()`.
+    #[test]
+    fn resized_list_setitem_nonneg_emits_direct_call_to_ll_setitem_fast() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let list_repr: Arc<ListRepr> = Arc::new(
+            ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let item_repr = list_repr.item_repr.clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_item = Variable::new();
+        v_item.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Void));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "setitem".to_string(),
+                vec![
+                    Hlvalue::Variable(v_list),
+                    Hlvalue::Variable(v_idx),
+                    Hlvalue::Variable(v_item),
+                ],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ true,
+                /* resized */ true,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+            SomeValue::Integer(SomeInteger::new(false, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+            Some(item_repr),
+        ]);
+
+        let result = list_repr
+            .rtype_setitem(&hop)
+            .unwrap_or_else(|err| panic!("resized list setitem nonneg: {err:?}"));
+        assert!(result.is_some());
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "rtype_setitem must call hop.exception_is_here()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_setitem_fast"),
+            "expected 'll_setitem_fast' in {dbg}"
+        );
+    }
+
+    /// The resized `ll_getitem_fast` helper body reads the `items` array
+    /// out of the `length`/`items` header struct before indexing:
+    /// `getfield(l, "items")` → `getarrayitem(items, index)` (vs
+    /// `FixedSizeListRepr`'s single `getarrayitem` on the bare array).
+    #[test]
+    fn build_ll_getitem_fast_helper_reads_items_then_getarrayitem() {
+        let rtyper = fresh_rtyper();
+        let repr = ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new");
+        let pygraph = build_ll_getitem_fast_helper_graph(
+            "ll_getitem_fast",
+            repr.lowleveltype().clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build_ll_getitem_fast_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let ops: Vec<_> = graph
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        assert_eq!(ops, vec!["getfield", "getarrayitem"]);
+    }
+
+    /// The resized `ll_setitem_fast` helper body reads the `items` array
+    /// out of the `length`/`items` header struct before storing:
+    /// `getfield(l, "items")` → `setarrayitem(items, index, item)`.
+    #[test]
+    fn build_ll_setitem_fast_helper_reads_items_then_setarrayitem() {
+        let rtyper = fresh_rtyper();
+        let repr = ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new");
+        let pygraph = build_ll_setitem_fast_helper_graph(
+            "ll_setitem_fast",
+            repr.lowleveltype().clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build_ll_setitem_fast_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let ops: Vec<_> = graph
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        assert_eq!(ops, vec!["getfield", "setarrayitem"]);
     }
 }

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -177,7 +177,7 @@ pub fn materialize_str_consts(jitcodes: &mut Vec<Arc<JitCode>>) {
             };
             // The slot must still hold its non-canonical sentinel — never a
             // real address (which has the high bits clear).
-            debug_assert_eq!(
+            assert_eq!(
                 (body.constants_r[idx] as u64) & SENTINEL_HIGH_MASK,
                 (majit_translate::assembler::STR_CONST_SENTINEL_BASE as u64) & SENTINEL_HIGH_MASK,
                 "constants_r[{idx}] did not hold a prebuilt-string sentinel",

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -110,17 +110,6 @@ pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
     }
 }
 
-/// STR `GcStruct` layout (`rstr.py:1226` `extra_item_after_alloc=True`),
-/// byte-identical to `bh_alloc_lowlevel_string` / `bh_newstr` (pyre-jit
-/// `eval.rs`) and the `malloc_varsize(STR)` the cutover codewriter lowers
-/// `ll_strconcat` into: `[hash:i64 @0][length:usize @8][chars:u8 @16..][NUL]`.
-/// The `chars` array stores its length inline at `@8` (RPython array length
-/// prefix) and an extra trailing byte for the C null terminator.
-const STR_HASH_OFFSET: usize = 0;
-const STR_LEN_OFFSET: usize = std::mem::size_of::<usize>();
-const STR_CHARS_OFFSET: usize = 2 * std::mem::size_of::<usize>();
-const STR_BASE_SIZE: usize = STR_CHARS_OFFSET + 1;
-
 /// High 16 bits of a deferred prebuilt-string sentinel (see
 /// [`majit_translate::assembler::STR_CONST_SENTINEL_BASE`]).  x86-64 user
 /// addresses occupy `0..2^48`, so a real GCREF / host-static address always
@@ -128,27 +117,22 @@ const STR_BASE_SIZE: usize = STR_CHARS_OFFSET + 1;
 /// pattern.
 const SENTINEL_HIGH_MASK: u64 = 0xFFFF_0000_0000_0000;
 
-/// Allocate and fill one immortal runtime STR block for a prebuilt-string
-/// constant, returning its address.  `alloc_zeroed` (never freed, outside
-/// the nursery/oldgen) gives a block the collector treats as a non-moving
-/// root target (`can_move = false`); the trailing NUL at `chars + len` is
-/// the zeroed extra item.  The layout mirrors the runtime allocator exactly
-/// so the block is indistinguishable from a `bh_newstr` result to every
-/// downstream reader (`getarraysize`, `getarrayitem`, `ll_strhash`).
-fn materialize_prebuilt_str(bytes: &[u8], precomputed_hash: i64) -> i64 {
-    let total = STR_BASE_SIZE + bytes.len();
-    let layout = std::alloc::Layout::from_size_align(total, std::mem::align_of::<usize>())
-        .expect("prebuilt STR layout");
-    let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
-    assert!(!ptr.is_null(), "prebuilt STR alloc_zeroed returned null");
-    unsafe {
-        (ptr.add(STR_HASH_OFFSET) as *mut i64).write(precomputed_hash);
-        (ptr.add(STR_LEN_OFFSET) as *mut usize).write(bytes.len());
-        for (i, &b) in bytes.iter().enumerate() {
-            ptr.add(STR_CHARS_OFFSET + i).write(b);
-        }
-    }
-    ptr as i64
+/// Materialize one immortal runtime `W_StrObject` for a prebuilt-string
+/// constant, returning its address.  `box_str_constant` leaks (never freed,
+/// outside the nursery) a `W_StrObject` whose `value: *mut Wtf8Buf`
+/// indirection at `STR_VALUE_OFFSET` is exactly what the trace readers
+/// follow: `bh_strlen` / `bh_strgetitem` (`pyre_cpu.rs`) and the compiled
+/// `PyreStrDescr` fast path both dereference that pointer, so the block is
+/// indistinguishable from a `bh_newstr` result.  It is the same builder
+/// `pyre-jit`'s `flatten.rs` uses for runtime string literals, and interns
+/// identical literals by content (the runtime analog of the assembler's
+/// per-jitcode dedup).  `precomputed_hash` is unused at runtime —
+/// `W_StrObject` carries no hash slot, so `ll_strhash` recomputes it from
+/// `value` on demand.
+fn materialize_prebuilt_str(bytes: &[u8], _precomputed_hash: i64) -> i64 {
+    let wtf8 = rustpython_wtf8::Wtf8::from_bytes(bytes)
+        .expect("prebuilt STR constant bytes are not valid WTF-8");
+    pyre_object::strobject::box_str_constant(wtf8) as i64
 }
 
 /// Materialize every deferred prebuilt-string constant the codewriter
@@ -235,20 +219,11 @@ mod tests {
         Arc::new(jc)
     }
 
-    /// Read back a materialized STR block: `(length, bytes, hash)`.
-    unsafe fn read_str_block(addr: i64) -> (usize, Vec<u8>, i64) {
-        let p = addr as *const u8;
-        let hash = unsafe { *(p.add(STR_HASH_OFFSET) as *const i64) };
-        let len = unsafe { *(p.add(STR_LEN_OFFSET) as *const usize) };
-        let mut bytes = Vec::with_capacity(len);
-        for i in 0..len {
-            bytes.push(unsafe { *p.add(STR_CHARS_OFFSET + i) });
-        }
-        (len, bytes, hash)
-    }
-
     #[test]
-    fn materialize_str_consts_overwrites_sentinel_with_str_block() {
+    fn materialize_str_consts_overwrites_sentinel_with_str_object() {
+        use majit_ir::GcRef;
+        use majit_metainterp::cpu::Cpu;
+
         let descs = vec![StrConstDescriptor {
             constants_r_index: 0,
             bytes: b"hello".to_vec(),
@@ -262,12 +237,19 @@ mod tests {
         assert_eq!(
             (addr as u64) & SENTINEL_HIGH_MASK,
             0,
-            "a real STR address must have the sentinel high bits clear",
+            "a real W_StrObject address must have the sentinel high bits clear",
         );
-        let (len, bytes, hash) = unsafe { read_str_block(addr) };
-        assert_eq!(len, 5);
-        assert_eq!(bytes, b"hello");
-        assert_eq!(hash, 0x1234_5678);
+        // Validate against the exact readers a live trace uses — the
+        // `W_StrObject.value` indirection at `STR_VALUE_OFFSET`.  This is the
+        // test that would have caught the old low-level-block layout bug:
+        // `bh_strlen` follows the value pointer, so a non-`W_StrObject` block
+        // would read garbage / fault here.
+        let cpu = crate::pyre_cpu::PyreCpu::new();
+        assert_eq!(cpu.bh_strlen(GcRef(addr as usize)), Some(5));
+        let got: Vec<u8> = (0..5)
+            .map(|i| cpu.bh_strgetitem(GcRef(addr as usize), i).unwrap() as u8)
+            .collect();
+        assert_eq!(got, b"hello");
     }
 
     #[test]
@@ -284,12 +266,18 @@ mod tests {
         materialize_str_consts(&mut jcs);
         let a0 = jcs[0].body().constants_r[0];
         let a1 = jcs[1].body().constants_r[0];
-        assert_eq!(a0, a1, "identical literals must share one immortal block");
+        assert_eq!(
+            a0, a1,
+            "identical literals must share one immortal W_StrObject",
+        );
         assert_ne!(a0, sentinel(0));
     }
 
     #[test]
-    fn materialize_str_consts_empty_string_has_trailing_nul() {
+    fn materialize_str_consts_empty_string() {
+        use majit_ir::GcRef;
+        use majit_metainterp::cpu::Cpu;
+
         let descs = vec![StrConstDescriptor {
             constants_r_index: 0,
             bytes: Vec::new(),
@@ -298,11 +286,7 @@ mod tests {
         let mut jcs = vec![jitcode_with_str_consts(descs)];
         materialize_str_consts(&mut jcs);
         let addr = jcs[0].body().constants_r[0];
-        let (len, bytes, hash) = unsafe { read_str_block(addr) };
-        assert_eq!(len, 0);
-        assert!(bytes.is_empty());
-        assert_eq!(hash, -1);
-        let nul = unsafe { *(addr as *const u8).add(STR_CHARS_OFFSET) };
-        assert_eq!(nul, 0, "extra_item_after_alloc trailing NUL must be zeroed");
+        let cpu = crate::pyre_cpu::PyreCpu::new();
+        assert_eq!(cpu.bh_strlen(GcRef(addr as usize)), Some(0));
     }
 }


### PR DESCRIPTION
Fix #37

## Summary

This batch sits on top of `main` (11 commits) and spans the majit translator/rtyper and the JIT-trace codegen.

**rtyper — ListRepr getitem/setitem**
- Port `pair(ListRepr, IntegerRepr).rtype_getitem/rtype_setitem` for the **resized** list: read the `items` array out of the `Ptr(GcStruct("list", length, items))` header, lower the nonneg + `dum_nocheck` fast path through `ll_getitem_fast`/`ll_setitem_fast`. The checked-IndexError and negative-index branches decline (`TyperError` → dual-gate legacy Skip) until those helpers land — never a miscompile. Result `recast` is the identity for the primitive items live subjects build today; GC-instance element reprs are deferred to #305.
- Guard `FixedSizeListRepr` getitem against the checkidx IndexError branch and document its `recast` gap.
- Lower `core::slice::<Impl>::reverse` to an `ll_reverse` swap loop.

**front/annotator — per-instantiation generic-enum ClassDefs (#100)**
- Project per-instantiation Ref-payload enum variant ClassDefs (`Result<T,PyError>::Ok`, `Option<T>::Some`, …) keyed by a rendered generic-argument suffix; strip the suffix for the instantiation-invariant discriminant-table lookup; rebuild `Result{suffix}::{Ok,Err}` shells in the result_exc lowering so each instantiation gets a distinct payload attribute instead of unioning.

**jit_codewriter / jit-trace — opname helpers + prebuilt strings**
- Resolve opname helpers as regular calls; recover `LoweredBlackholeOp` purity in an opname-aware way.
- Build prebuilt-string constants as `W_StrObject` values and assert the prebuilt-string sentinel in release.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Rust `slice.reverse()` method calls
  * Enabled `getitem`/`setitem` operations on resized lists

* **Bug Fixes**
  * Improved generic type instantiation handling in enum variant dispatch and field lookups
  * Fixed string constant materialization for runtime values
  * Enhanced Result type instantiation preservation across generic variants

* **Tests**
  * Added unit tests for generic name canonicalization, opname helper resolution, and list operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->