### PR TITLE
JIT trace coverage: pre-opcode guard snapshots, portal entry routing, kept-stack branch guards

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -1575,53 +1575,69 @@ impl VirtualState {
             // NonNull accepts any virtual (virtual is always nonnull).
             (VirtualStateInfo::NonNull, other) if other.is_virtual() => Ok(()),
 
-            // ── IntBounded target ── (virtualstate.py:483-499)
-            (VirtualStateInfo::IntBounded(b1), VirtualStateInfo::IntBounded(b2))
-                if b2.lower >= b1.lower && b2.upper <= b1.upper =>
-            {
-                Ok(())
-            }
-            (VirtualStateInfo::IntBounded(b), VirtualStateInfo::Constant(Value::Int(v)))
-                if b.contains(*v) =>
-            {
-                Ok(())
-            }
-            (VirtualStateInfo::IntBounded(bounds), VirtualStateInfo::Unknown(_)) => {
-                // virtualstate.py:493-499 _generate_guards_unkown:
-                //   if (runtime_box is not None and
-                //       self.intbound.contains(runtime_box.getint())):
-                //       self.intbound.make_guards(box, extra_guards, state.optimizer)
-                //   else: raise VirtualStatesCantMatch("intbounds don't match")
-                // `runtime_box.getint()` reads the box's own _resint (no
-                // _forwarded walk); gate on the runtime int actually falling
-                // within bounds — not on mere OpRef presence. The emitted op
-                // stream is identical to upstream: `GuardBounds.to_ops` calls
-                // `IntBound::make_guards` (intutils.py:1264-1289) verbatim, so
-                // the same INT_GE/INT_LE/INT_AND + GUARD_TRUE/GUARD_VALUE
-                // sequence is produced. Only materialization is deferred:
-                // `generate_guards` may reject a later position and discard the
-                // whole `extra_guards` list (loop at :1388), and pyre's const
-                // creation / OpRef-position allocation are non-rollbackable
-                // global side-effects (unlike RPython's throwaway ResOperation
-                // objects). Recording a `GuardRequirement` intent here and
-                // materializing it in `to_ops` only after a successful match
-                // keeps the const pool untouched on a rejected match.
-                let within = runtime_box
-                    .and_then(|rb| state.ctx.runtime_value_of(rb))
-                    .and_then(|v| match v {
-                        Value::Int(i) => Some(i),
-                        _ => None,
-                    })
-                    .is_some_and(|i| bounds.contains(i));
-                if within {
-                    state.extra_guards.push(GuardRequirement::GuardBounds {
-                        arg_index: arg_idx,
-                        box_opref,
-                        bounds: bounds.clone(),
-                    });
+            // ── IntBounded target ── (virtualstate.py:483-499 _generate_guards_unkown)
+            //
+            //   other_intbound = other.intbound        # other is an int leaf
+            //   if self.intbound is None: return
+            //   if other_intbound.is_within_range(self.lower, self.upper): return
+            //   if runtime_box is not None and self.intbound.contains(runtime_box.getint()):
+            //       self.intbound.make_guards(box, extra_guards, optimizer); return
+            //   raise VirtualStatesCantMatch
+            //
+            // `self.intbound` is always present here (IntBounded wraps it); the
+            // upstream `is None` always-match case maps to the `Unknown(Int)`
+            // leaf, handled by the `(Unknown(_), _)` arm above. The incoming int
+            // leaf supplies `other_intbound`: IntBounded carries it directly, a
+            // Constant(Int) contributes the singleton `[v, v]`, and an
+            // `Unknown(Int)` leaf has no static bound (treated as
+            // not-statically-within, deferring to the runtime check). The type
+            // gate (`info_type_matches`) above guarantees `incoming` is one of
+            // these three for an IntBounded target.
+            (VirtualStateInfo::IntBounded(b1), incoming_int) => {
+                let statically_within = match incoming_int {
+                    VirtualStateInfo::IntBounded(b2) => b2.is_within_range(b1.lower, b1.upper),
+                    VirtualStateInfo::Constant(Value::Int(v)) => b1.contains(*v),
+                    // Unknown(Int): no static bound → fall to the runtime check.
+                    _ => false,
+                };
+                if statically_within {
                     Ok(())
                 } else {
-                    Err(())
+                    // virtualstate.py:493-498 runtime fallback: emit
+                    // `IntBound.make_guards` when the concrete runtime int falls
+                    // within self's bound, else VirtualStatesCantMatch.
+                    // `runtime_box.getint()` reads the box's own _resint (no
+                    // _forwarded walk); gate on the runtime int actually falling
+                    // within bounds — not on mere OpRef presence. The emitted op
+                    // stream is identical to upstream: `GuardBounds.to_ops` calls
+                    // `IntBound::make_guards` (intutils.py:1264-1289) verbatim, so
+                    // the same INT_GE/INT_LE/INT_AND + GUARD_TRUE/GUARD_VALUE
+                    // sequence is produced. Only materialization is deferred:
+                    // `generate_guards` may reject a later position and discard
+                    // the whole `extra_guards` list (loop at :1388), and pyre's
+                    // const creation / OpRef-position allocation are
+                    // non-rollbackable global side-effects (unlike RPython's
+                    // throwaway ResOperation objects). Recording a
+                    // `GuardRequirement` intent here and materializing it in
+                    // `to_ops` only after a successful match keeps the const pool
+                    // untouched on a rejected match.
+                    let within = runtime_box
+                        .and_then(|rb| state.ctx.runtime_value_of(rb))
+                        .and_then(|v| match v {
+                            Value::Int(i) => Some(i),
+                            _ => None,
+                        })
+                        .is_some_and(|i| b1.contains(i));
+                    if within {
+                        state.extra_guards.push(GuardRequirement::GuardBounds {
+                            arg_index: arg_idx,
+                            box_opref,
+                            bounds: b1.clone(),
+                        });
+                        Ok(())
+                    } else {
+                        Err(())
+                    }
                 }
             }
 
@@ -2761,6 +2777,29 @@ fn export_single_value_inner(
         }
         Type::Int
     });
+    // virtualstate.py:476-481 NotVirtualStateInfoInt.__init__: an int leaf's
+    // info is `getintbound(op)` (optimizer.py:335-338 — always an IntBound for a
+    // non-constant int), and the constructor widens it (`info.widen_update()`)
+    // and stores it as `self.intbound`. Carry that here so the loop/bridge close
+    // can emit `IntBound.make_guards` (virtualstate.py:493-498): when a peeled
+    // loop's exit guard has been const-folded away (because the loop-variant
+    // bound proved it redundant), the bound on this leaf is what makes the bridge
+    // that re-enters the loop re-emit the bound check — without it the re-entered
+    // loop has no exit and runs forever. A widened-unbounded bound carries no
+    // information, so collapse it back to the always-match `Unknown` leaf
+    // (behaviorally identical to NotVirtualStateInfoInt with an unbounded
+    // `intbound`: `_generate_guards_unkown`'s `is_within_range(MININT, MAXINT)`
+    // is always true → no guard).
+    if tp == Type::Int {
+        if let Some(widened) = ctx
+            .get_box_replacement_box(opref)
+            .and_then(|b| ctx.peek_intbound_box(&b))
+            .map(|b| b.widen())
+            .filter(|b| !b.is_unbounded())
+        {
+            return VirtualStateInfo::IntBounded(widened);
+        }
+    }
     VirtualStateInfo::Unknown(tp)
 }
 

--- a/pyre/bench/synth/if_else_jump_forward.py
+++ b/pyre/bench/synth/if_else_jump_forward.py
@@ -1,0 +1,23 @@
+N = 1500000
+
+
+def main():
+    # `if cond: ... else: ...` inside a hot `while` loop.  The THEN block ends
+    # with an unconditional forward jump over the ELSE body (JUMP_FORWARD), so
+    # the loop body exercises JUMP_FORWARD on the hot (THEN) path.  The
+    # condition is THEN-dominant (true 6/7 of the time) so the compiled trace
+    # stabilizes on the THEN arm — which carries the forward jump — while the
+    # ELSE arm stays live as an occasional bridge.  Pure integer arithmetic
+    # keeps the result identical across CPython, PyPy, and pyre.
+    i = 0
+    acc = 0
+    while i < N:
+        if i % 7 != 0:
+            acc = acc + (i % 17)
+        else:
+            acc = acc - (i % 31)
+        i = i + 1
+    print(acc)
+
+
+main()

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4559,15 +4559,16 @@ fn exec_or_eval(
             frame.setdictscope_object(implicit_caller_locals)?;
         }
     }
-    // run() rather than execute_frame so that
+    // run_with_jit rather than execute_frame so that
     // `eval(compile("(x for x in [])", ..., 'eval'))` of generator-flagged
     // code returns the wrapped generator object instead of executing the
-    // body inline.
+    // body inline, and so the exec'd body reaches the JIT portal (a hot loop
+    // inside exec()'d source warms into a trace like any function would).
     // STORE_GLOBAL / DELETE_GLOBAL writes during the run land on the
     // storage proxy and back-mirror to the dict object, so the user dict
     // and the frame's globals stay one and the same throughout the run
     // (pyopcode.py:771-776 parity — no entry/exit drain needed).
-    let result = frame.run();
+    let result = frame.run_with_jit();
 
     let _ = raw_code; // keep raw_code alive until after exec for safety.
     match result {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2744,7 +2744,12 @@ fn build_class_inner(
         frame.setdictscope(class_ns_ptr)?;
     }
 
-    frame.execute_frame(None, None)?;
+    // Route the class body through the JIT portal (like the exec / import
+    // run-sites) so a hot class-level loop can warm and compile.  The body's
+    // NEWLOCALS bindings land in a distinct `w_locals` dict; that dict's
+    // values are rooted by the `debugdata.w_locals` walk in
+    // `walk_pyframe_roots`.
+    frame.run_with_jit()?;
 
     // The body wrote through the custom mapping; mirror its final contents
     // into class_ns for the downstream type construction (classcell capture,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -501,6 +501,17 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                             visitor(&mut *(value as *mut majit_ir::GcRef));
                             walk_raw_function_roots(*value, visitor);
                         }
+                        // The class-body namespace's lazily-cached canonical
+                        // `W_DictObject` (the storage's `mirror_target`,
+                        // materialized when the body's locals are accessed as a
+                        // dict) is GC-managed but reachable only through this
+                        // off-GC storage field; forward it so a relocating
+                        // collection updates the cache instead of leaving a
+                        // dangling pointer, mirroring the type-namespace walk
+                        // above and the globals back-mirror below.
+                        if let Some(mirror_slot) = (&mut *w_locals).mirror_target_slot_mut() {
+                            visitor(&mut *(mirror_slot as *mut PyObjectRef as *mut majit_ir::GcRef));
+                        }
                     }
                 }
                 // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Its slot

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -460,6 +460,38 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                     visitor(&mut *(w_locals_object_slot as *mut majit_ir::GcRef));
                     let w_f_trace_slot = &mut d.w_f_trace as *mut PyObjectRef;
                     visitor(&mut *(w_f_trace_slot as *mut majit_ir::GcRef));
+                    // A NEWLOCALS class body (`setdictscope` with a plain dict,
+                    // call.rs build_class_inner) binds names into
+                    // `debugdata.w_locals` — a raw DictStorage distinct from the
+                    // globals storage and not exposed as `w_locals_object`.  The
+                    // values it stores live nowhere else this walker reaches (the
+                    // globals walk below covers only the globals storage; the
+                    // array walk covers fastlocals), so a minor collection would
+                    // relocate a young binding and leave a dangling ref that
+                    // faults on a later read or guard-failure resume.  Forward
+                    // those values in place, mirroring the globals walk.  Skip
+                    // the module alias (`w_locals` IS the globals storage,
+                    // walked below) and the mapping/object scope (`w_locals`
+                    // null — rooted via `w_locals_object`).
+                    let w_locals = d.w_locals;
+                    let globals_storage = if (*frame).w_globals_obj.is_null() {
+                        std::ptr::null_mut()
+                    } else {
+                        pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(
+                            (*frame).w_globals_obj,
+                        ) as *mut crate::DictStorage
+                    };
+                    if !w_locals.is_null() && w_locals != globals_storage {
+                        let value_slots: Vec<*mut PyObjectRef> = (&mut *w_locals)
+                            .values_mut()
+                            .iter_mut()
+                            .map(|value| value as *mut PyObjectRef)
+                            .collect();
+                        for value in value_slots {
+                            visitor(&mut *(value as *mut majit_ir::GcRef));
+                            walk_raw_function_roots(*value, visitor);
+                        }
+                    }
                 }
                 // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Visit
                 // the canonical `w_globals` slot first so the visitor

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -510,7 +510,9 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                         // dangling pointer, mirroring the type-namespace walk
                         // above and the globals back-mirror below.
                         if let Some(mirror_slot) = (&mut *w_locals).mirror_target_slot_mut() {
-                            visitor(&mut *(mirror_slot as *mut PyObjectRef as *mut majit_ir::GcRef));
+                            visitor(
+                                &mut *(mirror_slot as *mut PyObjectRef as *mut majit_ir::GcRef),
+                            );
                         }
                     }
                 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -451,6 +451,16 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                 // fast path field anymore.
                 let w_builtin_slot = &mut (*(frame)).w_builtin as *mut PyObjectRef;
                 visitor(&mut *(w_builtin_slot as *mut majit_ir::GcRef));
