### PR TITLE
_pickle follow-ups: defaultdict, dict/deque reduce, bytes buffer protocol, stable reverse sort

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10520,6 +10520,39 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
             let n = pyre_object::w_str_get_wtf8(needle).as_bytes();
             return Ok(n.is_empty() || h.windows(n.len()).any(|w| w == n));
         }
+        // bytes / bytearray: stringmethods.py descr_contains via
+        // `_op_val(allow_char=True)` — an int needle is a single byte value
+        // (range-checked), a bytes-like needle is matched as a substring (an
+        // empty needle is always present), and any other type is a TypeError.
+        // The upstream buffer-protocol fallback that also accepts a memoryview
+        // is not implemented for bytes methods here.
+        if pyre_object::bytesobject::is_bytes_like(haystack) {
+            let hay = pyre_object::bytesobject::bytes_like_data(haystack);
+            if is_int(needle) || is_long(needle) {
+                // `_single_char`: `int_w` then `0 <= c < 256`; a bignum is
+                // necessarily out of range (its `int_w` overflows upstream).
+                let v = if is_int(needle) {
+                    pyre_object::w_int_get_value(needle)
+                } else {
+                    -1
+                };
+                if !(0..=255).contains(&v) {
+                    return Err(PyError::value_error("byte must be in range(0, 256)"));
+                }
+                return Ok(hay.contains(&(v as u8)));
+            }
+            if pyre_object::bytesobject::is_bytes_like(needle) {
+                let sub = pyre_object::bytesobject::bytes_like_data(needle);
+                return Ok(sub.is_empty() || hay.windows(sub.len()).any(|w| w == sub));
+            }
+            let tname = match crate::typedef::r#type(needle) {
+                Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+                None => "object".to_string(),
+            };
+            return Err(PyError::type_error(format!(
+                "a bytes-like object is required, not '{tname}'"
+            )));
+        }
         // dict: key containment (dictobject.py __contains__)
         if is_dict(haystack) {
             return match pyre_object::dictmultiobject::w_dict_lookup_checked(haystack, needle) {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10541,8 +10541,8 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                 }
                 return Ok(hay.contains(&(v as u8)));
             }
-            if pyre_object::bytesobject::is_bytes_like(needle) {
-                let sub = pyre_object::bytesobject::bytes_like_data(needle);
+            if let Some(src) = crate::typedef::buffer_as_bytes_like(needle) {
+                let sub = pyre_object::bytesobject::bytes_like_data(src);
                 return Ok(sub.is_empty() || hay.windows(sub.len()).any(|w| w == sub));
             }
             let tname = match crate::typedef::r#type(needle) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5801,6 +5801,13 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     // `__lt__` raises, sort halts with that error.  Rust's
     // `sort_by` closure cannot return Result, so capture the first
     // error via a Cell and surface it after the sort completes.
+    // `listsort.py descr_sort` reverses before and after a stable
+    // ascending sort for `reverse=True`, so equal elements keep their
+    // original relative order (a stable descending sort). A single
+    // post-sort reverse would instead flip ties.
+    if reverse {
+        keyed.reverse();
+    }
     let sort_error: std::cell::Cell<Option<crate::PyError>> = std::cell::Cell::new(None);
     let sort_lt = |ka: PyObjectRef, kb: PyObjectRef| -> bool {
         if sort_error
@@ -5854,6 +5861,7 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     if let Some(err) = sort_error.take() {
         return Err(err);
     }
+    // Second half of the `reverse=True` double-reverse (see above).
     if reverse {
         keyed.reverse();
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5648,6 +5648,16 @@ fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
                 let n = pyre_object::w_tuple_len(obj) as i64;
                 return Ok(pyre_object::reversedobject::w_reversed_new(obj, n - 1));
             }
+            // bytes / bytearray expose the sequence protocol at the C level but
+            // not as `__getitem__` / `__len__` type slots, so they would miss
+            // the `PySequence_Check` path below. `getitem` indexes them
+            // (returning the int byte) for `W_ReversedIterator` to walk.
+            if pyre_object::bytesobject::is_bytes(obj)
+                || pyre_object::bytearrayobject::is_bytearray(obj)
+            {
+                let n = crate::baseobjspace::len_w(obj)?;
+                return Ok(pyre_object::reversedobject::w_reversed_new(obj, n - 1));
+            }
         }
         // range: rangeobject.py W_RangeObject.descr_reversed — reflect
         // the span and hand back a fresh reverse-walking iterator. (range is

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -216,6 +216,13 @@ fn memoryview_ndim(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     Ok(w_int_new(1))
 }
 
+/// `memoryview.__repr__` — `memory_repr`: `<memory at 0x...>` keyed on the
+/// view's own address, not the default `<memoryview object at 0x...>`.
+fn memoryview_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let mv = args.first().copied().unwrap_or(w_none());
+    Ok(w_str_new(&format!("<memory at {mv:?}>")))
+}
+
 /// Unpack a memoryview-or-bytes-like operand to its element-value list,
 /// or `None` when it is neither (so `__eq__` can return NotImplemented).
 /// A memoryview unpacks per its own `itemsize` (so a cast view yields the
@@ -601,6 +608,11 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
                 ns,
                 "tobytes",
                 make_builtin_function_with_arity("tobytes", memoryview_tobytes, 1),
