### PR TITLE
rtyper : ListIteratorRepr + dual-gate prepass census reduction

### DIFF
--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -1,0 +1,372 @@
+//! Iterator `next()` → `next` op + StopIteration handler lowering.
+//!
+//! ## Positioning
+//!
+//! Layer 3 of the iterator vertical (annotator iter/next ops = Layer 1,
+//! rtyper `ListIteratorRepr` = Layer 2): the front-end lift that turns a
+//! Rust `Iterator::next()` call and its `Option` match into the graph's
+//! native `next` op with a StopIteration exception edge.
+//!
+//! Rust source models `for x in it` as
+//! ```text
+//!     opt = Iterator::next(&mut it);    // -> Option<T>
+//!     match opt { Some(x) => body, None => break }
+//! ```
+//! lowered (in MIR) as a `__discriminant` read on `opt` plus a two-way
+//! `switchInt` (None = 0, Some = 1).  RPython's `next` op returns the
+//! element directly and raises `StopIteration` at exhaustion
+//! (`rpython/flowspace/operation.py` `next`; the annotator's
+//! `op.next.can_only_throw` is `[StopIteration, RuntimeError]`).  This
+//! module rewrites the value-encoded Option diamond into that exception
+//! representation — the mirror of [`crate::front::result_exc`]'s
+//! `Result`/`?` rewrite.  The Option diamond is the same shape minus the
+//! `branch()` indirection, and its exception edge targets the loop-break
+//! arm (a local `StopIteration` catch) instead of `exceptblock` — the
+//! `try: x = next(it) except StopIteration: break` shape.  The rewrite
+//! gates on the iterator tracing back to an `iter` op
+//! (`originates_from_iter_op`), so only a list iterator reaches it, and
+//! `ListIteratorRepr::rtype_next` raises solely `StopIteration` — the
+//! block carries no catch-all propagation edge (the `RuntimeError` half
+//! of `next`'s conservative `can_only_throw` is dict-iterator mutation
+//! detection that never fires here, and `flowin` drops the unhandled
+//! remainder).
+//!
+//! ## The rewrite (`rewire_one_next_site`)
+//!
+//! Block A holds the `next()` residual call producing `opt`; block C is
+//! its single successor — the discriminant switch.  The rewrite:
+//! 1. replaces A's residual call with the native `next` op (the
+//!    `[__iter_next]` marker the [`crate::translator::rtyper::flowspace_adapter`]
+//!    maps to the raising flowspace `next` op), reusing `opt` as the
+//!    element result;
+//! 2. closes A with `LastException` exits — normal → the `Some` arm
+//!    (`opt.__pos_0` collapses to the element), `StopIteration` → the
+//!    `None` arm (loop break).
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `next` callee
+//! makes the rtyper census Skip the graph (no regression vs the legacy
+//! walker).
+
+use crate::flowspace::model::{ConstValue, Constant, Variable};
+use crate::front::result_exc::{
+    assert_block_pure_besides, assert_single_pred, back_substitute, collapse_pos0_read,
+    follow_single_exit, split_diamond_exits,
+};
+use crate::model::{
+    CallTarget, ExitCase, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
+};
+
+/// The `[__iter_next]` FunctionPath marker the rewrite emits in place of
+/// the residual `Iterator::next()` call.  `flowspace_adapter::translate_op`
+/// maps it to the raising flowspace `next` op (`operation.rs` `OpKind::Next`).
+pub(crate) fn next_op_segments() -> Vec<String> {
+    vec!["__iter_next".to_string()]
+}
+
+/// `true` iff `segments` is the `[__iter_next]` marker.
+pub(crate) fn is_iter_next_segments(segments: &[String]) -> bool {
+    segments.len() == 1 && segments[0] == "__iter_next"
+}
+
+/// `true` iff the residual call target is an `Iterator::next()` — a
+/// `next`-leaf method or FunctionPath.  Combined with an `Option` return
+/// type at the recording site, this records a `next`-diamond candidate;
+/// the rewrite itself validates the surrounding match shape.
+pub(crate) fn is_iterator_next_target(target: &CallTarget) -> bool {
+    match target {
+        CallTarget::Method { name, .. } => name == "next",
+        CallTarget::FunctionPath { segments } => segments.last().is_some_and(|s| s == "next"),
+        _ => false,
+    }
+}
+
+/// `true` iff `segments` is the `iter` op the front-end lowers a
+/// slice/Vec/array iterator constructor to (`["core", "slice", "iter"]` —
+/// `front::mir`'s `is_concrete_iter_constructor` lowering and the explicit
+/// `.iter()` bridge both emit it; `flowspace_adapter::core_bridge_opname`
+/// maps it to the `iter` flowspace op feeding `ListIteratorRepr`).
+fn is_iter_op_segments(segments: &[String]) -> bool {
+    segments.len() == 3 && segments[0] == "core" && segments[1] == "slice" && segments[2] == "iter"
+}
+
+/// `true` iff `var` originates — directly or through loop-carried block
+/// inputargs — from an `iter` op (a list iterator).  A backward walk: a
+/// var produced by an `iter` op is a list iterator; a var that is a block
+/// inputarg is traced to each predecessor's link arg in the matching slot
+/// (so the loop header's iterator phi resolves through its entry edge to
+/// the pre-loop `iter` op, while the back edge re-threads an already-seen
+/// var).  Conservative: a var produced by any other op (a reborrow, a
+/// foreign iterator constructor) is not followed, so the walk returns
+/// `true` only on a positively-confirmed `iter` source.
+fn originates_from_iter_op(graph: &FunctionGraph, var: &Variable) -> bool {
+    let mut visited: Vec<Variable> = Vec::new();
+    let mut stack: Vec<Variable> = vec![var.clone()];
+    while let Some(v) = stack.pop() {
+        if visited.contains(&v) {
+            continue;
+        }
+        visited.push(v.clone());
+        // (1) produced directly by an iter op → confirmed list iterator.
+        for b in &graph.blocks {
+            for op in &b.operations {
+                if op.result.as_ref() == Some(&v)
+                    && let OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } = &op.kind
+                    && is_iter_op_segments(segments)
+                {
+                    return true;
+                }
+            }
+        }
+        // (2) a block inputarg → trace each predecessor's link arg in the
+        // matching slot (the loop-carried iterator phi).
+        for b in &graph.blocks {
+            if let Some(pos) = b.inputargs.iter().position(|iv| iv == &v) {
+                let target_id = b.id;
+                for pb in &graph.blocks {
+                    for link in &pb.exits {
+                        if link.target == target_id
+                            && let Some(LinkArg::Value(src)) = link.args.get(pos)
+                        {
+                            stack.push(src.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// The typed `StopIteration` exitcase the `next` block's break link
+/// carries — the handler analogue of [`crate::model::exception_exitcase`]
+/// (`Exception` catch-all), narrowed to the single exception the loop
+/// catches.  `ConstValue::builtin` resolves the class to a `HostObject`,
+/// the `Constant(HostObject(class))` shape `annrpython::flowin` matches.
+fn stopiteration_exitcase() -> ExitCase {
+    ExitCase::Const(ConstValue::builtin("StopIteration"))
+}
+
+fn int_const(i: i64) -> LinkArg {
+    LinkArg::Const(Constant::new(ConstValue::Int(i)))
+}
+
+/// Rewrite every recorded `next()` call site into the `next` op +
+/// StopIteration handler shape.  Fail-safe: a site whose surrounding
+/// `Option` match does not fit the for-loop shape is left as the residual
+/// call (Skip), so a mismatch never regresses a graph the legacy walker
+/// already handled.  Returns the number of sites rewritten.
+pub(crate) fn rewire_next_call_sites(graph: &mut FunctionGraph, sites: &[Variable]) -> usize {
+    let mut rewritten = 0;
+    for opt in sites {
+        match rewire_one_next_site(graph, opt) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `next` call; the unregistered callee
+                // makes the rtyper census Skip this graph (no regression).
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_next_site(graph: &mut FunctionGraph, opt: &Variable) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `next()` residual call producing `opt`, closed by
+    // lower_call with a single forwarding exit.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(opt))
+        })
+        .ok_or_else(|| format!("{name}: next() result var has no producer block"))?;
+
+    // The call must be A's last op (lower_call closes the block right
+    // after pushing it) so it becomes the block's `raising_op`.
+    let call_idx = graph.blocks[a].operations.len() - 1;
+    let last_is_call = graph.blocks[a].operations[call_idx].result.as_ref() == Some(opt);
+    if !last_is_call {
+        return Err(format!(
+            "{name}: next() call is not the last op of block {a}"
+        ));
+    }
+    // Capture the iterator operand (the `next` op's single argument).
+    let iter_arg = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+        other => {
+            return Err(format!(
+                "{name}: next() producer op is not a 1-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // The 2-exit StopIteration-only shape is faithful ONLY for a list
+    // iterator (`ListIteratorRepr::rtype_next` / `ll_listnext` raises
+    // solely `StopIteration`).  A non-list iterator's `next` annotates
+    // `OpKind::Next` over a non-list tag (poison / mis-tag panic) and its
+    // `can_only_throw` carries the live `RuntimeError` half the shape
+    // drops.  `is_iterator_next_target` alone cannot tell them apart, so
+    // gate on the iterator tracing back to an `iter` op — the front-end's
+    // slice/Vec/array iterator constructor (`front::mir`
+    // `is_concrete_iter_constructor` + the `.iter()` bridge, both lowered
+    // to `["core", "slice", "iter"]`).  Anything else declines (the
+    // residual call keeps the rtyper Skip), so a non-list iterator never
+    // reaches the rewrite.
+    if !originates_from_iter_op(graph, &iter_arg) {
+        return Err(format!(
+            "{name}: next() iterator operand does not originate from an iter op — \
+             not a list-iterator for-loop"
+        ));
+    }
+
+    // A's single exit → C (the Option discriminant switch).  Unlike the
+    // Result `?` diamond there is no intervening `branch()` block.
+    let (c, opt_c) = follow_single_exit(graph, a, opt)
+        .map_err(|e| format!("{name}: next call block exit: {e}"))?;
+    assert_single_pred(graph, c, &name)?;
+
+    // Block C: `d = opt.__discriminant`; `switch d { 0 → None, 1 → Some }`.
+    let (disc_idx, disc_var) = graph.blocks[c]
+        .operations
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::FieldRead { base, field, .. }
+                if *base == opt_c && field.name == "__discriminant" =>
+            {
+                op.result.clone().map(|r| (i, r))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: block {c} lacks the Option __discriminant read"))?;
+    match &graph.blocks[c].exitswitch {
+        Some(ExitSwitch::Value(v)) if *v == disc_var => {}
+        other => {
+            return Err(format!(
+                "{name}: block {c} exitswitch {other:?} is not the Option discriminant switch"
+            ));
+        }
+    }
+    // Block C is bypassed; only the discriminant read may carry an effect.
+    assert_block_pure_besides(graph, c, &[disc_idx], "discriminant", &name)?;
+
+    // Option discriminant: None = 0, Some = 1.  `split_diamond_exits`
+    // returns `(case 0, case 1)` = `(None arm, Some arm)`.
+    let (none_link, some_link) = split_diamond_exits(&graph.blocks[c].exits, &name)?;
+    let some_target = some_link.target;
+    let none_target = none_link.target;
+
+    // Some arm (normal exit): the `next` op result IS the element.  Map
+    // the Some-link args back to A scope; the forwarded Option value
+    // becomes the element result, the threaded discriminant the constant 1.
+    let mut normal_args: Vec<LinkArg> = Vec::with_capacity(some_link.args.len());
+    let mut payload_positions: Vec<usize> = Vec::new();
+    for (i, arg) in some_link.args.iter().enumerate() {
+        match arg {
+            LinkArg::Const(c0) => normal_args.push(LinkArg::Const(c0.clone())),
+            LinkArg::Value(v) => {
+                if *v == opt_c {
+                    normal_args.push(LinkArg::Value(opt.clone()));
+                    payload_positions.push(i);
+                } else if *v == disc_var {
+                    normal_args.push(int_const(1));
+                } else {
+                    let v_a = back_substitute(graph, &[(a, c)], v, &name)?;
+                    normal_args.push(LinkArg::Value(v_a));
+                }
+            }
+        }
+    }
+
+    // The payload collapse below (`collapse_pos0_read` per position) is
+    // the only fallible mutation; it mutates the Some target on success
+    // but can still `Err` on a later position.  With at most one position
+    // the collapse is the first mutation and itself atomic (it errs before
+    // writing), so a decline leaves the graph byte-identical.  Two or more
+    // positions (the same Option threaded into several Some-link slots)
+    // could half-collapse before a later `Err`, handing the legacy walker
+    // a partially-rewritten graph — decline that unusual shape up front to
+    // keep the "validate-before-mutate" fail-safe contract airtight.
+    if payload_positions.len() > 1 {
+        return Err(format!(
+            "{name}: Option value threaded into {} Some-arm slots — multi-slot \
+             payload collapse is not fail-safe",
+            payload_positions.len()
+        ));
+    }
+
+    // None arm (StopIteration exit): the loop-break continuation.  A plain
+    // for-loop break carries only loop state, never the exhausted Option;
+    // decline if it forwards `opt_c`.
+    let mut none_args: Vec<LinkArg> = Vec::with_capacity(none_link.args.len());
+    for arg in &none_link.args {
+        match arg {
+            LinkArg::Const(c0) => none_args.push(LinkArg::Const(c0.clone())),
+            LinkArg::Value(v) => {
+                if *v == opt_c {
+                    return Err(format!(
+                        "{name}: None arm of block {c} forwards the Option value — unsupported"
+                    ));
+                } else if *v == disc_var {
+                    none_args.push(int_const(0));
+                } else {
+                    let v_a = back_substitute(graph, &[(a, c)], v, &name)?;
+                    none_args.push(LinkArg::Value(v_a));
+                }
+            }
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // The Some target reads the payload via `opt.__pos_0`; with the `next`
+    // result flowing directly, that read collapses to the carried value.
+    for pos in payload_positions {
+        collapse_pos0_read(graph, some_target, pos, &name)?;
+    }
+
+    // Replace A's residual `next()` call with the native `next` op: the
+    // `[__iter_next]` marker, the iterator as its single operand, `opt`
+    // reused as the element.  The `LastException` exitswitch below makes
+    // the block a `canraise` block whose `raising_op` is this op.
+    graph.blocks[a].operations[call_idx].kind = OpKind::Call {
+        target: CallTarget::FunctionPath {
+            segments: next_op_segments(),
+        },
+        args: vec![iter_arg],
+        result_ty: ValueType::Ref(None),
+    };
+
+    // Rewire A: `LastException` exits.
+    //   normal        → Some arm (element)
+    //   StopIteration → None arm (loop break)
+    // `OpKind::Next.can_only_throw` is the conservative `[StopIteration,
+    // RuntimeError]` default, but the `originates_from_iter_op` gate above
+    // admits only a list iterator, and `ListIteratorRepr::rtype_next`
+    // (`ll_listnext`) raises solely `StopIteration` — the `RuntimeError`
+    // half is dict-iterator mutation-detection that never materialises
+    // here.  The annotator's
+    // `flowin` drops the unhandled-exception remainder, so no catch-all
+    // propagation edge to `exceptblock` is synthesised (preserving the
+    // front graph's "exceptblock edges == MIR unwind terminators"
+    // invariant).
+    let stop_etype = graph.alloc_value_var();
+    let stop_evalue = graph.alloc_value_var();
+    let mut stopiter_link = Link::new_mixed(none_args, none_target, Some(stopiteration_exitcase()));
+    stopiter_link.last_exception = Some(LinkArg::Value(stop_etype));
+    stopiter_link.last_exc_value = Some(LinkArg::Value(stop_evalue));
+
+    let block_a = &mut graph.blocks[a];
+    block_a.exitswitch = Some(ExitSwitch::LastException);
+    block_a.exits = vec![
+        Link::new_mixed(normal_args, some_target, None),
+        stopiter_link,
+    ];
+    Ok(())
+}

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4292,6 +4292,33 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<String>::deref` / `<str>::deref` and the Wtf8 string
+                // family: a `Deref` between two string-value types is a
+                // pointer-follow with no transformation.  `String` / `&str`
+                // / `Wtf8` / `Wtf8Buf` all project to the single immutable
+                // `s_unicode0` value, so the deref is identity — alias the
+                // destination to the argument directly (the same zero-op
+                // shape as the reflexive `into` above) instead of falling
+                // through to the residual `method("deref", …)` build, an
+                // unregistered callee.  `deref_cast_root` returns `None` for
+                // these (the `&str` dest resolves no struct root), so the
+                // cast arm below declines; gate on the receiver AND the
+                // destination both being string values so slice / `Vec`
+                // derefs (`&[T]`, root `Builtin::Slice`) keep their ordinary
+                // path.
+                if args.len() == 1
+                    && is_deref_call(&reg, self.llbc)
+                    && first_arg_ty
+                        .as_ref()
+                        .is_some_and(|t| tyref_is_string_value(t, self.llbc))
+                    && tyref_is_string_value(&call.dest.ty, self.llbc)
+                {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `<Box<T>>::deref` / `<Rc<T>>::deref` / `<Arc<T>>::deref`
                 // / the workspace `FrameBox::deref` (+ their `deref_mut`)
                 // whose `&T` is a registered struct.  The handle is one
@@ -8449,6 +8476,50 @@ fn tyref_strips_to_str(ty: &TyRef, llbc: &Llbc) -> bool {
         .and_then(|id| id.get("Builtin"))
         .and_then(serde_json::Value::as_str)
         == Some("Str")
+}
+
+/// Whether a `TyRef` resolves (behind `Ref` / dedup wrappers) to a
+/// string-family value: the `alloc::string::String` ADT, the
+/// `rustpython_wtf8` `Wtf8` / `Wtf8Buf` wrappers, or the `{Builtin: "Str"}`
+/// node (the bare `str` deref destination).  All four project to the
+/// single immutable `s_unicode0` value, so a `deref` between any two of
+/// them is value-identity.
+fn tyref_is_string_value(ty: &TyRef, llbc: &Llbc) -> bool {
+    let Some(node) = tyref_node(ty, llbc).and_then(|n| strip_ty_wrappers(n, llbc)) else {
+        return false;
+    };
+    // `{Builtin: "Str"}` — the bare `str` value (no ADT def-id).
+    if node
+        .get("Adt")
+        .and_then(|a| a.get("id"))
+        .and_then(|id| id.get("Builtin"))
+        .and_then(serde_json::Value::as_str)
+        == Some("Str")
+    {
+        return true;
+    }
+    // Named string ADTs: `alloc::string::String` and the WTF-8 wrappers.
+    adt_node_def_id(node)
+        .and_then(|id| llbc.type_by_id(id))
+        .is_some_and(|td| {
+            let np = td.item_meta.name_path();
+            np == "alloc::string::String"
+                || matches!(np.rsplit("::").next(), Some("Wtf8" | "Wtf8Buf"))
+        })
+}
+
+/// Whether `reg` resolves to a `Deref::deref` / `DerefMut::deref_mut`
+/// leaf, by the callee's `name_path` suffix.  Unlike `deref_cast_root`
+/// this makes no claim about the dereferenced type — the caller pairs it
+/// with a `tyref_is_string_value` receiver / dest gate.
+fn is_deref_call(reg: &RegularCall, llbc: &Llbc) -> bool {
+    let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+        return false;
+    };
+    llbc.fn_by_id(*id).is_some_and(|fd| {
+        let np = fd.item_meta.name_path();
+        np.ends_with("::deref") || np.ends_with("::deref_mut")
+    })
 }
 
 /// The qualified declaration path of a `TyRef`'s base ADT, after

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1115,7 +1115,10 @@ pub fn lower_fun_decl_with_static_addrs(
     let result_exc_ok_is_unit = result_exc_callee
         && crate::front::result_exc::tyref_result_ok_is_unit(&fd.signature.output, llbc);
     let finish = |lo: &mut Lowering<'_>| -> Result<(), LowerError> {
-        if !lo.result_exc_call_results.is_empty() || result_exc_callee {
+        if !lo.result_exc_call_results.is_empty()
+            || result_exc_callee
+            || !lo.next_call_results.is_empty()
+        {
             // The exception-link transforms run on a simplified graph,
             // as exceptiontransform.py does (graphs reach it after
             // `simplify_graph`, simplify.py:1075): the discriminant
@@ -1166,7 +1169,20 @@ pub fn lower_fun_decl_with_static_addrs(
         // treat a no-predecessor block as an extra root
         // (`transform_dead_op_vars`'s start set), and before the
         // `jit_codewriter` consumers that scan `graph.blocks` directly.
-        if !lo.result_exc_call_results.is_empty() || result_exc_callee {
+        // The `next`-diamond rewrite (`front::iter_next`) runs on the same
+        // simplified graph: the Option discriminant switch's default→Abort
+        // arm must be pruned first, identically to the `?` diamond.  It is
+        // fail-safe — a non-for-loop `Option` match is left as the residual
+        // call — so it runs over every recorded site and reports how many
+        // it actually rewrote.  Only an actual rewrite detaches blocks (the
+        // discriminant switch), so the unreachable-block sweep is gated on
+        // that count, leaving a declined graph byte-identical.
+        let next_rewritten = if lo.next_call_results.is_empty() {
+            0
+        } else {
+            crate::front::iter_next::rewire_next_call_sites(&mut lo.graph, &lo.next_call_results)
+        };
+        if !lo.result_exc_call_results.is_empty() || result_exc_callee || next_rewritten > 0 {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
         simplify_lowered_graph(&mut lo.graph);
@@ -1462,6 +1478,10 @@ struct Lowering<'a> {
     /// per-instantiation `<…>` suffix (Ref-shaped payloads only) keying
     /// the rebuilt `Ok`/`Err` shells' ClassDef per instantiation.
     result_exc_call_results: Vec<(Variable, Option<String>)>,
+    /// `Iterator::next()` call results (`Option<T>`-typed) recorded for
+    /// the `next`-diamond rewiring pass (`front::iter_next`) that runs
+    /// after the body lowering completes.
+    next_call_results: Vec<Variable>,
 }
 
 impl<'a> Lowering<'a> {
@@ -1592,6 +1612,7 @@ impl<'a> Lowering<'a> {
             const_discriminant_locals: std::collections::HashMap::new(),
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
+            next_call_results: Vec::new(),
         })
     }
 
@@ -4635,6 +4656,39 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // The concrete container `IntoIterator::into_iter` impls
+                // (`&[T]`/`Vec`/`[T;N]`) construct a container iterator.
+                // Emit the `iter` operation on the container receiver — the
+                // `("slice","iter")` bridge routes it to `Repr::rtype_iter`
+                // (`ListIteratorRepr` via `make_iterator_repr`) — instead of
+                // the unregistered concrete-impl `FunctionPath` callee.  The
+                // canonical `core::slice::iter` segments are the bridge's
+                // recognised token; the receiver annotation (a `SomeList`)
+                // supplies the actual element repr.
+                if args.len() == 1 && self.is_concrete_iter_constructor(&reg) {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec![
+                                    "core".to_string(),
+                                    "slice".to_string(),
+                                    "iter".to_string(),
+                                ],
+                            },
+                            args: vec![args[0].clone()],
+                            result_ty: ValueType::Ref(None),
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `alloc::fmt::format` of a no-placeholder constant
                 // message — `format!("literal")`, whose `format_args!`
                 // lowered to `Arguments::from_str` (aliased to its
@@ -4972,6 +5026,17 @@ impl<'a> Lowering<'a> {
             );
             self.result_exc_call_results
                 .push((result_var.clone(), suffix));
+        }
+        // Capture `Iterator::next()` results (`Option<T>`-typed) for the
+        // `next`-diamond rewiring pass (`front::iter_next`).  Recognition
+        // is liberal — any `next`-leaf call returning `Option` — because
+        // the rewrite itself validates the surrounding for-loop match and
+        // declines (leaving the residual call) on any other shape.
+        if let OpKind::Call { target, .. } = &op_kind
+            && crate::front::iter_next::is_iterator_next_target(target)
+            && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
+        {
+            self.next_call_results.push(result_var.clone());
         }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var),
@@ -5641,6 +5706,30 @@ impl<'a> Lowering<'a> {
         };
         self.llbc.fn_by_id(*id).is_some_and(|fd| {
             fd.item_meta.name_path() == "core::iter::traits::collect::<Impl>::into_iter"
+        })
+    }
+
+    /// The concrete container `IntoIterator` impls — `<&[T] as
+    /// IntoIterator>::into_iter` and the `Vec` / array forms.  Unlike the
+    /// reflexive blanket (`is_reflexive_into_iter`), the receiver type
+    /// (the container) differs from the destination (a fresh iterator), so
+    /// they cannot be identity-aliased; the caller lowers them to the
+    /// `iter` operation on the container instead of an unregistered
+    /// `FunctionPath` callee.  The explicit `<[T]>::iter` already routes to
+    /// `iter` through the `("slice","iter")` bridge
+    /// (`flowspace_adapter::nonraising_core_bridge_opname`), so it is not
+    /// matched here.
+    fn is_concrete_iter_constructor(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::iter::<Impl>::into_iter"
+                    | "alloc::vec::<Impl>::into_iter"
+                    | "core::array::<Impl>::into_iter"
+            )
         })
     }
 

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -67,6 +67,7 @@
 //! the only extraction gap is std `thread_local!` accessor stubs,
 //! treated as opaque ops.
 
+pub(crate) mod iter_next;
 pub mod llbc_hints;
 pub mod mir;
 pub mod mir_dispatch;

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -172,6 +172,21 @@ pub(crate) fn tyref_is_result_of_pyerror(ty: &TyRef, llbc: &Llbc) -> bool {
     adt_path_of(err_body, llbc).is_some_and(|p| p == "pyre_interpreter::error::PyError")
 }
 
+/// True when `ty` is `core::option::Option<T>` — the return type of an
+/// `Iterator::next()` call, recognised by [`crate::front::iter_next`] to
+/// record the `next`-diamond rewrite site.
+pub(crate) fn tyref_is_option(ty: &TyRef, llbc: &Llbc) -> bool {
+    let body = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return false,
+        },
+    };
+    adt_path_of(body, llbc).as_deref() == Some("core::option::Option")
+}
+
 /// The per-instantiation `<…>` suffix for a scoped callee's
 /// `Result<T, PyError>` return type, or `None` when the instantiation is
 /// not Ref-shaped (bool/int payloads stay on the bare `Result::Ok`
@@ -1263,7 +1278,7 @@ fn forwards_to_returnblock(graph: &FunctionGraph, block: usize, var: &Variable) 
 /// variable that is `succ`'s inputarg maps through `pred`'s single
 /// exit, a variable defined inside an intermediate block cannot flow
 /// back and fails loud.
-fn back_substitute(
+pub(crate) fn back_substitute(
     graph: &FunctionGraph,
     chain: &[(usize, usize)],
     var: &Variable,
@@ -1301,7 +1316,7 @@ fn back_substitute(
 
 /// `block`'s single exit must carry `var`; returns the target block
 /// index and the inputarg `var` binds to there.
-fn follow_single_exit(
+pub(crate) fn follow_single_exit(
     graph: &FunctionGraph,
     block: usize,
     var: &Variable,
@@ -1332,7 +1347,11 @@ fn follow_single_exit(
 
 /// The diamond's intermediate blocks must have exactly one
 /// predecessor — the chain we arrived through.
-fn assert_single_pred(graph: &FunctionGraph, block: usize, name: &str) -> Result<(), String> {
+pub(crate) fn assert_single_pred(
+    graph: &FunctionGraph,
+    block: usize,
+    name: &str,
+) -> Result<(), String> {
     let preds = graph
         .blocks
         .iter()
@@ -1352,7 +1371,7 @@ fn assert_single_pred(graph: &FunctionGraph, block: usize, name: &str) -> Result
 /// as one explicit case plus a `default` arm covering the
 /// complementary discriminant (mir.rs `SwitchTargets::SwitchInt`),
 /// so a `default` link stands in for whichever of 0/1 is absent.
-fn split_diamond_exits(exits: &[Link], name: &str) -> Result<(Link, Link), String> {
+pub(crate) fn split_diamond_exits(exits: &[Link], name: &str) -> Result<(Link, Link), String> {
     use crate::flowspace::model::ConstValue;
     use crate::model::ExitCase;
     if exits.len() != 2 {
@@ -1399,7 +1418,7 @@ fn split_diamond_exits(exits: &[Link], name: &str) -> Result<(Link, Link), Strin
 /// exception links are equivalent only when the removed shape is pure
 /// control / unwrap / reraise plumbing.  Pure extras (constants, reads)
 /// are harmless to bypass and are allowed.
-fn assert_block_pure_besides(
+pub(crate) fn assert_block_pure_besides(
     graph: &FunctionGraph,
     block: usize,
     recognized: &[usize],
@@ -1481,7 +1500,7 @@ fn verify_break_arm_is_reraise(
 /// In the continue-arm target, the `__pos_0` read off the inputarg at
 /// `pos` collapses: the inherited value already *is* the payload.
 /// Deletes the read and renames its result to the inputarg.
-fn collapse_pos0_read(
+pub(crate) fn collapse_pos0_read(
     graph: &mut FunctionGraph,
     target: crate::model::BlockId,
     pos: usize,

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1900,6 +1900,13 @@ pub fn run_two_phase_prepass(
     call_registry.two_phase().prepass_done = true;
 }
 
+/// Whether the `PYRE_RTYPER_VERBOSE` de-aggregating census is enabled.
+/// Matches the `== "1"` contract the codewriter's coverage gauge uses
+/// (`codewriter.rs`), so a literal `PYRE_RTYPER_VERBOSE=0` stays off.
+fn rtyper_verbose_enabled() -> bool {
+    std::env::var_os("PYRE_RTYPER_VERBOSE").is_some_and(|v| v == "1")
+}
+
 fn run_two_phase_prepass_inner(
     call_registry: &PyreCallRegistry,
     candidate_graphs: &HashSet<crate::parse::CallPath>,
@@ -1943,7 +1950,7 @@ fn run_two_phase_prepass_inner(
                 // otherwise lumps every Phase-A failure under one opaque
                 // "subject not annotated/rtyped" Skip. Surface the per-graph
                 // reason so the onion can be triaged.
-                if std::env::var("PYRE_RTYPER_VERBOSE").is_ok() {
+                if rtyper_verbose_enabled() {
                     let reason = match other {
                         Ok(Err(e)) => format!("annotate Err: {e:?}"),
                         Err(p) => {
@@ -2045,7 +2052,7 @@ fn run_phase_b_rtype_isolated(
             match res {
                 Ok(Ok(())) => rtyper.mark_already_seen(&block),
                 ref other @ (Ok(Err(_)) | Err(_)) => {
-                    if std::env::var("PYRE_RTYPER_VERBOSE").is_ok() {
+                    if rtyper_verbose_enabled() {
                         let reason = match other {
                             Ok(Err(e)) => format!("rtype Err: {e:?}"),
                             Err(p) => {

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -804,6 +804,15 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // exc-edge and classdef walls; the legacy walker keeps
         // handling these graphs until each Repr is ported.
         || msg.contains("rtyper_makerepr — port")
+        // The list-iterator `next` lowering (`ll_listnext`, which raises
+        // `StopIteration`) is not yet ported; `ListIteratorRepr::rtype_next`
+        // fail-louds with this shape.  `newiter` / `iter` ARE ported, so a
+        // graph can reach `next` once the front-end lifts the iterator
+        // protocol — keep those graphs on the legacy walker until
+        // `ll_listnext` lands.  Same category as the `rtyper_makerepr —
+        // port` unported-Repr Skip above (an unported op lowering, not a
+        // fixpoint-absorption deviation).
+        || msg.contains("rtype_next — ll_listnext")
         // TODO(annotator-fixpoint-fail-loud) — STRICT-PARITY REGRESSION
         // vs main / PyPy.  `bookkeeper.py:108-127` propagates fixpoint
         // exceptions uncaught and `annrpython.py:643` lets

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1907,6 +1907,129 @@ fn rtyper_verbose_enabled() -> bool {
     std::env::var_os("PYRE_RTYPER_VERBOSE").is_some_and(|v| v == "1")
 }
 
+/// Map a captured prepass failure reason to its orthodox-disposition
+/// bucket — the named [`is_known_unported`] category (or, for the
+/// FunctionPath-not-registered family, the unregistered callee's nature)
+/// whose port closes it. Turns the opaque "two-phase Skip" count into a
+/// ranked, finite legacy-walker-deletion worklist: each bucket names a
+/// concrete piece of work (port a Repr, lower a construct in `front::mir`,
+/// residual-ize a helper, specialize a generic ADT).
+fn classify_unported_reason(reason: &str) -> &'static str {
+    // ── rtyper-stage named gaps (most specific first) ──
+    if reason.contains("rtyper_makerepr — port") {
+        "REPR-PORT (rlist/rdict/robject/iterator)"
+    } else if reason.contains("cannot unify instances with no common base class")
+        || reason.contains("don't know how to convert from")
+    {
+        "GENERIC-ADT-SPECIALIZE (per-instantiation classdef)"
+    } else if reason.contains("rtype_cast_ptr_to_int")
+        || reason.contains("is of instances of the non-pointers")
+        || reason.contains("noneify() not supported")
+    {
+        "FRONTEND-TYPED-PTR (address-of-local / host-static / null)"
+    } else if reason.contains("Call with CallTarget::Indirect") {
+        "DYN-TRAIT-INDIRECT (lower_indirect_calls)"
+    } else if reason.contains("no upstream pair(s1, s2).union() handler") {
+        "UNION-PAIR-PORT"
+    } else if reason.contains("rbase missing") {
+        "REPR-SETUP-ORDER (call_all_setups)"
+    } else if reason.contains("calltable row not found in CallFamily") {
+        "RPBC-CALLFAMILY (seeded-method registration)"
+    } else if reason.contains("InstanceRepr.convert_const") {
+        "FIELD-PROJECTION (typed-Ref field rows)"
+    } else if reason.contains("MissingRTypeAttribute")
+        || reason.contains("Cannot find attribute ")
+        || reason.contains("classdef-less instance")
+    {
+        "CLASSDEF-LESS-INSTANCE (typed-Ref ClassDef)"
+    } else if reason.contains("KeyError: no binding for arg")
+        || reason.contains("inputarg lacks annotation")
+        || (reason.contains("variable ") && reason.contains(" used before definition"))
+    {
+        "ANNOTATION-SLOT-GAP (cross-block threading)"
+    }
+    // ── FunctionPath-not-registered family, split by callee nature ──
+    else if reason.contains("not registered in PyreCallRegistry")
+        || reason.contains("translate_op")
+        || reason.contains("cachedgraph")
+    {
+        if reason.contains("core::ptr")
+            || reason.contains("from_raw_parts")
+            || reason.contains("box_assume_init")
+            || reason.contains("mut_ptr")
+            || reason.contains("const_ptr")
+        {
+            "FRONTEND-RAWPTR (raw_store/raw_load op)"
+        } else if reason.contains("GcType")
+            || reason.contains("type_id")
+            || reason.contains("__dyn_call")
+        {
+            "FRONTEND-VTABLE (gc_id / indirect_call)"
+        } else if reason.contains("SHADOW_STACK")
+            || reason.contains("TL_")
+            || reason.contains("TYPEOBJECT_CACHE")
+            || reason.contains("W_TYPE_TYPEOBJECT")
+            || reason.contains("CALL_DEPTH")
+            || reason.contains("PENDING_EXCEPTION")
+        {
+            "FRONTEND-THREADLOCAL/ONCELOCK (threadlocalref_get)"
+        } else if reason.contains("into_iter")
+            || reason.contains("reverse")
+            || reason.contains("chars")
+            || reason.contains("::iter")
+        {
+            "FRONTEND-ITERATOR (Vec-as-array / next protocol)"
+        } else if reason.contains("bigint")
+            || reason.contains("malachite")
+            || reason.contains("indexmap")
+            || reason.contains("IndexMap")
+        {
+            "RESIDUAL-FOREIGN (dont_look_inside + fnaddr)"
+        } else if (reason.contains("bool") && reason.contains("then"))
+            || reason.contains("filter")
+            || reason.contains("FnMut")
+            || reason.contains("FnOnce")
+        {
+            "RESIDUAL-CLOSURE (dont_look_inside)"
+        } else {
+            "FUNCPATH-OTHER (registry / residual)"
+        }
+    }
+    // ── annotator-stage catch-alls ──
+    else if reason.contains("UnionError") {
+        "UNION-ERROR (generic-ADT phi / pair)"
+    } else if reason.contains("Blocked block -- operation cannot succeed") {
+        "BLOCKED-BLOCK (annotation dead-end downstream)"
+    } else if reason.contains("compute_at_fixpoint failed")
+        || reason.contains("complete_pending_blocks failed")
+        || reason.contains("AnnotatorError")
+    {
+        "ANNOTATOR-FIXPOINT-OTHER (no inner cause surfaced)"
+    } else {
+        "UNCLASSIFIED"
+    }
+}
+
+/// Print a sorted disposition histogram for a prepass phase's failures
+/// (`PYRE_RTYPER_VERBOSE`). The ranked buckets are the legacy-walker
+/// deletion worklist; as each disposition's port lands its bucket shrinks.
+fn emit_disposition_histogram(phase: &str, reasons: &[String]) {
+    let mut counts: std::collections::BTreeMap<&'static str, usize> =
+        std::collections::BTreeMap::new();
+    for r in reasons {
+        *counts.entry(classify_unported_reason(r)).or_insert(0) += 1;
+    }
+    let mut rows: Vec<(&'static str, usize)> = counts.into_iter().collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    eprintln!(
+        "[PREPASS histogram {phase}] {} failures by orthodox disposition:",
+        reasons.len()
+    );
+    for (cat, n) in rows {
+        eprintln!("[PREPASS histogram {phase}]   {n:>4}  {cat}");
+    }
+}
+
 fn run_two_phase_prepass_inner(
     call_registry: &PyreCallRegistry,
     candidate_graphs: &HashSet<crate::parse::CallPath>,
@@ -1922,6 +2045,7 @@ fn run_two_phase_prepass_inner(
     paths.sort_by_key(|p| p.canonical_key());
 
     // ── Phase A — annotate-all over the portal closure ───────────────
+    let mut phase_a_reasons: Vec<String> = Vec::new();
     for path in &paths {
         let Some(legacy) = function_graphs.get(path) else {
             continue;
@@ -1964,6 +2088,7 @@ fn run_two_phase_prepass_inner(
                         Ok(Ok(_)) => unreachable!(),
                     };
                     eprintln!("[PREPASS phaseA fail] {:?}: {reason}", path);
+                    phase_a_reasons.push(reason);
                 }
                 // Annotate-half failed (or panicked): repair shared-callee state
                 // and leave the graph uncached so publish Skips it to the legacy
@@ -1978,6 +2103,10 @@ fn run_two_phase_prepass_inner(
                 }));
             }
         }
+    }
+
+    if rtyper_verbose_enabled() {
+        emit_disposition_histogram("phaseA", &phase_a_reasons);
     }
 
     // ── compute_at_fixpoint runs per-subject inside drive_subject's
@@ -2007,6 +2136,7 @@ fn run_phase_b_rtype_isolated(
     let Ok((annotator, rtyper)) = call_registry.ensure_session() else {
         return;
     };
+    let mut phase_b_reasons: Vec<String> = Vec::new();
     loop {
         // Skip-tolerant repr setup: a single unported repr (e.g. DictRepr)
         // must not abort rtyping of every other annotated graph. The graph
@@ -2069,6 +2199,7 @@ fn run_phase_b_rtype_isolated(
                             "[PREPASS phaseB fail] {:?}: {reason}",
                             gopt.as_ref().map(GraphKey::of)
                         );
+                        phase_b_reasons.push(reason);
                     }
                     match &gopt {
                         Some(g) => {
@@ -2099,6 +2230,9 @@ fn run_phase_b_rtype_isolated(
                 }
             }
         }
+    }
+    if rtyper_verbose_enabled() {
+        emit_disposition_histogram("phaseB", &phase_b_reasons);
     }
     // MixLevelHelperAnnotator drain (rtyper.py:238-241) is a no-op while R4 is
     // unported — specialize_block never queues helper graphs today. When R4

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -804,15 +804,6 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // exc-edge and classdef walls; the legacy walker keeps
         // handling these graphs until each Repr is ported.
         || msg.contains("rtyper_makerepr — port")
-        // The list-iterator `next` lowering (`ll_listnext`, which raises
-        // `StopIteration`) is not yet ported; `ListIteratorRepr::rtype_next`
-        // fail-louds with this shape.  `newiter` / `iter` ARE ported, so a
-        // graph can reach `next` once the front-end lifts the iterator
-        // protocol — keep those graphs on the legacy walker until
-        // `ll_listnext` lands.  Same category as the `rtyper_makerepr —
-        // port` unported-Repr Skip above (an unported op lowering, not a
-        // fixpoint-absorption deviation).
-        || msg.contains("rtype_next — ll_listnext")
         // TODO(annotator-fixpoint-fail-loud) — STRICT-PARITY REGRESSION
         // vs main / PyPy.  `bookkeeper.py:108-127` propagates fixpoint
         // exceptions uncaught and `annrpython.py:643` lets

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -503,8 +503,9 @@ fn normalize_unary_op_name(pyre_name: &str) -> Result<String, TyperError> {
         "str" => Ok("str".to_string()),
         other => Err(TyperError::missing_rtype_operation(format!(
             "normalize_unary_op_name: pyre UnaryOp `{other}` has no \
-             flowspace counterpart (operation.py:465-474 registers \
-             only `pos` / `neg` / `invert` / `bool` as unary ops; \
+             flowspace counterpart (operation.py registers \
+             `pos` / `neg` / `invert` / `bool` and the ported `str` \
+             as unary ops; \
              `same_as` is rtyper's internal renaming op per \
              rtyper.py:478-481; all 13 typed cast names retired \
              across Slices A.3 / B.1 / A.4a / A.4b / A.4c — frontend \

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -740,6 +740,15 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
             target: crate::model::CallTarget::FunctionPath { segments },
             ..
         } if is_slice_reverse_segments(segments) => false,
+        // `[__iter_next]` (`front::iter_next`) lowers to the raising
+        // flowspace `next` op (`operation.rs` `OpKind::Next.can_only_throw
+        // = [StopIteration, RuntimeError]`).  Matched before the general
+        // `Call` arm, mirroring [`translate_op`]'s `[__iter_next]` arm.
+        OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if args.len() == 1 && crate::front::iter_next::is_iter_next_segments(segments) => true,
         // simple_call -> `CallOp.canraise` is `[Exception]` for a
         // non-builtin callable (operation.py:648-661).  Constant builtin
         // callables (int / float / chr / unicode) carry the narrower
@@ -1241,6 +1250,17 @@ pub fn translate_op(
                     // the shared table `op_canraise` mirrors.
                     if let Some(opname) = nonraising_core_bridge_opname(segments, arg_hls.len()) {
                         return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
+                    }
+                    // `[__iter_next]` (`front::iter_next`) → the raising
+                    // flowspace `next` op (`operation.rs` `OpKind::Next`,
+                    // `can_only_throw = [StopIteration, RuntimeError]`).  The
+                    // block's `LastException` exits — set by the front-end
+                    // `next`-diamond rewrite — carry the exception edges, so
+                    // no edge-building happens here (unlike a `?`-tail op).
+                    if crate::front::iter_next::is_iter_next_segments(segments)
+                        && arg_hls.len() == 1
+                    {
+                        return Ok(vec![FlowspaceOp::new("next", arg_hls, result)]);
                     }
                     // `min`/`max` are the exception: they lower to a
                     // `simple_call(<builtin>)` (raising like any builtin

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -153,6 +153,10 @@ pub enum ReprClassId {
     /// `rrange.py:43 RangeRepr(AbstractRangeRepr)` — the immutable
     /// `range()`-result list repr (`GcStruct("range", start, stop)`).
     RangeRepr,
+    /// `rlist.py:437 AbstractListIteratorRepr(IteratorRepr)` — the
+    /// iterator over a list/slice (`GcStruct("listiter", ("list", LIST),
+    /// ("index", Signed))`).
+    ListIteratorRepr,
 }
 
 impl ReprClassId {
@@ -208,6 +212,10 @@ impl ReprClassId {
             WeakRefRepr => &[WeakRefRepr, Repr],
             EmulatedWeakRefRepr => &[EmulatedWeakRefRepr, Repr],
             RangeRepr => &[RangeRepr, Repr],
+            // `ListIteratorRepr → AbstractListIteratorRepr → IteratorRepr
+            // → Repr`; the abstract bases carry no pairtype entries, so
+            // the resolution chain collapses to `Self → Repr`.
+            ListIteratorRepr => &[ListIteratorRepr, Repr],
         }
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -29,8 +29,8 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 };
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, RPythonTyper, helper_pygraph_from_graph, variable_with_lltype,
-    void_field_const,
+    ConvertedTo, HighLevelOp, RPythonTyper, constant_with_lltype, exception_args,
+    helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
 
 /// RPython `class FixedSizeListRepr(AbstractFixedSizeListRepr,
@@ -1369,24 +1369,54 @@ impl Repr for ListIteratorRepr {
     }
 
     /// RPython `AbstractListIteratorRepr.rtype_next(self, hop)`
-    /// (`rlist.py:444-449`) — `ll_listnext` reads `l = iter.list`,
-    /// bounds-checks `index >= l.ll_length()` (raising `StopIteration`),
-    /// increments `iter.index`, and returns `l.ll_getitem_fast(index)`.
-    /// Deferred to the follow-on slice; that slice must also:
-    /// - raise `StopIteration` via a link to the helper graph's
-    ///   `exceptblock` (the first low-level helper in the port to raise);
-    /// - thread `listitem.mutated` to pick `ll_listnext` vs
-    ///   `ll_listnext_foldable` (see [`ListIteratorRepr::list_is_fixed`]);
-    /// - recast the result through `external_item_repr` (`rlist.py:449,67`)
-    ///   — dropped here for the same reason as getitem (#305), an identity
-    ///   for primitive items but needed for a GC-instance element list.
-    /// The deferral surfaces as a Skip (see `is_known_unported`), keeping
-    /// the subject on the legacy walker rather than miscompiling.
-    fn rtype_next(&self, _hop: &HighLevelOp) -> RTypeResult {
-        let _ = (&self.item_repr, self.list_is_fixed);
-        Err(TyperError::missing_rtype_operation(
-            "ListIteratorRepr.rtype_next — ll_listnext (raise StopIteration) deferred",
-        ))
+    /// (`rlist.py:444-449`):
+    ///
+    /// ```python
+    /// def rtype_next(self, hop):
+    ///     v_iter, = hop.inputargs(self)
+    ///     hop.has_implicit_exception(StopIteration)
+    ///     hop.exception_is_here()
+    ///     v_res = hop.gendirectcall(self.ll_listnext, v_iter)
+    ///     return self.r_list.recast(hop.llops, v_res)
+    /// ```
+    ///
+    /// `ll_listnext` (the `index >= ll_length()` bounds-check that raises
+    /// `StopIteration`) lowers to [`build_ll_listnext_helper_graph`]. The
+    /// foldable vs non-foldable selection (`ll_listnext_foldable`,
+    /// `lltypesystem/rlist.py:462-466`) is NOT an rtyper-level distinction:
+    /// both lower to the bare `getarrayitem` op, and the `getitem_foldable`
+    /// oopspec is a tracing-time hint the codewriter applies — exactly as
+    /// `rtype_len` lowers both `ll_len` / `ll_len_foldable` to `getarraysize`.
+    /// The upstream result `recast` (`rlist.py:449,67`) is omitted for the
+    /// same reason as getitem: `ListIteratorRepr` keeps only the internal
+    /// `item_repr` (identity for primitive items; a GC-instance element list
+    /// is deferred to the #305 `external_item_repr` slice).
+    fn rtype_next(&self, hop: &HighLevelOp) -> RTypeResult {
+        let v_iter = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        hop.has_implicit_exception("StopIteration");
+        hop.exception_is_here()?;
+        let item_lltype = self.item_repr.lowleveltype().clone();
+        let iter_lltype = self.lltype.clone();
+        let list_lltype = self.list_lltype.clone();
+        let list_is_fixed = self.list_is_fixed;
+        let iter_for_builder = iter_lltype.clone();
+        let list_for_builder = list_lltype.clone();
+        let item_for_builder = item_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_listnext".to_string(),
+            vec![iter_lltype],
+            item_lltype,
+            move |_rtyper, _args, _result| {
+                build_ll_listnext_helper_graph(
+                    "ll_listnext",
+                    iter_for_builder.clone(),
+                    list_for_builder.clone(),
+                    item_for_builder.clone(),
+                    list_is_fixed,
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, v_iter)
     }
 }
 
@@ -1487,6 +1517,215 @@ pub(crate) fn build_ll_listiter_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["lst".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `ll_listnext` (`lltypesystem/rlist.py:476-482`):
+///
+/// ```python
+/// def ll_listnext(iter):
+///     l = iter.list
+///     index = iter.index
+///     if index >= l.ll_length():
+///         raise StopIteration
+///     iter.index = index + 1
+///     return l.ll_getitem_fast(index)
+/// ```
+///
+/// Two-block CFG mirroring [`lowlevel_range_check_helper_graph`]'s
+/// raise-to-`exceptblock` shape:
+/// - **startblock**: `l = getfield(iter, "list")`,
+///   `index = getfield(iter, "index")`, `len = ll_length(l)`
+///   (`getarraysize(l)` for the fixed array receiver, `getfield(l,
+///   "length")` for the resized header struct), `cond = int_lt(index,
+///   len)`. `exitswitch = cond`: the `false` (out-of-bounds) exit links to
+///   `graph.exceptblock` with `exception_args("StopIteration")`, the `true`
+///   exit carries `(iter, l, index)` to the continue block.
+/// - **continue**: `iter.index = int_add(index, 1)`, then
+///   `res = ll_getitem_fast(l, index)` (`getarrayitem(l, index)` for the
+///   fixed array; `getfield(l, "items")` then `getarrayitem(items, index)`
+///   for the resized struct), return `res`.
+pub(crate) fn build_ll_listnext_helper_graph(
+    name: &str,
+    iter_lltype: LowLevelType,
+    list_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    list_is_fixed: bool,
+) -> Result<PyGraph, TyperError> {
+    // The resized list keeps its element array in the "items" field; the
+    // fixed list IS the bare `Ptr(GcArray)`.
+    let items_lltype = if list_is_fixed {
+        None
+    } else {
+        let extracted = match &list_lltype {
+            LowLevelType::Ptr(p) => match &p.TO {
+                PtrTarget::Struct(s) => s._flds.get("items").cloned(),
+                _ => None,
+            },
+            _ => None,
+        };
+        Some(extracted.ok_or_else(|| {
+            TyperError::message(
+                "build_ll_listnext_helper_graph: resized list lltype missing items field",
+            )
+        })?)
+    };
+
+    let iter_arg = variable_with_lltype("iter", iter_lltype.clone());
+    let startblock = Block::shared(vec![Hlvalue::Variable(iter_arg.clone())]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // upstream `raise StopIteration` — the [etype, evalue] pair the
+    // exceptblock link carries.
+    let exc_args = exception_args("StopIteration")?;
+
+    // startblock: l = iter.list; index = iter.index; len = ll_length(l);
+    //             cond = index < len.
+    let v_l = variable_with_lltype("l", list_lltype.clone());
+    let v_index = variable_with_lltype("index", LowLevelType::Signed);
+    let v_len = variable_with_lltype("len", LowLevelType::Signed);
+    let v_cond = variable_with_lltype("cond", LowLevelType::Bool);
+    {
+        let mut b = startblock.borrow_mut();
+        b.operations.push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(iter_arg.clone()), void_field_const("list")],
+            Hlvalue::Variable(v_l.clone()),
+        ));
+        b.operations.push(SpaceOperation::new(
+            "getfield",
+            vec![
+                Hlvalue::Variable(iter_arg.clone()),
+                void_field_const("index"),
+            ],
+            Hlvalue::Variable(v_index.clone()),
+        ));
+        if list_is_fixed {
+            b.operations.push(SpaceOperation::new(
+                "getarraysize",
+                vec![Hlvalue::Variable(v_l.clone())],
+                Hlvalue::Variable(v_len.clone()),
+            ));
+        } else {
+            b.operations.push(SpaceOperation::new(
+                "getfield",
+                vec![Hlvalue::Variable(v_l.clone()), void_field_const("length")],
+                Hlvalue::Variable(v_len.clone()),
+            ));
+        }
+        b.operations.push(SpaceOperation::new(
+            "int_lt",
+            vec![
+                Hlvalue::Variable(v_index.clone()),
+                Hlvalue::Variable(v_len.clone()),
+            ],
+            Hlvalue::Variable(v_cond.clone()),
+        ));
+        b.exitswitch = Some(Hlvalue::Variable(v_cond.clone()));
+    }
+
+    // continue block receives (iter, l, index).
+    let c_iter = variable_with_lltype("iter", iter_lltype);
+    let c_l = variable_with_lltype("l", list_lltype);
+    let c_index = variable_with_lltype("index", LowLevelType::Signed);
+    let cont = Block::shared(vec![
+        Hlvalue::Variable(c_iter.clone()),
+        Hlvalue::Variable(c_l.clone()),
+        Hlvalue::Variable(c_index.clone()),
+    ]);
+
+    startblock.closeblock(vec![
+        // index < len -> continue (carry iter, l, index).
+        Link::new(
+            vec![
+                Hlvalue::Variable(iter_arg),
+                Hlvalue::Variable(v_l),
+                Hlvalue::Variable(v_index),
+            ],
+            Some(cont.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        // index >= len -> raise StopIteration.
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // continue: iter.index = index + 1; res = ll_getitem_fast(l, index).
+    let v_newindex = variable_with_lltype("newindex", LowLevelType::Signed);
+    let v_res = variable_with_lltype("res", item_lltype.clone());
+    {
+        let mut b = cont.borrow_mut();
+        b.operations.push(SpaceOperation::new(
+            "int_add",
+            vec![
+                Hlvalue::Variable(c_index.clone()),
+                constant_with_lltype(ConstValue::Int(1), LowLevelType::Signed),
+            ],
+            Hlvalue::Variable(v_newindex.clone()),
+        ));
+        b.operations.push(SpaceOperation::new(
+            "setfield",
+            vec![
+                Hlvalue::Variable(c_iter),
+                void_field_const("index"),
+                Hlvalue::Variable(v_newindex),
+            ],
+            Hlvalue::Variable(variable_with_lltype("v", LowLevelType::Void)),
+        ));
+        if let Some(items_lltype) = items_lltype {
+            let v_items = variable_with_lltype("items", items_lltype);
+            b.operations.push(SpaceOperation::new(
+                "getfield",
+                vec![Hlvalue::Variable(c_l.clone()), void_field_const("items")],
+                Hlvalue::Variable(v_items.clone()),
+            ));
+            b.operations.push(SpaceOperation::new(
+                "getarrayitem",
+                vec![Hlvalue::Variable(v_items), Hlvalue::Variable(c_index)],
+                Hlvalue::Variable(v_res.clone()),
+            ));
+        } else {
+            b.operations.push(SpaceOperation::new(
+                "getarrayitem",
+                vec![Hlvalue::Variable(c_l), Hlvalue::Variable(c_index)],
+                Hlvalue::Variable(v_res.clone()),
+            ));
+        }
+    }
+    cont.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_res)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["iter".to_string()],
         func,
     ))
 }
@@ -2418,5 +2657,175 @@ mod tests {
         };
         let dbg = format!("{:?}", c.value);
         assert!(dbg.contains("ll_listiter"), "expected 'll_listiter' in {dbg}");
+    }
+
+    /// `ll_listnext` over a fixed list: startblock bounds-checks via
+    /// `getfield`/`getfield`/`getarraysize`/`int_lt` and the continue block
+    /// `int_add`/`setfield`/`getarrayitem` (`lltypesystem/rlist.py:476-482`).
+    /// The out-of-bounds exit links to the graph's `exceptblock`.
+    #[test]
+    fn build_ll_listnext_helper_fixed_bounds_checks_and_getarrayitem() {
+        let rtyper = fresh_rtyper_live();
+        let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let r_iter =
+            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
+                .expect("ListIteratorRepr::new");
+        let pygraph = build_ll_listnext_helper_graph(
+            "ll_listnext",
+            r_iter.lowleveltype().clone(),
+            r_list.lowleveltype().clone(),
+            LowLevelType::Signed,
+            true,
+        )
+        .expect("build_ll_listnext_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let start_ops: Vec<_> = graph
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        assert_eq!(start_ops, vec!["getfield", "getfield", "getarraysize", "int_lt"]);
+        // startblock branches on the bounds-check; one exit raises via the
+        // graph's exceptblock.
+        let start = graph.startblock.borrow();
+        assert!(start.exitswitch.is_some(), "bounds-check exitswitch");
+        let except_key = crate::flowspace::model::BlockKey::of(&graph.exceptblock);
+        let raises = start.exits.iter().any(|lnk| {
+            lnk.borrow()
+                .target
+                .as_ref()
+                .is_some_and(|t| crate::flowspace::model::BlockKey::of(t) == except_key)
+        });
+        assert!(raises, "one startblock exit must link to exceptblock (raise StopIteration)");
+        // the non-raising exit's continue block reads the element.
+        let cont_ops: Vec<Vec<String>> = graph
+            .iterblocks()
+            .iter()
+            .map(|b| b.borrow().operations.iter().map(|op| op.opname.clone()).collect())
+            .collect();
+        assert!(
+            cont_ops
+                .iter()
+                .any(|seq| seq == &vec!["int_add".to_string(), "setfield".to_string(), "getarrayitem".to_string()]),
+            "continue block must int_add/setfield/getarrayitem, got {cont_ops:?}"
+        );
+    }
+
+    /// `ll_listnext` over a resized list reads `length` from the header and
+    /// `items` array before `getarrayitem` (`lltypesystem/rlist.py` ADTIList).
+    #[test]
+    fn build_ll_listnext_helper_resized_reads_length_and_items() {
+        let rtyper = fresh_rtyper_live();
+        let r_list = ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new");
+        let r_iter =
+            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, false)
+                .expect("ListIteratorRepr::new");
+        let pygraph = build_ll_listnext_helper_graph(
+            "ll_listnext",
+            r_iter.lowleveltype().clone(),
+            r_list.lowleveltype().clone(),
+            LowLevelType::Signed,
+            false,
+        )
+        .expect("build_ll_listnext_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let start_ops: Vec<_> = graph
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        // resized length via getfield "length" (not getarraysize).
+        assert_eq!(start_ops, vec!["getfield", "getfield", "getfield", "int_lt"]);
+        let cont_ops: Vec<Vec<String>> = graph
+            .iterblocks()
+            .iter()
+            .map(|b| b.borrow().operations.iter().map(|op| op.opname.clone()).collect())
+            .collect();
+        assert!(
+            cont_ops.iter().any(|seq| seq
+                == &vec![
+                    "int_add".to_string(),
+                    "setfield".to_string(),
+                    "getfield".to_string(),
+                    "getarrayitem".to_string()
+                ]),
+            "resized continue must read items array before getarrayitem, got {cont_ops:?}"
+        );
+    }
+
+    /// `next(iter)` rtypes through `ListIteratorRepr::rtype_next` to a
+    /// `direct_call(ll_listnext, v_iter)`, recording the implicit
+    /// `StopIteration` (`rlist.py:444-449`).
+    #[test]
+    fn list_iterator_next_emits_direct_call_to_ll_listnext() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let list_repr = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let iter_repr: Arc<ListIteratorRepr> = Arc::new(
+            ListIteratorRepr::new(list_repr.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
+                .expect("ListIteratorRepr::new"),
+        );
+        let iter_lltype = iter_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_iter = Variable::new();
+        v_iter.set_concretetype(Some(iter_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "next".to_string(),
+                vec![Hlvalue::Variable(v_iter)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::Iterator(crate::annotator::model::SomeIterator::new(
+                SomeValue::List(SomeList::new(ListDef::new(
+                    None,
+                    SomeValue::Integer(SomeInteger::new(false, false)),
+                    false,
+                    false,
+                ))),
+                vec![],
+            )));
+        hop.args_r
+            .borrow_mut()
+            .push(Some(iter_repr.clone() as Arc<dyn Repr>));
+
+        let result = iter_repr
+            .rtype_next(&hop)
+            .unwrap_or_else(|err| panic!("list next: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "rtype_next must call hop.exception_is_here()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(dbg.contains("ll_listnext"), "expected 'll_listnext' in {dbg}");
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -57,6 +57,11 @@ pub struct FixedSizeListRepr {
     /// (gcref-wrapped) element repr; its lowleveltype is the array
     /// element type and the `getitem` result type.
     item_repr: Arc<dyn Repr>,
+    /// `self.external_item_repr` (`rlist.py` `_setup_repr`) — the
+    /// surface element repr `recast` converts the internal `getitem`
+    /// result back to. For a primitive item `externalvsinternal` returns
+    /// the same repr, so `recast` is an identity (see [`list_recast`]).
+    external_item_repr: Arc<dyn Repr>,
 }
 
 impl FixedSizeListRepr {
@@ -66,7 +71,7 @@ impl FixedSizeListRepr {
         // gcref so the array element type is never a gc container
         // (which `ArrayType::gc` rejects); non-instance reprs pass
         // through unchanged.
-        let (_external, internal) =
+        let (external, internal) =
             crate::translator::rtyper::rclass::externalvsinternal(rtyper, item_repr)?;
         let item_lltype = internal.lowleveltype().clone();
         let arr = ArrayType::gc(item_lltype);
@@ -77,8 +82,33 @@ impl FixedSizeListRepr {
             state: ReprState::new(),
             lltype,
             item_repr: internal,
+            external_item_repr: external,
         })
     }
+}
+
+/// RPython `AbstractBaseListRepr.recast(self, llops, v)` (`rlist.py:67`):
+///
+/// ```python
+/// def recast(self, llops, v):
+///     return llops.convertvar(v, self.item_repr, self.external_item_repr)
+/// ```
+///
+/// Converts an element value produced at the internal `item_repr` back to
+/// the surface `external_item_repr` (`getitem` / `next` results). For a
+/// primitive item `externalvsinternal` returns the same repr instance, so
+/// `convertvar` short-circuits on its `ptr::eq` identity check and emits no
+/// op; a GC-instance element list (`external != internal`) routes through
+/// the pairtype dispatch.
+fn list_recast(
+    hop: &HighLevelOp,
+    v: Hlvalue,
+    item_repr: &Arc<dyn Repr>,
+    external_item_repr: &Arc<dyn Repr>,
+) -> Result<Hlvalue, TyperError> {
+    hop.llops
+        .borrow_mut()
+        .convertvar(v, item_repr.as_ref(), external_item_repr.as_ref())
 }
 
 impl Repr for FixedSizeListRepr {
@@ -160,18 +190,12 @@ impl Repr for FixedSizeListRepr {
     /// a `TyperError` until those helpers land — Rust slice indexing never
     /// produces them.
     ///
-    /// The upstream result `recast` (`rlist.py:266`
-    /// `return r_lst.recast(hop.llops, v_res)` → `convertvar(v, item_repr,
-    /// external_item_repr)`) is omitted: `FixedSizeListRepr::new` keeps only
-    /// the internal `item_repr` and drops the `external_item_repr` half of
-    /// `externalvsinternal`, so getitem returns the internal repr directly.
-    /// That is correct for every list a live subject builds today — a
-    /// primitive item has `external == internal`, making recast an identity —
-    /// but a GC-instance list (`external != internal`) would return the
-    /// internal/root repr instead of the concrete external repr. Deferred to
-    /// the #305 slice that models `external_item_repr`: pyre's `convertvar`
-    /// keys identity on `Arc::ptr_eq`, so a same-lltype-different-`Arc`
-    /// recast added now would `TyperError` every currently-green getitem.
+    /// The upstream result `recast` (`rlist.py:267`
+    /// `return r_lst.recast(hop.llops, v_res)`) converts the internal
+    /// `getitem` result back to `external_item_repr` via [`list_recast`].
+    /// For a primitive item `externalvsinternal` returns the same repr, so
+    /// `convertvar` short-circuits to identity and emits no op; a GC-instance
+    /// list (`external != internal`) routes through the pairtype dispatch.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::annotator::model::SomeValue;
         if hop.has_implicit_exception("IndexError") {
@@ -219,7 +243,15 @@ impl Repr for FixedSizeListRepr {
                 )
             },
         )?;
-        hop.gendirectcall(&helper, args)
+        let v_res = hop.gendirectcall(&helper, args)?.ok_or_else(|| {
+            TyperError::message("list rtype_getitem: ll_fixed_getitem_fast returned Void")
+        })?;
+        Ok(Some(list_recast(
+            hop,
+            v_res,
+            &self.item_repr,
+            &self.external_item_repr,
+        )?))
     }
 
     /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
@@ -360,6 +392,7 @@ impl Repr for FixedSizeListRepr {
         Ok(Arc::new(ListIteratorRepr::new(
             self.lltype.clone(),
             self.item_repr.clone(),
+            self.external_item_repr.clone(),
             true,
         )?))
     }
@@ -450,6 +483,10 @@ pub struct ListRepr {
     /// `self.item_repr` (`rlist.py:111`) — the internal (gcref-wrapped)
     /// element repr.
     item_repr: Arc<dyn Repr>,
+    /// `self.external_item_repr` (`rlist.py` `_setup_repr`) — the surface
+    /// element repr `recast` converts the internal result back to (identity
+    /// for primitive items; see [`list_recast`]).
+    external_item_repr: Arc<dyn Repr>,
 }
 
 impl ListRepr {
@@ -458,7 +495,7 @@ impl ListRepr {
         // gcref normalisation as `FixedSizeListRepr`: gc `InstanceRepr`
         // items become the generic `Ptr(OBJECT)` gcref so the array
         // element type is never a gc container.
-        let (_external, internal) =
+        let (external, internal) =
             crate::translator::rtyper::rclass::externalvsinternal(rtyper, item_repr)?;
         let item_lltype = internal.lowleveltype().clone();
         // upstream `get_itemarray_lowleveltype()` — `GcArray(ITEM)` (the
@@ -485,6 +522,7 @@ impl ListRepr {
             state: ReprState::new(),
             lltype,
             item_repr: internal,
+            external_item_repr: external,
         })
     }
 }
@@ -537,11 +575,9 @@ impl Repr for ListRepr {
     /// (IndexError-raising) branches surface a `TyperError` until those
     /// helpers land.
     ///
-    /// The upstream result `recast` (`rlist.py:266`) is omitted for the
-    /// same reason as `FixedSizeListRepr`: `ListRepr::new` keeps only the
-    /// internal `item_repr`, an identity recast for the primitive items a
-    /// live subject builds today. A GC-instance list (`external !=
-    /// internal`) is deferred to the #305 `external_item_repr` slice.
+    /// The upstream result `recast` (`rlist.py:267`) converts the internal
+    /// result back to `external_item_repr` via [`list_recast`] — identity
+    /// for primitive items, pairtype dispatch for a GC-instance list.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::annotator::model::SomeValue;
         if hop.has_implicit_exception("IndexError") {
@@ -589,7 +625,15 @@ impl Repr for ListRepr {
                 )
             },
         )?;
-        hop.gendirectcall(&helper, args)
+        let v_res = hop.gendirectcall(&helper, args)?.ok_or_else(|| {
+            TyperError::message("list rtype_getitem: ll_getitem_fast returned Void")
+        })?;
+        Ok(Some(list_recast(
+            hop,
+            v_res,
+            &self.item_repr,
+            &self.external_item_repr,
+        )?))
     }
 
     /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
@@ -667,6 +711,7 @@ impl Repr for ListRepr {
         Ok(Arc::new(ListIteratorRepr::new(
             self.lltype.clone(),
             self.item_repr.clone(),
+            self.external_item_repr.clone(),
             false,
         )?))
     }
@@ -1252,6 +1297,11 @@ pub struct ListIteratorRepr {
     list_lltype: LowLevelType,
     /// `r_list.item_repr` — the element repr `ll_listnext` returns.
     item_repr: Arc<dyn Repr>,
+    /// `r_list.external_item_repr` (`lltypesystem/rlist.py:457`
+    /// `self.external_item_repr = r_list.external_item_repr`) — the surface
+    /// element repr `rtype_next` recasts the `ll_listnext` result back to
+    /// (identity for primitive items; see [`list_recast`]).
+    external_item_repr: Arc<dyn Repr>,
     /// The `ll_length` read-out SHAPE only: `true` for `FixedSizeListRepr`
     /// (length via `getarraysize` on the bare `Ptr(GcArray)`), `false` for
     /// the resized `ListRepr` (length via `getfield(l, "length")` on the
@@ -1270,6 +1320,7 @@ impl ListIteratorRepr {
     pub fn new(
         list_lltype: LowLevelType,
         item_repr: Arc<dyn Repr>,
+        external_item_repr: Arc<dyn Repr>,
         list_is_fixed: bool,
     ) -> Result<Self, TyperError> {
         // upstream `Ptr(GcStruct('listiter', ('list', r_list.lowleveltype),
@@ -1289,6 +1340,7 @@ impl ListIteratorRepr {
             lltype,
             list_lltype,
             item_repr,
+            external_item_repr,
             list_is_fixed,
         })
     }
@@ -1387,10 +1439,11 @@ impl Repr for ListIteratorRepr {
     /// both lower to the bare `getarrayitem` op, and the `getitem_foldable`
     /// oopspec is a tracing-time hint the codewriter applies — exactly as
     /// `rtype_len` lowers both `ll_len` / `ll_len_foldable` to `getarraysize`.
-    /// The upstream result `recast` (`rlist.py:449,67`) is omitted for the
-    /// same reason as getitem: `ListIteratorRepr` keeps only the internal
-    /// `item_repr` (identity for primitive items; a GC-instance element list
-    /// is deferred to the #305 `external_item_repr` slice).
+    /// The upstream result `recast` (`rlist.py:449` `self.r_list.recast`,
+    /// `rlist.py:67`) converts the `ll_listnext` result back to
+    /// `external_item_repr` via [`list_recast`] — identity for primitive
+    /// items (no op emitted), pairtype dispatch for a GC-instance element
+    /// list.
     fn rtype_next(&self, hop: &HighLevelOp) -> RTypeResult {
         let v_iter = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
         hop.has_implicit_exception("StopIteration");
@@ -1416,7 +1469,15 @@ impl Repr for ListIteratorRepr {
                 )
             },
         )?;
-        hop.gendirectcall(&helper, v_iter)
+        let v_res = hop
+            .gendirectcall(&helper, v_iter)?
+            .ok_or_else(|| TyperError::message("list rtype_next: ll_listnext returned Void"))?;
+        Ok(Some(list_recast(
+            hop,
+            v_res,
+            &self.item_repr,
+            &self.external_item_repr,
+        )?))
     }
 }
 
@@ -2533,6 +2594,7 @@ mod tests {
         let r_iter = ListIteratorRepr::new(
             r_list.lowleveltype().clone(),
             signed_repr() as Arc<dyn Repr>,
+            signed_repr() as Arc<dyn Repr>,
             true,
         )
         .expect("ListIteratorRepr::new");
@@ -2581,6 +2643,7 @@ mod tests {
         let r_iter = ListIteratorRepr::new(
             r_list.lowleveltype().clone(),
             signed_repr() as Arc<dyn Repr>,
+            signed_repr() as Arc<dyn Repr>,
             true,
         )
         .expect("ListIteratorRepr::new");
@@ -2617,11 +2680,15 @@ mod tests {
                 .expect("FixedSizeListRepr::new"),
         );
         let list_lltype = list_repr.lowleveltype().clone();
-        let iter_lltype =
-            ListIteratorRepr::new(list_lltype.clone(), signed_repr() as Arc<dyn Repr>, true)
-                .expect("ListIteratorRepr::new")
-                .lowleveltype()
-                .clone();
+        let iter_lltype = ListIteratorRepr::new(
+            list_lltype.clone(),
+            signed_repr() as Arc<dyn Repr>,
+            signed_repr() as Arc<dyn Repr>,
+            true,
+        )
+        .expect("ListIteratorRepr::new")
+        .lowleveltype()
+        .clone();
 
         let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
             rtyper.clone(),
@@ -2682,6 +2749,7 @@ mod tests {
             .expect("FixedSizeListRepr::new");
         let r_iter = ListIteratorRepr::new(
             r_list.lowleveltype().clone(),
+            signed_repr() as Arc<dyn Repr>,
             signed_repr() as Arc<dyn Repr>,
             true,
         )
@@ -2753,6 +2821,7 @@ mod tests {
         let r_iter = ListIteratorRepr::new(
             r_list.lowleveltype().clone(),
             signed_repr() as Arc<dyn Repr>,
+            signed_repr() as Arc<dyn Repr>,
             false,
         )
         .expect("ListIteratorRepr::new");
@@ -2816,6 +2885,7 @@ mod tests {
         let iter_repr: Arc<ListIteratorRepr> = Arc::new(
             ListIteratorRepr::new(
                 list_repr.lowleveltype().clone(),
+                signed_repr() as Arc<dyn Repr>,
                 signed_repr() as Arc<dyn Repr>,
                 true,
             )

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -345,6 +345,24 @@ impl Repr for FixedSizeListRepr {
             ))),
         }
     }
+
+    /// RPython `lltypesystem/rlist.py` `make_iterator_repr` on the
+    /// `AbstractBaseListRepr`: the no-variant case mints
+    /// `ListIteratorRepr(self)`; the `("reversed",)` variant
+    /// (`ReversedListIteratorRepr`) is deferred.
+    fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+        if !variant.is_empty() {
+            return Err(TyperError::missing_rtype_operation(
+                "FixedSizeListRepr.make_iterator_repr: non-default variant \
+                 (reversed) deferred",
+            ));
+        }
+        Ok(Arc::new(ListIteratorRepr::new(
+            self.lltype.clone(),
+            self.item_repr.clone(),
+            true,
+        )?))
+    }
 }
 
 /// Synthesise `LLHelpers`-style `ll_fixed_length`
@@ -633,6 +651,24 @@ impl Repr for ListRepr {
             },
         )?;
         hop.gendirectcall(&helper, args)
+    }
+
+    /// RPython `lltypesystem/rlist.py` `make_iterator_repr` on the
+    /// `AbstractBaseListRepr`: the no-variant case mints
+    /// `ListIteratorRepr(self)`; the `("reversed",)` variant
+    /// (`ReversedListIteratorRepr`) is deferred. The resized receiver is
+    /// flagged so `ll_listnext` reads `length` via the struct header.
+    fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+        if !variant.is_empty() {
+            return Err(TyperError::missing_rtype_operation(
+                "ListRepr.make_iterator_repr: non-default variant (reversed) deferred",
+            ));
+        }
+        Ok(Arc::new(ListIteratorRepr::new(
+            self.lltype.clone(),
+            self.item_repr.clone(),
+            false,
+        )?))
     }
 }
 
@@ -1180,6 +1216,277 @@ pub(crate) fn build_ll_reverse_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["l".to_string()],
+        func,
+    ))
+}
+
+/// RPython `class ListIteratorRepr(AbstractListIteratorRepr)`
+/// (`lltypesystem/rlist.py:453-461`):
+///
+/// ```python
+/// class ListIteratorRepr(AbstractListIteratorRepr):
+///     def __init__(self, r_list):
+///         self.r_list = r_list
+///         self.lowleveltype = Ptr(GcStruct('listiter',
+///             ('list', r_list.lowleveltype),
+///             ('index', Signed)))
+///         self.ll_listiter = ll_listiter
+///         self.ll_listnext = ll_listnext
+///         self.ll_getnextindex = ll_getnextindex
+/// ```
+///
+/// The Rust port stores the list's `lowleveltype` + `item_repr` + resized
+/// flag rather than the full `r_list` repr: `make_iterator_repr` is a
+/// `&self` method on the list repr and cannot reproduce the `Arc<dyn
+/// Repr>` the upstream `r_list` field holds, so the iterator carries
+/// exactly the data its `ll_listiter` / `ll_listnext` helpers consume —
+/// the iter struct shape, the element repr, and the `getarraysize`-vs-
+/// `length`-field length distinction.
+#[derive(Debug)]
+pub struct ListIteratorRepr {
+    state: ReprState,
+    /// `Ptr(GcStruct('listiter', ('list', LIST), ('index', Signed)))`.
+    lltype: LowLevelType,
+    /// `r_list.lowleveltype` — the `list` field type and the receiver
+    /// `ll_listnext` reads through.
+    list_lltype: LowLevelType,
+    /// `r_list.item_repr` — the element repr `ll_listnext` returns.
+    item_repr: Arc<dyn Repr>,
+    /// The `ll_length` read-out SHAPE only: `true` for `FixedSizeListRepr`
+    /// (length via `getarraysize` on the bare `Ptr(GcArray)`), `false` for
+    /// the resized `ListRepr` (length via `getfield(l, "length")` on the
+    /// header struct). This does NOT capture the `ll_listnext` vs
+    /// `ll_listnext_foldable` selection, which upstream gates on
+    /// `isinstance(FixedSizeListRepr) AND not r_list.listitem.mutated`
+    /// (`lltypesystem/rlist.py:462-466`): a `FixedSizeListRepr` can still
+    /// be `mutated` (in-place setitem without resize), and that list takes
+    /// the non-foldable `ll_listnext`. The deferred `ll_listnext` slice
+    /// must thread `listitem.mutated` separately — selecting foldable from
+    /// `list_is_fixed` alone would fold a mutable load and miscompile.
+    list_is_fixed: bool,
+}
+
+impl ListIteratorRepr {
+    pub fn new(
+        list_lltype: LowLevelType,
+        item_repr: Arc<dyn Repr>,
+        list_is_fixed: bool,
+    ) -> Result<Self, TyperError> {
+        // upstream `Ptr(GcStruct('listiter', ('list', r_list.lowleveltype),
+        // ('index', Signed)))`.
+        let listiter_struct = StructType::gc(
+            "listiter",
+            vec![
+                ("list".to_string(), list_lltype.clone()),
+                ("index".to_string(), LowLevelType::Signed),
+            ],
+        );
+        let lltype = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Struct(listiter_struct),
+        }));
+        Ok(ListIteratorRepr {
+            state: ReprState::new(),
+            lltype,
+            list_lltype,
+            item_repr,
+            list_is_fixed,
+        })
+    }
+}
+
+impl Repr for ListIteratorRepr {
+    fn lowleveltype(&self) -> &LowLevelType {
+        &self.lltype
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "ListIteratorRepr"
+    }
+
+    fn repr_class_id(&self) -> super::pairtype::ReprClassId {
+        super::pairtype::ReprClassId::ListIteratorRepr
+    }
+
+    /// RPython `IteratorRepr.rtype_iter(self, hop)` (rmodel.py:266-268) —
+    /// `iter(iter(x)) <==> iter(x)`: the iterator is its own iterator, so
+    /// the op is the identity on the receiver.
+    fn rtype_iter(&self, hop: &HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        Ok(Some(vlist[0].clone()))
+    }
+
+    /// RPython `AbstractListIteratorRepr.newiter(self, hop)`
+    /// (`rlist.py:439-442`):
+    ///
+    /// ```python
+    /// def newiter(self, hop):
+    ///     v_lst, = hop.inputargs(self.r_list)
+    ///     citerptr = hop.inputconst(Void, self.lowleveltype)
+    ///     return hop.gendirectcall(self.ll_listiter, citerptr, v_lst)
+    /// ```
+    ///
+    /// The Void `citerptr` type-tag is baked into the `ll_listiter`
+    /// helper's `malloc` op (the helper is minted per-`ListIteratorRepr`),
+    /// matching how `TupleRepr.newtuple` bakes the struct lltype into its
+    /// malloc rather than threading a Void runtime arg.
+    fn newiter(&self, hop: &HighLevelOp) -> RTypeResult {
+        // upstream `v_lst, = hop.inputargs(self.r_list)`. The iter()
+        // operand's repr (the list repr) is `hop.args_r[0]`; using it as
+        // the conversion target keeps the `convertvar` identity
+        // short-circuit. (A non-primitive `Ptr` list lltype has no
+        // primitive repr, so `ConvertedTo::LowLevelType` cannot convert
+        // it — the list repr the operand already carries is required.)
+        let r_list = {
+            let args_r = hop.args_r.borrow();
+            args_r
+                .first()
+                .and_then(|o| o.clone())
+                .ok_or_else(|| TyperError::message("ListIteratorRepr.newiter: arg0 repr missing"))?
+        };
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(r_list.as_ref())])?;
+        hop.exception_cannot_occur()?;
+        let list_lltype = self.list_lltype.clone();
+        let listiter_lltype = self.lltype.clone();
+        let list_for_builder = list_lltype.clone();
+        let iter_for_builder = listiter_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_listiter".to_string(),
+            vec![list_lltype],
+            listiter_lltype,
+            move |_rtyper, _args, _result| {
+                build_ll_listiter_helper_graph(
+                    "ll_listiter",
+                    list_for_builder.clone(),
+                    iter_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, vlist)
+    }
+
+    /// RPython `AbstractListIteratorRepr.rtype_next(self, hop)`
+    /// (`rlist.py:444-449`) — `ll_listnext` reads `l = iter.list`,
+    /// bounds-checks `index >= l.ll_length()` (raising `StopIteration`),
+    /// increments `iter.index`, and returns `l.ll_getitem_fast(index)`.
+    /// Deferred to the follow-on slice; that slice must also:
+    /// - raise `StopIteration` via a link to the helper graph's
+    ///   `exceptblock` (the first low-level helper in the port to raise);
+    /// - thread `listitem.mutated` to pick `ll_listnext` vs
+    ///   `ll_listnext_foldable` (see [`ListIteratorRepr::list_is_fixed`]);
+    /// - recast the result through `external_item_repr` (`rlist.py:449,67`)
+    ///   — dropped here for the same reason as getitem (#305), an identity
+    ///   for primitive items but needed for a GC-instance element list.
+    /// The deferral surfaces as a Skip (see `is_known_unported`), keeping
+    /// the subject on the legacy walker rather than miscompiling.
+    fn rtype_next(&self, _hop: &HighLevelOp) -> RTypeResult {
+        let _ = (&self.item_repr, self.list_is_fixed);
+        Err(TyperError::missing_rtype_operation(
+            "ListIteratorRepr.rtype_next — ll_listnext (raise StopIteration) deferred",
+        ))
+    }
+}
+
+/// Synthesise `ll_listiter` (`lltypesystem/rlist.py:470-474`):
+///
+/// ```python
+/// def ll_listiter(ITERPTR, lst):
+///     iter = malloc(ITERPTR.TO)
+///     iter.list = lst
+///     iter.index = 0
+///     return iter
+/// ```
+///
+/// Single-block graph: `malloc(listiter struct)` → `setfield(iter,
+/// "list", lst)` → `setfield(iter, "index", 0)` → return iter. The
+/// `ITERPTR` type-tag is baked into the `malloc` op's Void operand (the
+/// helper is minted with the iter lltype known), so the runtime signature
+/// is `ll_listiter(lst)`.
+pub(crate) fn build_ll_listiter_helper_graph(
+    name: &str,
+    list_lltype: LowLevelType,
+    listiter_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let lst_arg = variable_with_lltype("lst", list_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(lst_arg.clone())]);
+    let return_var = variable_with_lltype("result", listiter_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // upstream `malloc(ITERPTR.TO)` — the Void `c1` carries the inner
+    // listiter Struct lltype, `cflags` the gc flavor, exactly as
+    // `TupleRepr.newtuple` encodes its malloc.
+    let LowLevelType::Ptr(ptr) = &listiter_lltype else {
+        return Err(TyperError::message(
+            "build_ll_listiter_helper_graph: listiter lltype is not Ptr",
+        ));
+    };
+    let inner_struct = match &ptr.TO {
+        PtrTarget::Struct(body) => body.clone(),
+        other => {
+            return Err(TyperError::message(format!(
+                "build_ll_listiter_helper_graph: Ptr target must be Struct, got {other:?}"
+            )));
+        }
+    };
+    let c1 = Constant::with_concretetype(
+        ConstValue::LowLevelType(Box::new(LowLevelType::Struct(Box::new(inner_struct)))),
+        LowLevelType::Void,
+    );
+    let cflags =
+        Constant::with_concretetype(ConstValue::byte_str("flavor=gc"), LowLevelType::Void);
+    let v_iter = variable_with_lltype("iter", listiter_lltype.clone());
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "malloc",
+        vec![Hlvalue::Constant(c1), Hlvalue::Constant(cflags)],
+        Hlvalue::Variable(v_iter.clone()),
+    ));
+    // iter.list = lst
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(v_iter.clone()),
+            void_field_const("list"),
+            Hlvalue::Variable(lst_arg),
+        ],
+        Hlvalue::Variable(variable_with_lltype("v0", LowLevelType::Void)),
+    ));
+    // iter.index = 0
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(v_iter.clone()),
+            void_field_const("index"),
+            Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::Int(0),
+                LowLevelType::Signed,
+            )),
+        ],
+        Hlvalue::Variable(variable_with_lltype("v1", LowLevelType::Void)),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_iter)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["lst".to_string()],
         func,
     ))
 }
@@ -1973,5 +2280,143 @@ mod tests {
             ]),
             "expected the read-both-before-write swap body, got {block_op_seqs:?}"
         );
+    }
+
+    /// `ListIteratorRepr`'s lowleveltype is `Ptr(GcStruct("listiter",
+    /// ("list", LIST), ("index", Signed)))` (`lltypesystem/rlist.py:455-458`).
+    #[test]
+    fn list_iterator_repr_lltype_is_ptr_gcstruct_list_index() {
+        let rtyper = fresh_rtyper();
+        let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let r_iter =
+            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
+                .expect("ListIteratorRepr::new");
+        assert_eq!(r_iter.class_name(), "ListIteratorRepr");
+        assert_eq!(r_iter.repr_class_id(), ReprClassId::ListIteratorRepr);
+
+        let LowLevelType::Ptr(ptr) = r_iter.lowleveltype() else {
+            panic!("ListIteratorRepr lltype must be a Ptr");
+        };
+        let PtrTarget::Struct(body) = &ptr.TO else {
+            panic!("ListIteratorRepr Ptr target must be a Struct");
+        };
+        assert_eq!(body._name, "listiter");
+        assert_eq!(body._flds.get("index"), Some(&LowLevelType::Signed));
+        // the `list` field carries the list repr's own lowleveltype.
+        assert_eq!(body._flds.get("list"), Some(r_list.lowleveltype()));
+    }
+
+    /// `SomeIterator(SomeList)` routes through `SomeIterator.rtyper_makerepr`
+    /// → `r_container.make_iterator_repr()` → `ListIteratorRepr`
+    /// (`rmodel.py:274-282`).
+    #[test]
+    fn makerepr_somelist_iterator_routes_to_list_iterator_repr() {
+        let rtyper = fresh_rtyper_live();
+        let ldef = ListDef::new(
+            None,
+            SomeValue::Integer(SomeInteger::new(false, false)),
+            false,
+            false,
+        );
+        let s_list = SomeValue::List(SomeList::new(ldef));
+        let s_iter = SomeValue::Iterator(crate::annotator::model::SomeIterator::new(s_list, vec![]));
+        let repr = rtyper_makerepr(&s_iter, &rtyper).expect("rtyper_makerepr list iterator");
+        assert_eq!(repr.class_name(), "ListIteratorRepr");
+        assert_eq!(repr.repr_class_id(), ReprClassId::ListIteratorRepr);
+    }
+
+    /// `ll_listiter` body is `malloc(listiter)` → `setfield(iter, "list",
+    /// lst)` → `setfield(iter, "index", 0)` (`lltypesystem/rlist.py:470-474`).
+    #[test]
+    fn build_ll_listiter_helper_emits_malloc_then_two_setfields() {
+        let rtyper = fresh_rtyper();
+        let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let r_iter =
+            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
+                .expect("ListIteratorRepr::new");
+        let pygraph = build_ll_listiter_helper_graph(
+            "ll_listiter",
+            r_list.lowleveltype().clone(),
+            r_iter.lowleveltype().clone(),
+        )
+        .expect("build_ll_listiter_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let ops: Vec<_> = graph
+            .startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect();
+        assert_eq!(ops, vec!["malloc", "setfield", "setfield"]);
+    }
+
+    /// `iter(list)` rtypes through the default `Repr.rtype_iter`
+    /// (`make_iterator_repr().newiter(hop)`) to a `direct_call(ll_listiter,
+    /// v_lst)` (`rmodel.py:229-231` + `rlist.py:439-442`).
+    #[test]
+    fn fixed_size_list_iter_emits_direct_call_to_ll_listiter() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let iter_lltype =
+            ListIteratorRepr::new(list_lltype.clone(), signed_repr() as Arc<dyn Repr>, true)
+                .expect("ListIteratorRepr::new")
+                .lowleveltype()
+                .clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(iter_lltype));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "iter".to_string(),
+                vec![Hlvalue::Variable(v_list)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .push(SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                false,
+                false,
+            ))));
+        hop.args_r
+            .borrow_mut()
+            .push(Some(list_repr.clone() as Arc<dyn Repr>));
+
+        let result = list_repr
+            .rtype_iter(&hop)
+            .unwrap_or_else(|err| panic!("list iter: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(dbg.contains("ll_listiter"), "expected 'll_listiter' in {dbg}");
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -1469,8 +1469,7 @@ pub(crate) fn build_ll_listiter_helper_graph(
         ConstValue::LowLevelType(Box::new(LowLevelType::Struct(Box::new(inner_struct)))),
         LowLevelType::Void,
     );
-    let cflags =
-        Constant::with_concretetype(ConstValue::byte_str("flavor=gc"), LowLevelType::Void);
+    let cflags = Constant::with_concretetype(ConstValue::byte_str("flavor=gc"), LowLevelType::Void);
     let v_iter = variable_with_lltype("iter", listiter_lltype.clone());
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "malloc",
@@ -1595,7 +1594,10 @@ pub(crate) fn build_ll_listnext_helper_graph(
         let mut b = startblock.borrow_mut();
         b.operations.push(SpaceOperation::new(
             "getfield",
-            vec![Hlvalue::Variable(iter_arg.clone()), void_field_const("list")],
+            vec![
+                Hlvalue::Variable(iter_arg.clone()),
+                void_field_const("list"),
+            ],
             Hlvalue::Variable(v_l.clone()),
         ));
         b.operations.push(SpaceOperation::new(
@@ -2528,9 +2530,12 @@ mod tests {
         let rtyper = fresh_rtyper();
         let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
             .expect("FixedSizeListRepr::new");
-        let r_iter =
-            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
-                .expect("ListIteratorRepr::new");
+        let r_iter = ListIteratorRepr::new(
+            r_list.lowleveltype().clone(),
+            signed_repr() as Arc<dyn Repr>,
+            true,
+        )
+        .expect("ListIteratorRepr::new");
         assert_eq!(r_iter.class_name(), "ListIteratorRepr");
         assert_eq!(r_iter.repr_class_id(), ReprClassId::ListIteratorRepr);
 
@@ -2559,7 +2564,8 @@ mod tests {
             false,
         );
         let s_list = SomeValue::List(SomeList::new(ldef));
-        let s_iter = SomeValue::Iterator(crate::annotator::model::SomeIterator::new(s_list, vec![]));
+        let s_iter =
+            SomeValue::Iterator(crate::annotator::model::SomeIterator::new(s_list, vec![]));
         let repr = rtyper_makerepr(&s_iter, &rtyper).expect("rtyper_makerepr list iterator");
         assert_eq!(repr.class_name(), "ListIteratorRepr");
         assert_eq!(repr.repr_class_id(), ReprClassId::ListIteratorRepr);
@@ -2572,9 +2578,12 @@ mod tests {
         let rtyper = fresh_rtyper();
         let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
             .expect("FixedSizeListRepr::new");
-        let r_iter =
-            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
-                .expect("ListIteratorRepr::new");
+        let r_iter = ListIteratorRepr::new(
+            r_list.lowleveltype().clone(),
+            signed_repr() as Arc<dyn Repr>,
+            true,
+        )
+        .expect("ListIteratorRepr::new");
         let pygraph = build_ll_listiter_helper_graph(
             "ll_listiter",
             r_list.lowleveltype().clone(),
@@ -2656,7 +2665,10 @@ mod tests {
             panic!("expected Constant funcptr as direct_call arg 0");
         };
         let dbg = format!("{:?}", c.value);
-        assert!(dbg.contains("ll_listiter"), "expected 'll_listiter' in {dbg}");
+        assert!(
+            dbg.contains("ll_listiter"),
+            "expected 'll_listiter' in {dbg}"
+        );
     }
 
     /// `ll_listnext` over a fixed list: startblock bounds-checks via
@@ -2668,9 +2680,12 @@ mod tests {
         let rtyper = fresh_rtyper_live();
         let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
             .expect("FixedSizeListRepr::new");
-        let r_iter =
-            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
-                .expect("ListIteratorRepr::new");
+        let r_iter = ListIteratorRepr::new(
+            r_list.lowleveltype().clone(),
+            signed_repr() as Arc<dyn Repr>,
+            true,
+        )
+        .expect("ListIteratorRepr::new");
         let pygraph = build_ll_listnext_helper_graph(
             "ll_listnext",
             r_iter.lowleveltype().clone(),
@@ -2687,7 +2702,10 @@ mod tests {
             .iter()
             .map(|op| op.opname.clone())
             .collect();
-        assert_eq!(start_ops, vec!["getfield", "getfield", "getarraysize", "int_lt"]);
+        assert_eq!(
+            start_ops,
+            vec!["getfield", "getfield", "getarraysize", "int_lt"]
+        );
         // startblock branches on the bounds-check; one exit raises via the
         // graph's exceptblock.
         let start = graph.startblock.borrow();
@@ -2699,17 +2717,29 @@ mod tests {
                 .as_ref()
                 .is_some_and(|t| crate::flowspace::model::BlockKey::of(t) == except_key)
         });
-        assert!(raises, "one startblock exit must link to exceptblock (raise StopIteration)");
+        assert!(
+            raises,
+            "one startblock exit must link to exceptblock (raise StopIteration)"
+        );
         // the non-raising exit's continue block reads the element.
         let cont_ops: Vec<Vec<String>> = graph
             .iterblocks()
             .iter()
-            .map(|b| b.borrow().operations.iter().map(|op| op.opname.clone()).collect())
+            .map(|b| {
+                b.borrow()
+                    .operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .collect()
+            })
             .collect();
         assert!(
-            cont_ops
-                .iter()
-                .any(|seq| seq == &vec!["int_add".to_string(), "setfield".to_string(), "getarrayitem".to_string()]),
+            cont_ops.iter().any(|seq| seq
+                == &vec![
+                    "int_add".to_string(),
+                    "setfield".to_string(),
+                    "getarrayitem".to_string()
+                ]),
             "continue block must int_add/setfield/getarrayitem, got {cont_ops:?}"
         );
     }
@@ -2720,9 +2750,12 @@ mod tests {
     fn build_ll_listnext_helper_resized_reads_length_and_items() {
         let rtyper = fresh_rtyper_live();
         let r_list = ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new");
-        let r_iter =
-            ListIteratorRepr::new(r_list.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, false)
-                .expect("ListIteratorRepr::new");
+        let r_iter = ListIteratorRepr::new(
+            r_list.lowleveltype().clone(),
+            signed_repr() as Arc<dyn Repr>,
+            false,
+        )
+        .expect("ListIteratorRepr::new");
         let pygraph = build_ll_listnext_helper_graph(
             "ll_listnext",
             r_iter.lowleveltype().clone(),
@@ -2740,11 +2773,20 @@ mod tests {
             .map(|op| op.opname.clone())
             .collect();
         // resized length via getfield "length" (not getarraysize).
-        assert_eq!(start_ops, vec!["getfield", "getfield", "getfield", "int_lt"]);
+        assert_eq!(
+            start_ops,
+            vec!["getfield", "getfield", "getfield", "int_lt"]
+        );
         let cont_ops: Vec<Vec<String>> = graph
             .iterblocks()
             .iter()
-            .map(|b| b.borrow().operations.iter().map(|op| op.opname.clone()).collect())
+            .map(|b| {
+                b.borrow()
+                    .operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .collect()
+            })
             .collect();
         assert!(
             cont_ops.iter().any(|seq| seq
@@ -2772,8 +2814,12 @@ mod tests {
         let list_repr = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
             .expect("FixedSizeListRepr::new");
         let iter_repr: Arc<ListIteratorRepr> = Arc::new(
-            ListIteratorRepr::new(list_repr.lowleveltype().clone(), signed_repr() as Arc<dyn Repr>, true)
-                .expect("ListIteratorRepr::new"),
+            ListIteratorRepr::new(
+                list_repr.lowleveltype().clone(),
+                signed_repr() as Arc<dyn Repr>,
+                true,
+            )
+            .expect("ListIteratorRepr::new"),
         );
         let iter_lltype = iter_repr.lowleveltype().clone();
 
@@ -2796,9 +2842,8 @@ mod tests {
             llops.clone(),
         );
         hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
-        hop.args_s
-            .borrow_mut()
-            .push(SomeValue::Iterator(crate::annotator::model::SomeIterator::new(
+        hop.args_s.borrow_mut().push(SomeValue::Iterator(
+            crate::annotator::model::SomeIterator::new(
                 SomeValue::List(SomeList::new(ListDef::new(
                     None,
                     SomeValue::Integer(SomeInteger::new(false, false)),
@@ -2806,7 +2851,8 @@ mod tests {
                     false,
                 ))),
                 vec![],
-            )));
+            ),
+        ));
         hop.args_r
             .borrow_mut()
             .push(Some(iter_repr.clone() as Arc<dyn Repr>));
@@ -2826,6 +2872,9 @@ mod tests {
             panic!("expected Constant funcptr as direct_call arg 0");
         };
         let dbg = format!("{:?}", c.value);
-        assert!(dbg.contains("ll_listnext"), "expected 'll_listnext' in {dbg}");
+        assert!(
+            dbg.contains("ll_listnext"),
+            "expected 'll_listnext' in {dbg}"
+        );
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -1018,8 +1018,30 @@ pub trait Repr: Debug + std::any::Any {
         Err(self.missing_rtype_operation("issubtype"))
     }
 
-    fn rtype_iter(&self, _hop: &HighLevelOp) -> RTypeResult {
-        Err(self.missing_rtype_operation("iter"))
+    /// RPython `Repr.rtype_iter(self, hop)` (rmodel.py:229-231):
+    ///
+    /// ```python
+    /// def rtype_iter(self, hop):
+    ///     r_iter = self.make_iterator_repr()
+    ///     return r_iter.newiter(hop)
+    /// ```
+    fn rtype_iter(&self, hop: &HighLevelOp) -> RTypeResult {
+        let r_iter = self.make_iterator_repr(&[])?;
+        r_iter.newiter(hop)
+    }
+
+    /// RPython `Repr.make_iterator_repr(self, *variant)` (rmodel.py:233-235):
+    /// the base raises a `TyperError`; container reprs (list, range, dict,
+    /// str) override to mint their iterator repr.
+    fn make_iterator_repr(&self, _variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+        Err(self.missing_rtype_operation("make_iterator_repr"))
+    }
+
+    /// RPython `IteratorRepr.newiter(self, hop)` — only iterator reprs
+    /// implement it (the `ll_*iter` constructor `gendirectcall`); the base
+    /// raises.
+    fn newiter(&self, _hop: &HighLevelOp) -> RTypeResult {
+        Err(self.missing_rtype_operation("newiter"))
     }
 
     fn rtype_long(&self, _hop: &HighLevelOp) -> RTypeResult {
@@ -3004,9 +3026,22 @@ pub fn rtyper_makerepr(
         SomeValue::Dict(_) => Err(TyperError::missing_rtype_operation(
             "SomeDict.rtyper_makerepr — port rpython/rtyper/rdict.py DictRepr",
         )),
-        SomeValue::Iterator(_) => Err(TyperError::missing_rtype_operation(
-            "SomeIterator.rtyper_makerepr — port rpython/rtyper/rrange.py EnumerateIteratorRepr etc.",
-        )),
+        // rmodel.py:274-282 — SomeIterator.rtyper_makerepr:
+        //   r_container = rtyper.getrepr(self.s_container)
+        //   if self.variant and self.variant[0] == "enumerate":
+        //       ... EnumerateIteratorRepr  (deferred — rrange.py)
+        //   return r_container.make_iterator_repr(*self.variant)
+        SomeValue::Iterator(s_iter) => {
+            if s_iter.variant.first().map(String::as_str) == Some("enumerate") {
+                Err(TyperError::missing_rtype_operation(
+                    "SomeIterator(enumerate).rtyper_makerepr — port \
+                     rpython/rtyper/rrange.py EnumerateIteratorRepr",
+                ))
+            } else {
+                let r_container = rtyper.getrepr(s_iter.s_container.as_ref())?;
+                r_container.make_iterator_repr(&s_iter.variant)
+            }
+        }
         // rpbc.py:35-62 — SomePBC.rtyper_makerepr. Only the degenerate
         // single-FunctionDesc / can_be_None=False branch is ported
         // today; the remaining arms surface as

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -91,14 +91,17 @@ fn lowers_branch_loop_sum_with_calls_and_discriminant() {
             }
         }
     }
-    // `branch_loop_sum` calls `<[i64]>::iter` once and
-    // `Iterator::next` once per loop iteration; the second call sits
-    // inside the loop body so there's exactly one `Call` op for it
-    // in the static IR.
-    assert_eq!(call_count, 2, "expected 2 body Call ops");
+    // `branch_loop_sum` calls `<[i64]>::iter` once (the `iter` op) and
+    // `Iterator::next` once (lifted to the `[__iter_next]` op); both are
+    // `Call` ops in the static IR.
+    assert_eq!(call_count, 2, "expected 2 body Call ops (iter + next)");
+    // The `next`-diamond rewrite (`front::iter_next`) replaces the
+    // `Option` step's `__discriminant` switch with the `next` op's
+    // StopIteration exception edge, so the discriminant read is consumed
+    // and its (now-unreachable) block dropped.
     assert_eq!(
-        discr_count, 1,
-        "expected 1 __discriminant FieldRead for the Option step"
+        discr_count, 0,
+        "the Option __discriminant read is consumed by the next rewrite"
     );
 }
 
@@ -329,7 +332,7 @@ fn front_graph_carries_no_synthesized_exception_edges() {
     //      Assert / Drop success block contributes zero such edges.
     use majit_charon_reader::ullbc::{TermKind, Unstructured};
     use majit_translate::front::mir::lower_fun_decl;
-    use majit_translate::model::ExitSwitch;
+    use majit_translate::model::{CallTarget, ExitSwitch, OpKind};
 
     let llbc = load_corpus();
     let mut checked = 0usize;
@@ -340,8 +343,26 @@ fn front_graph_carries_no_synthesized_exception_edges() {
         let graph = lower_fun_decl(&llbc, fd)
             .unwrap_or_else(|e| panic!("{} failed to lower: {e}", fd.item_meta.name_path()));
 
-        // Invariant A.
+        // Invariant A.  The iterator `next`-diamond rewrite
+        // (`front::iter_next`) is the one sanctioned synthesized
+        // exception edge: a `for x in it` loop's `StopIteration` catch
+        // (the RPython `next` op raising at exhaustion).  Its block — the
+        // one carrying the `[__iter_next]` op — legitimately closes with
+        // `LastException`; every other block must still drop on_unwind
+        // rather than lower a try/except.
         for b in &graph.blocks {
+            let is_next_handler = b.operations.iter().any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.len() == 1 && segments[0] == "__iter_next"
+                )
+            });
+            if is_next_handler {
+                continue;
+            }
             assert!(
                 b.exitswitch != Some(ExitSwitch::LastException),
                 "{}: block {:?} carries a LastException exitswitch — a typed \
@@ -352,7 +373,16 @@ fn front_graph_carries_no_synthesized_exception_edges() {
             );
         }
 
-        // Invariant B.
+        // Invariant B: no Call/Assert/Drop on_unwind edge leaks into the
+        // front graph, i.e. every live edge into the exceptblock is a bare
+        // panic-propagation raise (`UnwindResume` / `Abort` -> set_raise),
+        // so the live count never EXCEEDS the MIR's raise terminators.  It
+        // may be fewer: a graph that runs `clear_unreachable_blocks` (the
+        // iterator `next`-diamond and `?` rewrites do) prunes the dead
+        // panic-cleanup blocks the driver leaves unreachable — those
+        // pruned blocks were already dead exceptblock edges, never live
+        // control flow.  A leak, by contrast, sits in a REACHABLE success
+        // block and would push the live count above the raise count.
         let raises_in_mir = body
             .body
             .iter()
@@ -368,17 +398,91 @@ fn front_graph_carries_no_synthesized_exception_edges() {
             .iter()
             .filter(|b| b.exits.iter().any(|l| l.target == graph.exceptblock))
             .count();
-        assert_eq!(
-            edges_into_exceptblock, raises_in_mir,
-            "{}: {} block(s) link to the exceptblock but the MIR has {} \
+        assert!(
+            edges_into_exceptblock <= raises_in_mir,
+            "{}: {} block(s) link to the exceptblock but the MIR has only {} \
              UnwindResume/Abort terminator(s) — a Call/Assert/Drop on_unwind \
              edge leaked into the front graph",
-            graph.name, edges_into_exceptblock, raises_in_mir,
+            graph.name,
+            edges_into_exceptblock,
+            raises_in_mir,
         );
         checked += 1;
     }
     assert!(
         checked >= 4,
         "expected to lower at least the 4 corpus shapes, got {checked}",
+    );
+}
+
+/// `branch_loop_sum`'s `for &v in slice` lifts to the native `iter` +
+/// `[__iter_next]` ops: Layer 3 of the iterator vertical replaces the
+/// residual `Iterator::next()` call (an unregistered callee that would
+/// make the rtyper census Skip) with the `next` op + a `LastException`
+/// block, the way `front::iter_next` rewrites the `Option` match diamond.
+#[test]
+fn branch_loop_sum_lifts_next_to_iter_next_op() {
+    use majit_translate::model::{CallTarget, ExitSwitch, OpKind};
+    let llbc = load_corpus();
+    let graph = lower_function(&llbc, "branch_loop_sum").expect("lowering");
+
+    let mut iter_next_blocks = Vec::new();
+    let mut residual_next = 0usize;
+    for (i, b) in graph.blocks.iter().enumerate() {
+        for op in &b.operations {
+            match &op.kind {
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments.len() == 1 && segments[0] == "__iter_next" => {
+                    iter_next_blocks.push(i);
+                }
+                OpKind::Call {
+                    target: CallTarget::Method { name, .. },
+                    ..
+                } if name == "next" => residual_next += 1,
+                _ => {}
+            }
+        }
+    }
+
+    assert_eq!(
+        iter_next_blocks.len(),
+        1,
+        "expected exactly one `[__iter_next]` op after the rewrite",
+    );
+    assert_eq!(
+        residual_next, 0,
+        "the residual `Iterator::next()` call must be replaced",
+    );
+
+    // The `[__iter_next]` block is a `canraise` block: `LastException`
+    // exitswitch with a normal (Some) exit and a StopIteration (break)
+    // exit.  No catch-all propagation edge — list `next` raises only
+    // StopIteration.
+    let a = iter_next_blocks[0];
+    assert!(
+        matches!(graph.blocks[a].exitswitch, Some(ExitSwitch::LastException)),
+        "the next block must close with LastException exits",
+    );
+    assert_eq!(
+        graph.blocks[a].exits.len(),
+        2,
+        "normal -> Some, StopIteration -> break",
+    );
+    // Exactly one exit (the normal/Some arm) carries no exitcase.
+    let normal = graph.blocks[a]
+        .exits
+        .iter()
+        .filter(|l| l.exitcase.is_none())
+        .count();
+    assert_eq!(normal, 1, "exactly one non-exception (Some) exit");
+    // The exceptblock gains no edge from the rewrite.
+    assert!(
+        !graph.blocks[a]
+            .exits
+            .iter()
+            .any(|l| l.target == graph.exceptblock),
+        "the next rewrite must not link to the exceptblock",
     );
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -43,6 +43,9 @@ pub fn set_pending_hash_error(e: PyError) {
     PENDING_HASH_ERROR.with(|cell| cell.set(Some(e)));
 }
 
+/// `dont_look_inside`: the `PENDING_HASH_ERROR` thread-local `.with`
+/// read has no extractable graph; the call stays a residual.
+#[majit_macros::dont_look_inside]
 pub fn take_pending_hash_error() -> PyError {
     PENDING_HASH_ERROR.with(|cell| {
         cell.take()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5558,7 +5558,7 @@ pub unsafe fn _pure_lookup_class_with_method_cache(
     w_name: PyObjectRef,
     version_tag: u64,
 ) -> PyObjectRef {
-    let name = pyre_object::strobject::w_str_get_value(w_name);
+    let name = pyre_object::unicodeobject::w_str_get_value(w_name);
     _cached_lookup_where(w_type, name, version_tag).0
 }
 
@@ -5657,7 +5657,7 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
     // lookup folds to a `CALL_PURE_R` instead of aborting the trace.  The
     // interned, immortal `w_name` (`box_str_constant`) is the green token the
     // trace folds on; both residuals share it.
-    let w_name = pyre_object::strobject::box_str_constant(rustpython_wtf8::Wtf8::new(name));
+    let w_name = pyre_object::unicodeobject::box_str_constant(rustpython_wtf8::Wtf8::new(name));
     let w_value = _pure_lookup_where_with_method_cache(w_type, w_name, version_tag);
     if w_value.is_null() {
         None

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5537,6 +5537,31 @@ pub unsafe fn _pure_lookup_where_with_method_cache(
     _cached_lookup_where(w_type, name, version_tag).1
 }
 
+/// `lookup_where` *class* projection — the `@elidable` companion of
+/// [`_pure_lookup_where_with_method_cache`] returning the defining-class
+/// half (`(w_class, w_value).0`) of the `(version_tag, name)`-keyed
+/// `MethodCache` entry.  PyPy's single elidable returns the whole
+/// `(w_class, w_value)` tuple (`typeobject.py:510-511`); the residual-call
+/// ABI carries one raw register, so the two halves are exposed as two
+/// single-register elidable surfaces over the same cache entry.  The front
+/// door [`lookup_where_with_method_cache`] reads both halves through these
+/// residuals so the thread-local `MethodCache` machinery stays off the
+/// trace surface.  The value half runs first and fills the slot, so this
+/// call is a guaranteed cache hit.
+///
+/// See [`_pure_lookup_where_with_method_cache`] for the interned-`w_name`
+/// ABI and the null-as-`None` convention (a negative result has a null
+/// `w_class`).
+#[majit_macros::elidable]
+pub unsafe fn _pure_lookup_class_with_method_cache(
+    w_type: PyObjectRef,
+    w_name: PyObjectRef,
+    version_tag: u64,
+) -> PyObjectRef {
+    let name = pyre_object::strobject::w_str_get_value(w_name);
+    _cached_lookup_where(w_type, name, version_tag).0
+}
+
 /// The `MethodCache` probe/fill shared by the `@elidable` JIT surface
 /// and the interpreter front door.  Probes the `(version_tag, name)`
 /// slot; on a miss runs the raw MRO walk (`typeobject.py:478-489
@@ -5624,10 +5649,20 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
         // typeobject.py:507-509 — no version tag: uncacheable.
         return lookup_where(w_type, name);
     }
-    let (w_class, w_value) = _cached_lookup_where(w_type, name, version_tag);
+    // typeobject.py:510-511 — `w_class, w_value =
+    // self._pure_lookup_where_with_method_cache(name, version_tag)`.  The
+    // tuple is split across two single-register elidable residuals over the
+    // same cache entry (see `_pure_lookup_class_with_method_cache`), so the
+    // thread-local `MethodCache` read stays off the trace surface and the
+    // lookup folds to a `CALL_PURE_R` instead of aborting the trace.  The
+    // interned, immortal `w_name` (`box_str_constant`) is the green token the
+    // trace folds on; both residuals share it.
+    let w_name = pyre_object::strobject::box_str_constant(rustpython_wtf8::Wtf8::new(name));
+    let w_value = _pure_lookup_where_with_method_cache(w_type, w_name, version_tag);
     if w_value.is_null() {
         None
     } else {
+        let w_class = _pure_lookup_class_with_method_cache(w_type, w_name, version_tag);
         Some((w_class, w_value))
     }
 }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -55,6 +55,11 @@ thread_local! {
 
 /// Stash an error from the bare-PyObjectRef call path so a caller that
 /// recognizes the NULL return can recover the original PyError.
+///
+/// `dont_look_inside`: the `PENDING_CALL_ERROR` thread-local `.with`
+/// read has no extractable graph, so the call stays a residual (the
+/// fnaddr is registered in `jit_trace_fnaddrs`).
+#[majit_macros::dont_look_inside]
 pub fn set_call_error(e: PyError) {
     PENDING_CALL_ERROR.with(|slot| {
         *slot.borrow_mut() = Some(e);
@@ -66,11 +71,13 @@ pub fn set_call_error(e: PyError) {
 /// helpers (`call_function_impl`, `call_function_impl_raw`,
 /// `call_user_function_with_args`) immediately after the call so the
 /// error refers to the most recent failed dispatch.
+#[majit_macros::dont_look_inside]
 pub fn take_call_error() -> Option<PyError> {
     PENDING_CALL_ERROR.with(|slot| slot.borrow_mut().take())
 }
 
 /// Clear any pending stashed error without consuming it.
+#[majit_macros::dont_look_inside]
 pub fn clear_call_error() {
     PENDING_CALL_ERROR.with(|slot| {
         slot.borrow_mut().take();

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1377,6 +1377,22 @@ pub fn jit_static_int_values() -> Vec<(&'static str, i64)> {
             "dictmultiobject::W_DICT_OBJECT_SIZE",
             pyre_object::dictmultiobject::W_DICT_OBJECT_SIZE as i64,
         ),
+        (
+            "specialisedtupleobject::SPECIALISED_TUPLE_II_OBJECT_SIZE",
+            pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_II_OBJECT_SIZE as i64,
+        ),
+        (
+            "specialisedtupleobject::SPECIALISED_TUPLE_FF_OBJECT_SIZE",
+            pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_FF_OBJECT_SIZE as i64,
+        ),
+        (
+            "specialisedtupleobject::SPECIALISED_TUPLE_OO_OBJECT_SIZE",
+            pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_OBJECT_SIZE as i64,
+        ),
+        (
+            "instanceobject::W_INSTANCE_OBJECT_SIZE",
+            pyre_object::instanceobject::W_INSTANCE_OBJECT_SIZE as i64,
+        ),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -774,7 +774,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::clear_call_error",
         clear_call_error as *const (),
     );
-    let take_pending_hash_error: fn() -> crate::PyError = crate::baseobjspace::take_pending_hash_error;
+    let take_pending_hash_error: fn() -> crate::PyError =
+        crate::baseobjspace::take_pending_hash_error;
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::baseobjspace::take_pending_hash_error",
@@ -800,7 +801,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // thread-local reads with no extractable graph).  The slowpath is
     // already a C-ABI residual the backend calls directly; the wrappers
     // become residual Calls.
-    let stack_slowpath: extern "C" fn(usize) -> u8 = crate::stack_check::pyre_stack_too_big_slowpath;
+    let stack_slowpath: extern "C" fn(usize) -> u8 =
+        crate::stack_check::pyre_stack_too_big_slowpath;
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::stack_check::pyre_stack_too_big_slowpath",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -795,6 +795,31 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         callable_proxy_type as *const (),
     );
 
+    // Stack-overflow / JIT-pending-exception bookkeeping accessors, all
+    // `#[dont_look_inside]` (PYRE_STACKTOOBIG static / TL_JIT_PENDING_EXCEPTION
+    // thread-local reads with no extractable graph).  The slowpath is
+    // already a C-ABI residual the backend calls directly; the wrappers
+    // become residual Calls.
+    let stack_slowpath: extern "C" fn(usize) -> u8 = crate::stack_check::pyre_stack_too_big_slowpath;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::stack_check::pyre_stack_too_big_slowpath",
+        stack_slowpath as *const (),
+    );
+    let stack_check: fn() -> Result<(), crate::PyError> = crate::stack_check::stack_check;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::stack_check::stack_check",
+        stack_check as *const (),
+    );
+    let drain_jit_pending: fn() -> Result<(), crate::PyError> =
+        crate::stack_check::drain_jit_pending_exception;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::stack_check::drain_jit_pending_exception",
+        drain_jit_pending as *const (),
+    );
+
     // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
     // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`
     // only honours the assertion when `function_fnaddrs.contains_key(p)`,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1232,12 +1232,21 @@ pub fn jit_static_pytype_addrs() -> Vec<(&'static str, i64)> {
             excobject::EXC_UNICODE_ERROR_TYPE
         ),
         pytype_addr!(
+            "excobject::EXC_MODULE_NOT_FOUND_ERROR_TYPE",
+            excobject::EXC_MODULE_NOT_FOUND_ERROR_TYPE
+        ),
+        pytype_addr!(
+            "excobject::EXC_SYNTAX_ERROR_TYPE",
+            excobject::EXC_SYNTAX_ERROR_TYPE
+        ),
+        pytype_addr!(
             "generatorobject::GENERATOR_TYPE",
             generatorobject::GENERATOR_TYPE
         ),
         pytype_addr!("pyobject::INT_TYPE", pyobject::INT_TYPE),
         pytype_addr!("pyobject::BOOL_TYPE", pyobject::BOOL_TYPE),
         pytype_addr!("pyobject::FLOAT_TYPE", pyobject::FLOAT_TYPE),
+        pytype_addr!("pyobject::COMPLEX_TYPE", pyobject::COMPLEX_TYPE),
         pytype_addr!("pyobject::STR_TYPE", pyobject::STR_TYPE),
         pytype_addr!("pyobject::LIST_TYPE", pyobject::LIST_TYPE),
         pytype_addr!("pyobject::TUPLE_TYPE", pyobject::TUPLE_TYPE),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -729,6 +729,27 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         set_current_exc as *const (),
     );
 
+    // `w_type` / `w_object` — the `type` / `object` typeobject accessors
+    // read the `W_TYPE_TYPEOBJECT` / `W_OBJECT_TYPEOBJECT` `OnceLock<usize>`
+    // slots set once at startup.  Both carry `#[dont_look_inside]` (the
+    // `OnceLock::get` read has no registry-resolvable accessor graph), so
+    // the codewriter classifies the calls `Residual` and needs these
+    // bindings to bake real funcptrs instead of `symbolic_fnaddr_for_path`
+    // hashes.  Callers spell them `crate::typedef::w_type()`, the sole
+    // path form, with no crate-root re-export.
+    let w_type: fn() -> pyre_object::PyObjectRef = crate::typedef::w_type;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::typedef::w_type",
+        w_type as *const (),
+    );
+    let w_object: fn() -> pyre_object::PyObjectRef = crate::typedef::w_object;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::typedef::w_object",
+        w_object as *const (),
+    );
+
     // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
     // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`
     // only honours the assertion when `function_fnaddrs.contains_key(p)`,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -750,6 +750,51 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         w_object as *const (),
     );
 
+    // Thread-local / `OnceLock` accessors that carry `#[dont_look_inside]`
+    // (the `.with` closure read has no extractable graph): the codewriter
+    // classifies the calls `Residual` and needs real funcptrs instead of
+    // `symbolic_fnaddr_for_path` hashes.  Error-slot twins of
+    // `get_current_exception` / `set_current_exception`, plus the weakref
+    // proxy type singletons (twins of `w_type` / `w_object`).
+    let set_call_error: fn(crate::PyError) = crate::call::set_call_error;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::set_call_error",
+        set_call_error as *const (),
+    );
+    let take_call_error: fn() -> Option<crate::PyError> = crate::call::take_call_error;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::take_call_error",
+        take_call_error as *const (),
+    );
+    let clear_call_error: fn() = crate::call::clear_call_error;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::clear_call_error",
+        clear_call_error as *const (),
+    );
+    let take_pending_hash_error: fn() -> crate::PyError = crate::baseobjspace::take_pending_hash_error;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::baseobjspace::take_pending_hash_error",
+        take_pending_hash_error as *const (),
+    );
+    let proxy_type: fn() -> pyre_object::PyObjectRef =
+        crate::module::_weakref::interp_weakref::proxy_type;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::module::_weakref::interp_weakref::proxy_type",
+        proxy_type as *const (),
+    );
+    let callable_proxy_type: fn() -> pyre_object::PyObjectRef =
+        crate::module::_weakref::interp_weakref::callable_proxy_type;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::module::_weakref::interp_weakref::callable_proxy_type",
+        callable_proxy_type as *const (),
+    );
+
     // `pyframe_get_pycode` / `ncells` / `npure_cellvars` / `PyFrame::ncells`
     // carry `#[elidable_cannot_raise]`.  `call.rs:has_cannot_raise_assertion`
     // only honours the assertion when `function_fnaddrs.contains_key(p)`,

--- a/pyre/pyre-interpreter/src/module/_weakref/interp_weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp_weakref.rs
@@ -169,6 +169,10 @@ fn init_proxy_type(ns: &mut DictStorage) {
     register_proxy_typedef_dict(ns, /*include_comparisons=*/ true);
 }
 
+/// `dont_look_inside`: the `PROXY_TYPE` thread-local `OnceLock` read has
+/// no extractable graph; the call stays a residual returning the lazily
+/// built type object (same shape as [`crate::typedef::w_type`]).
+#[majit_macros::dont_look_inside]
 pub fn proxy_type() -> PyObjectRef {
     PROXY_TYPE.with(|cell| {
         *cell.get_or_init(|| {
@@ -220,6 +224,8 @@ fn init_callable_proxy_type(ns: &mut DictStorage) {
     register_proxy_typedef_dict(ns, /*include_comparisons=*/ false);
 }
 
+/// `dont_look_inside` for the same reason as [`proxy_type`].
+#[majit_macros::dont_look_inside]
 pub fn callable_proxy_type() -> PyObjectRef {
     CALLABLE_PROXY_TYPE.with(|cell| {
         *cell.get_or_init(|| {

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -269,6 +269,7 @@ pub extern "C" fn pyre_stack_set_length_fraction(frac: f64) {
 /// Returns `1` on real stack overflow (caller should raise
 /// `RecursionError`), `0` otherwise.
 #[unsafe(no_mangle)]
+#[majit_macros::dont_look_inside]
 pub extern "C" fn pyre_stack_too_big_slowpath(current: usize) -> u8 {
     let max_stack_size = PYRE_STACKTOOBIG.stack_length.load(Ordering::Relaxed);
     // stack.c:38-40 OP_THREADLOCALREF_ADDR + baseptr = tl1->stack_end.
@@ -378,6 +379,7 @@ pub extern "C" fn pyre_stack_check_for_jit_prologue() -> i64 {
 /// Matches RPython `pos_exception()` → `propagate_exception_path`
 /// unwind semantics.
 #[inline]
+#[majit_macros::dont_look_inside]
 pub fn drain_jit_pending_exception() -> Result<(), PyError> {
     let obj = TL_JIT_PENDING_EXCEPTION.with(|slot| {
         let obj = slot.get();
@@ -457,6 +459,7 @@ pub fn get_recursion_limit() -> i32 {
 /// applies the 4-case logic (first-time capture, thread switch,
 /// underflow revision, or real overflow).
 #[inline]
+#[majit_macros::dont_look_inside]
 pub fn stack_check() -> Result<(), PyError> {
     let current = current_sp();
     let end = PYRE_STACKTOOBIG.stack_end.load(Ordering::Relaxed);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -906,6 +906,13 @@ static W_OBJECT_TYPEOBJECT: std::sync::OnceLock<usize> = std::sync::OnceLock::ne
 static W_TYPE_TYPEOBJECT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 /// Get the wrapped `type` typeobject.
+///
+/// `dont_look_inside` keeps the JIT from tracing into the `OnceLock`
+/// read: the slot is set once at startup and holds the runtime
+/// typeobject address, which has no registry-resolvable accessor, so
+/// the call stays a residual returning that pointer (the trace-side twin
+/// registers the fnaddr in `jit_trace_fnaddrs`).
+#[majit_macros::dont_look_inside]
 pub fn w_type() -> PyObjectRef {
     W_TYPE_TYPEOBJECT
         .get()
@@ -918,6 +925,9 @@ pub fn gettypeobject(tp: &PyType) -> PyObjectRef {
 }
 
 /// Get the wrapped `object` typeobject.
+///
+/// `dont_look_inside` for the same reason as [`w_type`].
+#[majit_macros::dont_look_inside]
 pub fn w_object() -> PyObjectRef {
     W_OBJECT_TYPEOBJECT
         .get()


### PR DESCRIPTION
#131

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Continues #131 — retiring the legacy type-flow walker by making the real RPython rtyper Match on more graphs, which shrinks the dual-gate prepass census of unported paths. Six tracks:

### rtyper Repr port — list iterator
- `rmodel`: `Repr::rtype_iter` default becomes `make_iterator_repr().newiter(hop)` (`rmodel.py:229`); add `make_iterator_repr` / `newiter` trait defaults; the `SomeIterator` arm of `rtyper_makerepr` resolves the container repr and delegates to `make_iterator_repr` (`rmodel.py:274-282`), deferring `enumerate`.
- `rlist`: `ListIteratorRepr` with `lowleveltype` `Ptr(GcStruct("listiter", ("list", LIST), ("index", Signed)))`, identity `rtype_iter`, and `newiter` via a `ll_listiter` helper graph (`malloc` + two `setfield`, baking the iter lltype into the `malloc` the way `TupleRepr.newtuple` does); `FixedSizeListRepr` and `ListRepr` gain `make_iterator_repr` overrides.
- `rlist`: `rtype_next` (`rlist.py:444-449`) and `ll_listnext` (`lltypesystem/rlist.py:476-482`) — a two-block helper that reads `list`/`index`, computes `ll_length` (`getarraysize` for the fixed array, `getfield "length"` for the resized struct), and on `index >= len` links to the graph's `exceptblock` with `exception_args("StopIteration")` (the first low-level helper in the port to raise), else increments `index` and reads `ll_getitem_fast`. `ll_listnext_foldable` is not an rtyper-level distinction — both lower to bare `getarrayitem`; the `getitem_foldable` oopspec is applied at the codewriter, the same way `ll_len` / `ll_len_foldable` both lower to `getarraysize`.
- `pairtype`: `ReprClassId::ListIteratorRepr` + its mro.

### front-end lift
- `front/mir`: alias the string-family `Deref::deref` (`String` / `str` / `Wtf8` / `Wtf8Buf`, all projecting to the single immutable `s_unicode0`) to its receiver, so the deref no longer aborts annotation as an unregistered `method("deref")` callee. Slice / `Vec` derefs keep their ordinary lowering.

### residual accessors (`#[dont_look_inside]` + fnaddr registration)
Thread-local / `OnceLock` slot accessors read through a `.with` closure with no extractable graph, so as look-inside candidates they fail the dual-gate prepass annotate ("static not registered in `PyreCallRegistry`"). Marking each `#[dont_look_inside]` makes callers emit a residual `Call`, and registering their fnaddrs in `jit_trace_fnaddrs` bakes real funcptrs instead of symbolic-path hashes (twins of `get_current_exception` / `set_current_exception`):
- `w_type` / `w_object` typeobject accessors (`W_TYPE_TYPEOBJECT` / `W_OBJECT_TYPEOBJECT`).
- `set` / `take` / `clear_call_error` (`PENDING_CALL_ERROR`), `take_pending_hash_error`, `proxy_type` / `callable_proxy_type` (weakref `PROXY_TYPE` / `CALLABLE_PROXY_TYPE`) — prepass phaseA Skips 529→523.
- `stack_check`, `pyre_stack_too_big_slowpath`, `drain_jit_pending_exception` — Skips 523→520. (`stack_check` runs at every function entry, so residualising it may cost call-heavy traces; `check.py` covers correctness only.)

### static catalogue folds
- `jit_fnaddr`: register `SPECIALISED_TUPLE_{II,FF,OO}_OBJECT_SIZE` / `W_INSTANCE_OBJECT_SIZE` in `jit_static_int_values()` (their `size_of::<T>()` initializers leave Charon's layout unresolved, so reads fell through to an unregistered 0-arg `FunctionPath` accessor) — Skips 534→530; and register the `COMPLEX` / `ModuleNotFoundError` / `SyntaxError` `PyType` singletons in `jit_static_pytype_addrs()`, so their global reads fold to a constant address.

### elidable cache surfaces
- `baseobjspace`: add `_pure_lookup_class_with_method_cache`, the `@elidable` defining-class projection companion of `_pure_lookup_where_with_method_cache`, and route `lookup_where_with_method_cache` through both single-register elidable surfaces. PyPy's single elidable returns the whole `(w_class, w_value)` tuple (`typeobject.py:510-511`); the residual-call ABI carries one raw register, so the two halves are exposed as two surfaces over the same `MethodCache` entry. The thread-local `MethodCache` read drops from the census.

### diagnostics (`PYRE_RTYPER_VERBOSE`-gated)
- `cutover`: classify each two-phase prepass Skip into an orthodox-disposition bucket (REPR-PORT, CLASSDEF-LESS-INSTANCE, FUNCPATH-OTHER, FRONTEND-RAWPTR/VTABLE/THREADLOCAL/ITERATOR, RESIDUAL-FOREIGN/CLOSURE, UNION-PAIR-PORT, BLOCKED-BLOCK, …) and emit a per-phase histogram.
- Address PR 216 review nits: verbose gating now uses the `== "1"` contract (was `is_ok()`, which also fired for `PYRE_RTYPER_VERBOSE=0`); the unsupported-unary diagnostic lists the ported `str` unary op.

### Verification
`majit-translate` lib tests pass; `check.py` dynasm 139/139, cranelift 139/139.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iterator `next()` support to the translation pipeline for improved loop handling.
  * Implemented full iterator support for list operations with element-type preservation.

* **Bug Fixes**
  * Fixed method-cache lookup behavior to improve performance during dynamic dispatch.

* **Chores**
  * Optimized JIT compilation internals to prevent unnecessary tracing of thread-local accessors.
  * Enhanced diagnostic aggregation in the type-resolution system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->