+                // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Forward
+                // its slot BEFORE anything chases its `dict_storage_proxy`:
+                // both the NEWLOCALS `w_locals` alias check below and the
+                // globals-storage walk further down read the proxy off this
+                // object, and reading the proxy off a not-yet-forwarded object
+                // would dereference a stale nursery address — a forwarding
+                // marker left by a sibling frame that shares the same module
+                // globals and was walked earlier in this collection.
+                let w_globals_obj_slot = &mut (*frame).w_globals as *mut PyObjectRef;
+                visitor(&mut *(w_globals_obj_slot as *mut majit_ir::GcRef));
                 // pyframe.py:147 `debugdata.w_locals` (and the pyre-only
                 // `w_locals_object` companion for non-dict mapping
                 // locals) carry GCREFs that survive the frame.
@@ -474,11 +484,11 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                     // walked below) and the mapping/object scope (`w_locals`
                     // null — rooted via `w_locals_object`).
                     let w_locals = d.w_locals;
-                    let globals_storage = if (*frame).w_globals_obj.is_null() {
+                    let globals_storage = if (*frame).w_globals.is_null() {
                         std::ptr::null_mut()
                     } else {
                         pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(
-                            (*frame).w_globals_obj,
+                            (*frame).w_globals,
                         ) as *mut crate::DictStorage
                     };
                     if !w_locals.is_null() && w_locals != globals_storage {
@@ -493,15 +503,12 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                         }
                     }
                 }