+            );
+            crate::dict_storage_store(
+                ns,
+                "__repr__",
+                make_builtin_function_with_arity("__repr__", memoryview_repr, 1),
             );
             crate::dict_storage_store(
                 ns,

--- a/pyre/pyre-interpreter/src/module/_collections/app_defaultdict.py
+++ b/pyre/pyre-interpreter/src/module/_collections/app_defaultdict.py
@@ -1,0 +1,84 @@
+"""App-level ``defaultdict`` for the ``_collections`` module.
+
+``defaultdict`` lives at app-level because, like PyPy, pyre cannot express an
+interp-level type that subclasses the app-level ``dict``
+(``app_defaultdict.py`` in PyPy exists for the same reason).  The class
+mirrors ``_collectionsmodule.c``'s ``defaultdict``:
+
+* ``__init__`` takes the ``default_factory`` (``None`` or a callable) as the
+  first positional argument and forwards the rest to ``dict.__init__``.
+* ``__missing__`` stores and returns ``default_factory()`` for an absent key,
+  or raises ``KeyError(key)`` when there is no factory.
+* ``__reduce__`` returns ``(type, args, None, None, iter(items))`` where
+  ``args`` is ``()`` for a ``None`` factory and ``(factory,)`` otherwise.
+* ``copy``/``__copy__``, ``__or__``/``__ror__`` and ``__repr__`` preserve the
+  exact type and the factory.
+
+Two deliberate departures from ``_collectionsmodule.c``, both forced by pyre
+storing a dict subclass's items in an instance attribute (which precludes
+``__slots__`` on the subclass, the device PyPy and CPython use to keep the
+factory off the instance dict):
+
+* the factory is held in the ordinary instance dict rather than a slot, so a
+  ``defaultdict`` instance carries a ``__dict__``;
+* ``__missing__`` is written here rather than at interp-level (PyPy keeps it
+  interp-level only for thread atomicity; the behaviour is identical).
+"""
+
+
+class defaultdict(dict):
+    __module__ = 'collections'
+
+    def __init__(self, *args, **kwds):
+        if args:
+            default_factory = args[0]
+            args = args[1:]
+            if default_factory is not None and not callable(default_factory):
+                raise TypeError("first argument must be callable or None")
+        else:
+            default_factory = None
+        self.default_factory = default_factory
+        dict.__init__(self, *args, **kwds)
+
+    def __missing__(self, key):
+        factory = self.default_factory
+        if factory is None:
+            raise KeyError(key)
+        self[key] = value = factory()
+        return value
+
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = ()
+        else:
+            args = (self.default_factory,)
+        return type(self), args, None, None, iter(self.items())
+
+    def copy(self):
+        return type(self)(self.default_factory, self)
+
+    __copy__ = copy
+
+    def __or__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        new = type(self)(self.default_factory)
+        new.update(self)
+        new.update(other)
+        return new
+
+    def __ror__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        new = type(self)(self.default_factory)
+        new.update(other)
+        new.update(self)
+        return new
+
+    def __repr__(self):
+        # ``defdict_repr``: "<typename>(<factory repr>, <dict repr>)".  The
+        # factory repr is not recursion-guarded (a factory that reprs back to
+        # the dict is not representable here), but the dict part rides
+        # ``dict.__repr__`` which renders a self-referential dict as "{...}".
+        return "%s(%r, %s)" % (
+            type(self).__name__, self.default_factory, dict.__repr__(self))

--- a/pyre/pyre-interpreter/src/module/_collections/app_defaultdict.py
+++ b/pyre/pyre-interpreter/src/module/_collections/app_defaultdict.py
@@ -75,10 +75,19 @@ class defaultdict(dict):
         new.update(self)
         return new
 
-    def __repr__(self):
+    def __repr__(self, recurse=set()):
         # ``defdict_repr``: "<typename>(<factory repr>, <dict repr>)".  The
-        # factory repr is not recursion-guarded (a factory that reprs back to
-        # the dict is not representable here), but the dict part rides
-        # ``dict.__repr__`` which renders a self-referential dict as "{...}".
-        return "%s(%r, %s)" % (
-            type(self).__name__, self.default_factory, dict.__repr__(self))
+        # factory repr is recursion-guarded so a factory that reprs back to the
+        # dict renders as "..." instead of recursing forever; the dict part
+        # rides ``dict.__repr__`` which renders a self-referential dict as
+        # "{...}".  (Not thread-safe, but good enough.)
+        dictrepr = dict.__repr__(self)
+        if id(self) in recurse:
+            factoryrepr = "..."
+        else:
+            try:
+                recurse.add(id(self))
+                factoryrepr = repr(self.default_factory)
+            finally:
+                recurse.remove(id(self))
+        return "%s(%s, %s)" % (type(self).__name__, factoryrepr, dictrepr)

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -1,12 +1,14 @@
 //! _collections module — PyPy: `pypy/module/_collections/`.
 //!
 //! Provides the C-accelerated `deque` / `defaultdict` / `OrderedDict`
-//! type stubs.  Pyre backs each instance with an attribute-dict list
-//! (`__data__`) or dict (`__data__` + `default_factory`); semantically
-//! correct for `collections.py`'s `MutableSequence` /
-//! `MutableMapping.register(...)` consumers but not performant.  PyPy's
-//! `W_Deque` is a doubly-linked block list — porting that needs typed
-//! payload backing on top of `py_class!`.
+//! types.  `deque` is the interp-level `py_class!` stub below, backed by
+//! an attribute-dict list (`__data__`); semantically correct for
+//! `collections.py`'s `MutableSequence` consumers but not performant
+//! (PyPy's `W_Deque` is a doubly-linked block list — porting that needs
+//! typed payload backing on top of `py_class!`).  `defaultdict` is the
+//! app-level `dict` subclass in `app_defaultdict.py`, mirroring PyPy's
+//! `app_defaultdict.py` (neither runtime can subclass the app-level
+//! `dict` from interp-level).
 
 use pyre_object::*;
 
@@ -544,62 +546,18 @@ mod deque_class {
     }
 }
 
-/// `pypy/module/_collections/interp_defaultdict.py` — `W_DefaultDict`
-/// stub backed by an inner dict at `self.__data__` plus
-/// `self.default_factory`.  A missing key invokes `default_factory` and
-/// stores the result (`W_DefaultDict.missing`); a missing key with no
-/// factory raises `KeyError(key)`.  Still a stub vs upstream: this type
-/// subclasses `object`, not `dict`, so `isinstance(d, dict)` is False, and
-/// `__missing__`/`__repr__`/`copy`/`__reduce__` are absent.
-mod defaultdict_class {
-    use super::*;
-
-    crate::py_class! {
-        "defaultdict",
-        methods: {
-            fn __init__(self_obj: PyObjectRef, factory: Option<PyObjectRef>) {
-                let _ = crate::baseobjspace::setattr_str(
-                    self_obj, "default_factory", factory.unwrap_or(w_none()));
-                let _ = crate::baseobjspace::setattr_str(self_obj, "__data__", w_dict_new());
-            }
-            fn __getitem__(self_obj: PyObjectRef, key: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
-                // `interp_defaultdict.py W_DefaultDict.missing` — present key
-                // returns stored value; missing key + no factory raises
-                // KeyError(key); missing key + factory invokes the factory
-                // and stores the result.
-                let d = crate::baseobjspace::getattr_str(self_obj, "__data__")
-                    .map_err(|_| crate::PyError::key_error_with_key(key))?;
-                unsafe {
-                    if let Some(v) = w_dict_lookup(d, key) {
-                        return Ok(v);
-                    }
-                }
-                let factory = crate::baseobjspace::getattr_str(self_obj, "default_factory")
-                    .unwrap_or_else(|_| w_none());
-                if factory.is_null() || unsafe { is_none(factory) } {
-                    return Err(crate::PyError::key_error_with_key(key));
-                }
-                let value = crate::call::call_function_impl_result(factory, &[])?;
-                unsafe { w_dict_store(d, key, value) };
-                Ok(value)
-            }
-            fn __setitem__(self_obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
-                if let Ok(d) = crate::baseobjspace::getattr_str(self_obj, "__data__") {
-                    unsafe { w_dict_store(d, key, value) };
-                }
-            }
-        }
-    }
-}
-
 crate::py_module! {
     "_collections",
     interpleveldefs: {
         "deque"           => deque_class::type_object(),
         "_deque_iterator" => crate::typedef::w_object(),
-        "defaultdict"     => defaultdict_class::type_object(),
         // `OrderedDict` is a dict subclass; alias to the dict type
         // object so `isinstance(d, OrderedDict)` matches dict instances.
         "OrderedDict"     => crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE),
+    },
+    // `defaultdict` is an app-level `dict` subclass — see the module
+    // header and `app_defaultdict.py` (PyPy `app_defaultdict.defaultdict`).
+    appleveldefs: {
+        "app_defaultdict.py" => ["defaultdict"],
     },
 }