-                // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Visit
-                // the canonical `w_globals` slot first so the visitor
-                // forwards it (and resolves any forwarding marker a sibling
-                // frame sharing the same module globals already left); only
-                // then is the object's `dict_storage_proxy` safe to chase for
-                // the backing storage.  Reading the proxy off a not-yet-
-                // forwarded object would dereference a stale nursery address.
-                let w_globals_obj_slot = &mut (*frame).w_globals as *mut PyObjectRef;
-                visitor(&mut *(w_globals_obj_slot as *mut majit_ir::GcRef));
+                // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Its slot
+                // was forwarded above (before the debugdata walk), so this
+                // object — and any forwarding marker a sibling frame sharing
+                // the same module globals already resolved — is current here;
+                // the object's `dict_storage_proxy` is therefore safe to chase
+                // for the backing storage.
                 let live_obj = (*frame).w_globals;
                 if !live_obj.is_null() {
                     let globals_ptr =

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1152,11 +1152,12 @@ fn exec_code_module(
     // Code.exec_code → space.createframe(...) + frame.run().  Surface
     // initialize_frame_scopes' freevar/closure mismatch (TypeError /
     // ValueError per pyframe.py:242-253) as PyError so the importer
-    // reports it instead of panicking.  Route through run() so the
+    // reports it instead of panicking.  Route through run_with_jit so the
     // GENERATOR / COROUTINE / ASYNC_GENERATOR dispatch in
-    // pyframe.py:268-273 holds for the import path too.
+    // pyframe.py:268-273 holds for the import path too, and so an imported
+    // module's top-level hot loop reaches the JIT portal.
     let mut frame = crate::createframe(w_code as *const (), namespace, execution_context, None)?;
-    frame.run()
+    frame.run_with_jit()
 }
 
 // ── appleveldef_install ──────────────────────────────────────────────
@@ -1190,7 +1191,7 @@ pub fn appleveldef_install(ns: &mut DictStorage, source: &str, filename: &str, n
     let w_code = crate::w_code_new(code_ptr as *const ());
     let mut frame = crate::createframe(w_code as *const (), app_ns_ptr, ctx, None)
         .unwrap_or_else(|e| panic!("appleveldef `{filename}`: createframe — {e:?}"));
-    if let Err(e) = frame.run() {
+    if let Err(e) = frame.run_with_jit() {
         panic!("appleveldef `{filename}`: exec — {e:?}");
     }
     let app_ns_ref = unsafe { &*app_ns_ptr };

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1699,6 +1699,30 @@ impl PyFrame {
         }
     }
 
+    /// `run`, but dispatching the non-generator body through the registered
+    /// eval function (`call::get_eval_fn`) instead of the plain interpreter.
+    ///
+    /// `interp_jit.py:81-99` applies the jitdriver to every frame uniformly,
+    /// so module / class / exec'd code reaches `jit_merge_point` exactly like
+    /// a called function does.  `run` hardcodes the plain interpreter, which
+    /// keeps these entry frames off the portal; this variant restores the
+    /// uniform routing for the run-sites that want it (exec / eval / import /
+    /// class body), matching how `call_user_function` reaches the portal via
+    /// `get_eval_fn`.
+    ///
+    /// `get_eval_fn` returns the plain interpreter while a trace / profile
+    /// function is installed (`FORCE_PLAIN_EVAL`), so `settrace` semantics are
+    /// unchanged; and when the portal declines a frame it falls back to
+    /// `execute_frame` (plain), so this never re-enters the portal.
+    #[inline]
+    pub fn run_with_jit(&mut self) -> crate::PyResult {
+        if self._is_generator_or_coroutine() {
+            self.initialize_as_generator()
+        } else {
+            crate::call::get_eval_fn()(self)
+        }
+    }
+
     /// pyframe.py:300 resume_execute_frame (send-path only).
     ///
     /// pyre does not emit YIELD_FROM/SEND yet, so `w_yielding_from` is

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1710,10 +1710,15 @@ impl PyFrame {
     /// class body), matching how `call_user_function` reaches the portal via
     /// `get_eval_fn`.
     ///
-    /// `get_eval_fn` returns the plain interpreter while a trace / profile
-    /// function is installed (`FORCE_PLAIN_EVAL`), so `settrace` semantics are
-    /// unchanged; and when the portal declines a frame it falls back to
-    /// `execute_frame` (plain), so this never re-enters the portal.
+    /// `settrace` is honored without forcing plain eval: installing a tracefunc
+    /// does not set `FORCE_PLAIN_EVAL` (that flag is a blackhole / `force_fn`
+    /// re-entry guard, unrelated to tracing).  The JIT eval override
+    /// (`eval_with_jit`) instead reads `ec.w_tracefunc` inline each bytecode
+    /// for line events and routes non-JIT-eligible frames through
+    /// `execute_frame` (so `call_trace` / `return_trace` frame events still
+    /// fire), exactly as a normal call reaches the portal via `get_eval_fn`;
+    /// and when the portal declines a frame it falls back to `execute_frame`
+    /// (plain), so this never re-enters the portal.
     #[inline]
     pub fn run_with_jit(&mut self) -> crate::PyResult {
         if self._is_generator_or_coroutine() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6281,8 +6281,10 @@ enum VstackOpClass {
     PopOnlyOrSideStore,
     /// Anything that does not fit the two simple shapes above — SWAP,
     /// UNPACK_SEQUENCE / UNPACK_EX (net push > 1), LOAD_GLOBAL pushing a
-    /// NULL sentinel beneath the result, super-instructions pushing two
-    /// locals, FOR_ITER, or any opcode this classifier does not recognise.
+    /// NULL sentinel beneath the result, STORE_FAST__STORE_FAST (net pop
+    /// 2), FOR_ITER, or any opcode this classifier does not recognise.
+    /// (The LOAD_FAST/STORE_FAST super-instructions whose net result is
+    /// the new TOS are modeled as `ResultToTos` above, not here.)
     /// Latches `vstack_valid = false` so the overlay falls back to the
     /// legacy behaviour (zero regression).
     Unmodeled,
@@ -6392,7 +6394,7 @@ fn classify_vstack_opcode(
             }
         }
 
-        // Everything else (SWAP, UNPACK_*, FOR_ITER, super-instructions,
+        // Everything else (SWAP, UNPACK_*, FOR_ITER, STORE_FAST__STORE_FAST,
         // TO_BOOL if present as a distinct variant, exception machinery,
         // …) is not modeled — decline and fall back to the legacy read.
         _ => VstackOpClass::Unmodeled,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -620,6 +620,45 @@ pub struct WalkContext<'frame, 'static_a: 'frame> {
     /// surfaces the `DispatchError` so a guard recorded without a resume
     /// snapshot aborts the walk instead of compiling.
     pub pending_guard_snapshot_error: Option<DispatchError>,
+    /// #73 PyPy-faithful kept-operand-stack snapshot: the walk-level
+    /// symbolic operand stack, indexed by ABSOLUTE operand-stack depth
+    /// (slot `s`, `s in 0..vstack_depth`).  The Python operand stack is
+    /// all-Ref (`W_Root`), so a single `Vec<OpRef>` (Ref bank) suffices.
+    /// This is the walker analog of PyPy's `MIFrame.registers_r`
+    /// valuestack array snapshotted by `get_list_of_active_boxes`
+    /// (`pyjitpl.py:177-234`) — the authoritative per-slot box source the
+    /// `stack_sync` vable overlay reads at a branch guard instead of the
+    /// unreliable `registers_r[stack_slot_color_map[s]]` static-color read.
+    ///
+    /// Maintained ONLY when `sym.owns_virtualizable_shadow()`; on any
+    /// unmodeled stack effect the maintenance sets `vstack_valid = false`
+    /// and `stack_sync` falls back to the legacy read (zero regression).
+    ///
+    /// SLICE 1 (#423): infrastructure landed fully INERT — the mirror is
+    /// maintained but the snapshot read stays LEGACY unless `PYRE_VSTACK_USE`
+    /// is set; `PYRE_VSTACK_DIAG` only logs mirror-vs-legacy disagreement.
+    pub vstack_boxes: Vec<OpRef>,
+    /// #73: the absolute operand-stack depth `vstack_boxes` currently
+    /// reflects — the depth ON ENTRY to the Python opcode at
+    /// `vstack_cur_pypc` (i.e. AFTER the previous opcode's stack effect
+    /// was reconciled).
+    pub vstack_depth: usize,
+    /// #73: the Python pc of the opcode currently being walked.  A change
+    /// in `python_pc_for_jitcode_pc(jit_pc)` from this value marks a
+    /// Python-opcode boundary, where the previous opcode's stack effect is
+    /// reconciled into `vstack_boxes` (see [`reconcile_vstack_at_boundary`]).
+    pub vstack_cur_pypc: u32,
+    /// #73: whether `vstack_boxes` is a trustworthy mirror of the live
+    /// operand stack.  Set `false` at walk entry until seeded, and latched
+    /// `false` permanently on the first unmodeled stack effect so the
+    /// `stack_sync` overlay declines to use it.
+    pub vstack_valid: bool,
+    /// #73: the last Ref box written via [`write_ref_reg`] during the
+    /// CURRENT Python opcode — the box a value-producing opcode lands on
+    /// the operand-stack TOS.  Reset to `OpRef::NONE` at every opcode
+    /// boundary; read by [`reconcile_vstack_at_boundary`] for the
+    /// RESULT-TO-TOS class.
+    pub vstack_last_ref: OpRef,
 }
 
 /// Outcome of dispatching one opcode. The walker uses this to decide
@@ -1121,6 +1160,15 @@ pub fn step(
     ctx: &mut WalkContext<'_, '_>,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let op: DecodedOp = decode_op_at(code, pc).ok_or(DispatchError::UndecodableOpcode { pc })?;
+    // #73 (SLICE 1, INERT): maintain the walk-level operand-stack box
+    // mirror.  Detects a Python-opcode boundary at this jitcode pc and
+    // reconciles the previous opcode's stack effect into `ctx.vstack_boxes`
+    // BEFORE this op runs.  Writes ONLY the new `vstack_*` fields — never
+    // the existing registers / snapshot / control flow — so the mirror is
+    // pure side-data until a later slice flips `PYRE_VSTACK_USE`.  No-op
+    // unless the full-body walk owns the virtualizable shadow and the
+    // mirror is still valid.
+    step_vstack_mirror(ctx, pc);
     handle(&op, code, ctx)
 }
 
@@ -1547,6 +1595,14 @@ fn write_ref_reg(
     if let Some(c_slot) = ctx.concrete_registers_r.get_mut(dst) {
         *c_slot = sanitized;
     }
+    // #73 (SLICE 1, INERT): record the box just written as the candidate
+    // operand-stack TOS for the current Python opcode.  A value-producing
+    // opcode (LOAD_*, BINARY_OP, COPY, …) lands its result on the stack
+    // TOS; this is the last Ref it writes, so capturing it here lets
+    // `reconcile_vstack_at_boundary` reconstruct the new TOS without a
+    // per-opcode hook.  Cheap unconditional write to a new side-field;
+    // only consumed when the mirror is valid (never alters existing state).
+    ctx.vstack_last_ref = value;
     Ok(())
 }
 
@@ -2228,7 +2284,22 @@ pub fn dispatch_via_miframe(
             // STORE_SUBSCR specialization off on this entry.
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
+        // #73 (SLICE 1, INERT): seed the walk-level operand-stack box mirror
+        // at entry.  The mirror is only enabled when the outer sym owns the
+        // virtualizable shadow (the production full-body loop trace) — the
+        // synthetic/test entries leave it disabled (`vstack_valid = false`).
+        // Seed at the FIRST-walked jitcode pc (`position`), not `entry_py_pc`,
+        // so the first `step_vstack_mirror` is a no-op (no spurious
+        // entry-boundary reconcile of the not-yet-executed first opcode).
+        // Pure side-data: the snapshot read stays LEGACY unless a later slice
+        // flips `PYRE_VSTACK_USE`.
+        seed_vstack_mirror(&mut wc, sym, position);
         let outcome = walk(jitcode_code, position, &mut wc);
         // Read final last_exc_value before wc drops so the borrow
         // checker can release sym for the writeback below.
@@ -2467,6 +2538,11 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
             outer_active_boxes,
             store_subscr_fn_addr: bh_store_subscr_fn_addr_cached(),
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let outcome = walk(entry_jitcode.code.as_slice(), 0, &mut wc);
         let final_last_exc = wc.last_exc_value;
@@ -3381,6 +3457,26 @@ fn setarrayitem_vable_via_metainterp(
         concrete,
     );
     walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    // #73 (SLICE 1, INERT): a Ref stored to the operand-stack region of the
+    // vable array is an operand-stack PUSH (portal `pyframe.pushvalue`
+    // lowers to `setarrayitem_vable_r(locals_cells_stack_w, depth, w_obj)`).
+    // Capture it as the current opcode's TOS box for the walk-level
+    // operand-stack mirror — this is the chokepoint that catches pushes which
+    // never go through `write_ref_reg` (notably COPY, whose duplicate is
+    // emitted as a bare pushvalue with no compute step).  Gate on the stack
+    // region (`index >= nlocals`) so a STORE_FAST/local-slot store does not
+    // masquerade as a stack TOS.  Writes ONLY `vstack_last_ref` (side-data);
+    // consumed only when the mirror is valid.
+    if value_bank == 'r' && ctx.vstack_valid {
+        let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+        if !full_body_sym.is_null() {
+            // SAFETY: pointer live for the full-body walk; read-only.
+            let nlocals = unsafe { (*full_body_sym).nlocals } as i64;
+            if index_value >= nlocals {
+                ctx.vstack_last_ref = value;
+            }
+        }
+    }
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 
@@ -6160,6 +6256,429 @@ fn fbw_terminate_void_with_finish(
     Ok(())
 }
 
+/// #73: classification of a Python opcode's effect on the walk-level
+/// symbolic operand stack ([`WalkContext::vstack_boxes`]), used by
+/// [`reconcile_vstack_at_boundary`] to update `vstack_boxes` at an
+/// opcode boundary.  The depth delta is already known from
+/// `depth_at_py_pc`; this only decides WHERE the new boxes come from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VstackOpClass {
+    /// A single net-result lands on the new TOS, and its box is the last
+    /// Ref written via [`write_ref_reg`] during this opcode
+    /// (`vstack_last_ref`).  Truncate to the new depth, then overwrite the
+    /// new TOS with `vstack_last_ref`.  Covers value producers whose
+    /// result is the topmost stack slot: LOAD_FAST / LOAD_CONST /
+    /// LOAD_GLOBAL(result) / LOAD_NAME / LOAD_ATTR / BINARY_OP /
+    /// BINARY_SUBSCR / COMPARE_OP / unary ops / TO_BOOL / CALL / COPY /
+    /// IS_OP / CONTAINS_OP / single-result BUILD_*.
+    ResultToTos,
+    /// The opcode only pops (and/or stores to a local/global/attr/subscr,
+    /// or is an unconditional control transfer).  Truncate to the new
+    /// depth WITHOUT touching the surviving TOS — the box already in that
+    /// slot is the live value.  Covers POP_TOP / POP_JUMP_IF_* /
+    /// STORE_FAST / STORE_GLOBAL / STORE_NAME / STORE_ATTR /
+    /// STORE_SUBSCR / STORE_SLICE / JUMP_* / RETURN_* / DELETE_*.
+    PopOnlyOrSideStore,
+    /// Anything that does not fit the two simple shapes above — SWAP,
+    /// UNPACK_SEQUENCE / UNPACK_EX (net push > 1), LOAD_GLOBAL pushing a
+    /// NULL sentinel beneath the result, super-instructions pushing two
+    /// locals, FOR_ITER, or any opcode this classifier does not recognise.
+    /// Latches `vstack_valid = false` so the overlay falls back to the
+    /// legacy behaviour (zero regression).
+    Unmodeled,
+}
+
+/// #73: classify `instr` for the [`VstackOpClass`] taxonomy.  Mirrors the
+/// stack-effect grouping in [`crate::liveness`]'s `stack_effects`, but
+/// collapsed to the three categories the operand-stack box maintenance
+/// cares about.  `op_arg` is read only where the net effect depends on it
+/// (LOAD_GLOBAL's NULL-sentinel low bit).
+fn classify_vstack_opcode(
+    instr: &pyre_interpreter::bytecode::Instruction,
+    op_arg: pyre_interpreter::OpArg,
+) -> VstackOpClass {
+    use pyre_interpreter::bytecode::Instruction;
+    match instr {
+        // Trivia / no stack effect — neither produces a TOS box nor pops.
+        // Treat as pop-only-or-side-store: truncate to the (unchanged)
+        // depth, leave the surviving slots intact.
+        Instruction::Nop
+        | Instruction::Resume { .. }
+        | Instruction::Cache
+        | Instruction::NotTaken
+        | Instruction::ExtendedArg => VstackOpClass::PopOnlyOrSideStore,
+
+        // Single value lands on the new TOS = the last Ref written.
+        Instruction::LoadConst { .. }
+        | Instruction::LoadSmallInt { .. }
+        | Instruction::LoadFast { .. }
+        | Instruction::LoadFastBorrow { .. }
+        | Instruction::LoadFastCheck { .. }
+        | Instruction::LoadFastAndClear { .. }
+        | Instruction::LoadName { .. }
+        | Instruction::LoadDeref { .. }
+        | Instruction::LoadLocals
+        | Instruction::Copy { .. }
+        | Instruction::UnaryNegative
+        | Instruction::UnaryNot
+        | Instruction::UnaryInvert
+        | Instruction::GetIter
+        | Instruction::GetLen
+        | Instruction::LoadAttr { .. }
+        | Instruction::ImportFrom { .. }
+        | Instruction::BinaryOp { .. }
+        | Instruction::CompareOp { .. }
+        | Instruction::IsOp { .. }
+        | Instruction::ContainsOp { .. }
+        | Instruction::Call { .. }
+        | Instruction::BuildTuple { .. }
+        | Instruction::BuildList { .. }
+        | Instruction::BuildSet { .. }
+        | Instruction::BuildMap { .. }
+        | Instruction::BuildString { .. } => VstackOpClass::ResultToTos,
+
+        // Pop-only / side-store / control transfer: the surviving TOS box
+        // is already in `vstack_boxes`, do NOT overwrite it from the last
+        // ref (which targets a local/global/attr, not the new stack TOS).
+        Instruction::PopTop
+        | Instruction::PopIter
+        | Instruction::PopExcept
+        | Instruction::StoreFast { .. }
+        | Instruction::StoreName { .. }
+        | Instruction::StoreGlobal { .. }
+        | Instruction::StoreDeref { .. }
+        | Instruction::StoreAttr { .. }
+        | Instruction::DeleteAttr { .. }
+        | Instruction::StoreSubscr
+        | Instruction::DeleteSubscr
+        | Instruction::StoreSlice
+        | Instruction::DeleteFast { .. }
+        | Instruction::DeleteName { .. }
+        | Instruction::DeleteGlobal { .. }
+        | Instruction::DeleteDeref { .. }
+        | Instruction::PopJumpIfTrue { .. }
+        | Instruction::PopJumpIfFalse { .. }
+        | Instruction::PopJumpIfNone { .. }
+        | Instruction::PopJumpIfNotNone { .. }
+        | Instruction::JumpForward { .. }
+        | Instruction::JumpBackward { .. }
+        | Instruction::JumpBackwardNoInterrupt { .. }
+        | Instruction::ReturnValue => VstackOpClass::PopOnlyOrSideStore,
+
+        // LOAD_GLOBAL: when `namei & 1`, a NULL sentinel is pushed BENEATH
+        // the result (+2), so the result is not the sole new TOS box and a
+        // single `vstack_last_ref` write cannot reconstruct both slots —
+        // decline.  When `namei & 1 == 0` it is a plain single-result push.
+        Instruction::LoadGlobal { namei } => {
+            if namei.get(op_arg) as usize & 1 != 0 {
+                VstackOpClass::Unmodeled
+            } else {
+                VstackOpClass::ResultToTos
+            }
+        }
+
+        // Everything else (SWAP, UNPACK_*, FOR_ITER, super-instructions,
+        // TO_BOOL if present as a distinct variant, exception machinery,
+        // …) is not modeled — decline and fall back to the legacy read.
+        _ => VstackOpClass::Unmodeled,
+    }
+}
+
+/// #73: reconcile the PREVIOUS Python opcode's stack effect into
+/// [`WalkContext::vstack_boxes`] at an opcode boundary, BEFORE the new
+/// opcode (`new_pypc`) is walked.  Running this before the new op means
+/// that when the new op is a branch guard, `vstack_boxes` already holds
+/// the correct boxes for the guard's resume depth.
+///
+/// `code` is the Python `CodeObject` of the outer (full-body) jitcode;
+/// `new_pypc` is the Python pc the walk is about to enter; `new_depth` is
+/// `depth_at_py_pc[new_pypc]` (stack-only).  The previous opcode is
+/// decoded from `code` at `ctx.vstack_cur_pypc`.
+///
+/// On any unmodeled effect (or a structurally impossible depth) the
+/// function latches `ctx.vstack_valid = false` so the `stack_sync`
+/// overlay declines to use `vstack_boxes` (legacy fallback, zero
+/// regression).
+fn reconcile_vstack_at_boundary(
+    ctx: &mut WalkContext<'_, '_>,
+    code: &pyre_interpreter::CodeObject,
+    new_pypc: u32,
+    new_depth: usize,
+) {
+    if !ctx.vstack_valid {
+        return;
+    }
+    let prev_pypc = ctx.vstack_cur_pypc as usize;
+    let Some((instr, op_arg)) = pyre_interpreter::decode_instruction_at(code, prev_pypc) else {
+        ctx.vstack_valid = false;
+        return;
+    };
+    let class = classify_vstack_opcode(&instr, op_arg);
+    if std::env::var_os("PYRE_VSTACK_DIAG").is_some() {
+        eprintln!(
+            "[vstack-reconcile] prev_pypc={prev_pypc} new_pypc={new_pypc} \
+             new_depth={new_depth} prev_depth={} class={class:?} last_ref={:?} instr={instr:?}",
+            ctx.vstack_depth, ctx.vstack_last_ref
+        );
+    }
+    // PER-OP RECONCILE.  In the SEQUENTIAL case the previous opcode's stack
+    // effect explains the depth change: a producer (`ResultToTos`) lands its
+    // result box (`vstack_last_ref`) on the new TOS; a pop / side-store just
+    // truncates.  This captures the kept boxes from the walk register file
+    // (LOAD_FAST / LOAD_NAME / COPY results) — values that may NOT be present
+    // in the virtualizable shadow (function-local LOAD_FAST temps live only
+    // in the walk register bank, never written through to the portal array).
+    match class {
+        VstackOpClass::ResultToTos => {
+            ctx.vstack_boxes.truncate(new_depth);
+            if ctx.vstack_boxes.len() < new_depth {
+                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            }
+            if new_depth > 0 && ctx.vstack_last_ref != OpRef::NONE {
+                ctx.vstack_boxes[new_depth - 1] = ctx.vstack_last_ref;
+            }
+        }
+        VstackOpClass::PopOnlyOrSideStore => {
+            ctx.vstack_boxes.truncate(new_depth);
+        }
+        VstackOpClass::Unmodeled => {
+            ctx.vstack_valid = false;
+        }
+    }
+    // The FBW walk follows jitcode control flow, not just sequential opcodes:
+    // an `and`/`or` chain's short-circuit continuation jumps BACKWARD to a
+    // deeper merge point, so the previous opcode did NOT produce the slots
+    // below the new TOS — the per-op reconcile leaves a NONE hole there.
+    // Recover those slots from the virtualizable shadow (kept current by the
+    // portal `setarrayitem_vable_r` pushes for values that ARE written
+    // through).  `reseed_vstack_from_shadow` rejects a NULL-const shadow slot
+    // (a function-local temp the portal never wrote), so a genuinely
+    // unrecoverable kept slot fails the re-seed.
+    //
+    // A non-reseedable hole does NOT latch `vstack_valid = false`: an
+    // Int/Float-bank operand-stack temp (e.g. the `while i < N` loop
+    // condition's `LoadConst N`, a transient `BINARY_OP` int result) is not
+    // a Ref the Ref-only mirror can ever hold, but it is CONSUMED before the
+    // all-Ref short-circuit guard region — invalidating the whole mirror
+    // there made it die at the loop condition, never reaching the kept-stack
+    // guard.  Instead keep the mirror TRACKING (advance position / depth)
+    // with the NONE slot left in place; `stack_sync` (USE) defers any NONE
+    // mirror slot to the legacy read.
+    if ctx.vstack_valid {
+        let hole = ctx
+            .vstack_boxes
+            .get(..new_depth)
+            .map(|s| s.iter().any(|&b| b == OpRef::NONE))
+            .unwrap_or(true);
+        if hole {
+            // Best-effort fill from the shadow; leave un-fillable slots NONE.
+            let _ = reseed_vstack_from_shadow(ctx, new_depth);
+        }
+    }
+    if ctx.vstack_valid {
+        ctx.vstack_cur_pypc = new_pypc;
+        ctx.vstack_depth = new_depth;
+        ctx.vstack_last_ref = OpRef::NONE;
+    }
+}
+
+/// #73: re-seed `ctx.vstack_boxes[0..new_depth]` from the virtualizable
+/// shadow's operand-stack slots (`virtualizable_box_at(nvs + nlocals + s)`).
+/// Used when a control-flow edge makes the per-opcode reconcile model
+/// inapplicable (a backward/forward jump landing at a different stack
+/// level).  The portal `pyframe.pushvalue` lowers every Ref push to
+/// `setarrayitem_vable_r(locals_cells_stack_w, depth, w_obj)`, so the
+/// shadow holds the live operand stack at a merge point.
+///
+/// Returns `true` on success (every slot `0..new_depth` sourced as a
+/// non-NONE box), `false` if any slot is unsourceable (caller then
+/// latches `vstack_valid = false`).
+fn reseed_vstack_from_shadow(ctx: &mut WalkContext<'_, '_>, new_depth: usize) -> bool {
+    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if full_body_sym.is_null() {
+        return false;
+    }
+    // SAFETY: pointer live for the full-body walk; read-only nlocals.
+    let nlocals = unsafe { (*full_body_sym).nlocals };
+    let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
+    // Only FILL the NONE holes the per-op reconcile could not source from
+    // the walk register file; keep the boxes the reconcile DID capture (the
+    // shadow may carry a stale value in a non-hole slot).  A hole the shadow
+    // also cannot source (NONE / NULL const-ptr — a function-local temp the
+    // portal never wrote through) fails the whole re-seed so the caller
+    // declines to the legacy read.
+    if ctx.vstack_boxes.len() < new_depth {
+        ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+    }
+    let mut all_present = true;
+    for s in 0..new_depth {
+        if ctx.vstack_boxes[s] != OpRef::NONE {
+            continue;
+        }
+        match ctx.trace_ctx.virtualizable_box_at(nvs + nlocals + s) {
+            Some(b) if b != OpRef::NONE && !opref_is_null_const_ptr(b) => {
+                ctx.vstack_boxes[s] = b;
+            }
+            // Fill what we can; an unsourceable hole (NONE / NULL const-ptr —
+            // an Int/Float-bank temp or a function-local the portal never
+            // wrote) stays NONE.  `stack_sync` defers a NONE slot to the
+            // legacy read, so an unfilled slot is never a corrupt box.
+            _ => all_present = false,
+        }
+    }
+    all_present
+}
+
+/// #73: map a jitcode pc to the Python opcode whose lowering region
+/// CONTAINS it, WITHOUT the `python_pc_for_jitcode_pc` block-head marker
+/// special-case.  For the operand-stack mirror we want the containing
+/// opcode (where the walk physically is), not the resume block-head a
+/// `-live-` marker names — the marker case returns an EARLIER py_pc and
+/// makes the mirror's boundary detection oscillate.  Uses only the
+/// `first_jit_pc_by_py_pc` containment table (largest `py` with
+/// `first_jit[py] <= jit_pc`); falls back to the nearest-`pc_map` heuristic
+/// when that table is empty (portal-bridge / fixture installs).
+fn vstack_containing_py_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
+    let first_jit = &metadata.first_jit_pc_by_py_pc;
+    if !first_jit.is_empty() {
+        let mut best: Option<(usize, u32)> = None;
+        for (py, &pos) in first_jit.iter().enumerate() {
+            if pos != usize::MAX && pos <= jit_pc && best.is_none_or(|(b, _)| pos >= b) {
+                best = Some((pos, py as u32));
+            }
+        }
+        if let Some((_, py)) = best {
+            return py;
+        }
+    }
+    let mut best_py = 0u32;
+    let mut best_jc = 0usize;
+    for (py, &jc) in metadata.pc_map.iter().enumerate() {
+        if jc <= jit_pc && jc >= best_jc {
+            best_jc = jc;
+            best_py = py as u32;
+        }
+    }
+    best_py
+}
+
+/// #73 (SLICE 1, INERT): step the walk-level operand-stack box mirror at
+/// the top of every jitcode `step`.  Detects a Python-opcode boundary by
+/// mapping the current `jit_pc` back to its containing Python opcode; when
+/// that differs from `ctx.vstack_cur_pypc`, reconciles the previous
+/// opcode's stack effect into `vstack_boxes` (see
+/// [`reconcile_vstack_at_boundary`]).
+///
+/// No-op unless the outer full-body sym owns the virtualizable shadow and
+/// `vstack_valid` is still set.  Reached only on the full-body walk
+/// (`FULL_BODY_SNAPSHOT_SYM` non-null); the per-opcode arm walk leaves the
+/// mirror untouched (its guards use the static outer coordinate).  Writes
+/// only the `vstack_*` side-fields; never the registers / snapshot.
+fn step_vstack_mirror(ctx: &mut WalkContext<'_, '_>, jit_pc: usize) {
+    if !ctx.vstack_valid {
+        return;
+    }
+    // Inside an inline sub-walk the `jit_pc` is a CALLEE coordinate that
+    // does not exist in the outer (`FULL_BODY_SNAPSHOT_SYM`) jitcode's
+    // pc_map, so `python_pc_for_jitcode_pc` would return garbage and a
+    // callee `write_ref_reg` would clobber `vstack_last_ref`.  Decline the
+    // whole mirror for any walk that inlines a Python call — the benches
+    // this targets (short-circuit `or`/`and` chains) are call-free, and
+    // declining is a clean fallback to the legacy read.
+    if INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get()) {
+        ctx.vstack_valid = false;
+        return;
+    }
+    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if full_body_sym.is_null() {
+        return;
+    }
+    // SAFETY: the pointer is live for the lifetime of the full-body walk
+    // (set in `dispatch_via_miframe`); read-only access to immutable
+    // layout fields (jitcode / code_ptr / metadata).
+    let sym = unsafe { &*full_body_sym };
+    if sym.jitcode.is_null() {
+        return;
+    }
+    let (new_pypc, code_ptr) = unsafe {
+        let jc = &*sym.jitcode;
+        if jc.payload.code_ptr.is_null() {
+            return;
+        }
+        (
+            vstack_containing_py_pc(&jc.payload.metadata, jit_pc),
+            jc.payload.code_ptr,
+        )
+    };
+    if new_pypc == ctx.vstack_cur_pypc {
+        return;
+    }
+    let code = unsafe { &*code_ptr };
+    let new_depth = crate::liveness::liveness_for(code_ptr)
+        .depth_at_py_pc()
+        .get(new_pypc as usize)
+        .copied()
+        .unwrap_or(0) as usize;
+    reconcile_vstack_at_boundary(ctx, code, new_pypc, new_depth);
+}
+
+/// #73 (SLICE 1, INERT): seed the walk-level operand-stack box mirror
+/// ([`WalkContext::vstack_boxes`]) at full-body-walk entry.  Enables the
+/// mirror (`vstack_valid = true`) only when the outer `sym` owns the
+/// virtualizable shadow AND the entry operand stack can be fully sourced
+/// from that shadow.  Sets `vstack_cur_pypc = entry_py_pc` and
+/// `vstack_depth = depth_at_py_pc[entry_py_pc]`, filling
+/// `vstack_boxes[0..depth]` from the virtualizable shadow's operand-stack
+/// slots (`virtualizable_box_at(nvs + nlocals + s)`) — the SAME source
+/// `collect_outer_active_boxes` / `stack_sync` read.  Any unsourceable
+/// slot leaves `vstack_valid = false` (legacy fallback, zero regression).
+fn seed_vstack_mirror(ctx: &mut WalkContext<'_, '_>, sym: &crate::state::PyreSym, start_pc: usize) {
+    if sym.jitcode.is_null() || !sym.owns_virtualizable_shadow() {
+        return;
+    }
+    // Seed the mirror's current coordinate at the containment py_pc of the
+    // ACTUAL first-walked jitcode op (`start_pc`), NOT the resume/loop-header
+    // `entry_py_pc`.  A loop trace's `walk()` starts at `position = start_pc`,
+    // whose containing Python opcode may precede `entry_py_pc` (the
+    // loop-header resume coordinate the snapshot reader uses).  Seeding
+    // `cur_pypc = entry_py_pc` then made the FIRST `step_vstack_mirror`
+    // produce a spurious "backward" boundary (e.g. `5 -> 4`) that reconciled
+    // the not-yet-executed first opcode with `last_ref = None`, leaving a
+    // NONE hole that latched `vstack_valid = false` for the whole walk.
+    // Seeding at the first op's own py_pc makes the first step a no-op
+    // (`new_pypc == cur_pypc` early-out), so the mirror only reconciles
+    // boundaries AFTER the entry — where a previous opcode actually ran.
+    let (first_pypc, depth, nlocals) = unsafe {
+        let jc = &*sym.jitcode;
+        if jc.payload.code_ptr.is_null() {
+            return;
+        }
+        let first_pypc = vstack_containing_py_pc(&jc.payload.metadata, start_pc);
+        let d = crate::liveness::liveness_for(jc.payload.code_ptr)
+            .depth_at_py_pc()
+            .get(first_pypc as usize)
+            .copied()
+            .unwrap_or(0) as usize;
+        (first_pypc, d, sym.nlocals)
+    };
+    let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
+    let mut boxes = Vec::with_capacity(depth);
+    for s in 0..depth {
+        // Read the operand-stack slot `s` from the virtualizable shadow.
+        // A missing / NONE slot means the entry stack box is not
+        // reconstructible here — decline the whole mirror for this walk.
+        match ctx.trace_ctx.virtualizable_box_at(nvs + nlocals + s) {
+            Some(b) if b != OpRef::NONE => boxes.push(b),
+            _ => return,
+        }
+    }
+    ctx.vstack_boxes = boxes;
+    ctx.vstack_depth = depth;
+    ctx.vstack_cur_pypc = first_pypc;
+    ctx.vstack_last_ref = OpRef::NONE;
+    ctx.vstack_valid = true;
+}
+
 /// Map a JitCode byte offset back to the Python PC of the opcode whose
 /// JitCode region contains it: the largest `py_pc` with
 /// `pc_map[py_pc] <= jit_pc` (ties → larger `py_pc`).  `pc_map[py_pc]` is
@@ -6987,19 +7506,91 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // kept operand, not the stale merge-color read.
                 let recovered: Vec<(u16, OpRef)> =
                     BRANCH_GUARD_KEPT_RECOVERED.with(|c| c.borrow().clone());
-                (0..depth.min(stack_color_map.len()))
+                // #73 (SLICE 1) PyPy-faithful kept-stack source — MEASUREMENT
+                // HARNESS, fully INERT by default.  The legacy read
+                // (`registers_r[stack_slot_color_map[s]]` + #420 recovered
+                // patch) is unreliable in loop traces: loop-carried slots are
+                // renamed to inputarg colors and chordal coloring reuses
+                // colors, so a static-color read can return a stale / reused
+                // box.  The walk-level operand-stack box mirror
+                // (`ctx.vstack_boxes[s]`, maintained per-op by
+                // `step_vstack_mirror`) is the analog of PyPy
+                // `MIFrame.registers_r` valuestack array.
+                //
+                // Default (both env vars UNSET): keep the legacy read EXACTLY
+                // — byte-identical to the prior `(0..depth.min(len))` loop (a
+                // slot with no color contributes a NONE legacy value, filtered
+                // out below, same as the old min-bound).  `PYRE_VSTACK_DIAG`:
+                // log every slot where the mirror disagrees with the legacy
+                // read (read-only — never changes the value used).
+                // `PYRE_VSTACK_USE`: flip to the mirror as the actual source
+                // (a LATER slice may lift this; out of scope for Slice 1).
+                // Both gated behind `ctx.vstack_valid` so an undermodeled walk
+                // falls back.
+                let vstack_diag = std::env::var_os("PYRE_VSTACK_DIAG").is_some();
+                let vstack_use = std::env::var_os("PYRE_VSTACK_USE").is_some();
+                // Iterate the FULL resume depth, not just
+                // `depth.min(stack_color_map.len())`.  Under `PYRE_VSTACK_USE`
+                // the mirror is the primary source for every slot `0..depth`,
+                // so a slot beyond the (possibly shorter) static color map is
+                // still covered.  Default / non-USE keeps the legacy bound
+                // semantics: a slot with no color reads NONE (legacy) → it is
+                // filtered out, identical to the old min-bounded loop.
+                (0..depth)
                     .filter_map(|s| {
-                        let color = stack_color_map[s];
-                        let v = recovered
-                            .iter()
-                            .find(|&&(dst, _)| dst == color)
-                            .map(|&(_, v)| v)
-                            .unwrap_or_else(|| {
-                                ctx.registers_r
-                                    .get(color as usize)
-                                    .copied()
-                                    .unwrap_or(OpRef::NONE)
-                            });
+                        // Legacy read: only defined for slots the static color
+                        // map covers; beyond it there is no legacy source.
+                        let color = stack_color_map.get(s).copied();
+                        let legacy = color.map_or(OpRef::NONE, |color| {
+                            recovered
+                                .iter()
+                                .find(|&&(dst, _)| dst == color)
+                                .map(|&(_, v)| v)
+                                .unwrap_or_else(|| {
+                                    ctx.registers_r
+                                        .get(color as usize)
+                                        .copied()
+                                        .unwrap_or(OpRef::NONE)
+                                })
+                        });
+                        // The mirror value for slot `s`, when the mirror is
+                        // valid and covers this depth.
+                        let mirror = if ctx.vstack_valid {
+                            ctx.vstack_boxes.get(s).copied()
+                        } else {
+                            None
+                        };
+                        if vstack_diag {
+                            match mirror {
+                                Some(m) if m != legacy => eprintln!(
+                                    "[vstack-diag] py_pc={py_pc} slot={s} color={color:?} \
+                                     legacy={legacy:?} mirror={m:?} \
+                                     vstack_depth={} vstack_valid={}",
+                                    ctx.vstack_depth, ctx.vstack_valid
+                                ),
+                                Some(_) => {}
+                                None => eprintln!(
+                                    "[vstack-diag] py_pc={py_pc} slot={s} color={color:?} \
+                                     legacy={legacy:?} mirror=NONE(valid={})",
+                                    ctx.vstack_valid
+                                ),
+                            }
+                        }
+                        let v = if vstack_use {
+                            // PRIMARY: the mirror for every slot `0..depth`.
+                            // Fall back to legacy only when the mirror lacks a
+                            // box for this slot (mirror invalid, slot beyond
+                            // the mirror, or a slot the mirror left NONE — e.g.
+                            // an Int-bank stack temp the Ref-only mirror does
+                            // not hold).  Never worse than the default read.
+                            match mirror {
+                                Some(m) if m != OpRef::NONE => m,
+                                _ => legacy,
+                            }
+                        } else {
+                            // INERT DEFAULT (Slice 1): legacy source only.
+                            legacy
+                        };
                         if v != OpRef::NONE && !opref_is_null_const_ptr(v) {
                             Some((nvs + nlocals + s, v))
                         } else {
@@ -8900,6 +9491,11 @@ fn try_walker_inline_user_call(
             is_full_body_walk: ctx.is_full_body_walk,
             store_subscr_fn_addr: ctx.store_subscr_fn_addr,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
             trace_ctx: ctx.trace_ctx,
             done_with_this_frame_descr_ref: ctx.done_with_this_frame_descr_ref.clone(),
             done_with_this_frame_descr_int: ctx.done_with_this_frame_descr_int.clone(),
@@ -12486,6 +13082,11 @@ fn run_sub_jitcode_walk(
             outer_active_boxes: ctx.outer_active_boxes.clone(),
             store_subscr_fn_addr: ctx.store_subscr_fn_addr,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         walk(sub_body.code, 0, &mut sub_wc)?
     };
@@ -14674,6 +15275,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         // Synthesize a 2-byte op fixture: `<opcode_byte> <reg_idx>`.
@@ -14732,6 +15338,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         // `getfield_vable_i/rd>i`: operand 0 (the box) sits at code[pc+1].
         let code = [0u8, 0x00, 0x00, 0x00, 0x00];
@@ -14780,6 +15391,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         // `setfield_vable_i/rid`: operand 0 (the box) sits at code[pc+1].
         let code = [0u8, 0x00, 0x00, 0x00, 0x00];
@@ -14846,6 +15462,11 @@ mod tests {
                 outer_active_boxes: Vec::new(),
                 store_subscr_fn_addr: None,
                 pending_guard_snapshot_error: None,
+                vstack_boxes: Vec::new(),
+                vstack_depth: 0,
+                vstack_cur_pypc: 0,
+                vstack_valid: false,
+                vstack_last_ref: OpRef::NONE,
             };
             let op = DecodedOp {
                 key,
@@ -15023,6 +15644,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("switch hit must dispatch");
@@ -15072,6 +15698,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("switch miss must dispatch");
@@ -15120,6 +15751,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         let err = step(&code, 0, &mut wc).expect_err("non-constant switch value must not guess");
@@ -15177,6 +15813,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("truthy branch must dispatch");
@@ -15226,6 +15867,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("falsy branch must dispatch");
@@ -15274,6 +15920,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         let err = step(&code, 0, &mut wc).expect_err("non-constant branch value must not guess");
@@ -15494,6 +16145,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         fbw_finish_payload_reset();
         let (outcome, end_pc) =
@@ -15655,6 +16311,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_r_i must dispatch");
@@ -15764,6 +16425,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_ir_r must dispatch");
@@ -15867,6 +16533,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&caller_code, 0, &mut wc).expect("inline_call_irf_r must dispatch");
@@ -15959,6 +16630,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err =
             step(&caller_code, 0, &mut wc).expect_err("I-list overflow must surface typed error");
@@ -16048,6 +16724,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, _) = walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
         assert_eq!(
@@ -16118,6 +16799,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&caller_code, 0, &mut wc)
             .expect_err("FailDescr at inline_call's d-slot must hit ExpectedJitCodeDescr");
@@ -16167,6 +16853,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&caller_code, 0, &mut wc)
             .expect_err("missing sub-jitcode must hit SubJitCodeNotFound");
@@ -16212,6 +16903,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("live/ must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -16266,6 +16962,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         fbw_finish_payload_reset();
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_return/r must dispatch");
@@ -16318,6 +17019,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("must surface RegisterOutOfRange");
         assert_eq!(
@@ -16373,6 +17079,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let ops_before = wc.trace_ctx.num_ops();
         fbw_finish_payload_reset();
@@ -16444,6 +17155,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = step(&code, 0, &mut wc).expect("int_return/i must dispatch");
@@ -16503,6 +17219,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let ops_before = wc.trace_ctx.num_ops();
         fbw_finish_payload_reset();
@@ -16563,6 +17284,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = step(&code, 0, &mut wc).expect("void_return/ must dispatch");
@@ -16611,6 +17337,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("raise/r must read its operand");
         assert_eq!(
@@ -16662,6 +17393,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("goto/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -16713,6 +17449,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("goto/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -16812,6 +17553,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("catch_exception/L with active exc must error");
@@ -16859,6 +17605,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("catch_exception/L must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -16918,6 +17669,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -17010,6 +17766,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, _next_pc) = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -17084,6 +17845,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("reraise/ must dispatch");
         assert_eq!(outcome, DispatchOutcome::Terminate);
@@ -17152,6 +17918,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("reraise/ without last_exc_value must error");
         assert_eq!(err, DispatchError::ReraiseWithoutLastExcValue { pc: 0 });
@@ -17198,6 +17969,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("raise/r must dispatch");
         assert_eq!(
@@ -17308,6 +18084,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         fbw_finish_payload_reset();
         let (outcome, end_pc) =
@@ -17422,6 +18203,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let ops_before = wc.trace_ctx.num_ops();
         let (outcome, _) = walk(&caller_code, 0, &mut wc).expect("caller must walk to terminator");
@@ -17483,6 +18269,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -17541,6 +18332,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("int_copy/i>i must dispatch");
         assert_eq!(
@@ -17590,6 +18386,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_copy dst OOR must surface a typed error");
         assert_eq!(
@@ -17638,6 +18439,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_copy/i>i must read its src operand");
         assert_eq!(
@@ -17706,6 +18512,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -17762,6 +18573,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("ref_copy/r>r must dispatch");
         assert_eq!(
@@ -17809,6 +18625,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("ref_copy dst OOR must surface a typed error");
         assert_eq!(
@@ -17855,6 +18676,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("ref_copy/r>r must read its src operand");
         assert_eq!(
@@ -17912,6 +18738,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -18095,6 +18926,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             int_between_record(&code, &op, &mut wc).expect("int_between_record must dispatch");
@@ -18224,6 +19060,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -18305,6 +19146,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("float_neg/f>f must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -18364,6 +19210,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -18448,6 +19299,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc)
             .unwrap_or_else(|e| panic!("`{opname}` must dispatch — got {:?}", e));
@@ -18512,6 +19368,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("float_add must read its src operand");
         assert_eq!(
@@ -18559,6 +19420,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_add must read its src operand");
         assert_eq!(
@@ -18608,6 +19474,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("int_add dst OOR must surface a typed error");
         assert_eq!(
@@ -18665,6 +19536,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("unsupported opname must hit UnsupportedOpname");
@@ -18714,6 +19590,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ptr_nonzero must record PtrNe");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -18790,6 +19671,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("abort/>r must dispatch");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -18848,6 +19734,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("ref_guard_value must record GuardValue");
@@ -18922,6 +19813,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("ref_guard_value Const arm");
         assert!(matches!(outcome, DispatchOutcome::Continue));
@@ -19009,6 +19905,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
@@ -19168,6 +20069,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -19244,6 +20150,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = try_execute_residual_call_via_executor(
             &mut wc,
@@ -19293,6 +20204,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = try_execute_residual_call_via_executor(
             &mut wc,
@@ -19357,6 +20273,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = try_execute_residual_call_via_executor(
             &mut wc,
@@ -19445,6 +20366,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let result = try_execute_residual_call_via_executor(
             &mut wc,
@@ -19537,6 +20463,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let result = try_execute_residual_call_via_executor(
             &mut wc,
@@ -19604,6 +20535,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("OS_NOT_IN_TRACE must surface a typed error");
         assert_eq!(
@@ -19659,6 +20595,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err =
             step(&code, 0, &mut wc).expect_err("OS_JIT_FORCE_VIRTUAL must surface a typed error");
@@ -19709,6 +20650,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -19768,6 +20714,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -19829,6 +20780,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         // The dst slot must hold the OpRef of the recorded CallR. Each
@@ -19910,6 +20866,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_r/iRd>r must dispatch");
         drop(wc);
@@ -19980,6 +20941,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
@@ -20049,6 +21015,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("dst OOR must surface a typed error");
         assert_eq!(
@@ -20100,6 +21071,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("descr index 5 with pool size 2 must surface DescrIndexOutOfRange");
@@ -20189,6 +21165,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
@@ -20275,6 +21256,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_r_i/iRd>i must dispatch");
         drop(wc);
@@ -20371,6 +21357,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) =
             step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
@@ -20497,6 +21488,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("residual_call_ir_r/iIRd>r must dispatch");
         drop(wc);
@@ -20559,6 +21555,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("FailDescr (not CallDescr) must surface ResidualCallDescrNotCallDescr");
@@ -20609,6 +21610,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc)
             .expect_err("R-list member out of range must surface RegisterOutOfRange");
@@ -20683,6 +21689,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, end_pc) =
             walk(&jc.code, 0, &mut wc).expect("ReturnValue arm must walk to a terminator");
@@ -20802,6 +21813,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, end_pc) =
             walk(&jc.code, 0, &mut wc).expect("PopTop arm must walk to a terminator");
@@ -20897,6 +21913,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&caller_code, 0, &mut wc).expect_err("arity overflow must surface error");
         assert_eq!(
@@ -20991,6 +22012,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, _) =
             walk(&caller_code, 0, &mut wc).expect("inline_call_r_v with void callee must succeed");
@@ -21064,6 +22090,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_r_v with non-void callee must reject");
@@ -21140,6 +22171,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, _) =
             walk(&caller_code, 0, &mut wc).expect("inline_call_ir_v with void callee must succeed");
@@ -21214,6 +22250,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_ir_v with non-void callee must reject");
@@ -21293,6 +22334,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, _) = walk(&caller_code, 0, &mut wc)
             .expect("inline_call_irf_v with void callee must succeed");
@@ -21370,6 +22416,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = walk(&caller_code, 0, &mut wc)
             .expect_err("inline_call_irf_v with non-void callee must reject");
@@ -21436,6 +22487,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -21523,6 +22579,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("getfield_gc_i must dispatch");
         let dst_post = wc.registers_i[5];
@@ -21588,6 +22649,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("getfield_gc_r must dispatch");
         let dst_post = wc.registers_r[6];
@@ -21641,6 +22707,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let err = step(&code, 0, &mut wc).expect_err("getfield_gc must validate r-reg");
         assert_eq!(
@@ -21706,6 +22777,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getfield_vable_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -21791,6 +22867,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("setfield_vable_i must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -21866,6 +22947,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_i must dispatch");
         drop(wc);
@@ -21919,6 +23005,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_i must dispatch");
         drop(wc);
@@ -21998,6 +23089,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("setfield_gc_r must dispatch");
         drop(wc);
@@ -22060,6 +23156,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -22136,6 +23237,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let _ = step(&code, 0, &mut wc).expect("getarrayitem_gc_r must dispatch");
         let dst_post = wc.registers_r[5];
@@ -22197,6 +23303,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         let (outcome, next_pc) = step(&code, 0, &mut wc).expect("setarrayitem_gc_r must dispatch");
         assert_eq!(outcome, DispatchOutcome::Continue);
@@ -22500,6 +23611,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         assert_eq!(
             walk(&code, 0, &mut wc),
@@ -22563,6 +23679,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
 
         // Arrival without a preceding `loop_header` stamp and with no
@@ -22644,6 +23765,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         assert_eq!(wc.trace_ctx.seen_loop_header_for_jdindex, -1);
         let (outcome, next) = step(&code, 0, &mut wc).expect("loop_header must dispatch");
@@ -22700,6 +23826,11 @@ mod tests {
             outer_active_boxes: Vec::new(),
             store_subscr_fn_addr: None,
             pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
         };
         assert_eq!(
             step(&code, 0, &mut wc),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6335,7 +6335,22 @@ fn classify_vstack_opcode(
         | Instruction::BuildList { .. }
         | Instruction::BuildSet { .. }
         | Instruction::BuildMap { .. }
-        | Instruction::BuildString { .. } => VstackOpClass::ResultToTos,
+        | Instruction::BuildString { .. }
+        // #73 SLICE 2: LOAD_FAST/STORE_FAST super-instructions.  Their net
+        // result still lands on the new TOS as the LAST Ref written (the
+        // second load, resp. the load following the store), so `ResultToTos`
+        // models the top slot correctly.  A two-push pair
+        // (`LoadFast(Borrow)LoadFast(Borrow)`, net +2) additionally leaves the
+        // slot BELOW the new TOS a NONE hole; the general hole-fill in
+        // `reconcile_vstack_at_boundary` recovers it from the virtualizable
+        // shadow (or defers it to the legacy read when unsourceable) WITHOUT
+        // invalidating the mirror.  Net-0 `StoreFastLoadFast` overwrites the
+        // consumed TOS with the loaded value (no hole).  Before this slice
+        // these fell through to `Unmodeled`, killing the mirror at the first
+        // super-instruction in a short-circuit / condexpr loop body.
+        | Instruction::LoadFastLoadFast { .. }
+        | Instruction::LoadFastBorrowLoadFastBorrow { .. }
+        | Instruction::StoreFastLoadFast { .. } => VstackOpClass::ResultToTos,
 
         // Pop-only / side-store / control transfer: the surviving TOS box
         // is already in `vstack_boxes`, do NOT overwrite it from the last

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13173,11 +13173,23 @@ fn handle(
                     }
                     _ => false,
                 };
-                // A kept-stack guard's not-taken arm is only safe to compile
-                // when the blackhole can reconstruct every value the arm reads
-                // on resume.  Two resume hazards make a kept-stack arm unsafe;
-                // each is described at its check below.  Decline → interpreter
-                // (correct).  Applies to depth-1 and depth > 1.
+                // PARITY DEVIATION (converges at the symbolic-valuestack
+                // capture, #73/#423): `opimpl_goto_if_not` (pyjitpl.py:511/520)
+                // always records GUARD_TRUE/FALSE for a non-constant condition
+                // and captures resumedata (pyjitpl.py:2603), never declining —
+                // its resume reconstruction is complete.  pyre's kept-stack
+                // resume reconstruction is NOT yet complete (the walker
+                // snapshot is partial; the trait leg has no snapshot at all, see
+                // `kept_stack_any_leg` above), so recording the guard and
+                // resuming would rebuild a kept slot as NULL / a wrong value:
+                // the #416/#420 boxed-int short-circuit / conditional-expression
+                // SIGSEGV + silent miscompile.  Until that capture lands pyre
+                // deviates by declining here.  A kept-stack guard's not-taken
+                // arm is only safe to compile when the blackhole can reconstruct
+                // every value the arm reads on resume.  Two resume hazards make
+                // a kept-stack arm unsafe; each is described at its check below.
+                // Decline → interpreter (correct).  Applies to depth-1 and
+                // depth > 1.
                 if kept_stack_any_leg && !relax_124 {
                     let liveness =
                         branch_arm_resume_ref_liveness(other_target, ctx.outer_jitcode_index);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6513,8 +6513,14 @@ fn branch_arm_reads_unrestorable_ref(
             return true;
         };
         match op.opname {
-            // Straight-line trivia: skip.
-            "live" => {
+            // Straight-line trivia: skip.  `catch_exception/L` is a no-op on
+            // the normal fall-through path — it only diverts to its handler
+            // target when an exception is in flight — so it is NOT a fresh
+            // resume coordinate.  The protected body after it is still part of
+            // this arm's straight-line resume region and its Ref reads must be
+            // scanned; treating it as a boundary (returning "restorable") would
+            // let an unrestorable read in the protected body slip through.
+            "live" | "catch_exception" => {
                 pc = op.next_pc;
                 continue;
             }
@@ -6529,7 +6535,7 @@ fn branch_arm_reads_unrestorable_ref(
             // boundary belongs to a different resume coordinate that gets its
             // own guard check, so nothing unrestorable was found here.
             "goto_if_not" | "jit_merge_point" | "loop_header" | "finish" | "leave_frame"
-            | "rvmprof_code" | "catch_exception" => {
+            | "rvmprof_code" => {
                 return false;
             }
             _ => {}
@@ -13230,13 +13236,21 @@ fn handle(
                         .as_deref()
                         .unwrap_or(&[])
                         .iter()
-                        .any(|&c| {
-                            matches!(
-                                ctx.concrete_registers_r.get(c as usize),
-                                Some(ConcreteValue::Ref(p)) if !p.is_null()
-                                    && unsafe { pyre_object::is_int(*p)
-                                        && !(0..256).contains(&pyre_object::w_int_get_value(*p)) }
-                            )
+                        .any(|&c| match ctx.concrete_registers_r.get(c as usize) {
+                            // The concrete shadow unboxes exact ints
+                            // (`ConcreteValue::from_pyobj`), so a kept slot that
+                            // holds a heap int can surface either already-unboxed
+                            // as `Int(v)` or still-boxed as `Ref(W_IntObject)`.
+                            // Match both shapes: a large (`< 0` or `>= 256`) value
+                            // is the unrestorable boxed-int hazard either way, and
+                            // matching only `Ref` would let an unboxed large int
+                            // bypass the decline.
+                            Some(ConcreteValue::Int(v)) => !(0..256).contains(v),
+                            Some(ConcreteValue::Ref(p)) if !p.is_null() => unsafe {
+                                pyre_object::is_int(*p)
+                                    && !(0..256).contains(&pyre_object::w_int_get_value(*p))
+                            },
+                            _ => false,
                         });
                     if reads_null_ref || uses_edge_recovery || kept_boxed_int {
                         return Err(DispatchError::BranchGuardUnrestorableKeptStackPermanent {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1064,6 +1064,21 @@ pub enum DispatchError {
     /// interpreter fallback (correct, untraced) instead of compiling a trace
     /// whose guard-failure path corrupts the frame.
     BranchGuardKeptStackUnsupported { pc: usize },
+    /// A kept-stack branch guard's not-taken (resume) arm READS a regular
+    /// Ref register (`< num_regs_r`) that is neither snapshot-live nor
+    /// produced inside the arm, so the blackhole resumes it as NULL and
+    /// feeds NULL into the consuming op — the boxed-int short-circuit /
+    /// conditional-expression resume miscompile (a heap `ConstPtr`, an int
+    /// outside the small-int cache, parked in a register live-across the
+    /// guard).  Unlike [`BranchGuardKeptStackUnsupported`], this shape is
+    /// miscompiled the SAME way by BOTH the full-body walk and the trait
+    /// leg (both re-execute the identical not-taken arm on deopt), so a
+    /// recoverable [`TraceAction::Abort`] that re-routes to the trait leg
+    /// only crashes there too.  The driver maps this to
+    /// `TraceAction::AbortPermanent` → `DONT_TRACE_HERE`: the loop runs in
+    /// the interpreter (correct, matching the pre-#416/#420 decline) and is
+    /// never retraced by either leg.
+    BranchGuardUnrestorableKeptStackPermanent { pc: usize },
     /// A callee compiled as its own Finish portal (reached via
     /// `call_user_function_with_eval`) accessed its frame through a
     /// `vable_*` op that found it to be a non-standard virtualizable,
@@ -6417,6 +6432,197 @@ fn branch_resume_stack_colors(target: usize) -> Option<Vec<u16>> {
         }
         Some((0..depth).map(|s| scm[s]).collect())
     }
+}
+
+/// The resume snapshot's live Ref register colors at a kept-stack branch
+/// guard's not-taken arm, plus the jitcode `num_regs_r` (the const-window
+/// boundary `n()`).  These are exactly the registers the blackhole restores
+/// into `registers_r` before re-executing the arm: the snapshot live set
+/// (`collect_outer_active_boxes` → `frame_liveness_reg_indices_by_bank_at`)
+/// plus the const-window registers at index `>= num_regs_r` (auto-loaded
+/// from `jitcode.constants_r` by `init_register_files_from_runtime_jitcode`).
+/// Same `FULL_BODY_SNAPSHOT_SYM` contract as [`branch_resume_stack_colors`].
+fn branch_arm_resume_ref_liveness(
+    target: usize,
+    outer_jitcode_index: u32,
+) -> Option<(std::collections::HashSet<u16>, u16)> {
+    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if full_body_sym.is_null() {
+        return None;
+    }
+    let sym = unsafe { &*full_body_sym };
+    if sym.jitcode.is_null() {
+        return None;
+    }
+    unsafe {
+        let jc = &*sym.jitcode;
+        if jc.payload.code_ptr.is_null() {
+            return None;
+        }
+        let code = &*jc.payload.code_ptr;
+        let py = python_pc_for_jitcode_pc(&jc.payload.metadata, target) as usize;
+        let py = skip_python_trivia_forward(code, py);
+        let banks = crate::state::frame_liveness_reg_indices_by_bank_at(
+            outer_jitcode_index as i32,
+            py as i32,
+        );
+        let live: std::collections::HashSet<u16> = banks.ref_.iter().map(|&c| c as u16).collect();
+        let num_regs_r = jc.payload.jitcode.num_regs_r() as u16;
+        Some((live, num_regs_r))
+    }
+}
+
+/// Scan a kept-stack branch guard's not-taken (resume) arm for a Ref
+/// register READ the blackhole cannot reconstruct on guard failure.
+///
+/// On deopt the blackhole rebuilds `registers_r` from the guard's resume
+/// snapshot — the snapshot-live Ref colors (`live_ref`) plus the auto-loaded
+/// const-window registers (index `>= num_regs_r`) — then re-executes the
+/// not-taken arm's static jitcode from `arm_start`.  A *regular* Ref
+/// register (`< num_regs_r`) the arm READS but that is neither in the
+/// snapshot nor produced by an earlier op in the arm is left at its
+/// init-zero (NULL): the blackhole then feeds NULL into the consuming op
+/// (e.g. `bh_binary_op(acc, NULL)` → SIGSEGV / wrong result).
+///
+/// That is the boxed-int short-circuit / conditional-expression resume
+/// miscompile: when the codewriter parks a heap constant (a co_consts
+/// `ConstPtr` — an int outside the small-int cache, `>= 257` or negative —
+/// or any value computed before the branch) in a regular register
+/// live-ACROSS the guard rather than materializing it inside the arm, the
+/// resume cannot restore it.  Cached small ints materialize via an in-arm
+/// `residual_call` (a write the blackhole re-executes), so their arms stay
+/// restorable and keep compiling.
+///
+/// Returns `true` (→ decline → interpreter, which is correct) on any read
+/// it cannot prove restorable, any op it cannot decode, and on overrun.
+/// Conservative by construction: a spurious `true` only forfeits a JIT
+/// optimization; a spurious `false` would compile a NULL-resuming guard.
+fn branch_arm_reads_unrestorable_ref(
+    code: &[u8],
+    arm_start: usize,
+    live_ref: &std::collections::HashSet<u16>,
+    num_regs_r: u16,
+) -> bool {
+    let restorable = |reg: u16, written: &std::collections::HashSet<u16>| {
+        reg >= num_regs_r || live_ref.contains(&reg) || written.contains(&reg)
+    };
+    let mut written: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    let mut pc = arm_start;
+    for _ in 0..512 {
+        let Some(op) = decode_op_at(code, pc) else {
+            return true;
+        };
+        match op.opname {
+            // Straight-line trivia: skip.
+            "live" => {
+                pc = op.next_pc;
+                continue;
+            }
+            // Unconditional jump: follow it (the conditional-expression
+            // then-arm reaches the merge through a `goto`).
+            "goto" => {
+                pc = read_label(code, &op, 0);
+                continue;
+            }
+            // Any merge / loop header / further guard / terminator ends this
+            // arm's straight-line resume region.  A Ref read past such a
+            // boundary belongs to a different resume coordinate that gets its
+            // own guard check, so nothing unrestorable was found here.
+            "goto_if_not" | "jit_merge_point" | "loop_header" | "finish" | "leave_frame"
+            | "rvmprof_code" | "catch_exception" => {
+                return false;
+            }
+            _ => {}
+        }
+        // Walk the operand bytes per `decode_op_at`'s argcode contract
+        // (`jitcode_runtime.rs`), flagging an unrestorable Ref read (`r` /
+        // `R`) and tracking the Ref destination write (`>r`).
+        let mut cursor = op.pc + 1;
+        let mut chars = op.argcodes.chars();
+        let mut dst_ref: Option<u16> = None;
+        while let Some(c) = chars.next() {
+            match c {
+                'i' | 'c' | 'f' => cursor += 1,
+                'r' => {
+                    let Some(&b) = code.get(cursor) else {
+                        return true;
+                    };
+                    if !restorable(b as u16, &written) {
+                        return true;
+                    }
+                    cursor += 1;
+                }
+                'L' | 'd' | 'j' => cursor += 2,
+                'I' | 'F' => {
+                    let Some(&len) = code.get(cursor) else {
+                        return true;
+                    };
+                    cursor += 1 + len as usize;
+                }
+                'R' => {
+                    let Some(&len) = code.get(cursor) else {
+                        return true;
+                    };
+                    cursor += 1;
+                    for _ in 0..len as usize {
+                        let Some(&b) = code.get(cursor) else {
+                            return true;
+                        };
+                        if !restorable(b as u16, &written) {
+                            return true;
+                        }
+                        cursor += 1;
+                    }
+                }
+                '>' => match chars.next() {
+                    Some('r') => {
+                        let Some(&b) = code.get(cursor) else {
+                            return true;
+                        };
+                        dst_ref = Some(b as u16);
+                        cursor += 1;
+                    }
+                    Some('i') | Some('f') => cursor += 1,
+                    _ => return true,
+                },
+                // Pyre helper payload (`*_pyre/P`): opaque operand shape —
+                // conservatively decline rather than mis-walk it.
+                'P' => return true,
+                _ => return true,
+            }
+        }
+        if let Some(d) = dst_ref {
+            written.insert(d);
+        }
+        if op.next_pc <= pc {
+            return true;
+        }
+        pc = op.next_pc;
+    }
+    true
+}
+
+/// The not-taken-arm Python stack depth at a branch guard's resume target,
+/// resolved leg-INDEPENDENTLY through the `MetaInterpStaticData` jitcode
+/// store (`pyjitcode_for_jitcode_index`) rather than the full-body-walk-only
+/// `FULL_BODY_SNAPSHOT_SYM`.  [`branch_resume_target_stack_depth`] returns
+/// `None` in the trait leg (where the bug surfaces just as it does in the
+/// full-body walk — both legs re-execute the same not-taken arm on deopt),
+/// so the unrestorable-kept-stack decline needs a depth probe that works in
+/// either leg.  A depth `> 0` marks the short-circuit / conditional-
+/// expression / chained-comparison kept-stack shape.
+fn branch_resume_target_stack_depth_any_leg(target: usize, jitcode_index: u32) -> Option<u16> {
+    let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)?;
+    if pjc.code_ptr.is_null() {
+        return None;
+    }
+    let code_obj = unsafe { &*pjc.code_ptr };
+    let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
+    let py = skip_python_trivia_forward(code_obj, py);
+    crate::liveness::liveness_for(pjc.code_ptr)
+        .depth_at_py_pc()
+        .get(py)
+        .copied()
 }
 
 /// `generate_guard` (`pyjitpl.py:2599-2603`) keys `after_residual_call`
@@ -12883,6 +13089,15 @@ fn handle(
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
                 let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
+                // `branch_resume_target_stack_depth` reads the full-body-walk-
+                // only `FULL_BODY_SNAPSHOT_SYM`, so `kept_stack` is always
+                // false in the trait leg — yet the trait leg re-executes the
+                // same not-taken arm on deopt and miscompiles the exact same
+                // boxed-int kept-stack shapes.  Probe the depth leg-
+                // independently for the unrestorable-arm decline below.
+                let kept_stack_any_leg =
+                    branch_resume_target_stack_depth_any_leg(other_target, ctx.outer_jitcode_index)
+                        .is_some_and(|d| d > 0);
                 // A kept-stack guard's not-taken arm keeps one or more
                 // operand-stack temps live across the guard.  The not-taken
                 // edge resolves the merge through inline `ref_copy(dst <- src)`
@@ -12952,6 +13167,83 @@ fn handle(
                     }
                     _ => false,
                 };
+                // A kept-stack guard's not-taken arm is only safe to compile
+                // when the blackhole can reconstruct every value the arm reads
+                // on resume.  Two resume hazards make a kept-stack arm unsafe;
+                // each is described at its check below.  Decline → interpreter
+                // (correct).  Applies to depth-1 and depth > 1.
+                if kept_stack_any_leg && !relax_124 {
+                    let liveness =
+                        branch_arm_resume_ref_liveness(other_target, ctx.outer_jitcode_index);
+                    // Hazard (1): the not-taken arm reads a regular Ref register
+                    // the blackhole resumes as NULL (the conditional-expression
+                    // boxed-int NULL-deref crash).
+                    let reads_null_ref = match &liveness {
+                        Some((live_ref, num_regs_r)) => branch_arm_reads_unrestorable_ref(
+                            code,
+                            other_target,
+                            live_ref,
+                            *num_regs_r,
+                        ),
+                        // Liveness unavailable (the trait leg, where
+                        // `FULL_BODY_SNAPSHOT_SYM` is null, or an unresolved
+                        // coordinate) — cannot prove restorable, so decline.
+                        None => true,
+                    };
+                    // Hazard (2): the not-taken edge carries `ref_copy` renames
+                    // (`kept_recovered` non-empty) — the #416/#420 short-circuit
+                    // / chained-comparison kept-stack recovery.  That recovery
+                    // re-uses ONE register's snapshot value for the kept slot,
+                    // but the two branch arms produce DIFFERENT values there; it
+                    // happens to work only when the not-taken arm re-materializes
+                    // the value in-arm (a small-int `c`-immediate `w_int_new`).
+                    // A heap int constant (`< 0` or `>= 256`) is pre-built and
+                    // hoisted as a loop-invariant the arm does NOT re-materialize,
+                    // so the recovery reconstructs a WRONG value — the boxed-int
+                    // short-circuit silent miscompile (`((i & 1) and 1000000)`).
+                    // The boxed vs small distinction is not recoverable at record
+                    // time (the const is dedup'd with the loop bound, never read
+                    // directly by the resume arm — it would need the
+                    // symbolic-valuestack capture of #73/#124), so decline the
+                    // whole recovery path: correct, matching the pre-#416 decline.
+                    // Conditional expressions carry no edge rename (empty
+                    // `kept_recovered`) and keep compiling.
+                    let uses_edge_recovery = kept_recovered
+                        .as_deref()
+                        .is_some_and(|moves| !moves.is_empty());
+                    // Hazard (3): a kept operand-stack slot itself holds a heap
+                    // int outside the 1-byte immediate range `[0, 256)` (the
+                    // accumulator in `acc += (x if c else y)`).  A kept-stack
+                    // branch guard resumes MID-jitcode; the blackhole rebuilds
+                    // that slot from the guard's resume snapshot, but a hoisted
+                    // boxed-int slot is reconstructed with a WRONG / NULL value
+                    // (the conditional-expression boxed-int crash, e.g.
+                    // `257 if (i < 1000000) else 3` where the optimizer folds
+                    // the always-true guard yet leaves a stale resume coord).
+                    // A cached small int (`0..=255`) re-materializes losslessly,
+                    // so a small-int kept slot stays restorable and keeps
+                    // compiling.  Whether the boxed slot's restore happens to
+                    // succeed depends on optimizer guard-folding the record does
+                    // not see, so decline whenever a kept slot is a boxed int —
+                    // correct (interpreter), matching the pre-#416 decline.
+                    let kept_boxed_int = branch_resume_stack_colors(other_target)
+                        .as_deref()
+                        .unwrap_or(&[])
+                        .iter()
+                        .any(|&c| {
+                            matches!(
+                                ctx.concrete_registers_r.get(c as usize),
+                                Some(ConcreteValue::Ref(p)) if !p.is_null()
+                                    && unsafe { pyre_object::is_int(*p)
+                                        && !(0..256).contains(&pyre_object::w_int_get_value(*p)) }
+                            )
+                        });
+                    if reads_null_ref || uses_edge_recovery || kept_boxed_int {
+                        return Err(DispatchError::BranchGuardUnrestorableKeptStackPermanent {
+                            pc: op.pc,
+                        });
+                    }
+                }
                 if depth_gt_1 && !recovery_complete && !relax_124 {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2242,6 +2242,16 @@ pub(crate) fn instruction_needs_pre_opcode_snapshot(instruction: Instruction) ->
             // form) ignores pre_opcode_registers_r, so capturing it there is
             // inert; only the trait leg consults it.
             | Instruction::LoadAttr { .. }
+            // LIST_APPEND reaches the trait leg in an inline frame (it is
+            // walker-routed at the root). list_append_value pop_value's the
+            // appended value, then the strategy fast path emits non-residual
+            // guards at resume_pc=orgpc: guard_class / guard_list_strategy on
+            // the peeked list and, for int/float-storage lists, an unbox
+            // guard_class / guard_value on the popped value. The sibling
+            // comprehension helpers (SET_ADD / MAP_ADD / LIST_EXTEND / …) have
+            // no tracer override and abort before popping, so only LIST_APPEND
+            // qualifies.
+            | Instruction::ListAppend { .. }
     )
 }
 
@@ -9066,6 +9076,14 @@ mod tests {
         let load_attr_code = compile_function_body("def f(lst, x):\n    return lst.append(x)\n");
         assert!(contains_instruction(&load_attr_code, |instruction| {
             matches!(instruction, Instruction::LoadAttr { .. })
+                && instruction_needs_pre_opcode_snapshot(instruction)
+        }));
+
+        // LIST_APPEND (list comprehension) pops the appended value before the
+        // strategy fast path emits its list class / strategy / unbox guards.
+        let list_append_code = compile_function_body("def f(xs):\n    return [x for x in xs]\n");
+        assert!(contains_instruction(&list_append_code, |instruction| {
+            matches!(instruction, Instruction::ListAppend { .. })
                 && instruction_needs_pre_opcode_snapshot(instruction)
         }));
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2222,6 +2222,15 @@ pub(crate) fn instruction_needs_pre_opcode_snapshot(instruction: Instruction) ->
             | Instruction::UnaryNot
             | Instruction::UnaryInvert
             | Instruction::RaiseVarargs { .. }
+            // Both pop the operand stack (BUILD_TUPLE pop_n, UNPACK_SEQUENCE
+            // pop_value) before emitting a guard: trace_build_tuple_value emits
+            // the specialised-tuple w_class guards on the popped items, and
+            // unpack_sequence_value emits the sequence class / length guards on
+            // the popped sequence. Without the opcode-start snapshot the guard's
+            // resume state reflects the post-pop stack, so resuming at the
+            // opcode start restores the consumed operands as null / mismatched.
+            | Instruction::BuildTuple { .. }
+            | Instruction::UnpackSequence { .. }
     )
 }
 
@@ -9021,6 +9030,22 @@ mod tests {
         assert!(contains_instruction(&raise_code, |instruction| {
             matches!(instruction, Instruction::RaiseVarargs { .. })
                 && !instruction_may_raise(instruction)
+                && instruction_needs_pre_opcode_snapshot(instruction)
+        }));
+
+        // BUILD_TUPLE pops its operands before trace_build_tuple_value emits
+        // the specialised-tuple w_class guards.
+        let build_tuple_code = compile_function_body("def f(a, b):\n    return (a, b)\n");
+        assert!(contains_instruction(&build_tuple_code, |instruction| {
+            matches!(instruction, Instruction::BuildTuple { .. })
+                && instruction_needs_pre_opcode_snapshot(instruction)
+        }));
+
+        // UNPACK_SEQUENCE pops the sequence before unpack_sequence_value emits
+        // the sequence class / length guards.
+        let unpack_code = compile_function_body("def f(s):\n    a, b = s\n    return a + b\n");
+        assert!(contains_instruction(&unpack_code, |instruction| {
+            matches!(instruction, Instruction::UnpackSequence { .. })
                 && instruction_needs_pre_opcode_snapshot(instruction)
         }));
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2231,6 +2231,17 @@ pub(crate) fn instruction_needs_pre_opcode_snapshot(instruction: Instruction) ->
             // opcode start restores the consumed operands as null / mismatched.
             | Instruction::BuildTuple { .. }
             | Instruction::UnpackSequence { .. }
+            // LOAD_ATTR reaches the trait leg (execute_opcode_step) in two
+            // cases the dispatch gate carves out of the arm walk: the foldable
+            // builtin list-method form (append/pop/reverse on a list receiver)
+            // and any method-load inside an inline frame. Both run load_method,
+            // which pop_value's the receiver first, then emits a non-residual
+            // receiver class guard (guard_class) plus a version_tag guard_value
+            // — resume_pc=orgpc, so the consumed receiver must be in the
+            // opcode-start snapshot. The arm-walk leg (the common non-foldable
+            // form) ignores pre_opcode_registers_r, so capturing it there is
+            // inert; only the trait leg consults it.
+            | Instruction::LoadAttr { .. }
     )
 }
 
@@ -9046,6 +9057,15 @@ mod tests {
         let unpack_code = compile_function_body("def f(s):\n    a, b = s\n    return a + b\n");
         assert!(contains_instruction(&unpack_code, |instruction| {
             matches!(instruction, Instruction::UnpackSequence { .. })
+                && instruction_needs_pre_opcode_snapshot(instruction)
+        }));
+
+        // LOAD_ATTR's foldable list-method form (lst.append) reaches the trait
+        // leg load_method, which pop_value's the receiver before emitting the
+        // receiver class / version_tag guards.
+        let load_attr_code = compile_function_body("def f(lst, x):\n    return lst.append(x)\n");
+        assert!(contains_instruction(&load_attr_code, |instruction| {
+            matches!(instruction, Instruction::LoadAttr { .. })
                 && instruction_needs_pre_opcode_snapshot(instruction)
         }));
     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1100,6 +1100,13 @@ fn full_body_walk_trace(
                 eprintln!("[fbw-abort] start_pc={start_pc} Err={e:?}");
             }
             match e {
+                // A kept-stack branch guard whose not-taken arm reads an
+                // unrestorable boxed Ref register miscompiles identically in
+                // the trait leg, so re-routing there (the `fbw_decline` +
+                // recoverable `Abort` path below) would crash there too.
+                // Mark the location `DONT_TRACE_HERE` so it interprets
+                // permanently — correct, matching the pre-#416/#420 decline.
+                DE::BranchGuardUnrestorableKeptStackPermanent { .. } => TraceAction::AbortPermanent,
                 DE::AbortPermanentMarkerReached { .. }
                 | DE::GuardSnapshotVableUntyped { .. }
                 | DE::MayForceNullRefArgUnsupported { .. }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8146,6 +8146,17 @@ impl MIFrame {
         // whose MIFrame impls record the live namespace lookup/store IR and
         // advance the vsd shadow via push_value / pop_value — so the early
         // return bypasses `apply_walker_stack_effect`.
+        //
+        // These handlers record the LIVE namespace lookup / store, not a
+        // globals-only one.  Verified empirically once exec / import frames
+        // became portal-traced: an `exec(src, g, l)` (l is not g) hot loop
+        // compiles and still reads a locals-only name from `l` and a
+        // globals-only name from `g` (locals-first, then globals) and binds
+        // results back into `l` — so there is no LOAD_NAME==LOAD_GLOBAL /
+        // STORE_NAME==STORE_GLOBAL conflation to guard against on this path.
+        // A NEWLOCALS class body (its own distinct `w_locals` dict) is also
+        // portal-traced; its bindings are rooted by the `debugdata.w_locals`
+        // value walk in `walk_pyframe_roots`.
         if let Instruction::LoadName { namei } = instruction {
             use pyre_interpreter::OpcodeStepExecutor;
             let idx = namei.get(op_arg) as usize;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8615,6 +8615,29 @@ impl MIFrame {
             return Ok(Some(step));
         }
 
+        // JUMP_FORWARD — unconditional forward control flow: no guard, no loop
+        // close, no resume snapshot (`opimpl_goto`, pyjitpl.py:506 `self.pc =
+        // target`).  Delegate to the same pub `execute_jump_forward` the trait
+        // arm calls; its `jump_forward` → `set_next_instr(target)` sets the
+        // `pending_next_instr` the tracer consumes — the sole pc-advance source
+        // (the codewriter `emit_goto!` only emits graph IR, never advances the
+        // tracer).  `next_instr = self.orgpc + 1` (== the trait leg's `pc + 1`)
+        // feeds `jump_target_forward`'s `skip_caches(next_instr) + delta` for
+        // the identical target.  Returns `StepResult::Continue` — no CloseLoop
+        // coordination, unlike JumpBackward; forward by construction, so it
+        // never reaches the `can_enter_jit` / `loop_header` path.
+        if matches!(instruction, Instruction::JumpForward { .. }) {
+            let next_instr = self.orgpc + 1;
+            let step = pyre_interpreter::execute_jump_forward(
+                self,
+                code,
+                *instruction,
+                op_arg,
+                next_instr,
+            )?;
+            return Ok(Some(step));
+        }
+
         Ok(None)
     }
 
@@ -9935,6 +9958,16 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // no guard; the dispatch gate keeps inline-frame ReturnValue on
             // the trait leg, so only the root exit is flipped.
             | Instruction::ReturnValue
+            // JumpForward — the unconditional forward sibling of the back-edge
+            // family, handled by the entry hook (NOT the arm walk, whose
+            // emit_goto! only emits graph IR and never advances the tracer pc).
+            // The hook delegates to the same pub execute_jump_forward the trait
+            // dispatch arm calls, returning StepResult::Continue (no loop close,
+            // so no CloseLoop outcome to reject); it records no guard and no
+            // resume data (`opimpl_goto`).  Forward by construction, so it never
+            // reaches the can_enter_jit / loop_header path; the gate keeps
+            // inline-frame JumpForward on the trait leg, like the rest.
+            | Instruction::JumpForward { .. }
             // JumpBackward / JumpBackwardNoInterrupt — the loop back-edge,
             // handled by the entry hook (NOT the arm walk, which surfaces
             // SubReturn / rejects the top-level CloseLoop outcome).  The hook


### PR DESCRIPTION
#122

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Extends JIT trace coverage along three lines: pre-opcode guard snapshots for trait-leg opcodes that pop before guarding, routing more entry frames through the JIT portal, and compiling kept-stack branch guards that previously declined to the interpreter. 8 commits, 13 files, +609/−66.

### Pre-opcode guard snapshots (trait-leg opcodes that pop before guarding)

`BUILD_TUPLE`/`UNPACK_SEQUENCE`, `LOAD_ATTR`, and `LIST_APPEND` reach the trait leg and pop the operand stack before the recorder emits a guard at `resume_pc = orgpc`. Each is added to `instruction_needs_pre_opcode_snapshot` (`state.rs`) so `get_list_of_active_boxes` sizes `fail_args` from the pre-pop register file and the consumed operands are restored when resuming at the opcode start after a guard failure. Each commit adds a keeps-test assertion.

- **BUILD_TUPLE / UNPACK_SEQUENCE** (`663b1ed`) — specialised-tuple `w_class` guards on the popped items / sequence class + length guards on the popped sequence.
- **LOAD_ATTR** (`fb523eb`) — foldable builtin list-method form (`append`/`pop`/`reverse`) and inline-frame method loads; receiver `guard_class` + `version_tag` `guard_value`. The non-foldable arm-walk leg does not read `pre_opcode_registers_r`, so the capture is inert there.
- **LIST_APPEND** (`6284c3e`) — inline-frame strategy fast path; `guard_class` / `guard_list_strategy` on the peeked list plus an unbox `guard_class` / `guard_value` for int/float-storage lists. The sibling comprehension helpers abort before popping, so only `LIST_APPEND` qualifies.

### Route entry frames through the JIT portal

- **exec / import** (`3475b17`) — add `PyFrame::run_with_jit`: `run()`'s generator/coroutine check, but the non-generator body dispatches through the registered eval fn (`call::get_eval_fn`) instead of `execute_frame`, so these entry frames reach the JIT portal uniformly. settrace-safe (`get_eval_fn` returns the plain interpreter under `FORCE_PLAIN_EVAL`) and recursion-safe (a declined frame falls back to `execute_frame`, which never re-enters the portal). Routes `exec_or_eval`, the import `exec_code_module`, and `appleveldef_install` through it.
- **class body** (`5a0e9dc`) — `walk_pyframe_roots` now visits the values held in `debugdata.w_locals` (the raw `DictStorage` a `NEWLOCALS` class body binds names into), guarded to the plain-dict scope (skips the module-alias globals storage and the mapping/object scope). Without this, a minor collection relocated young ints bound by a hot class-level loop with nothing forwarding the slots, leaving dangling refs. With the values rooted, `build_class_inner` routes the class body through `run_with_jit`.

### FBW walker routing

- **JUMP_FORWARD** (`bd79f3c`) — routed through the walker entry hook in `try_walker_direct_opcode_dispatch`, delegating to `execute_jump_forward` with `next_instr = orgpc + 1` and returning `StepResult::Continue`; added to `production_walker_handles`. Required because the arm walk's `emit_goto!` emits only graph IR and never advances the tracer pc. New synth bench `if_else_jump_forward.py`.

### Kept-stack branch guards

- **depth-1** (`c35315c`) — narrow the `goto_if_not` kept-stack decline gate to `depth_gt_1 && !PYRE_RELAX_124`, so a guard whose not-taken arm resumes with one live operand-stack temp (short-circuit `and`/`or`, conditional expression, depth-1 chained comparison) recovers that temp via the positional `kept_stack_subst` path and compiles. Also flips the `m3_jitcode_pc_enabled()` default to off (the M3 direct-pc path reads the taken-path slot and silently miscompiles a leading-`and` short-circuit). New synth benches `short_circuit_value_local_kept.py`, `kept_stack_branch_depths.py`.
- **depth>1** (`43281db`) — decode the not-taken branch trampoline's inline `ref_copy` parallel-moves (`decode_branch_trampoline_ref_moves`) into `(dst, src)` resume-color pairs, resolve each to the live guard-state value `registers_r[src]`, and stash `{resume color → value}` in `BRANCH_GUARD_KEPT_RECOVERED`; `collect_outer_active_boxes` and the vable-shadow snapshot read it, overriding the positional heuristic. Compiles a depth>1 guard only when the decoded moves cover every distinct resume stack color, otherwise declines conservatively (an uncovered live-across slot or a cyclic `*_push`/`*_pop` move keeps the decline). New synth bench `kept_stack_depth_gt1.py`.

Validated on both backends (dynasm + cranelift) per commit; each behavioral change ships with a synth bench. `PYRE_RELAX_124` / `PYRE_M3_JITCODE_PC` remain env gates for the in-progress multi-temp follow-up.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

### Prompt & Model

Model: <!-- e.g. gpt-5.5 opus-4.7  -->

Prompt: <!-- Paste the original prompt, regardless of language. -->

### Answer

<!-- If the answer is not in English, attach an English copy as well. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Enhancements**
  * Improved JIT-mediated execution routing for `eval/exec`, class bodies, and module top-level execution
  * Improved tracer dispatch for forward jumps during opcode tracing

* **Reliability Improvements**
  * Strengthened kept-stack branch guard tracing to safely avoid unrestorable resume states
  * Improved GC root forwarding to keep globals/locals object references consistent
  * Preserved guarded bounded-integer behavior when exporting widened bounds

* **Tests & Benchmarks**
  * Added a new conditional-branch benchmark
  * Expanded unit coverage for pre-opcode snapshot gating across additional bytecodes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->