--- a/pyre/pyre-interpreter/src/module/_collections/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_collections/mod.rs
@@ -213,7 +213,10 @@ mod deque_class {
     }
 
     crate::py_class! {
-        "deque",
+        // Dotted name so the builtin `__module__` resolves to `collections`
+        // (the name dot-split fallback), matching CPython's
+        // `collections.deque`; `__name__` / `__qualname__` strip to `deque`.
+        "collections.deque",
         methods: {
             // `init(iterable=None, maxlen=None)` — remember maxlen, then
             // extend so the bound is enforced while filling.
@@ -398,6 +401,36 @@ mod deque_class {
                     _ => crate::call::call_function_impl_result(ty, &[list]),
                 }
             }
+            fn __reduce__(self_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+                // `_collectionsmodule.c deque_reduce` —
+                // `(type(self), args, state, iter(self))`.  `args` is
+                // `((), maxlen)` when the deque is bounded so the bound
+                // survives the round-trip, else `()`.  `state` is the generic
+                // instance state; the items ride the listitems iterator (the
+                // 4th element).
+                //
+                // The instance payload (`__data__`/`__maxlen__`/`__state__`)
+                // lives in the attribute side-dict (this type is hasdict so the
+                // attribute backing has somewhere to go), and a subclass keeps
+                // user attributes in that same dict with no separate `__dict__`
+                // descriptor exposed, so `object_getstate_default` reports
+                // `None` here and a deque subclass round-trips its type, items
+                // and bound but not extra instance attributes. Preserving those
+                // needs the typed-payload deque backing noted in the module
+                // header (the payload would then leave the attribute dict free
+                // to be a real instance `__dict__`).
+                let ty = unsafe { w_instance_get_type(self_obj) };
+                let w_maxlen = crate::baseobjspace::getattr_str(self_obj, "__maxlen__")
+                    .unwrap_or_else(|_| w_none());
+                let args = if w_maxlen.is_null() || unsafe { is_none(w_maxlen) } {
+                    w_tuple_new(vec![])
+                } else {
+                    w_tuple_new(vec![w_tuple_new(vec![]), w_maxlen])
+                };
+                let state = crate::reduce_protocol::object_getstate_default(self_obj)?;
+                let items = crate::baseobjspace::iter(w_list_new(snapshot(self_obj)))?;
+                Ok(w_tuple_new(vec![ty, args, state, items]))
+            }
             fn __len__(self_obj: PyObjectRef) -> i64 {
                 data(self_obj)
                     .map(|d| unsafe { w_list_len(d) } as i64)
@@ -485,7 +518,11 @@ mod deque_class {
                 let Some(_guard) = crate::display::ReprGuard::enter(self_obj) else {
                     return Ok("[...]".to_string());
                 };
-                let name = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
+                // The repr uses the short class name, so strip any dotted
+                // module prefix from the builtin tp_name (`collections.deque`
+                // → `deque`); a user subclass name has no dot.
+                let full = unsafe { w_type_get_name(w_instance_get_type(self_obj)) };
+                let name = full.rsplit('.').next().unwrap_or(full);
                 let listrepr = snapshot(self_obj)
                     .into_iter()
                     .map(|it| unsafe { crate::py_repr(it) })

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -277,7 +277,7 @@ impl W_Pickler {
         // protocol-< 3 save path would otherwise always apply.
         let proto = normalize_protocol(protocol)?;
         // `file must have a 'write' attribute` (interp_pickle.py:557).
-        if crate::baseobjspace::findattr(file, "write").is_none() {
+        if crate::baseobjspace::findattr_result(file, "write")?.is_none() {
             return Err(PyError::type_error("file must have a 'write' attribute"));
         }
         if !unsafe { pyre_object::is_none(buffer_callback) } && proto < 5 {
@@ -1020,9 +1020,9 @@ fn save_global_or_reduce(
     }
 
     // Everything else goes through the reduce protocol.
-    let w_rv = match crate::baseobjspace::findattr(w_obj, "__reduce_ex__") {
+    let w_rv = match crate::baseobjspace::findattr_result(w_obj, "__reduce_ex__")? {
         Some(reduce_ex) => call_fn(reduce_ex, &[pyre_object::w_int_new(ctx.proto)])?,
-        None => match crate::baseobjspace::findattr(w_obj, "__reduce__") {
+        None => match crate::baseobjspace::findattr_result(w_obj, "__reduce__")? {
             Some(reduce) => call_fn(reduce, &[])?,
             None => return Err(pickling_error("Can't pickle object: no __reduce_ex__")),
         },
@@ -1820,7 +1820,8 @@ fn whichmodule(w_obj: PyObjectRef, name: &str) -> Result<PyObjectRef, PyError> {
     // `__module__`. A non-string module name is invalid; reject it here with
     // `TypeError("module name must be a string")` — the same error it surfaces
     // once used, raised at resolution time rather than deferred to the import.
-    let from_attr: Option<String> = match crate::baseobjspace::findattr(w_obj, "__module__") {
+    let from_attr: Option<String> = match crate::baseobjspace::findattr_result(w_obj, "__module__")?
+    {
         Some(m) if !unsafe { pyre_object::is_none(m) } => {
             if !unsafe { pyre_object::is_str(m) } {
                 return Err(PyError::type_error("module name must be a string"));
@@ -1904,9 +1905,11 @@ fn save_global(
 ) -> Result<(), PyError> {
     let w_name = match w_name_opt {
         Some(n) => n,
-        None => crate::baseobjspace::findattr(w_obj, "__qualname__")
-            .or_else(|| crate::baseobjspace::findattr(w_obj, "__name__"))
-            .ok_or_else(|| pickling_error("Can't pickle object: no __qualname__ / __name__"))?,
+        None => match crate::baseobjspace::findattr_result(w_obj, "__qualname__")? {
+            Some(n) => n,
+            None => crate::baseobjspace::findattr_result(w_obj, "__name__")?
+                .ok_or_else(|| pickling_error("Can't pickle object: no __qualname__ / __name__"))?,
+        },
     };
     // `whichmodule` imports the home module (to verify the reference), so pin
     // `w_obj` / `w_name` and re-read them afterwards.
@@ -2068,7 +2071,7 @@ fn save_reduce(
     let has_dictitems = present(4);
     let has_state_setter = present(5);
 
-    let func_name = func_name_str(rv_get(0));
+    let func_name = func_name_str(rv_get(0))?;
 
     // Pin the args tuple; its elements are re-read per save.
     pyre_object::gc_roots::pin_root(rv_get(1));
@@ -2088,7 +2091,7 @@ fn save_reduce(
         if args_len != 3 {
             return Err(pickling_error("__newobj_ex__ requires three args"));
         }
-        if crate::baseobjspace::findattr(args_get(0), "__new__").is_none() {
+        if crate::baseobjspace::findattr_result(args_get(0), "__new__")?.is_none() {
             return Err(pickling_error(
                 "args[0] from __newobj_ex__ args has no __new__",
             ));
@@ -2167,7 +2170,7 @@ fn save_reduce(
         if args_len == 0 {
             return Err(pickling_error("__newobj__ requires at least one arg"));
         }
-        if crate::baseobjspace::findattr(args_get(0), "__new__").is_none() {
+        if crate::baseobjspace::findattr_result(args_get(0), "__new__")?.is_none() {
             return Err(pickling_error(
                 "args[0] from __newobj__ args has no __new__",
             ));
@@ -2245,12 +2248,16 @@ fn save_reduce(
 }
 
 /// The `__name__` of a callable as an owned `String`, if it is a str.
-fn func_name_str(w_func: PyObjectRef) -> Option<String> {
-    let w_name = crate::baseobjspace::findattr(w_func, "__name__")?;
+fn func_name_str(w_func: PyObjectRef) -> Result<Option<String>, PyError> {
+    let Some(w_name) = crate::baseobjspace::findattr_result(w_func, "__name__")? else {
+        return Ok(None);
+    };
     if unsafe { pyre_object::is_str(w_name) } {
-        Some(unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string())
+        Ok(Some(
+            unsafe { pyre_object::strobject::w_str_get_value(w_name) }.to_string(),
+        ))
     } else {
-        None
+        Ok(None)
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -835,7 +835,7 @@ fn dispatch(slot: usize, opcode: u8) -> Result<(), PyError> {
             pyre_object::gc_roots::pin_root(items);
             let items_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
             let w_list = top(slot, "APPENDS")?;
-            match crate::baseobjspace::findattr(w_list, "extend") {
+            match crate::baseobjspace::findattr_result(w_list, "extend")? {
                 Some(extend) if !unsafe { pyre_object::is_none(extend) } => {
                     call_fn(
                         extend,
@@ -1389,7 +1389,7 @@ fn persistent_load(slot: usize, w_pid: PyObjectRef) -> Result<PyObjectRef, PyErr
 /// via `__new__` without invoking `__init__`.
 fn instantiate(w_cls: PyObjectRef, w_args: PyObjectRef) -> Result<PyObjectRef, PyError> {
     let n = unsafe { pyre_object::listobject::w_list_len(w_args) };
-    let has_getinitargs = crate::baseobjspace::findattr(w_cls, "__getinitargs__").is_some();
+    let has_getinitargs = crate::baseobjspace::findattr_result(w_cls, "__getinitargs__")?.is_some();
     let is_type = unsafe { pyre_object::typeobject::is_type(w_cls) };
     if n > 0 || !is_type || has_getinitargs {
         let args: Vec<PyObjectRef> = (0..n)
@@ -1444,7 +1444,7 @@ fn new_instance_kw(
 /// `load_build` — apply pickled state to a freshly created instance.
 fn build_instance(w_inst: PyObjectRef, w_state: PyObjectRef) -> Result<(), PyError> {
     // __setstate__ takes precedence.
-    if let Some(setstate) = crate::baseobjspace::findattr(w_inst, "__setstate__") {
+    if let Some(setstate) = crate::baseobjspace::findattr_result(w_inst, "__setstate__")? {
         if !unsafe { pyre_object::is_none(setstate) } {
             call_fn(setstate, &[w_state])?;
             return Ok(());

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1319,25 +1319,31 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             }
             return tuple_concat(a, b);
         }
-        if pyre_object::bytesobject::is_bytes_like(a) && pyre_object::bytesobject::is_bytes_like(b)
-        {
-            if needs_bytes_binop_dispatch(a, b, "__add__", "__radd__") {
-                if let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")? {
-                    return Ok(result);
+        // `bytes`/`bytearray` `__add__` accepts any buffer on the right (a
+        // memoryview included), and the result type follows the left operand:
+        // `bytes + <buffer>` is bytes, `bytearray + <buffer>` is bytearray.
+        if pyre_object::bytesobject::is_bytes_like(a) {
+            if let Some(b_src) = crate::typedef::buffer_as_bytes_like(b) {
+                // Only a real bytes-like rhs can carry a subclass `__radd__`;
+                // a memoryview cannot, so dispatch only when both are bytes-like.
+                if pyre_object::bytesobject::is_bytes_like(b)
+                    && needs_bytes_binop_dispatch(a, b, "__add__", "__radd__")
+                {
+                    if let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+                    {
+                        return Ok(result);
+                    }
                 }
-            }
-            let a_data = pyre_object::bytesobject::bytes_like_data(a);
-            let b_data = pyre_object::bytesobject::bytes_like_data(b);
-            let mut result = a_data.to_vec();
-            result.extend_from_slice(b_data);
-            // bytes + bytes → bytes; anything with bytearray → bytearray
-            return Ok(
-                if pyre_object::bytesobject::is_bytes(a) && pyre_object::bytesobject::is_bytes(b) {
+                let a_data = pyre_object::bytesobject::bytes_like_data(a);
+                let b_data = pyre_object::bytesobject::bytes_like_data(b_src);
+                let mut result = a_data.to_vec();
+                result.extend_from_slice(b_data);
+                return Ok(if pyre_object::bytesobject::is_bytes(a) {
                     pyre_object::bytesobject::w_bytes_from_bytes(&result)
                 } else {
                     pyre_object::bytearrayobject::w_bytearray_from_bytes(&result)
-                },
-            );
+                });
+            }
         }
         // Forward `__add__` + reflected `__radd__` per
         // `descroperation.py:_make_binop_impl` — try_dispatch_binary_special

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3460,6 +3460,14 @@ pub fn dict_init_or_update(
     if let Some(other) = positional.get(1).copied() {
         dict_update1(dict, other)?;
     }
+    let backing = resolve_dict_backing(dict);
+    if backing.is_null() {
+        // A dict subclass declared with `__slots__` has no attribute storage
+        // for its item backing (pyre keeps a dict subclass's items in an
+        // instance attribute), so there is nowhere to merge into. Full
+        // slotted-dict-subclass support needs intrinsic dict backing.
+        return Ok(w_none());
+    }
     if let Some(kwargs) = kwargs_dict {
         unsafe {
             for (k, v) in pyre_object::w_dict_items(kwargs) {
@@ -3468,11 +3476,11 @@ pub fn dict_init_or_update(
                 {
                     continue;
                 }
-                dict_store_checked(resolve_dict_backing(dict), k, v)?;
+                dict_store_checked(backing, k, v)?;
             }
         }
     }
-    dict_sync_dict_storage_proxy(resolve_dict_backing(dict));
+    dict_sync_dict_storage_proxy(backing);
     Ok(w_none())
 }
 
@@ -3533,6 +3541,9 @@ fn dict_subclass_uses_default_iter(other: PyObjectRef) -> bool {
 /// `entries` / `dstorage`).  Early-return for module dicts.
 fn dict_sync_dict_storage_proxy(dict: PyObjectRef) {
     unsafe {
+        if dict.is_null() {
+            return;
+        }
         if pyre_object::dictmultiobject::is_module_dict(dict) {
             return;
         }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3436,15 +3436,23 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
     Ok(())
 }
 
+/// `dictmultiobject.py:1430-1443 init_or_update` — shared by `dict.__init__`
+/// and `dict.update`; `name` selects the error-message verb (`"dict"` vs
+/// `"update"`). Stores resolve the subclass backing before writing, so a dict
+/// subclass instance is updated through its backing dict rather than its own
+/// (uninitialised) strategy slot.
+///
 /// `__pyre_kw__`-marked dict is the kwargs vehicle pyre's CALL_KW
 /// emits for builtin callees (`call.rs:727-744`).
-pub fn dict_method_update(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "dict.update() needs the receiver");
+pub fn dict_init_or_update(
+    args: &[PyObjectRef],
+    name: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    assert!(!args.is_empty(), "dict init_or_update needs the receiver");
     let (positional, kwargs_dict) = crate::builtins::split_builtin_kwargs(args);
-    // `dictmultiobject.py:1430-1435 init_or_update`
     if positional.len() > 2 {
         return Err(crate::PyError::type_error(format!(
-            "update expected at most 1 argument, got {}",
+            "{name} expected at most 1 argument, got {}",
             positional.len() - 1
         )));
     }
@@ -3466,6 +3474,13 @@ pub fn dict_method_update(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     }
     dict_sync_dict_storage_proxy(resolve_dict_backing(dict));
     Ok(w_none())
+}
+
+/// `dictmultiobject.py:137-139 descr_update` → `init_or_update`; the verb in
+/// the arity error is `update`.
+pub fn dict_method_update(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    assert!(!args.is_empty(), "dict.update() needs the receiver");
+    dict_init_or_update(args, "update")
 }
 
 /// `dictmultiobject.py:1380-1386 update1` —

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1457,27 +1457,16 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return crate::builtins::builtin_dict_ctor(&args[1..]);
     }
 
-    // cls is a dict subclass — create instance with backing dict
-    // PyPy: allocate W_DictObject with custom type
+    // cls is a dict subclass — create the instance with an empty backing
+    // dict. `__new__` must NOT populate from the constructor arguments:
+    // `object.__new__`/`dict.__new__` ignore them, and filling is the job of
+    // `__init__` (the inherited `dict.__init__` for a plain subclass, or the
+    // subclass override). Pre-filling here double-applies the argument for a
+    // subclass whose `__init__` accumulates (e.g. `Counter`, whose `update`
+    // adds rather than sets).
     let instance = pyre_object::w_instance_new(cls);
     let backing = pyre_object::w_dict_new();
     let _ = crate::baseobjspace::setattr_str(instance, "__dict_data__", backing);
-
-    // Initialize from args if provided
-    if args.len() > 1 {
-        // dict(iterable) or dict(**kwargs)
-        let src = args[1];
-        unsafe {
-            if pyre_object::is_dict(src) {
-                // `w_dict_items` dispatches through `is_module_dict`
-                // so `dict(some_module.__dict__)` and `dict(**module_dict)`
-                // walk the strategy storage when given a module dict.
-                for (k, v) in pyre_object::w_dict_items(src) {
-                    pyre_object::w_dict_store(backing, k, v);
-                }
-            }
-        }
-    }
     Ok(instance)
 }
 /// boolobject.py descr_new — bool.__new__(cls, obj=False)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2549,36 +2549,7 @@ fn init_dict_type(ns: &mut DictStorage) {
         ns,
         "__init__",
         make_builtin_function("__init__", |args| {
-            if args.is_empty() {
-                return Ok(pyre_object::w_none());
-            }
-            let (positional, kwargs_dict) = crate::builtins::split_builtin_kwargs(args);
-            // `dictmultiobject.py:1431-1435 init_or_update` —
-            // at most 1 positional arg after self
-            if positional.len() > 2 {
-                return Err(crate::PyError::type_error(format!(
-                    "dict expected at most 1 argument, got {}",
-                    positional.len() - 1,
-                )));
-            }
-            let self_dict = positional[0];
-            if let Some(src) = positional.get(1).copied() {
-                crate::type_methods::dict_update1(self_dict, src)?;
-            }
-            // `dictmultiobject.py:1442-1443` — merge kwargs
-            if let Some(kw) = kwargs_dict {
-                unsafe {
-                    for (k, v) in pyre_object::w_dict_items(kw) {
-                        if pyre_object::is_str(k)
-                            && pyre_object::w_str_get_wtf8(k).as_str() == Ok("__pyre_kw__")
-                        {
-                            continue;
-                        }
-                        crate::type_methods::dict_store_checked(self_dict, k, v)?;
-                    }
-                }
-            }
-            Ok(pyre_object::w_none())
+            crate::type_methods::dict_init_or_update(args, "dict")
         }),
     );
     dict_storage_store(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9141,8 +9141,8 @@ fn init_bytes_type(ns: &mut DictStorage) {
 /// object or a single integer in `range(0, 256)` standing for one byte.
 fn bytes_sub_arg(w_sub: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
-        if pyre_object::bytesobject::is_bytes_like(w_sub) {
-            Ok(pyre_object::bytesobject::bytes_like_data(w_sub).to_vec())
+        if let Some(src) = buffer_as_bytes_like(w_sub) {
+            Ok(pyre_object::bytesobject::bytes_like_data(src).to_vec())
         } else if pyre_object::is_int(w_sub) {
             let v = pyre_object::w_int_get_value(w_sub);
             if !(0..=255).contains(&v) {
@@ -9150,9 +9150,10 @@ fn bytes_sub_arg(w_sub: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
             }
             Ok(vec![v as u8])
         } else {
-            Err(crate::PyError::type_error(
-                "argument should be integer or bytes-like object",
-            ))
+            Err(crate::PyError::type_error(format!(
+                "argument should be integer or bytes-like object, not '{}'",
+                type_name_of(w_sub)
+            )))
         }
     }
 }
@@ -9310,20 +9311,20 @@ fn bytes_prefix_match(
     };
     let needle = args[1];
     unsafe {
-        if pyre_object::bytesobject::is_bytes_like(needle) {
-            return Ok(test(pyre_object::bytesobject::bytes_like_data(needle)));
+        if let Some(src) = buffer_as_bytes_like(needle) {
+            return Ok(test(pyre_object::bytesobject::bytes_like_data(src)));
         }
         if pyre_object::is_tuple(needle) {
             let n = pyre_object::w_tuple_len(needle) as i64;
             for i in 0..n {
                 let item = pyre_object::w_tuple_getitem(needle, i).expect("index is in range");
-                if !pyre_object::bytesobject::is_bytes_like(item) {
+                let Some(src) = buffer_as_bytes_like(item) else {
                     return Err(crate::PyError::type_error(format!(
                         "a bytes-like object is required, not '{}'",
-                        (*(*item).ob_type).name
+                        type_name_of(item)
                     )));
-                }
-                if test(pyre_object::bytesobject::bytes_like_data(item)) {
+                };
+                if test(pyre_object::bytesobject::bytes_like_data(src)) {
                     return Ok(true);
                 }
             }
@@ -9331,7 +9332,7 @@ fn bytes_prefix_match(
         }
         Err(crate::PyError::type_error(format!(
             "{method} first arg must be bytes or a tuple of bytes, not {}",
-            (*(*needle).ob_type).name
+            type_name_of(needle)
         )))
     }
 }
@@ -9398,12 +9399,12 @@ fn bytes_strip(
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let chars: Option<Vec<u8>> = match args.get(1) {
         Some(&a) if !a.is_null() && unsafe { !pyre_object::is_none(a) } => {
-            if unsafe { pyre_object::bytesobject::is_bytes_like(a) } {
-                Some(unsafe { pyre_object::bytesobject::bytes_like_data(a) }.to_vec())
+            if let Some(src) = buffer_as_bytes_like(a) {
+                Some(unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec())
             } else {
                 return Err(crate::PyError::type_error(format!(
                     "a bytes-like object is required, not '{}'",
-                    unsafe { (*(*a).ob_type).name }
+                    type_name_of(a)
                 )));
             }
         }
@@ -9443,19 +9444,47 @@ fn bytes_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     bytes_strip(args, false, true)
 }
 
+/// Resolve a buffer-providing object to a bytes-like object whose bytes
+/// `bytes_like_data` can read: bytes / bytearray resolve to themselves, and
+/// the `memoryview` stub resolves to its backing buffer (`__pyre_buf__`).
+/// Returns `None` for anything else.  Lets bytes / bytearray methods accept
+/// any buffer argument the way `space.buffer_w(w_obj, space.BUF_SIMPLE)`
+/// does upstream, without treating a memoryview as bytes-like elsewhere.
+pub(crate) fn buffer_as_bytes_like(obj: PyObjectRef) -> Option<PyObjectRef> {
+    if unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
+        return Some(obj);
+    }
+    // The memoryview stub stores its backing bytes-like at `__pyre_buf__`
+    // (`builtins.rs` memoryview `__new__` / `cast`); a cast keeps the same
+    // root buffer, so one level of unwrap suffices.
+    let tp = r#type(obj)?;
+    if unsafe { pyre_object::w_type_get_name(tp) } != "memoryview" {
+        return None;
+    }
+    let buf = crate::baseobjspace::getattr_str(obj, "__pyre_buf__").ok()?;
+    unsafe { pyre_object::bytesobject::is_bytes_like(buf) }.then_some(buf)
+}
+
 /// Require `obj` to be a bytes-like object, returning its bytes; raises
 /// the CPython `a bytes-like object is required, not '<type>'` TypeError
-/// otherwise.
+/// otherwise.  A memoryview is accepted through its backing buffer.
 fn require_bytes_like(obj: PyObjectRef) -> Result<&'static [u8], crate::PyError> {
-    unsafe {
-        if pyre_object::bytesobject::is_bytes_like(obj) {
-            Ok(pyre_object::bytesobject::bytes_like_data(obj))
-        } else {
-            Err(crate::PyError::type_error(format!(
-                "a bytes-like object is required, not '{}'",
-                (*(*obj).ob_type).name
-            )))
-        }
+    match buffer_as_bytes_like(obj) {
+        Some(src) => Ok(unsafe { pyre_object::bytesobject::bytes_like_data(src) }),
+        None => Err(crate::PyError::type_error(format!(
+            "a bytes-like object is required, not '{}'",
+            type_name_of(obj)
+        ))),
+    }
+}
+
+/// The Python-visible class name of `obj` (its `w_class`/type name), used in
+/// bytes-method TypeErrors.  More accurate than the raw `ob_type` name for
+/// instance-layout objects (e.g. a memoryview reports `memoryview`).
+fn type_name_of(obj: PyObjectRef) -> String {
+    match r#type(obj) {
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp) }.to_string(),
+        None => unsafe { (*(*obj).ob_type).name.to_string() },
     }
 }
 
@@ -9620,12 +9649,12 @@ fn bytes_split(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, crate
         .or_else(|| crate::builtins::kwarg_get(kwargs, "sep"));
     let sep: Option<Vec<u8>> = match sep_arg {
         Some(o) if !o.is_null() && unsafe { !pyre_object::is_none(o) } => {
-            if unsafe { pyre_object::bytesobject::is_bytes_like(o) } {
-                Some(unsafe { pyre_object::bytesobject::bytes_like_data(o) }.to_vec())
+            if let Some(src) = buffer_as_bytes_like(o) {
+                Some(unsafe { pyre_object::bytesobject::bytes_like_data(src) }.to_vec())
             } else {
                 return Err(crate::PyError::type_error(format!(
                     "a bytes-like object is required, not '{}'",
-                    unsafe { (*(*o).ob_type).name }
+                    type_name_of(o)
                 )));
             }
         }
@@ -9728,13 +9757,13 @@ fn bytes_method_join(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         if i > 0 {
             out.extend_from_slice(sep);
         }
-        if unsafe { !pyre_object::bytesobject::is_bytes_like(item) } {
+        let Some(src) = buffer_as_bytes_like(item) else {
             return Err(crate::PyError::type_error(format!(
                 "sequence item {i}: expected a bytes-like object, {} found",
-                unsafe { (*(*item).ob_type).name }
+                type_name_of(item)
             )));
-        }
-        out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(item) });
+        };
+        out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(src) });
     }
     Ok(new_bytes_like(args[0], &out))
 }
@@ -9756,11 +9785,22 @@ fn bytes_partition(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, c
         bytes_rfind_subslice(data, sep)
     };
     match found {
-        Some(i) => Ok(pyre_object::w_tuple_new(vec![
-            new_bytes_like(args[0], &data[..i]),
-            new_bytes_like(args[0], sep),
-            new_bytes_like(args[0], &data[i + sep.len()..]),
-        ])),
+        Some(i) => {
+            // `stringlib_partition` hands back the separator argument object
+            // itself for a bytes receiver (so a memoryview separator survives
+            // as the middle element); `bytearray_partition` builds a fresh
+            // bytearray slice for all three parts.
+            let middle = if unsafe { pyre_object::bytesobject::is_bytes(args[0]) } {
+                args[1]
+            } else {
+                new_bytes_like(args[0], sep)
+            };
+            Ok(pyre_object::w_tuple_new(vec![
+                new_bytes_like(args[0], &data[..i]),
+                middle,
+                new_bytes_like(args[0], &data[i + sep.len()..]),
+            ]))
+        }
         None => {
             // A bytearray receiver must not alias into the result tuple
             // (mutating it would mutate the tuple); hand back a fresh copy.
@@ -10104,8 +10144,8 @@ fn bytes_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let table: Option<&[u8]> = unsafe {
         if pyre_object::is_none(table_obj) {
             None
-        } else if pyre_object::bytesobject::is_bytes_like(table_obj) {
-            let t = pyre_object::bytesobject::bytes_like_data(table_obj);
+        } else if let Some(src) = buffer_as_bytes_like(table_obj) {
+            let t = pyre_object::bytesobject::bytes_like_data(src);
             if t.len() != 256 {
                 return Err(crate::PyError::value_error(
                     "translation table must be 256 characters long",
@@ -10115,7 +10155,7 @@ fn bytes_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         } else {
             return Err(crate::PyError::type_error(format!(
                 "a bytes-like object is required, not '{}'",
-                (*(*table_obj).ob_type).name
+                type_name_of(table_obj)
             )));
         }
     };
@@ -10126,14 +10166,14 @@ fn bytes_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     let mut deleted = [false; 256];
     if let Some(d) = delete_obj {
         if !d.is_null() && unsafe { !pyre_object::is_none(d) } {
-            if unsafe { pyre_object::bytesobject::is_bytes_like(d) } {
-                for &b in unsafe { pyre_object::bytesobject::bytes_like_data(d) } {
+            if let Some(src) = buffer_as_bytes_like(d) {
+                for &b in unsafe { pyre_object::bytesobject::bytes_like_data(src) } {
                     deleted[b as usize] = true;
                 }
             } else {
                 return Err(crate::PyError::type_error(format!(
                     "a bytes-like object is required, not '{}'",
-                    unsafe { (*(*d).ob_type).name }
+                    type_name_of(d)
                 )));
             }
         }
@@ -11542,10 +11582,9 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                 let b = args[1];
                 unsafe {
                     let a_data = pyre_object::bytesobject::bytes_like_data(a);
-                    let b_data = if pyre_object::bytesobject::is_bytes_like(b) {
-                        pyre_object::bytesobject::bytes_like_data(b).to_vec()
-                    } else {
-                        vec![]
+                    let b_data = match buffer_as_bytes_like(b) {
+                        Some(src) => pyre_object::bytesobject::bytes_like_data(src).to_vec(),
+                        None => vec![],
                     };
                     let mut result = a_data.to_vec();
                     result.extend_from_slice(&b_data);
@@ -11567,8 +11606,8 @@ fn init_bytearray_type(ns: &mut DictStorage) {
                 let ba = args[0];
                 let other = args[1];
                 unsafe {
-                    if pyre_object::bytesobject::is_bytes_like(other) {
-                        let data = pyre_object::bytesobject::bytes_like_data(other).to_vec();
+                    if let Some(src) = buffer_as_bytes_like(other) {
+                        let data = pyre_object::bytesobject::bytes_like_data(src).to_vec();
                         pyre_object::bytearrayobject::w_bytearray_extend(ba, &data);
                     }
                 }


### PR DESCRIPTION
follow-up #163

## Summary

Pickle-adjacent correctness fixes across the collections / bytes / dict
surface. Each item is verified byte-identical to cpython-3.14.5
(`check.py` 132/132 on dynasm and cranelift, `cargo test` 363/0).

**pickle / reduce protocol**
- `_pickle`: route the save/load dunder lookups (`__reduce_ex__`,
  `__reduce__`, `__name__`, …) through `findattr_result` so a getattr that
  raises (RecursionError, a user `__getattr__` / descriptor) propagates the
  Python exception instead of panicking the process.
- `dict.__new__` no longer pre-fills a subclass's backing from the
  constructor argument — filling is `__init__`'s job. The pre-fill
  double-applied for an accumulating subclass (`Counter({'a': 2})` became
  `{'a': 4}`), which also corrupted Counter pickle round-trips.
- `collections.deque.__reduce__` returns `(type, args, state, iter(self))`
  with `args = ((), maxlen)` for a bounded deque, and the type is renamed
  `collections.deque` so `__module__` / `__name__` resolve correctly.

**collections.defaultdict**
- Reimplemented as an app-level `class defaultdict(dict)` (it was an
  `object`-subclass stub missing
  len/iter/keys/values/items/`__contains__`/copy/`__reduce__`/`__repr__`/`__missing__`,
  so pickling failed and `key in d` looped). Mirrors `_collectionsmodule.c`:
  `isinstance(d, dict)` is True, `__reduce__` drops the factory argument when
  it is None, `__or__` / `__ror__` / copy preserve the type and factory, and
  `__missing__` stores `default_factory()`.

**bytes / bytearray**
- `reversed()` accepts bytes / bytearray.
- `__contains__` performs substring membership (`b'foo' in b'xfooy'`), with
  an int-needle range check and the proper TypeError for other types.
- The bytes-method family accepts a memoryview / buffer argument
  (`buffer_as_bytes_like`); `bytes + <buffer>` follows the left operand's
  type; `partition` hands back the separator argument for a bytes receiver;
  the memoryview repr is `<memory at 0x...>`.

**dict / sorted**
- `dict.__init__` no longer crashes constructing a backing-less
  (`__slots__`) dict subclass.
- `sorted()` / `list.sort(reverse=True)` keep equal elements in their
  original order (a stable descending sort), fixing `Counter.most_common()`
  tie ordering.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `collections.defaultdict` support with full pickling and copy semantics

* **Bug Fixes**
  * Fixed `reversed()` iteration for bytes and bytearray
  * Corrected `sorted(reverse=True)` stability behavior
  * Improved `memoryview` string representation
  * Enhanced error handling in pickle/unpickle operations
  * Improved bytes/bytearray operations with buffer-like objects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->