### PR TITLE
Operand box-identity: delete Operand::Box, re-key side-tables

### DIFF
--- a/majit/majit-backend-cranelift/Cargo.toml
+++ b/majit/majit-backend-cranelift/Cargo.toml
@@ -32,5 +32,6 @@ dynasm = ["majit-metainterp/dynasm"]
 cranelift = ["majit-metainterp/cranelift"]
 
 [dev-dependencies]
+majit-ir = { workspace = true, features = ["test-support"] }
 majit-metainterp = { workspace = true }
 smallvec = { workspace = true }

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16337,10 +16337,49 @@ mod tests {
     use majit_ir::descr::{Descr, EffectInfo, ExtraEffect, SizeDescr};
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
-        let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let o = Op::new(opcode, &bx);
         o.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(o)
+    }
+
+    /// Test-only operand-source for op args / failargs: bind `a` to a
+    /// synthetic producer carrying the same position so the box sheds to
+    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
+    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
+    /// producer graph); `to_opref()` is unchanged, so position-based
+    /// assertions are identical.
+    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+        use majit_ir::box_ref::BoxRef;
+        use majit_ir::resoperation::{Op, OpCode};
+        use majit_ir::{OpRef, Type};
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                std::mem::forget(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let p = std::rc::Rc::new(Op::new(opcode, &[]));
+                p.pos.set(a);
+                let b = BoxRef::from_bound_op(&p);
+                std::mem::forget(p);
+                b
+            }
+        }
     }
 
     /// llsupport/gc.py:563 GcLLDescr_framework
@@ -16370,7 +16409,7 @@ mod tests {
         pos: u32,
         descr: majit_ir::DescrRef,
     ) -> majit_ir::OpRc {
-        let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let o = Op::with_descr(opcode, &bx, descr);
         o.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(o)
@@ -17256,8 +17295,8 @@ mod tests {
             OpRef::NONE.raw(),
         );
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_ref(1)),
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_ref(1)),
+            rb(OpRef::input_arg_int(0)),
         ]);
         let ops = vec![
             mk_op(
@@ -17463,9 +17502,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -17560,9 +17597,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -17631,9 +17666,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        bridge_guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        bridge_guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let bridge_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             bridge_guard,
@@ -17703,9 +17736,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        root_guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        root_guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             root_guard,
@@ -17771,9 +17802,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        bridge_guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        bridge_guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let bridge_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             bridge_guard,
@@ -18292,9 +18321,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 1);
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op_with_descr(
@@ -18342,9 +18369,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 1);
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op_with_descr(
@@ -18385,9 +18410,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op_with_descr(
@@ -18438,9 +18461,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op_with_descr(
@@ -18495,9 +18516,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 3);
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op_with_descr(
@@ -18569,9 +18588,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op_with_descr(
@@ -20547,8 +20564,8 @@ mod tests {
         );
         // Explicit fail_args: save both i0 and i1 plus the computed sum (i0+i1)
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
         ]);
 
         let ops = vec![
@@ -20642,8 +20659,8 @@ mod tests {
             OpRef::NONE.raw(),
         );
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_float(1)),
-            BoxRef::from_opref(OpRef::input_arg_ref(2)),
+            rb(OpRef::input_arg_float(1)),
+            rb(OpRef::input_arg_ref(2)),
         ]);
         let ops = vec![
             mk_op(
@@ -20692,10 +20709,10 @@ mod tests {
             OpRef::NONE.raw(),
         );
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_ref(1)),
-            BoxRef::from_opref(OpRef::input_arg_float(2)),
-            BoxRef::from_opref(OpRef::input_arg_ref(3)),
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_ref(1)),
+            rb(OpRef::input_arg_float(2)),
+            rb(OpRef::input_arg_ref(3)),
         ]);
         let ops = vec![
             mk_op(
@@ -20888,8 +20905,8 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
+            rb(OpRef::input_arg_int(0)),
         ]);
         let ops = vec![
             mk_op(
@@ -20964,8 +20981,8 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
+            rb(OpRef::input_arg_int(0)),
         ]);
         let ops = vec![
             mk_op(
@@ -21039,9 +21056,9 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::int_op(3)),
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
+            rb(OpRef::int_op(3)),
+            rb(OpRef::input_arg_int(0)),
         ]);
         let ops = vec![
             mk_op(
@@ -21098,9 +21115,9 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::int_op(3)),
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
+            rb(OpRef::int_op(3)),
+            rb(OpRef::input_arg_int(0)),
         ]);
         let ops = vec![
             mk_op(
@@ -21169,9 +21186,9 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::float_op(3)),
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
+            rb(OpRef::float_op(3)),
+            rb(OpRef::input_arg_int(0)),
         ]);
         let ops = vec![
             mk_op(
@@ -21611,9 +21628,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
                 OpCode::Label,
@@ -21687,9 +21702,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
                 OpCode::Label,
@@ -21767,9 +21780,9 @@ mod tests {
         ];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(4)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_ref(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::input_arg_ref(2)),
+            rb(OpRef::input_arg_ref(0)),
+            rb(OpRef::input_arg_int(1)),
+            rb(OpRef::input_arg_ref(2)),
         ]);
         let root_ops = vec![
             mk_op_with_descr(
@@ -21866,9 +21879,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
                 OpCode::Label,
@@ -21953,9 +21964,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
                 OpCode::Label,
@@ -22068,9 +22077,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
                 OpCode::Label,
@@ -22188,7 +22195,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1))]);
+        guard.setfailargs(smallvec::smallvec![rb(OpRef::int_op(1))]);
         let root_ops = vec![
             // Peeled preamble: runs once on the initial host entry, before the
             // first LABEL.  A loader re-entry must skip it.
@@ -22679,9 +22686,9 @@ mod tests {
         let inputargs = vec![];
         let mut guard = mk_op(OpCode::GuardNonnull, &[OpRef::ref_op(2)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::ref_op(0)),
-            BoxRef::from_opref(OpRef::ref_op(1)),
-            BoxRef::from_opref(OpRef::ref_op(2))
+            rb(OpRef::ref_op(0)),
+            rb(OpRef::ref_op(1)),
+            rb(OpRef::ref_op(2))
         ]);
         let ops = vec![
             mk_op(OpCode::Label, &[], OpRef::NONE.raw()),
@@ -22856,7 +22863,7 @@ mod tests {
         // Ref-typed OpRef variant.
         let str0 = OpRef::ref_op(0);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22908,7 +22915,7 @@ mod tests {
         let src = OpRef::ref_op(0);
         let dst = OpRef::ref_op(3);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22962,7 +22969,7 @@ mod tests {
         // pointer use the Ref-typed OpRef variant.
         let buf = OpRef::ref_op(0);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22996,7 +23003,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_ref(0)];
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -23042,7 +23049,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_ref(0)];
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -23304,8 +23311,8 @@ mod tests {
         let guard_op = Op::new(OpCode::GuardNotInvalidated, &[]);
         guard_op.pos.set(OpRef::int_op(OpRef::NONE.raw()));
         guard_op.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
         ]);
 
         let ops = vec![
@@ -23355,7 +23362,7 @@ mod tests {
 
         let guard_inv = Op::new(OpCode::GuardNotInvalidated, &[]);
         guard_inv.pos.set(OpRef::int_op(OpRef::NONE.raw()));
-        guard_inv.setfailargs(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(1))]);
+        guard_inv.setfailargs(smallvec::smallvec![rb(OpRef::int_op(1))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op(
@@ -23405,9 +23412,7 @@ mod tests {
 
         let guard_inv = Op::new(OpCode::GuardNotInvalidated, &[]);
         guard_inv.pos.set(OpRef::int_op(OpRef::NONE.raw()));
-        guard_inv.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-            OpRef::input_arg_int(0)
-        )]);
+        guard_inv.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             std::rc::Rc::new(guard_inv),
@@ -23458,8 +23463,8 @@ mod tests {
             OpRef::NONE.raw(),
         );
         guard1.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_int(1)),
         ]);
         let int_add = mk_op(
             OpCode::IntAdd,
@@ -23467,7 +23472,7 @@ mod tests {
             2,
         );
         let mut guard2 = mk_op(OpCode::GuardFalse, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard2.setfailargs(smallvec::smallvec![BoxRef::from_opref(OpRef::int_op(2))]);
+        guard2.setfailargs(smallvec::smallvec![rb(OpRef::int_op(2))]);
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -23527,9 +23532,9 @@ mod tests {
             OpRef::NONE.raw(),
         );
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::input_arg_ref(1)),
-            BoxRef::from_opref(OpRef::input_arg_float(2)),
+            rb(OpRef::input_arg_int(0)),
+            rb(OpRef::input_arg_ref(1)),
+            rb(OpRef::input_arg_float(2)),
         ]);
         let ops = vec![
             mk_op(
@@ -23594,9 +23599,7 @@ mod tests {
             mk_op(OpCode::IntGt, &[OpRef::int_op(1), OpRef::int_op(101)], 2),
             {
                 let mut g = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-                g.setfailargs(smallvec::smallvec![BoxRef::from_opref(
-                    OpRef::input_arg_int(0)
-                )]);
+                g.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
                 g
             },
             mk_op(OpCode::Finish, &[OpRef::int_op(1)], OpRef::NONE.raw()),

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16343,44 +16343,7 @@ mod tests {
         std::rc::Rc::new(o)
     }
 
-    /// Test-only operand-source for op args / failargs: bind `a` to a
-    /// synthetic producer carrying the same position so the box sheds to
-    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
-    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
-    /// producer graph); `to_opref()` is unchanged, so position-based
-    /// assertions are identical.
-    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-        use majit_ir::box_ref::BoxRef;
-        use majit_ir::resoperation::{Op, OpCode};
-        use majit_ir::{OpRef, Type};
-        if a.is_none() || a.is_constant() {
-            return BoxRef::from_opref(a);
-        }
-        let ty = a.ty().unwrap_or(Type::Void);
-        match a {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-                let b = BoxRef::from_bound_inputarg(&ia);
-                std::mem::forget(ia);
-                b
-            }
-            _ => {
-                let opcode = match ty {
-                    Type::Int => OpCode::SameAsI,
-                    Type::Float => OpCode::SameAsF,
-                    Type::Ref => OpCode::SameAsR,
-                    Type::Void => OpCode::Jump,
-                };
-                let p = std::rc::Rc::new(Op::new(opcode, &[]));
-                p.pos.set(a);
-                let b = BoxRef::from_bound_op(&p);
-                std::mem::forget(p);
-                b
-            }
-        }
-    }
+    use majit_ir::box_ref::bound_box_from_opref as rb;
 
     /// llsupport/gc.py:563 GcLLDescr_framework
     ///   .get_typeid_from_classptr_if_gcremovetypeptr

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16335,9 +16335,10 @@ mod tests {
     use majit_gc::trace::TypeInfo;
     use majit_ir::box_ref::BoxRef;
     use majit_ir::descr::{Descr, EffectInfo, ExtraEffect, SizeDescr};
+    use majit_ir::operand::Operand;
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
-        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
         let o = Op::new(opcode, &bx);
         o.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(o)
@@ -16372,7 +16373,7 @@ mod tests {
         pos: u32,
         descr: majit_ir::DescrRef,
     ) -> majit_ir::OpRc {
-        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
         let o = Op::with_descr(opcode, &bx, descr);
         o.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(o)
@@ -22826,7 +22827,7 @@ mod tests {
         // Ref-typed OpRef variant.
         let str0 = OpRef::ref_op(0);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22878,7 +22879,7 @@ mod tests {
         let src = OpRef::ref_op(0);
         let dst = OpRef::ref_op(3);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22932,7 +22933,7 @@ mod tests {
         // pointer use the Ref-typed OpRef variant.
         let buf = OpRef::ref_op(0);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22966,7 +22967,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_ref(0)];
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -23012,7 +23013,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_ref(0)];
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![

--- a/majit/majit-backend-cranelift/tests/integration.rs
+++ b/majit/majit-backend-cranelift/tests/integration.rs
@@ -72,44 +72,7 @@ fn make_descr(_index: u32) -> DescrRef {
     majit_backend::make_resume_guard_descr_typed(Vec::new())
 }
 
-/// Test-only operand-source for op args / failargs: bind `a` to a
-/// synthetic producer carrying the same position so the box sheds to
-/// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-/// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-/// The synthetic producer is intentionally leaked (`mem::forget`) so the
-/// box's `Weak` upgrades for the life of the test process (fixtures hold no
-/// producer graph); `to_opref()` is unchanged, so position-based
-/// assertions are identical.
-fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-    use majit_ir::box_ref::BoxRef;
-    use majit_ir::resoperation::{Op, OpCode};
-    use majit_ir::{OpRef, Type};
-    if a.is_none() || a.is_constant() {
-        return BoxRef::from_opref(a);
-    }
-    let ty = a.ty().unwrap_or(Type::Void);
-    match a {
-        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-            let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-            let b = BoxRef::from_bound_inputarg(&ia);
-            std::mem::forget(ia);
-            b
-        }
-        _ => {
-            let opcode = match ty {
-                Type::Int => OpCode::SameAsI,
-                Type::Float => OpCode::SameAsF,
-                Type::Ref => OpCode::SameAsR,
-                Type::Void => OpCode::Jump,
-            };
-            let p = std::rc::Rc::new(Op::new(opcode, &[]));
-            p.pos.set(a);
-            let b = BoxRef::from_bound_op(&p);
-            std::mem::forget(p);
-            b
-        }
-    }
-}
+use majit_ir::box_ref::bound_box_from_opref as rb;
 
 // ---------------------------------------------------------------------------
 // Test 1: Simple arithmetic (trace -> optimize -> compile -> execute)

--- a/majit/majit-backend-cranelift/tests/integration.rs
+++ b/majit/majit-backend-cranelift/tests/integration.rs
@@ -9,6 +9,7 @@ use majit_backend::{
 };
 use majit_backend_cranelift::{CraneliftBackend, force_token_to_dead_frame, jit_exc_raise};
 use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 use majit_ir::{
     ArrayDescr, Descr, DescrRef, FieldDescr, GcRef, InputArg, Op, OpCode, OpRef, Type, Value,
 };
@@ -2288,15 +2289,15 @@ fn test_call_assembler_callee_guard_failure_frame_stack() {
     //   input(x) -> cmp = x > 10 -> guard_true(cmp) -> finish(x)
     let callee_inputargs = vec![InputArg::new_int(0)];
     let mut callee_ops = vec![
-        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
+        Op::new(OpCode::Label, &[Operand::from_boxref(&rb(OpRef::input_arg_int(0)))]),
         Op::new(
             OpCode::IntGt,
-            &[rb(OpRef::input_arg_int(0)), rb(OpRef::const_int(10))],
+            &[Operand::from_boxref(&rb(OpRef::input_arg_int(0))), Operand::from_boxref(&rb(OpRef::const_int(10)))],
         ),
-        Op::with_descr(OpCode::GuardTrue, &[rb(OpRef::int_op(1))], make_descr(0)),
+        Op::with_descr(OpCode::GuardTrue, &[Operand::from_boxref(&rb(OpRef::int_op(1)))], make_descr(0)),
         Op::with_descr(
             OpCode::Finish,
-            &[rb(OpRef::input_arg_int(0))],
+            &[Operand::from_boxref(&rb(OpRef::input_arg_int(0)))],
             make_descr(1),
         ),
     ];

--- a/majit/majit-backend-cranelift/tests/integration.rs
+++ b/majit/majit-backend-cranelift/tests/integration.rs
@@ -72,6 +72,45 @@ fn make_descr(_index: u32) -> DescrRef {
     majit_backend::make_resume_guard_descr_typed(Vec::new())
 }
 
+/// Test-only operand-source for op args / failargs: bind `a` to a
+/// synthetic producer carrying the same position so the box sheds to
+/// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+/// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+/// The synthetic producer is intentionally leaked (`mem::forget`) so the
+/// box's `Weak` upgrades for the life of the test process (fixtures hold no
+/// producer graph); `to_opref()` is unchanged, so position-based
+/// assertions are identical.
+fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+    use majit_ir::box_ref::BoxRef;
+    use majit_ir::resoperation::{Op, OpCode};
+    use majit_ir::{OpRef, Type};
+    if a.is_none() || a.is_constant() {
+        return BoxRef::from_opref(a);
+    }
+    let ty = a.ty().unwrap_or(Type::Void);
+    match a {
+        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+            let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+            let b = BoxRef::from_bound_inputarg(&ia);
+            std::mem::forget(ia);
+            b
+        }
+        _ => {
+            let opcode = match ty {
+                Type::Int => OpCode::SameAsI,
+                Type::Float => OpCode::SameAsF,
+                Type::Ref => OpCode::SameAsR,
+                Type::Void => OpCode::Jump,
+            };
+            let p = std::rc::Rc::new(Op::new(opcode, &[]));
+            p.pos.set(a);
+            let b = BoxRef::from_bound_op(&p);
+            std::mem::forget(p);
+            b
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: Simple arithmetic (trace -> optimize -> compile -> execute)
 // ---------------------------------------------------------------------------
@@ -2286,25 +2325,15 @@ fn test_call_assembler_callee_guard_failure_frame_stack() {
     //   input(x) -> cmp = x > 10 -> guard_true(cmp) -> finish(x)
     let callee_inputargs = vec![InputArg::new_int(0)];
     let mut callee_ops = vec![
-        Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        ),
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
         Op::new(
             OpCode::IntGt,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::const_int(10)),
-            ],
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::const_int(10))],
         ),
-        Op::with_descr(
-            OpCode::GuardTrue,
-            &[BoxRef::from_opref(OpRef::int_op(1))],
-            make_descr(0),
-        ),
+        Op::with_descr(OpCode::GuardTrue, &[rb(OpRef::int_op(1))], make_descr(0)),
         Op::with_descr(
             OpCode::Finish,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
+            &[rb(OpRef::input_arg_int(0))],
             make_descr(1),
         ),
     ];

--- a/majit/majit-backend-cranelift/tests/integration.rs
+++ b/majit/majit-backend-cranelift/tests/integration.rs
@@ -2289,12 +2289,22 @@ fn test_call_assembler_callee_guard_failure_frame_stack() {
     //   input(x) -> cmp = x > 10 -> guard_true(cmp) -> finish(x)
     let callee_inputargs = vec![InputArg::new_int(0)];
     let mut callee_ops = vec![
-        Op::new(OpCode::Label, &[Operand::from_boxref(&rb(OpRef::input_arg_int(0)))]),
+        Op::new(
+            OpCode::Label,
+            &[Operand::from_boxref(&rb(OpRef::input_arg_int(0)))],
+        ),
         Op::new(
             OpCode::IntGt,
-            &[Operand::from_boxref(&rb(OpRef::input_arg_int(0))), Operand::from_boxref(&rb(OpRef::const_int(10)))],
+            &[
+                Operand::from_boxref(&rb(OpRef::input_arg_int(0))),
+                Operand::from_boxref(&rb(OpRef::const_int(10))),
+            ],
         ),
-        Op::with_descr(OpCode::GuardTrue, &[Operand::from_boxref(&rb(OpRef::int_op(1)))], make_descr(0)),
+        Op::with_descr(
+            OpCode::GuardTrue,
+            &[Operand::from_boxref(&rb(OpRef::int_op(1)))],
+            make_descr(0),
+        ),
         Op::with_descr(
             OpCode::Finish,
             &[Operand::from_boxref(&rb(OpRef::input_arg_int(0)))],

--- a/majit/majit-backend-dynasm/Cargo.toml
+++ b/majit/majit-backend-dynasm/Cargo.toml
@@ -16,4 +16,5 @@ dynasmrt = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
+majit-ir = { workspace = true, features = ["test-support"] }
 majit-trace = { workspace = true }

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -637,34 +637,64 @@ mod tests {
 
     use super::{GuardKind, IntBinKind, IntCmpKind, LirOp, TracePlan};
 
+    /// Test-only operand-source for op args / failargs: bind `a` to a
+    /// synthetic producer carrying the same position so the box sheds to
+    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
+    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
+    /// producer graph); `to_opref()` is unchanged, so position-based
+    /// assertions are identical.
+    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+        use majit_ir::box_ref::BoxRef;
+        use majit_ir::resoperation::{Op, OpCode};
+        use majit_ir::{OpRef, Type};
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                std::mem::forget(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let p = std::rc::Rc::new(Op::new(opcode, &[]));
+                p.pos.set(a);
+                let b = BoxRef::from_bound_op(&p);
+                std::mem::forget(p);
+                b
+            }
+        }
+    }
+
     #[test]
     fn lowers_simple_integer_loop_shape() {
         let i0 = OpRef::int_op(0);
         let c1 = OpRef::const_int(1);
         let c10 = OpRef::const_int(10);
 
-        let mut label = Op::new(OpCode::Label, &[BoxRef::from_opref(i0)]);
+        let mut label = Op::new(OpCode::Label, &[rb(i0)]);
         label.pos.set(OpRef::int_op(10));
 
-        let mut add = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(i0), BoxRef::from_opref(c1)],
-        );
+        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(OpRef::int_op(1));
 
-        let mut lt = Op::new(
-            OpCode::IntLt,
-            &[
-                BoxRef::from_opref(OpRef::int_op(1)),
-                BoxRef::from_opref(c10),
-            ],
-        );
+        let mut lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(1)), rb(c10)]);
         lt.pos.set(OpRef::int_op(2));
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(1))].into());
-        let mut jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]);
+        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
+        let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
         let plan = TracePlan::build(
@@ -702,18 +732,15 @@ mod tests {
         let i0 = OpRef::int_op(0);
         let c1 = OpRef::const_int(1);
 
-        let mut add = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(i0), BoxRef::from_opref(c1)],
-        );
+        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(OpRef::int_op(1));
 
-        let mut is_true = Op::new(OpCode::IntIsTrue, &[BoxRef::from_opref(OpRef::int_op(1))]);
+        let mut is_true = Op::new(OpCode::IntIsTrue, &[rb(OpRef::int_op(1))]);
         is_true.pos.set(OpRef::int_op(2));
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(1))].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
         let mut finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
 
@@ -744,19 +771,16 @@ mod tests {
         let i0 = OpRef::int_op(0);
         let c1 = OpRef::const_int(1);
 
-        let mut add = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(i0), BoxRef::from_opref(c1)],
-        );
+        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(OpRef::int_op(1));
 
-        let mut is_true = Op::new(OpCode::IntIsTrue, &[BoxRef::from_opref(OpRef::int_op(1))]);
+        let mut is_true = Op::new(OpCode::IntIsTrue, &[rb(OpRef::int_op(1))]);
         is_true.pos.set(OpRef::int_op(2));
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(1))].into());
-        let mut jump = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]);
+        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
+        let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
         let plan = TracePlan::build(
@@ -778,24 +802,18 @@ mod tests {
 
         let mut load = Op::new(
             OpCode::GcLoadIndexedI,
-            &[
-                BoxRef::from_opref(base),
-                BoxRef::from_opref(index),
-                BoxRef::from_opref(scale),
-                BoxRef::from_opref(offset),
-                BoxRef::from_opref(size),
-            ],
+            &[rb(base), rb(index), rb(scale), rb(offset), rb(size)],
         );
         load.pos.set(OpRef::int_op(3));
         let store = Op::new(
             OpCode::GcStoreIndexed,
             &[
-                BoxRef::from_opref(base),
-                BoxRef::from_opref(index),
-                BoxRef::from_opref(value),
-                BoxRef::from_opref(scale),
-                BoxRef::from_opref(offset),
-                BoxRef::from_opref(size),
+                rb(base),
+                rb(index),
+                rb(value),
+                rb(scale),
+                rb(offset),
+                rb(size),
             ],
         );
 
@@ -836,7 +854,7 @@ mod tests {
     #[test]
     fn lowers_misc_opcode_without_fallback() {
         let i0 = OpRef::int_op(0);
-        let mut same_as = Op::new(OpCode::SameAsI, &[BoxRef::from_opref(i0)]);
+        let mut same_as = Op::new(OpCode::SameAsI, &[rb(i0)]);
         same_as.pos.set(OpRef::int_op(1));
         let debug = Op::new(OpCode::JitDebug, &[]);
 
@@ -866,12 +884,12 @@ mod tests {
     #[test]
     fn lowers_remaining_guard_kinds_without_fallback() {
         let i0 = OpRef::int_op(0);
-        let mut is_object = Op::new(OpCode::GuardIsObject, &[BoxRef::from_opref(i0)]);
+        let mut is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         is_object.pos.set(OpRef::int_op(1));
-        is_object.setfailargs(vec![BoxRef::from_opref(i0)].into());
+        is_object.setfailargs(vec![rb(i0)].into());
         let mut future = Op::new(OpCode::GuardFutureCondition, &[]);
         future.pos.set(OpRef::int_op(2));
-        future.setfailargs(vec![BoxRef::from_opref(i0)].into());
+        future.setfailargs(vec![rb(i0)].into());
         let plan = TracePlan::build(
             &[InputArg::from_type(Type::Ref, i0.raw())],
             &[is_object, future],

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -632,12 +632,11 @@ fn add_refs(live: &mut Vec<OpRef>, args: &[OpRef]) {
 
 #[cfg(test)]
 mod tests {
-    use majit_ir::box_ref::BoxRef;
     use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
 
     use super::{GuardKind, IntBinKind, IntCmpKind, LirOp, TracePlan};
 
-    use majit_ir::box_ref::bound_box_from_opref as rb;
+    use majit_ir::box_ref::bound_operand_from_opref as rb;
 
     #[test]
     fn lowers_simple_integer_loop_shape() {
@@ -656,7 +655,7 @@ mod tests {
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
         let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
@@ -703,7 +702,7 @@ mod tests {
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
         let mut finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
 
@@ -742,7 +741,7 @@ mod tests {
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
         let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
@@ -849,10 +848,10 @@ mod tests {
         let i0 = OpRef::int_op(0);
         let mut is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         is_object.pos.set(OpRef::int_op(1));
-        is_object.setfailargs(vec![rb(i0)].into());
+        is_object.setfailargs(vec![rb(i0).to_boxref()].into());
         let mut future = Op::new(OpCode::GuardFutureCondition, &[]);
         future.pos.set(OpRef::int_op(2));
-        future.setfailargs(vec![rb(i0)].into());
+        future.setfailargs(vec![rb(i0).to_boxref()].into());
         let plan = TracePlan::build(
             &[InputArg::from_type(Type::Ref, i0.raw())],
             &[is_object, future],

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -637,44 +637,7 @@ mod tests {
 
     use super::{GuardKind, IntBinKind, IntCmpKind, LirOp, TracePlan};
 
-    /// Test-only operand-source for op args / failargs: bind `a` to a
-    /// synthetic producer carrying the same position so the box sheds to
-    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
-    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
-    /// producer graph); `to_opref()` is unchanged, so position-based
-    /// assertions are identical.
-    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-        use majit_ir::box_ref::BoxRef;
-        use majit_ir::resoperation::{Op, OpCode};
-        use majit_ir::{OpRef, Type};
-        if a.is_none() || a.is_constant() {
-            return BoxRef::from_opref(a);
-        }
-        let ty = a.ty().unwrap_or(Type::Void);
-        match a {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-                let b = BoxRef::from_bound_inputarg(&ia);
-                std::mem::forget(ia);
-                b
-            }
-            _ => {
-                let opcode = match ty {
-                    Type::Int => OpCode::SameAsI,
-                    Type::Float => OpCode::SameAsF,
-                    Type::Ref => OpCode::SameAsR,
-                    Type::Void => OpCode::Jump,
-                };
-                let p = std::rc::Rc::new(Op::new(opcode, &[]));
-                p.pos.set(a);
-                let b = BoxRef::from_bound_op(&p);
-                std::mem::forget(p);
-                b
-            }
-        }
-    }
+    use majit_ir::box_ref::bound_box_from_opref as rb;
 
     #[test]
     fn lowers_simple_integer_loop_shape() {

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -6027,42 +6027,7 @@ mod tests {
     use majit_ir::box_ref::BoxRef;
     use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
 
-    /// Test-only operand-source for op args / failargs: bind `a` to a
-    /// synthetic producer carrying the same position so the box sheds to
-    /// `Operand::Op` / `Operand::InputArg` — the deleted position-only operand
-    /// is rejected by `from_boxref` (#9). Const / None shed directly via
-    /// `from_opref`. The synthetic producer is intentionally leaked
-    /// (`mem::forget`) so the box's `Weak` upgrades for the life of the test
-    /// process (fixtures build standalone boxes with no producer graph to
-    /// root them); the leak is bounded by the test binary's lifetime.
-    /// `to_opref()` is unchanged, so position-based assertions are identical.
-    fn rb(a: OpRef) -> BoxRef {
-        if a.is_none() || a.is_constant() {
-            return BoxRef::from_opref(a);
-        }
-        let ty = a.ty().unwrap_or(Type::Void);
-        match a {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                let ia = std::rc::Rc::new(InputArg::from_type(ty, a.raw()));
-                let b = BoxRef::from_bound_inputarg(&ia);
-                std::mem::forget(ia);
-                b
-            }
-            _ => {
-                let opcode = match ty {
-                    Type::Int => OpCode::SameAsI,
-                    Type::Float => OpCode::SameAsF,
-                    Type::Ref => OpCode::SameAsR,
-                    Type::Void => OpCode::Jump,
-                };
-                let p = std::rc::Rc::new(Op::new(opcode, &[]));
-                p.pos.set(a);
-                let b = BoxRef::from_bound_op(&p);
-                std::mem::forget(p);
-                b
-            }
-        }
-    }
+    use majit_ir::box_ref::bound_box_from_opref as rb;
 
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
         let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -6024,8 +6024,8 @@ fn loc_eq(a: &Loc, b: &Loc) -> bool {
 mod tests {
     use super::*;
     use majit_ir::VecAssoc;
-    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
     use majit_ir::operand::Operand;
+    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
 
     use majit_ir::box_ref::bound_operand_from_opref as rb;
 

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -6024,13 +6024,13 @@ fn loc_eq(a: &Loc, b: &Loc) -> bool {
 mod tests {
     use super::*;
     use majit_ir::VecAssoc;
-    use majit_ir::box_ref::BoxRef;
     use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
+    use majit_ir::operand::Operand;
 
-    use majit_ir::box_ref::bound_box_from_opref as rb;
+    use majit_ir::box_ref::bound_operand_from_opref as rb;
 
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
-        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
         let mut op = Op::new(opcode, &bx);
         op.pos.set(OpRef::int_op(pos));
         op
@@ -6038,7 +6038,7 @@ mod tests {
 
     fn make_guard(opcode: OpCode, pos: u32, args: &[OpRef], fail_args: &[OpRef]) -> Op {
         let mut op = make_op(opcode, pos, args);
-        op.setfailargs(fail_args.iter().map(|a| rb(*a)).collect());
+        op.setfailargs(fail_args.iter().map(|a| rb(*a).to_boxref()).collect());
         op
     }
 
@@ -6201,7 +6201,7 @@ mod tests {
         is_true.pos.set(i2);
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(i2)]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(i1)].into());
+        guard.setfailargs(vec![rb(i1).to_boxref()].into());
         let mut finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
         finish.setfailargs(vec![].into());

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -6027,8 +6027,45 @@ mod tests {
     use majit_ir::box_ref::BoxRef;
     use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
 
+    /// Test-only operand-source for op args / failargs: bind `a` to a
+    /// synthetic producer carrying the same position so the box sheds to
+    /// `Operand::Op` / `Operand::InputArg` — the deleted position-only operand
+    /// is rejected by `from_boxref` (#9). Const / None shed directly via
+    /// `from_opref`. The synthetic producer is intentionally leaked
+    /// (`mem::forget`) so the box's `Weak` upgrades for the life of the test
+    /// process (fixtures build standalone boxes with no producer graph to
+    /// root them); the leak is bounded by the test binary's lifetime.
+    /// `to_opref()` is unchanged, so position-based assertions are identical.
+    fn rb(a: OpRef) -> BoxRef {
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = std::rc::Rc::new(InputArg::from_type(ty, a.raw()));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                std::mem::forget(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let p = std::rc::Rc::new(Op::new(opcode, &[]));
+                p.pos.set(a);
+                let b = BoxRef::from_bound_op(&p);
+                std::mem::forget(p);
+                b
+            }
+        }
+    }
+
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
-        let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let mut op = Op::new(opcode, &bx);
         op.pos.set(OpRef::int_op(pos));
         op
@@ -6036,7 +6073,7 @@ mod tests {
 
     fn make_guard(opcode: OpCode, pos: u32, args: &[OpRef], fail_args: &[OpRef]) -> Op {
         let mut op = make_op(opcode, pos, args);
-        op.setfailargs(fail_args.iter().map(|a| BoxRef::from_opref(*a)).collect());
+        op.setfailargs(fail_args.iter().map(|a| rb(*a)).collect());
         op
     }
 
@@ -6193,16 +6230,13 @@ mod tests {
 
         let inputargs = vec![InputArg::from_type(Type::Int, i0.raw())];
 
-        let mut add = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(i0), BoxRef::from_opref(c1)],
-        );
+        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(i1);
-        let mut is_true = Op::new(OpCode::IntIsTrue, &[BoxRef::from_opref(i1)]);
+        let mut is_true = Op::new(OpCode::IntIsTrue, &[rb(i1)]);
         is_true.pos.set(i2);
-        let mut guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(i2)]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[rb(i2)]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![BoxRef::from_opref(i1)].into());
+        guard.setfailargs(vec![rb(i1)].into());
         let mut finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
         finish.setfailargs(vec![].into());
@@ -6245,14 +6279,7 @@ mod tests {
         let c0 = OpRef::const_int(0);
         let inputargs = vec![InputArg::from_type(Type::Ref, i0.raw())];
 
-        let store = Op::new(
-            OpCode::GcStore,
-            &[
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(c0),
-                BoxRef::from_opref(i0),
-            ],
-        );
+        let store = Op::new(OpCode::GcStore, &[rb(i0), rb(c0), rb(i0)]);
         let ops = vec![store];
 
         let mut ra = RegAlloc::new(majit_ir::VecAssoc::new(), &inputargs, &ops);
@@ -6297,9 +6324,9 @@ mod tests {
             InputArg::from_type(Type::Int, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::IntIsTrue, &[BoxRef::from_opref(i0)]);
+        let mut raw = Op::new(OpCode::IntIsTrue, &[rb(i0)]);
         raw.pos.set(i2);
-        let mut finish = Op::new(OpCode::Finish, &[BoxRef::from_opref(i1)]);
+        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6341,10 +6368,10 @@ mod tests {
             InputArg::from_type(Type::Int, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(i0)]);
+        let mut raw = Op::new(OpCode::GuardTrue, &[rb(i0)]);
         raw.pos.set(OpRef::int_op(2));
         raw.setfailargs(vec![].into());
-        let mut finish = Op::new(OpCode::Finish, &[BoxRef::from_opref(i1)]);
+        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6378,16 +6405,9 @@ mod tests {
             InputArg::from_type(Type::Ref, i1.raw()),
         ];
 
-        let mut raw = Op::new(
-            OpCode::GcLoadI,
-            &[
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(c0),
-                BoxRef::from_opref(c8),
-            ],
-        );
+        let mut raw = Op::new(OpCode::GcLoadI, &[rb(i0), rb(c0), rb(c8)]);
         raw.pos.set(i2);
-        let mut finish = Op::new(OpCode::Finish, &[BoxRef::from_opref(i1)]);
+        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6429,16 +6449,8 @@ mod tests {
             InputArg::from_type(Type::Int, i2.raw()),
         ];
 
-        let raw = Op::new(
-            OpCode::GcStore,
-            &[
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(c0),
-                BoxRef::from_opref(i2),
-                BoxRef::from_opref(c8),
-            ],
-        );
-        let mut finish = Op::new(OpCode::Finish, &[BoxRef::from_opref(i1)]);
+        let raw = Op::new(OpCode::GcStore, &[rb(i0), rb(c0), rb(i2), rb(c8)]);
+        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6474,9 +6486,9 @@ mod tests {
             InputArg::from_type(Type::Int, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::SameAsI, &[BoxRef::from_opref(i0)]);
+        let mut raw = Op::new(OpCode::SameAsI, &[rb(i0)]);
         raw.pos.set(i2);
-        let mut finish = Op::new(OpCode::Finish, &[BoxRef::from_opref(i1)]);
+        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3346,10 +3346,10 @@ mod tests {
     use majit_gc::collector::{GcConfig, MiniMarkGC};
     use majit_gc::header::header_of;
     use majit_gc::trace::TypeInfo;
+    use majit_ir::operand::Operand;
     use majit_ir::{
         CallDescr, DescrRef, EffectInfo, ExtraEffect, InputArg, OopSpecIndex, OpCode, Type, Value,
     };
-    use majit_ir::operand::Operand;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -4110,7 +4110,13 @@ mod tests {
         let mut token = JitCellToken::new(1603);
         backend.register_pending_target(token.number, vec![Type::Int, Type::Ref], 2, 2, -1);
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)).to_boxref(), rb(OpRef::input_arg_ref(1)).to_boxref()].into());
+        guard.setfailargs(
+            vec![
+                rb(OpRef::input_arg_int(0)).to_boxref(),
+                rb(OpRef::input_arg_ref(1)).to_boxref(),
+            ]
+            .into(),
+        );
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4706,7 +4712,13 @@ mod tests {
             &[OpRef::input_arg_ref(1), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref(), rb(OpRef::input_arg_ref(1)).to_boxref()].into());
+        guard.setfailargs(
+            vec![
+                rb(OpRef::input_arg_ref(0)).to_boxref(),
+                rb(OpRef::input_arg_ref(1)).to_boxref(),
+            ]
+            .into(),
+        );
         let ops = vec![
             mk_op(
                 OpCode::Label,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3359,44 +3359,7 @@ mod tests {
         );
     }
 
-    /// Test-only operand-source for op args / failargs: bind `a` to a
-    /// synthetic producer carrying the same position so the box sheds to
-    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
-    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
-    /// producer graph); `to_opref()` is unchanged, so position-based
-    /// assertions are identical.
-    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-        use majit_ir::box_ref::BoxRef;
-        use majit_ir::resoperation::{Op, OpCode};
-        use majit_ir::{OpRef, Type};
-        if a.is_none() || a.is_constant() {
-            return BoxRef::from_opref(a);
-        }
-        let ty = a.ty().unwrap_or(Type::Void);
-        match a {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-                let b = BoxRef::from_bound_inputarg(&ia);
-                std::mem::forget(ia);
-                b
-            }
-            _ => {
-                let opcode = match ty {
-                    Type::Int => OpCode::SameAsI,
-                    Type::Float => OpCode::SameAsF,
-                    Type::Ref => OpCode::SameAsR,
-                    Type::Void => OpCode::Jump,
-                };
-                let p = std::rc::Rc::new(Op::new(opcode, &[]));
-                p.pos.set(a);
-                let b = BoxRef::from_bound_op(&p);
-                std::mem::forget(p);
-                b
-            }
-        }
-    }
+    use majit_ir::box_ref::bound_box_from_opref as rb;
 
     #[derive(Debug)]
     struct TestCallAssemblerDescr {

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3346,10 +3346,10 @@ mod tests {
     use majit_gc::collector::{GcConfig, MiniMarkGC};
     use majit_gc::header::header_of;
     use majit_gc::trace::TypeInfo;
-    use majit_ir::box_ref::BoxRef;
     use majit_ir::{
         CallDescr, DescrRef, EffectInfo, ExtraEffect, InputArg, OopSpecIndex, OpCode, Type, Value,
     };
+    use majit_ir::operand::Operand;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -3359,7 +3359,7 @@ mod tests {
         );
     }
 
-    use majit_ir::box_ref::bound_box_from_opref as rb;
+    use majit_ir::box_ref::bound_operand_from_opref as rb;
 
     #[derive(Debug)]
     struct TestCallAssemblerDescr {
@@ -3454,7 +3454,7 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
-        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
         let op = Op::new(opcode, &bx);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(op)
@@ -4023,7 +4023,7 @@ mod tests {
         // referenced via `OpRef::input_arg_int(0)`. Variant-aware Eq/Hash
         // treats `IntOp(0)` and `InputArgInt(0)` as disjoint Box classes.
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_int(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)).to_boxref()].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op(
@@ -4110,7 +4110,7 @@ mod tests {
         let mut token = JitCellToken::new(1603);
         backend.register_pending_target(token.number, vec![Type::Int, Type::Ref], 2, 2, -1);
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_ref(1))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)).to_boxref(), rb(OpRef::input_arg_ref(1)).to_boxref()].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4210,7 +4210,7 @@ mod tests {
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4395,7 +4395,7 @@ mod tests {
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4500,7 +4500,7 @@ mod tests {
         entry_getfield.setdescr(field_descr.clone());
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
         let mut call1 = mk_op(
             OpCode::CallAssemblerI,
             &[OpRef::input_arg_ref(0), OpRef::int_op(4)],
@@ -4616,7 +4616,7 @@ mod tests {
             &[OpRef::input_arg_ref(0), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
             guard,
@@ -4706,7 +4706,7 @@ mod tests {
             &[OpRef::input_arg_ref(1), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)), rb(OpRef::input_arg_ref(1))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref(), rb(OpRef::input_arg_ref(1)).to_boxref()].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3359,6 +3359,45 @@ mod tests {
         );
     }
 
+    /// Test-only operand-source for op args / failargs: bind `a` to a
+    /// synthetic producer carrying the same position so the box sheds to
+    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
+    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
+    /// producer graph); `to_opref()` is unchanged, so position-based
+    /// assertions are identical.
+    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+        use majit_ir::box_ref::BoxRef;
+        use majit_ir::resoperation::{Op, OpCode};
+        use majit_ir::{OpRef, Type};
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                std::mem::forget(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let p = std::rc::Rc::new(Op::new(opcode, &[]));
+                p.pos.set(a);
+                let b = BoxRef::from_bound_op(&p);
+                std::mem::forget(p);
+                b
+            }
+        }
+    }
+
     #[derive(Debug)]
     struct TestCallAssemblerDescr {
         arg_types: Vec<Type>,
@@ -3452,7 +3491,7 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
-        let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let op = Op::new(opcode, &bx);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(op)
@@ -4021,7 +4060,7 @@ mod tests {
         // referenced via `OpRef::input_arg_int(0)`. Variant-aware Eq/Hash
         // treats `IntOp(0)` and `InputArgInt(0)` as disjoint Box classes.
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::input_arg_int(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_int(0))].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op(
@@ -4108,13 +4147,7 @@ mod tests {
         let mut token = JitCellToken::new(1603);
         backend.register_pending_target(token.number, vec![Type::Int, Type::Ref], 2, 2, -1);
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(
-            vec![
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_ref(1)),
-            ]
-            .into(),
-        );
+        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_ref(1))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4214,7 +4247,7 @@ mod tests {
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4399,7 +4432,7 @@ mod tests {
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4504,7 +4537,7 @@ mod tests {
         entry_getfield.setdescr(field_descr.clone());
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let mut call1 = mk_op(
             OpCode::CallAssemblerI,
             &[OpRef::input_arg_ref(0), OpRef::int_op(4)],
@@ -4620,7 +4653,7 @@ mod tests {
             &[OpRef::input_arg_ref(0), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(vec![BoxRef::from_opref(OpRef::input_arg_ref(0))].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
             guard,
@@ -4710,13 +4743,7 @@ mod tests {
             &[OpRef::input_arg_ref(1), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(
-            vec![
-                BoxRef::from_opref(OpRef::input_arg_ref(0)),
-                BoxRef::from_opref(OpRef::input_arg_ref(1)),
-            ]
-            .into(),
-        );
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)), rb(OpRef::input_arg_ref(1))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -20,6 +20,45 @@ use majit_backend_dynasm::runner::DynasmBackend;
 
 static EXCEPTION_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+/// Test-only operand-source for op args / failargs: bind `a` to a
+/// synthetic producer carrying the same position so the box sheds to
+/// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+/// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+/// The synthetic producer is intentionally leaked (`mem::forget`) so the
+/// box's `Weak` upgrades for the life of the test process (fixtures hold no
+/// producer graph); `to_opref()` is unchanged, so position-based
+/// assertions are identical.
+fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+    use majit_ir::box_ref::BoxRef;
+    use majit_ir::resoperation::{Op, OpCode};
+    use majit_ir::{OpRef, Type};
+    if a.is_none() || a.is_constant() {
+        return BoxRef::from_opref(a);
+    }
+    let ty = a.ty().unwrap_or(Type::Void);
+    match a {
+        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+            let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+            let b = BoxRef::from_bound_inputarg(&ia);
+            std::mem::forget(ia);
+            b
+        }
+        _ => {
+            let opcode = match ty {
+                Type::Int => OpCode::SameAsI,
+                Type::Float => OpCode::SameAsF,
+                Type::Ref => OpCode::SameAsR,
+                Type::Void => OpCode::Jump,
+            };
+            let p = std::rc::Rc::new(Op::new(opcode, &[]));
+            p.pos.set(a);
+            let b = BoxRef::from_bound_op(&p);
+            std::mem::forget(p);
+            b
+        }
+    }
+}
+
 #[test]
 fn test_just_finish() {
     // Simplest possible trace: just FINISH with no args
@@ -59,16 +98,13 @@ fn test_simple_int_add() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let i0 = inputargs[0].opref();
 
-    let add_op = Op::new(
-        OpCode::IntAdd,
-        &[BoxRef::from_opref(i0), BoxRef::from_opref(const_1)],
-    );
+    let add_op = Op::new(OpCode::IntAdd, &[rb(i0), rb(const_1)]);
     add_op.pos.set(OpRef::int_op(1)); // result is OpRef::int_op(1)
 
-    let finish_op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(1))]);
+    let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![Type::Int]);
-    finish_op.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(1))].into());
+    finish_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -100,16 +136,13 @@ fn test_finish_infers_int_type_when_explicit_types_are_empty() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let i0 = inputargs[0].opref();
 
-    let add_op = Op::new(
-        OpCode::IntAdd,
-        &[BoxRef::from_opref(i0), BoxRef::from_opref(const_1)],
-    );
+    let add_op = Op::new(OpCode::IntAdd, &[rb(i0), rb(const_1)]);
     add_op.pos.set(OpRef::int_op(1));
 
-    let finish_op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(1))]);
+    let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![]);
-    finish_op.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(1))].into());
+    finish_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -136,16 +169,13 @@ fn test_float_add() {
 
     let inputargs = vec![InputArg::from_type(Type::Float, 0)];
 
-    let add_op = Op::new(
-        OpCode::FloatAdd,
-        &[BoxRef::from_opref(i0), BoxRef::from_opref(const_half)],
-    );
+    let add_op = Op::new(OpCode::FloatAdd, &[rb(i0), rb(const_half)]);
     add_op.pos.set(OpRef::float_op(1));
 
-    let finish_op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::float_op(1))]);
+    let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![BoxRef::from_opref(OpRef::float_op(1))].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(1))].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -187,26 +217,19 @@ fn test_setarrayitem_raw_float_roundtrip() {
 
     let set_op = Op::new(
         OpCode::SetarrayitemRaw,
-        &[
-            BoxRef::from_opref(base),
-            BoxRef::from_opref(const_index),
-            BoxRef::from_opref(value),
-        ],
+        &[rb(base), rb(const_index), rb(value)],
     );
     set_op.pos.set(OpRef::void_op(2));
     set_op.setdescr(array_descr.clone());
 
-    let get_op = Op::new(
-        OpCode::GetarrayitemRawF,
-        &[BoxRef::from_opref(base), BoxRef::from_opref(const_index)],
-    );
+    let get_op = Op::new(OpCode::GetarrayitemRawF, &[rb(base), rb(const_index)]);
     get_op.pos.set(OpRef::float_op(3));
     get_op.setdescr(array_descr);
 
-    let finish_op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::float_op(3))]);
+    let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(3))]);
     finish_op.pos.set(OpRef::void_op(4));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![BoxRef::from_opref(OpRef::float_op(3))].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(3))].into());
 
     let ops = vec![set_op, get_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -240,28 +263,18 @@ fn test_setarrayitem_raw_float_roundtrip_with_variable_index() {
     let index = inputargs[1].opref();
     let value = inputargs[2].opref();
 
-    let set_op = Op::new(
-        OpCode::SetarrayitemRaw,
-        &[
-            BoxRef::from_opref(base),
-            BoxRef::from_opref(index),
-            BoxRef::from_opref(value),
-        ],
-    );
+    let set_op = Op::new(OpCode::SetarrayitemRaw, &[rb(base), rb(index), rb(value)]);
     set_op.pos.set(OpRef::void_op(3));
     set_op.setdescr(array_descr.clone());
 
-    let get_op = Op::new(
-        OpCode::GetarrayitemRawF,
-        &[BoxRef::from_opref(base), BoxRef::from_opref(index)],
-    );
+    let get_op = Op::new(OpCode::GetarrayitemRawF, &[rb(base), rb(index)]);
     get_op.pos.set(OpRef::float_op(4));
     get_op.setdescr(array_descr);
 
-    let finish_op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::float_op(4))]);
+    let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(4))]);
     finish_op.pos.set(OpRef::void_op(5));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![BoxRef::from_opref(OpRef::float_op(4))].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(4))].into());
 
     let ops = vec![set_op, get_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -297,37 +310,28 @@ fn test_guard_and_loop() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let loop_descr = make_loop_target_descr(token.number, false);
 
-    let label_op = Op::new(
-        OpCode::Label,
-        &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-    );
+    let label_op = Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]);
     label_op.pos.set(OpRef::void_op(100));
     label_op.setdescr(loop_descr.clone());
 
     let add_op = Op::new(
         OpCode::IntAdd,
-        &[
-            BoxRef::from_opref(OpRef::input_arg_int(0)),
-            BoxRef::from_opref(OpRef::const_int(1)),
-        ],
+        &[rb(OpRef::input_arg_int(0)), rb(OpRef::const_int(1))],
     );
     add_op.pos.set(OpRef::int_op(1));
 
     let lt_op = Op::new(
         OpCode::IntLt,
-        &[
-            BoxRef::from_opref(OpRef::int_op(1)),
-            BoxRef::from_opref(OpRef::const_int(5)),
-        ],
+        &[rb(OpRef::int_op(1)), rb(OpRef::const_int(5))],
     );
     lt_op.pos.set(OpRef::int_op(2));
 
-    let guard_op = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+    let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Int]);
-    guard_op.setfailargs(vec![BoxRef::from_opref(OpRef::int_op(1))].into());
+    guard_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
 
-    let jump_op = Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::int_op(1))]);
+    let jump_op = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
     jump_op.pos.set(OpRef::void_op(4));
     jump_op.setdescr(loop_descr);
 
@@ -363,73 +367,46 @@ fn test_float_loop_carried_across_jump() {
 
     let label_op = Op::new(
         OpCode::Label,
-        &[
-            BoxRef::from_opref(OpRef::input_arg_float(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-        ],
+        &[rb(OpRef::input_arg_float(0)), rb(OpRef::input_arg_int(1))],
     );
     label_op.pos.set(OpRef::void_op(100));
     label_op.setdescr(loop_descr.clone());
 
     let lt_op = Op::new(
         OpCode::IntLt,
-        &[
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::const_int(5)),
-        ],
+        &[rb(OpRef::input_arg_int(1)), rb(OpRef::const_int(5))],
     );
     lt_op.pos.set(OpRef::int_op(2));
 
-    let guard_op = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+    let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Float, Type::Int]);
-    guard_op.setfailargs(
-        vec![
-            BoxRef::from_opref(OpRef::input_arg_float(0)),
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-        ]
-        .into(),
-    );
+    guard_op.setfailargs(vec![rb(OpRef::input_arg_float(0)), rb(OpRef::input_arg_int(1))].into());
 
-    let cast_op = Op::new(
-        OpCode::CastIntToFloat,
-        &[BoxRef::from_opref(OpRef::input_arg_int(1))],
-    );
+    let cast_op = Op::new(OpCode::CastIntToFloat, &[rb(OpRef::input_arg_int(1))]);
     cast_op.pos.set(OpRef::float_op(4));
 
     let mul_op = Op::new(
         OpCode::FloatMul,
-        &[
-            BoxRef::from_opref(OpRef::float_op(4)),
-            BoxRef::from_opref(OpRef::const_float(0.5)),
-        ],
+        &[rb(OpRef::float_op(4)), rb(OpRef::const_float(0.5))],
     );
     mul_op.pos.set(OpRef::float_op(5));
 
     let add_op = Op::new(
         OpCode::FloatAdd,
-        &[
-            BoxRef::from_opref(OpRef::input_arg_float(0)),
-            BoxRef::from_opref(OpRef::float_op(5)),
-        ],
+        &[rb(OpRef::input_arg_float(0)), rb(OpRef::float_op(5))],
     );
     add_op.pos.set(OpRef::float_op(6));
 
     let inc_op = Op::new(
         OpCode::IntAdd,
-        &[
-            BoxRef::from_opref(OpRef::input_arg_int(1)),
-            BoxRef::from_opref(OpRef::const_int(1)),
-        ],
+        &[rb(OpRef::input_arg_int(1)), rb(OpRef::const_int(1))],
     );
     inc_op.pos.set(OpRef::int_op(7));
 
     let jump_op = Op::new(
         OpCode::Jump,
-        &[
-            BoxRef::from_opref(OpRef::float_op(6)),
-            BoxRef::from_opref(OpRef::int_op(7)),
-        ],
+        &[rb(OpRef::float_op(6)), rb(OpRef::int_op(7))],
     );
     jump_op.pos.set(OpRef::void_op(8));
     jump_op.setdescr(loop_descr);
@@ -480,26 +457,17 @@ fn test_gc_typeinfo_guards_use_dynasm_emit() {
     let inputargs = vec![InputArg::from_type(Type::Ref, 0)];
     let i0 = inputargs[0].opref();
 
-    let guard_gc_type = Op::new(
-        OpCode::GuardGcType,
-        &[BoxRef::from_opref(i0), BoxRef::from_opref(const_child_tid)],
-    );
+    let guard_gc_type = Op::new(OpCode::GuardGcType, &[rb(i0), rb(const_child_tid)]);
     guard_gc_type.pos.set(OpRef::void_op(1));
     guard_gc_type.set_fail_arg_types(vec![]);
     guard_gc_type.setfailargs(vec![].into());
 
-    let guard_is_object = Op::new(OpCode::GuardIsObject, &[BoxRef::from_opref(i0)]);
+    let guard_is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
     guard_is_object.pos.set(OpRef::void_op(2));
     guard_is_object.set_fail_arg_types(vec![]);
     guard_is_object.setfailargs(vec![].into());
 
-    let guard_subclass = Op::new(
-        OpCode::GuardSubclass,
-        &[
-            BoxRef::from_opref(i0),
-            BoxRef::from_opref(const_root_vtable),
-        ],
-    );
+    let guard_subclass = Op::new(OpCode::GuardSubclass, &[rb(i0), rb(const_root_vtable)]);
     guard_subclass.pos.set(OpRef::void_op(3));
     guard_subclass.set_fail_arg_types(vec![]);
     guard_subclass.setfailargs(vec![].into());
@@ -538,13 +506,10 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
 
         let inputargs = vec![InputArg::from_type(Type::Ref, 0)];
         let i0 = inputargs[0].opref();
-        let guard_gc_type = Op::new(
-            OpCode::GuardGcType,
-            &[BoxRef::from_opref(i0), BoxRef::from_opref(const_child_tid)],
-        );
+        let guard_gc_type = Op::new(OpCode::GuardGcType, &[rb(i0), rb(const_child_tid)]);
         guard_gc_type.pos.set(OpRef::void_op(1));
         guard_gc_type.set_fail_arg_types(vec![Type::Ref]);
-        guard_gc_type.setfailargs(vec![BoxRef::from_opref(i0)].into());
+        guard_gc_type.setfailargs(vec![rb(i0)].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -576,10 +541,10 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
 
         let inputargs = vec![InputArg::from_type(Type::Ref, 0)];
         let i0 = inputargs[0].opref();
-        let guard_is_object = Op::new(OpCode::GuardIsObject, &[BoxRef::from_opref(i0)]);
+        let guard_is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         guard_is_object.pos.set(OpRef::void_op(1));
         guard_is_object.set_fail_arg_types(vec![Type::Ref]);
-        guard_is_object.setfailargs(vec![BoxRef::from_opref(i0)].into());
+        guard_is_object.setfailargs(vec![rb(i0)].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -618,16 +583,10 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
 
         let inputargs = vec![InputArg::from_type(Type::Ref, 0)];
         let i0 = inputargs[0].opref();
-        let guard_subclass = Op::new(
-            OpCode::GuardSubclass,
-            &[
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(const_root_a_vtable),
-            ],
-        );
+        let guard_subclass = Op::new(OpCode::GuardSubclass, &[rb(i0), rb(const_root_a_vtable)]);
         guard_subclass.pos.set(OpRef::void_op(1));
         guard_subclass.set_fail_arg_types(vec![Type::Ref]);
-        guard_subclass.setfailargs(vec![BoxRef::from_opref(i0)].into());
+        guard_subclass.setfailargs(vec![rb(i0)].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -662,18 +621,15 @@ fn test_exception_guards_use_dynasm_emit() {
 
     let inputargs = vec![];
 
-    let guard_exception = Op::new(
-        OpCode::GuardException,
-        &[BoxRef::from_opref(const_expected_class)],
-    );
+    let guard_exception = Op::new(OpCode::GuardException, &[rb(const_expected_class)]);
     guard_exception.pos.set(OpRef::ref_op(0));
     guard_exception.set_fail_arg_types(vec![]);
     guard_exception.setfailargs(vec![].into());
 
-    let finish_op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::ref_op(0))]);
+    let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::ref_op(0))]);
     finish_op.pos.set(OpRef::void_op(1));
     finish_op.set_fail_arg_types(vec![Type::Ref]);
-    finish_op.setfailargs(vec![BoxRef::from_opref(OpRef::ref_op(0))].into());
+    finish_op.setfailargs(vec![rb(OpRef::ref_op(0))].into());
 
     let ops = vec![guard_exception, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -343,7 +343,13 @@ fn test_float_loop_carried_across_jump() {
     let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Float, Type::Int]);
-    guard_op.setfailargs(vec![rb(OpRef::input_arg_float(0)).to_boxref(), rb(OpRef::input_arg_int(1)).to_boxref()].into());
+    guard_op.setfailargs(
+        vec![
+            rb(OpRef::input_arg_float(0)).to_boxref(),
+            rb(OpRef::input_arg_int(1)).to_boxref(),
+        ]
+        .into(),
+    );
 
     let cast_op = Op::new(OpCode::CastIntToFloat, &[rb(OpRef::input_arg_int(1))]);
     cast_op.pos.set(OpRef::float_op(4));

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -11,7 +11,6 @@ use std::rc::Rc;
 use std::sync::{LazyLock, Mutex};
 
 use majit_backend::{Backend, JitCellToken};
-use majit_ir::box_ref::BoxRef;
 use majit_ir::{
     GcRef, InputArg, Op, OpCode, OpRef, Type, Value, make_array_descr, make_loop_target_descr,
 };
@@ -20,7 +19,7 @@ use majit_backend_dynasm::runner::DynasmBackend;
 
 static EXCEPTION_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-use majit_ir::box_ref::bound_box_from_opref as rb;
+use majit_ir::box_ref::bound_operand_from_opref as rb;
 
 #[test]
 fn test_just_finish() {
@@ -67,7 +66,7 @@ fn test_simple_int_add() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![Type::Int]);
-    finish_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
+    finish_op.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -105,7 +104,7 @@ fn test_finish_infers_int_type_when_explicit_types_are_empty() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![]);
-    finish_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
+    finish_op.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -138,7 +137,7 @@ fn test_float_add() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![rb(OpRef::float_op(1))].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(1)).to_boxref()].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -192,7 +191,7 @@ fn test_setarrayitem_raw_float_roundtrip() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(3))]);
     finish_op.pos.set(OpRef::void_op(4));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![rb(OpRef::float_op(3))].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(3)).to_boxref()].into());
 
     let ops = vec![set_op, get_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -237,7 +236,7 @@ fn test_setarrayitem_raw_float_roundtrip_with_variable_index() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(4))]);
     finish_op.pos.set(OpRef::void_op(5));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![rb(OpRef::float_op(4))].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(4)).to_boxref()].into());
 
     let ops = vec![set_op, get_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -292,7 +291,7 @@ fn test_guard_and_loop() {
     let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Int]);
-    guard_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
+    guard_op.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
 
     let jump_op = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
     jump_op.pos.set(OpRef::void_op(4));
@@ -344,7 +343,7 @@ fn test_float_loop_carried_across_jump() {
     let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Float, Type::Int]);
-    guard_op.setfailargs(vec![rb(OpRef::input_arg_float(0)), rb(OpRef::input_arg_int(1))].into());
+    guard_op.setfailargs(vec![rb(OpRef::input_arg_float(0)).to_boxref(), rb(OpRef::input_arg_int(1)).to_boxref()].into());
 
     let cast_op = Op::new(OpCode::CastIntToFloat, &[rb(OpRef::input_arg_int(1))]);
     cast_op.pos.set(OpRef::float_op(4));
@@ -472,7 +471,7 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
         let guard_gc_type = Op::new(OpCode::GuardGcType, &[rb(i0), rb(const_child_tid)]);
         guard_gc_type.pos.set(OpRef::void_op(1));
         guard_gc_type.set_fail_arg_types(vec![Type::Ref]);
-        guard_gc_type.setfailargs(vec![rb(i0)].into());
+        guard_gc_type.setfailargs(vec![rb(i0).to_boxref()].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -507,7 +506,7 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
         let guard_is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         guard_is_object.pos.set(OpRef::void_op(1));
         guard_is_object.set_fail_arg_types(vec![Type::Ref]);
-        guard_is_object.setfailargs(vec![rb(i0)].into());
+        guard_is_object.setfailargs(vec![rb(i0).to_boxref()].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -549,7 +548,7 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
         let guard_subclass = Op::new(OpCode::GuardSubclass, &[rb(i0), rb(const_root_a_vtable)]);
         guard_subclass.pos.set(OpRef::void_op(1));
         guard_subclass.set_fail_arg_types(vec![Type::Ref]);
-        guard_subclass.setfailargs(vec![rb(i0)].into());
+        guard_subclass.setfailargs(vec![rb(i0).to_boxref()].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -592,7 +591,7 @@ fn test_exception_guards_use_dynasm_emit() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::ref_op(0))]);
     finish_op.pos.set(OpRef::void_op(1));
     finish_op.set_fail_arg_types(vec![Type::Ref]);
-    finish_op.setfailargs(vec![rb(OpRef::ref_op(0))].into());
+    finish_op.setfailargs(vec![rb(OpRef::ref_op(0)).to_boxref()].into());
 
     let ops = vec![guard_exception, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -20,44 +20,7 @@ use majit_backend_dynasm::runner::DynasmBackend;
 
 static EXCEPTION_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
-/// Test-only operand-source for op args / failargs: bind `a` to a
-/// synthetic producer carrying the same position so the box sheds to
-/// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-/// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-/// The synthetic producer is intentionally leaked (`mem::forget`) so the
-/// box's `Weak` upgrades for the life of the test process (fixtures hold no
-/// producer graph); `to_opref()` is unchanged, so position-based
-/// assertions are identical.
-fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-    use majit_ir::box_ref::BoxRef;
-    use majit_ir::resoperation::{Op, OpCode};
-    use majit_ir::{OpRef, Type};
-    if a.is_none() || a.is_constant() {
-        return BoxRef::from_opref(a);
-    }
-    let ty = a.ty().unwrap_or(Type::Void);
-    match a {
-        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-            let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-            let b = BoxRef::from_bound_inputarg(&ia);
-            std::mem::forget(ia);
-            b
-        }
-        _ => {
-            let opcode = match ty {
-                Type::Int => OpCode::SameAsI,
-                Type::Float => OpCode::SameAsF,
-                Type::Ref => OpCode::SameAsR,
-                Type::Void => OpCode::Jump,
-            };
-            let p = std::rc::Rc::new(Op::new(opcode, &[]));
-            p.pos.set(a);
-            let b = BoxRef::from_bound_op(&p);
-            std::mem::forget(p);
-            b
-        }
-    }
-}
+use majit_ir::box_ref::bound_box_from_opref as rb;
 
 #[test]
 fn test_just_finish() {

--- a/majit/majit-backend-wasm/Cargo.toml
+++ b/majit/majit-backend-wasm/Cargo.toml
@@ -30,5 +30,6 @@ wasm-encoder = { workspace = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
+majit-ir = { workspace = true, features = ["test-support"] }
 wasmparser = { workspace = true }
 smallvec = { workspace = true }

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -19,44 +19,7 @@ fn make_op(opcode: OpCode, args: &[OpRef], pos: OpRef) -> Op {
     op
 }
 
-/// Test-only operand-source for op args / failargs: bind `a` to a
-/// synthetic producer carrying the same position so the box sheds to
-/// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-/// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-/// The synthetic producer is intentionally leaked (`mem::forget`) so the
-/// box's `Weak` upgrades for the life of the test process (fixtures hold no
-/// producer graph); `to_opref()` is unchanged, so position-based
-/// assertions are identical.
-fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-    use majit_ir::box_ref::BoxRef;
-    use majit_ir::resoperation::{Op, OpCode};
-    use majit_ir::{OpRef, Type};
-    if a.is_none() || a.is_constant() {
-        return BoxRef::from_opref(a);
-    }
-    let ty = a.ty().unwrap_or(Type::Void);
-    match a {
-        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-            let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-            let b = BoxRef::from_bound_inputarg(&ia);
-            std::mem::forget(ia);
-            b
-        }
-        _ => {
-            let opcode = match ty {
-                Type::Int => OpCode::SameAsI,
-                Type::Float => OpCode::SameAsF,
-                Type::Ref => OpCode::SameAsR,
-                Type::Void => OpCode::Jump,
-            };
-            let p = std::rc::Rc::new(Op::new(opcode, &[]));
-            p.pos.set(a);
-            let b = BoxRef::from_bound_op(&p);
-            std::mem::forget(p);
-            b
-        }
-    }
-}
+use majit_ir::box_ref::bound_box_from_opref as rb;
 
 fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
     let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -13,19 +13,58 @@ fn validate_wasm(bytes: &[u8]) {
 }
 
 fn make_op(opcode: OpCode, args: &[OpRef], pos: OpRef) -> Op {
-    let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+    let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
     let mut op = Op::new(opcode, &bx);
     op.pos.set(pos);
     op
 }
 
+/// Test-only operand-source for op args / failargs: bind `a` to a
+/// synthetic producer carrying the same position so the box sheds to
+/// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+/// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+/// The synthetic producer is intentionally leaked (`mem::forget`) so the
+/// box's `Weak` upgrades for the life of the test process (fixtures hold no
+/// producer graph); `to_opref()` is unchanged, so position-based
+/// assertions are identical.
+fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+    use majit_ir::box_ref::BoxRef;
+    use majit_ir::resoperation::{Op, OpCode};
+    use majit_ir::{OpRef, Type};
+    if a.is_none() || a.is_constant() {
+        return BoxRef::from_opref(a);
+    }
+    let ty = a.ty().unwrap_or(Type::Void);
+    match a {
+        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+            let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+            let b = BoxRef::from_bound_inputarg(&ia);
+            std::mem::forget(ia);
+            b
+        }
+        _ => {
+            let opcode = match ty {
+                Type::Int => OpCode::SameAsI,
+                Type::Float => OpCode::SameAsF,
+                Type::Ref => OpCode::SameAsR,
+                Type::Void => OpCode::Jump,
+            };
+            let p = std::rc::Rc::new(Op::new(opcode, &[]));
+            p.pos.set(a);
+            let b = BoxRef::from_bound_op(&p);
+            std::mem::forget(p);
+            b
+        }
+    }
+}
+
 fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
-    let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+    let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
     let mut op = Op::new(opcode, &bx);
-    op.setfailargs(smallvec![BoxRef::from_opref(fail_args[0]); 0]);
+    op.setfailargs(smallvec![rb(fail_args[0]); 0]);
     let mut fa: smallvec::SmallVec<[BoxRef; 3]> = smallvec::SmallVec::new();
     for &a in fail_args {
-        fa.push(BoxRef::from_opref(a));
+        fa.push(rb(a));
     }
     op.setfailargs(fa);
     op
@@ -35,11 +74,8 @@ fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
 fn test_empty_trace() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let ops = vec![{
-        let mut op = Op::new(
-            OpCode::Finish,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        );
-        op.setfailargs(smallvec![BoxRef::from_opref(OpRef::input_arg_int(0))]);
+        let mut op = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
+        op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
         op
     }];
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
@@ -75,10 +111,7 @@ fn test_int_add_loop() {
     let ops = vec![
         Op::new(
             OpCode::Label,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_int(1))],
         ),
         make_op(
             OpCode::IntAdd,
@@ -100,13 +133,7 @@ fn test_int_add_loop() {
             &[OpRef::int_op(4)],
             &[OpRef::int_op(3), OpRef::int_op(2)],
         ),
-        Op::new(
-            OpCode::Jump,
-            &[
-                BoxRef::from_opref(OpRef::int_op(3)),
-                BoxRef::from_opref(OpRef::int_op(2)),
-            ],
-        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(3)), rb(OpRef::int_op(2))]),
     ];
 
     let (bytes, guards) = codegen::build_wasm_module(
@@ -161,8 +188,8 @@ fn test_float_ops() {
             OpRef::int_op(8),
         ),
         {
-            let mut op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::float_op(7))]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::float_op(7))]);
+            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(7))]);
+            op.setfailargs(smallvec![rb(OpRef::float_op(7))]);
             op
         },
     ];
@@ -197,8 +224,8 @@ fn test_call_generates_import() {
             OpRef::int_op(1),
         ),
         {
-            let mut op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(1))]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::int_op(1))]);
+            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(1))]);
             op
         },
     ];
@@ -244,10 +271,7 @@ fn test_guard_types() {
     let ops = vec![
         Op::new(
             OpCode::Label,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_int(1))],
         ),
         // GuardTrue
         make_guard(
@@ -282,21 +306,18 @@ fn test_guard_types() {
         // GuardNoOverflow (0 args)
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         // GuardNotInvalidated (0 args, always pass)
         {
             let mut op = Op::new(OpCode::GuardNotInvalidated, &[]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         Op::new(
             OpCode::Jump,
-            &[
-                BoxRef::from_opref(OpRef::input_arg_int(0)),
-                BoxRef::from_opref(OpRef::input_arg_int(1)),
-            ],
+            &[rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_int(1))],
         ),
     ];
 
@@ -325,27 +346,21 @@ fn test_exception_guards() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
 
     let ops = vec![
-        Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        ),
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
         // GuardNoException — 0 args, fails when an exception is pending.
         {
             let mut op = Op::new(OpCode::GuardNoException, &[]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         // GuardException(expected_type) — caught value bound to int_op(1).
         {
-            let mut op = Op::new(
-                OpCode::GuardException,
-                &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-            );
+            let mut op = Op::new(OpCode::GuardException, &[rb(OpRef::input_arg_int(0))]);
             op.pos.set(OpRef::int_op(1));
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
-        Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]),
+        Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
@@ -378,16 +393,13 @@ fn test_guard_gc_type_uses_immediate_typeid() {
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
 
     let ops = vec![
-        Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        ),
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
         make_guard(
             OpCode::GuardGcType,
             &[OpRef::input_arg_int(0), OpRef::const_int(0x42)],
             &[OpRef::input_arg_int(0)],
         ),
-        Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]),
+        Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
     ];
 
     let (bytes, guards) = codegen::build_wasm_module(
@@ -440,16 +452,13 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
 
     let ops = vec![
-        Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        ),
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
         make_guard(
             OpCode::GuardIsObject,
             &[OpRef::input_arg_int(0)],
             &[OpRef::input_arg_int(0)],
         ),
-        Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]),
+        Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
@@ -486,16 +495,13 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
 
     let ops = vec![
-        Op::new(
-            OpCode::Label,
-            &[BoxRef::from_opref(OpRef::input_arg_int(0))],
-        ),
+        Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
         make_guard(
             OpCode::GuardSubclass,
             &[OpRef::input_arg_int(0), class_constant],
             &[OpRef::input_arg_int(0)],
         ),
-        Op::new(OpCode::Jump, &[BoxRef::from_opref(OpRef::input_arg_int(0))]),
+        Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
     ];
 
     let mut info = enabled_guard_gc_type_info();
@@ -576,8 +582,8 @@ fn test_sameas_and_conversions() {
             OpRef::int_op(9),
         ),
         {
-            let mut op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(9))]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::int_op(9))]);
+            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(9))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(9))]);
             op
         },
     ];
@@ -612,7 +618,7 @@ fn test_overflow_ops() {
         ),
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::int_op(2))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
             op
         },
         make_op(
@@ -622,12 +628,12 @@ fn test_overflow_ops() {
         ),
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::int_op(3))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(3))]);
             op
         },
         {
-            let mut op = Op::new(OpCode::Finish, &[BoxRef::from_opref(OpRef::int_op(2))]);
-            op.setfailargs(smallvec![BoxRef::from_opref(OpRef::int_op(2))]);
+            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
             op
         },
     ];

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use majit_backend_wasm::codegen;
 use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
 use smallvec::smallvec;
 
@@ -13,21 +14,21 @@ fn validate_wasm(bytes: &[u8]) {
 }
 
 fn make_op(opcode: OpCode, args: &[OpRef], pos: OpRef) -> Op {
-    let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+    let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
     let mut op = Op::new(opcode, &bx);
     op.pos.set(pos);
     op
 }
 
-use majit_ir::box_ref::bound_box_from_opref as rb;
+use majit_ir::box_ref::bound_operand_from_opref as rb;
 
 fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
-    let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+    let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
     let mut op = Op::new(opcode, &bx);
-    op.setfailargs(smallvec![rb(fail_args[0]); 0]);
+    op.setfailargs(smallvec![rb(fail_args[0]).to_boxref(); 0]);
     let mut fa: smallvec::SmallVec<[BoxRef; 3]> = smallvec::SmallVec::new();
     for &a in fail_args {
-        fa.push(rb(a));
+        fa.push(rb(a).to_boxref());
     }
     op.setfailargs(fa);
     op
@@ -38,7 +39,7 @@ fn test_empty_trace() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let ops = vec![{
         let mut op = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
-        op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+        op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
         op
     }];
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
@@ -152,7 +153,7 @@ fn test_float_ops() {
         ),
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(7))]);
-            op.setfailargs(smallvec![rb(OpRef::float_op(7))]);
+            op.setfailargs(smallvec![rb(OpRef::float_op(7)).to_boxref()]);
             op
         },
     ];
@@ -188,7 +189,7 @@ fn test_call_generates_import() {
         ),
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(1))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(1)).to_boxref()]);
             op
         },
     ];
@@ -269,13 +270,13 @@ fn test_guard_types() {
         // GuardNoOverflow (0 args)
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
             op
         },
         // GuardNotInvalidated (0 args, always pass)
         {
             let mut op = Op::new(OpCode::GuardNotInvalidated, &[]);
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
             op
         },
         Op::new(
@@ -313,14 +314,14 @@ fn test_exception_guards() {
         // GuardNoException — 0 args, fails when an exception is pending.
         {
             let mut op = Op::new(OpCode::GuardNoException, &[]);
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
             op
         },
         // GuardException(expected_type) — caught value bound to int_op(1).
         {
             let mut op = Op::new(OpCode::GuardException, &[rb(OpRef::input_arg_int(0))]);
             op.pos.set(OpRef::int_op(1));
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
             op
         },
         Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
@@ -546,7 +547,7 @@ fn test_sameas_and_conversions() {
         ),
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(9))]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(9))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(9)).to_boxref()]);
             op
         },
     ];
@@ -581,7 +582,7 @@ fn test_overflow_ops() {
         ),
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(2)).to_boxref()]);
             op
         },
         make_op(
@@ -591,12 +592,12 @@ fn test_overflow_ops() {
         ),
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(3))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(3)).to_boxref()]);
             op
         },
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(2)).to_boxref()]);
             op
         },
     ];

--- a/majit/majit-gc/Cargo.toml
+++ b/majit/majit-gc/Cargo.toml
@@ -26,3 +26,6 @@ majit-ir = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 # env.py:413-433 get_L2cache_darwin uses sysctl() to size the nursery.
 libc = { workspace = true }
+
+[dev-dependencies]
+majit-ir = { workspace = true, features = ["test-support"] }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -72,6 +72,26 @@ fn opref_to_box(r: OpRef) -> BoxRef {
     }
 }
 
+fn mk_op(opcode: OpCode, args: &[BoxRef]) -> Op {
+    Op::new(
+        opcode,
+        &args
+            .iter()
+            .map(|b| Operand::from_boxref(b))
+            .collect::<Vec<Operand>>(),
+    )
+}
+fn mk_op_descr(opcode: OpCode, args: &[BoxRef], descr: DescrRef) -> Op {
+    Op::with_descr(
+        opcode,
+        &args
+            .iter()
+            .map(|b| Operand::from_boxref(b))
+            .collect::<Vec<Operand>>(),
+        descr,
+    )
+}
+
 /// Alignment for nursery allocations (8 bytes).
 const NURSERY_ALIGN: usize = 8;
 
@@ -588,7 +608,7 @@ impl RewriteState {
             return load.clone();
         }
         let index_box = BoxRef::new_const(Value::Int(index as i64));
-        let load = self.emit(Op::new(OpCode::LoadFromGcTable, &[index_box]));
+        let load = self.emit(mk_op(OpCode::LoadFromGcTable, &[index_box]));
         self.gcrefs_recently_loaded.insert(index, load.clone());
         load
     }
@@ -614,7 +634,7 @@ impl RewriteState {
             if let Some(Value::Ref(gcref)) = op.arg(i).const_value() {
                 if !gcref.is_null() {
                     let load = self.remove_constptr(gcref);
-                    op.setarg(i, load);
+                    op.setarg(i, Operand::from_boxref(&load));
                 }
             }
         }
@@ -693,8 +713,8 @@ impl RewriteState {
     /// `is_subtraction` distinguishes INT_SUB (negate the constant
     /// before storing) from INT_ADD.  Mirrors rewrite.py:1015.
     fn record_int_add_or_sub(&mut self, op: &Op, is_subtraction: bool) {
-        let v_arg0 = op.arg(0);
-        let v_arg1 = op.arg(1);
+        let v_arg0 = op.arg(0).to_boxref();
+        let v_arg1 = op.arg(1).to_boxref();
         let (box_arg, mut constant) = if let Some(c) = self.resolve_constant(&v_arg1) {
             let signed = if is_subtraction { -c } else { c };
             (v_arg0, signed)
@@ -786,7 +806,7 @@ impl RewriteState {
         // optimizer.py:651-652 force_box loop parity:
         //   for i in range(op.numargs()): op.setarg(i, ...)
         for i in 0..rewritten.num_args() {
-            rewritten.setarg(i, self.resolve(rewritten.arg(i)));
+            rewritten.setarg(i, Operand::from_boxref(&self.resolve(rewritten.arg(i).to_boxref())));
         }
         if let Some(fail_args) = rewritten.fail_args_mut() {
             for arg in fail_args.iter_mut() {
@@ -897,10 +917,10 @@ impl RewriteState {
 
             let op = &self.out[pz.out_index];
             // resoperation.py:290 AbstractResOp.setarg parity.
-            op.setarg(1, scaled_start);
-            op.setarg(2, scaled_len);
-            op.setarg(3, one.clone());
-            op.setarg(4, one);
+            op.setarg(1, Operand::from_boxref(&scaled_start));
+            op.setarg(2, Operand::from_boxref(&scaled_len));
+            op.setarg(3, Operand::from_boxref(&one.clone()));
+            op.setarg(4, Operand::from_boxref(&one));
         }
 
         // rewrite.py:760-766 — NULL-pointer writes still pending for
@@ -932,7 +952,7 @@ impl RewriteState {
                 let ofs_ref = self.const_int(ofs);
                 let zero_ref = self.const_int(0);
                 let word_ref = self.const_int(8);
-                let store = Op::new(
+                let store = mk_op(
                     OpCode::GcStore,
                     &[ptr_box.clone(), ofs_ref, zero_ref, word_ref],
                 );
@@ -986,7 +1006,7 @@ impl GcRewriterImpl {
         }
         // rewrite.py:445 `next_op.getarg(0) is not op` — in pyre OpRef
         // carries the same identity role as RPython's box object.
-        if box_to_opref(&next_op.arg(0)) != op.pos.get() {
+        if box_to_opref(&next_op.arg(0).to_boxref()) != op.pos.get() {
             return false;
         }
         self.remove_tested_failarg(next_op, i + 1, st);
@@ -1013,7 +1033,7 @@ impl GcRewriterImpl {
             Some(fa) if !fa.is_empty() => fa,
             _ => return,
         };
-        let target = box_to_opref(&op.arg(0));
+        let target = box_to_opref(&op.arg(0).to_boxref());
         // rewrite.py:456-459: guard's failargs contain the tested box?
         let Some(idx) = fail_args.iter().position(|a| box_to_opref(a) == target) else {
             return;
@@ -1021,7 +1041,7 @@ impl GcRewriterImpl {
         // rewrite.py:463 `value = int(opnum == rop.GUARD_FALSE)`
         let value: i64 = i64::from(op.opcode == OpCode::GuardFalse);
         let const_ref = st.const_int(value);
-        let same = Op::new(OpCode::SameAsI, &[const_ref]);
+        let same = mk_op(OpCode::SameAsI, &[const_ref]);
         let same_pos = st.emit_result(same, OpRef::NONE);
 
         // rewrite.py:466-469 — rewrite failargs + stash the copy-and-changed
@@ -1162,7 +1182,7 @@ impl GcRewriterImpl {
             .expect("handle_new_array descr must be ArrayDescr");
 
         let item_size = descr.item_size();
-        let v_length = st.resolve(op.arg(0)); // the length operand
+        let v_length = st.resolve(op.arg(0).to_boxref()); // the length operand
         let length_const = st.resolve_constant(&v_length);
 
         // rewrite.py:548-558 — total_size for the constant-size /
@@ -1378,7 +1398,7 @@ impl GcRewriterImpl {
         let c_zero = st.const_int(0);
         let c_scale_a = st.const_int(scale);
         let c_scale_b = st.const_int(scale);
-        let zero_op = Op::new(
+        let zero_op = mk_op(
             OpCode::ZeroArray,
             &[v_arr.clone(), c_zero, v_length_scaled, c_scale_a, c_scale_b],
         );
@@ -1439,7 +1459,7 @@ impl GcRewriterImpl {
         st.emitting_an_operation_that_can_collect();
         let kind_ref = st.const_int(kind);
         let itemsize_ref = st.const_int(ad.item_size() as i64);
-        let varsize_op = Op::new(
+        let varsize_op = mk_op(
             OpCode::CallMallocNurseryVarsize,
             &[kind_ref, itemsize_ref, v_length],
         );
@@ -1456,10 +1476,10 @@ impl GcRewriterImpl {
         st: &mut RewriteState,
     ) -> BoxRef {
         st.emitting_an_operation_that_can_collect();
-        let call_op = Op::new(OpCode::CallR, args);
+        let call_op = mk_op(OpCode::CallR, args);
         call_op.setdescr(calldescr);
         let result = st.emit_result(call_op, result_pos);
-        st.emit(Op::new(OpCode::CheckMemoryError, &[result.clone()]));
+        st.emit(mk_op(OpCode::CheckMemoryError, &[result.clone()]));
         result
     }
 
@@ -1670,10 +1690,10 @@ impl GcRewriterImpl {
         }
 
         // rewrite.py:1065-1068 — effective source / destination addresses.
-        let src_gcptr = st.resolve(op.arg(0));
-        let dst_gcptr = st.resolve(op.arg(1));
-        let src_index = st.resolve(op.arg(2));
-        let dst_index = st.resolve(op.arg(3));
+        let src_gcptr = st.resolve(op.arg(0).to_boxref());
+        let dst_gcptr = st.resolve(op.arg(1).to_boxref());
+        let src_index = st.resolve(op.arg(2).to_boxref());
+        let dst_index = st.resolve(op.arg(3).to_boxref());
 
         let i1 = self.emit_load_effective_address(src_gcptr, src_index, basesize, itemscale, st);
         let i2 = self.emit_load_effective_address(dst_gcptr, dst_index, basesize, itemscale, st);
@@ -1683,23 +1703,23 @@ impl GcRewriterImpl {
         //   UNICODE: arg = ConstInt(op.getarg(4).getint() << itemscale)
         //            or INT_LSHIFT(op.getarg(4), ConstInt(itemscale))
         let arg = if op.opcode == OpCode::Copystrcontent {
-            st.resolve(op.arg(4))
+            st.resolve(op.arg(4).to_boxref())
         } else {
-            let v_length = st.resolve(op.arg(4));
+            let v_length = st.resolve(op.arg(4).to_boxref());
             if let Some(c) = st.resolve_constant(&v_length) {
                 // rewrite.py:1073-1074 — constant-fold the shift.
                 st.const_int(c << itemscale)
             } else {
                 // rewrite.py:1075-1078 — emit INT_LSHIFT.
                 let shift_ref = st.const_int(itemscale);
-                let lshift = Op::new(OpCode::IntLshift, &[v_length, shift_ref]);
+                let lshift = mk_op(OpCode::IntLshift, &[v_length, shift_ref]);
                 st.emit_result(lshift, OpRef::NONE)
             }
         };
 
         // rewrite.py:1079-1080 — CALL_N(memcpy_fn, i2, i1, arg, descr=memcpy_descr).
         let memcpy_fn_const = st.const_int(memcpy_fn);
-        let call_op = Op::new(OpCode::CallN, &[memcpy_fn_const, i2, i1, arg]);
+        let call_op = mk_op(OpCode::CallN, &[memcpy_fn_const, i2, i1, arg]);
         call_op.setdescr(memcpy_descr);
         st.emit(call_op);
     }
@@ -1723,7 +1743,7 @@ impl GcRewriterImpl {
             // rewrite.py:1083-1088 — single LEA op.
             let base_ref = st.const_int(base);
             let shift_ref = st.const_int(itemscale);
-            let lea = Op::new(
+            let lea = mk_op(
                 OpCode::LoadEffectiveAddress,
                 &[v_gcptr, v_index, base_ref, shift_ref],
             );
@@ -1736,15 +1756,15 @@ impl GcRewriterImpl {
             //   i1  = INT_ADD(i1b, ConstInt(base))
             let scaled = if itemscale > 0 {
                 let shift_ref = st.const_int(itemscale);
-                let lshift = Op::new(OpCode::IntLshift, &[v_index, shift_ref]);
+                let lshift = mk_op(OpCode::IntLshift, &[v_index, shift_ref]);
                 st.emit_result(lshift, OpRef::NONE)
             } else {
                 v_index
             };
-            let add1 = Op::new(OpCode::IntAdd, &[v_gcptr, scaled]);
+            let add1 = mk_op(OpCode::IntAdd, &[v_gcptr, scaled]);
             let i1b = st.emit_result(add1, OpRef::NONE);
             let base_ref = st.const_int(base);
-            let add2 = Op::new(OpCode::IntAdd, &[i1b, base_ref]);
+            let add2 = mk_op(OpCode::IntAdd, &[i1b, base_ref]);
             st.emit_result(add2, OpRef::NONE)
         }
     }
@@ -1761,7 +1781,7 @@ impl GcRewriterImpl {
     /// the lowered GC_STORE (forwarded by `transform_to_gc_load`) lands
     /// after the WB.
     fn handle_write_barrier_setfield(&self, op: &Op, st: &mut RewriteState) {
-        let obj = st.resolve(op.arg(0));
+        let obj = st.resolve(op.arg(0).to_boxref());
         if st.wb_already_applied(&obj) {
             return;
         }
@@ -1779,7 +1799,7 @@ impl GcRewriterImpl {
             .getdescr()
             .and_then(|d| d.as_field_descr().map(|fd| fd.is_pointer_field()))
             .unwrap_or(false);
-        let val = st.resolve(op.arg(1));
+        let val = st.resolve(op.arg(1).to_boxref());
         let val_is_ref = if field_is_ptr {
             match st.result_type_of(&val) {
                 Some(tp) => tp == Type::Ref,
@@ -1800,7 +1820,7 @@ impl GcRewriterImpl {
 
     /// rewrite.py:948-953 `gen_write_barrier`.
     fn gen_write_barrier(&self, v_base: BoxRef, st: &mut RewriteState) {
-        let wb_op = Op::new(OpCode::CondCallGcWb, &[v_base.clone()]);
+        let wb_op = mk_op(OpCode::CondCallGcWb, &[v_base.clone()]);
         st.emit(wb_op);
         st.remember_wb(&v_base);
     }
@@ -1824,7 +1844,7 @@ impl GcRewriterImpl {
             return;
         };
         let offset = fd.offset() as i64;
-        let base = st.resolve(op.arg(0));
+        let base = st.resolve(op.arg(0).to_boxref());
         if let Some(entries) = st._delayed_zero_setfields.get_mut(&box_to_opref(&base)) {
             entries.remove(&offset);
         }
@@ -1843,8 +1863,8 @@ impl GcRewriterImpl {
     ///     self.remember_setarrayitem_occurred(array_box, index_box.getint())
     /// ```
     fn consider_setarrayitem_gc(&self, op: &Op, st: &mut RewriteState) {
-        let array_ref = st.resolve(op.arg(0));
-        let index_ref = op.arg(1);
+        let array_ref = st.resolve(op.arg(0).to_boxref());
+        let index_ref = op.arg(1).to_boxref();
         if st.resolve_constant(&array_ref).is_some() {
             return;
         }
@@ -1861,10 +1881,10 @@ impl GcRewriterImpl {
     /// and then `self.emit_op(op)` follows the forwarding. We do the
     /// equivalent in the caller by invoking handle_setarrayitem after WB.
     fn handle_write_barrier_setarrayitem(&self, op: &Op, st: &mut RewriteState) {
-        let val = st.resolve(op.arg(0));
+        let val = st.resolve(op.arg(0).to_boxref());
         // rewrite.py:938-942
         if !st.wb_already_applied(&val) {
-            let v = st.resolve(op.arg(2));
+            let v = st.resolve(op.arg(2).to_boxref());
             let val_is_ref = match st.result_type_of(&v) {
                 Some(tp) => tp == Type::Ref,
                 // None only for the OpRef::None / virtual marker (no type
@@ -1876,7 +1896,7 @@ impl GcRewriterImpl {
                     .unwrap_or(false),
             };
             if val_is_ref && !st.is_null_constant(&v) {
-                self.gen_write_barrier_array(val, st.resolve(op.arg(1)), st);
+                self.gen_write_barrier_array(val, st.resolve(op.arg(1).to_boxref()), st);
             }
         }
     }
@@ -1894,9 +1914,9 @@ impl GcRewriterImpl {
             .expect("SETARRAYITEM descr must be ArrayDescr");
         let itemsize = ad.item_size() as i64;
         let basesize = ad.base_size() as i64;
-        let ptr = st.resolve(op.arg(0));
-        let index = st.resolve(op.arg(1));
-        let value = st.resolve(op.arg(2));
+        let ptr = st.resolve(op.arg(0).to_boxref());
+        let index = st.resolve(op.arg(1).to_boxref());
+        let value = st.resolve(op.arg(2).to_boxref());
         self.emit_gc_store_or_indexed(
             Some(op),
             ptr,
@@ -1944,13 +1964,13 @@ impl GcRewriterImpl {
             None => {
                 let offset_ref = st.const_int(offset);
                 let itemsize_ref = st.const_int(itemsize);
-                Op::new(OpCode::GcStore, &[ptr, offset_ref, value, itemsize_ref])
+                mk_op(OpCode::GcStore, &[ptr, offset_ref, value, itemsize_ref])
             }
             Some(idx) => {
                 let factor_ref = st.const_int(factor);
                 let offset_ref = st.const_int(offset);
                 let itemsize_ref = st.const_int(itemsize);
-                Op::new(
+                mk_op(
                     OpCode::GcStoreIndexed,
                     &[ptr, idx, value, factor_ref, offset_ref, itemsize_ref],
                 )
@@ -2021,10 +2041,10 @@ impl GcRewriterImpl {
             let mul_op = if (factor & (factor - 1)) == 0 {
                 let shift = (factor as u64).trailing_zeros() as i64;
                 let shift_ref = st.const_int(shift);
-                Op::new(OpCode::IntLshift, &[index_box.clone(), shift_ref])
+                mk_op(OpCode::IntLshift, &[index_box.clone(), shift_ref])
             } else {
                 let factor_ref = st.const_int(factor);
-                Op::new(OpCode::IntMul, &[index_box.clone(), factor_ref])
+                mk_op(OpCode::IntMul, &[index_box.clone(), factor_ref])
             };
             return (1, offset, ScaledIndex::PreScale(mul_op));
         }
@@ -2044,8 +2064,8 @@ impl GcRewriterImpl {
         let itemsize = ad.item_size() as i64;
         let ofs = ad.base_size() as i64;
         let sign = ad.is_item_signed();
-        let ptr = st.resolve(op.arg(0));
-        let index = st.resolve(op.arg(1));
+        let ptr = st.resolve(op.arg(0).to_boxref());
+        let index = st.resolve(op.arg(1).to_boxref());
         self.emit_gc_load_or_indexed(op, ptr, index, itemsize, itemsize, ofs, sign, st);
     }
 
@@ -2092,13 +2112,13 @@ impl GcRewriterImpl {
             None => {
                 let offset_ref = st.const_int(offset);
                 let itemsize_ref = st.const_int(itemsize_enc);
-                Op::new(get_gc_load(optype), &[ptr, offset_ref, itemsize_ref])
+                mk_op(get_gc_load(optype), &[ptr, offset_ref, itemsize_ref])
             }
             Some(idx) => {
                 let factor_ref = st.const_int(factor);
                 let offset_ref = st.const_int(offset);
                 let itemsize_ref = st.const_int(itemsize_enc);
-                Op::new(
+                mk_op(
                     get_gc_load_indexed(optype),
                     &[ptr, idx, factor_ref, offset_ref, itemsize_ref],
                 )
@@ -2196,9 +2216,9 @@ impl GcRewriterImpl {
                 .expect("RAW_STORE descr must be ArrayDescr");
             let itemsize = ad.item_size() as i64;
             let ofs = ad.base_size() as i64;
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
-            let value = st.resolve(op.arg(2));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
+            let value = st.resolve(op.arg(2).to_boxref());
             self.emit_gc_store_or_indexed(Some(op), ptr, index, value, itemsize, 1, ofs, st);
             return false;
         }
@@ -2211,8 +2231,8 @@ impl GcRewriterImpl {
             let itemsize = ad.item_size() as i64;
             let ofs = ad.base_size() as i64;
             let sign = ad.is_item_signed();
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
             self.emit_gc_load_or_indexed(op, ptr, index, itemsize, 1, ofs, sign, st);
             return false;
         }
@@ -2233,8 +2253,8 @@ impl GcRewriterImpl {
             let itemsize = ad.item_size() as i64;
             let fieldsize = fd.field_size() as i64;
             let sign = fd.is_field_signed();
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
             self.emit_gc_load_or_indexed(op, ptr, index, fieldsize, itemsize, ofs, sign, st);
             return false;
         }
@@ -2254,9 +2274,9 @@ impl GcRewriterImpl {
             let ofs = (ad.base_size() + fd.offset()) as i64;
             let itemsize = ad.item_size() as i64;
             let fieldsize = fd.field_size() as i64;
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
-            let value = st.resolve(op.arg(2));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
+            let value = st.resolve(op.arg(2).to_boxref());
             self.emit_gc_store_or_indexed(
                 Some(op),
                 ptr,
@@ -2293,7 +2313,7 @@ impl GcRewriterImpl {
             let ofs = fd.offset() as i64;
             let itemsize = fd.field_size() as i64;
             let sign = fd.is_field_signed();
-            let ptr = st.resolve(op.arg(0));
+            let ptr = st.resolve(op.arg(0).to_boxref());
             let cint_zero = st.const_int(0);
             let is_gc = matches!(
                 opnum,
@@ -2319,8 +2339,8 @@ impl GcRewriterImpl {
                 .expect("SETFIELD descr must be FieldDescr");
             let ofs = fd.offset() as i64;
             let itemsize = fd.field_size() as i64;
-            let ptr = st.resolve(op.arg(0));
-            let value = st.resolve(op.arg(1));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let value = st.resolve(op.arg(1).to_boxref());
             let cint_zero = st.const_int(0);
             self.emit_gc_store_or_indexed(Some(op), ptr, cint_zero, value, itemsize, 1, ofs, st);
             return false;
@@ -2337,7 +2357,7 @@ impl GcRewriterImpl {
                 .offset() as i64;
             // rewrite.py:272 WORD itemsize, unsigned.
             let word = std::mem::size_of::<usize>() as i64;
-            let ptr = st.resolve(op.arg(0));
+            let ptr = st.resolve(op.arg(0).to_boxref());
             let cint_zero = st.const_int(0);
             self.emit_gc_load_or_indexed(op, ptr, cint_zero, word, 1, ofs, NOT_SIGNED, st);
             return false;
@@ -2358,7 +2378,7 @@ impl GcRewriterImpl {
                 .len_descr()
                 .expect("STR/UNICODE ArrayDescr must carry lendescr");
             let ofs = ld.offset() as i64;
-            let ptr = st.resolve(op.arg(0));
+            let ptr = st.resolve(op.arg(0).to_boxref());
             let cint_zero = st.const_int(0);
             self.emit_gc_load_or_indexed(op, ptr, cint_zero, word, 1, ofs, NOT_SIGNED, st);
             return false;
@@ -2377,7 +2397,7 @@ impl GcRewriterImpl {
                 .expect("STRHASH/UNICODEHASH descr must be a FieldDescr");
             assert_eq!(fd.field_size() as i64, word, "rewrite.py:286/292 assert");
             let ofs = fd.offset() as i64;
-            let ptr = st.resolve(op.arg(0));
+            let ptr = st.resolve(op.arg(0).to_boxref());
             let cint_zero = st.const_int(0);
             self.emit_gc_load_or_indexed(op, ptr, cint_zero, word, 1, ofs, true, st);
             return false;
@@ -2388,8 +2408,8 @@ impl GcRewriterImpl {
         // asserted upstream at rewrite.py:298.
         if matches!(opnum, OpCode::Strgetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ true);
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
             self.emit_gc_load_or_indexed(
                 op, ptr, index, itemsize, itemsize, basesize, NOT_SIGNED, st,
             );
@@ -2399,8 +2419,8 @@ impl GcRewriterImpl {
         // extra_item_after_alloc, so basesize is used as-is.
         if matches!(opnum, OpCode::Unicodegetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ false);
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
             self.emit_gc_load_or_indexed(
                 op, ptr, index, itemsize, itemsize, basesize, NOT_SIGNED, st,
             );
@@ -2409,9 +2429,9 @@ impl GcRewriterImpl {
         // rewrite.py:307-313 STRSETITEM.
         if matches!(opnum, OpCode::Strsetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ true);
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
-            let value = st.resolve(op.arg(2));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
+            let value = st.resolve(op.arg(2).to_boxref());
             self.emit_gc_store_or_indexed(
                 Some(op),
                 ptr,
@@ -2427,9 +2447,9 @@ impl GcRewriterImpl {
         // rewrite.py:314-318 UNICODESETITEM.
         if matches!(opnum, OpCode::Unicodesetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ false);
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
-            let value = st.resolve(op.arg(2));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
+            let value = st.resolve(op.arg(2).to_boxref());
             self.emit_gc_store_or_indexed(
                 Some(op),
                 ptr,
@@ -2448,32 +2468,32 @@ impl GcRewriterImpl {
             OpCode::GcLoadIndexedI | OpCode::GcLoadIndexedR | OpCode::GcLoadIndexedF
         ) {
             let scale = st
-                .resolve_constant(&op.arg(2))
+                .resolve_constant(&op.arg(2).to_boxref())
                 .expect("GC_LOAD_INDEXED scale must be ConstInt");
             let offset = st
-                .resolve_constant(&op.arg(3))
+                .resolve_constant(&op.arg(3).to_boxref())
                 .expect("GC_LOAD_INDEXED offset must be ConstInt");
             let size = st
-                .resolve_constant(&op.arg(4))
+                .resolve_constant(&op.arg(4).to_boxref())
                 .expect("GC_LOAD_INDEXED size must be ConstInt");
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
             self.emit_gc_load_or_indexed(op, ptr, index, size.abs(), scale, offset, size < 0, st);
             return false;
         }
         if matches!(opnum, OpCode::GcStoreIndexed) {
             let scale = st
-                .resolve_constant(&op.arg(3))
+                .resolve_constant(&op.arg(3).to_boxref())
                 .expect("GC_STORE_INDEXED scale must be ConstInt");
             let offset = st
-                .resolve_constant(&op.arg(4))
+                .resolve_constant(&op.arg(4).to_boxref())
                 .expect("GC_STORE_INDEXED offset must be ConstInt");
             let size = st
-                .resolve_constant(&op.arg(5))
+                .resolve_constant(&op.arg(5).to_boxref())
                 .expect("GC_STORE_INDEXED size must be ConstInt");
-            let ptr = st.resolve(op.arg(0));
-            let index = st.resolve(op.arg(1));
-            let value = st.resolve(op.arg(2));
+            let ptr = st.resolve(op.arg(0).to_boxref());
+            let index = st.resolve(op.arg(1).to_boxref());
+            let value = st.resolve(op.arg(2).to_boxref());
             // rewrite.py:338: use abs(size) for safety even though store
             // size is expected to be positive.
             self.emit_gc_store_or_indexed(
@@ -2505,7 +2525,7 @@ impl GcRewriterImpl {
             let length = st.known_length(&v_base, LARGE);
             if length >= LARGE {
                 // Unknown or too big: produce COND_CALL_GC_WB_ARRAY.
-                let wb_op = Op::new(OpCode::CondCallGcWbArray, &[v_base, v_index]);
+                let wb_op = mk_op(OpCode::CondCallGcWbArray, &[v_base, v_index]);
                 st.emit(wb_op);
                 // rewrite.py:970: a WB_ARRAY is not enough to prevent
                 // any future write barriers, so don't remember_wb!
@@ -2513,7 +2533,7 @@ impl GcRewriterImpl {
             }
         }
         // Fall-back: produce a regular write_barrier.
-        let wb_op = Op::new(OpCode::CondCallGcWb, &[v_base.clone()]);
+        let wb_op = mk_op(OpCode::CondCallGcWb, &[v_base.clone()]);
         st.emit(wb_op);
         st.remember_wb(&v_base);
     }
@@ -2552,12 +2572,12 @@ impl GcRewriterImpl {
             let new_total = st.pending_malloc_total + size;
             if self.can_use_nursery(new_total) {
                 let new_total_ref = st.const_int(new_total as i64);
-                st.out[prev_idx].setarg(0, new_total_ref);
+                st.out[prev_idx].setarg(0, Operand::from_boxref(&new_total_ref));
                 st.pending_malloc_total = new_total;
 
                 // rewrite.py:896: NURSERY_PTR_INCREMENT(last, ConstInt(previous_size))
                 let prev_size_ref = st.const_int(st.previous_size as i64);
-                let incr_op = Op::new(
+                let incr_op = mk_op(
                     OpCode::NurseryPtrIncrement,
                     &[st.last_malloced_ref.clone(), prev_size_ref],
                 );
@@ -2572,7 +2592,7 @@ impl GcRewriterImpl {
         // rewrite.py:903: CALL_MALLOC_NURSERY(ConstInt(size))
         st.emitting_an_operation_that_can_collect();
         let size_ref = st.const_int(size as i64);
-        let op = Op::new(OpCode::CallMallocNursery, &[size_ref]);
+        let op = mk_op(OpCode::CallMallocNursery, &[size_ref]);
         let r = st.emit_result(op, result_pos);
         st.pending_malloc_idx = Some(st.out.len() - 1);
         st.pending_malloc_total = size;
@@ -2626,7 +2646,7 @@ impl GcRewriterImpl {
         let ofs = st.const_int(-(crate::header::GcHeader::SIZE as i64) + tid_fd.offset() as i64);
         let tid_val = st.const_int(tid as i64);
         let size = st.const_int(tid_fd.field_size() as i64);
-        let store = Op::new(OpCode::GcStore, &[obj, ofs, tid_val, size]);
+        let store = mk_op(OpCode::GcStore, &[obj, ofs, tid_val, size]);
         st.emit(store);
     }
 
@@ -2722,13 +2742,13 @@ impl GcRewriterImpl {
         // sign_size) where (ofs, sign_size, sign) = unpack_fielddescr(
         // descrs.jfi_frame_size).
         let jfi_frame_size_ofs = st.const_int(std::mem::size_of::<isize>() as i64);
-        let size = st.emit(Op::new(
+        let size = st.emit(mk_op(
             OpCode::GcLoadI,
             &[llfi.clone(), jfi_frame_size_ofs, signed_size.clone()],
         ));
         // rewrite.py:634 — gen_malloc_nursery_varsize_frame(size)
         st.emitting_an_operation_that_can_collect();
-        let malloc_op = Op::new(OpCode::CallMallocNurseryVarsizeFrame, &[size]);
+        let malloc_op = mk_op(OpCode::CallMallocNurseryVarsizeFrame, &[size]);
         let frame = st.emit_result(malloc_op, OpRef::NONE);
         st.remember_wb(&frame);
 
@@ -2759,7 +2779,7 @@ impl GcRewriterImpl {
         // Both read/write lltype.Signed values (jfi_frame_depth and the
         // jf_frame length field).
         let jfi_frame_depth_ofs = st.const_int(0);
-        let length = st.emit(Op::new(
+        let length = st.emit(mk_op(
             OpCode::GcLoadI,
             &[llfi.clone(), jfi_frame_depth_ofs, signed_size],
         ));
@@ -2804,7 +2824,7 @@ impl GcRewriterImpl {
             //                      offset = basesize + array_offset.
             let offset = descrs.jf_frame_baseitemofs as i32 + index_list[i];
             let ofs_ref = st.const_int(offset as i64);
-            st.emit(Op::new(
+            st.emit(mk_op(
                 OpCode::GcStore,
                 &[frame.clone(), ofs_ref, arg.clone(), itemsize_ref],
             ));
@@ -2818,7 +2838,7 @@ impl GcRewriterImpl {
         } else {
             vec![frame]
         };
-        let call_asm = Op::new(op.opcode, &new_args);
+        let call_asm = mk_op(op.opcode, &new_args);
         if let Some(d) = op.getdescr() {
             call_asm.setdescr(d);
         }
@@ -3018,10 +3038,16 @@ impl GcRewriter for GcRewriterImpl {
                 OpCode::GuardAlwaysFails => {
                     let zero = st.const_int(0);
                     let one = st.const_int(1);
-                    let same = Op::new(OpCode::SameAsI, &[zero]);
+                    let same = mk_op(OpCode::SameAsI, &[zero]);
                     let same_pos = st.emit_result(same, OpRef::NONE);
-                    let newop =
-                        op.copy_and_change(OpCode::GuardValue, Some(&[same_pos, one]), None);
+                    let newop = op.copy_and_change(
+                        OpCode::GuardValue,
+                        Some(&[
+                            Operand::from_boxref(&same_pos),
+                            Operand::from_boxref(&one),
+                        ]),
+                        None,
+                    );
                     let rewritten = st.rewrite_op(&newop);
                     st.emit(rewritten);
                 }
@@ -3047,7 +3073,7 @@ impl GcRewriter for GcRewriterImpl {
                 // ── Everything else: pass through unchanged. ──
                 OpCode::CondCallGcWb => {
                     let rewritten = st.rewrite_op(op);
-                    let obj = rewritten.arg(0);
+                    let obj = rewritten.arg(0).to_boxref();
                     st.emit(rewritten);
                     st.remember_wb(&obj);
                 }
@@ -3300,16 +3326,17 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let args: Vec<Operand> = args.iter().map(|a| ro(*a)).collect();
         let op = Op::new(opcode, &args);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
     }
 
     use majit_ir::box_ref::bound_box_from_opref as rb;
+    use majit_ir::box_ref::bound_operand_from_opref as ro;
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let args: Vec<Operand> = args.iter().map(|a| ro(*a)).collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
@@ -3450,7 +3477,7 @@ mod tests {
         let length_ref = OpRef::int_op(100); // some prior op producing the length
         let ops = vec![Op::with_descr(
             OpCode::NewArray,
-            &[rb(length_ref)],
+            &[ro(length_ref)],
             array_descr_int(),
         )];
 
@@ -3484,7 +3511,7 @@ mod tests {
         //   round_up(GcHeader::SIZE + 4104) = 4112 > 4096 → returns None.
         let mut constants: VecAssoc<u32, Const> = VecAssoc::new();
         constants.insert(10_000, Const::Int(512));
-        let new_array = Op::with_descr(OpCode::NewArray, &[rb(len_ref)], array_descr_ref());
+        let new_array = Op::with_descr(OpCode::NewArray, &[ro(len_ref)], array_descr_ref());
         new_array.pos.set(OpRef::ref_op(0));
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
 
@@ -3544,7 +3571,7 @@ mod tests {
         let val = OpRef::ref_op(1);
         let ops = vec![Op::with_descr(
             OpCode::SetfieldGc,
-            &[rb(obj), rb(val)],
+            &[ro(obj), ro(val)],
             ref_field_descr(),
         )];
 
@@ -3570,7 +3597,7 @@ mod tests {
         let obj = OpRef::ref_op(0);
         let ops = vec![Op::with_descr(
             OpCode::GetfieldGcPureR,
-            &[rb(obj)],
+            &[ro(obj)],
             ref_field_descr(),
         )];
 
@@ -3601,7 +3628,7 @@ mod tests {
         let idx = OpRef::int_op(1);
         let ops = vec![Op::with_descr(
             OpCode::GetarrayitemRawR,
-            &[rb(obj), rb(idx)],
+            &[ro(obj), ro(idx)],
             array_descr_ref(),
         )];
 
@@ -3626,7 +3653,7 @@ mod tests {
         let val = OpRef::ref_op(1);
         let ops = vec![Op::with_descr(
             OpCode::SetfieldGc,
-            &[rb(obj), rb(val)],
+            &[ro(obj), ro(val)],
             int_field_descr(),
         )];
 
@@ -3738,7 +3765,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], descr),
             Op::with_descr(
                 OpCode::SetfieldGc,
-                &[rb(OpRef::ref_op(0)), rb(val)],
+                &[ro(OpRef::ref_op(0)), ro(val)],
                 ref_field_descr_ref_at(24),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -3772,9 +3799,9 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))],
+                &[ro(OpRef::int_op(0)), ro(OpRef::int_op(1))],
             ),
-            Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]),
+            Op::new(OpCode::GuardTrue, &[ro(OpRef::int_op(2))]),
             Op::new(OpCode::Jump, &[]),
         ];
 
@@ -3865,7 +3892,7 @@ mod tests {
         let rw = make_rewriter();
         let ops = vec![
             Op::with_descr(OpCode::New, &[], size_descr(24, 1)),
-            Op::new(OpCode::CallN, &[rb(OpRef::ref_op(99))]),
+            Op::new(OpCode::CallN, &[ro(OpRef::ref_op(99))]),
             Op::with_descr(OpCode::New, &[], size_descr(24, 2)),
         ];
 
@@ -3889,8 +3916,8 @@ mod tests {
         let val1 = OpRef::ref_op(1);
         let val2 = OpRef::ref_op(2);
         let ops = vec![
-            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val1)], ref_field_descr()),
-            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val2)], ref_field_descr()),
+            Op::with_descr(OpCode::SetfieldGc, &[ro(obj), ro(val1)], ref_field_descr()),
+            Op::with_descr(OpCode::SetfieldGc, &[ro(obj), ro(val2)], ref_field_descr()),
         ];
 
         let result = rw.rewrite_for_gc(&ops);
@@ -3928,7 +3955,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(32, 1)),
             Op::with_descr(
                 OpCode::SetfieldGc,
-                &[rb(OpRef::ref_op(0)), rb(OpRef::ref_op(99))], // arg(0) = pos of the alloc = 0
+                &[ro(OpRef::ref_op(0)), ro(OpRef::ref_op(99))], // arg(0) = pos of the alloc = 0
                 ref_field_descr(),
             ),
         ];
@@ -4005,7 +4032,7 @@ mod tests {
         let val = OpRef::ref_op(2);
         let ops = vec![Op::with_descr(
             OpCode::SetarrayitemGc,
-            &[rb(obj), rb(idx), rb(val)],
+            &[ro(obj), ro(idx), ro(val)],
             array_descr_ref(),
         )];
 
@@ -4026,10 +4053,10 @@ mod tests {
         let obj = OpRef::ref_op(0);
         let val = OpRef::ref_op(1);
         let ops = vec![
-            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val)], ref_field_descr()),
+            Op::with_descr(OpCode::SetfieldGc, &[ro(obj), ro(val)], ref_field_descr()),
             // This call can collect, clearing the WB set.
-            Op::new(OpCode::CallN, &[rb(OpRef::ref_op(99))]),
-            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val)], ref_field_descr()),
+            Op::new(OpCode::CallN, &[ro(OpRef::ref_op(99))]),
+            Op::with_descr(OpCode::SetfieldGc, &[ro(obj), ro(val)], ref_field_descr()),
         ];
 
         let result = rw.rewrite_for_gc(&ops);
@@ -4140,9 +4167,9 @@ mod tests {
         // rewrite the guard's failargs to reference the SAME_AS_I output.
         let rw = make_rewriter();
 
-        let int_lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
+        let int_lt = Op::new(OpCode::IntLt, &[ro(OpRef::int_op(0)), ro(OpRef::int_op(1))]);
         int_lt.pos.set(OpRef::int_op(2));
-        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardTrue, &[ro(OpRef::int_op(2))]);
         guard.store_final_boxes(vec![
             rb(OpRef::int_op(0)),
             rb(OpRef::int_op(2)),
@@ -4188,9 +4215,9 @@ mod tests {
     fn test_comparison_guard_false_hoists_with_one_constant() {
         // GUARD_FALSE: rewrite.py:463 `value = int(opnum == GUARD_FALSE)` ⇒ 1.
         let rw = make_rewriter();
-        let int_eq = Op::new(OpCode::IntEq, &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
+        let int_eq = Op::new(OpCode::IntEq, &[ro(OpRef::int_op(0)), ro(OpRef::int_op(1))]);
         int_eq.pos.set(OpRef::int_op(2));
-        let guard = Op::new(OpCode::GuardFalse, &[rb(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardFalse, &[ro(OpRef::int_op(2))]);
         guard.store_final_boxes(vec![rb(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
@@ -4264,10 +4291,10 @@ mod tests {
         // Guard that does NOT test the previous op's result: merge does
         // not fire, no SAME_AS_I is emitted.
         let rw = make_rewriter();
-        let int_lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
+        let int_lt = Op::new(OpCode::IntLt, &[ro(OpRef::int_op(0)), ro(OpRef::int_op(1))]);
         int_lt.pos.set(OpRef::int_op(2));
         // GuardTrue reads some unrelated OpRef::ref_op(5), not OpRef::ref_op(2).
-        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(5))]);
+        let guard = Op::new(OpCode::GuardTrue, &[ro(OpRef::int_op(5))]);
         guard.store_final_boxes(vec![rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
@@ -4302,7 +4329,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[rb(OpRef::int_op(3))],
+            &[ro(OpRef::int_op(3))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4313,27 +4340,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(10)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(10)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(11)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(11)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(12)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(12)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
@@ -4369,7 +4396,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[rb(OpRef::int_op(4))],
+            &[ro(OpRef::int_op(4))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4380,18 +4407,18 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(10)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(10)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(11)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(11)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
@@ -4452,7 +4479,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[rb(OpRef::int_op(3))],
+            &[ro(OpRef::int_op(3))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4460,7 +4487,7 @@ mod tests {
 
         let ops = vec![
             new_array,
-            Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(50))]),
+            Op::new(OpCode::GuardTrue, &[ro(OpRef::int_op(50))]),
             Op::new(OpCode::Finish, &[]),
         ];
 
@@ -4510,7 +4537,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[rb(OpRef::int_op(5))],
+            &[ro(OpRef::int_op(5))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4521,27 +4548,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(10)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(10)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(12)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(12)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(14)),
-                    rb(OpRef::int_op(100)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(14)),
+                    ro(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
@@ -4581,7 +4608,7 @@ mod tests {
         // Plain NEW_ARRAY (not CLEAR) should NOT produce any ZERO_ARRAY.
         let rw = make_rewriter();
         let new_array =
-            Op::with_descr(OpCode::NewArray, &[rb(OpRef::int_op(3))], array_descr_int());
+            Op::with_descr(OpCode::NewArray, &[ro(OpRef::int_op(3))], array_descr_int());
         new_array.pos.set(OpRef::ref_op(0));
 
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
@@ -4665,16 +4692,16 @@ mod tests {
             let mut constants: VecAssoc<u32, Const> = VecAssoc::new();
             constants.insert(10_000, Const::Int(num_elem));
             let new_array =
-                Op::with_descr(OpCode::NewArrayClear, &[rb(len_ref)], array_descr_ref());
+                Op::with_descr(OpCode::NewArrayClear, &[ro(len_ref)], array_descr_ref());
             new_array.pos.set(OpRef::ref_op(0));
             let ops = vec![
                 new_array,
                 Op::with_descr(
                     OpCode::SetarrayitemGc,
                     &[
-                        rb(OpRef::ref_op(0)),
-                        rb(OpRef::int_op(1)),
-                        rb(OpRef::ref_op(2)),
+                        ro(OpRef::ref_op(0)),
+                        ro(OpRef::int_op(1)),
+                        ro(OpRef::ref_op(2)),
                     ],
                     array_descr_ref(),
                 ),
@@ -4709,9 +4736,9 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(1)),
-                    rb(OpRef::ref_op(2)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(1)),
+                    ro(OpRef::ref_op(2)),
                 ],
                 array_descr_ref(),
             ),
@@ -4736,9 +4763,9 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rb(OpRef::ref_op(0)),
-                    rb(OpRef::int_op(1)),
-                    rb(OpRef::int_op(2)),
+                    ro(OpRef::ref_op(0)),
+                    ro(OpRef::int_op(1)),
+                    ro(OpRef::int_op(2)),
                 ],
                 array_descr_int(),
             ),
@@ -4809,7 +4836,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copystrcontent,
-            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
+            &[ro(p0), ro(p1), ro(i0), ro(i1), ro(i_len)],
             str_array_descr(),
         )];
 
@@ -4880,7 +4907,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copyunicodecontent,
-            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
+            &[ro(p0), ro(p1), ro(i0), ro(i1), ro(i_len)],
             unicode_array_descr(),
         )];
 
@@ -4936,7 +4963,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copystrcontent,
-            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
+            &[ro(p0), ro(p1), ro(i0), ro(i1), ro(i_len)],
             str_array_descr(),
         )];
 
@@ -4997,7 +5024,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copyunicodecontent,
-            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
+            &[ro(p0), ro(p1), ro(i0), ro(i1), ro(i_len)],
             unicode_array_descr(),
         )];
 
@@ -5131,7 +5158,7 @@ mod tests {
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![Op::new(
             OpCode::GuardNonnull,
-            &[BoxRef::new_const(Value::Ref(r))],
+            &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
         )];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5152,8 +5179,8 @@ mod tests {
         let rw = make_rewriter();
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![
-            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
-            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
         ];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5183,8 +5210,8 @@ mod tests {
         let r0 = majit_ir::GcRef(0x4000);
         let r1 = majit_ir::GcRef(0x5000);
         let ops = vec![
-            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r0))]),
-            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r1))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r0)))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r1)))]),
         ];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5208,7 +5235,7 @@ mod tests {
         let null = majit_ir::GcRef(0);
         let ops = vec![Op::new(
             OpCode::GuardNonnull,
-            &[BoxRef::new_const(Value::Ref(null))],
+            &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(null)))],
         )];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5228,9 +5255,9 @@ mod tests {
         let rw = make_rewriter();
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![
-            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
             Op::new(OpCode::Label, &[]),
-            Op::new(OpCode::GuardNonnull, &[BoxRef::new_const(Value::Ref(r))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
         ];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5251,7 +5278,7 @@ mod tests {
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![Op::new(
             OpCode::JitDebug,
-            &[BoxRef::new_const(Value::Ref(r))],
+            &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
         )];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -3306,41 +3306,7 @@ mod tests {
         op
     }
 
-    /// Test-only operand-source for op args / failargs: bind `a` to a
-    /// synthetic producer carrying the same position so the box sheds to
-    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
-    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
-    /// producer graph); `to_opref()` is unchanged, so position-based
-    /// assertions are identical.
-    fn rb(a: OpRef) -> BoxRef {
-        if a.is_none() || a.is_constant() {
-            return BoxRef::from_opref(a);
-        }
-        let ty = a.ty().unwrap_or(Type::Void);
-        match a {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-                let b = BoxRef::from_bound_inputarg(&ia);
-                std::mem::forget(ia);
-                b
-            }
-            _ => {
-                let opcode = match ty {
-                    Type::Int => OpCode::SameAsI,
-                    Type::Float => OpCode::SameAsF,
-                    Type::Ref => OpCode::SameAsR,
-                    Type::Void => OpCode::Jump,
-                };
-                let p = std::rc::Rc::new(Op::new(opcode, &[]));
-                p.pos.set(a);
-                let b = BoxRef::from_bound_op(&p);
-                std::mem::forget(p);
-                b
-            }
-        }
-    }
+    use majit_ir::box_ref::bound_box_from_opref as rb;
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
         let args: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -915,13 +915,26 @@ impl RewriteState {
         // directly.
         let pending_zsf = std::mem::take(&mut self._delayed_zero_setfields);
         for (ptr, entries) in pending_zsf {
+            // The pending-zero base is the result of an earlier malloc/New
+            // already emitted into `self.out`; bind the GC_STORE base to that
+            // producer so the arg sheds to `Operand::Op` (RPython keeps the
+            // base Box object). `opref_to_box` only synthesises a
+            // position-only box for GC/backend reads that never reach
+            // `from_boxref`; used as an op arg it would be rejected, so resolve
+            // the producer here. `to_opref()` is unchanged either way.
+            let ptr_box = self
+                .out
+                .iter()
+                .find(|o| o.pos.get() == ptr)
+                .map(|o| BoxRef::from_bound_op(o))
+                .unwrap_or_else(|| opref_to_box(ptr));
             for ofs in entries.iter().copied() {
                 let ofs_ref = self.const_int(ofs);
                 let zero_ref = self.const_int(0);
                 let word_ref = self.const_int(8);
                 let store = Op::new(
                     OpCode::GcStore,
-                    &[opref_to_box(ptr), ofs_ref, zero_ref, word_ref],
+                    &[ptr_box.clone(), ofs_ref, zero_ref, word_ref],
                 );
                 self.emit(store);
             }
@@ -3287,14 +3300,50 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let args: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let op = Op::new(opcode, &args);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
     }
 
+    /// Test-only operand-source for op args / failargs: bind `a` to a
+    /// synthetic producer carrying the same position so the box sheds to
+    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
+    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
+    /// producer graph); `to_opref()` is unchanged, so position-based
+    /// assertions are identical.
+    fn rb(a: OpRef) -> BoxRef {
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                std::mem::forget(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let p = std::rc::Rc::new(Op::new(opcode, &[]));
+                p.pos.set(a);
+                let b = BoxRef::from_bound_op(&p);
+                std::mem::forget(p);
+                b
+            }
+        }
+    }
+
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let args: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
@@ -3435,7 +3484,7 @@ mod tests {
         let length_ref = OpRef::int_op(100); // some prior op producing the length
         let ops = vec![Op::with_descr(
             OpCode::NewArray,
-            &[BoxRef::from_opref(length_ref)],
+            &[rb(length_ref)],
             array_descr_int(),
         )];
 
@@ -3469,11 +3518,7 @@ mod tests {
         //   round_up(GcHeader::SIZE + 4104) = 4112 > 4096 → returns None.
         let mut constants: VecAssoc<u32, Const> = VecAssoc::new();
         constants.insert(10_000, Const::Int(512));
-        let new_array = Op::with_descr(
-            OpCode::NewArray,
-            &[BoxRef::from_opref(len_ref)],
-            array_descr_ref(),
-        );
+        let new_array = Op::with_descr(OpCode::NewArray, &[rb(len_ref)], array_descr_ref());
         new_array.pos.set(OpRef::ref_op(0));
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
 
@@ -3533,7 +3578,7 @@ mod tests {
         let val = OpRef::ref_op(1);
         let ops = vec![Op::with_descr(
             OpCode::SetfieldGc,
-            &[BoxRef::from_opref(obj), BoxRef::from_opref(val)],
+            &[rb(obj), rb(val)],
             ref_field_descr(),
         )];
 
@@ -3559,7 +3604,7 @@ mod tests {
         let obj = OpRef::ref_op(0);
         let ops = vec![Op::with_descr(
             OpCode::GetfieldGcPureR,
-            &[BoxRef::from_opref(obj)],
+            &[rb(obj)],
             ref_field_descr(),
         )];
 
@@ -3590,7 +3635,7 @@ mod tests {
         let idx = OpRef::int_op(1);
         let ops = vec![Op::with_descr(
             OpCode::GetarrayitemRawR,
-            &[BoxRef::from_opref(obj), BoxRef::from_opref(idx)],
+            &[rb(obj), rb(idx)],
             array_descr_ref(),
         )];
 
@@ -3615,7 +3660,7 @@ mod tests {
         let val = OpRef::ref_op(1);
         let ops = vec![Op::with_descr(
             OpCode::SetfieldGc,
-            &[BoxRef::from_opref(obj), BoxRef::from_opref(val)],
+            &[rb(obj), rb(val)],
             int_field_descr(),
         )];
 
@@ -3727,10 +3772,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], descr),
             Op::with_descr(
                 OpCode::SetfieldGc,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(val),
-                ],
+                &[rb(OpRef::ref_op(0)), rb(val)],
                 ref_field_descr_ref_at(24),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -3764,12 +3806,9 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[
-                    BoxRef::from_opref(OpRef::int_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                ],
+                &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))],
             ),
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]),
+            Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]),
             Op::new(OpCode::Jump, &[]),
         ];
 
@@ -3860,7 +3899,7 @@ mod tests {
         let rw = make_rewriter();
         let ops = vec![
             Op::with_descr(OpCode::New, &[], size_descr(24, 1)),
-            Op::new(OpCode::CallN, &[BoxRef::from_opref(OpRef::ref_op(99))]),
+            Op::new(OpCode::CallN, &[rb(OpRef::ref_op(99))]),
             Op::with_descr(OpCode::New, &[], size_descr(24, 2)),
         ];
 
@@ -3884,16 +3923,8 @@ mod tests {
         let val1 = OpRef::ref_op(1);
         let val2 = OpRef::ref_op(2);
         let ops = vec![
-            Op::with_descr(
-                OpCode::SetfieldGc,
-                &[BoxRef::from_opref(obj), BoxRef::from_opref(val1)],
-                ref_field_descr(),
-            ),
-            Op::with_descr(
-                OpCode::SetfieldGc,
-                &[BoxRef::from_opref(obj), BoxRef::from_opref(val2)],
-                ref_field_descr(),
-            ),
+            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val1)], ref_field_descr()),
+            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val2)], ref_field_descr()),
         ];
 
         let result = rw.rewrite_for_gc(&ops);
@@ -3931,10 +3962,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(32, 1)),
             Op::with_descr(
                 OpCode::SetfieldGc,
-                &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::ref_op(99)),
-                ], // arg(0) = pos of the alloc = 0
+                &[rb(OpRef::ref_op(0)), rb(OpRef::ref_op(99))], // arg(0) = pos of the alloc = 0
                 ref_field_descr(),
             ),
         ];
@@ -4011,11 +4039,7 @@ mod tests {
         let val = OpRef::ref_op(2);
         let ops = vec![Op::with_descr(
             OpCode::SetarrayitemGc,
-            &[
-                BoxRef::from_opref(obj),
-                BoxRef::from_opref(idx),
-                BoxRef::from_opref(val),
-            ],
+            &[rb(obj), rb(idx), rb(val)],
             array_descr_ref(),
         )];
 
@@ -4036,18 +4060,10 @@ mod tests {
         let obj = OpRef::ref_op(0);
         let val = OpRef::ref_op(1);
         let ops = vec![
-            Op::with_descr(
-                OpCode::SetfieldGc,
-                &[BoxRef::from_opref(obj), BoxRef::from_opref(val)],
-                ref_field_descr(),
-            ),
+            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val)], ref_field_descr()),
             // This call can collect, clearing the WB set.
-            Op::new(OpCode::CallN, &[BoxRef::from_opref(OpRef::ref_op(99))]),
-            Op::with_descr(
-                OpCode::SetfieldGc,
-                &[BoxRef::from_opref(obj), BoxRef::from_opref(val)],
-                ref_field_descr(),
-            ),
+            Op::new(OpCode::CallN, &[rb(OpRef::ref_op(99))]),
+            Op::with_descr(OpCode::SetfieldGc, &[rb(obj), rb(val)], ref_field_descr()),
         ];
 
         let result = rw.rewrite_for_gc(&ops);
@@ -4158,19 +4174,13 @@ mod tests {
         // rewrite the guard's failargs to reference the SAME_AS_I output.
         let rw = make_rewriter();
 
-        let int_lt = Op::new(
-            OpCode::IntLt,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let int_lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
         int_lt.pos.set(OpRef::int_op(2));
-        let guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.store_final_boxes(vec![
-            BoxRef::from_opref(OpRef::int_op(0)),
-            BoxRef::from_opref(OpRef::int_op(2)),
-            BoxRef::from_opref(OpRef::int_op(1)),
+            rb(OpRef::int_op(0)),
+            rb(OpRef::int_op(2)),
+            rb(OpRef::int_op(1)),
         ]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
@@ -4212,16 +4222,10 @@ mod tests {
     fn test_comparison_guard_false_hoists_with_one_constant() {
         // GUARD_FALSE: rewrite.py:463 `value = int(opnum == GUARD_FALSE)` ⇒ 1.
         let rw = make_rewriter();
-        let int_eq = Op::new(
-            OpCode::IntEq,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let int_eq = Op::new(OpCode::IntEq, &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
         int_eq.pos.set(OpRef::int_op(2));
-        let guard = Op::new(OpCode::GuardFalse, &[BoxRef::from_opref(OpRef::int_op(2))]);
-        guard.store_final_boxes(vec![BoxRef::from_opref(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardFalse, &[rb(OpRef::int_op(2))]);
+        guard.store_final_boxes(vec![rb(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
         let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -4248,10 +4252,7 @@ mod tests {
         // copy_and_change.
         let rw = make_rewriter();
         let guard = Op::new(OpCode::GuardAlwaysFails, &[]);
-        guard.store_final_boxes(vec![
-            BoxRef::from_opref(OpRef::int_op(10)),
-            BoxRef::from_opref(OpRef::int_op(11)),
-        ]);
+        guard.store_final_boxes(vec![rb(OpRef::int_op(10)), rb(OpRef::int_op(11))]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
         let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -4297,20 +4298,11 @@ mod tests {
         // Guard that does NOT test the previous op's result: merge does
         // not fire, no SAME_AS_I is emitted.
         let rw = make_rewriter();
-        let int_lt = Op::new(
-            OpCode::IntLt,
-            &[
-                BoxRef::from_opref(OpRef::int_op(0)),
-                BoxRef::from_opref(OpRef::int_op(1)),
-            ],
-        );
+        let int_lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
         int_lt.pos.set(OpRef::int_op(2));
         // GuardTrue reads some unrelated OpRef::ref_op(5), not OpRef::ref_op(2).
-        let guard = Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(5))]);
-        guard.store_final_boxes(vec![
-            BoxRef::from_opref(OpRef::int_op(0)),
-            BoxRef::from_opref(OpRef::int_op(1)),
-        ]);
+        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(5))]);
+        guard.store_final_boxes(vec![rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
         let result = rw.rewrite_for_gc(&ops);
@@ -4344,7 +4336,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[BoxRef::from_opref(OpRef::int_op(3))],
+            &[rb(OpRef::int_op(3))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4355,27 +4347,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(10)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(10)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(11)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(11)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(12)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(12)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
@@ -4411,7 +4403,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[BoxRef::from_opref(OpRef::int_op(4))],
+            &[rb(OpRef::int_op(4))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4422,18 +4414,18 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(10)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(10)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(11)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(11)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
@@ -4494,7 +4486,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[BoxRef::from_opref(OpRef::int_op(3))],
+            &[rb(OpRef::int_op(3))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4502,7 +4494,7 @@ mod tests {
 
         let ops = vec![
             new_array,
-            Op::new(OpCode::GuardTrue, &[BoxRef::from_opref(OpRef::int_op(50))]),
+            Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(50))]),
             Op::new(OpCode::Finish, &[]),
         ];
 
@@ -4552,7 +4544,7 @@ mod tests {
         rw.malloc_zero_filled = false;
         let new_array = Op::with_descr(
             OpCode::NewArrayClear,
-            &[BoxRef::from_opref(OpRef::int_op(5))],
+            &[rb(OpRef::int_op(5))],
             array_descr_int(),
         );
         new_array.pos.set(OpRef::ref_op(0));
@@ -4563,27 +4555,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(10)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(10)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(12)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(12)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(14)),
-                    BoxRef::from_opref(OpRef::int_op(100)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(14)),
+                    rb(OpRef::int_op(100)),
                 ],
                 array_descr_int(),
             ),
@@ -4622,11 +4614,8 @@ mod tests {
     fn test_pending_zero_no_clear() {
         // Plain NEW_ARRAY (not CLEAR) should NOT produce any ZERO_ARRAY.
         let rw = make_rewriter();
-        let new_array = Op::with_descr(
-            OpCode::NewArray,
-            &[BoxRef::from_opref(OpRef::int_op(3))],
-            array_descr_int(),
-        );
+        let new_array =
+            Op::with_descr(OpCode::NewArray, &[rb(OpRef::int_op(3))], array_descr_int());
         new_array.pos.set(OpRef::ref_op(0));
 
         let ops = vec![new_array, Op::new(OpCode::Finish, &[])];
@@ -4709,20 +4698,17 @@ mod tests {
             let len_ref = OpRef::int_op(10_000);
             let mut constants: VecAssoc<u32, Const> = VecAssoc::new();
             constants.insert(10_000, Const::Int(num_elem));
-            let new_array = Op::with_descr(
-                OpCode::NewArrayClear,
-                &[BoxRef::from_opref(len_ref)],
-                array_descr_ref(),
-            );
+            let new_array =
+                Op::with_descr(OpCode::NewArrayClear, &[rb(len_ref)], array_descr_ref());
             new_array.pos.set(OpRef::ref_op(0));
             let ops = vec![
                 new_array,
                 Op::with_descr(
                     OpCode::SetarrayitemGc,
                     &[
-                        BoxRef::from_opref(OpRef::ref_op(0)),
-                        BoxRef::from_opref(OpRef::int_op(1)),
-                        BoxRef::from_opref(OpRef::ref_op(2)),
+                        rb(OpRef::ref_op(0)),
+                        rb(OpRef::int_op(1)),
+                        rb(OpRef::ref_op(2)),
                     ],
                     array_descr_ref(),
                 ),
@@ -4757,9 +4743,9 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::ref_op(2)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(1)),
+                    rb(OpRef::ref_op(2)),
                 ],
                 array_descr_ref(),
             ),
@@ -4784,9 +4770,9 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    BoxRef::from_opref(OpRef::ref_op(0)),
-                    BoxRef::from_opref(OpRef::int_op(1)),
-                    BoxRef::from_opref(OpRef::int_op(2)),
+                    rb(OpRef::ref_op(0)),
+                    rb(OpRef::int_op(1)),
+                    rb(OpRef::int_op(2)),
                 ],
                 array_descr_int(),
             ),
@@ -4857,13 +4843,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copystrcontent,
-            &[
-                BoxRef::from_opref(p0),
-                BoxRef::from_opref(p1),
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(i1),
-                BoxRef::from_opref(i_len),
-            ],
+            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
             str_array_descr(),
         )];
 
@@ -4934,13 +4914,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copyunicodecontent,
-            &[
-                BoxRef::from_opref(p0),
-                BoxRef::from_opref(p1),
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(i1),
-                BoxRef::from_opref(i_len),
-            ],
+            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
             unicode_array_descr(),
         )];
 
@@ -4996,13 +4970,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copystrcontent,
-            &[
-                BoxRef::from_opref(p0),
-                BoxRef::from_opref(p1),
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(i1),
-                BoxRef::from_opref(i_len),
-            ],
+            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
             str_array_descr(),
         )];
 
@@ -5063,13 +5031,7 @@ mod tests {
         let i_len = OpRef::int_op(4);
         let ops = vec![Op::with_descr(
             OpCode::Copyunicodecontent,
-            &[
-                BoxRef::from_opref(p0),
-                BoxRef::from_opref(p1),
-                BoxRef::from_opref(i0),
-                BoxRef::from_opref(i1),
-                BoxRef::from_opref(i_len),
-            ],
+            &[rb(p0), rb(p1), rb(i0), rb(i1), rb(i_len)],
             unicode_array_descr(),
         )];
 

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -806,7 +806,10 @@ impl RewriteState {
         // optimizer.py:651-652 force_box loop parity:
         //   for i in range(op.numargs()): op.setarg(i, ...)
         for i in 0..rewritten.num_args() {
-            rewritten.setarg(i, Operand::from_boxref(&self.resolve(rewritten.arg(i).to_boxref())));
+            rewritten.setarg(
+                i,
+                Operand::from_boxref(&self.resolve(rewritten.arg(i).to_boxref())),
+            );
         }
         if let Some(fail_args) = rewritten.fail_args_mut() {
             for arg in fail_args.iter_mut() {
@@ -3042,10 +3045,7 @@ impl GcRewriter for GcRewriterImpl {
                     let same_pos = st.emit_result(same, OpRef::NONE);
                     let newop = op.copy_and_change(
                         OpCode::GuardValue,
-                        Some(&[
-                            Operand::from_boxref(&same_pos),
-                            Operand::from_boxref(&one),
-                        ]),
+                        Some(&[Operand::from_boxref(&same_pos), Operand::from_boxref(&one)]),
                         None,
                     );
                     let rewritten = st.rewrite_op(&newop);
@@ -5179,8 +5179,14 @@ mod tests {
         let rw = make_rewriter();
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+            ),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+            ),
         ];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5210,8 +5216,14 @@ mod tests {
         let r0 = majit_ir::GcRef(0x4000);
         let r1 = majit_ir::GcRef(0x5000);
         let ops = vec![
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r0)))]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r1)))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r0)))],
+            ),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r1)))],
+            ),
         ];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());
@@ -5255,9 +5267,15 @@ mod tests {
         let rw = make_rewriter();
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+            ),
             Op::new(OpCode::Label, &[]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+            ),
         ];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecAssoc::new());

--- a/majit/majit-ir/Cargo.toml
+++ b/majit/majit-ir/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 repository.workspace = true
 description = "Intermediate representation for majit JIT compiler"
 
+[features]
+# Exposes `box_ref::test_support` cross-crate so downstream test suites
+# (backends / gc / jit-trace) can build bound BoxRefs from a single helper
+# instead of duplicating it. Enabled only from `[dev-dependencies]`, so it
+# never reaches a production build (resolver = "2").
+test-support = []
+
 [dependencies]
 smallvec = { workspace = true }
 serde = { workspace = true }

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -1167,6 +1167,52 @@ pub(crate) mod test_support {
     }
 }
 
+/// Cross-crate test helper (enabled via the `test-support` feature): turn an
+/// `OpRef` into a **bound** `BoxRef` for op-argument / fail-arg fixtures.
+/// `None`/`Const` route through [`BoxRef::from_opref`]; an `InputArg` position
+/// binds a fresh `InputArg`, a `ResOp` position a fresh `SameAs*`/`Jump` `Op`
+/// at that position (`from_bound_op`/`from_bound_inputarg`). The synthetic
+/// producer is parked in a thread-local pool so the box's `Weak` upgrades for
+/// the test thread's lifetime — no `mem::forget`. `to_opref()` is unchanged,
+/// so OpRef-based assertions still hold. Replaces the per-crate `fn rb` copies
+/// in the backend / gc / jit-trace test suites.
+#[cfg(feature = "test-support")]
+pub fn bound_box_from_opref(a: OpRef) -> BoxRef {
+    use crate::resoperation::{Op, OpCode};
+    use crate::value::InputArg;
+
+    thread_local! {
+        static PRODUCER_ROOTS: std::cell::RefCell<Vec<std::rc::Rc<dyn std::any::Any>>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    if a.is_none() || a.is_constant() {
+        return BoxRef::from_opref(a);
+    }
+    let ty = a.ty().unwrap_or(Type::Void);
+    let (b, rooted): (BoxRef, std::rc::Rc<dyn std::any::Any>) = match a {
+        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+            let ia = std::rc::Rc::new(InputArg::from_type(ty, a.raw()));
+            let b = BoxRef::from_bound_inputarg(&ia);
+            (b, ia)
+        }
+        _ => {
+            let opcode = match ty {
+                Type::Int => OpCode::SameAsI,
+                Type::Float => OpCode::SameAsF,
+                Type::Ref => OpCode::SameAsR,
+                Type::Void => OpCode::Jump,
+            };
+            let op = std::rc::Rc::new(Op::new(opcode, &[]));
+            op.pos.set(a);
+            let b = BoxRef::from_bound_op(&op);
+            (b, op)
+        }
+    };
+    PRODUCER_ROOTS.with(|p| p.borrow_mut().push(rooted));
+    b
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -1114,9 +1114,10 @@ const _: fn() = || {
 /// modules (`resoperation.rs`, …). Mirror of `majit-metainterp`'s
 /// `box::test_support`: production binds every `AbstractResOp` /
 /// `AbstractInputArg` box to its `Op` / `InputArg` identity, so tests
-/// that seed op operands directly must do the same to keep them off the
-/// position-only `Operand::Box` catch-all (the box still `to_opref()`s to
-/// the same `(type, position)`, so OpRef-based assertions are unchanged).
+/// that seed op operands directly must do the same — an unbound
+/// position-only box is rejected by `from_boxref` (the box still
+/// `to_opref()`s to the same `(type, position)`, so OpRef-based assertions
+/// are unchanged).
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::{BoxRef, OpRef, Type};

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -1213,6 +1213,17 @@ pub fn bound_box_from_opref(a: OpRef) -> BoxRef {
     b
 }
 
+/// `Operand`-yielding sibling of [`bound_box_from_opref`]: op-arg / fail-arg
+/// fixtures that take an [`Operand`](crate::operand::Operand) directly mint a
+/// **bound** `Operand::Op` / `Operand::InputArg` (or `None` / `Const`) so the
+/// flipped `Op::new(&[Operand])` is fed a producer-bound operand, never a
+/// position-only box. Used behind the per-crate `as rb` import in the backend /
+/// gc / jit-trace test suites.
+#[cfg(feature = "test-support")]
+pub fn bound_operand_from_opref(a: OpRef) -> crate::operand::Operand {
+    crate::operand::Operand::from_boxref(&bound_box_from_opref(a))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -206,8 +206,9 @@ impl Op {
         // `GuardResOp._fail_args` holds the Box objects themselves
         // (resoperation.py:483); shed genuinely-bound boxes to their
         // live-tracking producer operand, exactly like `Op.args`
-        // (`Operand::from_boxref`). Position-only / Const boxes stay
-        // `Operand::Box` until their writers bind producers.
+        // (`Operand::from_boxref`). A Const box sheds to `Operand::Const`;
+        // an unbound position-only fail-arg is a contract violation and
+        // panics (every writer binds its producer).
         *self.fail_args.borrow_mut() = Some(
             fail_args
                 .iter()

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -308,17 +308,14 @@ impl Op {
     ///  sb.used_boxes)` extends the LABEL arg list when finishing the
     /// peel pass.  pyre's matching call lives in `unroll.rs` and
     /// rebuilds the SmallVec rather than pushing onto `args`.
-    pub fn initarglist(&self, args: smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>) {
-        *self.args.borrow_mut() = args
-            .iter()
-            .map(crate::operand::Operand::from_boxref)
-            .collect();
+    pub fn initarglist(&self, args: smallvec::SmallVec<[crate::operand::Operand; 3]>) {
+        *self.args.borrow_mut() = args;
     }
 
     /// `resoperation.py:290 AbstractResOp.setarg` parity — position-wise
     /// in-place arg mutation.  Subclass mixins index `_arg0/_arg1/...`
     /// or `_args[i]`; pyre indexes the SmallVec directly.
-    pub fn setarg(&self, i: usize, box_: crate::box_ref::BoxRef) {
-        self.args.borrow_mut()[i] = crate::operand::Operand::from_boxref(&box_);
+    pub fn setarg(&self, i: usize, arg: crate::operand::Operand) {
+        self.args.borrow_mut()[i] = arg;
     }
 }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -240,7 +240,8 @@ impl Operand {
         // is preserved; the fresh `Rc` is a new const identity).
         if b.is_constant() {
             return Operand::Const(Rc::new(Cell::new(
-                b.const_value().expect("is_constant box carries a const value"),
+                b.const_value()
+                    .expect("is_constant box carries a const value"),
             )));
         }
         // A position-only box (no producer Rc, non-const) reaches here only if
@@ -493,7 +494,10 @@ mod tests {
         assert_eq!(Operand::from_bound_op(&op), Operand::from_bound_op(&op));
         // Distinct ops at the same position -> distinct identity.
         let op_other = op_at(0, Type::Int);
-        assert_ne!(Operand::from_bound_op(&op), Operand::from_bound_op(&op_other));
+        assert_ne!(
+            Operand::from_bound_op(&op),
+            Operand::from_bound_op(&op_other)
+        );
 
         // Equal-valued constants minted separately are NOT `==` (distinct Rc),
         // even though they are `same_box`-equal.

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -49,15 +49,6 @@ pub enum Operand {
     /// it type-narrows to a dedicated const-box `Rc` when the `BoxRef`
     /// wrapper is deleted (#9 endgame).
     Const(BoxRef),
-    /// MIGRATION-ONLY catch-all (`#9` operand-union flip): a not-yet-converted
-    /// [`BoxRef`] for the operands `from_boxref` cannot yet lower to a pure
-    /// `Op`/`InputArg`/`Const` — position-only operands minted by
-    /// `BoxRef::from_opref` (no live producer to bind). Holding the original
-    /// `BoxRef` makes the storage flip byte-identical: `to_boxref` clones the
-    /// same `Rc<Box>` back, preserving box identity and GC-walkability
-    /// verbatim. Ground down to zero (then deleted) as later slices bind
-    /// these.
-    Box(BoxRef),
 }
 
 impl Operand {
@@ -101,7 +92,6 @@ impl Operand {
             // Re-encodes from the box's live `Cell` value, so a GC-moved
             // `ConstPtr` reads back at its post-move address.
             Operand::Const(b) => b.to_opref(),
-            Operand::Box(b) => b.to_opref(),
         }
     }
 
@@ -111,7 +101,6 @@ impl Operand {
         match self {
             Operand::Op(op) => Some(op.pos.get().raw()),
             Operand::InputArg(ia) => Some(ia.index),
-            Operand::Box(b) => b.position(),
             Operand::Const(_) | Operand::None => None,
         }
     }
@@ -122,7 +111,6 @@ impl Operand {
             Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
             Operand::InputArg(ia) => ia.tp,
             Operand::Const(b) => b.type_(),
-            Operand::Box(b) => b.type_(),
             Operand::None => Type::Void,
         }
     }
@@ -132,7 +120,6 @@ impl Operand {
     pub fn const_value(&self) -> Option<Value> {
         match self {
             Operand::Const(b) => b.const_value(),
-            Operand::Box(b) => b.const_value(),
             _ => None,
         }
     }
@@ -142,43 +129,26 @@ impl Operand {
     pub fn const_int(&self) -> Option<i64> {
         match self {
             Operand::Const(b) => b.const_int(),
-            Operand::Box(b) => b.const_int(),
             _ => None,
         }
     }
 
     /// `resoperation.py:47 is_constant`.
     pub fn is_constant(&self) -> bool {
-        match self {
-            Operand::Const(_) => true,
-            Operand::Box(b) => b.is_constant(),
-            _ => false,
-        }
+        matches!(self, Operand::Const(_))
     }
 
     pub fn is_inputarg(&self) -> bool {
-        match self {
-            Operand::InputArg(_) => true,
-            Operand::Box(b) => b.is_inputarg(),
-            _ => false,
-        }
+        matches!(self, Operand::InputArg(_))
     }
 
     pub fn is_resop(&self) -> bool {
-        match self {
-            Operand::Op(_) => true,
-            Operand::Box(b) => b.is_resop(),
-            _ => false,
-        }
+        matches!(self, Operand::Op(_))
     }
 
     /// True for the absent-slot sentinel — the mirror of `OpRef::is_none`.
     pub fn is_none(&self) -> bool {
-        match self {
-            Operand::None => true,
-            Operand::Box(b) => b.is_none(),
-            _ => false,
-        }
+        matches!(self, Operand::None)
     }
 
     /// `resoperation.py:38 AbstractValue.same_box`: pointer identity
@@ -206,7 +176,6 @@ impl Operand {
             // The SAME `Rc<Box>` back — `_args[i]` returns the stored
             // Const object, never a fresh equal-valued one.
             Operand::Const(b) => b.clone(),
-            Operand::Box(b) => b.clone(),
         }
     }
 
@@ -224,11 +193,15 @@ impl Operand {
     /// otherwise a bound operand reading the already-remapped live pos would
     /// double-remap.
     ///
-    /// A position-only box (no bound handle — e.g. `from_opref`) and a Const
-    /// box (value-typed, GC-walked in place through its `Cell`) carry no
-    /// producer to track and stay `Operand::Box`, whose `to_boxref` returns
-    /// the same `Rc<Box>` (identity, `Cell`-backed GC walk, frozen position
-    /// snapshot all preserved).
+    /// A Const box (value-typed, GC-walked in place through its `Cell`) lowers
+    /// to `Operand::Const`, whose `to_boxref` returns the same `Rc<Box>`
+    /// (identity + `Cell`-backed GC walk preserved). A position-only box (no
+    /// bound handle — `BoxRef::from_opref` of a non-const ResOp/InputArg
+    /// position) has no `Operand` to lower to and is a contract violation: by
+    /// #9 every operand source binds its producer (`from_bound_op` /
+    /// `from_bound_inputarg`) or carries a const. The drain to zero was proven
+    /// across the lib corpus and the bench suite (`MAJIT_DIAG_OPERAND_BOX`),
+    /// so this case panics rather than fabricating an untracked operand.
     pub fn from_boxref(b: &BoxRef) -> Operand {
         if b.is_none() {
             return Operand::None;
@@ -238,10 +211,7 @@ impl Operand {
         // `AbstractResOp`/`AbstractInputArg` directly), so its position
         // auto-tracks the producer's `op.pos` and its forwarding resolves
         // through the canonical `Op`/`InputArg`. The strong `Rc` keeps the
-        // producer alive (acyclic on the SSA use-before-def DAG). A
-        // position-only box (no bound handle) and a Const box (value-typed,
-        // GC-walked in place via its `Cell`) have no producer to carry and
-        // stay `Operand::Box`.
+        // producer alive (acyclic on the SSA use-before-def DAG).
         if let Some(op) = b.bound_op() {
             return Operand::Op(op);
         }
@@ -250,66 +220,40 @@ impl Operand {
         }
         // A Const box lowers to the terminal `Operand::Const` carrying the
         // same `Rc<Box>` (history.py Const object identity + `Cell`-backed
-        // GC walk preserved). Only position-only boxes remain `Operand::Box`.
+        // GC walk preserved).
         if b.is_constant() {
             return Operand::Const(b.clone());
         }
-        // Only position-only boxes (no producer Rc) reach here.
-        //
-        // Drain status (#9 keystone): the gauge fires ZERO times across the
-        // full synth corpus (117 benches, measured). The two former live
-        // sources are bound at their origin: short-preamble `short_inputargs`
-        // now mint via `from_bound_inputarg` over a rooted `InputArg` Rc
-        // carried through the preview → export → import channel
-        // (`short_inputarg_refs`, resolving to `Operand::InputArg`), and
-        // `emit_constant_*` SAME_AS placeholders take the constant box as their
-        // source (resolving to `Operand::Const`). `MAJIT_DIAG_OPERAND_BOX=1`
-        // reports each mint's position-only `OpRef`; off by default, no
-        // behavior change in the gate. A new mint from the WIRED pipeline
-        // appearing here is a regression — bind it at its producer.
-        //
-        // The remaining minters are of two kinds, both gating variant deletion:
-        // (1) unit-test fixtures that build `from_opref` / `new_inputarg`
-        // position-only boxes directly (no producer graph); and (2) the ported
-        // SIMD vectorizer machinery — `Renamer::rename` (renamer.rs:51/64),
-        // `vector.rs` pack/unpack/copy, `GuardStrengthenOpt` (guard.rs), and the
-        // vectorizer-coupled unroll peel-remap — which set op args via
-        // `from_opref(renamed)` of a non-const ResOp/InputArg position. That
-        // machinery is NOT in the production pass pipeline
-        // (optimizer.rs `default_pipeline` wires no `OptVector`), so it
-        // never runs and the gauge stays zero — but it is reachable the moment
-        // the vectorizer is wired. Deleting the `Operand::Box` variant — and
-        // with it the `BoxRef` operand carrier — is therefore gated on BOTH
-        // migrating the fixtures to bound producers AND either binding those
-        // vectorizer minters or removing the unwired vectorizer; until then the
-        // fall-through stays a real fallback, NOT an `unreachable!` tripwire
-        // (which would become a latent panic once the vectorizer is enabled).
-        if std::env::var_os("MAJIT_DIAG_OPERAND_BOX").is_some() {
-            eprintln!("OPERAND_BOX_MINT {:?}", b.to_opref());
-        }
-        Operand::Box(b.clone())
+        // A position-only box (no producer Rc, non-const) reaches here only if
+        // some operand source skipped binding its producer — an invariant
+        // violation under the #9 operand-union model where `_args[i]` is
+        // always a producer or a constant. Bind it at its producer
+        // (`from_bound_op` / `from_bound_inputarg`) instead of routing an
+        // unbound position through here.
+        panic!(
+            "from_boxref: position-only box {:?} has no producer to bind — \
+             every operand source must carry a bound producer or a const (#9)",
+            b.to_opref()
+        )
     }
 
-    /// True only for the live-tracking bound variants (`Op` / `InputArg`),
-    /// whose `to_opref()` reads the producer's CURRENT `op.pos`. Excludes the
-    /// frozen `Operand::Box` snapshot even when it wraps a ResOp / InputArg
-    /// box — unlike [`Operand::is_resop`] / [`Operand::is_inputarg`], which
-    /// fold the snapshot case in. The position-remap passes use this to skip
-    /// operands that auto-track a renumbered producer (no snapshot rewrite
-    /// needed); only position-only `Operand::Box` operands carry a stale
-    /// position the remap table must rewrite.
+    /// True for the live-tracking producer variants (`Op` / `InputArg`),
+    /// whose `to_opref()` reads the producer's CURRENT `op.pos`. The
+    /// position-remap passes use this to skip operands that auto-track a
+    /// renumbered producer (no snapshot rewrite needed); `Const` / `None`
+    /// carry no position to remap.
     pub fn is_bound(&self) -> bool {
         matches!(self, Operand::Op(_) | Operand::InputArg(_))
     }
 
     /// GC walk over any inline `ConstPtr` reachable from this operand
-    /// (`resoperation.py` `walk_const_ptr_refs`). Const / position-only
-    /// operands are held `Cell`-backed in their box, so their `GcRef`
-    /// updates in place; pure `Op` / `InputArg` carry no inline const (their
-    /// own `value` slot is walked at the producer).
+    /// (`resoperation.py` `walk_const_ptr_refs`). A `Const` operand is held
+    /// `Cell`-backed in its box, so its `GcRef` updates in place; pure `Op` /
+    /// `InputArg` carry no inline const (their own `value` slot is walked at
+    /// the producer).
     pub fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
         match self {
-            Operand::Const(b) | Operand::Box(b) => b.walk_const_ptr_refs(visitor),
+            Operand::Const(b) => b.walk_const_ptr_refs(visitor),
             Operand::None | Operand::Op(_) | Operand::InputArg(_) => {}
         }
     }
@@ -441,19 +385,20 @@ mod tests {
         assert_eq!(o.const_int(), Some(11));
         assert_eq!(o.to_boxref().as_ptr(), cbox.as_ptr());
 
-        // Position-only box (from_opref, no live producer) -> kept as Box
-        // (no bound handle to shed onto); NOT bound, frozen position survives.
-        let pos_only = BoxRef::from_opref(OpRef::op_typed(4, Type::Int));
-        let o = Operand::from_boxref(&pos_only);
-        assert!(matches!(o, Operand::Box(_)));
-        assert!(!o.is_bound());
-        assert_eq!(o.position(), Some(4));
-        assert_eq!(o.to_boxref().as_ptr(), pos_only.as_ptr());
-
         // None sentinel -> Operand::None.
         assert!(matches!(
             Operand::from_boxref(&BoxRef::none()),
             Operand::None
         ));
+    }
+
+    /// A position-only box (`from_opref`, no live producer, non-const) has no
+    /// `Operand` to lower to under the #9 operand-union model — `from_boxref`
+    /// panics rather than fabricating an untracked operand.
+    #[test]
+    #[should_panic(expected = "has no producer to bind")]
+    fn from_boxref_panics_on_position_only_box() {
+        let pos_only = BoxRef::from_opref(OpRef::op_typed(4, Type::Int));
+        let _ = Operand::from_boxref(&pos_only);
     }
 }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -287,6 +287,53 @@ impl Operand {
     }
 }
 
+impl PartialEq for Operand {
+    /// Object identity, mirroring [`BoxRef`]'s pure `Rc::ptr_eq`
+    /// (`box_ref.rs:1050`): `AbstractValue` defines no `__eq__`
+    /// (`resoperation.py:29-39`), so every plain box-keyed dict keys by `is`.
+    /// `Op` / `InputArg` / `Const` each carry an `Rc`, so `==` is `ptr_eq` on
+    /// that producer/const handle; two `none()` sentinels match (Python's
+    /// singleton `None`). Equal-valued constants minted separately are NOT
+    /// equal here — value equality is the opt-in [`same_box`](Self::same_box)
+    /// (`history.py:211`), never `==`, so a `same_box`-deduping table must
+    /// build an explicit value-keyed map, not key on `Operand`.
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Operand::None, Operand::None) => true,
+            (Operand::Op(a), Operand::Op(b)) => Rc::ptr_eq(a, b),
+            (Operand::InputArg(a), Operand::InputArg(b)) => Rc::ptr_eq(a, b),
+            (Operand::Const(a), Operand::Const(b)) => Rc::ptr_eq(a, b),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Operand {}
+
+impl std::hash::Hash for Operand {
+    /// Identity hashing consistent with [`eq`](Self::eq) — the
+    /// `compute_identity_hash` default (`resoperation.py:33-35`). A
+    /// per-variant tag keeps cross-variant collisions from aliasing, and the
+    /// `Rc` address is the identity for `Op` / `InputArg` / `Const`.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Operand::None => 0u8.hash(state),
+            Operand::Op(op) => {
+                1u8.hash(state);
+                (Rc::as_ptr(op) as *const () as usize).hash(state);
+            }
+            Operand::InputArg(ia) => {
+                2u8.hash(state);
+                (Rc::as_ptr(ia) as *const () as usize).hash(state);
+            }
+            Operand::Const(cell) => {
+                3u8.hash(state);
+                (Rc::as_ptr(cell) as usize).hash(state);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -429,5 +476,45 @@ mod tests {
     fn from_boxref_panics_on_position_only_box() {
         let pos_only = BoxRef::from_opref(OpRef::op_typed(4, Type::Int));
         let _ = Operand::from_boxref(&pos_only);
+    }
+
+    /// `Eq` is object identity (`Rc::ptr_eq`), the `BoxRef`-key behaviour the
+    /// re-keyed side tables depend on: same `Rc` is equal, a fresh mint is
+    /// not — including for constants (value equality is `same_box`, never
+    /// `==`). A clone shares the `Rc`, so it stays equal and `HashSet`-stable.
+    #[test]
+    fn eq_and_hash_are_object_identity() {
+        use std::collections::HashSet;
+
+        let op = op_at(0, Type::Int);
+        // Same producer Rc -> equal; a clone shares the Rc -> equal.
+        let a = Operand::from_bound_op(&op);
+        assert_eq!(a, a.clone());
+        assert_eq!(Operand::from_bound_op(&op), Operand::from_bound_op(&op));
+        // Distinct ops at the same position -> distinct identity.
+        let op_other = op_at(0, Type::Int);
+        assert_ne!(Operand::from_bound_op(&op), Operand::from_bound_op(&op_other));
+
+        // Equal-valued constants minted separately are NOT `==` (distinct Rc),
+        // even though they are `same_box`-equal.
+        let c1 = Operand::const_(Const::Int(4));
+        let c2 = Operand::const_(Const::Int(4));
+        assert_ne!(c1, c2);
+        assert!(c1.same_box(&c2));
+        // A clone shares the const Rc -> equal.
+        assert_eq!(c1, c1.clone());
+
+        // None is a singleton; cross-variant never matches.
+        assert_eq!(Operand::none(), Operand::none());
+        assert_ne!(Operand::none(), Operand::const_(Const::Int(0)));
+
+        // Hash agrees with Eq: a clone resolves the same bucket/membership.
+        let mut set = HashSet::new();
+        set.insert(Operand::from_bound_op(&op));
+        assert!(set.contains(&Operand::from_bound_op(&op)));
+        assert!(!set.contains(&Operand::from_bound_op(&op_other)));
+        set.insert(c1.clone());
+        assert!(set.contains(&c1));
+        assert!(!set.contains(&c2));
     }
 }

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -23,6 +23,7 @@
 use crate::box_ref::BoxRef;
 use crate::resoperation::{OpRc, OpRef};
 use crate::value::{Const, GcRef, InputArgRc, Type, Value};
+use std::cell::Cell;
 use std::rc::Rc;
 
 /// An operand stored in `Op.args` / `Op.fail_args`.
@@ -40,15 +41,20 @@ pub enum Operand {
     /// An input-arg producer (`resoperation.py` `AbstractInputArg`).
     InputArg(InputArgRc),
     /// A constant (`history.py:227/268/314` `ConstInt`/`ConstFloat`/
-    /// `ConstPtr`). Upstream `Const` is a heap object — `_args[i]` returns
-    /// the stored object, `==` is Python `is`, and value equality is the
-    /// explicit `same_constant` (history.py:211) — so the operand carries
-    /// the const box by `Rc` (object identity across reads of one slot,
-    /// `Cell`-backed GC walk of an inline `ConstPtr`), NOT a bare value.
-    /// The carrier is the const-kind [`BoxRef`] for the migration window;
-    /// it type-narrows to a dedicated const-box `Rc` when the `BoxRef`
-    /// wrapper is deleted (#9 endgame).
-    Const(BoxRef),
+    /// `ConstPtr`). The value lives in an `Rc<Cell<Value>>`: the `Cell` lets
+    /// the GC root walker forward an inline `ConstPtr` `GcRef` in place
+    /// through a shared `&self` borrow of `Op.args` (`walk_const_ptr_refs`
+    /// get/visit/set cycle), and the `Rc` gives the const an object identity
+    /// — `==` is `Rc::ptr_eq` (resoperation.py:29-39 `AbstractValue` keys by
+    /// `is`), so two distinct `const_` mints compare unequal while a clone
+    /// shares the same const object (`getarglist_copy` reuses the same
+    /// `Const`). Value equality is the opt-in `same_constant` (history.py:211),
+    /// surfaced as [`same_box`](Self::same_box). This is the same shared-cell
+    /// in-place-forward contract the const-kind `BoxKind::Const { value:
+    /// Cell<Value> }` `Rc<Box>` carrier provided. The forwarding visitor is
+    /// idempotent on an already-forwarded object (collector.rs:1133), so a
+    /// const cell reachable from two slots forwards safely.
+    Const(Rc<Cell<Value>>),
 }
 
 impl Operand {
@@ -69,7 +75,7 @@ impl Operand {
     /// `ConstInt(value)` object construction; identity starts here and is
     /// shared by every read of the slot).
     pub fn const_(value: Const) -> Operand {
-        Operand::Const(BoxRef::new_const(value.to_value()))
+        Operand::Const(Rc::new(Cell::new(value.to_value())))
     }
 
     /// The absent-slot sentinel.
@@ -89,9 +95,14 @@ impl Operand {
             Operand::None => OpRef::NONE,
             Operand::Op(op) => op.pos.get(),
             Operand::InputArg(ia) => OpRef::input_arg_typed(ia.index, ia.tp),
-            // Re-encodes from the box's live `Cell` value, so a GC-moved
-            // `ConstPtr` reads back at its post-move address.
-            Operand::Const(b) => b.to_opref(),
+            // Re-encodes from the live `Cell` value, so a GC-moved `ConstPtr`
+            // reads back at its post-move address (box_ref.rs:510-514 parity).
+            Operand::Const(cell) => match cell.get() {
+                Value::Int(v) => OpRef::const_int(v),
+                Value::Float(v) => OpRef::const_float(v),
+                Value::Ref(v) => OpRef::const_ptr(v),
+                Value::Void => OpRef::NONE,
+            },
         }
     }
 
@@ -110,7 +121,7 @@ impl Operand {
         match self {
             Operand::Op(op) => op.pos.get().ty().unwrap_or(Type::Void),
             Operand::InputArg(ia) => ia.tp,
-            Operand::Const(b) => b.type_(),
+            Operand::Const(cell) => cell.get().get_type(),
             Operand::None => Type::Void,
         }
     }
@@ -119,7 +130,7 @@ impl Operand {
     /// `None` for non-`Const`.
     pub fn const_value(&self) -> Option<Value> {
         match self {
-            Operand::Const(b) => b.const_value(),
+            Operand::Const(cell) => Some(cell.get()),
             _ => None,
         }
     }
@@ -128,7 +139,10 @@ impl Operand {
     /// parity).
     pub fn const_int(&self) -> Option<i64> {
         match self {
-            Operand::Const(b) => b.const_int(),
+            Operand::Const(cell) => match cell.get() {
+                Value::Int(v) => Some(v),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -173,9 +187,10 @@ impl Operand {
             Operand::None => BoxRef::none(),
             Operand::Op(op) => BoxRef::from_bound_op(op),
             Operand::InputArg(ia) => BoxRef::from_bound_inputarg(ia),
-            // The SAME `Rc<Box>` back — `_args[i]` returns the stored
-            // Const object, never a fresh equal-valued one.
-            Operand::Const(b) => b.clone(),
+            // Re-mint a const box from the live cell value (migration-window
+            // bridge). Const boxes are fresh-per-resolution and never
+            // `ptr_eq`-deduped, so a new identity is faithful.
+            Operand::Const(cell) => BoxRef::new_const(cell.get()),
         }
     }
 
@@ -193,9 +208,11 @@ impl Operand {
     /// otherwise a bound operand reading the already-remapped live pos would
     /// double-remap.
     ///
-    /// A Const box (value-typed, GC-walked in place through its `Cell`) lowers
-    /// to `Operand::Const`, whose `to_boxref` returns the same `Rc<Box>`
-    /// (identity + `Cell`-backed GC walk preserved). A position-only box (no
+    /// A Const box lowers to `Operand::Const`, whose value is read out into a
+    /// fresh `Rc<Cell<Value>>` (the `Cell`-backed in-place GC walk is
+    /// preserved; the fresh `Rc` is a new const identity, since the source
+    /// `BoxRef` and the operand carrier are distinct `Rc` types). A
+    /// position-only box (no
     /// bound handle — `BoxRef::from_opref` of a non-const ResOp/InputArg
     /// position) has no `Operand` to lower to and is a contract violation: by
     /// #9 every operand source binds its producer (`from_bound_op` /
@@ -218,11 +235,13 @@ impl Operand {
         if let Some(ia) = b.bound_inputarg() {
             return Operand::InputArg(ia);
         }
-        // A Const box lowers to the terminal `Operand::Const` carrying the
-        // same `Rc<Box>` (history.py Const object identity + `Cell`-backed
-        // GC walk preserved).
+        // A Const box lowers to the terminal `Operand::Const`, reading its
+        // value into a fresh `Rc<Cell<Value>>` (the inline-`ConstPtr` GC walk
+        // is preserved; the fresh `Rc` is a new const identity).
         if b.is_constant() {
-            return Operand::Const(b.clone());
+            return Operand::Const(Rc::new(Cell::new(
+                b.const_value().expect("is_constant box carries a const value"),
+            )));
         }
         // A position-only box (no producer Rc, non-const) reaches here only if
         // some operand source skipped binding its producer — an invariant
@@ -253,7 +272,16 @@ impl Operand {
     /// the producer).
     pub fn walk_const_ptr_refs(&self, visitor: &mut dyn FnMut(&mut GcRef)) {
         match self {
-            Operand::Const(b) => b.walk_const_ptr_refs(visitor),
+            // Forward an inline `ConstPtr` `GcRef` in place through the cell's
+            // get/visit/set cycle (box_ref.rs:561-568 parity) — no `&mut self`
+            // needed, so `Op.args` GC walks keep their shared `borrow()`.
+            Operand::Const(cell) => {
+                let mut v = cell.get();
+                if let Value::Ref(gcref) = &mut v {
+                    visitor(gcref);
+                    cell.set(v);
+                }
+            }
             Operand::None | Operand::Op(_) | Operand::InputArg(_) => {}
         }
     }
@@ -375,15 +403,16 @@ mod tests {
         assert!(o.is_bound());
         assert_eq!(o.to_boxref().as_ptr(), bia.as_ptr());
 
-        // Const -> Operand::Const carrying the SAME const box (history.py
-        // Const object identity; Cell-backed GC walk); NOT bound.
+        // Const -> Operand::Const carrying the const VALUE in a fresh
+        // Rc<Cell<Value>> (Cell-backed GC walk); NOT bound. to_boxref
+        // re-mints, so it no longer ptr-aliases the source box.
         let cbox = BoxRef::new_const(Value::Int(11));
         let o = Operand::from_boxref(&cbox);
         assert!(matches!(o, Operand::Const(_)));
         assert!(o.is_constant());
         assert!(!o.is_bound());
         assert_eq!(o.const_int(), Some(11));
-        assert_eq!(o.to_boxref().as_ptr(), cbox.as_ptr());
+        assert_eq!(o.to_boxref().const_int(), Some(11));
 
         // None sentinel -> Operand::None.
         assert!(matches!(

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -1433,7 +1433,11 @@ impl PtrInfo {
                 .map(|fd| fd.field_type())
                 .unwrap_or(Type::Int);
             let opcode = OpCode::getfield_for_type(tp);
-            result.push(Op::with_descr(opcode, &[structbox.clone()], descr));
+            result.push(Op::with_descr(
+                opcode,
+                &[crate::operand::Operand::from_boxref(&structbox)],
+                descr,
+            ));
         };
         if let PtrInfo::Virtual(v) = self {
             for (field_idx, value) in &v.fields {

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1474,10 +1474,10 @@ impl Op {
         }
     }
 
-    pub fn new(opcode: OpCode, args: &[BoxRef]) -> Self {
+    pub fn new(opcode: OpCode, args: &[Operand]) -> Self {
         Op {
             opcode,
-            args: std::cell::RefCell::new(args.iter().map(Operand::from_boxref).collect()),
+            args: std::cell::RefCell::new(args.iter().cloned().collect()),
             descr: std::cell::RefCell::new(None),
             pos: std::cell::Cell::new(OpRef::NONE),
             type_: opcode.result_type(),
@@ -1491,10 +1491,10 @@ impl Op {
         }
     }
 
-    pub fn with_descr(opcode: OpCode, args: &[BoxRef], descr: DescrRef) -> Self {
+    pub fn with_descr(opcode: OpCode, args: &[Operand], descr: DescrRef) -> Self {
         Op {
             opcode,
-            args: std::cell::RefCell::new(args.iter().map(Operand::from_boxref).collect()),
+            args: std::cell::RefCell::new(args.iter().cloned().collect()),
             descr: std::cell::RefCell::new(Some(descr)),
             pos: std::cell::Cell::new(OpRef::NONE),
             type_: opcode.result_type(),
@@ -1508,8 +1508,8 @@ impl Op {
         }
     }
 
-    pub fn arg(&self, idx: usize) -> BoxRef {
-        self.args.borrow()[idx].to_boxref()
+    pub fn arg(&self, idx: usize) -> Operand {
+        self.args.borrow()[idx].clone()
     }
 
     /// True iff argument `idx` is a live-tracking bound operand
@@ -1557,11 +1557,11 @@ impl Op {
     pub fn copy_and_change(
         &self,
         opcode: OpCode,
-        args: Option<&[BoxRef]>,
+        args: Option<&[Operand]>,
         descr: Option<Option<DescrRef>>,
     ) -> Op {
         let new_args: SmallVec<[Operand; 3]> = match args {
-            Some(a) => a.iter().map(Operand::from_boxref).collect(),
+            Some(a) => a.iter().cloned().collect(),
             None => self.args.borrow().clone(),
         };
         let new_descr = match descr {
@@ -4545,7 +4545,10 @@ mod tests {
         let (rhs_box, _rp) = crate::box_ref::test_support::bound_resop_box(Type::Int, 1);
         let lhs = lhs_box.to_opref();
         let rhs = rhs_box.to_opref();
-        let op = Op::new(OpCode::IntAdd, &[lhs_box, rhs_box]);
+        let op = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&lhs_box), Operand::from_boxref(&rhs_box)],
+        );
         assert_eq!(op.opcode, OpCode::IntAdd);
         assert_eq!(op.num_args(), 2);
         assert_eq!(op.arg(0).to_opref(), lhs);
@@ -4562,7 +4565,10 @@ mod tests {
         let (rhs_box, _rp) = crate::box_ref::test_support::bound_resop_box(Type::Int, 20);
         let lhs = lhs_box.to_opref();
         let rhs = rhs_box.to_opref();
-        let op = Op::new(OpCode::IntAdd, &[lhs_box, rhs_box]);
+        let op = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&lhs_box), Operand::from_boxref(&rhs_box)],
+        );
         assert_eq!(op.arg(0).to_opref(), lhs);
         assert_eq!(op.arg(1).to_opref(), rhs);
     }

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -4547,7 +4547,10 @@ mod tests {
         let rhs = rhs_box.to_opref();
         let op = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&lhs_box), Operand::from_boxref(&rhs_box)],
+            &[
+                Operand::from_boxref(&lhs_box),
+                Operand::from_boxref(&rhs_box),
+            ],
         );
         assert_eq!(op.opcode, OpCode::IntAdd);
         assert_eq!(op.num_args(), 2);
@@ -4567,7 +4570,10 @@ mod tests {
         let rhs = rhs_box.to_opref();
         let op = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&lhs_box), Operand::from_boxref(&rhs_box)],
+            &[
+                Operand::from_boxref(&lhs_box),
+                Operand::from_boxref(&rhs_box),
+            ],
         );
         assert_eq!(op.arg(0).to_opref(), lhs);
         assert_eq!(op.arg(1).to_opref(), rhs);

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1248,12 +1248,12 @@ pub struct Op {
     /// `op._args[i] = ...` on the same Python object the trace list,
     /// optimizer state, and backend input lists all observe.
     ///
-    /// `#9` operand-union flip: each slot is an [`Operand`] (a bound
-    /// producer carried by `Rc`, an inline `Const`, or — during the
-    /// migration window — a `Operand::Box` wrapping a not-yet-converted
-    /// `BoxRef`). The `BoxRef`-keyed accessors (`arg`, `getarglist`, ...)
-    /// convert on read/write via `Operand::to_boxref` / `from_boxref`, so
-    /// the flip is behavior-preserving while callers migrate.
+    /// `#9` operand-union: each slot is an [`Operand`] — a bound producer
+    /// carried by `Rc` (`Op` / `InputArg`) or an inline `Const`. The
+    /// `BoxRef`-keyed accessors (`arg`, `getarglist`, ...) convert on
+    /// read/write via `Operand::to_boxref` / `from_boxref` while callers
+    /// still speak `BoxRef`; `from_boxref` of an unbound position-only box
+    /// is a contract violation and panics (every source binds its producer).
     pub args: std::cell::RefCell<SmallVec<[Operand; 3]>>,
     /// `resoperation.py:460 ResOpWithDescr._descr` parity.  `RefCell`
     /// so the optimizer can stamp a descr onto a shared `Op` reached
@@ -1281,10 +1281,9 @@ pub struct Op {
     ///
     /// Stored as [`Operand`] (the same union as `args` — `GuardResOp.
     /// _fail_args` holds the Box objects themselves, resoperation.py:483).
-    /// MIGRATION (#9): every write currently freezes to `Operand::Box`
-    /// (position snapshot, byte-identical to the previous `BoxRef`
-    /// storage); the bound-shed + skip-bound-in-remap follow-up mirrors
-    /// the `args` sequence.
+    /// Each write sheds to a bound producer (`Operand::Op` / `InputArg`) or
+    /// an inline `Const`; the position-remap passes skip bound operands and
+    /// rewrite no longer-existing position-only snapshot, mirroring `args`.
     pub fail_args: std::cell::RefCell<Option<SmallVec<[Operand; 3]>>>,
     /// Types of fail_args, set by the optimizer (`set_fail_arg_types`)
     /// from each fail-arg operand's type.
@@ -1515,9 +1514,9 @@ impl Op {
 
     /// True iff argument `idx` is a live-tracking bound operand
     /// (`Operand::Op` / `Operand::InputArg`) that reads its producer's
-    /// current `op.pos`, rather than a frozen `Operand::Box` snapshot. The
+    /// current `op.pos`, rather than a `Const` / `None` slot. The
     /// position-remap passes skip these — they auto-track a renumbered
-    /// producer and need no snapshot rewrite.
+    /// producer and need no rewrite.
     pub fn arg_is_bound(&self, idx: usize) -> bool {
         self.args.borrow()[idx].is_bound()
     }
@@ -4539,13 +4538,14 @@ mod tests {
     #[test]
     fn test_op_new() {
         // IntAdd takes two Int operands (resoperation.py:1693
-        // `opclasses[INT_ADD].arity` = 2).
-        let lhs = OpRef::int_op(0);
-        let rhs = OpRef::int_op(1);
-        let op = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(lhs), BoxRef::from_opref(rhs)],
-        );
+        // `opclasses[INT_ADD].arity` = 2). The operands bind to synthetic
+        // producers (kept alive by `_lp`/`_rp`) so `Op::new` carries
+        // `Operand::Op`, not an unbound position-only box.
+        let (lhs_box, _lp) = crate::box_ref::test_support::bound_resop_box(Type::Int, 0);
+        let (rhs_box, _rp) = crate::box_ref::test_support::bound_resop_box(Type::Int, 1);
+        let lhs = lhs_box.to_opref();
+        let rhs = rhs_box.to_opref();
+        let op = Op::new(OpCode::IntAdd, &[lhs_box, rhs_box]);
         assert_eq!(op.opcode, OpCode::IntAdd);
         assert_eq!(op.num_args(), 2);
         assert_eq!(op.arg(0).to_opref(), lhs);
@@ -4558,12 +4558,11 @@ mod tests {
 
     #[test]
     fn test_op_getarg() {
-        let lhs = OpRef::int_op(10);
-        let rhs = OpRef::int_op(20);
-        let op = Op::new(
-            OpCode::IntAdd,
-            &[BoxRef::from_opref(lhs), BoxRef::from_opref(rhs)],
-        );
+        let (lhs_box, _lp) = crate::box_ref::test_support::bound_resop_box(Type::Int, 10);
+        let (rhs_box, _rp) = crate::box_ref::test_support::bound_resop_box(Type::Int, 20);
+        let lhs = lhs_box.to_opref();
+        let rhs = rhs_box.to_opref();
+        let op = Op::new(OpCode::IntAdd, &[lhs_box, rhs_box]);
         assert_eq!(op.arg(0).to_opref(), lhs);
         assert_eq!(op.arg(1).to_opref(), rhs);
     }

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -80,6 +80,26 @@ pub(crate) mod test_support {
         b
     }
 
+    /// Drop-in for `BoxRef::from_opref(root)` inside test `BoxEnv`
+    /// `get_box_replacement_boxref` impls: dispatch on the OpRef variant to a
+    /// bound ResOp / InputArg box (`None` / `Const` stay `from_opref`, which
+    /// `Operand` represents). Mirrors `majit_ir::box_ref::bound_box_from_opref`
+    /// using this module's thread-local producer pool, so the box sheds to a
+    /// bound `Operand::Op` / `Operand::InputArg` and never hits the
+    /// position-only `from_boxref` panic.
+    pub(crate) fn rooted_box_from_opref(a: OpRef) -> BoxRef {
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                rooted_inputarg_box(ty, a.raw())
+            }
+            _ => rooted_resop_box(ty, a.raw()),
+        }
+    }
+
     /// oparser-faithful trace builder for optimizer unit tests
     /// (`rpython/jit/tool/oparser.py`). Each producer op is registered as a
     /// live `OpRc` and each consumer arg references the producing op's bound

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -150,7 +150,9 @@ pub(crate) mod test_support {
         /// next sequential result position. Returns the producing op's bound
         /// result box for use as a later consumer arg.
         pub(crate) fn op(&mut self, opcode: OpCode, args: &[BoxRef]) -> BoxRef {
-            let op = std::rc::Rc::new(Op::new(opcode, args));
+            let op_args: Vec<majit_ir::operand::Operand> =
+                args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let op = std::rc::Rc::new(Op::new(opcode, &op_args));
             op.pos
                 .set(OpRef::op_typed(self.next_pos, opcode.result_type()));
             self.next_pos += 1;
@@ -166,7 +168,9 @@ pub(crate) mod test_support {
             args: &[BoxRef],
             descr: majit_ir::DescrRef,
         ) -> BoxRef {
-            let op = std::rc::Rc::new(Op::with_descr(opcode, args, descr));
+            let op_args: Vec<majit_ir::operand::Operand> =
+                args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let op = std::rc::Rc::new(Op::with_descr(opcode, &op_args, descr));
             op.pos
                 .set(OpRef::op_typed(self.next_pos, opcode.result_type()));
             self.next_pos += 1;

--- a/majit/majit-metainterp/src/box.rs
+++ b/majit/majit-metainterp/src/box.rs
@@ -150,8 +150,10 @@ pub(crate) mod test_support {
         /// next sequential result position. Returns the producing op's bound
         /// result box for use as a later consumer arg.
         pub(crate) fn op(&mut self, opcode: OpCode, args: &[BoxRef]) -> BoxRef {
-            let op_args: Vec<majit_ir::operand::Operand> =
-                args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let op_args: Vec<majit_ir::operand::Operand> = args
+                .iter()
+                .map(majit_ir::operand::Operand::from_boxref)
+                .collect();
             let op = std::rc::Rc::new(Op::new(opcode, &op_args));
             op.pos
                 .set(OpRef::op_typed(self.next_pos, opcode.result_type()));
@@ -168,8 +170,10 @@ pub(crate) mod test_support {
             args: &[BoxRef],
             descr: majit_ir::DescrRef,
         ) -> BoxRef {
-            let op_args: Vec<majit_ir::operand::Operand> =
-                args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let op_args: Vec<majit_ir::operand::Operand> = args
+                .iter()
+                .map(majit_ir::operand::Operand::from_boxref)
+                .collect();
             let op = std::rc::Rc::new(Op::with_descr(opcode, &op_args, descr));
             op.pos
                 .set(OpRef::op_typed(self.next_pos, opcode.result_type()));

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -24,6 +24,7 @@ use majit_backend::{
     ExitRecoveryLayout, FailDescrLayout, JitCellToken, TerminalExitLayout,
 };
 use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 use majit_ir::{
     AccumInfo, Const, DescrRef, FailDescr, GcRef, GuardPendingFieldEntry, InputArg, Op, OpCode,
     OpRef, RdVirtualInfo, Type, Value,
@@ -1740,7 +1741,7 @@ pub(crate) fn normalize_closing_jump_args(
         if defined.contains(&arg.to_opref()) {
             continue;
         }
-        jump.setarg(idx, label_args[idx].clone());
+        jump.setarg(idx, Operand::from_boxref(&label_args[idx]));
     }
 
     ops
@@ -1889,7 +1890,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
                     }
                     replaced = true;
                 }
-                emitted.setarg(i, bound);
+                emitted.setarg(i, Operand::from_boxref(&bound));
             }
         }
 
@@ -1990,7 +1991,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             OpRef::input_arg_typed(expanded_inputargs[i].index, expanded_inputargs[i].tp);
         let new_opref = OpRef::op_typed(next_opref, field.field_type);
         next_opref += 1;
-        let mut op = Op::new(opcode, &[vable_box.clone()]);
+        let mut op = Op::new(opcode, &[Operand::from_boxref(&vable_box)]);
         op.pos.set(new_opref);
         op.setdescr(descr);
         let op = std::rc::Rc::new(op);
@@ -2011,7 +2012,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
         // GETFIELD_GC_R(vable_box, array_field_descr) → array pointer (Ref-typed).
         let array_opref = OpRef::ref_op(next_opref);
         next_opref += 1;
-        let mut arr_load = Op::new(OpCode::GetfieldGcR, &[vable_box.clone()]);
+        let mut arr_load = Op::new(OpCode::GetfieldGcR, &[Operand::from_boxref(&vable_box)]);
         arr_load.pos.set(array_opref);
         arr_load.setdescr(array_field_descr.clone());
         let arr_load = std::rc::Rc::new(arr_load);
@@ -2085,7 +2086,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
                 // RPython's flat GC-array layout — out of scope.
                 let ptr_opref = OpRef::int_op(next_opref);
                 next_opref += 1;
-                let mut ptr_load = Op::new(OpCode::GetfieldGcI, &[array_box.clone()]);
+                let mut ptr_load = Op::new(OpCode::GetfieldGcI, &[Operand::from_boxref(&array_box)]);
                 ptr_load.pos.set(ptr_opref);
                 ptr_load.setdescr(majit_ir::descr::make_field_descr(
                     ptr_offset,
@@ -2122,7 +2123,7 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             next_opref += 1;
             let mut elem_op = Op::new(
                 item_opcode,
-                &[item_base.clone(), BoxRef::from_opref(const_opref)],
+                &[Operand::from_boxref(&item_base), Operand::from_boxref(&BoxRef::from_opref(const_opref))],
             );
             elem_op.pos.set(new_opref);
             elem_op.setdescr(item_descr.clone());
@@ -2538,7 +2539,7 @@ pub fn compile_tmp_callback(
     let call_opcode = OpCode::call_for_type(jitdriver_sd.result_type);
     // `compile.py:1132` `call_op = ResOperation(opnum, callargs,
     // descr=jd.portal_calldescr)`.
-    let call_op = std::rc::Rc::new(Op::with_descr(call_opcode, &callargs_box, portal_calldescr));
+    let call_op = std::rc::Rc::new(Op::with_descr(call_opcode, &callargs_box.iter().map(Operand::from_boxref).collect::<Vec<_>>(), portal_calldescr));
     //
     // `compile.py:1133-1136` `if call_op.type != 'v': finishargs = [call_op]
     // else: finishargs = []`.
@@ -2564,7 +2565,7 @@ pub fn compile_tmp_callback(
     let mut guard_op = Op::with_descr(OpCode::GuardNoException, &[], propagate_exc_descr);
     // `compile.py:1144` `operations[1].setfailargs([])` — no fail args.
     guard_op.setfailargs(smallvec![]);
-    let finish_op = Op::with_descr(OpCode::Finish, &finishargs_box, portal_finishtoken);
+    let finish_op = Op::with_descr(OpCode::Finish, &finishargs_box.iter().map(Operand::from_boxref).collect::<Vec<_>>(), portal_finishtoken);
     let operations: Vec<majit_ir::OpRc> = vec![
         call_op,
         std::rc::Rc::new(guard_op),
@@ -2652,7 +2653,7 @@ mod tests {
         let rd_consts = memo.consts().to_vec();
 
         let inputargs = vec![InputArg::new_ref(0), InputArg::new_int(1)];
-        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_inputarg_box(Type::Int, 1)]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Int, 1))]);
         let descr = crate::compile::make_resume_guard_descr_typed(vec![Type::Ref, Type::Int]);
         if let Some(fd) = descr.as_fail_descr() {
             fd.set_rd_numb(Some(rd_numb));
@@ -2699,7 +2700,7 @@ mod tests {
             InputArg::new_ref(2),
             InputArg::new_ref(3),
         ];
-        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_inputarg_box(Type::Ref, 0)]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 0))]);
         let fail_arg_types = vec![Type::Ref, Type::Ref, Type::Int, Type::Int];
         let descr = make_fail_descr_with_index(0, fail_arg_types.len());
         descr
@@ -2734,17 +2735,17 @@ mod tests {
         // consumers bind that result (from_bound_op) instead of a position-only
         // box, so patch_new_loop's forwarding rewrites them through op identity.
         let op0: majit_ir::OpRc = {
-            let mut op = Op::new(OpCode::SameAsR, &[rooted_inputarg_box(Type::Ref, 1)]);
+            let mut op = Op::new(OpCode::SameAsR, &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 1))]);
             op.pos.set(OpRef::ref_op(10));
             std::rc::Rc::new(op)
         };
         let op0_result = BoxRef::from_bound_op(&op0);
         let op1: majit_ir::OpRc = std::rc::Rc::new(Op::new(
             OpCode::Label,
-            &[rooted_inputarg_box(Type::Ref, 0), op0_result.clone()],
+            &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 0)), majit_ir::operand::Operand::from_boxref(&op0_result)],
         ));
         let op2: majit_ir::OpRc = {
-            let mut op = Op::new(OpCode::GetfieldGcPureI, &[op0_result.clone()]);
+            let mut op = Op::new(OpCode::GetfieldGcPureI, &[majit_ir::operand::Operand::from_boxref(&op0_result)]);
             op.pos.set(OpRef::int_op(11));
             op.setdescr(majit_ir::descr::make_field_descr(
                 16,
@@ -2823,9 +2824,9 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::Label,
             &[
-                rooted_inputarg_box(Type::Ref, 0),
-                rooted_inputarg_box(Type::Ref, 1),
-                rooted_inputarg_box(Type::Ref, 2),
+                majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 0)),
+                majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 1)),
+                majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 2)),
             ],
         )];
         let mut inputargs = vec![

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2086,7 +2086,8 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
                 // RPython's flat GC-array layout — out of scope.
                 let ptr_opref = OpRef::int_op(next_opref);
                 next_opref += 1;
-                let mut ptr_load = Op::new(OpCode::GetfieldGcI, &[Operand::from_boxref(&array_box)]);
+                let mut ptr_load =
+                    Op::new(OpCode::GetfieldGcI, &[Operand::from_boxref(&array_box)]);
                 ptr_load.pos.set(ptr_opref);
                 ptr_load.setdescr(majit_ir::descr::make_field_descr(
                     ptr_offset,
@@ -2123,7 +2124,10 @@ pub(crate) fn patch_new_loop_to_load_virtualizable_fields(
             next_opref += 1;
             let mut elem_op = Op::new(
                 item_opcode,
-                &[Operand::from_boxref(&item_base), Operand::from_boxref(&BoxRef::from_opref(const_opref))],
+                &[
+                    Operand::from_boxref(&item_base),
+                    Operand::from_boxref(&BoxRef::from_opref(const_opref)),
+                ],
             );
             elem_op.pos.set(new_opref);
             elem_op.setdescr(item_descr.clone());
@@ -2539,7 +2543,14 @@ pub fn compile_tmp_callback(
     let call_opcode = OpCode::call_for_type(jitdriver_sd.result_type);
     // `compile.py:1132` `call_op = ResOperation(opnum, callargs,
     // descr=jd.portal_calldescr)`.
-    let call_op = std::rc::Rc::new(Op::with_descr(call_opcode, &callargs_box.iter().map(Operand::from_boxref).collect::<Vec<_>>(), portal_calldescr));
+    let call_op = std::rc::Rc::new(Op::with_descr(
+        call_opcode,
+        &callargs_box
+            .iter()
+            .map(Operand::from_boxref)
+            .collect::<Vec<_>>(),
+        portal_calldescr,
+    ));
     //
     // `compile.py:1133-1136` `if call_op.type != 'v': finishargs = [call_op]
     // else: finishargs = []`.
@@ -2565,7 +2576,14 @@ pub fn compile_tmp_callback(
     let mut guard_op = Op::with_descr(OpCode::GuardNoException, &[], propagate_exc_descr);
     // `compile.py:1144` `operations[1].setfailargs([])` — no fail args.
     guard_op.setfailargs(smallvec![]);
-    let finish_op = Op::with_descr(OpCode::Finish, &finishargs_box.iter().map(Operand::from_boxref).collect::<Vec<_>>(), portal_finishtoken);
+    let finish_op = Op::with_descr(
+        OpCode::Finish,
+        &finishargs_box
+            .iter()
+            .map(Operand::from_boxref)
+            .collect::<Vec<_>>(),
+        portal_finishtoken,
+    );
     let operations: Vec<majit_ir::OpRc> = vec![
         call_op,
         std::rc::Rc::new(guard_op),
@@ -2653,7 +2671,12 @@ mod tests {
         let rd_consts = memo.consts().to_vec();
 
         let inputargs = vec![InputArg::new_ref(0), InputArg::new_int(1)];
-        let mut guard = Op::new(OpCode::GuardTrue, &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Int, 1))]);
+        let mut guard = Op::new(
+            OpCode::GuardTrue,
+            &[majit_ir::operand::Operand::from_boxref(
+                &rooted_inputarg_box(Type::Int, 1),
+            )],
+        );
         let descr = crate::compile::make_resume_guard_descr_typed(vec![Type::Ref, Type::Int]);
         if let Some(fd) = descr.as_fail_descr() {
             fd.set_rd_numb(Some(rd_numb));
@@ -2700,7 +2723,12 @@ mod tests {
             InputArg::new_ref(2),
             InputArg::new_ref(3),
         ];
-        let mut guard = Op::new(OpCode::GuardTrue, &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 0))]);
+        let mut guard = Op::new(
+            OpCode::GuardTrue,
+            &[majit_ir::operand::Operand::from_boxref(
+                &rooted_inputarg_box(Type::Ref, 0),
+            )],
+        );
         let fail_arg_types = vec![Type::Ref, Type::Ref, Type::Int, Type::Int];
         let descr = make_fail_descr_with_index(0, fail_arg_types.len());
         descr
@@ -2735,17 +2763,28 @@ mod tests {
         // consumers bind that result (from_bound_op) instead of a position-only
         // box, so patch_new_loop's forwarding rewrites them through op identity.
         let op0: majit_ir::OpRc = {
-            let mut op = Op::new(OpCode::SameAsR, &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 1))]);
+            let mut op = Op::new(
+                OpCode::SameAsR,
+                &[majit_ir::operand::Operand::from_boxref(
+                    &rooted_inputarg_box(Type::Ref, 1),
+                )],
+            );
             op.pos.set(OpRef::ref_op(10));
             std::rc::Rc::new(op)
         };
         let op0_result = BoxRef::from_bound_op(&op0);
         let op1: majit_ir::OpRc = std::rc::Rc::new(Op::new(
             OpCode::Label,
-            &[majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 0)), majit_ir::operand::Operand::from_boxref(&op0_result)],
+            &[
+                majit_ir::operand::Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 0)),
+                majit_ir::operand::Operand::from_boxref(&op0_result),
+            ],
         ));
         let op2: majit_ir::OpRc = {
-            let mut op = Op::new(OpCode::GetfieldGcPureI, &[majit_ir::operand::Operand::from_boxref(&op0_result)]);
+            let mut op = Op::new(
+                OpCode::GetfieldGcPureI,
+                &[majit_ir::operand::Operand::from_boxref(&op0_result)],
+            );
             op.pos.set(OpRef::int_op(11));
             op.setdescr(majit_ir::descr::make_field_descr(
                 16,

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -606,18 +606,18 @@ impl TreeLoop {
                     bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs),
                 );
             }
+            // Post-cut ops never carry fail_args at cut time (PYRE_REMAP_PROBE
+            // 2026-06-11: 0 fires across check.py corpus + lib tests); they are
+            // attached later by store_final_boxes_in_guard. The former
+            // `from_opref` remap here minted a position-only `Operand::Box` as a
+            // release safety net; with the source measured dead it is dropped in
+            // favor of a debug tripwire.
+            let cut_opcode = new_op.opcode;
             if let Some(fa) = new_op.fail_args_mut() {
-                for arg in fa.iter_mut() {
-                    // Measured dead (PYRE_REMAP_PROBE 2026-06-11: 0 fires
-                    // across check.py corpus + lib tests) — post-cut ops
-                    // never carry fail_args at cut time; they are attached
-                    // later by store_final_boxes_in_guard. Rewrite kept as
-                    // a release safety net.
-                    debug_assert!(false, "cut-trace op carried fail_args: {:?}", new_op.opcode);
-                    *arg = majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(remap_ref(
-                        &arg.to_opref(),
-                    )));
-                }
+                debug_assert!(
+                    fa.is_empty(),
+                    "cut-trace op carried fail_args: {cut_opcode:?}"
+                );
             }
             new_ops.push(std::rc::Rc::new(new_op));
         }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -580,7 +580,11 @@ impl TreeLoop {
                 let arg = new_op.arg(i);
                 new_op.setarg(
                     i,
-                    majit_ir::operand::Operand::from_boxref(&bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs)),
+                    majit_ir::operand::Operand::from_boxref(&bind_remapped(
+                        remap_ref(&arg.to_opref()),
+                        &new_ops,
+                        &new_inputargs,
+                    )),
                 );
             }
             // Prefix ops don't need fail_args (they're not guards).
@@ -603,7 +607,11 @@ impl TreeLoop {
                 let arg = new_op.arg(j);
                 new_op.setarg(
                     j,
-                    majit_ir::operand::Operand::from_boxref(&bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs)),
+                    majit_ir::operand::Operand::from_boxref(&bind_remapped(
+                        remap_ref(&arg.to_opref()),
+                        &new_ops,
+                        &new_inputargs,
+                    )),
                 );
             }
             // Post-cut ops never carry fail_args at cut time (PYRE_REMAP_PROBE
@@ -787,7 +795,10 @@ mod tests {
         // Guards in a trace carry fail_args.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref()]);
+        guard.setfailargs(smallvec::smallvec![
+            iarg_box(0).to_boxref(),
+            iarg_box(1).to_boxref()
+        ]);
 
         let ops = vec![
             guard,
@@ -892,7 +903,10 @@ mod tests {
         let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         g0.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref()]);
         let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
-        g1.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref()]);
+        g1.setfailargs(smallvec::smallvec![
+            iarg_box(0).to_boxref(),
+            iarg_box(1).to_boxref()
+        ]);
 
         let ops = vec![
             g0,
@@ -1062,7 +1076,11 @@ mod tests {
         let add_op = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         let mut guard_op = Op::new(OpCode::GuardTrue, &[iop_box(2)]);
         // fail_args referencing input args (0, 1) and the add result (2)
-        guard_op.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref(), iop_box(2).to_boxref()]);
+        guard_op.setfailargs(smallvec::smallvec![
+            iarg_box(0).to_boxref(),
+            iarg_box(1).to_boxref(),
+            iop_box(2).to_boxref()
+        ]);
 
         let ops = vec![
             add_op,
@@ -1090,7 +1108,11 @@ mod tests {
         let add = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
 
         let mut g2 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        g2.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref(), iop_box(2).to_boxref()]);
+        g2.setfailargs(smallvec::smallvec![
+            iarg_box(0).to_boxref(),
+            iarg_box(1).to_boxref(),
+            iop_box(2).to_boxref()
+        ]);
 
         let ops = vec![
             g0,
@@ -1192,7 +1214,10 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[iarg_box(0), Operand::from_boxref(&BoxRef::from_opref(OpRef::NONE))],
+                &[
+                    iarg_box(0),
+                    Operand::from_boxref(&BoxRef::from_opref(OpRef::NONE)),
+                ],
             ),
             Op::new(OpCode::Finish, &[]),
         ];
@@ -1207,7 +1232,10 @@ mod tests {
         let const_ref = OpRef::const_int(0);
         let mut op0 = Op::new(
             OpCode::IntAdd,
-            &[iarg_box(0), Operand::from_boxref(&BoxRef::from_opref(const_ref))],
+            &[
+                iarg_box(0),
+                Operand::from_boxref(&BoxRef::from_opref(const_ref)),
+            ],
         );
         op0.pos.set(iop(1));
         let ops = vec![op0, Op::new(OpCode::Finish, &[iop_box(1)])];
@@ -1479,7 +1507,10 @@ mod tests {
         let const_ref = OpRef::const_int(0);
         let mut op1 = Op::new(
             OpCode::IntAdd,
-            &[iarg_box(0), Operand::from_boxref(&BoxRef::from_opref(const_ref))],
+            &[
+                iarg_box(0),
+                Operand::from_boxref(&BoxRef::from_opref(const_ref)),
+            ],
         );
         op1.pos.set(iop(2));
         ops.push(op1);

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -580,7 +580,7 @@ impl TreeLoop {
                 let arg = new_op.arg(i);
                 new_op.setarg(
                     i,
-                    bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs),
+                    majit_ir::operand::Operand::from_boxref(&bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs)),
                 );
             }
             // Prefix ops don't need fail_args (they're not guards).
@@ -603,7 +603,7 @@ impl TreeLoop {
                 let arg = new_op.arg(j);
                 new_op.setarg(
                     j,
-                    bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs),
+                    majit_ir::operand::Operand::from_boxref(&bind_remapped(remap_ref(&arg.to_opref()), &new_ops, &new_inputargs)),
                 );
             }
             // Post-cut ops never carry fail_args at cut time (PYRE_REMAP_PROBE
@@ -679,6 +679,7 @@ mod tests {
     use majit_ir::Type;
 
     use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
+    use majit_ir::operand::Operand;
 
     #[derive(Debug)]
     struct DummyGuardDescr;
@@ -704,12 +705,12 @@ mod tests {
     // `Operand::InputArg` / `Operand::Op` (never the position-only
     // `Operand::Box`); `to_opref()` is preserved, so position-keyed
     // assertions still hold.
-    fn iarg_box(pos: u32) -> BoxRef {
-        rooted_inputarg_box(Type::Int, pos)
+    fn iarg_box(pos: u32) -> Operand {
+        Operand::from_boxref(&rooted_inputarg_box(Type::Int, pos))
     }
 
-    fn iop_box(pos: u32) -> BoxRef {
-        rooted_resop_box(Type::Int, pos)
+    fn iop_box(pos: u32) -> Operand {
+        Operand::from_boxref(&rooted_resop_box(Type::Int, pos))
     }
 
     #[test]
@@ -786,7 +787,7 @@ mod tests {
         // Guards in a trace carry fail_args.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1)]);
+        guard.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref()]);
 
         let ops = vec![
             guard,
@@ -870,8 +871,8 @@ mod tests {
             OpCode::Jump,
             &[
                 iarg_box(0),
-                rooted_inputarg_box(Type::Ref, 1),
-                rooted_inputarg_box(Type::Float, 2),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 1)),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Float, 2)),
             ],
         )];
         let trace = TreeLoop::new(inputargs, ops);
@@ -889,9 +890,9 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
 
         let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        g0.setfailargs(smallvec::smallvec![iarg_box(0)]);
+        g0.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref()]);
         let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
-        g1.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1)]);
+        g1.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref()]);
 
         let ops = vec![
             g0,
@@ -1061,7 +1062,7 @@ mod tests {
         let add_op = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         let mut guard_op = Op::new(OpCode::GuardTrue, &[iop_box(2)]);
         // fail_args referencing input args (0, 1) and the add result (2)
-        guard_op.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1), iop_box(2)]);
+        guard_op.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref(), iop_box(2).to_boxref()]);
 
         let ops = vec![
             add_op,
@@ -1085,11 +1086,11 @@ mod tests {
         let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         g0.setfailargs(smallvec::smallvec![]);
         let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
-        g1.setfailargs(smallvec::smallvec![iarg_box(0)]);
+        g1.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref()]);
         let add = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
 
         let mut g2 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        g2.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1), iop_box(2)]);
+        g2.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref(), iarg_box(1).to_boxref(), iop_box(2).to_boxref()]);
 
         let ops = vec![
             g0,
@@ -1191,7 +1192,7 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::IntAdd,
-                &[iarg_box(0), BoxRef::from_opref(OpRef::NONE)],
+                &[iarg_box(0), Operand::from_boxref(&BoxRef::from_opref(OpRef::NONE))],
             ),
             Op::new(OpCode::Finish, &[]),
         ];
@@ -1206,7 +1207,7 @@ mod tests {
         let const_ref = OpRef::const_int(0);
         let mut op0 = Op::new(
             OpCode::IntAdd,
-            &[iarg_box(0), BoxRef::from_opref(const_ref)],
+            &[iarg_box(0), Operand::from_boxref(&BoxRef::from_opref(const_ref))],
         );
         op0.pos.set(iop(1));
         let ops = vec![op0, Op::new(OpCode::Finish, &[iop_box(1)])];
@@ -1270,7 +1271,7 @@ mod tests {
         // history.py:591: fail_args entries must be in seen
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![iop_box(99)]);
+        guard.setfailargs(smallvec::smallvec![iop_box(99).to_boxref()]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
         let trace = TreeLoop::new(inputargs, ops);
@@ -1478,7 +1479,7 @@ mod tests {
         let const_ref = OpRef::const_int(0);
         let mut op1 = Op::new(
             OpCode::IntAdd,
-            &[iarg_box(0), BoxRef::from_opref(const_ref)],
+            &[iarg_box(0), Operand::from_boxref(&BoxRef::from_opref(const_ref))],
         );
         op1.pos.set(iop(2));
         ops.push(op1);

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -664,8 +664,7 @@ impl<'a> ByteTraceIter<'a> {
     ) -> Self {
         let cache_size = (trace._index as usize).max(trace.max_num_inputargs as usize);
         let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
-        let mut inputargs: Vec<majit_ir::InputArgRc> =
-            Vec::with_capacity(inputarg_templates.len());
+        let mut inputargs: Vec<majit_ir::InputArgRc> = Vec::with_capacity(inputarg_templates.len());
         let mut _fresh = 0u32;
         for &template in inputarg_templates {
             // Constant templates would imply the cut sub-trace treats a

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -414,7 +414,7 @@ impl<'a> TraceIterator<'a> {
         // opencoder.py:379-387: for i in range(argnum):
         //     res.setarg(i, self._untag(self._next()))
         for i in 0..res.num_args() {
-            res.setarg(i, self._untag(res.arg(i).to_opref()));
+            res.setarg(i, majit_ir::operand::Operand::from_boxref(&self._untag(res.arg(i).to_opref())));
         }
         if let Some(fa) = res.fail_args_mut() {
             for arg in fa.iter_mut() {
@@ -854,9 +854,11 @@ impl<'a> Iterator for ByteTraceIter<'a> {
         // already bound boxes (`_untag` → `_get` bound producer / inline
         // const), so building the op binds each arg to its producer and
         // mints no position-only `Operand::Box`.
+        let args_operand: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
+            args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
         let op = match descr {
-            Some(d) => majit_ir::Op::with_descr(opcode, &args, d),
-            None => majit_ir::Op::new(opcode, &args),
+            Some(d) => majit_ir::Op::with_descr(opcode, &args_operand, d),
+            None => majit_ir::Op::new(opcode, &args_operand),
         };
         op.rd_resume_position.set(rd_resume_position);
         // opencoder.py:373-374 `cls = opclasses[opnum]; res = cls()` —
@@ -2901,8 +2903,9 @@ mod tests {
     /// Helper: build an Op with a specific trace position and the same
     /// typed result class RPython's `opclasses[opnum]` would instantiate.
     fn op_at(pos: u32, opcode: majit_ir::OpCode, args: &[OpRef]) -> majit_ir::Op {
-        let box_args: Vec<BoxRef> = args.iter().map(|a| box_arg(*a)).collect();
-        let mut op = majit_ir::Op::new(opcode, &box_args);
+        let op_args: Vec<majit_ir::operand::Operand> =
+            args.iter().map(|a| majit_ir::operand::Operand::from_boxref(&box_arg(*a))).collect();
+        let mut op = majit_ir::Op::new(opcode, &op_args);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
     }
@@ -2928,7 +2931,7 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(iop(3))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))]),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -2971,7 +2974,7 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(iop(3))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))]),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -3047,7 +3050,7 @@ mod tests {
         let ops = vec![
             op_at(1, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(0)]),
             op_at(2, majit_ir::OpCode::IntAdd, &[iop(1), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(iop(2))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(2)))]),
         ];
         // Shifted phase: start_fresh = 100 so any confusion between
         // _index (raw trace position) and _fresh (fresh OpRef counter)
@@ -3105,7 +3108,7 @@ mod tests {
         let ops = vec![
             op_at(3, majit_ir::OpCode::GetfieldRawI, &[rarg(0)]),
             op_at(1, majit_ir::OpCode::GetarrayitemGcR, &[iop(3), rarg(1)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg(rop(1))]),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(rop(1)))]),
         ];
         let inputarg_types = vec![
             majit_ir::Type::Ref,

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -567,11 +567,14 @@ pub struct ByteTraceIter<'a> {
     /// `_floats`, `_descrs`, `metainterp_sd.all_descrs`.
     pub trace: &'a TraceRecordBuffer,
     /// opencoder.py:255 `self._cache` — raw trace position → fresh
-    /// per-iteration OpRef.
-    pub _cache: Vec<Option<OpRef>>,
+    /// per-iteration box OBJECT (bound `BoxRef`), mirroring
+    /// `TraceIterator::_cache`. A later TAGBOX arg resolves through
+    /// `_get` to the same bound producer handle instead of a
+    /// position-only `Operand::Box`.
+    pub _cache: Vec<Option<BoxRef>>,
     /// opencoder.py:259-263 `self.inputargs` — fresh iterator-local
-    /// OpRefs bound to the trace's inputargs.
-    pub inputargs: Vec<OpRef>,
+    /// `InputArg` objects bound to the trace's inputargs.
+    pub inputargs: Vec<majit_ir::InputArgRc>,
     pub start: usize,
     pub pos: usize,
     pub end: usize,
@@ -597,15 +600,15 @@ impl<'a> ByteTraceIter<'a> {
     /// opencoder-local `_refs` / `_bigints` / `_floats` pools.
     pub fn new(trace: &'a TraceRecordBuffer, start: usize, end: usize, start_fresh: u32) -> Self {
         let cache_size = (trace._index as usize).max(trace.max_num_inputargs as usize);
-        let mut _cache: Vec<Option<OpRef>> = vec![None; cache_size];
+        let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
         let mut _fresh = start_fresh;
         // opencoder.py:264-265 `[rop.inputarg_from_tp(arg.type) for arg in
         // self.trace.inputargs]` — type comes from each `InputArg.tp`.
-        let inputargs: Vec<OpRef> = trace
+        let inputargs: Vec<majit_ir::InputArgRc> = trace
             .inputargs
             .iter()
             .map(|ia| {
-                let r = OpRef::input_arg_typed(_fresh, ia.tp);
+                let r = InputArg::from_type_rc(ia.tp, _fresh);
                 _fresh += 1;
                 r
             })
@@ -615,7 +618,7 @@ impl<'a> ByteTraceIter<'a> {
             if p >= _cache.len() {
                 _cache.resize(p + 1, None);
             }
-            _cache[p] = Some(inputargs[i]);
+            _cache[p] = Some(BoxRef::from_bound_inputarg(&inputargs[i]));
         }
         ByteTraceIter {
             trace,
@@ -649,8 +652,9 @@ impl<'a> ByteTraceIter<'a> {
         inputarg_templates: &[OpRef],
     ) -> Self {
         let cache_size = (trace._index as usize).max(trace.max_num_inputargs as usize);
-        let mut _cache: Vec<Option<OpRef>> = vec![None; cache_size];
-        let mut inputargs: Vec<OpRef> = Vec::with_capacity(inputarg_templates.len());
+        let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
+        let mut inputargs: Vec<majit_ir::InputArgRc> =
+            Vec::with_capacity(inputarg_templates.len());
         let mut _fresh = 0u32;
         for &template in inputarg_templates {
             // Constant templates would imply the cut sub-trace treats a
@@ -671,14 +675,14 @@ impl<'a> ByteTraceIter<'a> {
                     template
                 )
             });
-            let fresh_ref = OpRef::input_arg_typed(_fresh, tp);
+            let fresh_ia = InputArg::from_type_rc(tp, _fresh);
             _fresh += 1;
-            inputargs.push(fresh_ref);
             let slot = template.raw() as usize;
             if slot >= _cache.len() {
                 _cache.resize(slot + 1, None);
             }
-            _cache[slot] = Some(fresh_ref);
+            _cache[slot] = Some(BoxRef::from_bound_inputarg(&fresh_ia));
+            inputargs.push(fresh_ia);
         }
         ByteTraceIter {
             trace,
@@ -716,8 +720,10 @@ impl<'a> ByteTraceIter<'a> {
     }
 
     /// opencoder.py:286-289 `_get`.
-    fn _get(&self, i: usize) -> OpRef {
-        self._cache[i].expect("ByteTraceIter._get: cache miss")
+    fn _get(&self, i: usize) -> BoxRef {
+        self._cache[i]
+            .clone()
+            .expect("ByteTraceIter._get: cache miss")
     }
 
     /// opencoder.py:321-335 `_untag` — full dispatch.
@@ -732,7 +738,7 @@ impl<'a> ByteTraceIter<'a> {
     ///
     /// `pub` because `SnapshotIterator::get` / `unpack_array`
     /// (opencoder.py:222-231) dispatch through `main_iter._untag`.
-    pub fn _untag(&mut self, tagged: i64) -> OpRef {
+    pub fn _untag(&mut self, tagged: i64) -> BoxRef {
         // RPython opencoder.py:321-322 uses arithmetic shift on a
         // Python int; in Rust we preserve sign by going through i64
         // rather than u32 for the value.
@@ -745,8 +751,9 @@ impl<'a> ByteTraceIter<'a> {
             }
             TAGINT => {
                 // opencoder.py:326-327 ConstInt(v) — signed small int.
-                // history.py:227 ConstInt.value inline.
-                OpRef::const_int(v)
+                // history.py:227 ConstInt.value inline. A const OpRef
+                // sheds to `Operand::Const`, never a position-only box.
+                BoxRef::from_opref(OpRef::const_int(v))
             }
             TAGCONSTPTR => {
                 // opencoder.py:328-329 ConstPtr(self.trace._refs[v]) —
@@ -754,7 +761,7 @@ impl<'a> ByteTraceIter<'a> {
                 // op-graph walker forwards `OpRef::ConstPtr(GcRef)`
                 // slots across minor collection.
                 let addr = self.trace._refs[v as usize];
-                OpRef::const_ptr(majit_ir::GcRef(addr as usize))
+                BoxRef::from_opref(OpRef::const_ptr(majit_ir::GcRef(addr as usize)))
             }
             TAGCONSTOTHER => {
                 // opencoder.py:330-334 bigint vs float split on bit 0.
@@ -762,11 +769,11 @@ impl<'a> ByteTraceIter<'a> {
                 if v & 1 != 0 {
                     // history.py:268 ConstFloat.value inline.
                     let bits = self.trace._floats[pool_idx];
-                    OpRef::const_float(f64::from_bits(bits as u64))
+                    BoxRef::from_opref(OpRef::const_float(f64::from_bits(bits as u64)))
                 } else {
                     // history.py:227 ConstInt.value inline.
                     let val = self.trace._bigints[pool_idx];
-                    OpRef::const_int(val)
+                    BoxRef::from_opref(OpRef::const_int(val))
                 }
             }
             other => unreachable!("ByteTraceIter: unknown tag {}", other),
@@ -775,8 +782,8 @@ impl<'a> ByteTraceIter<'a> {
 }
 
 impl<'a> Iterator for ByteTraceIter<'a> {
-    type Item = majit_ir::Op;
-    fn next(&mut self) -> Option<majit_ir::Op> {
+    type Item = majit_ir::OpRc;
+    fn next(&mut self) -> Option<majit_ir::OpRc> {
         if self.done() {
             return None;
         }
@@ -791,7 +798,7 @@ impl<'a> Iterator for ByteTraceIter<'a> {
             None => self._next() as usize,
         };
         // opencoder.py:395-408 — read `argnum` tagged args and untag.
-        let mut args: smallvec::SmallVec<[OpRef; 3]> = smallvec::SmallVec::new();
+        let mut args: smallvec::SmallVec<[BoxRef; 3]> = smallvec::SmallVec::new();
         for _ in 0..arity {
             let tagged = self._next();
             args.push(self._untag(tagged));
@@ -832,11 +839,13 @@ impl<'a> Iterator for ByteTraceIter<'a> {
         // RPython opencoder.py:425-431: `res = ResOperation(opnum, args)`
         // is a fresh Python object; the cache only receives non-void
         // results.  majit allocates an OpRef for every op (void or not)
-        // so later non-void ops get contiguous positions.
-        let box_args: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
-        let mut op = match descr {
-            Some(d) => majit_ir::Op::with_descr(opcode, &box_args, d),
-            None => majit_ir::Op::new(opcode, &box_args),
+        // so later non-void ops get contiguous positions. `args` are
+        // already bound boxes (`_untag` → `_get` bound producer / inline
+        // const), so building the op binds each arg to its producer and
+        // mints no position-only `Operand::Box`.
+        let op = match descr {
+            Some(d) => majit_ir::Op::with_descr(opcode, &args, d),
+            None => majit_ir::Op::new(opcode, &args),
         };
         op.rd_resume_position.set(rd_resume_position);
         // opencoder.py:373-374 `cls = opclasses[opnum]; res = cls()` —
@@ -847,13 +856,17 @@ impl<'a> Iterator for ByteTraceIter<'a> {
         let fresh_pos = OpRef::op_typed(self._fresh, opcode.result_type());
         self._fresh += 1;
         op.pos.set(fresh_pos);
+        // opencoder.py:400-401 `self._cache[self._index] = res` — the
+        // fresh op IS the cached box object, so a later TAGBOX arg binds
+        // to this exact `Rc` (`from_bound_op` → `Operand::Op`).
+        let op: majit_ir::OpRc = std::rc::Rc::new(op);
         // opencoder.py:429-431 — cache non-void result at `_index`, bump.
         if opcode.result_type() != Type::Void {
             let slot = self._index as usize;
             if slot >= self._cache.len() {
                 self._cache.resize(slot + 1, None);
             }
-            self._cache[slot] = Some(fresh_pos);
+            self._cache[slot] = Some(BoxRef::from_bound_op(&op));
             self._index += 1;
         }
         // opencoder.py:432 `self._count += 1`.
@@ -1165,7 +1178,7 @@ impl<'a> SnapshotIterator<'a> {
     /// Callers pass the iterator explicitly instead so this helper
     /// stays structurally equivalent to `main_iter._untag(index)`.
     pub fn get(&self, tagged: i64, main_iter: &mut ByteTraceIter<'_>) -> OpRef {
-        main_iter._untag(tagged)
+        main_iter._untag(tagged).to_opref()
     }
 
     /// opencoder.py:228-231 `unpack_array(arr)` — `[self.get(i) for
@@ -1178,7 +1191,8 @@ impl<'a> SnapshotIterator<'a> {
         arr: BoxArrayIter<'_>,
         main_iter: &mut ByteTraceIter<'_>,
     ) -> Vec<OpRef> {
-        arr.map(|tagged| main_iter._untag(tagged)).collect()
+        arr.map(|tagged| main_iter._untag(tagged).to_opref())
+            .collect()
     }
 }
 
@@ -1525,7 +1539,7 @@ impl TraceRecordBuffer {
         );
         let mut ops = Vec::new();
         while let Some(op) = iter.next() {
-            ops.push(op);
+            ops.push((*op).clone());
         }
         ops
     }
@@ -1541,7 +1555,7 @@ impl TraceRecordBuffer {
         );
         while let Some(op) = iter.next() {
             if op.pos.get() == pos {
-                return Some(op);
+                return Some((*op).clone());
             }
         }
         None
@@ -1558,7 +1572,7 @@ impl TraceRecordBuffer {
         );
         let mut last = None;
         while let Some(op) = iter.next() {
-            last = Some(op);
+            last = Some((*op).clone());
         }
         last
     }
@@ -3291,8 +3305,8 @@ mod tests {
         assert!(it.next().is_none());
         assert_eq!(it.inputargs.len(), 2);
         // start_fresh = max_num_inputargs = 2; inputargs get InputArgInt(2), InputArgInt(3).
-        assert_eq!(it.inputargs[0], iarg(2));
-        assert_eq!(it.inputargs[1], iarg(3));
+        assert_eq!(it.inputargs[0].opref(), iarg(2));
+        assert_eq!(it.inputargs[1].opref(), iarg(3));
     }
 
     /// M4 step 1: TAGBOX-only round-trip for 2-arg fixed-arity op.
@@ -3311,8 +3325,8 @@ mod tests {
         assert_eq!(pos, 2); // pre-bump `_index`, seeded to max_num_inputargs
 
         let mut it = buf.get_byte_iter();
-        let fresh_i0 = it.inputargs[0];
-        let fresh_i1 = it.inputargs[1];
+        let fresh_i0 = it.inputargs[0].opref();
+        let fresh_i1 = it.inputargs[1].opref();
         let op = it.next().expect("one op");
         assert_eq!(op.opcode, OpCode::IntAdd);
         assert_eq!(op.num_args(), 2);
@@ -3335,8 +3349,8 @@ mod tests {
         let _r3 = buf.record_op2(OpCode::IntMul, Box::ResOp(r2), Box::ResOp(0), None);
 
         let mut it = buf.get_byte_iter();
-        let fresh_i0 = it.inputargs[0];
-        let fresh_i1 = it.inputargs[1];
+        let fresh_i0 = it.inputargs[0].opref();
+        let fresh_i1 = it.inputargs[1].opref();
         let add = it.next().expect("IntAdd");
         assert_eq!(add.opcode, OpCode::IntAdd);
         assert_eq!(add.arg(0).to_opref(), fresh_i0);
@@ -3523,7 +3537,7 @@ mod tests {
         // `_cache` at ByteTraceIter::new).
         let tagbox = TraceRecordBuffer::_encode_box_position(0);
         let resolved_box = snap_it.get(tagbox, &mut main_iter);
-        let fresh_i0 = main_iter.inputargs[0];
+        let fresh_i0 = main_iter.inputargs[0].opref();
         assert_eq!(resolved_box, fresh_i0);
         // TAGINT(42) → pool-allocated constant OpRef.
         let tagint = TraceRecordBuffer::_encode_smallint(42);
@@ -3555,8 +3569,8 @@ mod tests {
 
         let mut main_iter =
             ByteTraceIter::new(&buf, buf._start as usize, buf._pos, buf.max_num_inputargs);
-        let expected_0 = main_iter.inputargs[0];
-        let expected_1 = main_iter.inputargs[1];
+        let expected_0 = main_iter.inputargs[0].opref();
+        let expected_1 = main_iter.inputargs[1].opref();
 
         let snap_it = SnapshotIterator::new(
             &buf._snapshot_data,
@@ -4313,8 +4327,8 @@ mod tests {
 
         // `self.unpack(t)` equivalent — ConstInt(1) decodes inline.
         let mut it = ByteTraceIter::new(&t, t._start as usize, t._pos, t.max_num_inputargs);
-        let fresh_i0 = it.inputargs[0];
-        let fresh_i1 = it.inputargs[1];
+        let fresh_i0 = it.inputargs[0].opref();
+        let fresh_i1 = it.inputargs[1].opref();
         let l0 = it.next().expect("first IntAdd");
         let l1 = it.next().expect("second IntAdd");
         assert!(it.done(), "only two ops recorded");
@@ -4385,7 +4399,7 @@ mod tests {
             // returns an inline-Const OpRef that resolves to `Value::Int(num)`.
             let mut it = ByteTraceIter::new(&t, 0, t._pos, t.max_num_inputargs);
             let tagged = it._next();
-            let opref = it._untag(tagged);
+            let opref = it._untag(tagged).to_opref();
             drop(it);
             assert_eq!(
                 opref.inline_const_to_value(),
@@ -4455,8 +4469,8 @@ mod tests {
         let cut = t.cut_trace_from(cut_point, vec![OpRef::int_op(add1), i1]);
         // (i0, i1), l, iter = self.unpack(t2)
         let mut it = cut.get_iter();
-        let fresh_add1 = it.inputargs[0];
-        let fresh_i1 = it.inputargs[1];
+        let fresh_add1 = it.inputargs[0].opref();
+        let fresh_i1 = it.inputargs[1].opref();
         let mut ops = Vec::new();
         while let Some(op) = it.next() {
             ops.push(op);

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -575,6 +575,16 @@ pub struct ByteTraceIter<'a> {
     /// opencoder.py:259-263 `self.inputargs` — fresh iterator-local
     /// `InputArg` objects bound to the trace's inputargs.
     pub inputargs: Vec<majit_ir::InputArgRc>,
+    /// Strong roots for every produced op cached in `_cache`. RPython's
+    /// `self._cache[self._index] = res` stores the ResOperation OBJECT, so
+    /// the cache itself owns it for the walk's lifetime; pyre's `_cache`
+    /// holds a `BoxRef` whose bound handle is only a `Weak<Op>`, so without
+    /// a strong root the producer `Rc` returned by `next()` is dropped by
+    /// the caller between iterations and a later TAGBOX arg's `_get` would
+    /// upgrade to `None` and re-mint a position-only box. Rooting each
+    /// cached producer here keeps the `Weak` upgradeable so the arg binds to
+    /// `Operand::Op` (parity with RPython's strong cache slot).
+    _produced_roots: Vec<majit_ir::OpRc>,
     pub start: usize,
     pub pos: usize,
     pub end: usize,
@@ -624,6 +634,7 @@ impl<'a> ByteTraceIter<'a> {
             trace,
             _cache,
             inputargs,
+            _produced_roots: Vec::new(),
             start,
             pos: start,
             end,
@@ -688,6 +699,7 @@ impl<'a> ByteTraceIter<'a> {
             trace,
             _cache,
             inputargs,
+            _produced_roots: Vec::new(),
             start,
             pos: start,
             end,
@@ -867,6 +879,11 @@ impl<'a> Iterator for ByteTraceIter<'a> {
                 self._cache.resize(slot + 1, None);
             }
             self._cache[slot] = Some(BoxRef::from_bound_op(&op));
+            // Root the producer strongly so the `_cache` Weak stays
+            // upgradeable for the rest of the walk even after the caller
+            // drops the `Rc` returned below (RPython's cache slot owns the
+            // ResOperation object outright).
+            self._produced_roots.push(op.clone());
             self._index += 1;
         }
         // opencoder.py:432 `self._count += 1`.

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -414,7 +414,10 @@ impl<'a> TraceIterator<'a> {
         // opencoder.py:379-387: for i in range(argnum):
         //     res.setarg(i, self._untag(self._next()))
         for i in 0..res.num_args() {
-            res.setarg(i, majit_ir::operand::Operand::from_boxref(&self._untag(res.arg(i).to_opref())));
+            res.setarg(
+                i,
+                majit_ir::operand::Operand::from_boxref(&self._untag(res.arg(i).to_opref())),
+            );
         }
         if let Some(fa) = res.fail_args_mut() {
             for arg in fa.iter_mut() {
@@ -854,8 +857,10 @@ impl<'a> Iterator for ByteTraceIter<'a> {
         // already bound boxes (`_untag` → `_get` bound producer / inline
         // const), so building the op binds each arg to its producer and
         // mints no position-only `Operand::Box`.
-        let args_operand: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
-            args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let args_operand: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> = args
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
         let op = match descr {
             Some(d) => majit_ir::Op::with_descr(opcode, &args_operand, d),
             None => majit_ir::Op::new(opcode, &args_operand),
@@ -2903,8 +2908,10 @@ mod tests {
     /// Helper: build an Op with a specific trace position and the same
     /// typed result class RPython's `opclasses[opnum]` would instantiate.
     fn op_at(pos: u32, opcode: majit_ir::OpCode, args: &[OpRef]) -> majit_ir::Op {
-        let op_args: Vec<majit_ir::operand::Operand> =
-            args.iter().map(|a| majit_ir::operand::Operand::from_boxref(&box_arg(*a))).collect();
+        let op_args: Vec<majit_ir::operand::Operand> = args
+            .iter()
+            .map(|a| majit_ir::operand::Operand::from_boxref(&box_arg(*a)))
+            .collect();
         let mut op = majit_ir::Op::new(opcode, &op_args);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
@@ -2931,7 +2938,10 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))]),
+            majit_ir::Op::new(
+                majit_ir::OpCode::Finish,
+                &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))],
+            ),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -2974,7 +2984,10 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))]),
+            majit_ir::Op::new(
+                majit_ir::OpCode::Finish,
+                &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))],
+            ),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -3050,7 +3063,10 @@ mod tests {
         let ops = vec![
             op_at(1, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(0)]),
             op_at(2, majit_ir::OpCode::IntAdd, &[iop(1), iarg(0)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(2)))]),
+            majit_ir::Op::new(
+                majit_ir::OpCode::Finish,
+                &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(2)))],
+            ),
         ];
         // Shifted phase: start_fresh = 100 so any confusion between
         // _index (raw trace position) and _fresh (fresh OpRef counter)
@@ -3108,7 +3124,10 @@ mod tests {
         let ops = vec![
             op_at(3, majit_ir::OpCode::GetfieldRawI, &[rarg(0)]),
             op_at(1, majit_ir::OpCode::GetarrayitemGcR, &[iop(3), rarg(1)]),
-            majit_ir::Op::new(majit_ir::OpCode::Finish, &[majit_ir::operand::Operand::from_boxref(&box_arg(rop(1)))]),
+            majit_ir::Op::new(
+                majit_ir::OpCode::Finish,
+                &[majit_ir::operand::Operand::from_boxref(&box_arg(rop(1)))],
+            ),
         ];
         let inputarg_types = vec![
             majit_ir::Type::Ref,

--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -885,7 +885,7 @@ impl IndexVar {
             let c = next_const(self.coefficient_mul);
             let op = Op::new(
                 OpCode::IntMul,
-                &[var_box(var, &mut first), BoxRef::from_opref(c)],
+                &[majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c))],
             );
             var = op.pos.get();
             tolist.push(op);
@@ -900,7 +900,7 @@ impl IndexVar {
             let c = next_const(self.constant);
             let op = Op::new(
                 OpCode::IntAdd,
-                &[var_box(var, &mut first), BoxRef::from_opref(c)],
+                &[majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c))],
             );
             var = op.pos.get();
             tolist.push(op);
@@ -910,7 +910,7 @@ impl IndexVar {
             let c = next_const(-self.constant);
             let op = Op::new(
                 OpCode::IntSub,
-                &[var_box(var, &mut first), BoxRef::from_opref(c)],
+                &[majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c))],
             );
             #[allow(unused_assignments)]
             {
@@ -1227,7 +1227,7 @@ impl<'a> IntegralForwardModification<'a> {
             idx.constant = if is_sub { v0 - v1 } else { v0 + v1 };
             self.set_index_var(result, idx);
         } else if Self::is_const(a0) {
-            let mut idx = self.get_or_create(a1, &b1);
+            let mut idx = self.get_or_create(a1, &b1.to_boxref());
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a0) {
                 if is_sub {
@@ -1238,7 +1238,7 @@ impl<'a> IntegralForwardModification<'a> {
             }
             self.set_index_var(result, idx);
         } else if Self::is_const(a1) {
-            let mut idx = self.get_or_create(a0, &b0);
+            let mut idx = self.get_or_create(a0, &b0.to_boxref());
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a1) {
                 if is_sub {
@@ -1250,7 +1250,7 @@ impl<'a> IntegralForwardModification<'a> {
             self.set_index_var(result, idx);
         } else {
             // Both non-const: track the variable.
-            let idx = self.get_or_create(a0, &b0);
+            let idx = self.get_or_create(a0, &b0.to_boxref());
             self.set_index_var(result, idx);
         }
     }
@@ -1269,7 +1269,7 @@ impl<'a> IntegralForwardModification<'a> {
             idx.constant = v0 * v1;
             self.set_index_var(result, idx);
         } else if Self::is_const(a0) {
-            let mut idx = self.get_or_create(a1, &b1);
+            let mut idx = self.get_or_create(a1, &b1.to_boxref());
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a0) {
                 idx.coefficient_mul *= v;
@@ -1277,7 +1277,7 @@ impl<'a> IntegralForwardModification<'a> {
             }
             self.set_index_var(result, idx);
         } else if Self::is_const(a1) {
-            let mut idx = self.get_or_create(a0, &b0);
+            let mut idx = self.get_or_create(a0, &b0.to_boxref());
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a1) {
                 idx.coefficient_mul *= v;
@@ -1296,7 +1296,7 @@ impl<'a> IntegralForwardModification<'a> {
         let array = op.arg(0).to_opref();
         let index_box = op.arg(1);
         let index = index_box.to_opref();
-        let idx_var = self.get_or_create(index, &index_box);
+        let idx_var = self.get_or_create(index, &index_box.to_boxref());
         if let Some(descr) = op.getdescr() {
             // dependency.py:954: descr.is_array_of_primitives()
             let is_prim = descr

--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -885,7 +885,10 @@ impl IndexVar {
             let c = next_const(self.coefficient_mul);
             let op = Op::new(
                 OpCode::IntMul,
-                &[majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c))],
+                &[
+                    majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)),
+                    majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c)),
+                ],
             );
             var = op.pos.get();
             tolist.push(op);
@@ -900,7 +903,10 @@ impl IndexVar {
             let c = next_const(self.constant);
             let op = Op::new(
                 OpCode::IntAdd,
-                &[majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c))],
+                &[
+                    majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)),
+                    majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c)),
+                ],
             );
             var = op.pos.get();
             tolist.push(op);
@@ -910,7 +916,10 @@ impl IndexVar {
             let c = next_const(-self.constant);
             let op = Op::new(
                 OpCode::IntSub,
-                &[majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c))],
+                &[
+                    majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)),
+                    majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(c)),
+                ],
             );
             #[allow(unused_assignments)]
             {

--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -705,6 +705,15 @@ pub fn schedule_operations(graph: &DependencyGraph) -> Vec<usize> {
 pub struct IndexVar {
     /// The base SSA variable.
     pub var: OpRef,
+    /// The BOUND box for `var`, captured from the real op arg at build time so
+    /// `get_operations` can carry `var` as `Operand::Op`/`InputArg` instead of
+    /// minting a position-only box. RPython's IndexVar holds the box object
+    /// (`dependency.py:983 self.var`); pyre's flat-OpRef `var` loses the
+    /// producer, so the box is captured alongside. `None` when no bound box was
+    /// available at construction (e.g. a synthetic-result var) — then
+    /// `get_operations` falls back to `from_opref`. Its `to_opref()` always
+    /// equals `var`.
+    pub var_box: Option<BoxRef>,
     /// If `var` is a ConstInt OpRef, the resolved integer value.
     /// dependency.py:1117-1118: isinstance(svar, ConstInt) comparison.
     pub var_const: Option<i64>,
@@ -720,6 +729,22 @@ impl IndexVar {
     pub fn new(var: OpRef) -> Self {
         IndexVar {
             var,
+            var_box: None,
+            var_const: None,
+            coefficient_mul: 1,
+            coefficient_div: 1,
+            constant: 0,
+        }
+    }
+
+    /// Like [`IndexVar::new`] but capturing the BOUND box for `var`
+    /// (`var_box.to_opref() == var`), used so `get_operations` carries a bound
+    /// operand rather than a position-only one.
+    pub fn new_boxed(var_box: BoxRef) -> Self {
+        let var = var_box.to_opref();
+        IndexVar {
+            var,
+            var_box: Some(var_box),
             var_const: None,
             coefficient_mul: 1,
             coefficient_div: 1,
@@ -731,6 +756,7 @@ impl IndexVar {
     pub fn new_const(var: OpRef, value: i64) -> Self {
         IndexVar {
             var,
+            var_box: None,
             var_const: Some(value),
             coefficient_mul: 1,
             coefficient_div: 1,
@@ -800,6 +826,7 @@ impl IndexVar {
     pub fn clone_var(&self) -> Self {
         IndexVar {
             var: self.var,
+            var_box: self.var_box.clone(),
             var_const: self.var_const,
             coefficient_mul: self.coefficient_mul,
             coefficient_div: self.coefficient_div,
@@ -815,16 +842,50 @@ impl IndexVar {
     /// `next_const`: callback to allocate a constant OpRef for a given i64 value.
     /// In RPython this is `ConstInt(value)` — an inline constant box.
     /// In majit, constants need explicit OpRef allocation.
+    ///
+    /// Box-carrying note: the `var` operand of the FIRST emitted op is
+    /// `self.var` — the IndexVar's base SSA variable (the loop's index inputarg
+    /// or another loop-body producer). RPython carries `self.var` as the live
+    /// index-var box object; pyre's flat-OpRef `var` lost it, so the bound box
+    /// is captured at build time into `self.var_box` (see `get_or_create`) and
+    /// re-installed here, carrying `Operand::Op`/`InputArg` instead of a
+    /// position-only box. The first-var arm falls back to `from_opref` only when
+    /// no box was captured (a synthetic-result var). The CHAINED `var =
+    /// op.pos.get()` references (when `coefficient_mul != 1`, i.e. an `IntAdd` /
+    /// `IntSub` consuming the prior `IntMul`) point at the just-created local
+    /// `Op` value — this fn returns `Vec<Op>`, not `Vec<OpRc>`, so there is no
+    /// producer `Rc` to bind to and the chained `var` stays a position-only
+    /// residual. `to_opref()` is preserved in every case; the constant arg `c`
+    /// always sheds to `Operand::Const`.
     pub fn get_operations(&self, mut next_const: impl FnMut(i64) -> OpRef) -> Vec<majit_ir::Op> {
         use majit_ir::{Op, OpCode};
+        // First-var box: the captured bound box when its `to_opref()` still
+        // matches `self.var` (it always does — `var`/`var_box` move together),
+        // else a position-only box for a box-less (synthetic) var.
+        let first_var = match &self.var_box {
+            Some(b) if b.to_opref() == self.var => b.clone(),
+            _ => BoxRef::from_opref(self.var),
+        };
         let mut var = self.var;
+        let mut first = true;
         let mut tolist = Vec::new();
+        // Carry `var` bound for the FIRST emitted op (from `first_var`); the
+        // chained references thereafter point at local `Op` values (no `Rc`),
+        // so they fall back to a position-only box.
+        let var_box = |var: OpRef, first: &mut bool| -> BoxRef {
+            if *first {
+                *first = false;
+                first_var.clone()
+            } else {
+                BoxRef::from_opref(var)
+            }
+        };
         if self.coefficient_mul != 1 {
             // dependency.py:1069: args = [var, ConstInt(self.coefficient_mul)]
             let c = next_const(self.coefficient_mul);
             let op = Op::new(
                 OpCode::IntMul,
-                &[BoxRef::from_opref(var), BoxRef::from_opref(c)],
+                &[var_box(var, &mut first), BoxRef::from_opref(c)],
             );
             var = op.pos.get();
             tolist.push(op);
@@ -839,7 +900,7 @@ impl IndexVar {
             let c = next_const(self.constant);
             let op = Op::new(
                 OpCode::IntAdd,
-                &[BoxRef::from_opref(var), BoxRef::from_opref(c)],
+                &[var_box(var, &mut first), BoxRef::from_opref(c)],
             );
             var = op.pos.get();
             tolist.push(op);
@@ -849,7 +910,7 @@ impl IndexVar {
             let c = next_const(-self.constant);
             let op = Op::new(
                 OpCode::IntSub,
-                &[BoxRef::from_opref(var), BoxRef::from_opref(c)],
+                &[var_box(var, &mut first), BoxRef::from_opref(c)],
             );
             #[allow(unused_assignments)]
             {
@@ -1137,13 +1198,17 @@ impl<'a> IntegralForwardModification<'a> {
         (self.constant_of)(opref)
     }
 
-    fn get_or_create(&mut self, arg: OpRef) -> IndexVar {
+    /// `arg_box` is the BOUND box for `arg` (`arg_box.to_opref() == arg`), used
+    /// to seed `IndexVar::var_box` so a freshly-created (un-tracked) index var
+    /// can carry `var` as a bound operand in `get_operations`. A tracked var
+    /// already in `index_vars` keeps its own (possibly box-carrying) entry.
+    fn get_or_create(&mut self, arg: OpRef, arg_box: &BoxRef) -> IndexVar {
         self.index_vars.get(&arg).cloned().unwrap_or_else(|| {
             if Self::is_const(arg) {
                 let val = self.const_val(arg).unwrap_or(0);
                 IndexVar::new_const(arg, val)
             } else {
-                IndexVar::new(arg)
+                IndexVar::new_boxed(arg_box.clone())
             }
         })
     }
@@ -1151,8 +1216,10 @@ impl<'a> IntegralForwardModification<'a> {
     /// dependency.py:896-920: operation_INT_ADD / operation_INT_SUB.
     fn inspect_additive(&mut self, op: &Op, is_sub: bool) {
         let result = op.pos.get();
-        let a0 = op.arg(0).to_opref();
-        let a1 = op.arg(1).to_opref();
+        let b0 = op.arg(0);
+        let b1 = op.arg(1);
+        let a0 = b0.to_opref();
+        let a1 = b1.to_opref();
         if Self::is_const(a0) && Self::is_const(a1) {
             let mut idx = IndexVar::new(result);
             let v0 = self.const_val(a0).unwrap_or(0);
@@ -1160,7 +1227,7 @@ impl<'a> IntegralForwardModification<'a> {
             idx.constant = if is_sub { v0 - v1 } else { v0 + v1 };
             self.set_index_var(result, idx);
         } else if Self::is_const(a0) {
-            let mut idx = self.get_or_create(a1);
+            let mut idx = self.get_or_create(a1, &b1);
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a0) {
                 if is_sub {
@@ -1171,7 +1238,7 @@ impl<'a> IntegralForwardModification<'a> {
             }
             self.set_index_var(result, idx);
         } else if Self::is_const(a1) {
-            let mut idx = self.get_or_create(a0);
+            let mut idx = self.get_or_create(a0, &b0);
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a1) {
                 if is_sub {
@@ -1183,7 +1250,7 @@ impl<'a> IntegralForwardModification<'a> {
             self.set_index_var(result, idx);
         } else {
             // Both non-const: track the variable.
-            let idx = self.get_or_create(a0);
+            let idx = self.get_or_create(a0, &b0);
             self.set_index_var(result, idx);
         }
     }
@@ -1191,8 +1258,10 @@ impl<'a> IntegralForwardModification<'a> {
     /// dependency.py:922-948: operation_INT_MUL.
     fn inspect_multiplicative(&mut self, op: &Op) {
         let result = op.pos.get();
-        let a0 = op.arg(0).to_opref();
-        let a1 = op.arg(1).to_opref();
+        let b0 = op.arg(0);
+        let b1 = op.arg(1);
+        let a0 = b0.to_opref();
+        let a1 = b1.to_opref();
         if Self::is_const(a0) && Self::is_const(a1) {
             let mut idx = IndexVar::new(result);
             let v0 = self.const_val(a0).unwrap_or(0);
@@ -1200,7 +1269,7 @@ impl<'a> IntegralForwardModification<'a> {
             idx.constant = v0 * v1;
             self.set_index_var(result, idx);
         } else if Self::is_const(a0) {
-            let mut idx = self.get_or_create(a1);
+            let mut idx = self.get_or_create(a1, &b1);
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a0) {
                 idx.coefficient_mul *= v;
@@ -1208,7 +1277,7 @@ impl<'a> IntegralForwardModification<'a> {
             }
             self.set_index_var(result, idx);
         } else if Self::is_const(a1) {
-            let mut idx = self.get_or_create(a0);
+            let mut idx = self.get_or_create(a0, &b0);
             idx = idx.clone_var();
             if let Some(v) = self.const_val(a1) {
                 idx.coefficient_mul *= v;
@@ -1225,8 +1294,9 @@ impl<'a> IntegralForwardModification<'a> {
             return;
         }
         let array = op.arg(0).to_opref();
-        let index = op.arg(1).to_opref();
-        let idx_var = self.get_or_create(index);
+        let index_box = op.arg(1);
+        let index = index_box.to_opref();
+        let idx_var = self.get_or_create(index, &index_box);
         if let Some(descr) = op.getdescr() {
             // dependency.py:954: descr.is_array_of_primitives()
             let is_prim = descr

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -76,7 +76,7 @@ impl Optimization for OptEarlyForce {
             // which uses ctx.current_pass_idx (== earlyforce_idx) for
             // emit_extra routing. This matches RPython's optforce=self.
             for i in 0..op.num_args() {
-                let arg_box = ctx.resolve_box_box_opt(&op.arg(i));
+                let arg_box = ctx.resolve_box_box_opt(&op.arg(i).to_boxref());
                 let arg = arg_box
                     .as_ref()
                     .map(|b| b.to_opref())
@@ -90,7 +90,7 @@ impl Optimization for OptEarlyForce {
                 if let Some(tracked) = ctx.take_potential_extra_op(arg) {
                     // shortpreamble.py:434: the resolved Box is handed
                     // to the builder; fall back to the operand's own box.
-                    let arg_b = arg_box.clone().unwrap_or_else(|| op.arg(i));
+                    let arg_b = arg_box.clone().unwrap_or_else(|| op.arg(i).to_boxref());
                     if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                         builder.add_preamble_op_from_pop(&tracked, arg_b);
                     } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {
@@ -125,6 +125,7 @@ mod tests {
     use super::*;
     use crate::r#box::test_support::rooted_inputarg_box;
     use crate::optimizeopt::optimizer::Optimizer;
+    use majit_ir::operand::Operand;
     use majit_ir::OpRef;
     use majit_ir::Type;
 
@@ -140,8 +141,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::CallMayForceN,
             &[
-                rooted_inputarg_box(Type::Ref, 100),
-                rooted_inputarg_box(Type::Ref, 101),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
             ],
         )];
         assign_positions(&mut ops);
@@ -160,8 +161,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntAdd,
             &[
-                rooted_inputarg_box(Type::Int, 100),
-                rooted_inputarg_box(Type::Int, 101),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Int, 100)),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Int, 101)),
             ],
         )];
         assign_positions(&mut ops);
@@ -179,7 +180,7 @@ mod tests {
     fn test_earlyforce_call_assembler_handled() {
         let mut ops = vec![Op::new(
             OpCode::CallAssemblerI,
-            &[rooted_inputarg_box(Type::Ref, 100)],
+            &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
         )];
         assign_positions(&mut ops);
 
@@ -220,7 +221,10 @@ mod tests {
             OpCode::CallMayForceF,
             OpCode::CallMayForceN,
         ] {
-            let mut ops = vec![Op::new(opcode, &[rooted_inputarg_box(Type::Ref, 100)])];
+            let mut ops = vec![Op::new(
+                opcode,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            )];
             assign_positions(&mut ops);
 
             let mut opt = Optimizer::new();
@@ -237,8 +241,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::SetfieldGc,
             &[
-                rooted_inputarg_box(Type::Ref, 100),
-                rooted_inputarg_box(Type::Int, 101),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                Operand::from_boxref(&rooted_inputarg_box(Type::Int, 101)),
             ],
         )];
         assign_positions(&mut ops);

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -125,9 +125,9 @@ mod tests {
     use super::*;
     use crate::r#box::test_support::rooted_inputarg_box;
     use crate::optimizeopt::optimizer::Optimizer;
-    use majit_ir::operand::Operand;
     use majit_ir::OpRef;
     use majit_ir::Type;
+    use majit_ir::operand::Operand;
 
     fn assign_positions(ops: &mut [Op]) {
         for (i, op) in ops.iter_mut().enumerate() {

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -234,7 +234,7 @@ impl Guard {
         // guard.py:86-87: compare = ResOperation(opnum, [box_rhs, other_rhs])
         let compare = Op::new(
             opnum,
-            &[BoxRef::from_opref(box_rhs), BoxRef::from_opref(other_rhs)],
+            &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(box_rhs)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(other_rhs))],
         );
         new_ops.push(compare.clone());
         // guard.py:89-91:
@@ -250,7 +250,7 @@ impl Guard {
         // make_compile_loop_version_descr_from reference-shares each
         // Arc<[T]> slot from the donor onto the fresh descr.
         let fresh_descr = crate::compile::make_compile_loop_version_descr_from(&self.op);
-        let mut guard_op = Op::new(self.op.opcode, &[BoxRef::from_opref(compare.pos.get())]);
+        let mut guard_op = Op::new(self.op.opcode, &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(compare.pos.get()))]);
         guard_op.setdescr(fresh_descr);
         // guard.py:94: guard.setfailargs(loop.label.getarglist_copy())
         guard_op.setfailargs(label_args.iter().map(|a| BoxRef::from_opref(*a)).collect());
@@ -361,11 +361,11 @@ impl Guard {
         // guard.py:138-140: cmp_op = ResOperation(opnum, [lhs, rhs])
         let cmp_op = Op::new(
             self.cmp_op.opcode,
-            &[BoxRef::from_opref(lhs), BoxRef::from_opref(rhs)],
+            &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(lhs)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(rhs))],
         );
         new_ops.push(cmp_op.clone());
         // guard.py:142-144: guard = ResOperation(opnum, [cmp_op], descr)
-        let mut guard = Op::new(self.op.opcode, &[BoxRef::from_opref(cmp_op.pos.get())]);
+        let mut guard = Op::new(self.op.opcode, &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(cmp_op.pos.get()))]);
         if let Some(d) = self.op.getdescr() {
             guard.setdescr(d);
         }
@@ -639,7 +639,7 @@ impl GuardStrengthenOpt {
         for i in 0..op.num_args() {
             let arg = op.arg(i).to_opref();
             if let Some(&replacement) = self.renamer.get(&arg) {
-                op.setarg(i, BoxRef::from_opref(replacement));
+                op.setarg(i, majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(replacement)));
             }
         }
     }
@@ -765,6 +765,7 @@ impl Default for GuardStrengthenOpt {
 mod tests {
     use super::*;
     use crate::optimizeopt::optimizer::Optimizer;
+    use majit_ir::operand::Operand;
 
     /// Attach a fresh `ResumeGuardDescr` to every guard op that lacks one,
     /// mirroring RPython's invariant (`optimizer.py:691 assert
@@ -798,10 +799,19 @@ mod tests {
 
         // Producer ops carry their result positions (base 100) so they do not
         // collide with the inputarg slots `[0, num_inputs)`.
-        let guard_true = std::rc::Rc::new(Op::new(OpCode::GuardTrue, &[i1.clone()]));
-        let sub = std::rc::Rc::new(Op::new(OpCode::IntSubOvf, &[i0, i2.clone()]));
+        let guard_true = std::rc::Rc::new(Op::new(
+            OpCode::GuardTrue,
+            &[Operand::from_boxref(&i1)],
+        ));
+        let sub = std::rc::Rc::new(Op::new(
+            OpCode::IntSubOvf,
+            &[Operand::from_boxref(&i0), Operand::from_boxref(&i2)],
+        ));
         let guard_ovf1 = std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[]));
-        let mul = std::rc::Rc::new(Op::new(OpCode::IntMulOvf, &[i2, i1]));
+        let mul = std::rc::Rc::new(Op::new(
+            OpCode::IntMulOvf,
+            &[Operand::from_boxref(&i2), Operand::from_boxref(&i1)],
+        ));
         let guard_ovf2 = std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[]));
 
         // Sequential positions from base 100 + a fresh ResumeGuardDescr on
@@ -816,7 +826,14 @@ mod tests {
 
         let sub_box = BoxRef::from_bound_op(&sub);
         let mul_box = BoxRef::from_bound_op(&mul);
-        let jump = std::rc::Rc::new(Op::new(OpCode::Jump, &[sub_box.clone(), sub_box, mul_box]));
+        let jump = std::rc::Rc::new(Op::new(
+            OpCode::Jump,
+            &[
+                Operand::from_boxref(&sub_box),
+                Operand::from_boxref(&sub_box),
+                Operand::from_boxref(&mul_box),
+            ],
+        ));
         jump.pos.set(OpRef::op_typed(105, jump.result_type()));
 
         let ops: Vec<OpRc> = vec![guard_true, sub, guard_ovf1, mul, guard_ovf2, jump];
@@ -878,13 +895,19 @@ mod tests {
         let i0 = rooted_inputarg_box(Type::Int, 0);
         let i1 = rooted_inputarg_box(Type::Int, 1);
         // v = (i0 > i1): intbounds bounds the comparison result to [0,1].
-        let int_gt = std::rc::Rc::new(Op::new(OpCode::IntGt, &[i0, i1]));
+        let int_gt = std::rc::Rc::new(Op::new(
+            OpCode::IntGt,
+            &[Operand::from_boxref(&i0), Operand::from_boxref(&i1)],
+        ));
         int_gt.pos.set(OpRef::int_op(100));
         let v = BoxRef::from_bound_op(&int_gt);
         // guard_value(v, 1)
         let guard_value = std::rc::Rc::new(Op::new(
             OpCode::GuardValue,
-            &[v, BoxRef::new_const(Value::Int(1))],
+            &[
+                Operand::from_boxref(&v),
+                Operand::from_boxref(&BoxRef::new_const(Value::Int(1))),
+            ],
         ));
         guard_value.pos.set(OpRef::void_op(0));
 

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -234,7 +234,10 @@ impl Guard {
         // guard.py:86-87: compare = ResOperation(opnum, [box_rhs, other_rhs])
         let compare = Op::new(
             opnum,
-            &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(box_rhs)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(other_rhs))],
+            &[
+                majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(box_rhs)),
+                majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(other_rhs)),
+            ],
         );
         new_ops.push(compare.clone());
         // guard.py:89-91:
@@ -250,7 +253,12 @@ impl Guard {
         // make_compile_loop_version_descr_from reference-shares each
         // Arc<[T]> slot from the donor onto the fresh descr.
         let fresh_descr = crate::compile::make_compile_loop_version_descr_from(&self.op);
-        let mut guard_op = Op::new(self.op.opcode, &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(compare.pos.get()))]);
+        let mut guard_op = Op::new(
+            self.op.opcode,
+            &[majit_ir::operand::Operand::from_boxref(
+                &BoxRef::from_opref(compare.pos.get()),
+            )],
+        );
         guard_op.setdescr(fresh_descr);
         // guard.py:94: guard.setfailargs(loop.label.getarglist_copy())
         guard_op.setfailargs(label_args.iter().map(|a| BoxRef::from_opref(*a)).collect());
@@ -361,11 +369,19 @@ impl Guard {
         // guard.py:138-140: cmp_op = ResOperation(opnum, [lhs, rhs])
         let cmp_op = Op::new(
             self.cmp_op.opcode,
-            &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(lhs)), majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(rhs))],
+            &[
+                majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(lhs)),
+                majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(rhs)),
+            ],
         );
         new_ops.push(cmp_op.clone());
         // guard.py:142-144: guard = ResOperation(opnum, [cmp_op], descr)
-        let mut guard = Op::new(self.op.opcode, &[majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(cmp_op.pos.get()))]);
+        let mut guard = Op::new(
+            self.op.opcode,
+            &[majit_ir::operand::Operand::from_boxref(
+                &BoxRef::from_opref(cmp_op.pos.get()),
+            )],
+        );
         if let Some(d) = self.op.getdescr() {
             guard.setdescr(d);
         }
@@ -639,7 +655,10 @@ impl GuardStrengthenOpt {
         for i in 0..op.num_args() {
             let arg = op.arg(i).to_opref();
             if let Some(&replacement) = self.renamer.get(&arg) {
-                op.setarg(i, majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(replacement)));
+                op.setarg(
+                    i,
+                    majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(replacement)),
+                );
             }
         }
     }
@@ -799,10 +818,7 @@ mod tests {
 
         // Producer ops carry their result positions (base 100) so they do not
         // collide with the inputarg slots `[0, num_inputs)`.
-        let guard_true = std::rc::Rc::new(Op::new(
-            OpCode::GuardTrue,
-            &[Operand::from_boxref(&i1)],
-        ));
+        let guard_true = std::rc::Rc::new(Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&i1)]));
         let sub = std::rc::Rc::new(Op::new(
             OpCode::IntSubOvf,
             &[Operand::from_boxref(&i0), Operand::from_boxref(&i2)],

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -52,6 +52,7 @@ use majit_ir::{
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::PtrInfoExt;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
+use majit_ir::operand::Operand;
 
 #[inline]
 fn make_nonnull_box(ctx: &mut OptContext, arg: &BoxRef) {
@@ -786,7 +787,7 @@ pub struct OptHeap {
     /// keyed by `BoxRef` identity (`Rc::ptr_eq`) — box identity, not the retired
     /// `opref.raw()` slot index. OptHeap ownership preserves `setup()`'s per-run
     /// reset, which a per-box flag on a shared `Box` could not bulk-clear.
-    unescaped: majit_ir::vec_set::VecSet<BoxRef>,
+    unescaped: majit_ir::vec_set::VecSet<Operand>,
     /// heapcache.py:209/298-307/453-455 `box._heapc_deps` — per-Box
     /// dependency list. RPython attaches `_heapc_deps: list | None`
     /// as an attribute on the `RefFrontendOp` Box object itself;
@@ -795,7 +796,7 @@ pub struct OptHeap {
     /// the value is recorded as a dependency of the container instead
     /// of being immediately escaped. When the container escapes later,
     /// all its dependencies are transitively escaped.
-    heapc_deps: crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, Vec<BoxRef>>,
+    heapc_deps: crate::optimizeopt::vec_assoc::VecAssoc<Operand, Vec<Operand>>,
 
     /// heap.py:27 Optimization.last_emitted_operation is REMOVED.
     /// Set to true when `_optimize_CALL_DICT_LOOKUP` folds a lookup;
@@ -924,10 +925,11 @@ impl OptHeap {
         if box_.is_constant() {
             return;
         }
-        self.unescaped.remove(box_);
-        if let Some(deps) = self.heapc_deps.remove(box_) {
+        let key = Operand::from_boxref(box_);
+        self.unescaped.remove(&key);
+        if let Some(deps) = self.heapc_deps.remove(&key) {
             for dep in deps {
-                self.escape_box(&dep);
+                self.escape_box(&dep.to_boxref());
             }
         }
     }
@@ -939,7 +941,7 @@ impl OptHeap {
         if box_.is_none() || box_.is_constant() {
             return false;
         }
-        self.unescaped.contains(box_)
+        self.unescaped.contains(&Operand::from_boxref(box_))
     }
 
     /// heapcache.py:224-230 `_escape_from_write`: when storing a value
@@ -966,9 +968,9 @@ impl OptHeap {
             && self.is_unescaped(&value_box)
         {
             self.heapc_deps
-                .entry(container_box.unwrap())
+                .entry(Operand::from_boxref(&container_box.unwrap()))
                 .or_insert_with(Vec::new)
-                .push(value_box);
+                .push(Operand::from_boxref(&value_box));
         } else if !value.is_none() {
             self.escape_box(&value_box);
         }
@@ -1680,7 +1682,7 @@ impl OptHeap {
             }
             owners.push(owner);
             if let Some(owner_box) = ctx.get_box_replacement_box(owner) {
-                if let Some(deps) = self.heapc_deps.get(&owner_box) {
+                if let Some(deps) = self.heapc_deps.get(&Operand::from_boxref(&owner_box)) {
                     stack.extend(deps.iter().map(|dep| dep.to_opref()));
                 }
             }
@@ -2935,7 +2937,7 @@ impl OptHeap {
         if opcode.is_malloc() {
             vb_set(&mut self.seen_allocation, op.pos.get().raw());
             if let Some(new_box) = ctx.get_box_replacement_box(op.pos.get()) {
-                self.unescaped.insert(new_box);
+                self.unescaped.insert(Operand::from_boxref(&new_box));
             }
             return OptimizationResult::Emit(op.clone());
         }
@@ -3058,7 +3060,7 @@ impl OptHeap {
             OpCode::New | OpCode::NewWithVtable | OpCode::NewArray | OpCode::NewArrayClear => {
                 vb_set(&mut self.seen_allocation, op.pos.get().raw());
                 if let Some(new_box) = ctx.get_box_replacement_box(op.pos.get()) {
-                    self.unescaped.insert(new_box);
+                    self.unescaped.insert(Operand::from_boxref(&new_box));
                 }
                 OptimizationResult::PassOn
             }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -348,8 +348,8 @@ impl CachedField {
             .as_ref()
             .map(OptHeap::field_slot_index)
             .unwrap_or(0);
-        let arg = ctx.resolve_box_box(&op.arg(1)).to_opref();
-        let struct_box = ctx.resolve_box_box(&op.arg(0));
+        let arg = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
+        let struct_box = ctx.resolve_box_box(&op.arg(0).to_boxref());
         self.register_info(&struct_box);
         ctx.structinfo_setfield(op, descr_idx, arg);
     }
@@ -404,7 +404,7 @@ impl CachedField {
                 .map(|fd| OpCode::getfield_for_type(fd.field_type()))
                 .unwrap_or(OpCode::GetfieldGcI);
             let mut op =
-                Op::with_descr(opcode, &[ctx.materialize_box_at(structbox)], descr.clone());
+                Op::with_descr(opcode, &[Operand::from_boxref(&ctx.materialize_box_at(structbox))], descr.clone());
             op.pos.set(cached_val);
             sb.add_heap_op(ctx, op);
         }
@@ -606,8 +606,8 @@ impl ArrayCachedItem {
 
     /// heap.py:252-255 ArrayCachedItem.put_field_back_to_info
     fn put_field_back_to_info(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg = ctx.resolve_box_box(&op.arg(2)).to_opref();
-        let struct_box = ctx.resolve_box_box(&op.arg(0));
+        let arg = ctx.resolve_box_box(&op.arg(2).to_boxref()).to_opref();
+        let struct_box = ctx.resolve_box_box(&op.arg(0).to_boxref());
         self.register_info(&struct_box);
         ctx.arrayinfo_setitem(op, self.index as usize, arg);
     }
@@ -653,7 +653,7 @@ impl ArrayCachedItem {
                 .unwrap_or(OpCode::GetarrayitemGcI);
             let arraybox_b = ctx.materialize_box_at(arraybox);
             let idx_b = ctx.materialize_box_at(idx_ref);
-            let mut op = Op::with_descr(opcode, &[arraybox_b, idx_b], descr.clone());
+            let mut op = Op::with_descr(opcode, &[Operand::from_boxref(&arraybox_b), Operand::from_boxref(&idx_b)], descr.clone());
             op.pos.set(cached_val);
             sb.add_heap_op(ctx, op);
         }
@@ -990,9 +990,9 @@ impl OptHeap {
     /// Canonicalizes array and index through get_box_replacement.
     fn arrayitem_key(op: &Op, ctx: &mut OptContext) -> Option<ArrayItemKey> {
         let descr = op.getdescr()?;
-        let array = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let array = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         let index_val = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))?;
         Some((array, descr.index(), index_val))
     }
@@ -1137,7 +1137,7 @@ impl OptHeap {
     /// array-pointer field (`GetfieldGc*`/`GetfieldRaw*` of the frame). Such
     /// writes are deferred at the export flush — see `emit_lazy_setfield`.
     fn writes_into_virtualizable(op: &Op, ctx: &OptContext) -> bool {
-        let Some(target) = ctx.resolve_box_box_opt(&op.arg(0)) else {
+        let Some(target) = ctx.resolve_box_box_opt(&op.arg(0).to_boxref()) else {
             return false;
         };
         if ctx.is_virtualizable(&target) {
@@ -1157,7 +1157,7 @@ impl OptHeap {
                         | OpCode::GetfieldRawF
                 ) =>
             {
-                ctx.resolve_box_box_opt(&producer.arg(0))
+                ctx.resolve_box_box_opt(&producer.arg(0).to_boxref())
                     .map_or(false, |frame| ctx.is_virtualizable(&frame))
             }
             _ => false,
@@ -1193,7 +1193,7 @@ impl OptHeap {
         // Resolve forwarding and route after heap
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..op.num_args() {
-            op.setarg(i, ctx.resolve_box_box(&op.arg(i)));
+            op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())));
         }
         // heap.py:136: emit_extra(op, emit=False) → next_optimization
         ctx.emit_extra(ctx.current_pass_idx, op.clone());
@@ -1324,7 +1324,7 @@ impl OptHeap {
             .collect();
         for (field_idx, descr, mut op) in field_entries {
             // heap.py:617-618: val = op.getarg(1); if is_virtual(val)
-            let is_virtual = ctx.is_virtual(&op.arg(1).get_box_replacement(false));
+            let is_virtual = ctx.is_virtual(&op.arg(1).to_boxref().get_box_replacement(false));
             if is_virtual {
                 // heap.py:618-619: virtual value → pendingfields
                 pendingfields.push(op);
@@ -1335,7 +1335,7 @@ impl OptHeap {
             // then put_field_back_to_info restores the cache.
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
-                op.setarg(i, ctx.resolve_box_box(&op.arg(i)));
+                op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())));
             }
             let final_value = op.arg(1);
             // heap.py:129,189-191: invalidate(descr) — purity self-gate
@@ -1380,7 +1380,7 @@ impl OptHeap {
             .collect();
         for (descr_idx, index, mut op) in array_entries {
             // heap.py:631-633: assert container not virtual; check value virtual
-            let is_virtual = ctx.is_virtual(&op.arg(2).get_box_replacement(false));
+            let is_virtual = ctx.is_virtual(&op.arg(2).to_boxref().get_box_replacement(false));
             if is_virtual {
                 // heap.py:634: pendingfields.append(op)
                 pendingfields.push(op);
@@ -1397,10 +1397,10 @@ impl OptHeap {
             }
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
-                op.setarg(i, ctx.resolve_box_box(&op.arg(i)));
+                op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())));
             }
             let final_value = op.arg(2);
-            let array_ref = op.arg(0);
+            let array_ref = op.arg(0).to_boxref();
             let descr = op.getdescr();
             let put_back_op = op.clone();
             // emit_extra(op, emit=False): route through passes after heap.
@@ -1505,7 +1505,7 @@ impl OptHeap {
         if op.num_args() < 5 {
             return false;
         }
-        let flag = match ctx.get_constant_int_or_bound_box(&op.arg(4).get_box_replacement(false)) {
+        let flag = match ctx.get_constant_int_or_bound_box(&op.arg(4).to_boxref().get_box_replacement(false)) {
             Some(v) => v,
             None => return false,
         };
@@ -1641,18 +1641,18 @@ impl OptHeap {
         if oopspec == OopSpecIndex::Arraycopy
             && has_single_write_descr
             && op.num_args() >= 6
-            && op.arg(3).get_box_replacement(false).const_int().is_some()
-            && op.arg(4).get_box_replacement(false).const_int().is_some()
-            && op.arg(5).get_box_replacement(false).const_int().is_some()
+            && op.arg(3).to_boxref().get_box_replacement(false).const_int().is_some()
+            && op.arg(4).to_boxref().get_box_replacement(false).const_int().is_some()
+            && op.arg(5).to_boxref().get_box_replacement(false).const_int().is_some()
         {
             return;
         }
         if oopspec == OopSpecIndex::Arraymove
             && has_single_write_descr
             && op.num_args() >= 5
-            && op.arg(2).get_box_replacement(false).const_int().is_some()
-            && op.arg(3).get_box_replacement(false).const_int().is_some()
-            && op.arg(4).get_box_replacement(false).const_int().is_some()
+            && op.arg(2).to_boxref().get_box_replacement(false).const_int().is_some()
+            && op.arg(3).to_boxref().get_box_replacement(false).const_int().is_some()
+            && op.arg(4).to_boxref().get_box_replacement(false).const_int().is_some()
         {
             return;
         }
@@ -1805,7 +1805,7 @@ impl OptHeap {
             }
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..pending_op.num_args() {
-                pending_op.setarg(i, ctx.resolve_box_box(&pending_op.arg(i)));
+                pending_op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&pending_op.arg(i).to_boxref())));
             }
             self.emit_postponed_if_referenced(&pending_op, heap_pass_idx, ctx);
             let final_value = pending_op.arg(1);
@@ -1841,12 +1841,12 @@ impl OptHeap {
         for (descr_idx, index, _obj, mut pending_op) in pending_arrays {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..pending_op.num_args() {
-                pending_op.setarg(i, ctx.resolve_box_box(&pending_op.arg(i)));
+                pending_op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&pending_op.arg(i).to_boxref())));
             }
             self.invalidate_arrayitem_cache(descr_idx, index, ctx);
             self.emit_postponed_if_referenced(&pending_op, heap_pass_idx, ctx);
             let final_value = pending_op.arg(2);
-            let array_ref = pending_op.arg(0);
+            let array_ref = pending_op.arg(0).to_boxref();
             let descr = pending_op.getdescr();
             let put_back_op = pending_op.clone();
             ctx.emit_extra(heap_pass_idx, pending_op);
@@ -2028,7 +2028,7 @@ impl OptHeap {
         //       self.optimizer.make_constant(op, resbox)
         if descr.is_always_pure() {
             if ctx
-                .get_constant_box(&op.arg(0).get_box_replacement(false))
+                .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                 .is_some()
             {
                 if let Some(value) = ctx.constant_fold(&op) {
@@ -2214,7 +2214,7 @@ impl OptHeap {
                 // First read after QUASIIMMUT_FIELD: emit the load, then cache
                 // the result so it survives calls (unlike normal mutable fields).
                 self.quasi_immut_cache.insert(qi_key, op.pos.get());
-                make_nonnull_box(ctx, &op.arg(0));
+                make_nonnull_box(ctx, &op.arg(0).to_boxref());
                 let obj_box = ctx
                     .get_box_replacement_box(obj)
                     .unwrap_or_else(|| BoxRef::from_opref(obj));
@@ -2230,7 +2230,7 @@ impl OptHeap {
         //     structinfo.setfield(descr, op.getarg(0), op, ...)
         // heap.py optimize_GETFIELD_GC_I default path also marks the base:
         //     self.make_nonnull(op.getarg(0))
-        make_nonnull_box(ctx, &op.arg(0));
+        make_nonnull_box(ctx, &op.arg(0).to_boxref());
         let obj_box = ctx
             .get_box_replacement_box(obj)
             .unwrap_or_else(|| BoxRef::from_opref(obj));
@@ -2256,7 +2256,7 @@ impl OptHeap {
             let cmp_pos = ctx.alloc_op_position_typed(OpCode::IntNe.result_type());
             let cmp_arg0 = ctx.materialize_box_at(op.pos.get());
             let cmp_arg1 = ctx.materialize_box_at(zero_ref);
-            let mut cmp_op = Op::new(OpCode::IntNe, &[cmp_arg0, cmp_arg1]);
+            let mut cmp_op = Op::new(OpCode::IntNe, &[Operand::from_boxref(&cmp_arg0), Operand::from_boxref(&cmp_arg1)]);
             cmp_op.pos.set(cmp_pos);
             ctx.emit(cmp_op);
             // unroll.py:409 parity: synthetic guards inherit
@@ -2265,7 +2265,7 @@ impl OptHeap {
             // arrives at store_final_boxes_in_guard with -1 and would
             // be silently dropped under the patchguardop-only fallback.
             let guard_arg = ctx.materialize_box_at(cmp_pos);
-            let guard_op = Op::new(OpCode::GuardTrue, &[guard_arg]);
+            let guard_op = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&guard_arg)]);
             if let Some(ref patch) = ctx.patchguardop {
                 guard_op
                     .rd_resume_position
@@ -2641,7 +2641,7 @@ impl OptHeap {
         // intermediate cache mutations can take &mut ctx without
         // tripping the borrow checker).
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let array_ref = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let array_ref = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
 
         // Try constant-index cache first.
         if let Some(key) = Self::arrayitem_key(op, ctx) {
@@ -2739,7 +2739,7 @@ impl OptHeap {
                     // can_cache=True: put_field_back_to_info
                     let final_value = lazy_op.arg(2);
                     let descr = lazy_op.getdescr();
-                    let lazy_obj_box = ctx.resolve_box_box(&lazy_op.arg(0));
+                    let lazy_obj_box = ctx.resolve_box_box(&lazy_op.arg(0).to_boxref());
                     self.cache_arrayitem(&lazy_obj_box, descr_idx, const_index, descr.as_ref());
                     ctx.arrayinfo_setitem(&lazy_op, const_index as usize, final_value.to_opref());
                 }
@@ -2842,7 +2842,7 @@ impl OptHeap {
             // when it falls through to record the new value (matching
             // pyre's `arrayinfo_setitem` below), `make_nonnull` still
             // fires.
-            make_nonnull_box(ctx, &op.arg(0));
+            make_nonnull_box(ctx, &op.arg(0).to_boxref());
             ctx.arrayinfo_setitem(op, const_index as usize, op.pos.get());
             return OptimizationResult::Emit(op.clone());
         }
@@ -2854,14 +2854,14 @@ impl OptHeap {
         if let Some(descr) = op.getdescr() {
             // heap.py:692-693: force lazy stores for this descr within the index bound
             let indexb = {
-                let b = ctx.resolve_box_box(&op.arg(1));
+                let b = ctx.resolve_box_box(&op.arg(1).to_boxref());
                 ctx.getintbound_handle(&b).borrow().clone()
             };
             self.force_lazy_setarrayitem(&descr, Some(&indexb), true, ctx);
 
             let descr_idx = descr.index();
             let arrayinfo = array_ref;
-            let indexbox = ctx.resolve_box_box(&op.arg(1)).to_opref();
+            let indexbox = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
                     let b_old = BoxRef::from_bound_op(op_rc);
@@ -2875,13 +2875,13 @@ impl OptHeap {
         }
 
         // heap.py line 701: make_nonnull(op.getarg(0)) (optimizer.py:440-451).
-        make_nonnull_box(ctx, &op.arg(0));
+        make_nonnull_box(ctx, &op.arg(0).to_boxref());
         OptimizationResult::Emit(op.clone())
     }
 
     fn optimize_setarrayitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         // heapcache.py:224-230 _escape_from_write parity:
-        let array_obj = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let array_obj = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         let stored_value = op.arg(2).to_opref();
         self.escape_from_write(ctx, array_obj, stored_value);
 
@@ -2894,13 +2894,13 @@ impl OptHeap {
                 //   return self.emit(op)
                 if let Some(descr) = op.getdescr() {
                     let indexb = {
-                        let b = ctx.resolve_box_box(&op.arg(1));
+                        let b = ctx.resolve_box_box(&op.arg(1).to_boxref());
                         ctx.getintbound_handle(&b).borrow().clone()
                     };
                     self.force_lazy_setarrayitem(&descr, Some(&indexb), false, ctx);
-                    let arrayinfo = ctx.resolve_box_box(&op.arg(0)).to_opref();
-                    let indexbox = ctx.resolve_box_box(&op.arg(1)).to_opref();
-                    let resbox = ctx.resolve_box_box(&op.arg(2)).to_opref();
+                    let arrayinfo = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+                    let indexbox = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
+                    let resbox = ctx.resolve_box_box(&op.arg(2).to_boxref()).to_opref();
                     self.arrayitem_submap(&descr)
                         .cache_varindex_write(arrayinfo, indexbox, resbox);
                 }
@@ -3143,7 +3143,7 @@ impl OptHeap {
                     if pending_op.opcode == OpCode::SetarrayitemGc {
                         let descr = pending_op.getdescr().unwrap().clone();
                         if let Some(index) =
-                            ctx.get_constant_int_box(&pending_op.arg(1).get_box_replacement(false))
+                            ctx.get_constant_int_box(&pending_op.arg(1).to_boxref().get_box_replacement(false))
                         {
                             let cai = self.arrayitem_cache(&descr, index);
                             cai.lazy_set = Some(pending_op);
@@ -3229,7 +3229,7 @@ impl OptHeap {
                     )
                 } else if op.num_args() > 1 {
                     let idx = ctx
-                        .get_constant_int_box(&op.arg(1).get_box_replacement(false))
+                        .get_constant_int_box(&op.arg(1).to_boxref().get_box_replacement(false))
                         .map(|v| v as u32);
                     (idx, idx.map(|v| v as usize))
                 } else {
@@ -3790,6 +3790,8 @@ mod tests {
     use crate::optimizeopt::optimizer::Optimizer;
     use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 
+    use majit_ir::operand::Operand;
+
     use super::OptHeap;
     use crate::r#box::BoxRef;
     use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
@@ -3802,8 +3804,8 @@ mod tests {
     /// never mint the position-only `Operand::Box`. `to_opref()` is identical
     /// to `from_opref(o)` either way, preserving every position-keyed
     /// assertion / cache key / trace-inputarg auto-seed.
-    fn bound_arg(o: OpRef) -> BoxRef {
-        match o {
+    fn bound_arg(o: OpRef) -> Operand {
+        Operand::from_boxref(&match o {
             OpRef::InputArgInt(i) => rooted_inputarg_box(Type::Int, i),
             OpRef::InputArgFloat(i) => rooted_inputarg_box(Type::Float, i),
             OpRef::InputArgRef(i) => rooted_inputarg_box(Type::Ref, i),
@@ -3814,7 +3816,7 @@ mod tests {
             // Const* (shed to Operand::Const), None, TempVar: no producer to
             // bind — the bare from_opref path does not mint.
             _ => BoxRef::from_opref(o),
-        }
+        })
     }
 
     /// Test SizeDescr that pretends to wrap a struct with `is_object()` matching
@@ -4088,10 +4090,10 @@ mod tests {
         preamble_op.pos.set(source);
         ctx.initialize_imported_short_preamble_builder(
             &[object, resolved],
-            &[bound_arg(object), bound_arg(resolved)],
+            &[bound_arg(object).to_boxref(), bound_arg(resolved).to_boxref()],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
-                res: bound_arg(source),
+                res: bound_arg(source).to_boxref(),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -4104,7 +4106,7 @@ mod tests {
             info.set_preamble_field(
                 OptHeap::field_slot_index(descr),
                 PreambleOp {
-                    op: bound_arg(source),
+                    op: bound_arg(source).to_boxref(),
                     invented_name: false,
                     preamble_op: std::rc::Rc::new(preamble_op),
                     same_as_source: None,
@@ -4211,14 +4213,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             // Terminate trace so lazy set is forced.
@@ -4340,8 +4342,10 @@ mod tests {
         op.pos.set(pos1);
         op.setarg(
             0,
-            ctx.resolve_box_box_opt(&op.arg(0))
-                .expect("constant receiver resolves to a BoxRef"),
+            Operand::from_boxref(
+                &ctx.resolve_box_box_opt(&op.arg(0).to_boxref())
+                    .expect("constant receiver resolves to a BoxRef"),
+            ),
         );
 
         let _ = heap.optimize_getfield(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
@@ -4357,12 +4361,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4386,16 +4390,16 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 102),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 102)),
                 ],
                 d.clone(),
             ),
@@ -4421,15 +4425,15 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4458,27 +4462,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 200),
-                    rooted_inputarg_box(Type::Int, 201),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 201)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4512,17 +4516,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d.clone(),
             ),
@@ -4543,14 +4547,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -4585,8 +4589,8 @@ mod tests {
         let mut op = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                rooted_resop_box(Type::Ref, 100),
-                rooted_resop_box(Type::Int, idx.raw()),
+                Operand::from_boxref(&rooted_resop_box(Type::Ref, 100)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
             ],
             d.clone(),
         );
@@ -4626,9 +4630,9 @@ mod tests {
         let mut op = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                rooted_resop_box(Type::Int, 100),
-                rooted_resop_box(Type::Int, idx.raw()),
-                rooted_resop_box(Type::Int, 101),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
             ],
             d.clone(),
         );
@@ -4683,15 +4687,15 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
-            Op::new(OpCode::GuardTrue, &[rooted_inputarg_box(Type::Int, 200)]),
+            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_inputarg_box(Type::Int, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4741,14 +4745,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
                 d0,
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4774,20 +4778,20 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldRaw,
                 &[
-                    rooted_inputarg_box(Type::Ref, 200),
-                    rooted_inputarg_box(Type::Ref, 201),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 201)),
                 ],
                 d1,
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4811,7 +4815,7 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             // assign_positions stamps GETFIELD's pos as IntOp(0); the
@@ -4820,8 +4824,8 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_resop_box(Type::Int, 0),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
                 d.clone(),
             ),
@@ -4846,19 +4850,19 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 0),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4880,12 +4884,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4903,12 +4907,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -4930,18 +4934,18 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
-                    rooted_resop_box(Type::Int, 102),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 102)),
                 ],
                 d.clone(),
             ),
@@ -4967,14 +4971,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -5010,19 +5014,19 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(
                 OpCode::IntAddOvf,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 0),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5046,27 +5050,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 101)),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Int, 102),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 102)),
                 ],
                 d1.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5093,13 +5097,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5124,13 +5128,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5159,23 +5163,23 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d_immut.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d_mut.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d_immut.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d_mut.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5202,12 +5206,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5228,13 +5232,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5253,13 +5257,13 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcF,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5323,14 +5327,14 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 201)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 201))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5353,23 +5357,23 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 300)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 300))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ), // cached
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 d.clone(),
             ), // cached
             Op::new(OpCode::Jump, &[]),
@@ -5400,20 +5404,20 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 200),
-                    rooted_inputarg_box(Type::Ref, 20),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 20)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5448,19 +5452,19 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_inputarg_box(Type::Ref, 10),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 10)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 plain_call_descr(100),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5495,19 +5499,19 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_inputarg_box(Type::Ref, 10),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 10)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
                 plain_call_descr(100),
             ), // pass p0 to call
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5543,27 +5547,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_inputarg_box(Type::Ref, 10),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 10)),
                 ],
                 d0.clone(),
             ), // p0.f0 = i10
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Ref, 1),
-                    rooted_resop_box(Type::Ref, 0),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
                 ],
                 d1.clone(),
             ), // p1.f1 = p0 (p0 escapes)
             Op::with_descr(
                 OpCode::CallN,
-                &[rooted_resop_box(Type::Ref, 1)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 1))],
                 plain_call_descr(100),
             ), // call(p1) (p1 escapes)
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
                 d0.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5594,20 +5598,20 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 200),
-                    rooted_inputarg_box(Type::Ref, 20),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 20)),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1.clone(),
             ), // different field
             Op::new(OpCode::Jump, &[]),
@@ -5636,26 +5640,26 @@ mod tests {
         let d = descr(0);
         let idx = OpRef::int_op(50);
         let mut ops = vec![
-            Op::new(OpCode::NewArray, &[rooted_resop_box(Type::Int, 5)]), // pos=0 -> p0
+            Op::new(OpCode::NewArray, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 5))]), // pos=0 -> p0
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_resop_box(Type::Int, idx.raw()),
-                    rooted_resop_box(Type::Int, 10),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[rooted_resop_box(Type::Int, 200)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 200))],
                 plain_call_descr(100),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d.clone(),
             ),
@@ -5679,14 +5683,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -5737,24 +5741,24 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_inputarg_box(Type::Ref, 10),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 10)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 plain_call_descr(100),
             ),
             Op::with_descr(
                 OpCode::CallN,
-                &[rooted_inputarg_box(Type::Ref, 201)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 201))],
                 plain_call_descr(101),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
                 d.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5783,7 +5787,7 @@ mod tests {
         // guard_nonnull(p0)   <- redundant, allocation is always non-null
         let mut ops = vec![
             Op::new(OpCode::New, &[]),
-            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5805,8 +5809,8 @@ mod tests {
         // guard_nonnull(p0)
         // guard_nonnull(p0)   <- redundant
         let mut ops = vec![
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5828,11 +5832,11 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5853,7 +5857,7 @@ mod tests {
     fn test_guard_nonnull_unknown_not_removed() {
         // guard_nonnull(p0)  <- first time seeing p0, must keep
         let mut ops = vec![
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5874,8 +5878,8 @@ mod tests {
         // guard_nonnull(p0)    <- still redundant (allocation is always non-null)
         let mut ops = vec![
             Op::new(OpCode::New, &[]),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
-            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5898,9 +5902,9 @@ mod tests {
         // call_n(some_func)   <- invalidates guard-derived nonnull
         // guard_nonnull(p0)   <- must re-emit
         let mut ops = vec![
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5925,11 +5929,11 @@ mod tests {
             Op::new(
                 OpCode::GuardNonnullClass,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5954,11 +5958,11 @@ mod tests {
             Op::new(
                 OpCode::GuardValue,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5979,7 +5983,7 @@ mod tests {
     fn test_guard_nonnull_after_new_with_vtable() {
         let mut ops = vec![
             Op::new(OpCode::NewWithVtable, &[]),
-            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5999,8 +6003,8 @@ mod tests {
     #[test]
     fn test_guard_nonnull_after_new_array() {
         let mut ops = vec![
-            Op::new(OpCode::NewArray, &[rooted_inputarg_box(Type::Ref, 5)]),
-            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Ref, 0)]),
+            Op::new(OpCode::NewArray, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 5))]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6072,18 +6076,18 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6121,18 +6125,18 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6163,7 +6167,7 @@ mod tests {
             Op::new(OpCode::GuardNotInvalidated, &[]),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[rooted_inputarg_box(Type::Ref, 200)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
@@ -6200,22 +6204,22 @@ mod tests {
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[rooted_resop_box(Type::Int, 200)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 200))],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d0,
             ),
@@ -6237,14 +6241,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -6299,22 +6303,22 @@ mod tests {
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d0.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceN,
-                &[rooted_resop_box(Type::Int, 200)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 200))],
                 call_d,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d0,
             ),
@@ -6336,14 +6340,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -6392,17 +6396,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 101),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
                 d.clone(),
             ),
             Op::new(
                 OpCode::GcLoadI,
                 &[
-                    rooted_inputarg_box(Type::Ref, 200),
-                    rooted_inputarg_box(Type::Ref, 8),
-                    rooted_inputarg_box(Type::Ref, 4),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 8)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 4)),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6426,12 +6430,12 @@ mod tests {
             Op::new(
                 OpCode::GcLoadI,
                 &[
-                    rooted_inputarg_box(Type::Ref, 100),
-                    rooted_inputarg_box(Type::Ref, 8),
-                    rooted_inputarg_box(Type::Ref, 4),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 8)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 4)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[rooted_inputarg_box(Type::Ref, 100)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6459,18 +6463,18 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::QuasiimmutField,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d0,
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1.clone(),
             ),
-            Op::new(OpCode::CallN, &[rooted_inputarg_box(Type::Ref, 200)]),
+            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[rooted_inputarg_box(Type::Ref, 100)],
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6535,17 +6539,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d.clone(),
             ),
@@ -6565,14 +6569,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -6615,17 +6619,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx5.raw()),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx5.raw())),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx6.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx6.raw())),
                 ],
                 d.clone(),
             ),
@@ -6652,14 +6656,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -6701,16 +6705,16 @@ mod tests {
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d.clone(),
             ),
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, idx.raw()),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
                 ],
                 d.clone(),
             ),
@@ -6730,14 +6734,14 @@ mod tests {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg) {
-                    Some(b) => b,
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            ctx.materialize_box_at(__ar).get_box_replacement(false)
+                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
                         }
                     }
                 };
@@ -6780,12 +6784,12 @@ mod tests {
         let d = descr(42);
         let mut ops = vec![
             {
-                let mut op = Op::new(OpCode::ArraylenGc, &[rooted_resop_box(Type::Int, 100)]);
+                let mut op = Op::new(OpCode::ArraylenGc, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]);
                 op.setdescr(d.clone());
                 op
             },
             {
-                let mut op = Op::new(OpCode::ArraylenGc, &[rooted_resop_box(Type::Int, 100)]);
+                let mut op = Op::new(OpCode::ArraylenGc, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]);
                 op.setdescr(d);
                 op
             },
@@ -6835,8 +6839,8 @@ mod tests {
                 descr: arr_descr.clone(),
                 lenbound: IntBound::from_constant(2),
                 items: vec![
-                    FieldEntry::Value(bound_arg(const_10)),
-                    FieldEntry::Value(bound_arg(const_20)),
+                    FieldEntry::Value(bound_arg(const_10).to_boxref()),
+                    FieldEntry::Value(bound_arg(const_20).to_boxref()),
                 ],
                 last_guard_pos: -1,
             }),
@@ -6847,8 +6851,8 @@ mod tests {
                 descr: arr_descr,
                 lenbound: IntBound::from_constant(2),
                 items: vec![
-                    FieldEntry::Value(bound_arg(const_10)),
-                    FieldEntry::Value(bound_arg(const_30)),
+                    FieldEntry::Value(bound_arg(const_10).to_boxref()),
+                    FieldEntry::Value(bound_arg(const_30).to_boxref()),
                 ],
                 last_guard_pos: -1,
             }),

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -403,8 +403,11 @@ impl CachedField {
                 .as_field_descr()
                 .map(|fd| OpCode::getfield_for_type(fd.field_type()))
                 .unwrap_or(OpCode::GetfieldGcI);
-            let mut op =
-                Op::with_descr(opcode, &[Operand::from_boxref(&ctx.materialize_box_at(structbox))], descr.clone());
+            let mut op = Op::with_descr(
+                opcode,
+                &[Operand::from_boxref(&ctx.materialize_box_at(structbox))],
+                descr.clone(),
+            );
             op.pos.set(cached_val);
             sb.add_heap_op(ctx, op);
         }
@@ -653,7 +656,14 @@ impl ArrayCachedItem {
                 .unwrap_or(OpCode::GetarrayitemGcI);
             let arraybox_b = ctx.materialize_box_at(arraybox);
             let idx_b = ctx.materialize_box_at(idx_ref);
-            let mut op = Op::with_descr(opcode, &[Operand::from_boxref(&arraybox_b), Operand::from_boxref(&idx_b)], descr.clone());
+            let mut op = Op::with_descr(
+                opcode,
+                &[
+                    Operand::from_boxref(&arraybox_b),
+                    Operand::from_boxref(&idx_b),
+                ],
+                descr.clone(),
+            );
             op.pos.set(cached_val);
             sb.add_heap_op(ctx, op);
         }
@@ -1193,7 +1203,10 @@ impl OptHeap {
         // Resolve forwarding and route after heap
         // optimizer.py:651-652 setarg loop parity.
         for i in 0..op.num_args() {
-            op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())));
+            op.setarg(
+                i,
+                Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())),
+            );
         }
         // heap.py:136: emit_extra(op, emit=False) → next_optimization
         ctx.emit_extra(ctx.current_pass_idx, op.clone());
@@ -1335,7 +1348,10 @@ impl OptHeap {
             // then put_field_back_to_info restores the cache.
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
-                op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())));
+                op.setarg(
+                    i,
+                    Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())),
+                );
             }
             let final_value = op.arg(1);
             // heap.py:129,189-191: invalidate(descr) — purity self-gate
@@ -1397,7 +1413,10 @@ impl OptHeap {
             }
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..op.num_args() {
-                op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())));
+                op.setarg(
+                    i,
+                    Operand::from_boxref(&ctx.resolve_box_box(&op.arg(i).to_boxref())),
+                );
             }
             let final_value = op.arg(2);
             let array_ref = op.arg(0).to_boxref();
@@ -1505,7 +1524,9 @@ impl OptHeap {
         if op.num_args() < 5 {
             return false;
         }
-        let flag = match ctx.get_constant_int_or_bound_box(&op.arg(4).to_boxref().get_box_replacement(false)) {
+        let flag = match ctx
+            .get_constant_int_or_bound_box(&op.arg(4).to_boxref().get_box_replacement(false))
+        {
             Some(v) => v,
             None => return false,
         };
@@ -1641,18 +1662,48 @@ impl OptHeap {
         if oopspec == OopSpecIndex::Arraycopy
             && has_single_write_descr
             && op.num_args() >= 6
-            && op.arg(3).to_boxref().get_box_replacement(false).const_int().is_some()
-            && op.arg(4).to_boxref().get_box_replacement(false).const_int().is_some()
-            && op.arg(5).to_boxref().get_box_replacement(false).const_int().is_some()
+            && op
+                .arg(3)
+                .to_boxref()
+                .get_box_replacement(false)
+                .const_int()
+                .is_some()
+            && op
+                .arg(4)
+                .to_boxref()
+                .get_box_replacement(false)
+                .const_int()
+                .is_some()
+            && op
+                .arg(5)
+                .to_boxref()
+                .get_box_replacement(false)
+                .const_int()
+                .is_some()
         {
             return;
         }
         if oopspec == OopSpecIndex::Arraymove
             && has_single_write_descr
             && op.num_args() >= 5
-            && op.arg(2).to_boxref().get_box_replacement(false).const_int().is_some()
-            && op.arg(3).to_boxref().get_box_replacement(false).const_int().is_some()
-            && op.arg(4).to_boxref().get_box_replacement(false).const_int().is_some()
+            && op
+                .arg(2)
+                .to_boxref()
+                .get_box_replacement(false)
+                .const_int()
+                .is_some()
+            && op
+                .arg(3)
+                .to_boxref()
+                .get_box_replacement(false)
+                .const_int()
+                .is_some()
+            && op
+                .arg(4)
+                .to_boxref()
+                .get_box_replacement(false)
+                .const_int()
+                .is_some()
         {
             return;
         }
@@ -1805,7 +1856,10 @@ impl OptHeap {
             }
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..pending_op.num_args() {
-                pending_op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&pending_op.arg(i).to_boxref())));
+                pending_op.setarg(
+                    i,
+                    Operand::from_boxref(&ctx.resolve_box_box(&pending_op.arg(i).to_boxref())),
+                );
             }
             self.emit_postponed_if_referenced(&pending_op, heap_pass_idx, ctx);
             let final_value = pending_op.arg(1);
@@ -1841,7 +1895,10 @@ impl OptHeap {
         for (descr_idx, index, _obj, mut pending_op) in pending_arrays {
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..pending_op.num_args() {
-                pending_op.setarg(i, Operand::from_boxref(&ctx.resolve_box_box(&pending_op.arg(i).to_boxref())));
+                pending_op.setarg(
+                    i,
+                    Operand::from_boxref(&ctx.resolve_box_box(&pending_op.arg(i).to_boxref())),
+                );
             }
             self.invalidate_arrayitem_cache(descr_idx, index, ctx);
             self.emit_postponed_if_referenced(&pending_op, heap_pass_idx, ctx);
@@ -2256,7 +2313,13 @@ impl OptHeap {
             let cmp_pos = ctx.alloc_op_position_typed(OpCode::IntNe.result_type());
             let cmp_arg0 = ctx.materialize_box_at(op.pos.get());
             let cmp_arg1 = ctx.materialize_box_at(zero_ref);
-            let mut cmp_op = Op::new(OpCode::IntNe, &[Operand::from_boxref(&cmp_arg0), Operand::from_boxref(&cmp_arg1)]);
+            let mut cmp_op = Op::new(
+                OpCode::IntNe,
+                &[
+                    Operand::from_boxref(&cmp_arg0),
+                    Operand::from_boxref(&cmp_arg1),
+                ],
+            );
             cmp_op.pos.set(cmp_pos);
             ctx.emit(cmp_op);
             // unroll.py:409 parity: synthetic guards inherit
@@ -3142,9 +3205,9 @@ impl OptHeap {
                 for pending_op in pending_virtual {
                     if pending_op.opcode == OpCode::SetarrayitemGc {
                         let descr = pending_op.getdescr().unwrap().clone();
-                        if let Some(index) =
-                            ctx.get_constant_int_box(&pending_op.arg(1).to_boxref().get_box_replacement(false))
-                        {
+                        if let Some(index) = ctx.get_constant_int_box(
+                            &pending_op.arg(1).to_boxref().get_box_replacement(false),
+                        ) {
                             let cai = self.arrayitem_cache(&descr, index);
                             cai.lazy_set = Some(pending_op);
                         } else {
@@ -4090,7 +4153,10 @@ mod tests {
         preamble_op.pos.set(source);
         ctx.initialize_imported_short_preamble_builder(
             &[object, resolved],
-            &[bound_arg(object).to_boxref(), bound_arg(resolved).to_boxref()],
+            &[
+                bound_arg(object).to_boxref(),
+                bound_arg(resolved).to_boxref(),
+            ],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
                 res: bound_arg(source).to_boxref(),
@@ -4430,7 +4496,10 @@ mod tests {
                 ],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -4554,7 +4623,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -4692,7 +4763,10 @@ mod tests {
                 ],
                 d.clone(),
             ),
-            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_inputarg_box(Type::Int, 200))]),
+            Op::new(
+                OpCode::GuardTrue,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Int, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -4978,7 +5052,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -5100,7 +5176,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5131,7 +5210,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5171,7 +5253,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d_mut.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5235,7 +5320,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcR,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5260,7 +5348,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcF,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5330,8 +5421,14 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 201))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 201))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5365,7 +5462,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
                 d.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 300))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 300))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -5640,7 +5740,10 @@ mod tests {
         let d = descr(0);
         let idx = OpRef::int_op(50);
         let mut ops = vec![
-            Op::new(OpCode::NewArray, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 5))]), // pos=0 -> p0
+            Op::new(
+                OpCode::NewArray,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 5))],
+            ), // pos=0 -> p0
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
@@ -5690,7 +5793,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -5787,7 +5892,10 @@ mod tests {
         // guard_nonnull(p0)   <- redundant, allocation is always non-null
         let mut ops = vec![
             Op::new(OpCode::New, &[]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5809,8 +5917,14 @@ mod tests {
         // guard_nonnull(p0)
         // guard_nonnull(p0)   <- redundant
         let mut ops = vec![
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5836,7 +5950,10 @@ mod tests {
                     Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5857,7 +5974,10 @@ mod tests {
     fn test_guard_nonnull_unknown_not_removed() {
         // guard_nonnull(p0)  <- first time seeing p0, must keep
         let mut ops = vec![
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5878,8 +5998,14 @@ mod tests {
         // guard_nonnull(p0)    <- still redundant (allocation is always non-null)
         let mut ops = vec![
             Op::new(OpCode::New, &[]),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5902,9 +6028,18 @@ mod tests {
         // call_n(some_func)   <- invalidates guard-derived nonnull
         // guard_nonnull(p0)   <- must re-emit
         let mut ops = vec![
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5933,7 +6068,10 @@ mod tests {
                     Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5962,7 +6100,10 @@ mod tests {
                     Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -5983,7 +6124,10 @@ mod tests {
     fn test_guard_nonnull_after_new_with_vtable() {
         let mut ops = vec![
             Op::new(OpCode::NewWithVtable, &[]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6003,8 +6147,14 @@ mod tests {
     #[test]
     fn test_guard_nonnull_after_new_array() {
         let mut ops = vec![
-            Op::new(OpCode::NewArray, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 5))]),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))]),
+            Op::new(
+                OpCode::NewArray,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 5))],
+            ),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 0))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6248,7 +6398,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -6347,7 +6499,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -6435,7 +6589,10 @@ mod tests {
                     Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 4)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
+            ),
             Op::new(OpCode::Jump, &[]),
         ];
         let result = run_heap_opt(&mut ops);
@@ -6471,7 +6628,10 @@ mod tests {
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
                 d1.clone(),
             ),
-            Op::new(OpCode::CallN, &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))]),
+            Op::new(
+                OpCode::CallN,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 200))],
+            ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
                 &[Operand::from_boxref(&rooted_inputarg_box(Type::Ref, 100))],
@@ -6576,7 +6736,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -6663,7 +6825,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -6741,7 +6905,9 @@ mod tests {
                         if __ar.is_none() {
                             arg.clone()
                         } else {
-                            Operand::from_boxref(&ctx.materialize_box_at(__ar).get_box_replacement(false))
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
                         }
                     }
                 };
@@ -6784,12 +6950,18 @@ mod tests {
         let d = descr(42);
         let mut ops = vec![
             {
-                let mut op = Op::new(OpCode::ArraylenGc, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]);
+                let mut op = Op::new(
+                    OpCode::ArraylenGc,
+                    &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))],
+                );
                 op.setdescr(d.clone());
                 op
             },
             {
-                let mut op = Op::new(OpCode::ArraylenGc, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]);
+                let mut op = Op::new(
+                    OpCode::ArraylenGc,
+                    &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))],
+                );
                 op.setdescr(d);
                 op
             },

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4636,6 +4636,10 @@ mod tests {
         ctx.make_constant_box(&b, majit_ir::Value::Int(3));
         let pos100 = ctx.materialize_box_at(OpRef::int_op(100));
         ctx.set_ptr_info(&pos100, PtrInfo::virtual_array(d.clone(), 8, false));
+        // Register a producer for the rhs operand position so the forced
+        // lazy setarrayitem resolves it to a bound `Operand::Op` producer
+        // rather than minting a position-only `Operand::Box`.
+        ctx.materialize_box_at(OpRef::int_op(101));
 
         let mut pass = OptHeap::new();
         pass.setup();
@@ -4946,6 +4950,12 @@ mod tests {
         let mut ctx = OptContext::new(ops.len());
         let b = ctx.materialize_box_at(idx);
         ctx.make_constant_box(&b, majit_ir::Value::Int(5));
+        // Register producers for the external operand positions so the
+        // forced lazy setarrayitem resolves its args to bound `Operand::Op`
+        // producers rather than minting a position-only `Operand::Box`.
+        ctx.materialize_box_at(OpRef::int_op(100));
+        ctx.materialize_box_at(OpRef::int_op(101));
+        ctx.materialize_box_at(OpRef::int_op(102));
 
         let mut pass = OptHeap::new();
         pass.setup();
@@ -5654,6 +5664,10 @@ mod tests {
         let mut ctx = OptContext::new(ops.len());
         let b = ctx.materialize_box_at(idx);
         ctx.make_constant_box(&b, majit_ir::Value::Int(3));
+        // Register a producer for the stored rhs operand position so the
+        // call-forced lazy setarrayitem resolves it to a bound `Operand::Op`
+        // producer rather than minting a position-only `Operand::Box`.
+        ctx.materialize_box_at(OpRef::int_op(10));
 
         let mut pass = OptHeap::new();
         pass.setup();
@@ -6622,6 +6636,11 @@ mod tests {
         ctx.make_constant_box(&b, majit_ir::Value::Int(5));
         let b = ctx.materialize_box_at(idx6);
         ctx.make_constant_box(&b, majit_ir::Value::Int(6));
+        // Register producers for the external operand positions so the
+        // forced lazy setarrayitem resolves its args to bound `Operand::Op`
+        // producers rather than minting a position-only `Operand::Box`.
+        ctx.materialize_box_at(OpRef::int_op(100));
+        ctx.materialize_box_at(OpRef::int_op(101));
 
         let mut pass = OptHeap::new();
         pass.setup();

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -5,8 +5,8 @@
 /// pointer info, virtual object state).
 use crate::r#box::BoxRef;
 use crate::optimizeopt::intutils::{IntBound, IntBoundMakeGuards};
-pub use majit_ir::rawbuffer::{RawBuffer, RawBufferError};
 use majit_ir::operand::Operand;
+pub use majit_ir::rawbuffer::{RawBuffer, RawBufferError};
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 
 fn lookup_field_descr(field_descrs: &[DescrRef], field_idx: u32) -> Option<DescrRef> {
@@ -456,7 +456,10 @@ impl PtrInfoExt for PtrInfo {
             // info.py:83-84: PtrInfo base — no-op
             PtrInfo::NonNull { .. } => {
                 // info.py:120-122: NonNullPtrInfo.make_guards
-                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                short.push(Op::new(
+                    OpCode::GuardNonnull,
+                    &[Operand::from_boxref(&op_b)],
+                ));
             }
             PtrInfo::Instance(info) => {
                 // info.py:336-353 InstancePtrInfo.make_guards line-by-line.
@@ -496,16 +499,28 @@ impl PtrInfoExt for PtrInfo {
                     // `cls_of_box()`.
                     let class_ref = alloc_const(ctx, Value::Int(cls));
                     if !ctx.remove_gctypeptr {
-                        short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
-                        short.push(Op::new(OpCode::GuardIsObject, &[Operand::from_boxref(&op_b)]));
+                        short.push(Op::new(
+                            OpCode::GuardNonnull,
+                            &[Operand::from_boxref(&op_b)],
+                        ));
+                        short.push(Op::new(
+                            OpCode::GuardIsObject,
+                            &[Operand::from_boxref(&op_b)],
+                        ));
                         short.push(Op::new(
                             OpCode::GuardClass,
-                            &[Operand::from_boxref(&op_b), Operand::from_boxref(&class_ref)],
+                            &[
+                                Operand::from_boxref(&op_b),
+                                Operand::from_boxref(&class_ref),
+                            ],
                         ));
                     } else {
                         short.push(Op::new(
                             OpCode::GuardNonnullClass,
-                            &[Operand::from_boxref(&op_b), Operand::from_boxref(&class_ref)],
+                            &[
+                                Operand::from_boxref(&op_b),
+                                Operand::from_boxref(&class_ref),
+                            ],
                         ));
                     }
                 } else if let Some(descr) = &info.descr {
@@ -514,18 +529,30 @@ impl PtrInfoExt for PtrInfo {
                         .map(|sd| sd.vtable() as i64)
                         .unwrap_or(0);
                     let vtable_const = alloc_const(ctx, Value::Int(vtable));
-                    short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                    short.push(Op::new(
+                        OpCode::GuardNonnull,
+                        &[Operand::from_boxref(&op_b)],
+                    ));
                     if !ctx.remove_gctypeptr {
-                        short.push(Op::new(OpCode::GuardIsObject, &[Operand::from_boxref(&op_b)]));
+                        short.push(Op::new(
+                            OpCode::GuardIsObject,
+                            &[Operand::from_boxref(&op_b)],
+                        ));
                     }
                     short.push(Op::new(
                         OpCode::GuardSubclass,
-                        &[Operand::from_boxref(&op_b), Operand::from_boxref(&vtable_const)],
+                        &[
+                            Operand::from_boxref(&op_b),
+                            Operand::from_boxref(&vtable_const),
+                        ],
                     ));
                 } else {
                     // info.py:353 fall-through with neither class nor
                     // descr — base NonNullPtrInfo.make_guards.
-                    short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                    short.push(Op::new(
+                        OpCode::GuardNonnull,
+                        &[Operand::from_boxref(&op_b)],
+                    ));
                 }
             }
             PtrInfo::Struct(info) => {
@@ -540,16 +567,25 @@ impl PtrInfoExt for PtrInfo {
                     .map(|sd| sd.type_id() as i64)
                     .unwrap_or(0);
                 let type_id_const = alloc_const(ctx, Value::Int(type_id));
-                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                short.push(Op::new(
+                    OpCode::GuardNonnull,
+                    &[Operand::from_boxref(&op_b)],
+                ));
                 short.push(Op::new(
                     OpCode::GuardGcType,
-                    &[Operand::from_boxref(&op_b), Operand::from_boxref(&type_id_const)],
+                    &[
+                        Operand::from_boxref(&op_b),
+                        Operand::from_boxref(&type_id_const),
+                    ],
                 ));
             }
             PtrInfo::Constant(gcref) => {
                 // info.py:715-716: ConstPtrInfo.make_guards
                 let c = alloc_const(ctx, Value::Ref(*gcref));
-                short.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&op_b), Operand::from_boxref(&c)]));
+                short.push(Op::new(
+                    OpCode::GuardValue,
+                    &[Operand::from_boxref(&op_b), Operand::from_boxref(&c)],
+                ));
             }
             PtrInfo::Array(info) => {
                 // info.py:632-639: ArrayPtrInfo.make_guards.
@@ -559,7 +595,10 @@ impl PtrInfoExt for PtrInfo {
                 //       lenop = ARRAYLEN_GC[op] (descr=self.descr)
                 //       short.append(lenop)
                 //       self.lenbound.make_guards(lenop, short, optimizer)
-                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                short.push(Op::new(
+                    OpCode::GuardNonnull,
+                    &[Operand::from_boxref(&op_b)],
+                ));
                 let type_id = info
                     .descr
                     .as_array_descr()
@@ -568,15 +607,21 @@ impl PtrInfoExt for PtrInfo {
                 let type_id_const = alloc_const(ctx, Value::Int(type_id));
                 short.push(Op::new(
                     OpCode::GuardGcType,
-                    &[Operand::from_boxref(&op_b), Operand::from_boxref(&type_id_const)],
+                    &[
+                        Operand::from_boxref(&op_b),
+                        Operand::from_boxref(&type_id_const),
+                    ],
                 ));
                 // Always emit ARRAYLEN_GC + bound guards: pyre's
                 // ArrayPtrInfo.lenbound is a plain `IntBound`, not an
                 // `Option`, so the parity check is on `is_unbounded()`
                 // rather than `is None`.
                 if !info.lenbound.is_unbounded() {
-                    let mut lenop =
-                        Op::with_descr(OpCode::ArraylenGc, &[Operand::from_boxref(&op_b)], info.descr.clone());
+                    let mut lenop = Op::with_descr(
+                        OpCode::ArraylenGc,
+                        &[Operand::from_boxref(&op_b)],
+                        info.descr.clone(),
+                    );
                     // info.py:637 `lenop = ResOperation(ARRAYLEN_GC, [op])`
                     // followed by `lenbound.make_guards(lenop, ...)` — the
                     // `lenop` object is the consumer's box arg via Python
@@ -606,17 +651,26 @@ impl PtrInfoExt for PtrInfo {
             // `RawSlicePtrInfo` (info.py:459) inherit this override.
             PtrInfo::VirtualRawBuffer(_) | PtrInfo::VirtualRawSlice(_) => {
                 let zero = alloc_const(ctx, Value::Int(0));
-                let mut eq_op = Op::new(OpCode::IntEq, &[Operand::from_boxref(&op_b), Operand::from_boxref(&zero)]);
+                let mut eq_op = Op::new(
+                    OpCode::IntEq,
+                    &[Operand::from_boxref(&op_b), Operand::from_boxref(&zero)],
+                );
                 // info.py:381 `op = ResOperation(INT_EQ, [...])` then
                 // `[op]` — INT_EQ result identity for GUARD_FALSE.
                 eq_op.pos.set(ctx.alloc_op_position_typed(Type::Int));
                 let eq_pos = eq_op.pos.get();
                 short.push(eq_op);
-                short.push(Op::new(OpCode::GuardFalse, &[Operand::from_boxref(&BoxRef::from_opref(eq_pos))]));
+                short.push(Op::new(
+                    OpCode::GuardFalse,
+                    &[Operand::from_boxref(&BoxRef::from_opref(eq_pos))],
+                ));
             }
             PtrInfo::Str(sinfo) => {
                 // vstring.py:116-126: StrPtrInfo.make_guards
-                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                short.push(Op::new(
+                    OpCode::GuardNonnull,
+                    &[Operand::from_boxref(&op_b)],
+                ));
                 if let Some(ref bound) = sinfo.lenbound {
                     if bound.lower >= 1 {
                         let lenop_code = if sinfo.mode == 0 {
@@ -1045,7 +1099,13 @@ fn force_box_impl(
                 );
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_value = ctx.resolve_box_box(&value_ref);
-                let mut set_op = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_value)]);
+                let mut set_op = Op::new(
+                    OpCode::SetfieldGc,
+                    &[
+                        Operand::from_boxref(&arg_alloc),
+                        Operand::from_boxref(&arg_value),
+                    ],
+                );
                 set_op.setdescr(descr);
                 emit_op(ctx, set_op);
             }
@@ -1092,7 +1152,13 @@ fn force_box_impl(
                 );
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_value = ctx.resolve_box_box(&value_ref);
-                let mut set_op = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_value)]);
+                let mut set_op = Op::new(
+                    OpCode::SetfieldGc,
+                    &[
+                        Operand::from_boxref(&arg_alloc),
+                        Operand::from_boxref(&arg_value),
+                    ],
+                );
                 set_op.setdescr(descr);
                 emit_op(ctx, set_op);
             }
@@ -1156,7 +1222,14 @@ fn force_box_impl(
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_idx = ctx.materialize_box_at(idx_ref);
                 let arg_sub = ctx.resolve_box_box(&subbox);
-                let mut set_op = Op::new(OpCode::SetarrayitemGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_idx), Operand::from_boxref(&arg_sub)]);
+                let mut set_op = Op::new(
+                    OpCode::SetarrayitemGc,
+                    &[
+                        Operand::from_boxref(&arg_alloc),
+                        Operand::from_boxref(&arg_idx),
+                        Operand::from_boxref(&arg_sub),
+                    ],
+                );
                 set_op.setdescr(descr.clone());
                 emit_op(ctx, set_op);
             }
@@ -1215,8 +1288,14 @@ fn force_box_impl(
                     let arg_alloc = ctx.materialize_box_at(alloc_ref);
                     let arg_idx = ctx.materialize_box_at(idx_ref);
                     let arg_sub = ctx.resolve_box_box(&subbox);
-                    let mut set_op =
-                        Op::new(OpCode::SetinteriorfieldGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_idx), Operand::from_boxref(&arg_sub)]);
+                    let mut set_op = Op::new(
+                        OpCode::SetinteriorfieldGc,
+                        &[
+                            Operand::from_boxref(&arg_alloc),
+                            Operand::from_boxref(&arg_idx),
+                            Operand::from_boxref(&arg_sub),
+                        ],
+                    );
                     if let Some(d) = fielddescrs.get(field_idx as usize).cloned() {
                         set_op.setdescr(d);
                     }
@@ -1238,7 +1317,13 @@ fn force_box_impl(
             let size_ref = ctx.emit_constant_int(size as i64);
             let arg_func = ctx.materialize_box_at(func_ref);
             let arg_size = ctx.materialize_box_at(size_ref);
-            let mut call_op = Op::new(OpCode::CallI, &[Operand::from_boxref(&arg_func), Operand::from_boxref(&arg_size)]);
+            let mut call_op = Op::new(
+                OpCode::CallI,
+                &[
+                    Operand::from_boxref(&arg_func),
+                    Operand::from_boxref(&arg_size),
+                ],
+            );
             call_op.pos.set(opref);
             if let Some(d) = calldescr {
                 call_op.setdescr(d);
@@ -1269,7 +1354,10 @@ fn force_box_impl(
 
             // info.py:425: CHECK_MEMORY_ERROR
             let arg_alloc = ctx.materialize_box_at(alloc_ref);
-            let check_op = Op::new(OpCode::CheckMemoryError, &[Operand::from_boxref(&arg_alloc)]);
+            let check_op = Op::new(
+                OpCode::CheckMemoryError,
+                &[Operand::from_boxref(&arg_alloc)],
+            );
             emit_op(ctx, check_op);
 
             // info.py:429-436: emit RAW_STORE for each buffered write.
@@ -1286,7 +1374,14 @@ fn force_box_impl(
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_offset = ctx.materialize_box_at(offset_ref);
                 let arg_value = ctx.resolve_box_box(&value_box);
-                let mut store_op = Op::new(OpCode::RawStore, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_offset), Operand::from_boxref(&arg_value)]);
+                let mut store_op = Op::new(
+                    OpCode::RawStore,
+                    &[
+                        Operand::from_boxref(&arg_alloc),
+                        Operand::from_boxref(&arg_offset),
+                        Operand::from_boxref(&arg_value),
+                    ],
+                );
                 store_op.setdescr(descr);
                 emit_op(ctx, store_op);
             }
@@ -1319,7 +1414,13 @@ fn force_box_impl(
             let offset_ref = ctx.emit_constant_int(slice.offset as i64);
             let arg_parent = ctx.resolve_box_box(&parent_forced);
             let arg_offset = ctx.materialize_box_at(offset_ref);
-            let mut add_op = Op::new(OpCode::IntAdd, &[Operand::from_boxref(&arg_parent), Operand::from_boxref(&arg_offset)]);
+            let mut add_op = Op::new(
+                OpCode::IntAdd,
+                &[
+                    Operand::from_boxref(&arg_parent),
+                    Operand::from_boxref(&arg_offset),
+                ],
+            );
             add_op.pos.set(opref);
             let new_ref = emit_op(ctx, add_op);
             // Preserve raw-slice identity; mark non-virtual via
@@ -1451,7 +1552,14 @@ fn force_box_impl(
                             let arg_newop = ctx.materialize_box_at(newop);
                             let arg_offset = ctx.resolve_box_box(&offset);
                             let arg_ch = ctx.materialize_box_at(ch_resolved);
-                            let setitem_op = Op::new(set_opcode, &[Operand::from_boxref(&arg_newop), Operand::from_boxref(&arg_offset), Operand::from_boxref(&arg_ch)]);
+                            let setitem_op = Op::new(
+                                set_opcode,
+                                &[
+                                    Operand::from_boxref(&arg_newop),
+                                    Operand::from_boxref(&arg_offset),
+                                    Operand::from_boxref(&arg_ch),
+                                ],
+                            );
                             emit_op(ctx, setitem_op);
                         }
                         offset = crate::optimizeopt::vstring::_int_add(&offset, &one, ctx);
@@ -1866,7 +1974,9 @@ mod tests {
         let mut replay = Op::new(
             OpCode::GetarrayitemGcI,
             &[
-                majit_ir::operand::Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10)),
+                majit_ir::operand::Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
+                ),
                 majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(0))),
             ],
         );
@@ -1899,7 +2009,9 @@ mod tests {
         let mut info = PtrInfo::instance(Some(descr), None);
         let replay = Op::new(
             OpCode::GetfieldGcI,
-            &[majit_ir::operand::Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10))],
+            &[majit_ir::operand::Operand::from_boxref(
+                &crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
+            )],
         );
         let pop = PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(88)),

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -6,6 +6,7 @@
 use crate::r#box::BoxRef;
 use crate::optimizeopt::intutils::{IntBound, IntBoundMakeGuards};
 pub use majit_ir::rawbuffer::{RawBuffer, RawBufferError};
+use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 
 fn lookup_field_descr(field_descrs: &[DescrRef], field_idx: u32) -> Option<DescrRef> {
@@ -455,7 +456,7 @@ impl PtrInfoExt for PtrInfo {
             // info.py:83-84: PtrInfo base — no-op
             PtrInfo::NonNull { .. } => {
                 // info.py:120-122: NonNullPtrInfo.make_guards
-                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
             }
             PtrInfo::Instance(info) => {
                 // info.py:336-353 InstancePtrInfo.make_guards line-by-line.
@@ -495,16 +496,16 @@ impl PtrInfoExt for PtrInfo {
                     // `cls_of_box()`.
                     let class_ref = alloc_const(ctx, Value::Int(cls));
                     if !ctx.remove_gctypeptr {
-                        short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
-                        short.push(Op::new(OpCode::GuardIsObject, &[op_b.clone()]));
+                        short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
+                        short.push(Op::new(OpCode::GuardIsObject, &[Operand::from_boxref(&op_b)]));
                         short.push(Op::new(
                             OpCode::GuardClass,
-                            &[op_b.clone(), class_ref.clone()],
+                            &[Operand::from_boxref(&op_b), Operand::from_boxref(&class_ref)],
                         ));
                     } else {
                         short.push(Op::new(
                             OpCode::GuardNonnullClass,
-                            &[op_b.clone(), class_ref.clone()],
+                            &[Operand::from_boxref(&op_b), Operand::from_boxref(&class_ref)],
                         ));
                     }
                 } else if let Some(descr) = &info.descr {
@@ -513,18 +514,18 @@ impl PtrInfoExt for PtrInfo {
                         .map(|sd| sd.vtable() as i64)
                         .unwrap_or(0);
                     let vtable_const = alloc_const(ctx, Value::Int(vtable));
-                    short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                    short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
                     if !ctx.remove_gctypeptr {
-                        short.push(Op::new(OpCode::GuardIsObject, &[op_b.clone()]));
+                        short.push(Op::new(OpCode::GuardIsObject, &[Operand::from_boxref(&op_b)]));
                     }
                     short.push(Op::new(
                         OpCode::GuardSubclass,
-                        &[op_b.clone(), vtable_const.clone()],
+                        &[Operand::from_boxref(&op_b), Operand::from_boxref(&vtable_const)],
                     ));
                 } else {
                     // info.py:353 fall-through with neither class nor
                     // descr — base NonNullPtrInfo.make_guards.
-                    short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                    short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
                 }
             }
             PtrInfo::Struct(info) => {
@@ -539,16 +540,16 @@ impl PtrInfoExt for PtrInfo {
                     .map(|sd| sd.type_id() as i64)
                     .unwrap_or(0);
                 let type_id_const = alloc_const(ctx, Value::Int(type_id));
-                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
                 short.push(Op::new(
                     OpCode::GuardGcType,
-                    &[op_b.clone(), type_id_const.clone()],
+                    &[Operand::from_boxref(&op_b), Operand::from_boxref(&type_id_const)],
                 ));
             }
             PtrInfo::Constant(gcref) => {
                 // info.py:715-716: ConstPtrInfo.make_guards
                 let c = alloc_const(ctx, Value::Ref(*gcref));
-                short.push(Op::new(OpCode::GuardValue, &[op_b.clone(), c.clone()]));
+                short.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&op_b), Operand::from_boxref(&c)]));
             }
             PtrInfo::Array(info) => {
                 // info.py:632-639: ArrayPtrInfo.make_guards.
@@ -558,7 +559,7 @@ impl PtrInfoExt for PtrInfo {
                 //       lenop = ARRAYLEN_GC[op] (descr=self.descr)
                 //       short.append(lenop)
                 //       self.lenbound.make_guards(lenop, short, optimizer)
-                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
                 let type_id = info
                     .descr
                     .as_array_descr()
@@ -567,7 +568,7 @@ impl PtrInfoExt for PtrInfo {
                 let type_id_const = alloc_const(ctx, Value::Int(type_id));
                 short.push(Op::new(
                     OpCode::GuardGcType,
-                    &[op_b.clone(), type_id_const.clone()],
+                    &[Operand::from_boxref(&op_b), Operand::from_boxref(&type_id_const)],
                 ));
                 // Always emit ARRAYLEN_GC + bound guards: pyre's
                 // ArrayPtrInfo.lenbound is a plain `IntBound`, not an
@@ -575,7 +576,7 @@ impl PtrInfoExt for PtrInfo {
                 // rather than `is None`.
                 if !info.lenbound.is_unbounded() {
                     let mut lenop =
-                        Op::with_descr(OpCode::ArraylenGc, &[op_b.clone()], info.descr.clone());
+                        Op::with_descr(OpCode::ArraylenGc, &[Operand::from_boxref(&op_b)], info.descr.clone());
                     // info.py:637 `lenop = ResOperation(ARRAYLEN_GC, [op])`
                     // followed by `lenbound.make_guards(lenop, ...)` — the
                     // `lenop` object is the consumer's box arg via Python
@@ -605,17 +606,17 @@ impl PtrInfoExt for PtrInfo {
             // `RawSlicePtrInfo` (info.py:459) inherit this override.
             PtrInfo::VirtualRawBuffer(_) | PtrInfo::VirtualRawSlice(_) => {
                 let zero = alloc_const(ctx, Value::Int(0));
-                let mut eq_op = Op::new(OpCode::IntEq, &[op_b.clone(), zero.clone()]);
+                let mut eq_op = Op::new(OpCode::IntEq, &[Operand::from_boxref(&op_b), Operand::from_boxref(&zero)]);
                 // info.py:381 `op = ResOperation(INT_EQ, [...])` then
                 // `[op]` — INT_EQ result identity for GUARD_FALSE.
                 eq_op.pos.set(ctx.alloc_op_position_typed(Type::Int));
                 let eq_pos = eq_op.pos.get();
                 short.push(eq_op);
-                short.push(Op::new(OpCode::GuardFalse, &[BoxRef::from_opref(eq_pos)]));
+                short.push(Op::new(OpCode::GuardFalse, &[Operand::from_boxref(&BoxRef::from_opref(eq_pos))]));
             }
             PtrInfo::Str(sinfo) => {
                 // vstring.py:116-126: StrPtrInfo.make_guards
-                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                short.push(Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&op_b)]));
                 if let Some(ref bound) = sinfo.lenbound {
                     if bound.lower >= 1 {
                         let lenop_code = if sinfo.mode == 0 {
@@ -623,7 +624,7 @@ impl PtrInfoExt for PtrInfo {
                         } else {
                             OpCode::Unicodelen
                         };
-                        let mut lenop = Op::new(lenop_code, &[op_b.clone()]);
+                        let mut lenop = Op::new(lenop_code, &[Operand::from_boxref(&op_b)]);
                         // vstring.py:124 `lenop = ResOperation(STRLEN, [op])`
                         // is consumed by `bound.make_guards(lenop, ...)`.
                         // Materialize the producer result before the chain.
@@ -1044,7 +1045,7 @@ fn force_box_impl(
                 );
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_value = ctx.resolve_box_box(&value_ref);
-                let mut set_op = Op::new(OpCode::SetfieldGc, &[arg_alloc, arg_value]);
+                let mut set_op = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_value)]);
                 set_op.setdescr(descr);
                 emit_op(ctx, set_op);
             }
@@ -1091,7 +1092,7 @@ fn force_box_impl(
                 );
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_value = ctx.resolve_box_box(&value_ref);
-                let mut set_op = Op::new(OpCode::SetfieldGc, &[arg_alloc, arg_value]);
+                let mut set_op = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_value)]);
                 set_op.setdescr(descr);
                 emit_op(ctx, set_op);
             }
@@ -1118,7 +1119,7 @@ fn force_box_impl(
                 OpCode::NewArray
             };
             let arg_len = ctx.materialize_box_at(len_ref);
-            let mut alloc_op = Op::new(alloc_opcode, &[arg_len]);
+            let mut alloc_op = Op::new(alloc_opcode, &[Operand::from_boxref(&arg_len)]);
             alloc_op.pos.set(opref);
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
@@ -1155,7 +1156,7 @@ fn force_box_impl(
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_idx = ctx.materialize_box_at(idx_ref);
                 let arg_sub = ctx.resolve_box_box(&subbox);
-                let mut set_op = Op::new(OpCode::SetarrayitemGc, &[arg_alloc, arg_idx, arg_sub]);
+                let mut set_op = Op::new(OpCode::SetarrayitemGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_idx), Operand::from_boxref(&arg_sub)]);
                 set_op.setdescr(descr.clone());
                 emit_op(ctx, set_op);
             }
@@ -1177,7 +1178,7 @@ fn force_box_impl(
 
             let len_ref = ctx.emit_constant_int(num_elements as i64);
             let arg_len = ctx.materialize_box_at(len_ref);
-            let mut alloc_op = Op::new(OpCode::NewArrayClear, &[arg_len]);
+            let mut alloc_op = Op::new(OpCode::NewArrayClear, &[Operand::from_boxref(&arg_len)]);
             alloc_op.pos.set(opref);
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
@@ -1215,7 +1216,7 @@ fn force_box_impl(
                     let arg_idx = ctx.materialize_box_at(idx_ref);
                     let arg_sub = ctx.resolve_box_box(&subbox);
                     let mut set_op =
-                        Op::new(OpCode::SetinteriorfieldGc, &[arg_alloc, arg_idx, arg_sub]);
+                        Op::new(OpCode::SetinteriorfieldGc, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_idx), Operand::from_boxref(&arg_sub)]);
                     if let Some(d) = fielddescrs.get(field_idx as usize).cloned() {
                         set_op.setdescr(d);
                     }
@@ -1237,7 +1238,7 @@ fn force_box_impl(
             let size_ref = ctx.emit_constant_int(size as i64);
             let arg_func = ctx.materialize_box_at(func_ref);
             let arg_size = ctx.materialize_box_at(size_ref);
-            let mut call_op = Op::new(OpCode::CallI, &[arg_func, arg_size]);
+            let mut call_op = Op::new(OpCode::CallI, &[Operand::from_boxref(&arg_func), Operand::from_boxref(&arg_size)]);
             call_op.pos.set(opref);
             if let Some(d) = calldescr {
                 call_op.setdescr(d);
@@ -1268,7 +1269,7 @@ fn force_box_impl(
 
             // info.py:425: CHECK_MEMORY_ERROR
             let arg_alloc = ctx.materialize_box_at(alloc_ref);
-            let check_op = Op::new(OpCode::CheckMemoryError, &[arg_alloc]);
+            let check_op = Op::new(OpCode::CheckMemoryError, &[Operand::from_boxref(&arg_alloc)]);
             emit_op(ctx, check_op);
 
             // info.py:429-436: emit RAW_STORE for each buffered write.
@@ -1285,7 +1286,7 @@ fn force_box_impl(
                 let arg_alloc = ctx.materialize_box_at(alloc_ref);
                 let arg_offset = ctx.materialize_box_at(offset_ref);
                 let arg_value = ctx.resolve_box_box(&value_box);
-                let mut store_op = Op::new(OpCode::RawStore, &[arg_alloc, arg_offset, arg_value]);
+                let mut store_op = Op::new(OpCode::RawStore, &[Operand::from_boxref(&arg_alloc), Operand::from_boxref(&arg_offset), Operand::from_boxref(&arg_value)]);
                 store_op.setdescr(descr);
                 emit_op(ctx, store_op);
             }
@@ -1318,7 +1319,7 @@ fn force_box_impl(
             let offset_ref = ctx.emit_constant_int(slice.offset as i64);
             let arg_parent = ctx.resolve_box_box(&parent_forced);
             let arg_offset = ctx.materialize_box_at(offset_ref);
-            let mut add_op = Op::new(OpCode::IntAdd, &[arg_parent, arg_offset]);
+            let mut add_op = Op::new(OpCode::IntAdd, &[Operand::from_boxref(&arg_parent), Operand::from_boxref(&arg_offset)]);
             add_op.pos.set(opref);
             let new_ref = emit_op(ctx, add_op);
             // Preserve raw-slice identity; mark non-virtual via
@@ -1400,7 +1401,7 @@ fn force_box_impl(
                 OpCode::Newstr
             };
             let arg_length = ctx.materialize_box_at(lengthbox);
-            let mut newstr_op = Op::new(new_opcode, &[arg_length]);
+            let mut newstr_op = Op::new(new_opcode, &[Operand::from_boxref(&arg_length)]);
             newstr_op.pos.set(opref);
             let newop = emit_op(ctx, newstr_op);
 
@@ -1450,7 +1451,7 @@ fn force_box_impl(
                             let arg_newop = ctx.materialize_box_at(newop);
                             let arg_offset = ctx.resolve_box_box(&offset);
                             let arg_ch = ctx.materialize_box_at(ch_resolved);
-                            let setitem_op = Op::new(set_opcode, &[arg_newop, arg_offset, arg_ch]);
+                            let setitem_op = Op::new(set_opcode, &[Operand::from_boxref(&arg_newop), Operand::from_boxref(&arg_offset), Operand::from_boxref(&arg_ch)]);
                             emit_op(ctx, setitem_op);
                         }
                         offset = crate::optimizeopt::vstring::_int_add(&offset, &one, ctx);
@@ -1865,8 +1866,8 @@ mod tests {
         let mut replay = Op::new(
             OpCode::GetarrayitemGcI,
             &[
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
-                BoxRef::from_opref(OpRef::const_int(0)),
+                majit_ir::operand::Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10)),
+                majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(0))),
             ],
         );
         replay.pos.set(OpRef::int_op(88));
@@ -1898,7 +1899,7 @@ mod tests {
         let mut info = PtrInfo::instance(Some(descr), None);
         let replay = Op::new(
             OpCode::GetfieldGcI,
-            &[crate::r#box::test_support::rooted_resop_box(Type::Int, 10)],
+            &[majit_ir::operand::Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10))],
         );
         let pop = PreambleOp {
             op: BoxRef::from_opref(OpRef::int_op(88)),

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3351,7 +3351,7 @@ impl Optimization for OptIntBounds {
         &self,
         args: &[OpRef],
         ctx: &OptContext,
-    ) -> crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, IntBound> {
+    ) -> crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::operand::Operand, IntBound> {
         let mut exported = crate::optimizeopt::vec_assoc::VecAssoc::new();
         for &arg in args {
             // An IntBound only lives on a value-bearing box; an unresolvable
@@ -3379,7 +3379,7 @@ impl Optimization for OptIntBounds {
                 if bound.is_unbounded() {
                     continue;
                 }
-                exported.insert(arg_box, bound);
+                exported.insert(majit_ir::operand::Operand::from_boxref(&arg_box), bound);
             }
         }
         exported

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -6,6 +6,7 @@ use crate::r#box::BoxRef;
 /// Propagates integer bounds information through the trace. When a guard tests
 /// a condition that is already known true from integer bounds, the guard can be
 /// removed. It also narrows bounds after guards and arithmetic operations.
+use majit_ir::operand::Operand;
 use majit_ir::{Op, OpCode, OpRef, Value};
 
 use crate::optimizeopt::intutils::IntBound;
@@ -48,7 +49,7 @@ fn replace_with(
     opcode: OpCode,
     args: &[crate::r#box::BoxRef],
 ) -> OptimizationResult {
-    let mut new_op = Op::new(opcode, args);
+    let mut new_op = Op::new(opcode, &args.iter().map(|b| Operand::from_boxref(b)).collect::<Vec<_>>());
     new_op.pos.set(original.pos.get());
     OptimizationResult::Restart(new_op)
 }
@@ -176,8 +177,8 @@ impl OptIntBounds {
     // ── Comparison optimizations ──
 
     fn optimize_int_lt(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_lt(&b1) {
@@ -192,8 +193,8 @@ impl OptIntBounds {
     }
 
     fn optimize_int_gt(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_gt(&b1) {
@@ -208,8 +209,8 @@ impl OptIntBounds {
     }
 
     fn optimize_int_le(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_le(&b1) || arg0.same_box(&arg1) {
@@ -224,8 +225,8 @@ impl OptIntBounds {
     }
 
     fn optimize_int_ge(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_ge(&b1) || arg0.same_box(&arg1) {
@@ -247,18 +248,18 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // eq_sub_eq: int_eq(int_sub(x, int_eq(x, a)), a) => 0 (4 forms)
         if let Some(arg0_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
-            let arg0_0 = self.resolve_box(arg0_sub.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_sub.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_sub.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_sub.arg(1).to_boxref(), ctx);
             let b_arg0_0 = self.getintbound_b(&arg0_0, ctx);
             if let Some(inner_eq) = self.as_operation_b(&arg0_1, OpCode::IntEq, ctx) {
-                let inner_0 = self.resolve_box(inner_eq.arg(0), ctx);
-                let inner_1 = self.resolve_box(inner_eq.arg(1), ctx);
+                let inner_0 = self.resolve_box(inner_eq.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(inner_eq.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // eq_sub_eq: int_eq(int_sub(x, int_eq(x, a)), a) => 0
@@ -278,12 +279,12 @@ impl OptIntBounds {
             }
         }
         if let Some(arg1_sub) = self.as_operation_b(&arg1, OpCode::IntSub, ctx) {
-            let arg1_0 = self.resolve_box(arg1_sub.arg(0), ctx);
-            let arg1_1 = self.resolve_box(arg1_sub.arg(1), ctx);
+            let arg1_0 = self.resolve_box(arg1_sub.arg(0).to_boxref(), ctx);
+            let arg1_1 = self.resolve_box(arg1_sub.arg(1).to_boxref(), ctx);
             let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
             if let Some(inner_eq) = self.as_operation_b(&arg1_1, OpCode::IntEq, ctx) {
-                let inner_0 = self.resolve_box(inner_eq.arg(0), ctx);
-                let inner_1 = self.resolve_box(inner_eq.arg(1), ctx);
+                let inner_0 = self.resolve_box(inner_eq.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(inner_eq.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // eq_sub_eq: int_eq(a, int_sub(x, int_eq(x, a))) => 0
@@ -343,8 +344,8 @@ impl OptIntBounds {
     /// autogenintrules.py:1324-1360 optimize_INT_NE — rules:
     /// ne_different_knownbits / ne_same / ne_zero.
     fn optimize_int_ne(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // ne_same: int_ne(x, x) => 0
@@ -376,8 +377,8 @@ impl OptIntBounds {
     // ── Unsigned comparison optimizations ──
 
     fn optimize_uint_lt(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_unsigned_lt(&b1) {
@@ -392,8 +393,8 @@ impl OptIntBounds {
     }
 
     fn optimize_uint_gt(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_unsigned_gt(&b1) {
@@ -408,8 +409,8 @@ impl OptIntBounds {
     }
 
     fn optimize_uint_le(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_unsigned_le(&b1) || arg0.same_box(&arg1) {
@@ -424,8 +425,8 @@ impl OptIntBounds {
     }
 
     fn optimize_uint_ge(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         let b1 = ctx.getintbound_handle(&arg1).borrow().clone();
         if b0.known_unsigned_ge(&b1) || arg0.same_box(&arg1) {
@@ -455,8 +456,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // add_zero: int_add(0, x) => x
@@ -475,8 +476,8 @@ impl OptIntBounds {
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
             if let Some(arg1_add) = self.as_operation_b(&arg1, OpCode::IntAdd, ctx) {
-                let inner_0 = self.resolve_box(arg1_add.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg1_add.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg1_add.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg1_add.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // add_reassoc_consts: int_add(C2, int_add(C1, x)) => int_add(x, C1+C2)
@@ -500,8 +501,8 @@ impl OptIntBounds {
                     );
                 }
             } else if let Some(arg1_sub) = self.as_operation_b(&arg1, OpCode::IntSub, ctx) {
-                let inner_0 = self.resolve_box(arg1_sub.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg1_sub.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg1_sub.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg1_sub.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // add_sub_c_x_c: int_add(C2, int_sub(C1, x)) => int_sub(C1+C2, x)
@@ -528,8 +529,8 @@ impl OptIntBounds {
         } else {
             // autogenintrules.py:89-142 — inner producer on arg0, outer const on arg1.
             if let Some(arg0_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
-                let inner_0 = self.resolve_box(arg0_add.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg0_add.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg0_add.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg0_add.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 if b1.is_constant() {
@@ -556,8 +557,8 @@ impl OptIntBounds {
                     }
                 }
             } else if let Some(arg0_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
-                let inner_0 = self.resolve_box(arg0_sub.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg0_sub.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg0_sub.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg0_sub.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 if b1.is_constant() {
@@ -598,8 +599,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // sub_x_x: int_sub(x, x) => 0
@@ -609,8 +610,8 @@ impl OptIntBounds {
         }
         // sub_add: int_sub(int_add(x, y), y) => x / int_sub(int_add(y, x), y) => x
         if let Some(arg0_int_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
-            let arg0_0 = self.resolve_box(arg0_int_add.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_int_add.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_int_add.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_add.arg(1).to_boxref(), ctx);
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) {
@@ -625,8 +626,8 @@ impl OptIntBounds {
             }
         } else if let Some(arg0_int_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
             // sub_or_x_y_y: int_sub(int_or(x, y), y) => x  (when x & y == 0)
-            let arg0_0 = self.resolve_box(arg0_int_or.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_int_or.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_int_or.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_or.arg(1).to_boxref(), ctx);
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
@@ -641,8 +642,8 @@ impl OptIntBounds {
             }
         } else if let Some(arg0_int_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
             // sub_xor_x_y_y: int_sub(int_xor(x, y), y) => x  (when x & y == 0)
-            let arg0_0 = self.resolve_box(arg0_int_xor.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_int_xor.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_int_xor.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_xor.arg(1).to_boxref(), ctx);
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if autogen_eq_b(&arg1, &b1, &arg0_1, &b0_1) && b0_0.and_bound(&b0_1).known_eq_const(0) {
@@ -667,14 +668,14 @@ impl OptIntBounds {
             return replace_with(op, OpCode::IntNeg, &[arg1.clone()]);
         }
         if let Some(arg0_int_invert) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
-            let arg0_0 = self.resolve_box(arg0_int_invert.arg(0), ctx);
+            let arg0_0 = self.resolve_box(arg0_int_invert.arg(0).to_boxref(), ctx);
             // sub_invert_one: int_sub(int_invert(x), -1) => int_neg(x)
             if b1.is_constant() && b1.get_constant_int() == -1 {
                 return replace_with(op, OpCode::IntNeg, &[arg0_0.clone()]);
             }
         } else if let Some(arg0_int_add) = self.as_operation_b(&arg0, OpCode::IntAdd, ctx) {
-            let arg0_0 = self.resolve_box(arg0_int_add.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_int_add.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_int_add.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_add.arg(1).to_boxref(), ctx);
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if b1.is_constant() {
@@ -701,8 +702,8 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_int_sub) = self.as_operation_b(&arg0, OpCode::IntSub, ctx) {
-            let arg0_0 = self.resolve_box(arg0_int_sub.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_int_sub.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_int_sub.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_int_sub.arg(1).to_boxref(), ctx);
             let b0_0 = self.getintbound_b(&arg0_0, ctx);
             let b0_1 = self.getintbound_b(&arg0_1, ctx);
             if b1.is_constant() {
@@ -730,8 +731,8 @@ impl OptIntBounds {
             }
         }
         if let Some(arg1_int_add) = self.as_operation_b(&arg1, OpCode::IntAdd, ctx) {
-            let arg1_0 = self.resolve_box(arg1_int_add.arg(0), ctx);
-            let arg1_1 = self.resolve_box(arg1_int_add.arg(1), ctx);
+            let arg1_0 = self.resolve_box(arg1_int_add.arg(0).to_boxref(), ctx);
+            let arg1_1 = self.resolve_box(arg1_int_add.arg(1).to_boxref(), ctx);
             let b1_0 = self.getintbound_b(&arg1_0, ctx);
             let b1_1 = self.getintbound_b(&arg1_1, ctx);
             // sub_add_neg: int_sub(y, int_add(x, y)) => int_neg(x)
@@ -754,8 +755,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // mul_zero: int_mul(0, x) => 0
@@ -800,8 +801,8 @@ impl OptIntBounds {
             }
         } else if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
             // mul_lshift: int_mul(int_lshift(1, y), x) => int_lshift(x, y)
-            let inner_0 = self.resolve_box(arg0_lshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_lshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant()
@@ -831,8 +832,8 @@ impl OptIntBounds {
             }
         } else if let Some(arg1_lshift) = self.as_operation_b(&arg1, OpCode::IntLshift, ctx) {
             // mul_lshift: int_mul(x, int_lshift(1, y)) => int_lshift(x, y)
-            let inner_0 = self.resolve_box(arg1_lshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg1_lshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg1_lshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg1_lshift.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant()
@@ -855,8 +856,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // and_known_result: int_and(a, b) bound is constant => ConstInt(C)
@@ -913,8 +914,8 @@ impl OptIntBounds {
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
             if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
-                let inner_0 = self.resolve_box(arg1_and.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg1_and.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg1_and.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg1_and.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // and_reassoc_consts: int_and(C2, int_and(C1, x)) => int_and(x, C1&C2)
@@ -939,8 +940,8 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
-            let inner_0 = self.resolve_box(arg0_and.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_and.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_and.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_and.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant() {
@@ -976,8 +977,8 @@ impl OptIntBounds {
                 return replace_with(op, OpCode::IntAnd, &[inner_1.clone(), inner_0.clone()]);
             }
         } else if let Some(arg0_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
-            let inner_0 = self.resolve_box(arg0_or.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_or.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_or.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_or.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_or: int_and(int_or(x, y), z) => int_and(x, z)
@@ -991,8 +992,8 @@ impl OptIntBounds {
         }
         // Symmetric arm: producer on arg1.
         if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
-            let inner_0 = self.resolve_box(arg1_and.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg1_and.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg1_and.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg1_and.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_absorb: int_and(a, int_and(a, b)) => int_and(a, b)
@@ -1004,8 +1005,8 @@ impl OptIntBounds {
                 return replace_with(op, OpCode::IntAnd, &[arg0.clone(), inner_0.clone()]);
             }
         } else if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
-            let inner_0 = self.resolve_box(arg1_or.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg1_or.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg1_or.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg1_or.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // and_or: int_and(z, int_or(x, y)) => int_and(x, z)
@@ -1036,8 +1037,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // or_known_result: int_or(a, b) bound is constant => ConstInt(C)
@@ -1073,8 +1074,8 @@ impl OptIntBounds {
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
             if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
-                let inner_0 = self.resolve_box(arg1_or.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg1_or.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg1_or.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg1_or.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // or_reassoc_consts: int_or(C2, int_or(C1, x)) => int_or(x, C1|C2)
@@ -1099,16 +1100,16 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
-            let arg0_0 = self.resolve_box(arg0_and.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_and.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_and.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_and.arg(1).to_boxref(), ctx);
             let b_arg0_0 = self.getintbound_b(&arg0_0, ctx);
             let b_arg0_1 = self.getintbound_b(&arg0_1, ctx);
             // or_and_two_parts shapes when outer = int_and(C, x):
             if b_arg0_0.is_constant() {
                 let c_arg0_0 = b_arg0_0.get_constant_int();
                 if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
-                    let arg1_0 = self.resolve_box(arg1_and.arg(0), ctx);
-                    let arg1_1 = self.resolve_box(arg1_and.arg(1), ctx);
+                    let arg1_0 = self.resolve_box(arg1_and.arg(0).to_boxref(), ctx);
+                    let arg1_1 = self.resolve_box(arg1_and.arg(1).to_boxref(), ctx);
                     let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
                     let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
                     if b_arg1_0.is_constant() {
@@ -1160,8 +1161,8 @@ impl OptIntBounds {
             if b_arg0_1.is_constant() {
                 let c_arg0_1 = b_arg0_1.get_constant_int();
                 if let Some(arg1_and) = self.as_operation_b(&arg1, OpCode::IntAnd, ctx) {
-                    let arg1_0 = self.resolve_box(arg1_and.arg(0), ctx);
-                    let arg1_1 = self.resolve_box(arg1_and.arg(1), ctx);
+                    let arg1_0 = self.resolve_box(arg1_and.arg(0).to_boxref(), ctx);
+                    let arg1_1 = self.resolve_box(arg1_and.arg(1).to_boxref(), ctx);
                     let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
                     let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
                     if b_arg1_0.is_constant() {
@@ -1211,8 +1212,8 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_or) = self.as_operation_b(&arg0, OpCode::IntOr, ctx) {
-            let arg0_0 = self.resolve_box(arg0_or.arg(0), ctx);
-            let arg0_1 = self.resolve_box(arg0_or.arg(1), ctx);
+            let arg0_0 = self.resolve_box(arg0_or.arg(0).to_boxref(), ctx);
+            let arg0_1 = self.resolve_box(arg0_or.arg(1).to_boxref(), ctx);
             let b_arg0_0 = self.getintbound_b(&arg0_0, ctx);
             let b_arg0_1 = self.getintbound_b(&arg0_1, ctx);
             if b_arg0_0.is_constant() && b1.is_constant() {
@@ -1246,8 +1247,8 @@ impl OptIntBounds {
         }
         // Symmetric arm: producer on arg1.
         if let Some(arg1_or) = self.as_operation_b(&arg1, OpCode::IntOr, ctx) {
-            let arg1_0 = self.resolve_box(arg1_or.arg(0), ctx);
-            let arg1_1 = self.resolve_box(arg1_or.arg(1), ctx);
+            let arg1_0 = self.resolve_box(arg1_or.arg(0).to_boxref(), ctx);
+            let arg1_1 = self.resolve_box(arg1_or.arg(1).to_boxref(), ctx);
             let b_arg1_0 = self.getintbound_b(&arg1_0, ctx);
             let b_arg1_1 = self.getintbound_b(&arg1_1, ctx);
             // or_absorb: int_or(a, int_or(a, b)) => int_or(a, b)
@@ -1271,8 +1272,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // xor_known_result: int_xor(a, b) bound is constant => ConstInt(C)
@@ -1299,8 +1300,8 @@ impl OptIntBounds {
                 return OptimizationResult::Remove;
             }
         } else if let Some(arg0_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
-            let inner_0 = self.resolve_box(arg0_xor.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_xor.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_xor.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_xor.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // xor_absorb: int_xor(int_xor(a, b), b) => a
@@ -1324,8 +1325,8 @@ impl OptIntBounds {
                 return OptimizationResult::Remove;
             }
         } else if let Some(arg1_xor) = self.as_operation_b(&arg1, OpCode::IntXor, ctx) {
-            let inner_0 = self.resolve_box(arg1_xor.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg1_xor.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg1_xor.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg1_xor.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // xor_absorb: int_xor(b, int_xor(a, b)) => a
@@ -1345,8 +1346,8 @@ impl OptIntBounds {
         if b0.is_constant() {
             let c_outer = b0.get_constant_int();
             if let Some(arg1_xor) = self.as_operation_b(&arg1, OpCode::IntXor, ctx) {
-                let inner_0 = self.resolve_box(arg1_xor.arg(0), ctx);
-                let inner_1 = self.resolve_box(arg1_xor.arg(1), ctx);
+                let inner_0 = self.resolve_box(arg1_xor.arg(0).to_boxref(), ctx);
+                let inner_1 = self.resolve_box(arg1_xor.arg(1).to_boxref(), ctx);
                 let b_inner_0 = self.getintbound_b(&inner_0, ctx);
                 let b_inner_1 = self.getintbound_b(&inner_1, ctx);
                 // xor_reassoc_consts: int_xor(C2, int_xor(C1, x)) => int_xor(x, C1^C2)
@@ -1379,8 +1380,8 @@ impl OptIntBounds {
                 return replace_with(op, OpCode::IntIsZero, &[arg1.clone()]);
             }
         } else if let Some(arg0_xor) = self.as_operation_b(&arg0, OpCode::IntXor, ctx) {
-            let inner_0 = self.resolve_box(arg0_xor.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_xor.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_xor.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_xor.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant() && b1.is_constant() {
@@ -1426,10 +1427,10 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
         // invert_invert: int_invert(int_invert(x)) => x
         if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntInvert, ctx) {
-            let inner_0 = self.resolve_box(inner.arg(0), ctx);
+            let inner_0 = self.resolve_box(inner.arg(0).to_boxref(), ctx);
             let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &inner_0);
             return OptimizationResult::Remove;
@@ -1444,10 +1445,10 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
         // neg_neg: int_neg(int_neg(x)) => x
         if let Some(inner) = self.as_operation_b(&arg0, OpCode::IntNeg, ctx) {
-            let inner_0 = self.resolve_box(inner.arg(0), ctx);
+            let inner_0 = self.resolve_box(inner.arg(0).to_boxref(), ctx);
             let b_old = BoxRef::from_bound_op(op_rc);
             ctx.make_equal_to(&b_old, &inner_0);
             return OptimizationResult::Remove;
@@ -1465,8 +1466,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // lshift_zero_x: int_lshift(0, x) => 0
@@ -1481,15 +1482,15 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
-            let inner_0 = self.resolve_box(arg0_and.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_and.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_and.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_and.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_0.is_constant() {
                 let c_arg0_0 = b_inner_0.get_constant_int();
                 if let Some(rshift) = self.as_operation_b(&inner_1, OpCode::IntRshift, ctx) {
-                    let r0 = self.resolve_box(rshift.arg(0), ctx);
-                    let r1 = self.resolve_box(rshift.arg(1), ctx);
+                    let r0 = self.resolve_box(rshift.arg(0).to_boxref(), ctx);
+                    let r1 = self.resolve_box(rshift.arg(1).to_boxref(), ctx);
                     let b_r1 = self.getintbound_b(&r1, ctx);
                     if b_r1.is_constant() && b1.is_constant() {
                         let c_r1 = b_r1.get_constant_int();
@@ -1507,8 +1508,8 @@ impl OptIntBounds {
                     }
                 } else if let Some(urshift) = self.as_operation_b(&inner_1, OpCode::UintRshift, ctx)
                 {
-                    let r0 = self.resolve_box(urshift.arg(0), ctx);
-                    let r1 = self.resolve_box(urshift.arg(1), ctx);
+                    let r0 = self.resolve_box(urshift.arg(0).to_boxref(), ctx);
+                    let r1 = self.resolve_box(urshift.arg(1).to_boxref(), ctx);
                     let b_r1 = self.getintbound_b(&r1, ctx);
                     if b_r1.is_constant() && b1.is_constant() {
                         let c_r1 = b_r1.get_constant_int();
@@ -1526,8 +1527,8 @@ impl OptIntBounds {
                     }
                 }
             } else if let Some(rshift) = self.as_operation_b(&inner_0, OpCode::IntRshift, ctx) {
-                let r0 = self.resolve_box(rshift.arg(0), ctx);
-                let r1 = self.resolve_box(rshift.arg(1), ctx);
+                let r0 = self.resolve_box(rshift.arg(0).to_boxref(), ctx);
+                let r1 = self.resolve_box(rshift.arg(1).to_boxref(), ctx);
                 let b_r1 = self.getintbound_b(&r1, ctx);
                 if b_r1.is_constant() && b_inner_1.is_constant() && b1.is_constant() {
                     let c_r1 = b_r1.get_constant_int();
@@ -1545,8 +1546,8 @@ impl OptIntBounds {
                     }
                 }
             } else if let Some(urshift) = self.as_operation_b(&inner_0, OpCode::UintRshift, ctx) {
-                let r0 = self.resolve_box(urshift.arg(0), ctx);
-                let r1 = self.resolve_box(urshift.arg(1), ctx);
+                let r0 = self.resolve_box(urshift.arg(0).to_boxref(), ctx);
+                let r1 = self.resolve_box(urshift.arg(1).to_boxref(), ctx);
                 let b_r1 = self.getintbound_b(&r1, ctx);
                 if b_r1.is_constant() && b_inner_1.is_constant() && b1.is_constant() {
                     let c_r1 = b_r1.get_constant_int();
@@ -1565,8 +1566,8 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
-            let inner_0 = self.resolve_box(arg0_lshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_lshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_boxref(), ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
@@ -1585,8 +1586,8 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_rshift) = self.as_operation_b(&arg0, OpCode::IntRshift, ctx) {
-            let inner_0 = self.resolve_box(arg0_rshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_rshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_rshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_rshift.arg(1).to_boxref(), ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
@@ -1603,8 +1604,8 @@ impl OptIntBounds {
                 }
             }
         } else if let Some(arg0_urshift) = self.as_operation_b(&arg0, OpCode::UintRshift, ctx) {
-            let inner_0 = self.resolve_box(arg0_urshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_urshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_urshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_urshift.arg(1).to_boxref(), ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
@@ -1633,8 +1634,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // rshift_zero_x: int_rshift(0, x) => 0
@@ -1649,8 +1650,8 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
-            let inner_0 = self.resolve_box(arg0_lshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_lshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // rshift_lshift: int_rshift(int_lshift(x, y), y) => x
@@ -1669,8 +1670,8 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         if let Some(arg0_rshift) = self.as_operation_b(&arg0, OpCode::IntRshift, ctx) {
-            let inner_0 = self.resolve_box(arg0_rshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_rshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_rshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_rshift.arg(1).to_boxref(), ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
@@ -1700,7 +1701,7 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         // is_true_true: int_is_true(x) => 1
         // when bound excludes 0: lower > 0, or upper < 0, or any tvalue bit set.
@@ -1715,8 +1716,8 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         if let Some(arg0_and) = self.as_operation_b(&arg0, OpCode::IntAnd, ctx) {
-            let inner_0 = self.resolve_box(arg0_and.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_and.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_and.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_and.arg(1).to_boxref(), ctx);
             let b_inner_0 = self.getintbound_b(&inner_0, ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             // is_true_and_minint: int_is_true(int_and(MININT, x)) => int_lt(x, 0)
@@ -1743,7 +1744,7 @@ impl OptIntBounds {
 
     /// autogenintrules.py:1403-1411 optimize_INT_IS_ZERO — rules: is_zero_true.
     fn optimize_int_is_zero(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         // is_zero_true: int_is_zero(x) => 0
         // when bound excludes 0: lower > 0, or upper < 0, or any tvalue bit set.
@@ -1762,7 +1763,7 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
         let b0 = ctx.getintbound_handle(&arg0).borrow().clone();
         // force_ge_zero_neg: int_force_ge_zero(x) => 0  (when x < 0)
         if b0.known_lt_const(0) {
@@ -1787,8 +1788,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // urshift_zero_x: uint_rshift(0, x) => 0
@@ -1809,8 +1810,8 @@ impl OptIntBounds {
             return OptimizationResult::Remove;
         }
         if let Some(arg0_lshift) = self.as_operation_b(&arg0, OpCode::IntLshift, ctx) {
-            let inner_0 = self.resolve_box(arg0_lshift.arg(0), ctx);
-            let inner_1 = self.resolve_box(arg0_lshift.arg(1), ctx);
+            let inner_0 = self.resolve_box(arg0_lshift.arg(0).to_boxref(), ctx);
+            let inner_1 = self.resolve_box(arg0_lshift.arg(1).to_boxref(), ctx);
             let b_inner_1 = self.getintbound_b(&inner_1, ctx);
             if b_inner_1.is_constant() && b1.is_constant() {
                 let c1 = b_inner_1.get_constant_int();
@@ -1850,8 +1851,8 @@ impl OptIntBounds {
 
     /// intbounds.py:114-146 postprocess_INT_ADD
     fn postprocess_int_add(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         // intbounds.py:119-123: if arg0 is arg1: b = b0.lshift_bound(1) (x+x is even)
         let b = if arg0.same_box(&arg1) {
@@ -1909,8 +1910,8 @@ impl OptIntBounds {
 
     /// intbounds.py: INT_SUB postprocess with constant inversion synthesis.
     fn postprocess_int_sub(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         let b = b0.sub_bound(&b1);
@@ -1943,23 +1944,23 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_mul(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.mul_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     fn postprocess_int_and(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.and_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     /// intbounds.py:60-71 postprocess_INT_OR
     fn postprocess_int_or(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // intbounds.py:65: if b0.and_bound(b1).known_eq_const(0):
@@ -1986,8 +1987,8 @@ impl OptIntBounds {
 
     /// intbounds.py:73-84 postprocess_INT_XOR
     fn postprocess_int_xor(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         // intbounds.py:78: if b0.and_bound(b1).known_eq_const(0):
@@ -2015,8 +2016,8 @@ impl OptIntBounds {
     /// intbounds.py: INT_LSHIFT pure_from_args synthesis.
     /// If res = INT_LSHIFT(a, b), then a = INT_RSHIFT(res, b).
     fn postprocess_int_lshift(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
         let b = b0.lshift_bound(&b1);
@@ -2033,47 +2034,47 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_rshift(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.rshift_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     fn postprocess_uint_rshift(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.urshift_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     fn postprocess_int_floordiv(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.py_div_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     fn postprocess_int_mod(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.mod_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     fn postprocess_int_neg(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b = self.getintbound_arg(op.arg(0), ctx);
+        let b = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
         let result = b.neg_bound();
         self.intersect_bound(op.pos.get(), &result, ctx);
     }
 
     fn postprocess_int_invert(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b = self.getintbound_arg(op.arg(0), ctx);
+        let b = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
         let result = b.invert_bound();
         self.intersect_bound(op.pos.get(), &result, ctx);
     }
 
     fn postprocess_int_force_ge_zero(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b_arg = self.getintbound_arg(op.arg(0), ctx);
+        let b_arg = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
         let mut result = IntBound::nonnegative();
         if b_arg.upper >= 0 {
             let _ = result.make_le(&b_arg);
@@ -2111,7 +2112,7 @@ impl OptIntBounds {
         // by calling ensure_ptr_info_arg0 (which constructs StrPtrInfo for
         // STRLEN per optimizer.py:490-491) and then invoking getlenbound on
         // the returned handle.
-        let arg0_box = ctx.resolve_box_box(&op.arg(0));
+        let arg0_box = ctx.resolve_box_box(&op.arg(0).to_boxref());
         ctx.make_nonnull_str(&arg0_box, 0);
         // `getlenbound` is a lazy-fill mutator on `StrPtrInfo.lenbound`
         // (`vstring.py:62`). Route through `with_ensured_ptr_info_arg0`
@@ -2128,7 +2129,7 @@ impl OptIntBounds {
         //     self.make_nonnull_str(op.getarg(0), vstring.mode_unicode)
         //     array = getptrinfo(op.getarg(0))
         //     self.optimizer.setintbound(op, array.getlenbound(vstring.mode_unicode))
-        let arg0_box = ctx.resolve_box_box(&op.arg(0));
+        let arg0_box = ctx.resolve_box_box(&op.arg(0).to_boxref());
         ctx.make_nonnull_str(&arg0_box, 1);
         // Same wrapper rationale as `postprocess_strlen` — lazy-fill
         // mutation on StrPtrInfo.lenbound needs BoxRef mirror.
@@ -2147,8 +2148,8 @@ impl OptIntBounds {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let b = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         if b1.is_constant() {
             let byte_size = b1.get_constant_int();
             let numbits = byte_size * 8;
@@ -2157,7 +2158,7 @@ impl OptIntBounds {
             if b.is_within_range(start, stop - 1) {
                 // The value already fits; replace with the input.
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx.resolve_box_box(&op.arg(0));
+                let b_arg = ctx.resolve_box_box(&op.arg(0).to_boxref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -2166,7 +2167,7 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_signext(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         if b1.is_constant() {
             let byte_size = b1.get_constant_int();
             let numbits = byte_size * 8;
@@ -2181,8 +2182,8 @@ impl OptIntBounds {
 
     /// intbounds.py:244-256 optimize_INT_ADD_OVF
     fn optimize_int_add_ovf(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         if b0.add_bound_cannot_overflow(&b1) {
             // replace_op_with(op, INT_ADD) + send_extra_operation
             let new_op = op.copy_and_change(OpCode::IntAdd, None, None);
@@ -2194,8 +2195,8 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_add_ovf(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b = if arg0.same_box(&arg1) {
             b0.mul2_bound_no_overflow()
@@ -2208,8 +2209,8 @@ impl OptIntBounds {
 
     /// intbounds.py:275-287 optimize_INT_SUB_OVF
     fn optimize_int_sub_ovf(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         // intbounds.py:278-279: b0/b1 are computed before the same_box check.
         let b0 = self.getintbound_b(&arg0, ctx);
         let b1 = self.getintbound_b(&arg1, ctx);
@@ -2229,16 +2230,16 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_sub_ovf(&mut self, op: &Op, ctx: &mut OptContext) {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         let b = b0.sub_bound_no_overflow(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     /// intbounds.py:298-305 optimize_INT_MUL_OVF
     fn optimize_int_mul_ovf(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let b0 = self.getintbound_arg(op.arg(0), ctx);
-        let b1 = self.getintbound_arg(op.arg(1), ctx);
+        let b0 = self.getintbound_arg(op.arg(0).to_boxref(), ctx);
+        let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
         if b0.mul_bound_cannot_overflow(&b1) {
             // replace_op_with(op, INT_MUL) + send_extra_operation
             let new_op = op.copy_and_change(OpCode::IntMul, None, None);
@@ -2250,8 +2251,8 @@ impl OptIntBounds {
     }
 
     fn postprocess_int_mul_ovf(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg0 = self.resolve_box(op.arg(0), ctx);
-        let arg1 = self.resolve_box(op.arg(1), ctx);
+        let arg0 = self.resolve_box(op.arg(0).to_boxref(), ctx);
+        let arg1 = self.resolve_box(op.arg(1).to_boxref(), ctx);
         let b0 = self.getintbound_b(&arg0, ctx);
         let b = if arg0.same_box(&arg1) {
             b0.square_bound_no_overflow()
@@ -2333,7 +2334,7 @@ impl OptIntBounds {
     /// the default dispatch in RPython. In majit, we do them here
     /// because we don't have per-opcode default dispatch.
     fn optimize_guard_true(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let cond = self.resolve_box(op.arg(0), ctx);
+        let cond = self.resolve_box(op.arg(0).to_boxref(), ctx);
 
         // Constant check: if condition is known constant nonzero, remove guard.
         if let Some(val) = ctx.get_constant_int_box(&cond) {
@@ -2356,7 +2357,7 @@ impl OptIntBounds {
     }
 
     fn optimize_guard_false(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let cond = self.resolve_box(op.arg(0), ctx);
+        let cond = self.resolve_box(op.arg(0).to_boxref(), ctx);
 
         if let Some(val) = ctx.get_constant_int_box(&cond) {
             if val == 0 {
@@ -2625,7 +2626,7 @@ impl OptIntBounds {
         // dispatch-entry rebind registers the operand, so `resolve_box_box`
         // resolves to the bound host the is_raw_ptr read and the downstream
         // bound write both use.
-        let arg0_box = self.resolve_box(arg0.clone(), ctx);
+        let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
         if ctx.is_raw_ptr(&arg0_box) {
             return;
         }
@@ -2635,17 +2636,17 @@ impl OptIntBounds {
         }
         let r_const = r.get_constant_int();
         if r_const == valnonzero {
-            let b1 = self.getintbound_arg(arg0.clone(), ctx);
+            let b1 = self.getintbound_arg(arg0.to_boxref(), ctx);
             if b1.known_nonnegative() {
                 let _ = ctx.with_intbound_mut(&arg0_box, |bm| bm.make_gt_const(0));
-                self.propagate_bounds_backward(&arg0, ctx);
+                self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
             } else if b1.known_le_const(0) {
                 let _ = ctx.with_intbound_mut(&arg0_box, |bm| bm.make_lt_const(0));
-                self.propagate_bounds_backward(&arg0, ctx);
+                self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
             }
         } else if r_const == valzero {
             self.make_constant_int_ref(arg0.to_opref(), 0, ctx);
-            self.propagate_bounds_backward(&arg0, ctx);
+            self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
         }
     }
 
@@ -2670,123 +2671,123 @@ impl OptIntBounds {
             OpCode::IntAdd | OpCode::IntAddOvf => {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
-                let arg1_box = self.resolve_box(arg1.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
+                let arg1_box = self.resolve_box(arg1.to_boxref(), ctx);
                 if ctx.is_raw_ptr(&arg0_box) || ctx.is_raw_ptr(&arg1_box) {
                     return;
                 }
-                let b1 = self.getintbound_arg(arg0.clone(), ctx);
-                let b2 = self.getintbound_arg(arg1.clone(), ctx);
+                let b1 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b2 = self.getintbound_arg(arg1.to_boxref(), ctx);
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.sub_bound(&b2);
                 let changed0 =
                     ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
                 let b = r.sub_bound(&b1);
                 let changed1 =
                     ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
-                    self.propagate_bounds_backward(&arg1, ctx);
+                    self.propagate_bounds_backward(&arg1.to_boxref(), ctx);
                 }
             }
             // intbounds.py:714-723 propagate_bounds_INT_SUB
             OpCode::IntSub | OpCode::IntSubOvf => {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
-                let b1 = self.getintbound_arg(arg0.clone(), ctx);
-                let b2 = self.getintbound_arg(arg1.clone(), ctx);
+                let b1 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b2 = self.getintbound_arg(arg1.to_boxref(), ctx);
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.add_bound(&b2);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                 let changed0 =
                     ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
                 let b = r.sub_bound(&b1).neg_bound();
-                let arg1_box = self.resolve_box(arg1.clone(), ctx);
+                let arg1_box = self.resolve_box(arg1.to_boxref(), ctx);
                 let changed1 =
                     ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
-                    self.propagate_bounds_backward(&arg1, ctx);
+                    self.propagate_bounds_backward(&arg1.to_boxref(), ctx);
                 }
             }
             // intbounds.py:725-737 propagate_bounds_INT_MUL
             OpCode::IntMul | OpCode::IntMulOvf => {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
-                let b1 = self.getintbound_arg(arg0.clone(), ctx);
-                let b2 = self.getintbound_arg(arg1.clone(), ctx);
+                let b1 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b2 = self.getintbound_arg(arg1.to_boxref(), ctx);
                 if op.opcode != OpCode::IntMulOvf && !b1.mul_bound_cannot_overflow(&b2) {
                     return;
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.py_div_bound(&b2);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                 let changed0 =
                     ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
                 let b = r.py_div_bound(&b1);
-                let arg1_box = self.resolve_box(arg1.clone(), ctx);
+                let arg1_box = self.resolve_box(arg1.to_boxref(), ctx);
                 let changed1 =
                     ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
-                    self.propagate_bounds_backward(&arg1, ctx);
+                    self.propagate_bounds_backward(&arg1.to_boxref(), ctx);
                 }
             }
             // intbounds.py:739-747 propagate_bounds_INT_LSHIFT
             OpCode::IntLshift => {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
-                let b1 = self.getintbound_arg(arg0.clone(), ctx);
-                let b2 = self.getintbound_arg(arg1.clone(), ctx);
+                let b1 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b2 = self.getintbound_arg(arg1.to_boxref(), ctx);
                 if !b1.lshift_bound_cannot_overflow(&b2) {
                     return;
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if let Ok(b) = r.lshift_bound_backwards(&b2) {
-                    let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                    let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                     let changed =
                         ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
-                        self.propagate_bounds_backward(&arg0, ctx);
+                        self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                     }
                 }
             }
             // intbounds.py:759-767 propagate_bounds_INT_RSHIFT
             OpCode::IntRshift => {
                 let arg0 = op.arg(0);
-                let b2 = self.getintbound_arg(op.arg(1), ctx);
+                let b2 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
                 if !b2.is_constant() {
                     return;
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.rshift_bound_backwards(&b2);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                 let changed =
                     ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
             }
             // intbounds.py:749-757 propagate_bounds_UINT_RSHIFT
             OpCode::UintRshift => {
                 let arg0 = op.arg(0);
-                let b2 = self.getintbound_arg(op.arg(1), ctx);
+                let b2 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
                 if !b2.is_constant() {
                     return;
                 }
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 let b = r.urshift_bound_backwards(&b2);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                 let changed =
                     ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
             }
             // intbounds.py:773-782 propagate_bounds_INT_AND
@@ -2794,22 +2795,22 @@ impl OptIntBounds {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
                 let r = self.getintbound_box(op.pos.get(), ctx);
-                let b0 = self.getintbound_arg(arg0.clone(), ctx);
-                let b1 = self.getintbound_arg(arg1.clone(), ctx);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
-                let arg1_box = self.resolve_box(arg1.clone(), ctx);
+                let b0 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b1 = self.getintbound_arg(arg1.to_boxref(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
+                let arg1_box = self.resolve_box(arg1.to_boxref(), ctx);
                 if let Ok(b) = b0.and_bound_backwards(&r) {
                     let changed =
                         ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
-                        self.propagate_bounds_backward(&arg1, ctx);
+                        self.propagate_bounds_backward(&arg1.to_boxref(), ctx);
                     }
                 }
                 if let Ok(b) = b1.and_bound_backwards(&r) {
                     let changed =
                         ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
-                        self.propagate_bounds_backward(&arg0, ctx);
+                        self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                     }
                 }
             }
@@ -2818,22 +2819,22 @@ impl OptIntBounds {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
                 let r = self.getintbound_box(op.pos.get(), ctx);
-                let b0 = self.getintbound_arg(arg0.clone(), ctx);
-                let b1 = self.getintbound_arg(arg1.clone(), ctx);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
-                let arg1_box = self.resolve_box(arg1.clone(), ctx);
+                let b0 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b1 = self.getintbound_arg(arg1.to_boxref(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
+                let arg1_box = self.resolve_box(arg1.to_boxref(), ctx);
                 if let Ok(b) = b0.or_bound_backwards(&r) {
                     let changed =
                         ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
-                        self.propagate_bounds_backward(&arg1, ctx);
+                        self.propagate_bounds_backward(&arg1.to_boxref(), ctx);
                     }
                 }
                 if let Ok(b) = b1.or_bound_backwards(&r) {
                     let changed =
                         ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                     if changed {
-                        self.propagate_bounds_backward(&arg0, ctx);
+                        self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                     }
                 }
             }
@@ -2842,22 +2843,22 @@ impl OptIntBounds {
                 let arg0 = op.arg(0);
                 let arg1 = op.arg(1);
                 let r = self.getintbound_box(op.pos.get(), ctx);
-                let b0 = self.getintbound_arg(arg0.clone(), ctx);
-                let b1 = self.getintbound_arg(arg1.clone(), ctx);
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
-                let arg1_box = self.resolve_box(arg1.clone(), ctx);
+                let b0 = self.getintbound_arg(arg0.to_boxref(), ctx);
+                let b1 = self.getintbound_arg(arg1.to_boxref(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
+                let arg1_box = self.resolve_box(arg1.to_boxref(), ctx);
                 // xor is its own inverse
                 let b = b0.xor_bound(&r);
                 let changed1 =
                     ctx.with_intbound_mut(&arg1_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed1 {
-                    self.propagate_bounds_backward(&arg1, ctx);
+                    self.propagate_bounds_backward(&arg1.to_boxref(), ctx);
                 }
                 let b = b1.xor_bound(&r);
                 let changed0 =
                     ctx.with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&b), Ok(true)));
                 if changed0 {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
             }
             // intbounds.py:481-487 propagate_bounds_INT_INVERT
@@ -2865,11 +2866,11 @@ impl OptIntBounds {
                 let arg0 = op.arg(0);
                 let bres = self.getintbound_box(op.pos.get(), ctx);
                 let bounds = bres.invert_bound();
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                 let changed = ctx
                     .with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&bounds), Ok(true)));
                 if changed {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
             }
             // intbounds.py:489-495 propagate_bounds_INT_NEG
@@ -2877,11 +2878,11 @@ impl OptIntBounds {
                 let arg0 = op.arg(0);
                 let bres = self.getintbound_box(op.pos.get(), ctx);
                 let bounds = bres.neg_bound();
-                let arg0_box = self.resolve_box(arg0.clone(), ctx);
+                let arg0_box = self.resolve_box(arg0.to_boxref(), ctx);
                 let changed = ctx
                     .with_intbound_mut(&arg0_box, |bm| matches!(bm.intersect(&bounds), Ok(true)));
                 if changed {
-                    self.propagate_bounds_backward(&arg0, ctx);
+                    self.propagate_bounds_backward(&arg0.to_boxref(), ctx);
                 }
             }
             // intbounds.py:608-615 propagate_bounds_INT_LT
@@ -2889,10 +2890,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_int_lt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_lt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_int_ge(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_ge(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2901,10 +2902,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_int_gt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_gt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_int_le(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_le(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2913,10 +2914,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_int_le(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_le(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_int_gt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_gt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2925,10 +2926,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_int_ge(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_ge(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_int_lt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_int_lt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2936,18 +2937,18 @@ impl OptIntBounds {
             OpCode::IntEq => {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() && r.lower == 1 {
-                    self.make_eq(&op.arg(0), &op.arg(1), ctx);
+                    self.make_eq(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                 } else if r.is_constant() && r.lower == 0 {
-                    self.make_ne(&op.arg(0), &op.arg(1), ctx);
+                    self.make_ne(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                 }
             }
             // intbounds.py:653-656 propagate_bounds_INT_NE
             OpCode::IntNe => {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() && r.lower == 0 {
-                    self.make_eq(&op.arg(0), &op.arg(1), ctx);
+                    self.make_eq(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                 } else if r.is_constant() && r.lower == 1 {
-                    self.make_ne(&op.arg(0), &op.arg(1), ctx);
+                    self.make_ne(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                 }
             }
             // intbounds.py:379-386 propagate_bounds_UINT_LT
@@ -2955,10 +2956,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_unsigned_lt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_lt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_unsigned_ge(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_ge(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2967,10 +2968,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_unsigned_gt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_gt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_unsigned_le(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_le(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2979,10 +2980,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_unsigned_le(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_le(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_unsigned_gt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_gt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -2991,10 +2992,10 @@ impl OptIntBounds {
                 let r = self.getintbound_box(op.pos.get(), ctx);
                 if r.is_constant() {
                     if r.lower == 1 {
-                        self.make_unsigned_ge(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_ge(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     } else {
                         debug_assert_eq!(r.lower, 0);
-                        self.make_unsigned_lt(&op.arg(0), &op.arg(1), ctx);
+                        self.make_unsigned_lt(&op.arg(0).to_boxref(), &op.arg(1).to_boxref(), ctx);
                     }
                 }
             }
@@ -3209,7 +3210,7 @@ impl Optimization for OptIntBounds {
                 if !is_int {
                     return;
                 }
-                self.propagate_bounds_backward(&op.arg(0), ctx);
+                self.propagate_bounds_backward(&op.arg(0).to_boxref(), ctx);
             }
 
             // ── Arithmetic postprocess ──
@@ -3302,8 +3303,8 @@ impl Optimization for OptIntBounds {
                             majit_ir::OopSpecIndex::IntPyDiv => {
                                 if op.num_args() >= 3 {
                                     // intbounds.py:165-169 post_call_INT_PY_DIV.
-                                    let b1 = self.getintbound_arg(op.arg(1), ctx);
-                                    let b2 = self.getintbound_arg(op.arg(2), ctx);
+                                    let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
+                                    let b2 = self.getintbound_arg(op.arg(2).to_boxref(), ctx);
                                     let result_bound = b1.py_div_bound(&b2);
                                     self.intersect_bound(op.pos.get(), &result_bound, ctx);
                                 }
@@ -3311,8 +3312,8 @@ impl Optimization for OptIntBounds {
                             majit_ir::OopSpecIndex::IntPyMod => {
                                 if op.num_args() >= 3 {
                                     // intbounds.py:171-175 post_call_INT_PY_MOD.
-                                    let b1 = self.getintbound_arg(op.arg(1), ctx);
-                                    let b2 = self.getintbound_arg(op.arg(2), ctx);
+                                    let b1 = self.getintbound_arg(op.arg(1).to_boxref(), ctx);
+                                    let b2 = self.getintbound_arg(op.arg(2).to_boxref(), ctx);
                                     let result_bound = b1.mod_bound(&b2);
                                     self.intersect_bound(op.pos.get(), &result_bound, ctx);
                                 }
@@ -3505,8 +3506,10 @@ mod tests {
                     // rather than re-minting an unbound `from_opref` box. Then
                     // resolve any forwarding box-native.
                     let canonical = ctx.materialize_box_at(ar);
-                    ctx.resolve_box_box_opt(&canonical)
-                        .unwrap_or_else(|| canonical.get_box_replacement(false))
+                    majit_ir::operand::Operand::from_boxref(
+                        &ctx.resolve_box_box_opt(&canonical)
+                            .unwrap_or_else(|| canonical.get_box_replacement(false)),
+                    )
                 };
                 resolved_op.setarg(i, resolved);
             }
@@ -3599,7 +3602,9 @@ mod tests {
                 other => crate::r#box::BoxRef::from_opref(other),
             })
             .collect();
-        let mut op = Op::new(opcode, &box_args);
+        let op_args: Vec<majit_ir::operand::Operand> =
+            box_args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let mut op = Op::new(opcode, &op_args);
         op.pos.set(OpRef::op_typed(pos, op.result_type()));
         op
     }

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -49,7 +49,13 @@ fn replace_with(
     opcode: OpCode,
     args: &[crate::r#box::BoxRef],
 ) -> OptimizationResult {
-    let mut new_op = Op::new(opcode, &args.iter().map(|b| Operand::from_boxref(b)).collect::<Vec<_>>());
+    let mut new_op = Op::new(
+        opcode,
+        &args
+            .iter()
+            .map(|b| Operand::from_boxref(b))
+            .collect::<Vec<_>>(),
+    );
     new_op.pos.set(original.pos.get());
     OptimizationResult::Restart(new_op)
 }
@@ -3602,8 +3608,10 @@ mod tests {
                 other => crate::r#box::BoxRef::from_opref(other),
             })
             .collect();
-        let op_args: Vec<majit_ir::operand::Operand> =
-            box_args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let op_args: Vec<majit_ir::operand::Operand> = box_args
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
         let mut op = Op::new(opcode, &op_args);
         op.pos.set(OpRef::op_typed(pos, op.result_type()));
         op

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -4,6 +4,7 @@
 ///
 /// Replaces signed integer division by a constant with a sequence of
 /// UINT_MUL_HIGH + shift operations, avoiding the expensive `idiv` instruction.
+use majit_ir::operand::Operand;
 use majit_ir::{Op, OpCode, OpRef};
 
 use crate::optimizeopt::OptContext;
@@ -114,13 +115,13 @@ pub fn division_operations(
         let t_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::IntRshift, &[arg_n, arg_shift63]),
+            Op::new(OpCode::IntRshift, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_shift63)]),
         );
 
         // nt = n ^ t
         let arg_n = ctx.materialize_box_at(n_ref);
         let arg_t = ctx.materialize_box_at(t_ref);
-        let nt_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[arg_n, arg_t]));
+        let nt_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_t)]));
 
         // mul = UINT_MUL_HIGH(nt, k)
         let arg_nt = ctx.materialize_box_at(nt_ref);
@@ -128,7 +129,7 @@ pub fn division_operations(
         let mul_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::UintMulHigh, &[arg_nt, arg_k]),
+            Op::new(OpCode::UintMulHigh, &[Operand::from_boxref(&arg_nt), Operand::from_boxref(&arg_k)]),
         );
 
         // sh = UINT_RSHIFT(mul, i)
@@ -137,18 +138,18 @@ pub fn division_operations(
         let sh_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::UintRshift, &[arg_mul, arg_i]),
+            Op::new(OpCode::UintRshift, &[Operand::from_boxref(&arg_mul), Operand::from_boxref(&arg_i)]),
         );
 
         // result = sh ^ t
         let arg_sh = ctx.materialize_box_at(sh_ref);
         let arg_t = ctx.materialize_box_at(t_ref);
-        emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[arg_sh, arg_t]))
+        emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[Operand::from_boxref(&arg_sh), Operand::from_boxref(&arg_t)]))
     } else {
         // mul = UINT_MUL_HIGH(n, k)
         let arg_n = ctx.materialize_box_at(n_ref);
         let arg_k = ctx.materialize_box_at(k_ref);
-        let mul_ref = emit_op(ctx, pass_idx, Op::new(OpCode::UintMulHigh, &[arg_n, arg_k]));
+        let mul_ref = emit_op(ctx, pass_idx, Op::new(OpCode::UintMulHigh, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_k)]));
 
         // result = UINT_RSHIFT(mul, i)
         let arg_mul = ctx.materialize_box_at(mul_ref);
@@ -156,7 +157,7 @@ pub fn division_operations(
         emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::UintRshift, &[arg_mul, arg_i]),
+            Op::new(OpCode::UintRshift, &[Operand::from_boxref(&arg_mul), Operand::from_boxref(&arg_i)]),
         )
     }
 }
@@ -177,7 +178,7 @@ pub fn modulo_operations(
     let m_ref = emit_constant_int(ctx, m);
     let arg_div = ctx.materialize_box_at(div_ref);
     let arg_m = ctx.materialize_box_at(m_ref);
-    let product_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntMul, &[arg_div, arg_m]));
+    let product_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntMul, &[Operand::from_boxref(&arg_div), Operand::from_boxref(&arg_m)]));
 
     // remainder = n - product
     let arg_n = ctx.materialize_box_at(n_ref);
@@ -185,7 +186,7 @@ pub fn modulo_operations(
     emit_op(
         ctx,
         pass_idx,
-        Op::new(OpCode::IntSub, &[arg_n, arg_product]),
+        Op::new(OpCode::IntSub, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_product)]),
     )
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -115,13 +115,26 @@ pub fn division_operations(
         let t_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::IntRshift, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_shift63)]),
+            Op::new(
+                OpCode::IntRshift,
+                &[
+                    Operand::from_boxref(&arg_n),
+                    Operand::from_boxref(&arg_shift63),
+                ],
+            ),
         );
 
         // nt = n ^ t
         let arg_n = ctx.materialize_box_at(n_ref);
         let arg_t = ctx.materialize_box_at(t_ref);
-        let nt_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_t)]));
+        let nt_ref = emit_op(
+            ctx,
+            pass_idx,
+            Op::new(
+                OpCode::IntXor,
+                &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_t)],
+            ),
+        );
 
         // mul = UINT_MUL_HIGH(nt, k)
         let arg_nt = ctx.materialize_box_at(nt_ref);
@@ -129,7 +142,10 @@ pub fn division_operations(
         let mul_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::UintMulHigh, &[Operand::from_boxref(&arg_nt), Operand::from_boxref(&arg_k)]),
+            Op::new(
+                OpCode::UintMulHigh,
+                &[Operand::from_boxref(&arg_nt), Operand::from_boxref(&arg_k)],
+            ),
         );
 
         // sh = UINT_RSHIFT(mul, i)
@@ -138,18 +154,35 @@ pub fn division_operations(
         let sh_ref = emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::UintRshift, &[Operand::from_boxref(&arg_mul), Operand::from_boxref(&arg_i)]),
+            Op::new(
+                OpCode::UintRshift,
+                &[Operand::from_boxref(&arg_mul), Operand::from_boxref(&arg_i)],
+            ),
         );
 
         // result = sh ^ t
         let arg_sh = ctx.materialize_box_at(sh_ref);
         let arg_t = ctx.materialize_box_at(t_ref);
-        emit_op(ctx, pass_idx, Op::new(OpCode::IntXor, &[Operand::from_boxref(&arg_sh), Operand::from_boxref(&arg_t)]))
+        emit_op(
+            ctx,
+            pass_idx,
+            Op::new(
+                OpCode::IntXor,
+                &[Operand::from_boxref(&arg_sh), Operand::from_boxref(&arg_t)],
+            ),
+        )
     } else {
         // mul = UINT_MUL_HIGH(n, k)
         let arg_n = ctx.materialize_box_at(n_ref);
         let arg_k = ctx.materialize_box_at(k_ref);
-        let mul_ref = emit_op(ctx, pass_idx, Op::new(OpCode::UintMulHigh, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_k)]));
+        let mul_ref = emit_op(
+            ctx,
+            pass_idx,
+            Op::new(
+                OpCode::UintMulHigh,
+                &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_k)],
+            ),
+        );
 
         // result = UINT_RSHIFT(mul, i)
         let arg_mul = ctx.materialize_box_at(mul_ref);
@@ -157,7 +190,10 @@ pub fn division_operations(
         emit_op(
             ctx,
             pass_idx,
-            Op::new(OpCode::UintRshift, &[Operand::from_boxref(&arg_mul), Operand::from_boxref(&arg_i)]),
+            Op::new(
+                OpCode::UintRshift,
+                &[Operand::from_boxref(&arg_mul), Operand::from_boxref(&arg_i)],
+            ),
         )
     }
 }
@@ -178,7 +214,14 @@ pub fn modulo_operations(
     let m_ref = emit_constant_int(ctx, m);
     let arg_div = ctx.materialize_box_at(div_ref);
     let arg_m = ctx.materialize_box_at(m_ref);
-    let product_ref = emit_op(ctx, pass_idx, Op::new(OpCode::IntMul, &[Operand::from_boxref(&arg_div), Operand::from_boxref(&arg_m)]));
+    let product_ref = emit_op(
+        ctx,
+        pass_idx,
+        Op::new(
+            OpCode::IntMul,
+            &[Operand::from_boxref(&arg_div), Operand::from_boxref(&arg_m)],
+        ),
+    );
 
     // remainder = n - product
     let arg_n = ctx.materialize_box_at(n_ref);
@@ -186,7 +229,13 @@ pub fn modulo_operations(
     emit_op(
         ctx,
         pass_idx,
-        Op::new(OpCode::IntSub, &[Operand::from_boxref(&arg_n), Operand::from_boxref(&arg_product)]),
+        Op::new(
+            OpCode::IntSub,
+            &[
+                Operand::from_boxref(&arg_n),
+                Operand::from_boxref(&arg_product),
+            ],
+        ),
     )
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/intutils.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intutils.rs
@@ -74,6 +74,7 @@ impl IntBoundMakeGuards for IntBound {
         ctx: &mut crate::optimizeopt::OptContext,
     ) {
         use crate::optimizeopt::Op;
+        use majit_ir::operand::Operand;
         use majit_ir::{OpCode, Type, Value};
 
         // history.py:227/268/314 Const{Int,Float,Ptr}.value inline: the
@@ -90,14 +91,14 @@ impl IntBoundMakeGuards for IntBound {
             let c = alloc_const(Value::Int(self.upper));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_c = ctx.materialize_box_at(c);
-            guards.push(Op::new(OpCode::GuardValue, &[arg_box, arg_c]));
+            guards.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_c)]));
             return;
         }
         if self.lower > i64::MIN {
             let bound = alloc_const(Value::Int(self.lower));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_bound = ctx.materialize_box_at(bound);
-            let mut op = Op::new(OpCode::IntGe, &[arg_box, arg_bound]);
+            let mut op = Op::new(OpCode::IntGe, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_bound)]);
             // intutils.py:1275 `op = ResOperation(rop.INT_GE, ...)` then
             // `[op]` — RPython uses the ResOperation object as identity.
             // pyre allocates a fresh Int OpRef into `op.pos` so the next
@@ -107,25 +108,25 @@ impl IntBoundMakeGuards for IntBound {
             let op_pos = op.pos.get();
             guards.push(op);
             let arg_op = ctx.materialize_box_at(op_pos);
-            guards.push(Op::new(OpCode::GuardTrue, &[arg_op]));
+            guards.push(Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&arg_op)]));
         }
         if self.upper < i64::MAX {
             let bound = alloc_const(Value::Int(self.upper));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_bound = ctx.materialize_box_at(bound);
-            let mut op = Op::new(OpCode::IntLe, &[arg_box, arg_bound]);
+            let mut op = Op::new(OpCode::IntLe, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_bound)]);
             // intutils.py:1281 INT_LE producer identity — see comment above.
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
             guards.push(op);
             let arg_op = ctx.materialize_box_at(op_pos);
-            guards.push(Op::new(OpCode::GuardTrue, &[arg_op]));
+            guards.push(Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&arg_op)]));
         }
         if !self.are_knownbits_implied() {
             let mask = alloc_const(Value::Int(!self.tmask as i64));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_mask = ctx.materialize_box_at(mask);
-            let mut op = Op::new(OpCode::IntAnd, &[arg_box, arg_mask]);
+            let mut op = Op::new(OpCode::IntAnd, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_mask)]);
             // intutils.py:1286 INT_AND producer identity — see comment above.
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
@@ -133,7 +134,7 @@ impl IntBoundMakeGuards for IntBound {
             let value = alloc_const(Value::Int(self.tvalue as i64));
             let arg_op = ctx.materialize_box_at(op_pos);
             let arg_value = ctx.materialize_box_at(value);
-            guards.push(Op::new(OpCode::GuardValue, &[arg_op, arg_value]));
+            guards.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_op), Operand::from_boxref(&arg_value)]));
         }
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/intutils.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intutils.rs
@@ -91,14 +91,23 @@ impl IntBoundMakeGuards for IntBound {
             let c = alloc_const(Value::Int(self.upper));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_c = ctx.materialize_box_at(c);
-            guards.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_c)]));
+            guards.push(Op::new(
+                OpCode::GuardValue,
+                &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_c)],
+            ));
             return;
         }
         if self.lower > i64::MIN {
             let bound = alloc_const(Value::Int(self.lower));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_bound = ctx.materialize_box_at(bound);
-            let mut op = Op::new(OpCode::IntGe, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_bound)]);
+            let mut op = Op::new(
+                OpCode::IntGe,
+                &[
+                    Operand::from_boxref(&arg_box),
+                    Operand::from_boxref(&arg_bound),
+                ],
+            );
             // intutils.py:1275 `op = ResOperation(rop.INT_GE, ...)` then
             // `[op]` — RPython uses the ResOperation object as identity.
             // pyre allocates a fresh Int OpRef into `op.pos` so the next
@@ -114,7 +123,13 @@ impl IntBoundMakeGuards for IntBound {
             let bound = alloc_const(Value::Int(self.upper));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_bound = ctx.materialize_box_at(bound);
-            let mut op = Op::new(OpCode::IntLe, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_bound)]);
+            let mut op = Op::new(
+                OpCode::IntLe,
+                &[
+                    Operand::from_boxref(&arg_box),
+                    Operand::from_boxref(&arg_bound),
+                ],
+            );
             // intutils.py:1281 INT_LE producer identity — see comment above.
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
@@ -126,7 +141,13 @@ impl IntBoundMakeGuards for IntBound {
             let mask = alloc_const(Value::Int(!self.tmask as i64));
             let arg_box = ctx.materialize_box_at(box_ref);
             let arg_mask = ctx.materialize_box_at(mask);
-            let mut op = Op::new(OpCode::IntAnd, &[Operand::from_boxref(&arg_box), Operand::from_boxref(&arg_mask)]);
+            let mut op = Op::new(
+                OpCode::IntAnd,
+                &[
+                    Operand::from_boxref(&arg_box),
+                    Operand::from_boxref(&arg_mask),
+                ],
+            );
             // intutils.py:1286 INT_AND producer identity — see comment above.
             op.pos.set(ctx.alloc_op_position_typed(Type::Int));
             let op_pos = op.pos.get();
@@ -134,7 +155,13 @@ impl IntBoundMakeGuards for IntBound {
             let value = alloc_const(Value::Int(self.tvalue as i64));
             let arg_op = ctx.materialize_box_at(op_pos);
             let arg_value = ctx.materialize_box_at(value);
-            guards.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_op), Operand::from_boxref(&arg_value)]));
+            guards.push(Op::new(
+                OpCode::GuardValue,
+                &[
+                    Operand::from_boxref(&arg_op),
+                    Operand::from_boxref(&arg_value),
+                ],
+            ));
         }
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -558,7 +558,7 @@ pub struct OptContext {
     /// A Phase-2 lookup that followed a label arg to its Phase-1 producer
     /// would re-express a per-iteration value in terms of the PREAMBLE's
     /// entry value, which the loop header does not carry per-iteration.
-    pub emitted_operations: majit_ir::vec_set::VecSet<crate::r#box::BoxRef>,
+    pub emitted_operations: majit_ir::vec_set::VecSet<majit_ir::operand::Operand>,
     /// Number of input arguments, used to offset emitted op positions
     /// so that variable indices don't collide with input arg indices.
     num_inputs: u32,
@@ -2805,7 +2805,7 @@ impl OptContext {
                 // admits producers present here, so the reused op must be
                 // marked emitted or it stays invisible to producer matching.
                 self.emitted_operations
-                    .insert(crate::r#box::BoxRef::from_bound_op(&reused));
+                    .insert(majit_ir::operand::Operand::from_bound_op(&reused));
                 self.new_operations.push(reused);
                 return op_pos;
             }
@@ -2849,7 +2849,7 @@ impl OptContext {
         }
         // optimizer.py:674 `self._emittedoperations[op] = None`.
         self.emitted_operations
-            .insert(crate::r#box::BoxRef::from_bound_op(&op_rc));
+            .insert(majit_ir::operand::Operand::from_bound_op(&op_rc));
         self.new_operations.push(op_rc);
         pos_ref
     }
@@ -6520,7 +6520,7 @@ impl OptContext {
         // so this is the same box recorded at emit).
         if !self
             .emitted_operations
-            .contains(&crate::r#box::BoxRef::from_bound_op(&producer))
+            .contains(&majit_ir::operand::Operand::from_bound_op(&producer))
         {
             return None;
         }
@@ -8504,7 +8504,7 @@ pub trait Optimization {
         &self,
         _args: &[OpRef],
         _ctx: &OptContext,
-    ) -> crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, IntBound> {
+    ) -> crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::operand::Operand, IntBound> {
         crate::optimizeopt::vec_assoc::VecAssoc::new()
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -684,8 +684,8 @@ pub struct OptContext {
     /// (`exported_short_inputargs[i]`) holds a WEAK handle to
     /// `exported_short_inputarg_refs[i]`; keeping the strong Rc alive here
     /// lets the box resolve to a real bound `InputArg` (so the operand binds
-    /// to `Operand::InputArg` instead of shedding to the position-only
-    /// `Operand::Box` catch-all). Carried alongside `exported_short_inputargs`
+    /// to `Operand::InputArg` instead of an unbound position-only box, which
+    /// `from_boxref` now rejects). Carried alongside `exported_short_inputargs`
     /// through the same export channel.
     pub exported_short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// optimizer.py: `can_replace_guards` — disable guard replacement during
@@ -2311,8 +2311,8 @@ impl OptContext {
         // The SAME_AS source is the constant itself (`make_constant_box` below
         // forwards the result to the same `Const`, so the op is a tautology
         // `result = ConstInt(value)`). A constant operand binds directly; a
-        // position-only `from_opref(pos_ref)` self-reference would shed to the
-        // catch-all `Operand::Box` with no live producer (#9).
+        // position-only `from_opref(pos_ref)` self-reference would have no live
+        // producer and `from_boxref` rejects it (#9).
         let mut op = Op::new(
             OpCode::SameAsI,
             &[crate::r#box::BoxRef::new_const(Value::Int(value))],

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -34,8 +34,8 @@ pub mod vstring;
 use crate::optimizeopt::intutils::{IntBound, IntBoundMakeGuards};
 use crate::resume::SnapshotBox;
 use info::{EnsuredPtrInfo, PtrInfo};
-use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 use majit_ir::operand::Operand;
+use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 use std::collections::VecDeque;
 
 pub type SnapshotBoxes = Vec<Option<Vec<SnapshotBox>>>;
@@ -450,7 +450,13 @@ impl ImportedShortPureOp {
             .iter()
             .map(|a| ctx.materialize_box_at(*a))
             .collect();
-        let mut replay = majit_ir::Op::new(opcode, &replay_arg_boxes.iter().map(Operand::from_boxref).collect::<Vec<_>>());
+        let mut replay = majit_ir::Op::new(
+            opcode,
+            &replay_arg_boxes
+                .iter()
+                .map(Operand::from_boxref)
+                .collect::<Vec<_>>(),
+        );
         // shortpreamble.py:112-126 PureOp.produce_op constructs TWO distinct
         // RPython Op objects:
         //
@@ -2316,7 +2322,9 @@ impl OptContext {
         // producer and `from_boxref` rejects it (#9).
         let mut op = Op::new(
             OpCode::SameAsI,
-            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(Value::Int(value)))],
+            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(
+                Value::Int(value),
+            ))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2332,7 +2340,9 @@ impl OptContext {
         // SAME_AS source is the constant ref itself; see `emit_constant_int`.
         let mut op = Op::new(
             OpCode::SameAsR,
-            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(Value::Ref(value)))],
+            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(
+                Value::Ref(value),
+            ))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2348,7 +2358,9 @@ impl OptContext {
         // SAME_AS source is the constant float itself; see `emit_constant_int`.
         let mut op = Op::new(
             OpCode::SameAsF,
-            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(Value::Float(value)))],
+            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(
+                Value::Float(value),
+            ))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -3195,7 +3207,10 @@ impl OptContext {
                         .collect();
                     let mut op = Op::new(
                         pure_call_opcode(produced_op.preamble_op.opcode),
-                        &resolved_arg_boxes.iter().map(Operand::from_boxref).collect::<Vec<_>>(),
+                        &resolved_arg_boxes
+                            .iter()
+                            .map(Operand::from_boxref)
+                            .collect::<Vec<_>>(),
                     );
                     op.pos.set(replay_pos(*source, produced_op));
                     if let Some(d) = produced_op.preamble_op.getdescr() {
@@ -3282,7 +3297,10 @@ impl OptContext {
                             };
                             let obj_b = dep_or_materialize(self, &produced, obj);
                             let index_b = dep_or_materialize(self, &produced, index_opref);
-                            let mut op = Op::new(opcode, &[Operand::from_boxref(&obj_b), Operand::from_boxref(&index_b)]);
+                            let mut op = Op::new(
+                                opcode,
+                                &[Operand::from_boxref(&obj_b), Operand::from_boxref(&index_b)],
+                            );
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             let res = self.materialize_box_at(op.pos.get());
@@ -3322,7 +3340,10 @@ impl OptContext {
                         return false;
                     }
                     let func_b = dep_or_materialize(self, &produced, func_opref);
-                    let mut op = Op::new(loop_invariant_opcode(result_type), &[Operand::from_boxref(&func_b)]);
+                    let mut op = Op::new(
+                        loop_invariant_opcode(result_type),
+                        &[Operand::from_boxref(&func_b)],
+                    );
                     op.pos.set(replay_pos(*source, produced_op));
                     let res = self.materialize_box_at(op.pos.get());
                     let new_pop = ProducedShortOp {
@@ -3605,7 +3626,10 @@ impl OptContext {
             // 268/314); no `seed_constant` step (its const arm is a no-op).
             let arg_b = ctx.materialize_box_at(arg);
             let c_b = ctx.materialize_box_at(c);
-            guards.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&c_b)]));
+            guards.push(Op::new(
+                OpCode::GuardValue,
+                &[Operand::from_boxref(&arg_b), Operand::from_boxref(&c_b)],
+            ));
         };
         for entry in &arg_entries {
             match &entry.info {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -35,6 +35,7 @@ use crate::optimizeopt::intutils::{IntBound, IntBoundMakeGuards};
 use crate::resume::SnapshotBox;
 use info::{EnsuredPtrInfo, PtrInfo};
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
+use majit_ir::operand::Operand;
 use std::collections::VecDeque;
 
 pub type SnapshotBoxes = Vec<Option<Vec<SnapshotBox>>>;
@@ -449,7 +450,7 @@ impl ImportedShortPureOp {
             .iter()
             .map(|a| ctx.materialize_box_at(*a))
             .collect();
-        let mut replay = majit_ir::Op::new(opcode, &replay_arg_boxes);
+        let mut replay = majit_ir::Op::new(opcode, &replay_arg_boxes.iter().map(Operand::from_boxref).collect::<Vec<_>>());
         // shortpreamble.py:112-126 PureOp.produce_op constructs TWO distinct
         // RPython Op objects:
         //
@@ -2315,7 +2316,7 @@ impl OptContext {
         // producer and `from_boxref` rejects it (#9).
         let mut op = Op::new(
             OpCode::SameAsI,
-            &[crate::r#box::BoxRef::new_const(Value::Int(value))],
+            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(Value::Int(value)))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2331,7 +2332,7 @@ impl OptContext {
         // SAME_AS source is the constant ref itself; see `emit_constant_int`.
         let mut op = Op::new(
             OpCode::SameAsR,
-            &[crate::r#box::BoxRef::new_const(Value::Ref(value))],
+            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(Value::Ref(value)))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2347,7 +2348,7 @@ impl OptContext {
         // SAME_AS source is the constant float itself; see `emit_constant_int`.
         let mut op = Op::new(
             OpCode::SameAsF,
-            &[crate::r#box::BoxRef::new_const(Value::Float(value))],
+            &[Operand::from_boxref(&crate::r#box::BoxRef::new_const(Value::Float(value)))],
         );
         op.pos.set(pos_ref);
         let opref = self.emit_extra(self.current_pass_idx, op);
@@ -2446,7 +2447,7 @@ impl OptContext {
             majit_ir::OpCode::Strlen
         };
         let arg1 = self.materialize_box_at(op_resolved);
-        let strlen_op = majit_ir::Op::new(strlen_opcode, &[arg1]);
+        let strlen_op = majit_ir::Op::new(strlen_opcode, &[Operand::from_boxref(&arg1)]);
         let result = self.emit_extra(self.current_pass_idx, strlen_op);
         // vstring.py:116: lengthop.set_forwarded(self.getlenbound(mode))
         // `set_forwarded` writes the bound unconditionally; route through
@@ -3194,7 +3195,7 @@ impl OptContext {
                         .collect();
                     let mut op = Op::new(
                         pure_call_opcode(produced_op.preamble_op.opcode),
-                        &resolved_arg_boxes,
+                        &resolved_arg_boxes.iter().map(Operand::from_boxref).collect::<Vec<_>>(),
                     );
                     op.pos.set(replay_pos(*source, produced_op));
                     if let Some(d) = produced_op.preamble_op.getdescr() {
@@ -3240,7 +3241,7 @@ impl OptContext {
                                 majit_ir::Type::Void => return false,
                             };
                             let obj_b = dep_or_materialize(self, &produced, obj);
-                            let mut op = Op::new(opcode, &[obj_b]);
+                            let mut op = Op::new(opcode, &[Operand::from_boxref(&obj_b)]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             let res = self.materialize_box_at(op.pos.get());
@@ -3281,7 +3282,7 @@ impl OptContext {
                             };
                             let obj_b = dep_or_materialize(self, &produced, obj);
                             let index_b = dep_or_materialize(self, &produced, index_opref);
-                            let mut op = Op::new(opcode, &[obj_b, index_b]);
+                            let mut op = Op::new(opcode, &[Operand::from_boxref(&obj_b), Operand::from_boxref(&index_b)]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             let res = self.materialize_box_at(op.pos.get());
@@ -3321,7 +3322,7 @@ impl OptContext {
                         return false;
                     }
                     let func_b = dep_or_materialize(self, &produced, func_opref);
-                    let mut op = Op::new(loop_invariant_opcode(result_type), &[func_b]);
+                    let mut op = Op::new(loop_invariant_opcode(result_type), &[Operand::from_boxref(&func_b)]);
                     op.pos.set(replay_pos(*source, produced_op));
                     let res = self.materialize_box_at(op.pos.get());
                     let new_pop = ProducedShortOp {
@@ -3604,7 +3605,7 @@ impl OptContext {
             // 268/314); no `seed_constant` step (its const arm is a no-op).
             let arg_b = ctx.materialize_box_at(arg);
             let c_b = ctx.materialize_box_at(c);
-            guards.push(Op::new(OpCode::GuardValue, &[arg_b, c_b]));
+            guards.push(Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&c_b)]));
         };
         for entry in &arg_entries {
             match &entry.info {
@@ -4160,7 +4161,7 @@ impl OptContext {
                     .iter()
                     .map(|op| ImportedShortAlias {
                         result: op.pos.get(),
-                        same_as_source: op.arg(0),
+                        same_as_source: op.arg(0).to_boxref(),
                         same_as_opcode: op.opcode,
                     })
                     .collect()
@@ -6027,7 +6028,7 @@ impl OptContext {
     fn maybe_replace_guard_value(&self, op: &mut Op) {
         let arg0 = op.arg(0);
         // optimizer.py:755: if op.getarg(0).type == 'i'
-        let arg0_resolved = self.resolve_box_box(&arg0).to_opref();
+        let arg0_resolved = self.resolve_box_box(&arg0.to_boxref()).to_opref();
         if self.opref_type(arg0_resolved) != Some(majit_ir::Type::Int) {
             return;
         }
@@ -6043,7 +6044,7 @@ impl OptContext {
         }
         let arg1 = op.arg(1);
         let Some(constvalue) = self
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|cb| cb.const_int())
         else {
             return;
@@ -6657,7 +6658,7 @@ impl OptContext {
         let mut argboxes: Vec<Value> = Vec::with_capacity(op.num_args());
         for i in 0..op.num_args() {
             argboxes.push(
-                self.get_constant_box(&op.arg(i).get_box_replacement(false))
+                self.get_constant_box(&op.arg(i).to_boxref().get_box_replacement(false))
                     .expect("constant_fold: arg must be Const (pure.rs:993-1006 pre-check)"),
             );
         }
@@ -6723,7 +6724,7 @@ impl OptContext {
         if opnum.is_getfield() {
             // optimizer.py:829-832 pure-getfield branch.
             let gcref = match self
-                .get_constant_box(&op.arg(0).get_box_replacement(false))
+                .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                 .expect("protect_speculative_operation: arg0 must be Const")
             {
                 Value::Ref(r) => r,
@@ -6751,7 +6752,7 @@ impl OptContext {
         ) {
             // optimizer.py:834-841 array branch.
             let array = match self
-                .get_constant_box(&op.arg(0).get_box_replacement(false))
+                .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                 .expect("protect_speculative_operation: array arg0 must be Const")
             {
                 Value::Ref(r) => r,
@@ -6778,7 +6779,7 @@ impl OptContext {
         } else if matches!(opnum, OpCode::Strgetitem | OpCode::Strlen) {
             // optimizer.py:843-848 string branch.
             let string = match self
-                .get_constant_box(&op.arg(0).get_box_replacement(false))
+                .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                 .expect("protect_speculative_operation: string arg0 must be Const")
             {
                 Value::Ref(r) => r,
@@ -6798,7 +6799,7 @@ impl OptContext {
         } else if matches!(opnum, OpCode::Unicodegetitem | OpCode::Unicodelen) {
             // optimizer.py:850-855 unicode branch.
             let unicode = match self
-                .get_constant_box(&op.arg(0).get_box_replacement(false))
+                .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                 .expect("protect_speculative_operation: unicode arg0 must be Const")
             {
                 Value::Ref(r) => r,
@@ -6827,7 +6828,7 @@ impl OptContext {
         //   index = self.get_constant_box(op.getarg(1)).getint()
         //   if not (0 <= index < arraylength): raise SpeculativeError
         let index = match self
-            .get_constant_box(&op.arg(1).get_box_replacement(false))
+            .get_constant_box(&op.arg(1).to_boxref().get_box_replacement(false))
             .expect("protect_speculative_operation: arg1 must be Const")
         {
             Value::Int(i) => i,
@@ -7893,7 +7894,7 @@ impl OptContext {
     /// constant case lands on `const_infos[gcref]`; the regular case
     /// runs `ensure_ptr_info_arg0(op).as_mut().setfield(...)`.
     pub fn structinfo_setfield(&mut self, op: &Op, field_idx: u32, value: OpRef) {
-        let arg0 = self.resolve_box_box(&op.arg(0)).to_opref();
+        let arg0 = self.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -7922,7 +7923,7 @@ impl OptContext {
     /// constant arg0 path so the const_infos slot is created as
     /// `PtrInfo::Array` rather than `PtrInfo::Instance`.
     pub fn arrayinfo_setitem(&mut self, op: &Op, index: usize, value: OpRef) {
-        let arg0 = self.resolve_box_box(&op.arg(0));
+        let arg0 = self.resolve_box_box(&op.arg(0).to_boxref());
         if arg0.is_constant() || arg0.const_value().is_some() {
             if let Some(descr) = op.getdescr() {
                 if let Some(info) = self.get_const_info_array_mut_box(&arg0, descr) {
@@ -8033,7 +8034,7 @@ impl OptContext {
     /// `arrayinfo.getlenbound(...)` patterns.
     pub fn ensure_ptr_info_arg0(&mut self, op: &Op) -> EnsuredPtrInfo {
         // optimizer.py:464: arg0 = self.get_box_replacement(op.getarg(0))
-        let arg0 = self.resolve_box_box(&op.arg(0)).to_opref();
+        let arg0 = self.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         // optimizer.py:465-466: if arg0.is_constant(): return info.ConstPtrInfo(arg0)
         //
         // PyPy's `info.ConstPtrInfo(arg0)` wraps the constant box itself,
@@ -8110,7 +8111,7 @@ impl OptContext {
         // `find_producer_op` returns). The Phase-1 heal links the operand's
         // input op to that canonical even at a shared position, so the
         // box-native terminal now carries the PtrInfo `heap`/`virtualize` set.
-        let arg0_box = self.resolve_box_box_opt(&op.arg(0));
+        let arg0_box = self.resolve_box_box_opt(&op.arg(0).to_boxref());
         if matches!(
             arg0_box.as_ref().and_then(|b| self.peek_ptr_info(b)),
             Some(
@@ -8687,7 +8688,10 @@ mod boxref_forwarding_tests {
         let consumer_arg = ctx.materialize_box_at(pos2);
 
         // The producer emits at pos 2.
-        let mut producer = Op::new(OpCode::IntLt, &[b0.clone(), b1.clone()]);
+        let mut producer = Op::new(
+            OpCode::IntLt,
+            &[Operand::from_boxref(&b0), Operand::from_boxref(&b1)],
+        );
         producer.pos.set(pos2);
         ctx.emit(producer);
 
@@ -10007,9 +10011,8 @@ mod ensure_ptr_info_arg0_tests {
         let descr: DescrRef = Arc::new(TestFieldDescr { index: 0, parent });
         let mut op = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
             )],
             descr,
         );
@@ -10025,9 +10028,8 @@ mod ensure_ptr_info_arg0_tests {
         });
         let mut op = Op::with_descr(
             OpCode::ArraylenGc,
-            &[crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
             )],
             descr,
         );
@@ -10096,9 +10098,8 @@ mod ensure_ptr_info_arg0_tests {
             });
             let mut op = Op::with_descr(
                 OpCode::Strlen,
-                &[crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Ref,
-                    0,
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 )],
                 descr,
             );
@@ -10133,9 +10134,8 @@ mod ensure_ptr_info_arg0_tests {
             });
             let mut op = Op::with_descr(
                 OpCode::Strlen,
-                &[crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Ref,
-                    0,
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
                 )],
                 descr,
             );
@@ -10458,8 +10458,14 @@ mod imported_short_preamble_fallback_tests {
         let mut replay_op = Op::new(
             OpCode::IntAdd,
             &[
-                crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Int, 7),
-                crate::r#box::test_support::rooted_resop_box(majit_ir::Type::Int, 8),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                    majit_ir::Type::Int,
+                    7,
+                )),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                    majit_ir::Type::Int,
+                    8,
+                )),
             ],
         );
         replay_op.pos.set(OpRef::int_op(14));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -790,7 +790,7 @@ impl Optimizer {
                 .expect("imported virtual leaf missing box.type");
             let same_as_op = majit_ir::OpCode::same_as_for_type(tp);
             let arg0 = ctx.materialize_box_at(*label_arg);
-            let mut op = majit_ir::Op::new(same_as_op, &[arg0]);
+            let mut op = majit_ir::Op::new(same_as_op, &[majit_ir::operand::Operand::from_boxref(&arg0)]);
             op.pos.set(ctx.reserve_pos_typed(tp));
             let fresh = op.pos.get();
             // Op.type_ carries `tp` intrinsically (resoperation.py:1693
@@ -1794,7 +1794,7 @@ impl Optimizer {
             | OpCode::GetarrayitemGcR
             | OpCode::GetarrayitemGcF => {
                 // Check arg(0) is not null constant.
-                if let Some(0) = ctx.get_constant_int_box(&op.arg(0).get_box_replacement(false)) {
+                if let Some(0) = ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false)) {
                     return false; // would deref null
                 }
                 true
@@ -2585,7 +2585,7 @@ impl Optimizer {
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
-                let resolved = ctx.resolve_box_box(&arg).to_opref();
+                let resolved = ctx.resolve_box_box(&arg.to_boxref()).to_opref();
                 let expected_ref =
                     i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
@@ -2594,7 +2594,7 @@ impl Optimizer {
                 // op/value_types chain. PtrInfo presence is an additional
                 // Ref-only side channel for inputargs not in `new_operations`.
                 let resolved_has_ptr_info = ctx
-                    .resolve_box_box_opt(&arg)
+                    .resolve_box_box_opt(&arg.to_boxref())
                     .as_ref()
                     .map_or(false, |b| ctx.has_ptr_info(b));
                 let resolved_is_ref =
@@ -2607,7 +2607,7 @@ impl Optimizer {
                         .is_some()
                 {
                     let arg_is_virtual = ctx
-                        .resolve_box_box_opt(&arg)
+                        .resolve_box_box_opt(&arg.to_boxref())
                         .as_ref()
                         .map_or(false, |b| ctx.is_virtual(b));
                     if arg_is_virtual {
@@ -2626,7 +2626,7 @@ impl Optimizer {
                     }
                 } else {
                     let arg = ctx.materialize_box_at(resolved);
-                    terminal_op.setarg(i, arg);
+                    terminal_op.setarg(i, majit_ir::operand::Operand::from_boxref(&arg));
                 }
             }
             for i in force_needed {
@@ -2640,7 +2640,7 @@ impl Optimizer {
                     Some(b) => b,
                     None => ctx.materialize_box_at(forced),
                 };
-                terminal_op.setarg(i, b_forced);
+                terminal_op.setarg(i, majit_ir::operand::Operand::from_boxref(&b_forced));
             }
             if self.skip_flush {
                 // flush=False: store for caller to consume.
@@ -2826,7 +2826,7 @@ impl Optimizer {
                         let same_as = OpCode::same_as_for_type(arg_type);
                         let fresh = ctx.alloc_op_position_typed(arg_type);
                         let arg0 = ctx.materialize_box_at(orig);
-                        let mut op = Op::new(same_as, &[arg0]);
+                        let mut op = Op::new(same_as, &[majit_ir::operand::Operand::from_boxref(&arg0)]);
                         op.pos.set(fresh);
                         // unroll.py:146 + compile.py:327 parity: accumulate the
                         // alias op in `extra_same_as` and splice it between the
@@ -3058,8 +3058,8 @@ impl Optimizer {
                                 continue;
                             }
                             let resolved =
-                                ctx.resolve_box_box_opt(&arg).unwrap_or_else(|| arg.clone());
-                            preamble_op.setarg(i, resolved);
+                                ctx.resolve_box_box_opt(&arg.to_boxref()).unwrap_or_else(|| arg.to_boxref());
+                            preamble_op.setarg(i, majit_ir::operand::Operand::from_boxref(&resolved));
                         }
                         if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
                             for arg in fail_args.iter_mut() {
@@ -4147,18 +4147,18 @@ impl Optimizer {
             // it to its terminal, so the stored arg is BOUND on every dispatch
             // path. A sentinel operand keeps its unbound arg box (const
             // operands resolve through the `Some` arm above).
-            let resolved = match ctx.resolve_box_box_opt(&arg) {
+            let resolved = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
                 Some(b) => b,
                 None => {
                     let argref = arg.to_opref();
                     if argref.is_none() {
-                        arg.clone()
+                        arg.to_boxref()
                     } else {
                         ctx.materialize_box_at(argref).get_box_replacement(false)
                     }
                 }
             };
-            resolved_op.setarg(i, resolved);
+            resolved_op.setarg(i, majit_ir::operand::Operand::from_boxref(&resolved));
         }
 
         let mut current_op = resolved_op;
@@ -4374,7 +4374,7 @@ impl Optimizer {
                 forced,
                 "emit_operation canonical box to_opref diverged from force_box",
             );
-            op.setarg(i, resolved);
+            op.setarg(i, majit_ir::operand::Operand::from_boxref(&resolved));
         }
         // force_box may force a virtual whose materialization defers an
         // `InvalidLoop`; abort before the emit / `expect` sites below.
@@ -4686,7 +4686,7 @@ impl Optimizer {
                             // (caught at pyjitpl/mod.rs:3454) on
                             // either invariant violation rather
                             // than silently coercing to 0.
-                            let boxindex = ctx.resolve_box_box(&pf_op.arg(1));
+                            let boxindex = ctx.resolve_box_box(&pf_op.arg(1).to_boxref());
                             let idx = match boxindex.const_int() {
                                 Some(v) if (0..=i32::MAX as i64).contains(&v) => v,
                                 // Defer the abort; the caller checks the signal
@@ -4708,8 +4708,8 @@ impl Optimizer {
                         majit_ir::GuardPendingFieldEntry {
                             descr: pf_op.getdescr(),
                             item_index,
-                            target: ctx.resolve_box_box(&target).to_opref(),
-                            value: ctx.resolve_box_box(&value).to_opref(),
+                            target: ctx.resolve_box_box(&target.to_boxref()).to_opref(),
+                            value: ctx.resolve_box_box(&value.to_boxref()).to_opref(),
                             target_tagged: majit_ir::resumedata::UNASSIGNED,
                             value_tagged: majit_ir::resumedata::UNASSIGNED,
                         }
@@ -5012,14 +5012,14 @@ impl Optimizer {
         }
         // optimizer.py:756-757: b = self.getintbound(op.getarg(0)); if b.is_bool()
         let b = {
-            let b = ctx.resolve_box_box(&arg0);
+            let b = ctx.resolve_box_box(&arg0.to_boxref());
             ctx.getintbound_handle(&b).borrow().clone()
         };
         if !b.is_bool() {
             return op;
         }
         // optimizer.py:762: constvalue = op.getarg(1).getint()
-        let Some(constvalue) = op.arg(1).get_box_replacement(false).const_int() else {
+        let Some(constvalue) = op.arg(1).to_boxref().get_box_replacement(false).const_int() else {
             return op;
         };
         // optimizer.py:763-775: 0 → GUARD_FALSE, 1 → GUARD_TRUE, else give up.
@@ -5102,6 +5102,7 @@ mod tests {
     use majit_ir::Type;
     use majit_ir::descr::make_size_descr;
     use majit_ir::descr::{CallDescr, EffectInfo, ExtraEffect, OopSpecIndex};
+    use majit_ir::operand::Operand;
     use majit_ir::{DescrRef, OpCode, OpRef};
     use std::cell::Cell;
     use std::rc::Rc;
@@ -5165,7 +5166,7 @@ mod tests {
         ) -> OptimizationResult {
             if op.opcode == OpCode::IntAdd {
                 // Check if second arg is constant 0
-                if let Some(0) = ctx.get_constant_int_box(&op.arg(1).get_box_replacement(false)) {
+                if let Some(0) = ctx.get_constant_int_box(&op.arg(1).to_boxref().get_box_replacement(false)) {
                     // Replace with first arg
                     let old = op.pos.get();
                     let new = op.arg(0).to_opref();
@@ -5425,7 +5426,7 @@ mod tests {
                 let alloc = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
                 let alloc_box = ctx.materialize_box_at(alloc);
                 let value = ctx.materialize_box_at(OpRef::int_op(0));
-                let mut set = Op::new(OpCode::SetfieldGc, &[alloc_box, value]);
+                let mut set = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&alloc_box), Operand::from_boxref(&value)]);
                 set.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set);
             }
@@ -5513,8 +5514,8 @@ mod tests {
         let ops = vec![Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         )];
         let result =
@@ -5535,8 +5536,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntMul,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         )];
         ops[0].pos.set(OpRef::int_op(2));
@@ -5563,39 +5564,39 @@ mod tests {
             Op::with_descr(
                 OpCode::CallMayForceR,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
                 call_descr_a,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcPureI,
-                &[rooted_resop_box(Type::Ref, 3)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 3))],
                 field_descr.clone(),
             ),
             Op::with_descr(
                 OpCode::CallMayForceR,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 2),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 2)),
                 ],
                 call_descr_b,
             ),
             Op::new(OpCode::GuardNotForced, &[]),
             Op::with_descr(
                 OpCode::GetfieldGcPureI,
-                &[rooted_resop_box(Type::Ref, 6)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 6))],
                 field_descr,
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 5),
-                    rooted_resop_box(Type::Int, 8),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 5)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 8)),
                 ],
             ),
-            Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 9)]),
+            Op::new(OpCode::Finish, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 9))]),
         ];
         for (idx, op) in ops.iter_mut().enumerate() {
             op.pos
@@ -5673,8 +5674,8 @@ mod tests {
         let mut call_a = Op::with_descr(
             OpCode::CallMayForceR,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
             call_descr_a,
         );
@@ -5698,19 +5699,19 @@ mod tests {
         guard_a.set_fail_arg_types(guard_types_a);
         let get_a_type = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[rooted_resop_box(Type::Ref, 3)],
+            &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 3))],
             field_descr.clone(),
         );
         let get_a_val = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[rooted_resop_box(Type::Ref, 3)],
+            &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 3))],
             field_descr_b.clone(),
         );
         let mut call_b = Op::with_descr(
             OpCode::CallMayForceR,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 2),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 2)),
             ],
             call_descr_b,
         );
@@ -5735,12 +5736,12 @@ mod tests {
         guard_b.set_fail_arg_types(guard_types_b);
         let get_b_type = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[rooted_resop_box(Type::Ref, 7)],
+            &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 7))],
             field_descr.clone(),
         );
         let get_b_val = Op::with_descr(
             OpCode::GetfieldGcPureI,
-            &[rooted_resop_box(Type::Ref, 7)],
+            &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 7))],
             field_descr,
         );
         // Second add arg references a live int getfield result (int_op(9) =
@@ -5752,11 +5753,11 @@ mod tests {
         let add = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 5),
-                rooted_resop_box(Type::Int, 9),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 5)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 9)),
             ],
         );
-        let finish = Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 9)]);
+        let finish = Op::new(OpCode::Finish, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 9))]);
 
         let mut ops = vec![
             call_a.clone(),
@@ -5847,14 +5848,14 @@ mod tests {
         opt.add_pass(Box::new(AddVirtualInputsOnce { added: false }));
 
         let mut ops = vec![
-            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
-            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
-            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 4)]),
+            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 4))]),
             Op::new(
                 OpCode::IntGt,
                 &[
-                    rooted_resop_box(Type::Int, 5),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 5)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
         ];
@@ -5890,14 +5891,14 @@ mod tests {
         }));
 
         let mut ops = vec![
-            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
-            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
-            Op::new(OpCode::GetfieldRawI, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
             Op::new(
                 OpCode::IntGt,
                 &[
-                    rooted_resop_box(Type::Int, 3),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 3)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
         ];
@@ -5928,8 +5929,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntGt,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
@@ -5950,8 +5951,8 @@ mod tests {
         let mut ops = vec![Op::new(
             OpCode::IntGt,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
@@ -5976,11 +5977,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
         ];
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
@@ -6051,8 +6052,8 @@ mod tests {
             Op::new(
                 OpCode::GuardValue,
                 &[
-                    rooted_resop_box(Type::Ref, 0),
-                    rooted_resop_box(Type::Ref, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 1)),
                 ],
             ),
             Op::new(OpCode::Finish, &[]),
@@ -6102,15 +6103,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
         ];
@@ -6157,14 +6158,26 @@ mod tests {
                 let alloc_a = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
                 let alloc_a_box = ctx.materialize_box_at(alloc_a);
                 let value_a = ctx.materialize_box_at(OpRef::int_op(0));
-                let mut set_a = Op::new(OpCode::SetfieldGc, &[alloc_a_box, value_a]);
+                let mut set_a = Op::new(
+                    OpCode::SetfieldGc,
+                    &[
+                        Operand::from_boxref(&alloc_a_box),
+                        Operand::from_boxref(&value_a),
+                    ],
+                );
                 set_a.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set_a);
 
                 let alloc_b = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
                 let alloc_b_box = ctx.materialize_box_at(alloc_b);
                 let value_b = ctx.materialize_box_at(OpRef::int_op(1));
-                let mut set_b = Op::new(OpCode::SetfieldGc, &[alloc_b_box, value_b]);
+                let mut set_b = Op::new(
+                    OpCode::SetfieldGc,
+                    &[
+                        Operand::from_boxref(&alloc_b_box),
+                        Operand::from_boxref(&value_b),
+                    ],
+                );
                 set_b.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set_b);
             }
@@ -6189,15 +6202,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
         ];
@@ -6249,15 +6262,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
         ];
@@ -6314,15 +6327,15 @@ mod tests {
         let size_descr = make_size_descr(16);
         let field_descr = majit_ir::make_field_descr(8, 8, Type::Int, majit_ir::ArrayFlag::Signed);
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 10)]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 10))]);
         guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], size_descr),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 11),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 11)),
                 ],
                 field_descr,
             ),
@@ -6398,7 +6411,7 @@ mod tests {
         ];
         opt.phase1_emit_ops.push(std::rc::Rc::new(majit_ir::Op::new(
             majit_ir::OpCode::SameAsI,
-            &[rooted_resop_box(Type::Int, 50)],
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))],
         )));
 
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -6456,8 +6469,8 @@ mod tests {
         let mut op = Op::new(
             OpCode::CallPureI,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         );
         op.setdescr(Arc::new(TestCallDescr {
@@ -6476,8 +6489,8 @@ mod tests {
         let mut op = Op::new(
             OpCode::CallPureI,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         );
         op.setdescr(Arc::new(TestCallDescr {
@@ -6497,14 +6510,14 @@ mod tests {
         let add_op = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         );
         assert!(opt.protect_speculative_operation(&add_op, &ctx));
 
         // Getfield on unknown arg is safe (not constant null)
-        let get_op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_box(Type::Int, 0)]);
+        let get_op = Op::new(OpCode::GetfieldGcI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]);
         assert!(opt.protect_speculative_operation(&get_op, &ctx));
     }
 
@@ -6517,8 +6530,8 @@ mod tests {
         opt.add_pending_field(Op::new(
             OpCode::SetfieldGc,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
             ],
         ));
         assert!(opt.has_pending_fields());
@@ -6652,7 +6665,9 @@ mod tests {
         let mut opt = Optimizer::new();
         let op = Op::new(
             OpCode::GuardNonnull,
-            &[ctx.materialize_box_at(OpRef::ref_op(10))],
+            &[Operand::from_boxref(
+                &ctx.materialize_box_at(OpRef::ref_op(10)),
+            )],
         );
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&op));
@@ -6682,8 +6697,8 @@ mod tests {
         let mut preamble_op = Op::new(
             OpCode::IntGe,
             &[
-                rooted_resop_box(Type::Int, 3),
-                rooted_resop_box(Type::Int, 10_000),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 3)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 10_000)),
             ],
         );
         preamble_op.pos.set(OpRef::int_op(14));
@@ -6709,7 +6724,7 @@ mod tests {
                 preamble_op: {
                     let mut op = majit_ir::Op::new(
                         majit_ir::OpCode::SameAsI,
-                        &[rooted_resop_box(Type::Int, 14)],
+                        &[Operand::from_boxref(&rooted_resop_box(Type::Int, 14))],
                     );
                     op.pos.set(OpRef::op_typed(14, op.result_type()));
                     std::rc::Rc::new(op)
@@ -6718,7 +6733,7 @@ mod tests {
             },
         );
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 14)]);
+        let mut guard = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 14))]);
         guard.pos.set(OpRef::op_typed(15, guard.result_type()));
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&guard));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -790,7 +790,10 @@ impl Optimizer {
                 .expect("imported virtual leaf missing box.type");
             let same_as_op = majit_ir::OpCode::same_as_for_type(tp);
             let arg0 = ctx.materialize_box_at(*label_arg);
-            let mut op = majit_ir::Op::new(same_as_op, &[majit_ir::operand::Operand::from_boxref(&arg0)]);
+            let mut op = majit_ir::Op::new(
+                same_as_op,
+                &[majit_ir::operand::Operand::from_boxref(&arg0)],
+            );
             op.pos.set(ctx.reserve_pos_typed(tp));
             let fresh = op.pos.get();
             // Op.type_ carries `tp` intrinsically (resoperation.py:1693
@@ -1794,7 +1797,9 @@ impl Optimizer {
             | OpCode::GetarrayitemGcR
             | OpCode::GetarrayitemGcF => {
                 // Check arg(0) is not null constant.
-                if let Some(0) = ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false)) {
+                if let Some(0) =
+                    ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false))
+                {
                     return false; // would deref null
                 }
                 true
@@ -2826,7 +2831,8 @@ impl Optimizer {
                         let same_as = OpCode::same_as_for_type(arg_type);
                         let fresh = ctx.alloc_op_position_typed(arg_type);
                         let arg0 = ctx.materialize_box_at(orig);
-                        let mut op = Op::new(same_as, &[majit_ir::operand::Operand::from_boxref(&arg0)]);
+                        let mut op =
+                            Op::new(same_as, &[majit_ir::operand::Operand::from_boxref(&arg0)]);
                         op.pos.set(fresh);
                         // unroll.py:146 + compile.py:327 parity: accumulate the
                         // alias op in `extra_same_as` and splice it between the
@@ -3057,9 +3063,11 @@ impl Optimizer {
                             if arg.is_none() {
                                 continue;
                             }
-                            let resolved =
-                                ctx.resolve_box_box_opt(&arg.to_boxref()).unwrap_or_else(|| arg.to_boxref());
-                            preamble_op.setarg(i, majit_ir::operand::Operand::from_boxref(&resolved));
+                            let resolved = ctx
+                                .resolve_box_box_opt(&arg.to_boxref())
+                                .unwrap_or_else(|| arg.to_boxref());
+                            preamble_op
+                                .setarg(i, majit_ir::operand::Operand::from_boxref(&resolved));
                         }
                         if let Some(fail_args) = preamble_op.fail_args.borrow_mut().as_mut() {
                             for arg in fail_args.iter_mut() {
@@ -5166,7 +5174,9 @@ mod tests {
         ) -> OptimizationResult {
             if op.opcode == OpCode::IntAdd {
                 // Check if second arg is constant 0
-                if let Some(0) = ctx.get_constant_int_box(&op.arg(1).to_boxref().get_box_replacement(false)) {
+                if let Some(0) =
+                    ctx.get_constant_int_box(&op.arg(1).to_boxref().get_box_replacement(false))
+                {
                     // Replace with first arg
                     let old = op.pos.get();
                     let new = op.arg(0).to_opref();
@@ -5426,7 +5436,13 @@ mod tests {
                 let alloc = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
                 let alloc_box = ctx.materialize_box_at(alloc);
                 let value = ctx.materialize_box_at(OpRef::int_op(0));
-                let mut set = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&alloc_box), Operand::from_boxref(&value)]);
+                let mut set = Op::new(
+                    OpCode::SetfieldGc,
+                    &[
+                        Operand::from_boxref(&alloc_box),
+                        Operand::from_boxref(&value),
+                    ],
+                );
                 set.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set);
             }
@@ -5596,7 +5612,10 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 8)),
                 ],
             ),
-            Op::new(OpCode::Finish, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 9))]),
+            Op::new(
+                OpCode::Finish,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 9))],
+            ),
         ];
         for (idx, op) in ops.iter_mut().enumerate() {
             op.pos
@@ -5757,7 +5776,10 @@ mod tests {
                 Operand::from_boxref(&rooted_resop_box(Type::Int, 9)),
             ],
         );
-        let finish = Op::new(OpCode::Finish, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 9))]);
+        let finish = Op::new(
+            OpCode::Finish,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 9))],
+        );
 
         let mut ops = vec![
             call_a.clone(),
@@ -5848,9 +5870,18 @@ mod tests {
         opt.add_pass(Box::new(AddVirtualInputsOnce { added: false }));
 
         let mut ops = vec![
-            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
-            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
-            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 4))]),
+            Op::new(
+                OpCode::GetfieldRawI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
+            Op::new(
+                OpCode::GetfieldRawI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
+            Op::new(
+                OpCode::GetfieldRawI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 4))],
+            ),
             Op::new(
                 OpCode::IntGt,
                 &[
@@ -5891,9 +5922,18 @@ mod tests {
         }));
 
         let mut ops = vec![
-            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
-            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
-            Op::new(OpCode::GetfieldRawI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::GetfieldRawI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
+            Op::new(
+                OpCode::GetfieldRawI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
+            Op::new(
+                OpCode::GetfieldRawI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
             Op::new(
                 OpCode::IntGt,
                 &[
@@ -5981,7 +6021,10 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))],
+            ),
         ];
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
@@ -6327,7 +6370,10 @@ mod tests {
         let size_descr = make_size_descr(16);
         let field_descr = majit_ir::make_field_descr(8, 8, Type::Int, majit_ir::ArrayFlag::Signed);
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 10))]);
+        let mut guard = Op::new(
+            OpCode::GuardTrue,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 10))],
+        );
         guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], size_descr),
@@ -6517,7 +6563,10 @@ mod tests {
         assert!(opt.protect_speculative_operation(&add_op, &ctx));
 
         // Getfield on unknown arg is safe (not constant null)
-        let get_op = Op::new(OpCode::GetfieldGcI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]);
+        let get_op = Op::new(
+            OpCode::GetfieldGcI,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+        );
         assert!(opt.protect_speculative_operation(&get_op, &ctx));
     }
 
@@ -6733,7 +6782,10 @@ mod tests {
             },
         );
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 14))]);
+        let mut guard = Op::new(
+            OpCode::GuardTrue,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 14))],
+        );
         guard.pos.set(OpRef::op_typed(15, guard.result_type()));
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&guard));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -809,29 +809,29 @@ impl Optimizer {
         // unroll.py:55: if op.get_forwarded() is not None: return
         // Skip heads that already have PtrInfo (duplicate entries from
         // aliased JUMP args sharing the same VirtualState position).
-        // Keyed by the virtual head's Box identity. `materialize_box_at` is
-        // position-stable (a head position resolves to one canonical Box),
-        // so two entries sharing a head dedupe by `Rc::ptr_eq`. The head is
-        // always a NEW (virtual-alloc) ResOp with a producer, so
-        // `get_box_replacement` returns the memoized bound Box that dedupes;
-        // a producer-less head resolves to a fresh unbound box that never
-        // matches, leaving it un-deduped (only costs a redundant idempotent
-        // `set_ptr_info`).
-        let mut installed_heads: majit_ir::vec_set::VecSet<crate::r#box::BoxRef> =
+        // Keyed by the virtual head's producer identity (`Operand` ptr_eq).
+        // A head is normally a NEW (virtual-alloc) ResOp with a producer, so
+        // `get_box_replacement_box` returns the memoized bound box and two
+        // entries sharing a head dedupe. A producer-less head resolves to
+        // None and is never dedupable (matching the prior fresh-unbound-box
+        // behaviour); its `set_ptr_info` is skipped below anyway.
+        let mut installed_heads: majit_ir::vec_set::VecSet<majit_ir::operand::Operand> =
             majit_ir::vec_set::VecSet::new();
         for entry in entries {
-            let head_key = ctx.get_box_replacement(entry.head);
-            if installed_heads.contains(&head_key) {
-                continue;
+            let head_box = ctx.get_box_replacement_box(entry.head);
+            if let Some(hk) = &head_box {
+                let head_key = majit_ir::operand::Operand::from_boxref(hk);
+                if installed_heads.contains(&head_key) {
+                    continue;
+                }
+                installed_heads.insert(head_key);
             }
-            installed_heads.insert(head_key);
             if std::env::var_os("MAJIT_LOG").is_some() {
                 eprintln!(
                     "[jit] install_imported_virtual head={:?} fields={:?}",
                     entry.head, entry.fields
                 );
             }
-            let head_box = ctx.get_box_replacement_box(entry.head);
             match &entry.kind {
                 ImportedVirtualKind::Instance { known_class } => {
                     if let Some(b) = &head_box {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -73,7 +73,7 @@ pub struct Optimizer {
     /// `ctx.get_box_replacement(op.pos)` so insert and lookup agree on the
     /// canonical box. Guard ops are never Const, so the key is always a
     /// ptr-stable ResOp box.
-    replaces_guard: crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, Op>,
+    replaces_guard: crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::operand::Operand, Op>,
     /// optimizer.py: `pendingfields` — heap fields that need to be
     /// written back before the next guard (lazy set forcing).
     pendingfields: Vec<Op>,
@@ -218,7 +218,7 @@ pub struct Optimizer {
     /// matches the optional `required_opnum`. The lookup resolves the
     /// queried opref through `ctx.get_box_replacement` so it compares the
     /// same canonical box the insert recorded.
-    pub emitted_operations: majit_ir::vec_set::VecSet<BoxRef>,
+    pub emitted_operations: majit_ir::vec_set::VecSet<majit_ir::operand::Operand>,
     /// One-shot explicit `input_ops` seed for the next
     /// `optimize_with_constants_and_inputs_at` run. When `Some`, the
     /// canonical producer `Rc<Op>` slice is used directly as
@@ -799,7 +799,7 @@ impl Optimizer {
             // `value_types` write needed (5).
             let op_rc = std::rc::Rc::new(op);
             ctx.emitted_operations
-                .insert(crate::r#box::BoxRef::from_bound_op(&op_rc));
+                .insert(majit_ir::operand::Operand::from_bound_op(&op_rc));
             ctx.new_operations.push(op_rc);
             // Update the field to reference the SameAs result.
             entries[*entry_idx].fields[*field_idx].1 = fresh;
@@ -1238,7 +1238,10 @@ impl Optimizer {
         replacement: Op,
     ) {
         if let Some(box_ref) = ctx.resolve_to_boxref(guard_pos) {
-            self.replaces_guard.insert(box_ref, replacement);
+            self.replaces_guard.insert(
+                majit_ir::operand::Operand::from_boxref(&box_ref),
+                replacement,
+            );
         }
     }
 
@@ -1254,13 +1257,16 @@ impl Optimizer {
         // replaces_guard is keyed by the raw `op` identity (optimizer.py:307),
         // so resolve to the producer box without following `_forwarded`.
         if let Some(box_ref) = ctx.resolve_to_boxref(old_pos) {
-            self.replaces_guard.insert(box_ref, new_guard);
+            self.replaces_guard
+                .insert(majit_ir::operand::Operand::from_boxref(&box_ref), new_guard);
         }
         // optimizer.py:747 `self._emittedoperations[new_op] = None` — new_op is
         // the canonical (get_box_replacement'd) emitted op, so this insert stays
         // canonical, matching the emit-set keying in `_emit_operation`.
         self.emitted_operations
-            .insert(ctx.get_box_replacement(new_pos));
+            .insert(majit_ir::operand::Operand::from_boxref(
+                &ctx.get_box_replacement(new_pos),
+            ));
     }
 
     /// optimizer.py:369-377 `as_operation(op, required_opnum=-1)`:
@@ -1296,8 +1302,20 @@ impl Optimizer {
         // is the producer box (chain root, before `_forwarded`); the emit set is
         // populated with the canonical box, so this matches iff the raw op is the
         // canonical op — exactly PyPy's `op in _emittedoperations`.
+        // A constant is never an emitted op; short-circuit before resolving so
+        // `from_boxref` never mints a throwaway Const key (which would harmlessly
+        // miss anyway, since no Const is ever inserted into the emit set).
+        if opref.is_constant() {
+            return None;
+        }
         match ctx.resolve_to_boxref(opref) {
-            Some(box_ref) if self.emitted_operations.contains(&box_ref) => Some(opref),
+            Some(box_ref)
+                if self
+                    .emitted_operations
+                    .contains(&majit_ir::operand::Operand::from_boxref(&box_ref)) =>
+            {
+                Some(opref)
+            }
             _ => None,
         }
     }
@@ -1672,7 +1690,7 @@ impl Optimizer {
     /// The exported loop state should record the boxes that survive the end of
     /// the preamble after virtuals have been forced into a loop-carried shape.
     pub fn force_at_the_end_of_preamble(&mut self, opref: OpRef, ctx: &mut OptContext) -> OpRef {
-        let mut rec: majit_ir::vec_set::VecSet<crate::r#box::BoxRef> =
+        let mut rec: majit_ir::vec_set::VecSet<majit_ir::operand::Operand> =
             majit_ir::vec_set::VecSet::new();
         self.force_at_the_end_of_preamble_rec(opref, ctx, &mut rec)
     }
@@ -1681,7 +1699,7 @@ impl Optimizer {
         &mut self,
         opref: OpRef,
         ctx: &mut OptContext,
-        rec: &mut majit_ir::vec_set::VecSet<crate::r#box::BoxRef>,
+        rec: &mut majit_ir::vec_set::VecSet<majit_ir::operand::Operand>,
     ) -> OpRef {
         let resolved = ctx.get_replacement_opref(opref);
         let resolved_box = ctx.get_box_replacement_box(opref);
@@ -1725,10 +1743,11 @@ impl Optimizer {
             let resolved_box_key = resolved_box
                 .clone()
                 .expect("virtual PtrInfo implies a resolved box");
-            if rec.contains(&resolved_box_key) {
+            let rec_key = majit_ir::operand::Operand::from_boxref(&resolved_box_key);
+            if rec.contains(&rec_key) {
                 return resolved;
             }
-            rec.insert(resolved_box_key);
+            rec.insert(rec_key);
             info.force_at_the_end_of_preamble(|child| {
                 self.force_at_the_end_of_preamble_rec(child, ctx, rec)
             });
@@ -4016,7 +4035,7 @@ impl Optimizer {
         args: &[OpRef],
         ctx: &mut OptContext,
     ) -> crate::optimizeopt::vec_assoc::VecAssoc<
-        crate::r#box::BoxRef,
+        majit_ir::operand::Operand,
         crate::optimizeopt::intutils::IntBound,
     > {
         let mut exported = crate::optimizeopt::vec_assoc::VecAssoc::new();
@@ -4380,10 +4399,10 @@ impl Optimizer {
             // `orig_op` identity (before get_box_replacement), so resolve to the
             // producer box without following `_forwarded`.
             if self.can_replace_guards {
-                if let Some(replacement) = ctx
-                    .resolve_to_boxref(op.pos.get())
-                    .and_then(|box_ref| self.replaces_guard.remove(&box_ref))
-                {
+                if let Some(replacement) = ctx.resolve_to_boxref(op.pos.get()).and_then(|box_ref| {
+                    self.replaces_guard
+                        .remove(&majit_ir::operand::Operand::from_boxref(&box_ref))
+                }) {
                     let target_pos = replacement.pos.get().raw() as usize;
                     if target_pos < ctx.new_operations.len() {
                         if std::env::var_os("MAJIT_LOG").is_some() {
@@ -4473,7 +4492,9 @@ impl Optimizer {
         // descriptor-sharing or other emit-bound state. Keyed by the
         // emitted op's canonical box (the box-identity analog of `op`).
         self.emitted_operations
-            .insert(ctx.get_box_replacement(emitted));
+            .insert(majit_ir::operand::Operand::from_boxref(
+                &ctx.get_box_replacement(emitted),
+            ));
         // optimizer.py:84-92 `_emit_operation` clears the REMOVED
         // sentinel on each successful emit. Cross-pass readers
         // (rewrite.py:712-718 `optimize_GUARD_NO_EXCEPTION`) see the

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -5,6 +5,7 @@
 /// When the same pure operation is seen again with the same arguments,
 /// the cached result is returned instead of recomputing.
 use majit_ir::{GcRef, Op, OpCode, OpRef, Value};
+use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::{PreambleOp, PtrInfoExt};
@@ -824,7 +825,7 @@ impl OptPure {
     ) -> Option<Value> {
         let mut arg_consts = Vec::with_capacity(op.num_args().saturating_sub(start_index));
         for i in start_index..op.num_args() {
-            let forced = self.force_box(&op.arg(i), ctx);
+            let forced = self.force_box(&op.arg(i).to_boxref(), ctx);
             let Some(const_value) = ctx
                 .get_box_replacement_box(forced)
                 .and_then(|b| ctx.get_constant_box(&b))
@@ -896,7 +897,7 @@ impl Optimization for OptPure {
                 // ops can have non-const args (e.g. `IntMulOvf(p, 1)`
                 // where p is an inputarg).
                 let all_args_const = (0..postponed.num_args()).all(|i| {
-                    ctx.get_constant_box(&postponed.arg(i).get_box_replacement(false))
+                    ctx.get_constant_box(&postponed.arg(i).to_boxref().get_box_replacement(false))
                         .is_some()
                 });
                 if all_args_const {
@@ -965,8 +966,8 @@ impl Optimization for OptPure {
                 // ctx.emit() bypasses that optimizer path, so mirror the
                 // force_box step here before recording the postponed op.
                 for i in 0..postponed.num_args() {
-                    let forced = self.force_box(&postponed.arg(i), ctx);
-                    postponed.setarg(i, ctx.materialize_box_at(forced));
+                    let forced = self.force_box(&postponed.arg(i).to_boxref(), ctx);
+                    postponed.setarg(i, Operand::from_boxref(&ctx.materialize_box_at(forced)));
                 }
                 // Record and emit both the OVF op and the guard.
                 self.cache.insert(key, postponed.pos.get());
@@ -975,8 +976,8 @@ impl Optimization for OptPure {
             } else {
                 // Not a GUARD_NO_OVERFLOW: emit the postponed op now.
                 for i in 0..postponed.num_args() {
-                    let forced = self.force_box(&postponed.arg(i), ctx);
-                    postponed.setarg(i, ctx.materialize_box_at(forced));
+                    let forced = self.force_box(&postponed.arg(i).to_boxref(), ctx);
+                    postponed.setarg(i, Operand::from_boxref(&ctx.materialize_box_at(forced)));
                 }
                 ctx.emit(postponed);
             }
@@ -1016,7 +1017,7 @@ impl Optimization for OptPure {
             //         self.optimizer.make_constant(op, resbox)
             //         return
             let all_args_const = (0..op.num_args()).all(|i| {
-                ctx.get_constant_box(&op.arg(i).get_box_replacement(false))
+                ctx.get_constant_box(&op.arg(i).to_boxref().get_box_replacement(false))
                     .is_some()
             });
             if all_args_const {
@@ -1264,7 +1265,7 @@ impl Optimization for OptPure {
             // objects); reuse them instead of re-deriving position-only
             // echoes from the OpRef table.
             let imported_args = entry.pop.preamble_op.getarglist();
-            let mut imported_op = Op::new(entry.opcode, &imported_args);
+            let mut imported_op = Op::new(entry.opcode, &imported_args.iter().map(Operand::from_boxref).collect::<Vec<_>>());
             imported_op.pos.set(entry.result);
             if let Some(d) = entry.descr.clone() {
                 imported_op.setdescr(d);
@@ -1354,7 +1355,8 @@ mod tests {
                 .and_then(|b| b.produced_short_op(&source_box))
                 .map(|p| p.preamble_op)
                 .unwrap_or_else(|| {
-                    let mut same_as = Op::new(OpCode::SameAsI, &[source_box.clone()]);
+                    let mut same_as =
+                        Op::new(OpCode::SameAsI, &[Operand::from_boxref(&source_box)]);
                     same_as.pos.set(source);
                     std::rc::Rc::new(same_as)
                 });
@@ -1458,9 +1460,10 @@ mod tests {
                     Arg::Const(v) => BoxRef::new_const(*v),
                 })
                 .collect();
+            let arg_ops: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
             let op = match &spec.descr {
-                Some(d) => std::rc::Rc::new(Op::with_descr(spec.opcode, &args, d.clone())),
-                None => std::rc::Rc::new(Op::new(spec.opcode, &args)),
+                Some(d) => std::rc::Rc::new(Op::with_descr(spec.opcode, &arg_ops, d.clone())),
+                None => std::rc::Rc::new(Op::new(spec.opcode, &arg_ops)),
             };
             op.pos.set(OpRef::op_typed(
                 num_inputs + i as u32,
@@ -1798,14 +1801,20 @@ mod tests {
         let b = crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1);
 
         // Simulate: op0 = int_add(a, b)
-        let op0 = Op::new(OpCode::IntAdd, &[a.clone(), b.clone()]);
+        let op0 = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&a), Operand::from_boxref(&b)],
+        );
         let mut op0 = op0;
         op0.pos.set(OpRef::int_op(2));
         let result0 = pass.propagate_forward(&op0, &std::rc::Rc::new(op0.clone()), &mut ctx);
         assert!(matches!(result0, OptimizationResult::PassOn));
 
         // Simulate: op1 = int_add(a, b) with same args
-        let op1 = Op::new(OpCode::IntAdd, &[a, b]);
+        let op1 = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&a), Operand::from_boxref(&b)],
+        );
         let mut op1 = op1;
         op1.pos.set(OpRef::int_op(3));
         let result1 = pass.propagate_forward(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx);
@@ -2178,16 +2187,16 @@ mod tests {
         // a Ref constant; the op carries that same box (no position-only mint).
         let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[struct_box.clone()], descr);
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[Operand::from_boxref(&struct_box)], descr);
         op.pos.set(OpRef::int_op(0));
         pass.setup();
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
         // carries the canonical const box the pass reads via get_constant_box.
         let resolved = ctx
-            .resolve_box_box_opt(&op.arg(0))
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
             .expect("constant arg resolves");
-        op.setarg(0, resolved);
+        op.setarg(0, Operand::from_boxref(&resolved));
 
         assert_eq!(ctx.constant_fold(&op), Some(Value::Int(123)));
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
@@ -2213,16 +2222,16 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureF, &[struct_box.clone()], descr);
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureF, &[Operand::from_boxref(&struct_box)], descr);
         op.pos.set(OpRef::float_op(0));
         pass.setup();
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
         // carries the canonical const box the pass reads via get_constant_box.
         let resolved = ctx
-            .resolve_box_box_opt(&op.arg(0))
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
             .expect("constant arg resolves");
-        op.setarg(0, resolved);
+        op.setarg(0, Operand::from_boxref(&resolved));
 
         assert_eq!(ctx.constant_fold(&op), Some(Value::Float(3.5)));
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
@@ -2250,16 +2259,16 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureR, &[struct_box.clone()], descr);
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureR, &[Operand::from_boxref(&struct_box)], descr);
         op.pos.set(OpRef::ref_op(0));
         pass.setup();
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
         // carries the canonical const box the pass reads via get_constant_box.
         let resolved = ctx
-            .resolve_box_box_opt(&op.arg(0))
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
             .expect("constant arg resolves");
-        op.setarg(0, resolved);
+        op.setarg(0, Operand::from_boxref(&resolved));
 
         assert_eq!(
             ctx.constant_fold(&op),
@@ -2291,15 +2300,15 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let arg_box = ctx.materialize_box_at(OpRef::int_op(10));
         ctx.make_constant_box(&arg_box, Value::Int(2));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[arg_box.clone()], descr);
+        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[Operand::from_boxref(&arg_box)], descr);
         op.pos.set(OpRef::int_op(0));
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
         // carries the canonical const box the pass reads via get_constant_box.
         let resolved = ctx
-            .resolve_box_box_opt(&op.arg(0))
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
             .expect("constant arg resolves");
-        op.setarg(0, resolved);
+        op.setarg(0, Operand::from_boxref(&resolved));
 
         let _ = ctx.constant_fold(&op);
     }
@@ -2358,7 +2367,13 @@ mod tests {
         let x8_box = ctx.materialize_box_at(OpRef::int_op(8));
         pass.pure_from_args2(OpCode::IntAdd, c5_a, x, OpRef::int_op(42));
 
-        let mut q = Op::new(OpCode::IntAdd, &[BoxRef::new_const(Value::Int(5)), x_box]);
+        let mut q = Op::new(
+            OpCode::IntAdd,
+            &[
+                Operand::from_boxref(&BoxRef::new_const(Value::Int(5))),
+                Operand::from_boxref(&x_box),
+            ],
+        );
         q.pos.set(OpRef::int_op(99));
         assert_eq!(
             pass.get_pure_result(&q, &ctx),
@@ -2367,7 +2382,13 @@ mod tests {
         );
 
         // A non-constant slot mismatch must still miss.
-        let mut q_miss = Op::new(OpCode::IntAdd, &[BoxRef::new_const(Value::Int(5)), x8_box]);
+        let mut q_miss = Op::new(
+            OpCode::IntAdd,
+            &[
+                Operand::from_boxref(&BoxRef::new_const(Value::Int(5))),
+                Operand::from_boxref(&x8_box),
+            ],
+        );
         q_miss.pos.set(OpRef::int_op(100));
         assert_eq!(pass.get_pure_result(&q_miss, &ctx), None);
     }
@@ -2392,7 +2413,10 @@ mod tests {
 
         // Query op carries the canonical ctx boxes (query_arg forwards to
         // canonical_arg via make_equal_to) — no position-only mint.
-        let mut q = Op::new(OpCode::IntAdd, &[b_query, b_other]);
+        let mut q = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&b_query), Operand::from_boxref(&b_other)],
+        );
         q.pos.set(OpRef::int_op(99));
         assert_eq!(
             pass.get_pure_result(&q, &ctx),
@@ -2414,12 +2438,18 @@ mod tests {
         let b40 = ctx.materialize_box_at(OpRef::int_op(40));
 
         // Manually record a pure operation via the API
-        let mut op = Op::new(OpCode::IntAdd, &[b10.clone(), b20.clone()]);
+        let mut op = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&b10), Operand::from_boxref(&b20)],
+        );
         op.pos.set(OpRef::int_op(0));
         pass.pure(&op);
 
         // Should find it via get_pure_result
-        let lookup_op = Op::new(OpCode::IntAdd, &[b10, b20]);
+        let lookup_op = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&b10), Operand::from_boxref(&b20)],
+        );
         assert!(pass.get_pure_result(&lookup_op, &ctx).is_some());
 
         // pure_from_args
@@ -2428,7 +2458,10 @@ mod tests {
             &[OpRef::int_op(30), OpRef::int_op(40)],
             OpRef::int_op(5),
         );
-        let mut lookup_mul = Op::new(OpCode::IntMul, &[b30, b40]);
+        let mut lookup_mul = Op::new(
+            OpCode::IntMul,
+            &[Operand::from_boxref(&b30), Operand::from_boxref(&b40)],
+        );
         lookup_mul.pos.set(OpRef::int_op(99));
         assert!(pass.get_pure_result(&lookup_mul, &ctx).is_some());
     }
@@ -2477,21 +2510,34 @@ mod tests {
         });
 
         // CALL_PURE lookup: start_index=0, descr matches (both None), args match
-        let op = Op::new(OpCode::CallPureI, &[b100.clone(), b101.clone()]);
+        let op = Op::new(
+            OpCode::CallPureI,
+            &[Operand::from_boxref(&b100), Operand::from_boxref(&b101)],
+        );
         assert_eq!(
             pass.lookup_known_result(&op, 0, &ctx),
             Some(OpRef::int_op(50))
         );
 
         // COND_CALL_VALUE lookup: start_index=1, skip arg(0)
-        let cond_op = Op::new(OpCode::CondCallValueI, &[b999.clone(), b100.clone(), b101]);
+        let cond_op = Op::new(
+            OpCode::CondCallValueI,
+            &[
+                Operand::from_boxref(&b999),
+                Operand::from_boxref(&b100),
+                Operand::from_boxref(&b101),
+            ],
+        );
         assert_eq!(
             pass.lookup_known_result(&cond_op, 1, &ctx),
             Some(OpRef::int_op(50))
         );
 
         // Args mismatch → None
-        let bad_args = Op::new(OpCode::CallPureI, &[b100, b999]);
+        let bad_args = Op::new(
+            OpCode::CallPureI,
+            &[Operand::from_boxref(&b100), Operand::from_boxref(&b999)],
+        );
         assert_eq!(pass.lookup_known_result(&bad_args, 0, &ctx), None);
     }
 
@@ -2615,7 +2661,10 @@ mod tests {
 
         let mut op = Op::new(
             OpCode::CallPureI,
-            &[BoxRef::new_const(Value::Int(0x1234)), arg0],
+            &[
+                Operand::from_boxref(&BoxRef::new_const(Value::Int(0x1234))),
+                Operand::from_boxref(&arg0),
+            ],
         );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(call_descr);
@@ -2642,7 +2691,10 @@ mod tests {
 
         let a0 = ctx.materialize_box_at(OpRef::int_op(0));
         let a1 = ctx.materialize_box_at(OpRef::int_op(1));
-        let mut op = Op::new(OpCode::IntAdd, &[a0, a1]);
+        let mut op = Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&a0), Operand::from_boxref(&a1)],
+        );
         op.pos.set(OpRef::int_op(2));
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
@@ -2681,7 +2733,14 @@ mod tests {
         let a100 = ctx.materialize_box_at(OpRef::int_op(100));
         let a0 = ctx.materialize_box_at(OpRef::int_op(0));
         let a1 = ctx.materialize_box_at(OpRef::int_op(1));
-        let mut op = Op::new(OpCode::CallPureI, &[a100, a0, a1]);
+        let mut op = Op::new(
+            OpCode::CallPureI,
+            &[
+                Operand::from_boxref(&a100),
+                Operand::from_boxref(&a0),
+                Operand::from_boxref(&a1),
+            ],
+        );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(
             vec![
@@ -2738,7 +2797,10 @@ mod tests {
         pass.setup();
 
         let a0 = ctx.materialize_box_at(OpRef::int_op(0));
-        let mut op = Op::new(OpCode::CallLoopinvariantI, &[func_box.clone(), a0]);
+        let mut op = Op::new(
+            OpCode::CallLoopinvariantI,
+            &[Operand::from_boxref(&func_box), Operand::from_boxref(&a0)],
+        );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(
             vec![majit_ir::Type::Int, majit_ir::Type::Int],
@@ -2753,7 +2815,8 @@ mod tests {
         for i in 0..op.num_args() {
             op.setarg(
                 i,
-                ctx.resolve_box_box_opt(&op.arg(i))
+                ctx.resolve_box_box_opt(&op.arg(i).to_boxref())
+                    .map(|b| Operand::from_boxref(&b))
                     .unwrap_or_else(|| op.arg(i).clone()),
             );
         }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1,3 +1,4 @@
+use majit_ir::operand::Operand;
 /// Pure operation optimization (Common Subexpression Elimination).
 ///
 /// Translated from rpython/jit/metainterp/optimizeopt/pure.py.
@@ -5,7 +6,6 @@
 /// When the same pure operation is seen again with the same arguments,
 /// the cached result is returned instead of recomputing.
 use majit_ir::{GcRef, Op, OpCode, OpRef, Value};
-use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::{PreambleOp, PtrInfoExt};
@@ -1265,7 +1265,13 @@ impl Optimization for OptPure {
             // objects); reuse them instead of re-deriving position-only
             // echoes from the OpRef table.
             let imported_args = entry.pop.preamble_op.getarglist();
-            let mut imported_op = Op::new(entry.opcode, &imported_args.iter().map(Operand::from_boxref).collect::<Vec<_>>());
+            let mut imported_op = Op::new(
+                entry.opcode,
+                &imported_args
+                    .iter()
+                    .map(Operand::from_boxref)
+                    .collect::<Vec<_>>(),
+            );
             imported_op.pos.set(entry.result);
             if let Some(d) = entry.descr.clone() {
                 imported_op.setdescr(d);
@@ -2187,7 +2193,11 @@ mod tests {
         // a Ref constant; the op carries that same box (no position-only mint).
         let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[Operand::from_boxref(&struct_box)], descr);
+        let mut op = Op::with_descr(
+            OpCode::GetfieldGcPureI,
+            &[Operand::from_boxref(&struct_box)],
+            descr,
+        );
         op.pos.set(OpRef::int_op(0));
         pass.setup();
 
@@ -2222,7 +2232,11 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureF, &[Operand::from_boxref(&struct_box)], descr);
+        let mut op = Op::with_descr(
+            OpCode::GetfieldGcPureF,
+            &[Operand::from_boxref(&struct_box)],
+            descr,
+        );
         op.pos.set(OpRef::float_op(0));
         pass.setup();
 
@@ -2259,7 +2273,11 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let struct_box = ctx.materialize_box_at(OpRef::ref_op(10));
         ctx.make_constant_box(&struct_box, Value::Ref(GcRef(ptr)));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureR, &[Operand::from_boxref(&struct_box)], descr);
+        let mut op = Op::with_descr(
+            OpCode::GetfieldGcPureR,
+            &[Operand::from_boxref(&struct_box)],
+            descr,
+        );
         op.pos.set(OpRef::ref_op(0));
         pass.setup();
 
@@ -2300,7 +2318,11 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         let arg_box = ctx.materialize_box_at(OpRef::int_op(10));
         ctx.make_constant_box(&arg_box, Value::Int(2));
-        let mut op = Op::with_descr(OpCode::GetfieldGcPureI, &[Operand::from_boxref(&arg_box)], descr);
+        let mut op = Op::with_descr(
+            OpCode::GetfieldGcPureI,
+            &[Operand::from_boxref(&arg_box)],
+            descr,
+        );
         op.pos.set(OpRef::int_op(0));
 
         // Resolve forwarded args (mirrors propagate_from_pass_range) so the op
@@ -2415,7 +2437,10 @@ mod tests {
         // canonical_arg via make_equal_to) — no position-only mint.
         let mut q = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&b_query), Operand::from_boxref(&b_other)],
+            &[
+                Operand::from_boxref(&b_query),
+                Operand::from_boxref(&b_other),
+            ],
         );
         q.pos.set(OpRef::int_op(99));
         assert_eq!(

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -132,7 +132,7 @@ impl Renamer {
         for i in 0..op.num_args() {
             let arg = op.arg(i);
             if let Some(renamed) = self.rename_map.get(&arg.to_opref()) {
-                op.setarg(i, renamed.clone());
+                op.setarg(i, majit_ir::operand::Operand::from_boxref(&renamed.clone()));
             }
         }
 

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -3,40 +3,122 @@
 //! Mirrors RPython's `optimizeopt/renamer.py`.
 //! Used during loop unrolling to rename OpRefs from one iteration to the next.
 
-use majit_ir::{Op, OpRef};
+use std::rc::Rc;
+
+use majit_ir::resoperation::{Op, OpCode, OpRc};
+use majit_ir::{InputArg, OpRef, Type};
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::vec_assoc::VecAssoc;
 
 /// renamer.py:3-58: Renamer — maps old OpRefs to new OpRefs during unrolling.
+///
+/// RPython `rename_map` maps box→box (`renamer.py:5`): the value IS the
+/// renamed-to box OBJECT, and `rename` does `op.setarg(i, rename_map.get(arg,
+/// arg))` — a BOUND box. pyre's `Op.args` carry `Operand`, which sheds a bound
+/// box (`Operand::Op` / `Operand::InputArg`) but mints a position-only
+/// `Operand::Box` for an unbound `from_opref` box. So the map value here is the
+/// renamed position's BOUND producer box; `rename` re-installs it directly,
+/// never re-deriving a position-only box. `to_opref()` of every renamed arg /
+/// failarg is byte-identical to the old position-keyed map (same renamed
+/// `OpRef`), so the only observable change is the box KIND (bound vs
+/// position-only).
 pub struct Renamer {
-    rename_map: VecAssoc<OpRef, OpRef>,
+    rename_map: VecAssoc<OpRef, BoxRef>,
+    /// Producer `Rc`s minted by [`Renamer::bound_box`] to back the bound map
+    /// values. The bound `BoxRef` holds only a `Weak<Op>` / `Weak<InputArg>`,
+    /// so its producer must be rooted for the upgrade to stay live. The
+    /// vectorizer's op buffers are `Vec<Op>` (value, not `Rc`), so no live
+    /// producer `Rc` is reachable for a renamed-to ResOp position; the renamer
+    /// synthesises one carrying the exact renamed `pos` (immutable once the
+    /// rename is registered — unroll / clone set the copied op's `pos` once and
+    /// never re-number it), so `from_bound_op(&rc).to_opref()` equals the
+    /// renamed `OpRef` byte-for-byte. Identity (`Rc::ptr_eq`) is irrelevant: the
+    /// dormant vectorizer keys every map by `OpRef`, never by box identity.
+    producer_roots: Vec<Rc<dyn std::any::Any>>,
 }
 
 impl Renamer {
     pub fn new() -> Self {
         Renamer {
             rename_map: VecAssoc::new(),
+            producer_roots: Vec::new(),
         }
     }
 
-    fn lookup(&self, opref: OpRef) -> Option<OpRef> {
-        self.rename_map.get(&opref).copied()
+    fn lookup(&self, opref: OpRef) -> Option<BoxRef> {
+        self.rename_map.get(&opref).cloned()
+    }
+
+    /// Like [`Renamer::rename_box`] but returns the BOUND map value (not just
+    /// its `OpRef`) on a hit, so callers that re-install an op arg / failarg can
+    /// carry the bound box directly instead of re-deriving a position-only box.
+    /// `None` on a miss (the caller leaves the existing operand untouched).
+    pub fn lookup_box(&self, opref: OpRef) -> Option<BoxRef> {
+        self.lookup(opref)
     }
 
     /// renamer.py:7-8: rename_box — look up the renamed OpRef.
-    /// Returns the original if no mapping exists.
+    /// Returns the original if no mapping exists. The map value is now a bound
+    /// box, so read its `to_opref()` — byte-identical to the old position-keyed
+    /// value.
     pub fn rename_box(&self, opref: OpRef) -> OpRef {
-        self.lookup(opref).unwrap_or(opref)
+        self.lookup(opref).map(|b| b.to_opref()).unwrap_or(opref)
     }
 
-    /// renamer.py:10-18: start_renaming — register a mapping from var to tovar.
+    /// Materialise a BOUND `BoxRef` for `r` whose `to_opref()` equals `r`,
+    /// rooting a synthetic producer so the bound box's `Weak` stays live.
+    ///
+    /// Const / None positions shed to `Operand::Const` / none through
+    /// `BoxRef::from_opref` (no `Operand::Box` mint). ResOp / InputArg positions
+    /// bind to a freshly-minted, rooted producer `Rc` carrying the same `pos`,
+    /// so they shed to `Operand::Op` / `Operand::InputArg`. This is the
+    /// production analogue of the test fixtures' `rooted_resop_box` /
+    /// `rooted_inputarg_box`: a real producer `Rc` is unavailable because the
+    /// vectorizer's buffers hold `Op` values, not `OpRc`.
+    pub fn bound_box(&mut self, r: OpRef) -> BoxRef {
+        if r.is_none() || r.is_constant() {
+            return BoxRef::from_opref(r);
+        }
+        let ty = r.ty().unwrap_or(Type::Void);
+        let pos = r.raw();
+        match r {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = Rc::new(InputArg::from_type(ty, pos));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                self.producer_roots.push(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let op: OpRc = Rc::new(Op::new(opcode, &[]));
+                op.pos.set(OpRef::op_typed(pos, ty));
+                let b = BoxRef::from_bound_op(&op);
+                self.producer_roots.push(op);
+                b
+            }
+        }
+    }
+
+    /// renamer.py:10-18: start_renaming — register a mapping from `var` to
+    /// `tovar`.
+    ///
+    /// The renamed-to position is bound to a rooted producer box (see
+    /// [`Renamer::bound_box`]) so `rename` re-installs a BOUND operand. The
+    /// `tovar.is_constant()` skip is kept (renamer.py:16-17): a constant in the
+    /// rename target is never installed (constants are not allowed in failargs).
     pub fn start_renaming(&mut self, var: OpRef, tovar: OpRef) {
         // renamer.py:16-17: don't rename constants.
         if tovar.is_constant() {
             return;
         }
-        self.rename_map.insert(var, tovar);
+        let bound = self.bound_box(tovar);
+        self.rename_map.insert(var, bound);
     }
 
     /// renamer.py:20-31: rename — apply renaming to all args and fail_args of an op.
@@ -45,10 +127,12 @@ impl Renamer {
         //   for i, arg in enumerate(op.getarglist()):
         //       arg = self.rename_map.get(arg, arg)
         //       op.setarg(i, arg)
+        // A hit re-installs the BOUND map value directly (no position-only
+        // re-derivation); a miss leaves the existing operand untouched.
         for i in 0..op.num_args() {
             let arg = op.arg(i);
-            if let Some(&renamed) = self.rename_map.get(&arg.to_opref()) {
-                op.setarg(i, BoxRef::from_opref(renamed));
+            if let Some(renamed) = self.rename_map.get(&arg.to_opref()) {
+                op.setarg(i, renamed.clone());
             }
         }
 
@@ -60,8 +144,7 @@ impl Renamer {
             if let Some(fail_args) = op.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
                     if let Some(renamed) = self.lookup(arg.to_opref()) {
-                        *arg =
-                            majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(renamed));
+                        *arg = majit_ir::operand::Operand::from_boxref(&renamed);
                     }
                 }
             }
@@ -74,7 +157,7 @@ impl Renamer {
     pub fn rename_failargs(&self, fail_args: &[OpRef]) -> Vec<OpRef> {
         fail_args
             .iter()
-            .map(|arg| self.lookup(*arg).unwrap_or(*arg))
+            .map(|arg| self.rename_box(*arg))
             .collect()
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -155,10 +155,7 @@ impl Renamer {
 
     /// renamer.py:33-42: rename_failargs — rename a slice of fail_args.
     pub fn rename_failargs(&self, fail_args: &[OpRef]) -> Vec<OpRef> {
-        fail_args
-            .iter()
-            .map(|arg| self.rename_box(*arg))
-            .collect()
+        fail_args.iter().map(|arg| self.rename_box(*arg)).collect()
     }
 
     /// renamer.py:44-57: rename_rd_snapshot — recursively rename snapshot boxes.

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1,10 +1,10 @@
+use majit_ir::operand::Operand;
 /// OptRewrite: algebraic simplification and constant folding.
 ///
 /// Translated from rpython/jit/metainterp/optimizeopt/rewrite.py.
 /// Rewrites operations into equivalent, cheaper operations.
 /// This includes constant folding for pure ops and algebraic identities.
 use majit_ir::{Op, OpCode, OpRef, Value};
-use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::{PreambleOp, PtrInfoExt};
@@ -185,7 +185,10 @@ impl OptRewrite {
                 let shift = divisor.trailing_zeros();
                 let shift_ref = self.emit_constant_int(ctx, shift as i64);
                 let arg_shift = ctx.materialize_box_at(shift_ref);
-                let result_ref = ctx.emit(Op::new(OpCode::IntRshift, &[arg0, Operand::from_boxref(&arg_shift)]));
+                let result_ref = ctx.emit(Op::new(
+                    OpCode::IntRshift,
+                    &[arg0, Operand::from_boxref(&arg_shift)],
+                ));
                 let b_old = BoxRef::from_bound_op(op_rc);
                 let b_res = ctx.get_box_replacement(result_ref);
                 ctx.make_equal_to(&b_old, &b_res);
@@ -375,7 +378,10 @@ impl OptRewrite {
                 {
                     let zero = self.emit_constant_int(ctx, 0);
                     let arg_zero = ctx.materialize_box_at(zero);
-                    let mut new_op = Op::new(OpCode::IntLt, &[inner.arg(0), Operand::from_boxref(&arg_zero)]);
+                    let mut new_op = Op::new(
+                        OpCode::IntLt,
+                        &[inner.arg(0), Operand::from_boxref(&arg_zero)],
+                    );
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -712,7 +718,9 @@ impl OptRewrite {
                 // previous gating on get_constant_int dropped the Ref
                 // case entirely so prior GUARD_NONNULL/GUARD_CLASS were
                 // never strengthened to GUARD_VALUE for Ref-typed args.
-                if let Some(c_value) = ctx.resolve_box_box_opt(&arg1.to_boxref()).and_then(|b| b.const_value())
+                if let Some(c_value) = ctx
+                    .resolve_box_box_opt(&arg1.to_boxref())
+                    .and_then(|b| b.const_value())
                 {
                     // rewrite.py:321-323: c_value.nonnull(). ConstInt.nonnull
                     // == (value != 0); ConstPtr.nonnull == (gcref != null).
@@ -837,13 +845,16 @@ impl OptRewrite {
         // ResumeAtPositionDescr — RPython's fresh ResumeGuardDescr() at
         // line 417 must not overwrite a RAPD marker (rewrite.py:421-422
         // "old descr must not be ResumeAtPositionDescr").
-        if let Some(old_guard) = ctx.get_last_guard(&op.arg(0).to_boxref().get_box_replacement(false)) {
+        if let Some(old_guard) =
+            ctx.get_last_guard(&op.arg(0).to_boxref().get_box_replacement(false))
+        {
             if old_guard.opcode == OpCode::GuardNonnull
                 && op.num_args() >= 2
                 && ctx.can_replace_guards
             {
                 // last_guard_pos is a _newoperations index.
-                let old_guard_idx = ctx.last_guard_pos(&op.arg(0).to_boxref().get_box_replacement(false));
+                let old_guard_idx =
+                    ctx.last_guard_pos(&op.arg(0).to_boxref().get_box_replacement(false));
                 if let Some(old_idx) = old_guard_idx
                     && !ctx.is_resume_at_position_guard(old_idx as i32)
                 {
@@ -1099,7 +1110,12 @@ impl OptRewrite {
             {
                 if shift_op.opcode == OpCode::IntLshift
                     && shift_op.num_args() >= 2
-                    && shift_op.arg(0).to_boxref().get_box_replacement(false).const_int() == Some(1)
+                    && shift_op
+                        .arg(0)
+                        .to_boxref()
+                        .get_box_replacement(false)
+                        .const_int()
+                        == Some(1)
                 {
                     let shiftvar = ctx.resolve_box_box(&shift_op.arg(1).to_boxref()).to_opref();
                     let shiftbound = {
@@ -1108,7 +1124,8 @@ impl OptRewrite {
                     };
                     if shiftbound.known_nonnegative() && shiftbound.known_lt_const(63) {
                         let arg_shift = ctx.materialize_box_at(shiftvar);
-                        let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, Operand::from_boxref(&arg_shift)]);
+                        let mut rshift_op =
+                            Op::new(OpCode::IntRshift, &[arg1, Operand::from_boxref(&arg_shift)]);
                         rshift_op.pos.set(op.pos.get());
                         ctx.emit_extra(ctx.current_pass_idx, rshift_op);
                         ctx.last_op_removed = true;
@@ -1146,7 +1163,8 @@ impl OptRewrite {
             let shift = val.trailing_zeros() as i64;
             let shift_const = ctx.make_constant_int(shift);
             let arg_shift = ctx.materialize_box_at(shift_const);
-            let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, Operand::from_boxref(&arg_shift)]);
+            let mut rshift_op =
+                Op::new(OpCode::IntRshift, &[arg1, Operand::from_boxref(&arg_shift)]);
             rshift_op.pos.set(op.pos.get());
             ctx.emit_extra(ctx.current_pass_idx, rshift_op);
             ctx.last_op_removed = true;
@@ -1354,7 +1372,13 @@ impl OptRewrite {
                 let idx_const = ctx.make_constant_int(index + source_start);
                 let arg_source = ctx.materialize_box_at(source_box);
                 let arg_idx = ctx.materialize_box_at(idx_const);
-                let mut getop = Op::new(opcode, &[Operand::from_boxref(&arg_source), Operand::from_boxref(&arg_idx)]);
+                let mut getop = Op::new(
+                    opcode,
+                    &[
+                        Operand::from_boxref(&arg_source),
+                        Operand::from_boxref(&arg_idx),
+                    ],
+                );
                 getop.setdescr(arraydescr.clone());
                 let pos = ctx.emit_extra(pass_idx, getop);
                 Some(pos)
@@ -1378,7 +1402,14 @@ impl OptRewrite {
                 let arg_dest = ctx.materialize_box_at(dest_box);
                 let arg_idx = ctx.materialize_box_at(idx_const);
                 let arg_val = ctx.materialize_box_at(val);
-                let mut setop = Op::new(OpCode::SetarrayitemGc, &[Operand::from_boxref(&arg_dest), Operand::from_boxref(&arg_idx), Operand::from_boxref(&arg_val)]);
+                let mut setop = Op::new(
+                    OpCode::SetarrayitemGc,
+                    &[
+                        Operand::from_boxref(&arg_dest),
+                        Operand::from_boxref(&arg_idx),
+                        Operand::from_boxref(&arg_val),
+                    ],
+                );
                 setop.setdescr(arraydescr.clone());
                 ctx.emit_extra(pass_idx, setop);
             }
@@ -1568,7 +1599,8 @@ impl OptRewrite {
                 if Self::is_exact_power_of_two(reciprocal) {
                     let recip_ref = self.emit_constant_float(ctx, reciprocal);
                     let arg_recip = ctx.materialize_box_at(recip_ref);
-                    let mut new_op = Op::new(OpCode::FloatMul, &[arg0, Operand::from_boxref(&arg_recip)]);
+                    let mut new_op =
+                        Op::new(OpCode::FloatMul, &[arg0, Operand::from_boxref(&arg_recip)]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -1762,7 +1794,9 @@ impl Optimization for OptRewrite {
                 //     if info and info.is_null():
                 //         raise InvalidLoop(...)
                 //     return self.optimize_GUARD_CLASS(op)
-                if let Some(info) = ctx.getptrinfo(&op.arg(0).to_boxref().get_box_replacement(false)) {
+                if let Some(info) =
+                    ctx.getptrinfo(&op.arg(0).to_boxref().get_box_replacement(false))
+                {
                     if info.is_null() {
                         return raise_invalid_loop("GUARD_NONNULL_CLASS proven to always fail");
                     }
@@ -1814,13 +1848,23 @@ impl Optimization for OptRewrite {
 
             // ── Conditional calls ──
             OpCode::CondCallN => {
-                if let Some(0) = ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false)) {
+                if let Some(0) =
+                    ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false))
+                {
                     ctx.last_op_removed = true;
                     return OptimizationResult::Remove;
                 }
-                if let Some(c) = ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false)) {
+                if let Some(c) =
+                    ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false))
+                {
                     if c != 0 {
-                        let mut call_op = Op::new(OpCode::CallN, &op.getarglist()[1..].iter().map(Operand::from_boxref).collect::<Vec<_>>());
+                        let mut call_op = Op::new(
+                            OpCode::CallN,
+                            &op.getarglist()[1..]
+                                .iter()
+                                .map(Operand::from_boxref)
+                                .collect::<Vec<_>>(),
+                        );
                         call_op.pos.set(op.pos.get());
                         if let Some(d) = op.getdescr() {
                             call_op.setdescr(d);
@@ -1850,7 +1894,13 @@ impl Optimization for OptRewrite {
                     } else {
                         OpCode::CallPureR
                     };
-                    let mut call_op = Op::new(call_opcode, &op.getarglist()[1..].iter().map(Operand::from_boxref).collect::<Vec<_>>());
+                    let mut call_op = Op::new(
+                        call_opcode,
+                        &op.getarglist()[1..]
+                            .iter()
+                            .map(Operand::from_boxref)
+                            .collect::<Vec<_>>(),
+                    );
                     call_op.pos.set(op.pos.get());
                     if let Some(d) = op.getdescr() {
                         call_op.setdescr(d);
@@ -2011,7 +2061,8 @@ impl Optimization for OptRewrite {
             | OpCode::CallLoopinvariantR
             | OpCode::CallLoopinvariantF
             | OpCode::CallLoopinvariantN => {
-                if let Some(func_val) = op.arg(0).to_boxref().get_box_replacement(false).const_int() {
+                if let Some(func_val) = op.arg(0).to_boxref().get_box_replacement(false).const_int()
+                {
                     // RPython: LoopInvariantOp.produce_op stores PreambleOp
                     // in loop_invariant_results during import. Transfer from
                     // ctx.imported_loop_invariant_results on first access.
@@ -2037,7 +2088,8 @@ impl Optimization for OptRewrite {
                             // dual-slot rule (mod.rs:1817 replay_pos).
                             let replay_pos = ctx.get_replacement_opref(source);
                             let source_box = ctx.materialize_box_at(source);
-                            let mut replay = Op::new(OpCode::SameAsI, &[Operand::from_boxref(&source_box)]);
+                            let mut replay =
+                                Op::new(OpCode::SameAsI, &[Operand::from_boxref(&source_box)]);
                             replay.pos.set(replay_pos);
                             self.loop_invariant_results.insert(
                                 func_val,
@@ -2146,10 +2198,15 @@ impl Optimization for OptRewrite {
             // upstream passes `op.getarg(0)` raw without a prior
             // `get_box_replacement` resolution. Pyre matches.
             OpCode::RecordExactValueI | OpCode::RecordExactValueR => {
-                let val = op.arg(1).to_boxref().get_box_replacement(false).const_value().expect(
-                    "rewrite.py:400 — RECORD_EXACT_VALUE expectedconstbox \
+                let val = op
+                    .arg(1)
+                    .to_boxref()
+                    .get_box_replacement(false)
+                    .const_value()
+                    .expect(
+                        "rewrite.py:400 — RECORD_EXACT_VALUE expectedconstbox \
                      must be a Const",
-                );
+                    );
                 ctx.make_constant_arg(&op.arg(0).to_boxref(), val);
                 OptimizationResult::Remove
             }
@@ -2253,7 +2310,12 @@ impl Optimization for OptRewrite {
             }
             OpCode::GuardValue => {
                 if op.num_args() >= 2 {
-                    if let Some(val) = op.arg(1).to_boxref().get_box_replacement(false).const_value() {
+                    if let Some(val) = op
+                        .arg(1)
+                        .to_boxref()
+                        .get_box_replacement(false)
+                        .const_value()
+                    {
                         ctx.make_constant_arg(&op.arg(0).to_boxref(), val);
                     }
                 }
@@ -2920,9 +2982,9 @@ mod tests {
                 // optimizer.py:651-652 setarg loop parity.
                 for i in 0..resolved.num_args() {
                     resolved.setarg(
-                    i,
-                    Operand::from_boxref(&ctx.resolve_box_box(&resolved.arg(i).to_boxref())),
-                );
+                        i,
+                        Operand::from_boxref(&ctx.resolve_box_box(&resolved.arg(i).to_boxref())),
+                    );
                 }
                 let __pf_rc = std::rc::Rc::new(resolved.clone());
                 ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -4,6 +4,7 @@
 /// Rewrites operations into equivalent, cheaper operations.
 /// This includes constant folding for pure ops and algebraic identities.
 use majit_ir::{Op, OpCode, OpRef, Value};
+use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::{PreambleOp, PtrInfoExt};
@@ -120,9 +121,9 @@ impl OptRewrite {
 
         // Constant fold
         if let (Some(a), Some(b)) = (
-            ctx.resolve_box_box_opt(&arg0)
+            ctx.resolve_box_box_opt(&arg0.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
-            ctx.resolve_box_box_opt(&arg1)
+            ctx.resolve_box_box_opt(&arg1.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
         ) {
             if let Some(result) = self.try_fold_binary_int(OpCode::IntFloorDiv, a, b) {
@@ -134,18 +135,18 @@ impl OptRewrite {
 
         // x // 1 -> x (identity)
         if let Some(1) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx.resolve_box_box(&arg0);
+            let b_arg = ctx.resolve_box_box(&arg0.to_boxref());
             ctx.make_equal_to(&b_old, &b_arg);
             return OptimizationResult::Remove;
         }
 
         // x // (-1) -> INT_NEG(x)
         if let Some(-1) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let mut neg = Op::new(OpCode::IntNeg, &[arg0]);
@@ -155,7 +156,7 @@ impl OptRewrite {
 
         // 0 // x -> 0 (zero dividend)
         if let Some(0) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b = ctx.materialize_box_at(op.pos.get());
@@ -165,8 +166,8 @@ impl OptRewrite {
 
         // x // x -> 1 (self-division, x != 0 guaranteed by semantics)
         if ctx
-            .resolve_box_box(&arg0)
-            .same_box(&ctx.resolve_box_box(&arg1))
+            .resolve_box_box(&arg0.to_boxref())
+            .same_box(&ctx.resolve_box_box(&arg1.to_boxref()))
         {
             let b = ctx.materialize_box_at(op.pos.get());
             ctx.make_constant_box(&b, Value::Int(1));
@@ -175,7 +176,7 @@ impl OptRewrite {
 
         // Strength reduction for constant divisor >= 2
         if let Some(divisor) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if divisor > 1 && divisor.count_ones() == 1 {
@@ -184,7 +185,7 @@ impl OptRewrite {
                 let shift = divisor.trailing_zeros();
                 let shift_ref = self.emit_constant_int(ctx, shift as i64);
                 let arg_shift = ctx.materialize_box_at(shift_ref);
-                let result_ref = ctx.emit(Op::new(OpCode::IntRshift, &[arg0, arg_shift]));
+                let result_ref = ctx.emit(Op::new(OpCode::IntRshift, &[arg0, Operand::from_boxref(&arg_shift)]));
                 let b_old = BoxRef::from_bound_op(op_rc);
                 let b_res = ctx.get_box_replacement(result_ref);
                 ctx.make_equal_to(&b_old, &b_res);
@@ -196,7 +197,7 @@ impl OptRewrite {
                 // rewrite.py:770 `known_nonneg = b1.known_nonnegative()`:
                 // a non-negative dividend skips the sign-correction ops.
                 let known_nonneg = ctx
-                    .resolve_box_box_opt(&arg0)
+                    .resolve_box_box_opt(&arg0.to_boxref())
                     .and_then(|b| ctx.peek_intbound_box(&b))
                     .map_or(false, |bound| bound.known_nonnegative());
                 let result = intdiv::division_operations(
@@ -230,9 +231,9 @@ impl OptRewrite {
 
         // Constant fold
         if let (Some(a), Some(b)) = (
-            ctx.resolve_box_box_opt(&arg0)
+            ctx.resolve_box_box_opt(&arg0.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
-            ctx.resolve_box_box_opt(&arg1)
+            ctx.resolve_box_box_opt(&arg1.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
         ) {
             if let Some(result) = self.try_fold_binary_int(OpCode::IntMod, a, b) {
@@ -244,7 +245,7 @@ impl OptRewrite {
 
         // x % 1 -> 0 (any integer mod 1 is 0)
         if let Some(1) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b = ctx.materialize_box_at(op.pos.get());
@@ -254,7 +255,7 @@ impl OptRewrite {
 
         // x % (-1) -> 0 (any integer mod -1 is 0)
         if let Some(-1) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b = ctx.materialize_box_at(op.pos.get());
@@ -264,7 +265,7 @@ impl OptRewrite {
 
         // 0 % x -> 0 (zero dividend)
         if let Some(0) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b = ctx.materialize_box_at(op.pos.get());
@@ -274,8 +275,8 @@ impl OptRewrite {
 
         // x % x -> 0 (self-modulo)
         if ctx
-            .resolve_box_box(&arg0)
-            .same_box(&ctx.resolve_box_box(&arg1))
+            .resolve_box_box(&arg0.to_boxref())
+            .same_box(&ctx.resolve_box_box(&arg1.to_boxref()))
         {
             let b = ctx.materialize_box_at(op.pos.get());
             ctx.make_constant_box(&b, Value::Int(0));
@@ -284,14 +285,14 @@ impl OptRewrite {
 
         // Strength reduction for constant divisor >= 3 (non-power-of-2)
         if let Some(divisor) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if divisor >= 3 && divisor.count_ones() != 1 {
                 // rewrite.py:809 `known_nonneg = b1.known_nonnegative()`:
                 // a non-negative dividend skips the sign-correction ops.
                 let known_nonneg = ctx
-                    .resolve_box_box_opt(&arg0)
+                    .resolve_box_box_opt(&arg0.to_boxref())
                     .and_then(|b| ctx.peek_intbound_box(&b))
                     .map_or(false, |bound| bound.known_nonnegative());
                 let result = intdiv::modulo_operations(
@@ -347,16 +348,16 @@ impl OptRewrite {
         // pointing into a virtual raw buffer) skips the is_bool
         // shortcut because the buffer pointer's intbound is unrelated
         // to its boolean truthiness.
-        let arg0_is_raw = ctx.is_raw_ptr(&op.arg(0).get_box_replacement(false));
+        let arg0_is_raw = ctx.is_raw_ptr(&op.arg(0).to_boxref().get_box_replacement(false));
         if !arg0_is_raw {
             if let Some(bound) = ctx
-                .resolve_box_box_opt(&arg0)
+                .resolve_box_box_opt(&arg0.to_boxref())
                 .and_then(|b| ctx.peek_intbound_box(&b))
             {
                 if bound.is_bool() {
                     // make_equal_to: replace INT_IS_TRUE result with arg0.
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_arg = ctx.resolve_box_box(&arg0);
+                    let b_arg = ctx.resolve_box_box(&arg0.to_boxref());
                     ctx.make_equal_to(&b_old, &b_arg);
                     return OptimizationResult::Remove;
                 }
@@ -365,16 +366,16 @@ impl OptRewrite {
 
         // is_true_and_minint: int_is_true(int_and(x, MININT)) => int_lt(x, 0)
         if let Some(inner) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|pb| ctx.get_producing_op(&pb))
         {
             if inner.opcode == OpCode::IntAnd {
-                if ctx.get_constant_int_box(&inner.arg(1).get_box_replacement(false))
+                if ctx.get_constant_int_box(&inner.arg(1).to_boxref().get_box_replacement(false))
                     == Some(i64::MIN)
                 {
                     let zero = self.emit_constant_int(ctx, 0);
                     let arg_zero = ctx.materialize_box_at(zero);
-                    let mut new_op = Op::new(OpCode::IntLt, &[inner.arg(0), arg_zero]);
+                    let mut new_op = Op::new(OpCode::IntLt, &[inner.arg(0), Operand::from_boxref(&arg_zero)]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -399,8 +400,8 @@ impl OptRewrite {
         //     arg1 = get_box_replacement(op.getarg(1))
         //     info0 = getptrinfo(arg0)
         //     info1 = getptrinfo(arg1)
-        let info0 = ctx.getptrinfo(&op.arg(0).get_box_replacement(false));
-        let info1 = ctx.getptrinfo(&op.arg(1).get_box_replacement(false));
+        let info0 = ctx.getptrinfo(&op.arg(0).to_boxref().get_box_replacement(false));
+        let info1 = ctx.getptrinfo(&op.arg(1).to_boxref().get_box_replacement(false));
 
         let is_virtual0 = info0.as_ref().is_some_and(|i| i.is_virtual());
         let is_virtual1 = info1.as_ref().is_some_and(|i| i.is_virtual());
@@ -413,8 +414,8 @@ impl OptRewrite {
                 // other` for non-Const infos), via getptrinfo_handle which
                 // preserves the `_forwarded` cell identity.
                 let same = match (
-                    ctx.getptrinfo_handle(&op.arg(0).get_box_replacement(false)),
-                    ctx.getptrinfo_handle(&op.arg(1).get_box_replacement(false)),
+                    ctx.getptrinfo_handle(&op.arg(0).to_boxref().get_box_replacement(false)),
+                    ctx.getptrinfo_handle(&op.arg(1).to_boxref().get_box_replacement(false)),
                 ) {
                     (Some(h0), Some(h1)) => h0.same_info(&h1),
                     _ => false,
@@ -434,8 +435,8 @@ impl OptRewrite {
         }
 
         // rewrite.py:528-531: null checks — fall back to OpRef for downstream
-        let arg0 = ctx.resolve_box_box(&op.arg(0)).to_opref();
-        let arg1 = ctx.resolve_box_box(&op.arg(1)).to_opref();
+        let arg0 = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+        let arg1 = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
         if info1.as_ref().is_some_and(|i| i.is_null()) {
             return self.optimize_nullness(op, arg0, expect_isnot, ctx);
         }
@@ -521,7 +522,7 @@ impl OptRewrite {
         let arg0 = op.arg(0);
 
         if let Some(a) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b = ctx.materialize_box_at(op.pos.get());
@@ -531,12 +532,12 @@ impl OptRewrite {
 
         // force_ge_zero_pos: int_force_ge_zero(x) => x (if x known nonneg)
         if let Some(bound) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|b| ctx.peek_intbound_box(&b))
         {
             if bound.known_nonnegative() {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx.resolve_box_box(&arg0);
+                let b_arg = ctx.resolve_box_box(&arg0.to_boxref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 return OptimizationResult::Remove;
             }
@@ -558,11 +559,11 @@ impl OptRewrite {
         let arg2 = op.arg(2);
 
         if let (Some(a), Some(b), Some(c)) = (
-            ctx.resolve_box_box_opt(&arg0)
+            ctx.resolve_box_box_opt(&arg0.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
-            ctx.resolve_box_box_opt(&arg1)
+            ctx.resolve_box_box_opt(&arg1.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
-            ctx.resolve_box_box_opt(&arg2)
+            ctx.resolve_box_box_opt(&arg2.to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b)),
         ) {
             let result = (a <= b && b < c) as i64;
@@ -606,7 +607,7 @@ impl OptRewrite {
         // which catches values narrowed to a single point by bounds analysis,
         // not just the constant pool.
         if let Some(val) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|b| ctx.get_constant_int_or_bound_box(&b))
         {
             if val != 0 {
@@ -624,7 +625,7 @@ impl OptRewrite {
 
         // rewrite.py:165-168: box.type=='i' checks intbound.is_constant().
         if let Some(val) = ctx
-            .resolve_box_box_opt(&arg0)
+            .resolve_box_box_opt(&arg0.to_boxref())
             .and_then(|b| ctx.get_constant_int_or_bound_box(&b))
         {
             if val == 0 {
@@ -659,11 +660,11 @@ impl OptRewrite {
         // arg0 is constant without checking equality, so we mirror that by
         // removing on equality but never raising on mismatch.
         if let Some(expected_int) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             if let Some(actual_int) = ctx
-                .resolve_box_box_opt(&arg0)
+                .resolve_box_box_opt(&arg0.to_boxref())
                 .and_then(|b| ctx.get_constant_int_or_bound_box(&b))
             {
                 if actual_int == expected_int {
@@ -672,9 +673,9 @@ impl OptRewrite {
                 return raise_invalid_loop("GUARD_VALUE proven to always fail");
             }
         } else if let (Some(actual), Some(expected)) = (
-            ctx.resolve_box_box_opt(&arg0)
+            ctx.resolve_box_box_opt(&arg0.to_boxref())
                 .and_then(|b| ctx.get_constant_box(&b)),
-            ctx.resolve_box_box_opt(&arg1)
+            ctx.resolve_box_box_opt(&arg1.to_boxref())
                 .and_then(|cb| cb.const_value()),
         ) {
             if actual == expected {
@@ -694,7 +695,7 @@ impl OptRewrite {
         // rewrite.py:284-301: optimize_GUARD_VALUE for Ref args.
         // getptrinfo synthesizes ConstPtrInfo for constant Refs, matching
         // `if info:` in RPython (which is True for ConstPtrInfo too).
-        let obj_box = ctx.resolve_box_box_opt(&arg0);
+        let obj_box = ctx.resolve_box_box_opt(&arg0.to_boxref());
         let obj_info = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b));
         if let Some(info) = obj_info {
             if info.is_virtual() {
@@ -711,7 +712,7 @@ impl OptRewrite {
                 // previous gating on get_constant_int dropped the Ref
                 // case entirely so prior GUARD_NONNULL/GUARD_CLASS were
                 // never strengthened to GUARD_VALUE for Ref-typed args.
-                if let Some(c_value) = ctx.resolve_box_box_opt(&arg1).and_then(|b| b.const_value())
+                if let Some(c_value) = ctx.resolve_box_box_opt(&arg1.to_boxref()).and_then(|b| b.const_value())
                 {
                     // rewrite.py:321-323: c_value.nonnull(). ConstInt.nonnull
                     // == (value != 0); ConstPtr.nonnull == (gcref != null).
@@ -732,7 +733,7 @@ impl OptRewrite {
                     // getptrinfo → ConstPtrInfo.get_known_class (info.py:763-772)
                     // which is exactly cls_of_box for constant pointers.
                     if let Some(prev_cls) = info.get_known_class(ctx.cpu.as_ref()) {
-                        if let Some(arg1_box) = ctx.resolve_box_box_opt(&arg1) {
+                        if let Some(arg1_box) = ctx.resolve_box_box_opt(&arg1.to_boxref()) {
                             if let Some(expected_cls) = ctx.get_known_class(&arg1_box) {
                                 if prev_cls != expected_cls {
                                     return raise_invalid_loop(
@@ -774,7 +775,7 @@ impl OptRewrite {
                         }
                         // postprocess_GUARD_VALUE (rewrite.py:303-305): make_constant
                         // with the actual c_value (preserving Int vs Ref typing).
-                        ctx.make_constant_arg(&arg0, c_value);
+                        ctx.make_constant_arg(&arg0.to_boxref(), c_value);
                         return OptimizationResult::Remove;
                     }
                 }
@@ -804,21 +805,21 @@ impl OptRewrite {
         // EnsuredPtrInfo borrow; downstream lookups re-acquire via
         // `getptrinfo` / `get_ptr_info` against the resolved OpRef.
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let obj = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let obj = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         // rewrite.py:397-407: ensure_ptr_info_arg0 → info.py:880 getptrinfo.
         // `getptrinfo(ConstPtr)` returns a synthesized ConstPtrInfo, so a
         // constant Ref arg0 is handled uniformly with virtual / instance
         // info: ConstPtrInfo.get_known_class(cpu) (info.py:763-772) reads
         // the typeptr at offset 0 via cls_of_box and compares against
         // expectedclassbox. Mismatch → proven-fail guard → InvalidLoop.
-        let obj_info_for_class = ctx.getptrinfo(&op.arg(0).get_box_replacement(false));
+        let obj_info_for_class = ctx.getptrinfo(&op.arg(0).to_boxref().get_box_replacement(false));
         if let Some(known_class) =
             obj_info_for_class.and_then(|i| i.get_known_class(ctx.cpu.as_ref()))
         {
             if op.num_args() >= 2 {
                 // RPython GuardClass / GuardNonnullClass class operands are
                 // ConstInt vtable addresses (`expectedclassbox.getint()`).
-                let expected = ctx.get_constant_int_box(&op.arg(1));
+                let expected = ctx.get_constant_int_box(&op.arg(1).to_boxref());
                 if let Some(expected) = expected {
                     if known_class == expected {
                         return OptimizationResult::Remove;
@@ -836,13 +837,13 @@ impl OptRewrite {
         // ResumeAtPositionDescr — RPython's fresh ResumeGuardDescr() at
         // line 417 must not overwrite a RAPD marker (rewrite.py:421-422
         // "old descr must not be ResumeAtPositionDescr").
-        if let Some(old_guard) = ctx.get_last_guard(&op.arg(0).get_box_replacement(false)) {
+        if let Some(old_guard) = ctx.get_last_guard(&op.arg(0).to_boxref().get_box_replacement(false)) {
             if old_guard.opcode == OpCode::GuardNonnull
                 && op.num_args() >= 2
                 && ctx.can_replace_guards
             {
                 // last_guard_pos is a _newoperations index.
-                let old_guard_idx = ctx.last_guard_pos(&op.arg(0).get_box_replacement(false));
+                let old_guard_idx = ctx.last_guard_pos(&op.arg(0).to_boxref().get_box_replacement(false));
                 if let Some(old_idx) = old_guard_idx
                     && !ctx.is_resume_at_position_guard(old_idx as i32)
                 {
@@ -884,7 +885,7 @@ impl OptRewrite {
                     // guard's position in last_guard_pos (optimizer.py:137
                     // parity) rather than snapping it to the tail of
                     // new_operations.
-                    if let Some(class_val) = ctx.get_constant_int_box(&op.arg(1)) {
+                    if let Some(class_val) = ctx.get_constant_int_box(&op.arg(1).to_boxref()) {
                         if let Some(b) = ctx.get_box_replacement_box(obj) {
                             crate::optimizeopt::optimizer::Optimizer::make_constant_class(
                                 ctx, &b, class_val, /* update_last_guard = */ false,
@@ -905,7 +906,7 @@ impl OptRewrite {
         // `is_virtual` guard and lets `Optimizer::make_constant_class`
         // dispatch on the live `Instance` / `Virtual` arm.
         if op.num_args() >= 2 {
-            if let Some(class_val) = ctx.get_constant_int_box(&op.arg(1)) {
+            if let Some(class_val) = ctx.get_constant_int_box(&op.arg(1).to_boxref()) {
                 ctx.pending_guard_class_postprocess =
                     Some(crate::optimizeopt::PendingGuardClassPostprocess { obj, class_val });
             }
@@ -976,11 +977,11 @@ impl OptRewrite {
         }
         let arg2 = op.arg(2);
         if let Some(1) = ctx
-            .resolve_box_box_opt(&arg2)
+            .resolve_box_box_opt(&arg2.to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx.resolve_box_box(&op.arg(1));
+            let b_arg = ctx.resolve_box_box(&op.arg(1).to_boxref());
             ctx.make_equal_to(&b_old, &b_arg);
             ctx.last_op_removed = true;
             return true;
@@ -1001,11 +1002,11 @@ impl OptRewrite {
         let arg1 = op.arg(1);
         let arg2 = op.arg(2);
         let b1 = {
-            let b = ctx.resolve_box_box(&arg1);
+            let b = ctx.resolve_box_box(&arg1.to_boxref());
             ctx.getintbound_handle(&b).borrow().clone()
         };
         let b2 = {
-            let b = ctx.resolve_box_box(&arg2);
+            let b = ctx.resolve_box_box(&arg2.to_boxref());
             ctx.getintbound_handle(&b).borrow().clone()
         };
 
@@ -1038,7 +1039,7 @@ impl OptRewrite {
         if val & (val - 1) == 0 {
             let mask = ctx.make_constant_int(val - 1);
             let arg_mask = ctx.materialize_box_at(mask);
-            let mut and_op = Op::new(OpCode::IntAnd, &[arg1, arg_mask]);
+            let mut and_op = Op::new(OpCode::IntAnd, &[arg1, Operand::from_boxref(&arg_mask)]);
             and_op.pos.set(op.pos.get());
             ctx.emit_extra(ctx.current_pass_idx, and_op);
             ctx.last_op_removed = true;
@@ -1073,11 +1074,11 @@ impl OptRewrite {
         let arg1 = op.arg(1);
         let arg2 = op.arg(2);
         let b1 = {
-            let b = ctx.resolve_box_box(&arg1);
+            let b = ctx.resolve_box_box(&arg1.to_boxref());
             ctx.getintbound_handle(&b).borrow().clone()
         };
         let b2 = {
-            let b = ctx.resolve_box_box(&arg2);
+            let b = ctx.resolve_box_box(&arg2.to_boxref());
             ctx.getintbound_handle(&b).borrow().clone()
         };
 
@@ -1093,21 +1094,21 @@ impl OptRewrite {
             // rewrite.py:731-740: x // (1 << y) → x >> y
             // when 0 <= y < LONG_BIT - 1
             if let Some(shift_op) = ctx
-                .resolve_box_box_opt(&arg2)
+                .resolve_box_box_opt(&arg2.to_boxref())
                 .and_then(|pb| ctx.get_producing_op(&pb))
             {
                 if shift_op.opcode == OpCode::IntLshift
                     && shift_op.num_args() >= 2
-                    && shift_op.arg(0).get_box_replacement(false).const_int() == Some(1)
+                    && shift_op.arg(0).to_boxref().get_box_replacement(false).const_int() == Some(1)
                 {
-                    let shiftvar = ctx.resolve_box_box(&shift_op.arg(1)).to_opref();
+                    let shiftvar = ctx.resolve_box_box(&shift_op.arg(1).to_boxref()).to_opref();
                     let shiftbound = {
                         let b = ctx.get_box_replacement(shiftvar);
                         ctx.getintbound_handle(&b).borrow().clone()
                     };
                     if shiftbound.known_nonnegative() && shiftbound.known_lt_const(63) {
                         let arg_shift = ctx.materialize_box_at(shiftvar);
-                        let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
+                        let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, Operand::from_boxref(&arg_shift)]);
                         rshift_op.pos.set(op.pos.get());
                         ctx.emit_extra(ctx.current_pass_idx, rshift_op);
                         ctx.last_op_removed = true;
@@ -1135,7 +1136,7 @@ impl OptRewrite {
         // rewrite.py:752-755: x // 1 → x
         if val == 1 {
             let b_old = BoxRef::from_bound_op(op_rc);
-            let b_arg = ctx.resolve_box_box(&arg1);
+            let b_arg = ctx.resolve_box_box(&arg1.to_boxref());
             ctx.make_equal_to(&b_old, &b_arg);
             ctx.last_op_removed = true;
             return Some(OptimizationResult::Remove);
@@ -1145,7 +1146,7 @@ impl OptRewrite {
             let shift = val.trailing_zeros() as i64;
             let shift_const = ctx.make_constant_int(shift);
             let arg_shift = ctx.materialize_box_at(shift_const);
-            let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, arg_shift]);
+            let mut rshift_op = Op::new(OpCode::IntRshift, &[arg1, Operand::from_boxref(&arg_shift)]);
             rshift_op.pos.set(op.pos.get());
             ctx.emit_extra(ctx.current_pass_idx, rshift_op);
             ctx.last_op_removed = true;
@@ -1353,7 +1354,7 @@ impl OptRewrite {
                 let idx_const = ctx.make_constant_int(index + source_start);
                 let arg_source = ctx.materialize_box_at(source_box);
                 let arg_idx = ctx.materialize_box_at(idx_const);
-                let mut getop = Op::new(opcode, &[arg_source, arg_idx]);
+                let mut getop = Op::new(opcode, &[Operand::from_boxref(&arg_source), Operand::from_boxref(&arg_idx)]);
                 getop.setdescr(arraydescr.clone());
                 let pos = ctx.emit_extra(pass_idx, getop);
                 Some(pos)
@@ -1377,7 +1378,7 @@ impl OptRewrite {
                 let arg_dest = ctx.materialize_box_at(dest_box);
                 let arg_idx = ctx.materialize_box_at(idx_const);
                 let arg_val = ctx.materialize_box_at(val);
-                let mut setop = Op::new(OpCode::SetarrayitemGc, &[arg_dest, arg_idx, arg_val]);
+                let mut setop = Op::new(OpCode::SetarrayitemGc, &[Operand::from_boxref(&arg_dest), Operand::from_boxref(&arg_idx), Operand::from_boxref(&arg_val)]);
                 setop.setdescr(arraydescr.clone());
                 ctx.emit_extra(pass_idx, setop);
             }
@@ -1396,7 +1397,7 @@ impl OptRewrite {
         }
         let arg0 = op.arg(0);
         let b_old = BoxRef::from_bound_op(op_rc);
-        let b_arg = ctx.resolve_box_box(&arg0);
+        let b_arg = ctx.resolve_box_box(&arg0.to_boxref());
         ctx.make_equal_to(&b_old, &b_arg);
         OptimizationResult::Remove
     }
@@ -1524,7 +1525,7 @@ impl OptRewrite {
         // rewrite.py:109: for lhs, rhs in [(arg1, arg2), (arg2, arg1)]:
         for (lhs, rhs) in [(&arg0, &arg1), (&arg1, &arg0)] {
             if let Some(v) = ctx
-                .resolve_box_box_opt(&lhs)
+                .resolve_box_box_opt(&lhs.to_boxref())
                 .and_then(|b| b.const_value())
                 .and_then(|v| match v {
                     Value::Float(f) => Some(f),
@@ -1533,7 +1534,7 @@ impl OptRewrite {
             {
                 if v == 1.0 {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_v2 = ctx.resolve_box_box(&rhs);
+                    let b_v2 = ctx.resolve_box_box(&rhs.to_boxref());
                     ctx.make_equal_to(&b_old, &b_v2);
                     return OptimizationResult::Remove;
                 }
@@ -1552,7 +1553,7 @@ impl OptRewrite {
         let arg0 = op.arg(0);
         let arg1 = op.arg(1);
         if let Some(divisor) = ctx
-            .resolve_box_box_opt(&arg1)
+            .resolve_box_box_opt(&arg1.to_boxref())
             .and_then(|b| b.const_value())
             .and_then(|v| match v {
                 Value::Float(f) => Some(f),
@@ -1567,7 +1568,7 @@ impl OptRewrite {
                 if Self::is_exact_power_of_two(reciprocal) {
                     let recip_ref = self.emit_constant_float(ctx, reciprocal);
                     let arg_recip = ctx.materialize_box_at(recip_ref);
-                    let mut new_op = Op::new(OpCode::FloatMul, &[arg0, arg_recip]);
+                    let mut new_op = Op::new(OpCode::FloatMul, &[arg0, Operand::from_boxref(&arg_recip)]);
                     new_op.pos.set(op.pos.get());
                     return OptimizationResult::Emit(new_op);
                 }
@@ -1592,12 +1593,12 @@ impl OptRewrite {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let v = ctx
-            .resolve_box_box_opt(&op.arg(0))
-            .or_else(|| Some(ctx.resolve_box_box(&op.arg(0))));
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
+            .or_else(|| Some(ctx.resolve_box_box(&op.arg(0).to_boxref())));
         if let Some(arg_op) = v.and_then(|pb| ctx.get_producing_op(&pb)) {
             if arg_op.opcode == OpCode::FloatNeg {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_inner = ctx.resolve_box_box(&arg_op.arg(0));
+                let b_inner = ctx.resolve_box_box(&arg_op.arg(0).to_boxref());
                 ctx.make_equal_to(&b_old, &b_inner);
                 return OptimizationResult::Remove;
             }
@@ -1612,7 +1613,7 @@ impl OptRewrite {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let v = ctx.resolve_box_box_opt(&op.arg(0));
+        let v = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
         if let Some(v) = v {
             if let Some(arg_op) = ctx.get_producing_op(&v) {
                 if arg_op.opcode == OpCode::FloatAbs {
@@ -1706,7 +1707,7 @@ impl Optimization for OptRewrite {
                 //         if opinfo.is_nonnull(): return
                 //         elif opinfo.is_null(): raise InvalidLoop(...)
                 //     return self.emit(op)
-                let obj_box = op.arg(0).get_box_replacement(false);
+                let obj_box = op.arg(0).to_boxref().get_box_replacement(false);
                 let obj = obj_box.to_opref();
                 if let Some(info) = ctx.getptrinfo(&obj_box) {
                     if info.is_nonnull() {
@@ -1734,8 +1735,8 @@ impl Optimization for OptRewrite {
                 //         if info.is_null(): return
                 //         elif info.is_nonnull(): raise InvalidLoop(...)
                 //     return self.emit(op)
-                let obj = ctx.resolve_box_box(&op.arg(0)).to_opref();
-                let obj_box = ctx.resolve_box_box_opt(&op.arg(0));
+                let obj = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+                let obj_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
                 if let Some(info) = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b)) {
                     if info.is_null() {
                         return OptimizationResult::Remove;
@@ -1748,9 +1749,9 @@ impl Optimization for OptRewrite {
                 //     self.make_constant(op.getarg(0), CONST_NULL)
                 // Ref-typed → Value::Ref(NULL); Int-typed → Value::Int(0).
                 if self.is_ref_typed(obj, ctx) {
-                    ctx.make_constant_arg(&op.arg(0), Value::Ref(majit_ir::GcRef(0)));
+                    ctx.make_constant_arg(&op.arg(0).to_boxref(), Value::Ref(majit_ir::GcRef(0)));
                 } else {
-                    ctx.make_constant_arg(&op.arg(0), Value::Int(0));
+                    ctx.make_constant_arg(&op.arg(0).to_boxref(), Value::Int(0));
                 }
                 OptimizationResult::PassOn
             }
@@ -1761,7 +1762,7 @@ impl Optimization for OptRewrite {
                 //     if info and info.is_null():
                 //         raise InvalidLoop(...)
                 //     return self.optimize_GUARD_CLASS(op)
-                if let Some(info) = ctx.getptrinfo(&op.arg(0).get_box_replacement(false)) {
+                if let Some(info) = ctx.getptrinfo(&op.arg(0).to_boxref().get_box_replacement(false)) {
                     if info.is_null() {
                         return raise_invalid_loop("GUARD_NONNULL_CLASS proven to always fail");
                     }
@@ -1772,7 +1773,7 @@ impl Optimization for OptRewrite {
             // was already checked at recording time and can be removed.
             OpCode::GuardIsObject => {
                 if ctx
-                    .get_constant_box(&op.arg(0).get_box_replacement(false))
+                    .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                     .is_some()
                 {
                     return OptimizationResult::Remove;
@@ -1782,7 +1783,7 @@ impl Optimization for OptRewrite {
             // rewrite.py: GUARD_GC_TYPE — if arg is a known constant, remove.
             OpCode::GuardGcType => {
                 if ctx
-                    .get_constant_box(&op.arg(0).get_box_replacement(false))
+                    .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                     .is_some()
                 {
                     return OptimizationResult::Remove;
@@ -1792,7 +1793,7 @@ impl Optimization for OptRewrite {
             // rewrite.py: GUARD_SUBCLASS — if arg is a known constant, remove.
             OpCode::GuardSubclass => {
                 if ctx
-                    .get_constant_box(&op.arg(0).get_box_replacement(false))
+                    .get_constant_box(&op.arg(0).to_boxref().get_box_replacement(false))
                     .is_some()
                 {
                     return OptimizationResult::Remove;
@@ -1813,13 +1814,13 @@ impl Optimization for OptRewrite {
 
             // ── Conditional calls ──
             OpCode::CondCallN => {
-                if let Some(0) = ctx.get_constant_int_box(&op.arg(0).get_box_replacement(false)) {
+                if let Some(0) = ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false)) {
                     ctx.last_op_removed = true;
                     return OptimizationResult::Remove;
                 }
-                if let Some(c) = ctx.get_constant_int_box(&op.arg(0).get_box_replacement(false)) {
+                if let Some(c) = ctx.get_constant_int_box(&op.arg(0).to_boxref().get_box_replacement(false)) {
                     if c != 0 {
-                        let mut call_op = Op::new(OpCode::CallN, &op.getarglist()[1..]);
+                        let mut call_op = Op::new(OpCode::CallN, &op.getarglist()[1..].iter().map(Operand::from_boxref).collect::<Vec<_>>());
                         call_op.pos.set(op.pos.get());
                         if let Some(d) = op.getdescr() {
                             call_op.setdescr(d);
@@ -1837,7 +1838,7 @@ impl Optimization for OptRewrite {
                 // rewrite.py:486-489: INFO_NONNULL → result is arg(0)
                 if nullness == Nullness::Nonnull {
                     let b_old = BoxRef::from_bound_op(op_rc);
-                    let b_arg = ctx.resolve_box_box(&op.arg(0));
+                    let b_arg = ctx.resolve_box_box(&op.arg(0).to_boxref());
                     ctx.make_equal_to(&b_old, &b_arg);
                     ctx.last_op_removed = true;
                     return OptimizationResult::Remove;
@@ -1849,7 +1850,7 @@ impl Optimization for OptRewrite {
                     } else {
                         OpCode::CallPureR
                     };
-                    let mut call_op = Op::new(call_opcode, &op.getarglist()[1..]);
+                    let mut call_op = Op::new(call_opcode, &op.getarglist()[1..].iter().map(Operand::from_boxref).collect::<Vec<_>>());
                     call_op.pos.set(op.pos.get());
                     if let Some(d) = op.getdescr() {
                         call_op.setdescr(d);
@@ -1869,8 +1870,8 @@ impl Optimization for OptRewrite {
                     //     arg0 = get_box_replacement(op.getarg(0))
                     //     arg1 = get_box_replacement(op.getarg(1))
                     //     self.pure_from_args2(rop.INSTANCE_PTR_EQ, arg1, arg0, op)
-                    let arg0 = ctx.resolve_box_box(&op.arg(0)).to_opref();
-                    let arg1 = ctx.resolve_box_box(&op.arg(1)).to_opref();
+                    let arg0 = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+                    let arg1 = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
                     ctx.register_pure_from_args2(OpCode::InstancePtrEq, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, false, instance, ctx);
@@ -1879,8 +1880,8 @@ impl Optimization for OptRewrite {
                 let instance = matches!(op.opcode, OpCode::InstancePtrNe);
                 if instance {
                     // rewrite.py:568-571 optimize_INSTANCE_PTR_NE: same swap.
-                    let arg0 = ctx.resolve_box_box(&op.arg(0)).to_opref();
-                    let arg1 = ctx.resolve_box_box(&op.arg(1)).to_opref();
+                    let arg0 = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+                    let arg1 = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
                     ctx.register_pure_from_args2(OpCode::InstancePtrNe, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, true, instance, ctx);
@@ -1907,7 +1908,7 @@ impl Optimization for OptRewrite {
             // jtransform.py:1264-1266: CAST_OPAQUE_PTR is identity (no-op).
             OpCode::CastOpaquePtr => {
                 let b_old = BoxRef::from_bound_op(op_rc);
-                let b_arg = ctx.resolve_box_box(&op.arg(0));
+                let b_arg = ctx.resolve_box_box(&op.arg(0).to_boxref());
                 ctx.make_equal_to(&b_old, &b_arg);
                 OptimizationResult::Remove
             }
@@ -2010,7 +2011,7 @@ impl Optimization for OptRewrite {
             | OpCode::CallLoopinvariantR
             | OpCode::CallLoopinvariantF
             | OpCode::CallLoopinvariantN => {
-                if let Some(func_val) = op.arg(0).get_box_replacement(false).const_int() {
+                if let Some(func_val) = op.arg(0).to_boxref().get_box_replacement(false).const_int() {
                     // RPython: LoopInvariantOp.produce_op stores PreambleOp
                     // in loop_invariant_results during import. Transfer from
                     // ctx.imported_loop_invariant_results on first access.
@@ -2036,7 +2037,7 @@ impl Optimization for OptRewrite {
                             // dual-slot rule (mod.rs:1817 replay_pos).
                             let replay_pos = ctx.get_replacement_opref(source);
                             let source_box = ctx.materialize_box_at(source);
-                            let mut replay = Op::new(OpCode::SameAsI, &[source_box.clone()]);
+                            let mut replay = Op::new(OpCode::SameAsI, &[Operand::from_boxref(&source_box)]);
                             replay.pos.set(replay_pos);
                             self.loop_invariant_results.insert(
                                 func_val,
@@ -2089,7 +2090,7 @@ impl Optimization for OptRewrite {
             // ── rewrite.py:373-374: optimize_ASSERT_NOT_NONE ──
             OpCode::AssertNotNone => {
                 // RPython: self.make_nonnull(op.getarg(0))
-                let obj_box = op.arg(0).get_box_replacement(false);
+                let obj_box = op.arg(0).to_boxref().get_box_replacement(false);
                 let has_info = ctx.has_ptr_info(&obj_box);
                 if !has_info {
                     ctx.set_ptr_info(&obj_box, crate::optimizeopt::info::PtrInfo::nonnull());
@@ -2111,11 +2112,11 @@ impl Optimization for OptRewrite {
                 if op.num_args() >= 2 {
                     // RPython `RECORD_EXACT_CLASS` carries the same ConstInt
                     // vtable address shape as GUARD_CLASS.
-                    let expected_class = ctx.get_constant_int_box(&op.arg(1));
+                    let expected_class = ctx.get_constant_int_box(&op.arg(1).to_boxref());
                     if let Some(expected_class) = expected_class {
                         // getptrinfo synthesizes ConstPtrInfo for constant
                         // Refs so `get_known_class` reads cls_of_box for them.
-                        let obj_box = op.arg(0).get_box_replacement(false);
+                        let obj_box = op.arg(0).to_boxref().get_box_replacement(false);
                         if let Some(known) = ctx
                             .getptrinfo(&obj_box)
                             .and_then(|i| i.get_known_class(ctx.cpu.as_ref()))
@@ -2145,11 +2146,11 @@ impl Optimization for OptRewrite {
             // upstream passes `op.getarg(0)` raw without a prior
             // `get_box_replacement` resolution. Pyre matches.
             OpCode::RecordExactValueI | OpCode::RecordExactValueR => {
-                let val = op.arg(1).get_box_replacement(false).const_value().expect(
+                let val = op.arg(1).to_boxref().get_box_replacement(false).const_value().expect(
                     "rewrite.py:400 — RECORD_EXACT_VALUE expectedconstbox \
                      must be a Const",
                 );
-                ctx.make_constant_arg(&op.arg(0), val);
+                ctx.make_constant_arg(&op.arg(0).to_boxref(), val);
                 OptimizationResult::Remove
             }
 
@@ -2245,15 +2246,15 @@ impl Optimization for OptRewrite {
     fn propagate_postprocess(&mut self, op: &Op, ctx: &mut OptContext) {
         match op.opcode {
             OpCode::GuardTrue => {
-                ctx.make_constant_arg(&op.arg(0), majit_ir::Value::Int(1));
+                ctx.make_constant_arg(&op.arg(0).to_boxref(), majit_ir::Value::Int(1));
             }
             OpCode::GuardFalse => {
-                ctx.make_constant_arg(&op.arg(0), majit_ir::Value::Int(0));
+                ctx.make_constant_arg(&op.arg(0).to_boxref(), majit_ir::Value::Int(0));
             }
             OpCode::GuardValue => {
                 if op.num_args() >= 2 {
-                    if let Some(val) = op.arg(1).get_box_replacement(false).const_value() {
-                        ctx.make_constant_arg(&op.arg(0), val);
+                    if let Some(val) = op.arg(1).to_boxref().get_box_replacement(false).const_value() {
+                        ctx.make_constant_arg(&op.arg(0).to_boxref(), val);
                     }
                 }
             }
@@ -2336,7 +2337,8 @@ mod tests {
                 .iter()
                 .map(|&p| BoxRef::from_bound_op(&ops[p as usize]))
                 .collect();
-            let op = std::rc::Rc::new(Op::new(spec.opcode, &args));
+            let arg_ops: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
+            let op = std::rc::Rc::new(Op::new(spec.opcode, &arg_ops));
             op.pos
                 .set(OpRef::op_typed(pos as u32, spec.opcode.result_type()));
             ops.push(op);
@@ -2453,14 +2455,16 @@ mod tests {
         // canonical BoxRef args that production passes receive.
         for i in 0..op.num_args() {
             let arg = op.arg(i);
-            let resolved = match ctx.resolve_box_box_opt(&arg) {
-                Some(b) => b,
+            let resolved = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                Some(b) => Operand::from_boxref(&b),
                 None => {
                     let argref = arg.to_opref();
                     if argref.is_none() {
                         arg.clone()
                     } else {
-                        ctx.materialize_box_at(argref).get_box_replacement(false)
+                        Operand::from_boxref(
+                            &ctx.materialize_box_at(argref).get_box_replacement(false),
+                        )
                     }
                 }
             };
@@ -2843,7 +2847,10 @@ mod tests {
             let mut resolved = (**op).clone();
             // optimizer.py:651-652 setarg loop parity.
             for i in 0..resolved.num_args() {
-                resolved.setarg(i, ctx.resolve_box_box(&resolved.arg(i)));
+                resolved.setarg(
+                    i,
+                    Operand::from_boxref(&ctx.resolve_box_box(&resolved.arg(i).to_boxref())),
+                );
             }
             let __pf_rc = std::rc::Rc::new(resolved.clone());
             ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
@@ -2912,7 +2919,10 @@ mod tests {
                 let mut resolved = (**op).clone();
                 // optimizer.py:651-652 setarg loop parity.
                 for i in 0..resolved.num_args() {
-                    resolved.setarg(i, ctx.resolve_box_box(&resolved.arg(i)));
+                    resolved.setarg(
+                    i,
+                    Operand::from_boxref(&ctx.resolve_box_box(&resolved.arg(i).to_boxref())),
+                );
                 }
                 let __pf_rc = std::rc::Rc::new(resolved.clone());
                 ctx.bind_input_resops(std::slice::from_ref(&__pf_rc));
@@ -3452,11 +3462,17 @@ mod tests {
         let (i1, _i1_rc) = bound_inputarg_box(majit_ir::Type::Int, 1);
         // A live producer for v (IntGt result) at int_op(2); the OpRc is held
         // in `int_gt` so the from_bound_op box's Weak upgrade stays live.
-        let int_gt = std::rc::Rc::new(Op::new(OpCode::IntGt, &[i0, i1]));
+        let int_gt = std::rc::Rc::new(Op::new(
+            OpCode::IntGt,
+            &[Operand::from_boxref(&i0), Operand::from_boxref(&i1)],
+        ));
         int_gt.pos.set(OpRef::int_op(2));
         let v = BoxRef::from_bound_op(&int_gt);
         let zero = BoxRef::new_const(Value::Int(0));
-        let guard_value = Op::new(OpCode::GuardValue, &[v, zero]);
+        let guard_value = Op::new(
+            OpCode::GuardValue,
+            &[Operand::from_boxref(&v), Operand::from_boxref(&zero)],
+        );
         let finish = Op::new(OpCode::Finish, &[]);
         let ops = {
             let mut gv = guard_value;

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -4,6 +4,7 @@
 //! pack sets, accumulation tracking, guard analysis, and cost models.
 
 use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
+use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
@@ -1123,7 +1124,7 @@ impl VecScheduleState {
                 .flat_map(|b| b.iter())
                 .find(|p| p.pos.get() == r)
             {
-                op.setarg(i, BoxRef::from_bound_op(rc));
+                op.setarg(i, Operand::from_boxref(&BoxRef::from_bound_op(rc)));
             }
         }
         // Also rebind any guard fail_args carried position-only.
@@ -1169,7 +1170,7 @@ impl VecScheduleState {
         count: usize,
     ) -> Op {
         let ba: Vec<BoxRef> = args.iter().map(|a| self.bound_arg_boxref(*a)).collect();
-        let op = Op::new(opcode, &ba);
+        let op = Op::new(opcode, &ba.iter().map(Operand::from_boxref).collect::<Vec<_>>());
         op.pos.set(self.alloc_op_pos(opcode.result_type()));
         let mut vinfo = majit_ir::VectorizationInfo::new();
         vinfo.setinfo(datatype, bytesize as i8, signed);
@@ -1301,10 +1302,11 @@ impl VecScheduleState {
             //   op = loop.label.copy_and_change(opnum, args).
             // The opcode ("opnum") is unchanged → loop_.label.opcode; descr None
             // means "keep self.descr"; copy_and_change preserves the result `pos`.
+            let args_ops: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
             let mut prefix_label =
                 loop_
                     .label
-                    .copy_and_change(loop_.label.opcode, Some(args.as_slice()), None);
+                    .copy_and_change(loop_.label.opcode, Some(args_ops.as_slice()), None);
             self.renamer.rename(&mut prefix_label); // schedule.py:772
             // The producers now live in `loop_.operations` / `loop_.prefix`
             // (oplist/invariant_oplist were moved above); rebind against them.
@@ -1320,10 +1322,11 @@ impl VecScheduleState {
                     &mut self.renamer,
                 ));
             }
+            let args_ops2: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
             let mut new_jump =
                 loop_
                     .jump
-                    .copy_and_change(loop_.jump.opcode, Some(args.as_slice()), None);
+                    .copy_and_change(loop_.jump.opcode, Some(args_ops2.as_slice()), None);
             self.renamer.rename(&mut new_jump);
             Self::rebind_op_args_in(&new_jump, &[&loop_.operations, &loop_.prefix]);
             loop_.jump = new_jump;

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -3,8 +3,8 @@
 //! Mirrors RPython's `schedule.py` and `vector.py`: pack groups,
 //! pack sets, accumulation tracking, guard analysis, and cost models.
 
-use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
 use majit_ir::operand::Operand;
+use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
@@ -1170,7 +1170,10 @@ impl VecScheduleState {
         count: usize,
     ) -> Op {
         let ba: Vec<BoxRef> = args.iter().map(|a| self.bound_arg_boxref(*a)).collect();
-        let op = Op::new(opcode, &ba.iter().map(Operand::from_boxref).collect::<Vec<_>>());
+        let op = Op::new(
+            opcode,
+            &ba.iter().map(Operand::from_boxref).collect::<Vec<_>>(),
+        );
         op.pos.set(self.alloc_op_pos(opcode.result_type()));
         let mut vinfo = majit_ir::VectorizationInfo::new();
         vinfo.setinfo(datatype, bytesize as i8, signed);

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -12,13 +12,17 @@ use crate::optimizeopt::dependency::DependencyGraph;
 /// producer buffers. A hit binds to the canonical producer `OpRc`
 /// (`from_bound_op` → `Operand::Op`, no mint); a miss (inputarg / external /
 /// constant) falls back to the position-only / const `from_opref` box.
-fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]]) -> BoxRef {
-    if !r.is_constant() && !r.is_none() {
-        if let Some(rc) = buffers.iter().flat_map(|b| b.iter()).find(|p| p.pos.get() == r) {
-            return BoxRef::from_bound_op(rc);
-        }
+fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]], renamer: &mut super::renamer::Renamer) -> BoxRef {
+    if r.is_constant() || r.is_none() {
+        return BoxRef::from_opref(r);
     }
-    BoxRef::from_opref(r)
+    if let Some(rc) = buffers.iter().flat_map(|b| b.iter()).find(|p| p.pos.get() == r) {
+        return BoxRef::from_bound_op(rc);
+    }
+    // No producer in the supplied buffers (e.g. a loop inputarg): bind to a
+    // renamer-rooted producer box carrying the same `pos`, never a
+    // position-only `Operand::Box`.
+    renamer.bound_box(r)
 }
 
 // ── vector.py:670-678: isomorphic ─────────────────────────────────────
@@ -1073,10 +1077,12 @@ impl VecScheduleState {
     /// producer box we look the position up among the ops already emitted
     /// into `oplist` / `invariant_oplist` (SSA guarantees a producer is
     /// emitted before its consumers). A hit binds to that exact producer
-    /// `Rc` (`BoxRef::from_bound_op` → `Operand::Op`, no mint); a miss
-    /// (inputarg / not-yet-vectorized scalar position, or a constant)
-    /// falls back to the position-only / const `from_opref` box.
-    pub fn bound_arg_boxref(&self, r: OpRef) -> BoxRef {
+    /// `Rc` (`BoxRef::from_bound_op` → `Operand::Op`, no mint); a constant
+    /// sheds to `Operand::Const`. A miss for a ResOp/InputArg position
+    /// (an inputarg, or a scalar not yet emitted as a vector op) is bound
+    /// to a renamer-rooted producer box carrying the same `pos`
+    /// (`Renamer::bound_box`), so no position-only `Operand::Box` is minted.
+    pub fn bound_arg_boxref(&mut self, r: OpRef) -> BoxRef {
         if r.is_constant() || r.is_none() {
             return BoxRef::from_opref(r);
         }
@@ -1088,7 +1094,7 @@ impl VecScheduleState {
         {
             return BoxRef::from_bound_op(rc);
         }
-        BoxRef::from_opref(r)
+        self.renamer.bound_box(r)
     }
 
     /// Re-bind an op's args to their producer boxes after the renamer has
@@ -1277,11 +1283,16 @@ impl VecScheduleState {
             // order. RPython's list may hold dups but expand() only appends fresh
             // boxes, so VecSet's de-dup is a no-op here. Each invariant var is a
             // vector op now living in `loop_.prefix`; bind to that producer box.
-            args.extend(
-                self.invariant_vector_vars
-                    .iter()
-                    .map(|r| bound_boxref_in(*r, &[&loop_.prefix, &loop_.operations])),
-            );
+            // Collected first so the per-var bind can take `&mut self.renamer`
+            // (the bound-box synthesis for an inputarg-position miss).
+            let inv_vars: Vec<OpRef> = self.invariant_vector_vars.iter().copied().collect();
+            for r in &inv_vars {
+                args.push(bound_boxref_in(
+                    *r,
+                    &[&loop_.prefix, &loop_.operations],
+                    &mut self.renamer,
+                ));
+            }
             // schedule.py:770-771: opnum = loop.label.getopnum();
             //   op = loop.label.copy_and_change(opnum, args).
             // The opcode ("opnum") is unchanged → loop_.label.opcode; descr None
@@ -1298,11 +1309,13 @@ impl VecScheduleState {
 
             // schedule.py:775-779: jump.
             let mut args = loop_.jump.getarglist_copy();
-            args.extend(
-                self.invariant_vector_vars
-                    .iter()
-                    .map(|r| bound_boxref_in(*r, &[&loop_.prefix, &loop_.operations])),
-            );
+            for r in &inv_vars {
+                args.push(bound_boxref_in(
+                    *r,
+                    &[&loop_.prefix, &loop_.operations],
+                    &mut self.renamer,
+                ));
+            }
             let mut new_jump =
                 loop_
                     .jump

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -3,10 +3,23 @@
 //! Mirrors RPython's `schedule.py` and `vector.py`: pack groups,
 //! pack sets, accumulation tracking, guard analysis, and cost models.
 
-use majit_ir::{Op, OpCode, OpRef, Type};
+use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
+
+/// Resolve an `OpRef` to a producer-bound `BoxRef` against the supplied
+/// producer buffers. A hit binds to the canonical producer `OpRc`
+/// (`from_bound_op` → `Operand::Op`, no mint); a miss (inputarg / external /
+/// constant) falls back to the position-only / const `from_opref` box.
+fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]]) -> BoxRef {
+    if !r.is_constant() && !r.is_none() {
+        if let Some(rc) = buffers.iter().flat_map(|b| b.iter()).find(|p| p.pos.get() == r) {
+            return BoxRef::from_bound_op(rc);
+        }
+    }
+    BoxRef::from_opref(r)
+}
 
 // ── vector.py:670-678: isomorphic ─────────────────────────────────────
 
@@ -754,7 +767,12 @@ pub struct VecScheduleState {
     /// Map from scalar OpRef → (index_in_vector, vector OpRef).
     pub box_to_vbox: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, (usize, OpRef)>,
     /// Output operations (vector + remaining scalar).
-    pub oplist: Vec<Op>,
+    ///
+    /// `Vec<OpRc>` (not `Vec<Op>`): each emitted op is the canonical producer
+    /// box for its value, so `create_vec_op` binds a new vector op's args to
+    /// the producer `Rc` already in this list (`Operand::from_bound_op`)
+    /// rather than minting a position-only `Operand::Box`.
+    pub oplist: Vec<OpRc>,
     /// Renamer for SSA fixup during vectorization.
     pub renamer: super::renamer::Renamer,
     /// Cost model for profitability analysis.
@@ -768,7 +786,8 @@ pub struct VecScheduleState {
     /// expand() (schedule.py:554-555), called from prepare_arguments().
     pub invariant_vector_vars: majit_ir::vec_set::VecSet<OpRef>,
     /// schedule.py:532: invariant_oplist — ops to emit before the loop.
-    pub invariant_oplist: Vec<Op>,
+    /// `Vec<OpRc>` for the same producer-identity reason as `oplist`.
+    pub invariant_oplist: Vec<OpRc>,
     /// schedule.py:595: accumulation info.
     pub accumulation: crate::optimizeopt::vec_assoc::VecAssoc<OpRef, AccumEntry>,
     /// Next OpRef counter for newly created vector ops.
@@ -899,7 +918,7 @@ impl VecScheduleState {
     pub fn forwarded_vecinfo_for_ref(
         &mut self,
         opref: OpRef,
-        ops: &[Op],
+        ops: &[OpRc],
     ) -> majit_ir::VectorizationInfo {
         if let Some(info) = self.get_forwarded_vecinfo(opref) {
             return info;
@@ -1047,6 +1066,86 @@ impl VecScheduleState {
         pos
     }
 
+    /// Resolve an arg `OpRef` to a producer-bound `BoxRef`.
+    ///
+    /// vector.py's renamer maps box→box and carries the box objects through
+    /// the scheduler. pyre's args are integer positions, so to recover the
+    /// producer box we look the position up among the ops already emitted
+    /// into `oplist` / `invariant_oplist` (SSA guarantees a producer is
+    /// emitted before its consumers). A hit binds to that exact producer
+    /// `Rc` (`BoxRef::from_bound_op` → `Operand::Op`, no mint); a miss
+    /// (inputarg / not-yet-vectorized scalar position, or a constant)
+    /// falls back to the position-only / const `from_opref` box.
+    pub fn bound_arg_boxref(&self, r: OpRef) -> BoxRef {
+        if r.is_constant() || r.is_none() {
+            return BoxRef::from_opref(r);
+        }
+        if let Some(rc) = self
+            .oplist
+            .iter()
+            .chain(self.invariant_oplist.iter())
+            .find(|op| op.pos.get() == r)
+        {
+            return BoxRef::from_bound_op(rc);
+        }
+        BoxRef::from_opref(r)
+    }
+
+    /// Re-bind an op's args to their producer boxes after the renamer has
+    /// rewritten them to new positions.
+    ///
+    /// The renamer (`renamer.rs`) maps old→new positions and, lacking a
+    /// producer view, sets each rewritten arg via `from_opref` (a
+    /// position-only box). This pass resolves every non-const arg against the
+    /// supplied producer buffers and rebinds the hits to the canonical
+    /// producer `OpRc` (`from_bound_op`), so no position-only `Operand::Box`
+    /// survives for an arg whose producer is in a buffer. Args with no buffer
+    /// producer (inputargs / constants) are left as the renamer set them.
+    /// Uses `Op::setarg` interior mutability (`&self`).
+    fn rebind_op_args_in(op: &Op, buffers: &[&[OpRc]]) {
+        for i in 0..op.num_args() {
+            let r = op.arg(i).to_opref();
+            if r.is_constant() || r.is_none() {
+                continue;
+            }
+            if let Some(rc) = buffers
+                .iter()
+                .flat_map(|b| b.iter())
+                .find(|p| p.pos.get() == r)
+            {
+                op.setarg(i, BoxRef::from_bound_op(rc));
+            }
+        }
+        // Also rebind any guard fail_args carried position-only.
+        if let Some(fa) = op.getfailargs() {
+            let mut rebound = fa.clone();
+            let mut changed = false;
+            for slot in rebound.iter_mut() {
+                let r = slot.to_opref();
+                if r.is_constant() || r.is_none() {
+                    continue;
+                }
+                if let Some(rc) = buffers
+                    .iter()
+                    .flat_map(|b| b.iter())
+                    .find(|p| p.pos.get() == r)
+                {
+                    *slot = BoxRef::from_bound_op(rc);
+                    changed = true;
+                }
+            }
+            if changed {
+                op.setfailargs(rebound);
+            }
+        }
+    }
+
+    /// Re-bind against the scheduler's own emitted buffers
+    /// (`oplist` / `invariant_oplist`).
+    pub fn rebind_op_args(&self, op: &Op) {
+        Self::rebind_op_args_in(op, &[&self.oplist, &self.invariant_oplist]);
+    }
+
     /// resoperation.py:111-116 (VecOperationNew): Create a vector op with
     /// proper VectorizationInfo. All vector helper functions should use this
     /// instead of raw Op::new + register_vec_type.
@@ -1059,7 +1158,7 @@ impl VecScheduleState {
         signed: bool,
         count: usize,
     ) -> Op {
-        let ba: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let ba: Vec<BoxRef> = args.iter().map(|a| self.bound_arg_boxref(*a)).collect();
         let op = Op::new(opcode, &ba);
         op.pos.set(self.alloc_op_pos(opcode.result_type()));
         let mut vinfo = majit_ir::VectorizationInfo::new();
@@ -1095,8 +1194,13 @@ impl VecScheduleState {
     }
 
     /// schedule.py:640-650: append to output.
+    ///
+    /// Wraps the finished op into the canonical producer `OpRc` as it enters
+    /// `oplist`, so a later `create_vec_op` whose args reference this op's
+    /// position binds directly to this `Rc` (`Operand::from_bound_op`) rather
+    /// than minting a position-only `Operand::Box`.
     pub fn append_to_oplist(&mut self, op: Op) {
-        self.oplist.push(op);
+        self.oplist.push(std::rc::Rc::new(op));
     }
 
     /// schedule.py:754-760: remember_args_in_vector — after creating a new
@@ -1107,7 +1211,7 @@ impl VecScheduleState {
         pack: &Pack,
         index: usize,
         vecbox: OpRef,
-        ops: &[Op],
+        ops: &[OpRc],
     ) {
         for (i, &member_idx) in pack.members.iter().enumerate() {
             let op = &ops[member_idx];
@@ -1146,6 +1250,9 @@ impl VecScheduleState {
 
         // schedule.py:765
         crate::optimizeopt::vector::ensure_args_unpacked(self, &mut loop_.jump, seen);
+        // Rebind the renamed / unpacked jump args to their producers (still in
+        // the scheduler's `oplist` / `invariant_oplist` before the moves below).
+        self.rebind_op_args(&loop_.jump);
 
         // schedule.py:116: loop.operations = self.oplist. In PyPy line 116 runs in
         // the base post_schedule (before 765) but ALIASES self.oplist, so any
@@ -1168,11 +1275,12 @@ impl VecScheduleState {
             // invariant_vector_vars is a VecSet (insertion-ordered re-export of
             // vecmap_rs::VecSet), so iterating reproduces RPython's list-append
             // order. RPython's list may hold dups but expand() only appends fresh
-            // boxes, so VecSet's de-dup is a no-op here.
+            // boxes, so VecSet's de-dup is a no-op here. Each invariant var is a
+            // vector op now living in `loop_.prefix`; bind to that producer box.
             args.extend(
                 self.invariant_vector_vars
                     .iter()
-                    .map(|r| BoxRef::from_opref(*r)),
+                    .map(|r| bound_boxref_in(*r, &[&loop_.prefix, &loop_.operations])),
             );
             // schedule.py:770-771: opnum = loop.label.getopnum();
             //   op = loop.label.copy_and_change(opnum, args).
@@ -1183,6 +1291,9 @@ impl VecScheduleState {
                     .label
                     .copy_and_change(loop_.label.opcode, Some(args.as_slice()), None);
             self.renamer.rename(&mut prefix_label); // schedule.py:772
+            // The producers now live in `loop_.operations` / `loop_.prefix`
+            // (oplist/invariant_oplist were moved above); rebind against them.
+            Self::rebind_op_args_in(&prefix_label, &[&loop_.operations, &loop_.prefix]);
             loop_.prefix_label = Some(prefix_label); // schedule.py:773
 
             // schedule.py:775-779: jump.
@@ -1190,13 +1301,14 @@ impl VecScheduleState {
             args.extend(
                 self.invariant_vector_vars
                     .iter()
-                    .map(|r| BoxRef::from_opref(*r)),
+                    .map(|r| bound_boxref_in(*r, &[&loop_.prefix, &loop_.operations])),
             );
             let mut new_jump =
                 loop_
                     .jump
                     .copy_and_change(loop_.jump.opcode, Some(args.as_slice()), None);
             self.renamer.rename(&mut new_jump);
+            Self::rebind_op_args_in(&new_jump, &[&loop_.operations, &loop_.prefix]);
             loop_.jump = new_jump;
         }
     }
@@ -1304,7 +1416,7 @@ impl From<NotAProfitableLoop> for VectorizeError {
 pub fn check_if_pack_supported(
     state: &mut VecScheduleState,
     pack: &Pack,
-    ops: &[Op],
+    ops: &[OpRc],
 ) -> Result<(), NotAProfitableLoop> {
     let first_op = &ops[pack.members[0]];
     // schedule.py:471-474: INT_MUL with bytesize 8 or 1 is not profitable
@@ -1358,7 +1470,7 @@ pub fn unpack_from_vector(
 pub fn prepare_fail_arguments(
     state: &mut VecScheduleState,
     pack: &Pack,
-    ops: &[Op],
+    ops: &[OpRc],
     vecop: &mut Op,
 ) {
     let first_op = &ops[pack.members[0]];
@@ -1395,7 +1507,7 @@ pub fn prepare_arguments(
     state: &mut VecScheduleState,
     pack: &Pack,
     args: &mut Vec<OpRef>,
-    ops: &[Op],
+    ops: &[OpRc],
 ) {
     for i in 0..args.len() {
         let arg = args[i];
@@ -1423,7 +1535,7 @@ fn assemble_scattered_values(
     pack: &Pack,
     args: &mut Vec<OpRef>,
     index: usize,
-    ops: &[Op],
+    ops: &[OpRc],
 ) {
     // schedule.py:422: collect each member's arg at this index
     let mut args_at_index: Vec<OpRef> = pack
@@ -1466,7 +1578,7 @@ fn gather(
     state: &mut VecScheduleState,
     vectors: &[(usize, OpRef)],
     count: usize,
-    ops: &[Op],
+    ops: &[OpRc],
 ) -> OpRef {
     let (_, mut arg) = vectors[0];
     let mut i = 1;
@@ -1486,13 +1598,13 @@ fn gather(
 }
 
 /// Get the lane count of a vector OpRef. Falls back to 1.
-fn get_vec_count(state: &mut VecScheduleState, opref: OpRef, ops: &[Op]) -> usize {
+fn get_vec_count(state: &mut VecScheduleState, opref: OpRef, ops: &[OpRc]) -> usize {
     state.forwarded_vecinfo_for_ref(opref, ops).count.max(1) as usize
 }
 
 /// Get (datatype, bytesize, signed) from a vector OpRef's vecinfo.
 /// Falls back to is_float_vector registry + default 8-byte.
-fn get_vec_info(state: &mut VecScheduleState, opref: OpRef, ops: &[Op]) -> (char, i32, bool) {
+fn get_vec_info(state: &mut VecScheduleState, opref: OpRef, ops: &[OpRc]) -> (char, i32, bool) {
     let vi = state.forwarded_vecinfo_for_ref(opref, ops);
     if vi.datatype != '\0' {
         return (vi.datatype, vi.bytesize as i32, vi.signed);
@@ -1517,7 +1629,7 @@ fn pack_into_vector(
     src: OpRef,
     sidx: usize,
     scount: usize,
-    ops: &[Op],
+    ops: &[OpRc],
 ) -> OpRef {
     // schedule.py:493: assert sidx == 0
     debug_assert!(sidx == 0, "pack_into_vector: sidx must be 0, got {}", sidx);
@@ -1556,7 +1668,7 @@ fn position_values(
     args: &mut Vec<OpRef>,
     index: usize,
     position: usize,
-    ops: &[Op],
+    ops: &[OpRc],
 ) {
     // schedule.py:453-460: position != 0 → unpack to reposition
     if position != 0 {
@@ -1577,7 +1689,7 @@ fn crop_vector(
     pack: &Pack,
     args: &mut Vec<OpRef>,
     index: usize,
-    ops: &[Op],
+    ops: &[OpRc],
 ) {
     let arg = args[index];
     let first_op = &ops[pack.members[0]];
@@ -1611,7 +1723,7 @@ fn crop_vector(
 }
 
 /// Helper: get bytesize for an OpRef that may be a vector op created during scheduling.
-fn get_op_bytesize_for_ref(state: &mut VecScheduleState, opref: OpRef, ops: &[Op]) -> i32 {
+fn get_op_bytesize_for_ref(state: &mut VecScheduleState, opref: OpRef, ops: &[OpRc]) -> i32 {
     state.forwarded_vecinfo_for_ref(opref, ops).getbytesize() as i32
 }
 
@@ -1629,7 +1741,7 @@ fn expand(
     args: &mut Vec<OpRef>,
     arg: OpRef,
     index: usize,
-    ops: &[Op],
+    ops: &[OpRc],
 ) {
     // schedule.py:532-537: choose target list (invariant vs inline)
     let is_invariant = arg.is_constant() || state.inputargs.contains_key(&arg);
@@ -1677,7 +1789,7 @@ fn expand(
         let vecop = state.create_vec_op(expand_opcode, &[arg], datatype, bytesize, signed, numops);
         let vecop_pos = vecop.pos.get();
         if is_invariant {
-            state.invariant_oplist.push(vecop);
+            state.invariant_oplist.push(std::rc::Rc::new(vecop));
             state.invariant_vector_vars.insert(vecop_pos);
         } else {
             state.append_to_oplist(vecop);
@@ -1722,7 +1834,7 @@ fn expand(
         state.create_vec_op(vec_create_opcode, &[], datatype, bytesize, signed, numops);
     let mut current_vec = vec_create.pos.get();
     if is_invariant {
-        state.invariant_oplist.push(vec_create);
+        state.invariant_oplist.push(std::rc::Rc::new(vec_create));
     } else {
         state.append_to_oplist(vec_create);
     }
@@ -1748,7 +1860,7 @@ fn expand(
         current_vec = pack_op.pos.get();
         state.costmodel.record_vector_pack(is_float, 0, 1);
         if is_invariant {
-            state.invariant_oplist.push(pack_op);
+            state.invariant_oplist.push(std::rc::Rc::new(pack_op));
         } else {
             state.append_to_oplist(pack_op);
         }
@@ -1762,7 +1874,7 @@ fn expand(
 }
 
 /// schedule.py:322-350: Turn a pack of scalar ops into a single vector op.
-pub fn turn_into_vector(state: &mut VecScheduleState, pack: &Pack, ops: &[Op]) {
+pub fn turn_into_vector(state: &mut VecScheduleState, pack: &Pack, ops: &[OpRc]) {
     if pack.members.is_empty() {
         return;
     }

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -16,7 +16,11 @@ fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]], renamer: &mut super::renamer::
     if r.is_constant() || r.is_none() {
         return BoxRef::from_opref(r);
     }
-    if let Some(rc) = buffers.iter().flat_map(|b| b.iter()).find(|p| p.pos.get() == r) {
+    if let Some(rc) = buffers
+        .iter()
+        .flat_map(|b| b.iter())
+        .find(|p| p.pos.get() == r)
+    {
         return BoxRef::from_bound_op(rc);
     }
     // No producer in the supplied buffers (e.g. a loop inputarg): bind to a

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -453,14 +453,14 @@ pub struct ShortBoxes {
     /// position through `ctx.materialize_box_at`, which memoizes one box
     /// per producer, so the same position yields the same object. Const
     /// results never key this map (they route to `const_short_boxes`).
-    potential_ops: VecAssoc<BoxRef, PotentialShortOp>,
+    potential_ops: VecAssoc<majit_ir::operand::Operand, PotentialShortOp>,
     /// shortpreamble.py:250 self.produced_short_boxes = {}
     /// (insertion order preserved by VecAssoc for deterministic export.)
     /// Keyed by the result Box (`shortop.res`), compared by object
     /// identity (shortpreamble.py:317/338) — lookups resolve their
     /// position through `ctx.materialize_box_at`, which memoizes one
     /// box per producer, so the same position yields the same object.
-    produced_short_boxes: VecAssoc<BoxRef, ProducedShortOp>,
+    produced_short_boxes: VecAssoc<majit_ir::operand::Operand, ProducedShortOp>,
     /// shortpreamble.py: const_short_boxes
     const_short_boxes: Vec<PreambleOp>,
     /// RPython shortpreamble.py: Const boxes are directly admissible in
@@ -499,7 +499,7 @@ pub struct ShortBoxes {
     /// for `materialize_one` recursion, keyed by the result Box
     /// (shortpreamble.py:314 `self.boxes_in_production[shortop.res]`).
     /// Active set is bounded by recursion depth (linear scan suffices).
-    boxes_in_production: VecSet<BoxRef>,
+    boxes_in_production: VecSet<majit_ir::operand::Operand>,
     /// The number of label args.
     pub num_label_args: usize,
 }
@@ -569,7 +569,10 @@ impl PotentialShortOp {
                         alt.same_as_source = Some(ctx.materialize_box_at(compound.res));
                         // shortpreamble.py:333 `self.produced_short_boxes[
                         // new_name] = lst[i]` — keyed by the alias box.
-                        sb.produced_short_boxes.insert(alt.res.clone(), alt.clone());
+                        sb.produced_short_boxes.insert(
+                            majit_ir::operand::Operand::from_boxref(&alt.res),
+                            alt.clone(),
+                        );
                     }
                     Some(chosen)
                 }
@@ -635,7 +638,8 @@ impl ShortBoxes {
     }
 
     fn add_op(&mut self, key: BoxRef, pop: PotentialShortOp) {
-        self.potential_ops.insert(key, pop);
+        self.potential_ops
+            .insert(majit_ir::operand::Operand::from_boxref(&key), pop);
     }
 
     /// Add a pure operation as a short-box candidate.
@@ -757,7 +761,7 @@ impl ShortBoxes {
         // — keyed by the label-arg Box itself; `arg_box` is its canonical
         // (producer-bound) box, shared with `res`.
         self.potential_ops.insert(
-            arg_box.clone(),
+            majit_ir::operand::Operand::from_boxref(&arg_box),
             PotentialShortOp::Preamble(PreambleOp {
                 res: arg_box,
                 op: std::rc::Rc::new(same_as),
@@ -795,7 +799,8 @@ impl ShortBoxes {
         // never key either set (they route to the Const arm below).
         if !opref.is_constant() {
             let key = ctx.materialize_box_at(opref);
-            if let Some(existing) = self.produced_short_boxes.get(&key) {
+            let okey = majit_ir::operand::Operand::from_boxref(&key);
+            if let Some(existing) = self.produced_short_boxes.get(&okey) {
                 // shortpreamble.py:285 `return ...preamble_op` — the
                 // dependency's replay op object itself, so preamble-op
                 // args carry the dep replay handle.
@@ -812,7 +817,7 @@ impl ShortBoxes {
                 }
                 return Some(BoxRef::from_bound_op(&existing.preamble_op));
             }
-            if self.boxes_in_production.contains(&key) {
+            if self.boxes_in_production.contains(&okey) {
                 return None;
             }
         }
@@ -880,18 +885,19 @@ impl ShortBoxes {
         // shortpreamble.py:311-339 add_op_to_short — guard, cycle set,
         // and final insert all key on `shortop.res` Box identity.
         let key = ctx.materialize_box_at(result);
-        if let Some(existing) = self.produced_short_boxes.get(&key) {
+        let okey = majit_ir::operand::Operand::from_boxref(&key);
+        if let Some(existing) = self.produced_short_boxes.get(&okey) {
             return Some(existing.clone());
         }
-        if self.boxes_in_production.contains(&key) {
+        if self.boxes_in_production.contains(&okey) {
             return None;
         }
-        let candidate = self.potential_ops.get(&key)?.clone();
-        self.boxes_in_production.insert(key.clone());
+        let candidate = self.potential_ops.get(&okey)?.clone();
+        self.boxes_in_production.insert(okey.clone());
         let produced = candidate.add_op_to_short(self, ctx);
-        self.boxes_in_production.remove(&key);
+        self.boxes_in_production.remove(&okey);
         let produced = produced?;
-        self.produced_short_boxes.insert(key, produced.clone());
+        self.produced_short_boxes.insert(okey, produced.clone());
         Some(produced)
     }
 
@@ -1050,7 +1056,10 @@ impl ShortBoxes {
             invented_name: false,
             same_as_source: None,
         });
-        let next = match self.potential_ops.get(&key) {
+        let next = match self
+            .potential_ops
+            .get(&majit_ir::operand::Operand::from_boxref(&key))
+        {
             Some(prev) => PotentialShortOp::Compound(CompoundOp {
                 res: result,
                 one: Box::new(pop),

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2242,7 +2242,7 @@ pub struct ShortPreambleBuilder {
     /// the dual key compensated for, so the two entries collapse to one. The
     /// PYRE_S8B_HARNESS census measured this lookup agreeing with the former
     /// position key on every live firing across the bench corpus.
-    produced_short_boxes: VecAssoc<BoxRef, ProducedShortOp>,
+    produced_short_boxes: VecAssoc<majit_ir::operand::Operand, ProducedShortOp>,
 }
 
 impl ShortPreambleBuilder {
@@ -2274,7 +2274,7 @@ impl ShortPreambleBuilder {
             if k.to_opref().is_constant() {
                 continue;
             }
-            produced_short_boxes.insert(k.clone(), v.clone());
+            produced_short_boxes.insert(majit_ir::operand::Operand::from_boxref(k), v.clone());
         }
         // shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
         // store the caller's renamed-box objects themselves. The empty
@@ -2303,7 +2303,10 @@ impl ShortPreambleBuilder {
         result: &BoxRef,
         visiting: &mut VecSet<BoxRef>,
     ) -> Option<majit_ir::OpRc> {
-        let produced = self.produced_short_boxes.get(result)?.clone();
+        let produced = self
+            .produced_short_boxes
+            .get(&majit_ir::operand::Operand::from_boxref(result))?
+            .clone();
         let canonical_result = produced.preamble_op.pos.get();
         if self.state.short_results.contains(&canonical_result) {
             return Some(produced.preamble_op);
@@ -2318,7 +2321,11 @@ impl ShortPreambleBuilder {
             }
             // shortpreamble.py:284-285 `if op in self.produced_short_boxes`:
             // the dependency check is by the arg Box identity.
-            if self.produced_short_boxes.get(arg).is_some() {
+            if self
+                .produced_short_boxes
+                .get(&majit_ir::operand::Operand::from_boxref(arg))
+                .is_some()
+            {
                 let _ = self.use_box_recursive(arg, visiting);
             }
         }
@@ -2386,7 +2393,9 @@ impl ShortPreambleBuilder {
     /// box-identity lookup hits — PYRE_S8B_HARNESS measured 82/82 agreement
     /// with the former position key on every live firing across the corpus.
     pub fn produced_short_op(&self, res: &BoxRef) -> Option<ProducedShortOp> {
-        self.produced_short_boxes.get(res).cloned()
+        self.produced_short_boxes
+            .get(&majit_ir::operand::Operand::from_boxref(res))
+            .cloned()
     }
 
     /// shortpreamble.py:432-440: add_preamble_op(preamble_op)
@@ -2427,7 +2436,11 @@ impl ShortPreambleBuilder {
     }
 
     pub fn add_preamble_op(&mut self, result: &BoxRef) -> bool {
-        let Some(produced) = self.produced_short_boxes.get(result).cloned() else {
+        let Some(produced) = self
+            .produced_short_boxes
+            .get(&majit_ir::operand::Operand::from_boxref(result))
+            .cloned()
+        else {
             return false;
         };
         // shortpreamble.py:435 `op = preamble_op.op.get_box_replacement()`

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -374,10 +374,10 @@ impl PreambleOp {
                 //   else:
                 //       preamble_op = ResOperation(sop.getopnum(), [preamble_arg, sop.getarg(1)], descr=sop.getdescr())
                 let preamble_arg = sb.produce_arg(ctx, self.op.arg(0).to_opref())?;
-                let args: smallvec::SmallVec<[BoxRef; 3]> = if self.op.opcode.is_getfield() {
-                    smallvec::smallvec![preamble_arg]
+                let args: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> = if self.op.opcode.is_getfield() {
+                    smallvec::smallvec![majit_ir::operand::Operand::from_boxref(&preamble_arg)]
                 } else {
-                    smallvec::smallvec![preamble_arg, self.op.arg(1)]
+                    smallvec::smallvec![majit_ir::operand::Operand::from_boxref(&preamble_arg), self.op.arg(1)]
                 };
                 self.op.copy_and_change(self.op.opcode, Some(&args), None)
             }
@@ -393,8 +393,8 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()))
-                    .collect::<Option<smallvec::SmallVec<[BoxRef; 3]>>>()?;
+                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()).map(|b| majit_ir::operand::Operand::from_boxref(&b)))
+                    .collect::<Option<smallvec::SmallVec<[majit_ir::operand::Operand; 3]>>>()?;
                 let opnum = if self.op.opcode.is_call() {
                     match self.op.opcode {
                         OpCode::CallI => OpCode::CallPureI,
@@ -417,8 +417,8 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()))
-                    .collect::<Option<smallvec::SmallVec<[BoxRef; 3]>>>()?;
+                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()).map(|b| majit_ir::operand::Operand::from_boxref(&b)))
+                    .collect::<Option<smallvec::SmallVec<[majit_ir::operand::Operand; 3]>>>()?;
                 let opnum = match self.op.opcode {
                     OpCode::CallI => OpCode::CallLoopinvariantI,
                     OpCode::CallR => OpCode::CallLoopinvariantR,
@@ -755,7 +755,7 @@ impl ShortBoxes {
         // returns (ptr_eq), keeping the BoxRef-keyed map ptr-stable.
         let _ = ctx.materialize_box_at(arg);
         let arg_box = ctx.materialize_box_at(arg);
-        let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[arg_box.clone()]);
+        let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[majit_ir::operand::Operand::from_boxref(&arg_box.clone())]);
         same_as.pos.set(arg);
         // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
         // — keyed by the label-arg Box itself; `arg_box` is its canonical
@@ -982,9 +982,11 @@ impl ShortBoxes {
             // shortpreamble.py:277-278: copy_and_change(opnum, [preamble_arg] + args[1:])
             let mut new_args = vec![preamble_arg];
             new_args.extend_from_slice(&getfield_op.getarglist()[1..]);
+            let new_args_operand: Vec<majit_ir::operand::Operand> =
+                new_args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
             let mut new_op = Op::with_descr(
                 getfield_op.opcode,
-                &new_args,
+                &new_args_operand,
                 getfield_op
                     .getdescr()
                     .unwrap_or_else(|| panic!("const_short_boxes heap op without descr")),
@@ -1699,12 +1701,12 @@ impl ProducedShortOp {
         // shortpreamble.py:66-68: if g.getarg(0) in exported_infos:
         //     setinfo_from_preamble(g.getarg(0), exported_infos[...])
         // Pass the Rc handle (unroll.py:61 identity preservation).
-        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg) {
+        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg.to_boxref()) {
             ctx.setinfo_from_preamble(obj_resolved, rc, Some(exported_infos));
         }
         let mut getfield_op = Op::new(
             OpCode::getfield_for_type(result_type),
-            &[ctx.materialize_box_at(obj_resolved)],
+            &[majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(obj_resolved))],
         );
         getfield_op.setdescr(descr.clone());
         // Cat-2.2 dual-slot rule (mod.rs:1817 replay_pos): replay.pos =
@@ -1835,15 +1837,15 @@ impl ProducedShortOp {
         // getarrayitem: if the base object has exported info, import it
         // before ensuring heap/array PtrInfo.
         // Pass the Rc handle (unroll.py:61 identity preservation).
-        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg) {
+        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg.to_boxref()) {
             ctx.setinfo_from_preamble(obj_resolved, rc, Some(exported_infos));
         }
         let index_const = ctx.make_constant_int(index);
         let mut getarrayitem_op = Op::new(
             OpCode::getarrayitem_for_type(result_type),
             &[
-                ctx.materialize_box_at(obj_resolved),
-                ctx.materialize_box_at(index_const),
+                majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(obj_resolved)),
+                majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(index_const)),
             ],
         );
         getarrayitem_op.setdescr(descr.clone());
@@ -2055,7 +2057,7 @@ impl AbstractShortPreambleBuilderState {
                 replay_op.pos.get()
             );
             let source = same_as_source.unwrap_or_else(|| op.clone());
-            let mut same_as = Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
+            let mut same_as = Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[majit_ir::operand::Operand::from_boxref(&source)]);
             same_as.pos.set(op.to_opref());
             self.extra_same_as.push(same_as);
         }
@@ -2464,7 +2466,9 @@ impl ShortPreambleBuilder {
         // shortpreamble.py:443 `ResOperation(rop.LABEL,
         // self.short_inputargs[:])` — the Label args are the stored
         // renamed-inputarg boxes themselves, not fresh mints.
-        result.push(Op::new(OpCode::Label, &self.state.short_inputargs));
+        let short_inputargs_operand: Vec<majit_ir::operand::Operand> =
+            self.state.short_inputargs.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        result.push(Op::new(OpCode::Label, &short_inputargs_operand));
         result.extend(self.state.short.iter().map(|op| (**op).clone()));
         let jump_args: Vec<BoxRef> = self
             .state
@@ -2472,7 +2476,9 @@ impl ShortPreambleBuilder {
             .iter()
             .map(BoxRef::from_bound_op)
             .collect();
-        result.push(Op::new(OpCode::Jump, &jump_args));
+        let jump_args_operand: Vec<majit_ir::operand::Operand> =
+            jump_args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        result.push(Op::new(OpCode::Jump, &jump_args_operand));
         result
     }
 
@@ -2688,7 +2694,7 @@ impl ExtendedShortPreambleBuilder {
             for i in 0..op.num_args() {
                 let arg = op.arg(i);
                 if let Some(remapped) = self.phase1_to_inputarg.get(&arg.to_opref()) {
-                    op.setarg(i, remapped.clone());
+                    op.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped.clone()));
                 }
             }
             // RPython use_box arg loop: insert missing deps before this op.
@@ -2734,7 +2740,9 @@ impl ExtendedShortPreambleBuilder {
                     })
             })
             .collect();
-        self.short.push(Op::new(OpCode::Jump, &jump_args_box));
+        let jump_args_box_operand: Vec<majit_ir::operand::Operand> =
+            jump_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        self.short.push(Op::new(OpCode::Jump, &jump_args_box_operand));
         // Reset state
         self.extra_same_as = self.base_extra_same_as.clone();
         self.short_preamble_jump.clear();
@@ -2806,7 +2814,7 @@ impl ExtendedShortPreambleBuilder {
         for i in 0..dep_op.num_args() {
             let a = dep_op.arg(i);
             if let Some(remapped) = self.phase1_to_inputarg.get(&a.to_opref()) {
-                dep_op.setarg(i, remapped.clone());
+                dep_op.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped.clone()));
             }
         }
         // Recurse into dep's own args first (transitive). If any sub-dep
@@ -2908,7 +2916,7 @@ impl ExtendedShortPreambleBuilder {
                     .clone()
                     .unwrap_or_else(|| resolved_op.clone());
                 let mut same_as =
-                    Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[source]);
+                    Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[majit_ir::operand::Operand::from_boxref(&source)]);
                 same_as.pos.set(op);
                 self.extra_same_as.push(same_as);
             }
@@ -2938,7 +2946,7 @@ impl ExtendedShortPreambleBuilder {
                 .unwrap_or_else(|| result.clone());
             let mut op = Op::new(
                 OpCode::same_as_for_type(produced.preamble_op.result_type()),
-                &[source],
+                &[majit_ir::operand::Operand::from_boxref(&source)],
             );
             op.pos.set(current_result);
             self.extra_same_as.push(op);
@@ -2976,7 +2984,7 @@ impl ExtendedShortPreambleBuilder {
         for i in 0..remapped.num_args() {
             let arg = remapped.arg(i);
             if let Some(r) = self.phase1_to_inputarg.get(&arg.to_opref()) {
-                remapped.setarg(i, r.clone());
+                remapped.setarg(i, majit_ir::operand::Operand::from_boxref(&r.clone()));
             }
         }
         remapped
@@ -3353,7 +3361,15 @@ pub fn build_short_preamble_from_exported_boxes(
 mod tests {
     use super::*;
     use crate::r#box::test_support::rooted_resop_box;
+    use majit_ir::operand::Operand;
     use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
+
+    /// oparser-faithful op-arg minter: a rooted resop producer shed to its
+    /// `Operand::Op` face (`from_boxref`). Op-arg slices take `Operand`, while
+    /// fail-args / builder side-tables keep the bare `rooted_resop_box` BoxRef.
+    fn rop(ty: Type, pos: u32) -> Operand {
+        Operand::from_boxref(&rooted_resop_box(ty, pos))
+    }
 
     fn assign_positions(ops: &mut [Op], base: u32) {
         for (i, op) in ops.iter_mut().enumerate() {
@@ -3379,34 +3395,34 @@ mod tests {
         // 4: int_add(v100, v101)     ← body computation
         // 5: Jump(v4, v101)          ← back-edge
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Label,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 4),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 4),
+                    rop(Type::Int, 101),
                 ],
             ),
         ];
@@ -3431,11 +3447,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::Finish, &[rop(Type::Int, 0)]),
         ];
 
         let sp = extract_short_preamble(&ops);
@@ -3448,13 +3464,13 @@ mod tests {
             Op::new(
                 OpCode::IntMulOvf,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 100),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 100),
                 ],
             ),
             Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Label, &[rooted_resop_box(Type::Int, 100)]),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::Label, &[rop(Type::Int, 100)]),
+            Op::new(OpCode::Jump, &[rop(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
         ops[1].setfailargs(vec![rooted_resop_box(Type::Int, 100)].into());
@@ -3471,13 +3487,13 @@ mod tests {
             Op::new(
                 OpCode::IntMulOvf,
                 &[
-                    rooted_resop_box(Type::Int, 200),
-                    rooted_resop_box(Type::Int, 200),
+                    rop(Type::Int, 200),
+                    rop(Type::Int, 200),
                 ],
             ),
             Op::new(OpCode::GuardNoOverflow, &[]),
-            Op::new(OpCode::Label, &[rooted_resop_box(Type::Int, 100)]),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::Label, &[rop(Type::Int, 100)]),
+            Op::new(OpCode::Jump, &[rop(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
         ops[1].setfailargs(vec![rooted_resop_box(Type::Int, 100)].into());
@@ -3493,13 +3509,13 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 0)]), // refs temporary, not label arg
-            Op::new(OpCode::Label, &[rooted_resop_box(Type::Int, 100)]), // only v100 is a label arg
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::GuardTrue, &[rop(Type::Int, 0)]), // refs temporary, not label arg
+            Op::new(OpCode::Label, &[rop(Type::Int, 100)]), // only v100 is a label arg
+            Op::new(OpCode::Jump, &[rop(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -3517,19 +3533,19 @@ mod tests {
         let mut builder = CollectedShortPreambleBuilder::new();
 
         // Simulate preamble processing
-        let guard1 = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]);
+        let guard1 = Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]);
         let guard2 = Op::new(
             OpCode::GuardClass,
             &[
-                rooted_resop_box(Type::Int, 101),
-                rooted_resop_box(Type::Int, 200),
+                rop(Type::Int, 101),
+                rop(Type::Int, 200),
             ],
         );
         let non_guard = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 100),
-                rooted_resop_box(Type::Int, 101),
+                rop(Type::Int, 100),
+                rop(Type::Int, 101),
             ],
         );
 
@@ -3541,7 +3557,7 @@ mod tests {
         builder.set_label_args(&[OpRef::int_op(100), OpRef::int_op(101)]);
 
         // After label, no more collection
-        let guard3 = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]);
+        let guard3 = Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]);
         builder.add_preamble_guard(&guard3); // should be ignored
 
         let sp = builder.build(None);
@@ -3556,8 +3572,8 @@ mod tests {
         let guard = Op::new(
             OpCode::GuardValue,
             &[
-                rooted_resop_box(Type::Int, 100),
-                rooted_resop_box(Type::Int, 200),
+                rop(Type::Int, 100),
+                rop(Type::Int, 200),
             ],
         );
         builder.add_preamble_guard(&guard);
@@ -3579,8 +3595,8 @@ mod tests {
         let pure_op = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 100),
-                rooted_resop_box(Type::Int, 101),
+                rop(Type::Int, 100),
+                rop(Type::Int, 101),
             ],
         );
         builder.add_preamble_op(&pure_op);
@@ -3596,34 +3612,34 @@ mod tests {
     fn test_extract_multiple_guards() {
         // Multiple guards in the preamble
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
-            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Int, 101)]),
+            Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
+            Op::new(OpCode::GuardNonnull, &[rop(Type::Int, 101)]),
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 200),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 200),
                 ],
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Label,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
         ];
@@ -3652,8 +3668,8 @@ mod tests {
                     let mut op = Op::new(
                         OpCode::IntAdd,
                         &[
-                            rooted_resop_box(Type::Int, 10),
-                            rooted_resop_box(Type::Int, 11),
+                            rop(Type::Int, 10),
+                            rop(Type::Int, 11),
                         ],
                     );
                     op.pos.set(OpRef::int_op(7));
@@ -3670,8 +3686,8 @@ mod tests {
                     let mut op = Op::new(
                         OpCode::IntSub,
                         &[
-                            rooted_resop_box(Type::Int, 7),
-                            rooted_resop_box(Type::Int, 11),
+                            rop(Type::Int, 7),
+                            rop(Type::Int, 11),
                         ],
                     );
                     op.pos.set(OpRef::int_op(8));
@@ -3717,8 +3733,8 @@ mod tests {
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
             &[
-                rooted_resop_box(Type::Int, 10),
-                rooted_resop_box(Type::Int, 11),
+                rop(Type::Int, 10),
+                rop(Type::Int, 11),
             ],
         );
         ovf.pos.set(OpRef::int_op(20));
@@ -3761,13 +3777,19 @@ mod tests {
         let in0 = rooted_resop_box(Type::Int, 0);
         let in1 = rooted_resop_box(Type::Int, 1);
         let producer7 = {
-            let mut op = Op::new(OpCode::IntAdd, &[in0.clone(), in1.clone()]);
+            let mut op = Op::new(
+                OpCode::IntAdd,
+                &[Operand::from_boxref(&in0), Operand::from_boxref(&in1)],
+            );
             op.pos.set(OpRef::int_op(7));
             std::rc::Rc::new(op)
         };
         let res7 = BoxRef::from_bound_op(&producer7);
         let producer8 = {
-            let mut op = Op::new(OpCode::IntMul, &[res7.clone(), in1.clone()]);
+            let mut op = Op::new(
+                OpCode::IntMul,
+                &[Operand::from_boxref(&res7), Operand::from_boxref(&in1)],
+            );
             op.pos.set(OpRef::int_op(8));
             std::rc::Rc::new(op)
         };
@@ -3815,12 +3837,12 @@ mod tests {
     #[test]
     fn test_build_from_preamble_and_label() {
         let mut preamble = vec![
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    rop(Type::Int, 100),
+                    rop(Type::Int, 101),
                 ],
             ),
         ];
@@ -3839,23 +3861,23 @@ mod tests {
         builder.set_label_args(&[OpRef::int_op(100), OpRef::int_op(101)]);
         builder.add_guard(Op::new(
             OpCode::GuardTrue,
-            &[rooted_resop_box(Type::Int, 100)],
+            &[rop(Type::Int, 100)],
         ));
         builder.add_pure_op(Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 100),
-                rooted_resop_box(Type::Int, 101),
+                rop(Type::Int, 100),
+                rop(Type::Int, 101),
             ],
         ));
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[rooted_resop_box(Type::Int, 100)],
+            &[rop(Type::Int, 100)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(102));
         builder.add_heap_op(heap);
-        builder.add_loopinvariant_op(Op::new(OpCode::CallI, &[rooted_resop_box(Type::Int, 100)]));
+        builder.add_loopinvariant_op(Op::new(OpCode::CallI, &[rop(Type::Int, 100)]));
         assert_eq!(builder.num_ops(), 4);
     }
 
@@ -3873,15 +3895,15 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 10),
-                rooted_resop_box(Type::Int, 11),
+                rop(Type::Int, 10),
+                rop(Type::Int, 11),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
         sb.add_pure_op(&mut __ctx, pure);
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[rooted_resop_box(Type::Int, 10)],
+            &[rop(Type::Int, 10)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(21));
@@ -3903,8 +3925,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 10),
-                rooted_resop_box(Type::Int, 999),
+                rop(Type::Int, 10),
+                rop(Type::Int, 999),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -3928,8 +3950,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 10),
-                rooted_resop_box(Type::Int, 999),
+                rop(Type::Int, 10),
+                rop(Type::Int, 999),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -3972,7 +3994,7 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[rooted_resop_box(Type::Int, 30)],
+            &[rop(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
@@ -3981,8 +4003,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 30),
-                rooted_resop_box(Type::Int, 31),
+                rop(Type::Int, 30),
+                rop(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(10));
@@ -4027,21 +4049,21 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[rooted_resop_box(Type::Int, 30)],
+            &[rop(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
-        let mut loopinv = Op::new(OpCode::CallI, &[rooted_resop_box(Type::Int, 30)]);
+        let mut loopinv = Op::new(OpCode::CallI, &[rop(Type::Int, 30)]);
         loopinv.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, loopinv, PreambleOpKind::LoopInvariant);
 
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 30),
-                rooted_resop_box(Type::Int, 31),
+                rop(Type::Int, 30),
+                rop(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -4086,7 +4108,7 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[rooted_resop_box(Type::Int, 30)],
+            &[rop(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(10));
@@ -4141,8 +4163,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 30),
-                rooted_resop_box(Type::Int, 31),
+                rop(Type::Int, 30),
+                rop(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(10));
@@ -4273,8 +4295,8 @@ mod tests {
         let mut ovf = Op::new(
             OpCode::IntAddOvf,
             &[
-                rooted_resop_box(Type::Int, 30),
-                rooted_resop_box(Type::Int, 31),
+                rop(Type::Int, 30),
+                rop(Type::Int, 31),
             ],
         );
         ovf.pos.set(OpRef::int_op(10));
@@ -4331,7 +4353,7 @@ mod tests {
 
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
-            &[rooted_resop_box(Type::Int, 30)],
+            &[rop(Type::Int, 30)],
             majit_ir::make_field_descr(0, 8, majit_ir::Type::Int, majit_ir::ArrayFlag::Signed),
         );
         heap.pos.set(OpRef::int_op(20));
@@ -4340,8 +4362,8 @@ mod tests {
         let mut pure = Op::new(
             OpCode::IntAdd,
             &[
-                rooted_resop_box(Type::Int, 30),
-                rooted_resop_box(Type::Int, 31),
+                rop(Type::Int, 30),
+                rop(Type::Int, 31),
             ],
         );
         pure.pos.set(OpRef::int_op(20));
@@ -4384,7 +4406,7 @@ mod tests {
     fn test_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
         let mut builder =
             ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[rooted_resop_box(Type::Int, 7)]);
-        let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_box(Type::Int, 30)]);
+        let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rop(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
             op: rooted_resop_box(Type::Int, 14),
@@ -4422,7 +4444,7 @@ mod tests {
         let sb =
             ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[rooted_resop_box(Type::Int, 7)]);
         let mut builder = ExtendedShortPreambleBuilder::new(0, &sb);
-        let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rooted_resop_box(Type::Int, 30)]);
+        let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rop(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
             op: rooted_resop_box(Type::Int, 14),

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2310,7 +2310,7 @@ impl ShortPreambleBuilder {
     fn use_box_recursive(
         &mut self,
         result: &BoxRef,
-        visiting: &mut VecSet<BoxRef>,
+        visiting: &mut VecSet<majit_ir::operand::Operand>,
     ) -> Option<majit_ir::OpRc> {
         let produced = self
             .produced_short_boxes
@@ -2320,7 +2320,7 @@ impl ShortPreambleBuilder {
         if self.state.short_results.contains(&canonical_result) {
             return Some(produced.preamble_op);
         }
-        if !visiting.insert(result.clone()) {
+        if !visiting.insert(majit_ir::operand::Operand::from_boxref(result)) {
             return None;
         }
         for arg in produced.preamble_op.getarglist().iter() {
@@ -2338,7 +2338,7 @@ impl ShortPreambleBuilder {
                 let _ = self.use_box_recursive(arg, visiting);
             }
         }
-        visiting.remove(result);
+        visiting.remove(&majit_ir::operand::Operand::from_boxref(result));
         Some(self.state.append_to_short(result.to_opref(), &produced))
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -374,11 +374,15 @@ impl PreambleOp {
                 //   else:
                 //       preamble_op = ResOperation(sop.getopnum(), [preamble_arg, sop.getarg(1)], descr=sop.getdescr())
                 let preamble_arg = sb.produce_arg(ctx, self.op.arg(0).to_opref())?;
-                let args: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> = if self.op.opcode.is_getfield() {
-                    smallvec::smallvec![majit_ir::operand::Operand::from_boxref(&preamble_arg)]
-                } else {
-                    smallvec::smallvec![majit_ir::operand::Operand::from_boxref(&preamble_arg), self.op.arg(1)]
-                };
+                let args: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
+                    if self.op.opcode.is_getfield() {
+                        smallvec::smallvec![majit_ir::operand::Operand::from_boxref(&preamble_arg)]
+                    } else {
+                        smallvec::smallvec![
+                            majit_ir::operand::Operand::from_boxref(&preamble_arg),
+                            self.op.arg(1)
+                        ]
+                    };
                 self.op.copy_and_change(self.op.opcode, Some(&args), None)
             }
             PreambleOpKind::Pure => {
@@ -393,7 +397,10 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()).map(|b| majit_ir::operand::Operand::from_boxref(&b)))
+                    .map(|arg| {
+                        sb.produce_arg(ctx, arg.to_opref())
+                            .map(|b| majit_ir::operand::Operand::from_boxref(&b))
+                    })
                     .collect::<Option<smallvec::SmallVec<[majit_ir::operand::Operand; 3]>>>()?;
                 let opnum = if self.op.opcode.is_call() {
                     match self.op.opcode {
@@ -417,7 +424,10 @@ impl PreambleOp {
                     .op
                     .getarglist()
                     .iter()
-                    .map(|arg| sb.produce_arg(ctx, arg.to_opref()).map(|b| majit_ir::operand::Operand::from_boxref(&b)))
+                    .map(|arg| {
+                        sb.produce_arg(ctx, arg.to_opref())
+                            .map(|b| majit_ir::operand::Operand::from_boxref(&b))
+                    })
                     .collect::<Option<smallvec::SmallVec<[majit_ir::operand::Operand; 3]>>>()?;
                 let opnum = match self.op.opcode {
                     OpCode::CallI => OpCode::CallLoopinvariantI,
@@ -755,7 +765,10 @@ impl ShortBoxes {
         // returns (ptr_eq), keeping the BoxRef-keyed map ptr-stable.
         let _ = ctx.materialize_box_at(arg);
         let arg_box = ctx.materialize_box_at(arg);
-        let mut same_as = Op::new(OpCode::same_as_for_type(arg_type), &[majit_ir::operand::Operand::from_boxref(&arg_box.clone())]);
+        let mut same_as = Op::new(
+            OpCode::same_as_for_type(arg_type),
+            &[majit_ir::operand::Operand::from_boxref(&arg_box.clone())],
+        );
         same_as.pos.set(arg);
         // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
         // — keyed by the label-arg Box itself; `arg_box` is its canonical
@@ -982,8 +995,10 @@ impl ShortBoxes {
             // shortpreamble.py:277-278: copy_and_change(opnum, [preamble_arg] + args[1:])
             let mut new_args = vec![preamble_arg];
             new_args.extend_from_slice(&getfield_op.getarglist()[1..]);
-            let new_args_operand: Vec<majit_ir::operand::Operand> =
-                new_args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let new_args_operand: Vec<majit_ir::operand::Operand> = new_args
+                .iter()
+                .map(majit_ir::operand::Operand::from_boxref)
+                .collect();
             let mut new_op = Op::with_descr(
                 getfield_op.opcode,
                 &new_args_operand,
@@ -1701,12 +1716,16 @@ impl ProducedShortOp {
         // shortpreamble.py:66-68: if g.getarg(0) in exported_infos:
         //     setinfo_from_preamble(g.getarg(0), exported_infos[...])
         // Pass the Rc handle (unroll.py:61 identity preservation).
-        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg.to_boxref()) {
+        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) =
+            exported_infos.get(&object_arg.to_boxref())
+        {
             ctx.setinfo_from_preamble(obj_resolved, rc, Some(exported_infos));
         }
         let mut getfield_op = Op::new(
             OpCode::getfield_for_type(result_type),
-            &[majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(obj_resolved))],
+            &[majit_ir::operand::Operand::from_boxref(
+                &ctx.materialize_box_at(obj_resolved),
+            )],
         );
         getfield_op.setdescr(descr.clone());
         // Cat-2.2 dual-slot rule (mod.rs:1817 replay_pos): replay.pos =
@@ -1837,7 +1856,9 @@ impl ProducedShortOp {
         // getarrayitem: if the base object has exported info, import it
         // before ensuring heap/array PtrInfo.
         // Pass the Rc handle (unroll.py:61 identity preservation).
-        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) = exported_infos.get(&object_arg.to_boxref()) {
+        if let Some(crate::optimizeopt::info::OpInfo::Ptr(rc)) =
+            exported_infos.get(&object_arg.to_boxref())
+        {
             ctx.setinfo_from_preamble(obj_resolved, rc, Some(exported_infos));
         }
         let index_const = ctx.make_constant_int(index);
@@ -2057,7 +2078,10 @@ impl AbstractShortPreambleBuilderState {
                 replay_op.pos.get()
             );
             let source = same_as_source.unwrap_or_else(|| op.clone());
-            let mut same_as = Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[majit_ir::operand::Operand::from_boxref(&source)]);
+            let mut same_as = Op::new(
+                OpCode::same_as_for_type(replay_op.result_type()),
+                &[majit_ir::operand::Operand::from_boxref(&source)],
+            );
             same_as.pos.set(op.to_opref());
             self.extra_same_as.push(same_as);
         }
@@ -2466,8 +2490,12 @@ impl ShortPreambleBuilder {
         // shortpreamble.py:443 `ResOperation(rop.LABEL,
         // self.short_inputargs[:])` — the Label args are the stored
         // renamed-inputarg boxes themselves, not fresh mints.
-        let short_inputargs_operand: Vec<majit_ir::operand::Operand> =
-            self.state.short_inputargs.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let short_inputargs_operand: Vec<majit_ir::operand::Operand> = self
+            .state
+            .short_inputargs
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
         result.push(Op::new(OpCode::Label, &short_inputargs_operand));
         result.extend(self.state.short.iter().map(|op| (**op).clone()));
         let jump_args: Vec<BoxRef> = self
@@ -2476,8 +2504,10 @@ impl ShortPreambleBuilder {
             .iter()
             .map(BoxRef::from_bound_op)
             .collect();
-        let jump_args_operand: Vec<majit_ir::operand::Operand> =
-            jump_args.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let jump_args_operand: Vec<majit_ir::operand::Operand> = jump_args
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
         result.push(Op::new(OpCode::Jump, &jump_args_operand));
         result
     }
@@ -2694,7 +2724,10 @@ impl ExtendedShortPreambleBuilder {
             for i in 0..op.num_args() {
                 let arg = op.arg(i);
                 if let Some(remapped) = self.phase1_to_inputarg.get(&arg.to_opref()) {
-                    op.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped.clone()));
+                    op.setarg(
+                        i,
+                        majit_ir::operand::Operand::from_boxref(&remapped.clone()),
+                    );
                 }
             }
             // RPython use_box arg loop: insert missing deps before this op.
@@ -2740,9 +2773,12 @@ impl ExtendedShortPreambleBuilder {
                     })
             })
             .collect();
-        let jump_args_box_operand: Vec<majit_ir::operand::Operand> =
-            jump_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
-        self.short.push(Op::new(OpCode::Jump, &jump_args_box_operand));
+        let jump_args_box_operand: Vec<majit_ir::operand::Operand> = jump_args_box
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
+        self.short
+            .push(Op::new(OpCode::Jump, &jump_args_box_operand));
         // Reset state
         self.extra_same_as = self.base_extra_same_as.clone();
         self.short_preamble_jump.clear();
@@ -2814,7 +2850,10 @@ impl ExtendedShortPreambleBuilder {
         for i in 0..dep_op.num_args() {
             let a = dep_op.arg(i);
             if let Some(remapped) = self.phase1_to_inputarg.get(&a.to_opref()) {
-                dep_op.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped.clone()));
+                dep_op.setarg(
+                    i,
+                    majit_ir::operand::Operand::from_boxref(&remapped.clone()),
+                );
             }
         }
         // Recurse into dep's own args first (transitive). If any sub-dep
@@ -2915,8 +2954,10 @@ impl ExtendedShortPreambleBuilder {
                     .same_as_source
                     .clone()
                     .unwrap_or_else(|| resolved_op.clone());
-                let mut same_as =
-                    Op::new(OpCode::same_as_for_type(replay_op.result_type()), &[majit_ir::operand::Operand::from_boxref(&source)]);
+                let mut same_as = Op::new(
+                    OpCode::same_as_for_type(replay_op.result_type()),
+                    &[majit_ir::operand::Operand::from_boxref(&source)],
+                );
                 same_as.pos.set(op);
                 self.extra_same_as.push(same_as);
             }
@@ -3396,35 +3437,11 @@ mod tests {
         // 5: Jump(v4, v101)          ← back-edge
         let mut ops = vec![
             Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
-            Op::new(
-                OpCode::Label,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
+            Op::new(OpCode::Label, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
             Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    rop(Type::Int, 4),
-                    rop(Type::Int, 101),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
+            Op::new(OpCode::Jump, &[rop(Type::Int, 4), rop(Type::Int, 101)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -3444,13 +3461,7 @@ mod tests {
     fn test_extract_no_label() {
         // No label = no peeling happened
         let ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
             Op::new(OpCode::Finish, &[rop(Type::Int, 0)]),
         ];
 
@@ -3463,10 +3474,7 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntMulOvf,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 100),
-                ],
+                &[rop(Type::Int, 100), rop(Type::Int, 100)],
             ),
             Op::new(OpCode::GuardNoOverflow, &[]),
             Op::new(OpCode::Label, &[rop(Type::Int, 100)]),
@@ -3486,10 +3494,7 @@ mod tests {
         let mut ops = vec![
             Op::new(
                 OpCode::IntMulOvf,
-                &[
-                    rop(Type::Int, 200),
-                    rop(Type::Int, 200),
-                ],
+                &[rop(Type::Int, 200), rop(Type::Int, 200)],
             ),
             Op::new(OpCode::GuardNoOverflow, &[]),
             Op::new(OpCode::Label, &[rop(Type::Int, 100)]),
@@ -3506,15 +3511,9 @@ mod tests {
     fn test_extract_skips_non_label_guards() {
         // Guards that don't reference label args should not be included
         let mut ops = vec![
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
             Op::new(OpCode::GuardTrue, &[rop(Type::Int, 0)]), // refs temporary, not label arg
-            Op::new(OpCode::Label, &[rop(Type::Int, 100)]), // only v100 is a label arg
+            Op::new(OpCode::Label, &[rop(Type::Int, 100)]),   // only v100 is a label arg
             Op::new(OpCode::Jump, &[rop(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
@@ -3536,18 +3535,9 @@ mod tests {
         let guard1 = Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]);
         let guard2 = Op::new(
             OpCode::GuardClass,
-            &[
-                rop(Type::Int, 101),
-                rop(Type::Int, 200),
-            ],
+            &[rop(Type::Int, 101), rop(Type::Int, 200)],
         );
-        let non_guard = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 100),
-                rop(Type::Int, 101),
-            ],
-        );
+        let non_guard = Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]);
 
         builder.add_preamble_guard(&guard1);
         builder.add_preamble_guard(&guard2);
@@ -3571,10 +3561,7 @@ mod tests {
         // Preamble has guard on v100 and v101
         let guard = Op::new(
             OpCode::GuardValue,
-            &[
-                rop(Type::Int, 100),
-                rop(Type::Int, 200),
-            ],
+            &[rop(Type::Int, 100), rop(Type::Int, 200)],
         );
         builder.add_preamble_guard(&guard);
 
@@ -3592,13 +3579,7 @@ mod tests {
         let mut builder = CollectedShortPreambleBuilder::new();
 
         // add_preamble_op accepts any op type (not just guards)
-        let pure_op = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 100),
-                rop(Type::Int, 101),
-            ],
-        );
+        let pure_op = Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]);
         builder.add_preamble_op(&pure_op);
 
         builder.set_label_args(&[OpRef::int_op(100), OpRef::int_op(101)]);
@@ -3616,32 +3597,11 @@ mod tests {
             Op::new(OpCode::GuardNonnull, &[rop(Type::Int, 101)]),
             Op::new(
                 OpCode::GuardClass,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 200),
-                ],
+                &[rop(Type::Int, 100), rop(Type::Int, 200)],
             ),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
-            Op::new(
-                OpCode::Label,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
-            Op::new(
-                OpCode::Jump,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
+            Op::new(OpCode::Label, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
+            Op::new(OpCode::Jump, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -3665,13 +3625,7 @@ mod tests {
         let exported = vec![
             PreambleOp {
                 op: {
-                    let mut op = Op::new(
-                        OpCode::IntAdd,
-                        &[
-                            rop(Type::Int, 10),
-                            rop(Type::Int, 11),
-                        ],
-                    );
+                    let mut op = Op::new(OpCode::IntAdd, &[rop(Type::Int, 10), rop(Type::Int, 11)]);
                     op.pos.set(OpRef::int_op(7));
                     std::rc::Rc::new(op)
                 },
@@ -3683,13 +3637,7 @@ mod tests {
             },
             PreambleOp {
                 op: {
-                    let mut op = Op::new(
-                        OpCode::IntSub,
-                        &[
-                            rop(Type::Int, 7),
-                            rop(Type::Int, 11),
-                        ],
-                    );
+                    let mut op = Op::new(OpCode::IntSub, &[rop(Type::Int, 7), rop(Type::Int, 11)]);
                     op.pos.set(OpRef::int_op(8));
                     std::rc::Rc::new(op)
                 },
@@ -3730,13 +3678,7 @@ mod tests {
             rooted_resop_box(Type::Int, 101),
         ];
 
-        let mut ovf = Op::new(
-            OpCode::IntAddOvf,
-            &[
-                rop(Type::Int, 10),
-                rop(Type::Int, 11),
-            ],
-        );
+        let mut ovf = Op::new(OpCode::IntAddOvf, &[rop(Type::Int, 10), rop(Type::Int, 11)]);
         ovf.pos.set(OpRef::int_op(20));
         let guard = Op::new(OpCode::GuardNoOverflow, &[]);
 
@@ -3838,13 +3780,7 @@ mod tests {
     fn test_build_from_preamble_and_label() {
         let mut preamble = vec![
             Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]),
-            Op::new(
-                OpCode::IntAdd,
-                &[
-                    rop(Type::Int, 100),
-                    rop(Type::Int, 101),
-                ],
-            ),
+            Op::new(OpCode::IntAdd, &[rop(Type::Int, 100), rop(Type::Int, 101)]),
         ];
         assign_positions(&mut preamble, 0);
 
@@ -3859,16 +3795,10 @@ mod tests {
     fn test_extended_builder() {
         let mut builder = CollectedExtendedShortPreambleBuilder::new();
         builder.set_label_args(&[OpRef::int_op(100), OpRef::int_op(101)]);
-        builder.add_guard(Op::new(
-            OpCode::GuardTrue,
-            &[rop(Type::Int, 100)],
-        ));
+        builder.add_guard(Op::new(OpCode::GuardTrue, &[rop(Type::Int, 100)]));
         builder.add_pure_op(Op::new(
             OpCode::IntAdd,
-            &[
-                rop(Type::Int, 100),
-                rop(Type::Int, 101),
-            ],
+            &[rop(Type::Int, 100), rop(Type::Int, 101)],
         ));
         let mut heap = Op::with_descr(
             OpCode::GetfieldGcI,
@@ -3892,13 +3822,7 @@ mod tests {
         for arg in [OpRef::int_op(10), OpRef::int_op(11), OpRef::int_op(12)] {
             sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
         }
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 10),
-                rop(Type::Int, 11),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 10), rop(Type::Int, 11)]);
         pure.pos.set(OpRef::int_op(20));
         sb.add_pure_op(&mut __ctx, pure);
         let mut heap = Op::with_descr(
@@ -3922,13 +3846,7 @@ mod tests {
         let mut __ctx = crate::optimizeopt::OptContext::new(256);
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10)]);
         sb.add_short_input_arg(&mut __ctx, OpRef::int_op(10), majit_ir::Type::Int);
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 10),
-                rop(Type::Int, 999),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 10), rop(Type::Int, 999)]);
         pure.pos.set(OpRef::int_op(20));
         sb.add_pure_op(&mut __ctx, pure);
 
@@ -3947,13 +3865,7 @@ mod tests {
         let mut sb = ShortBoxes::with_label_args(&[OpRef::int_op(10)]);
         sb.add_short_input_arg(&mut __ctx, OpRef::int_op(10), majit_ir::Type::Int);
         sb.note_known_constant(OpRef::int_op(999));
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 10),
-                rop(Type::Int, 999),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 10), rop(Type::Int, 999)]);
         pure.pos.set(OpRef::int_op(20));
         sb.add_pure_op(&mut __ctx, pure);
 
@@ -4000,13 +3912,7 @@ mod tests {
         heap.pos.set(OpRef::int_op(10));
         sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 30),
-                rop(Type::Int, 31),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 30), rop(Type::Int, 31)]);
         pure.pos.set(OpRef::int_op(10));
         sb.add_potential_op(&mut __ctx, None, pure, PreambleOpKind::Pure);
 
@@ -4059,13 +3965,7 @@ mod tests {
         loopinv.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, loopinv, PreambleOpKind::LoopInvariant);
 
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 30),
-                rop(Type::Int, 31),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 30), rop(Type::Int, 31)]);
         pure.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, pure, PreambleOpKind::Pure);
 
@@ -4160,13 +4060,7 @@ mod tests {
 
         // A pure op whose result coincides with label arg 10, depending on the
         // other two label args (avoids a self-referential in-production cycle).
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 30),
-                rop(Type::Int, 31),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 30), rop(Type::Int, 31)]);
         pure.pos.set(OpRef::int_op(10));
         sb.add_pure_op(&mut ctx, pure);
 
@@ -4292,13 +4186,7 @@ mod tests {
             sb.add_short_input_arg(&mut __ctx, arg, majit_ir::Type::Int);
         }
 
-        let mut ovf = Op::new(
-            OpCode::IntAddOvf,
-            &[
-                rop(Type::Int, 30),
-                rop(Type::Int, 31),
-            ],
-        );
+        let mut ovf = Op::new(OpCode::IntAddOvf, &[rop(Type::Int, 30), rop(Type::Int, 31)]);
         ovf.pos.set(OpRef::int_op(10));
         sb.add_potential_op(&mut __ctx, None, ovf, PreambleOpKind::Pure);
 
@@ -4359,13 +4247,7 @@ mod tests {
         heap.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, heap, PreambleOpKind::Heap);
 
-        let mut pure = Op::new(
-            OpCode::IntAdd,
-            &[
-                rop(Type::Int, 30),
-                rop(Type::Int, 31),
-            ],
-        );
+        let mut pure = Op::new(OpCode::IntAdd, &[rop(Type::Int, 30), rop(Type::Int, 31)]);
         pure.pos.set(OpRef::int_op(20));
         sb.add_potential_op(&mut __ctx, None, pure, PreambleOpKind::Pure);
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3772,7 +3772,9 @@ impl OptUnroll {
             for a in &jump_args {
                 jump_args_box.push(ctx.materialize_box_at(*a));
             }
-            let mut jump = Op::new(OpCode::Jump, &jump_args_box);
+            let jump_args_box_operand: Vec<majit_ir::operand::Operand> =
+                jump_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let mut jump = Op::new(OpCode::Jump, &jump_args_box_operand);
             jump.setdescr(target_token.as_jump_target_descr());
             // unroll.py:357 lets send_extra_operation raise InvalidLoop. This
             // function returns Option (flag convention); propagate consumed
@@ -4006,7 +4008,7 @@ impl OptUnroll {
                         // unroll.py:367: mapping values are the replayed op
                         // objects; bind to the registered producer (memoized
                         // on box_cache) rather than minting an unbound box.
-                        Some(&mapped) => new_op.setarg(i, ctx.materialize_box_at(mapped)),
+                        Some(&mapped) => new_op.setarg(i, majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(mapped))),
                         None => {
                             // RPython: _map_args raises KeyError for unmapped
                             // args. This is equivalent to InvalidLoop — the
@@ -4765,7 +4767,7 @@ fn emit_alias_same_as_for_imports(
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
 ) {
     for alias in imported_short_aliases {
-        let mut op = Op::new(alias.same_as_opcode, &[alias.same_as_source.clone()]);
+        let mut op = Op::new(alias.same_as_opcode, &[majit_ir::operand::Operand::from_boxref(&alias.same_as_source.clone())]);
         op.pos.set(alias.result);
         result.push(std::rc::Rc::new(op));
     }
@@ -4839,7 +4841,9 @@ fn assemble_peeled_trace_with_jump_args(
         for a in start_label_args {
             start_label_args_box.push(ctx.materialize_box_at(*a));
         }
-        let mut start_label = Op::new(OpCode::Label, &start_label_args_box);
+        let start_label_args_box_operand: Vec<majit_ir::operand::Operand> =
+            start_label_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let mut start_label = Op::new(OpCode::Label, &start_label_args_box_operand);
         start_label.pos.set(OpRef::NONE);
         start_label.setdescr(start_label_descr);
         result.push(std::rc::Rc::new(start_label));
@@ -5031,7 +5035,7 @@ fn assemble_peeled_trace_with_jump_args(
                         });
                     if tp != Type::Void {
                         let arg_source = ctx.materialize_box_at(source);
-                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[arg_source]);
+                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[majit_ir::operand::Operand::from_boxref(&arg_source)]);
                         same_as.pos.set(arg);
                         fallthrough_aliases.push(same_as);
                     }
@@ -5049,7 +5053,9 @@ fn assemble_peeled_trace_with_jump_args(
     for a in &full_label_args {
         full_label_args_box.push(ctx.materialize_box_at(*a));
     }
-    let mut label_op = Op::new(OpCode::Label, &full_label_args_box);
+    let full_label_args_box_operand: Vec<majit_ir::operand::Operand> =
+        full_label_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+    let mut label_op = Op::new(OpCode::Label, &full_label_args_box_operand);
     // resoperation.py:260 AbstractResOp.type = 'v' default — Label has no
     // result Box, so its OpRef position carries the Void tag rather than
     // a stray Int tag. `op_index` filters Void ops so this OpRef never
@@ -5229,7 +5235,7 @@ fn assemble_peeled_trace_with_jump_args(
                     Some(rc) => BoxRef::from_bound_op(rc),
                     None => ctx.materialize_box_at(mapped),
                 };
-                new_op.setarg(i, boxed);
+                new_op.setarg(i, majit_ir::operand::Operand::from_boxref(&boxed));
             }
         }
         if new_op.opcode == OpCode::Label {
@@ -5318,10 +5324,10 @@ fn assemble_peeled_trace_with_jump_args(
                 extended_args.push(mapped_arg);
                 original_args.push(BoxRef::from_opref(source_arg));
             }
-            let mut extended_args_box: smallvec::SmallVec<[BoxRef; 3]> =
+            let mut extended_args_box: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
                 smallvec::SmallVec::with_capacity(extended_args.len());
             for a in &extended_args {
-                extended_args_box.push(ctx.materialize_box_at(*a));
+                extended_args_box.push(majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(*a)));
             }
             new_op.initarglist(extended_args_box);
         }
@@ -5398,10 +5404,10 @@ fn assemble_peeled_trace_with_jump_args(
                 }
             }
             // unroll.py-style bulk replace: jump arity is finalized here.
-            let mut jump_args_box: smallvec::SmallVec<[BoxRef; 3]> =
+            let mut jump_args_box: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
                 smallvec::SmallVec::with_capacity(jump_args.len());
             for a in &jump_args {
-                jump_args_box.push(ctx.materialize_box_at(*a));
+                jump_args_box.push(majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(*a)));
             }
             new_op.initarglist(jump_args_box);
         }
@@ -5459,12 +5465,14 @@ fn assemble_peeled_trace_with_jump_args(
                     .iter()
                     .map(|a| a.to_opref())
                     .collect();
-                let mut new_args = result[label_idx].getarglist_copy();
+                let new_args_boxref = result[label_idx].getarglist_copy();
+                let mut new_args: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
+                    new_args_boxref.iter().map(majit_ir::operand::Operand::from_boxref).collect();
                 new_args.extend(
                     extra_live_args
                         .into_iter()
                         .filter(|arg| !existing.contains(arg))
-                        .map(BoxRef::from_opref),
+                        .map(|arg| majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(arg))),
                 );
                 result[label_idx].initarglist(new_args);
             }
@@ -5607,7 +5615,7 @@ impl OptUnroll {
             for i in 0..peeled.num_args() {
                 let arg = peeled.arg(i);
                 if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                    peeled.setarg(i, remapped_producer_box(ctx, new_ref));
+                    peeled.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped_producer_box(ctx, new_ref)));
                 }
                 // Args referencing ops outside the buffer (e.g., input args)
                 // are kept as-is.
@@ -5633,7 +5641,9 @@ impl OptUnroll {
         // Emit Label between peeled and original body.
         // The Label's args match the Jump's args, forming the loop header.
         let label_pos = ctx.reserve_pos_typed(OpCode::Label.result_type());
-        let mut label_op = Op::new(OpCode::Label, &jump_op.getarglist());
+        let jump_label_args: Vec<majit_ir::operand::Operand> =
+            jump_op.getarglist().iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let mut label_op = Op::new(OpCode::Label, &jump_label_args);
         label_op.pos.set(label_pos);
         ctx.emit(label_op);
 
@@ -5657,7 +5667,7 @@ impl OptUnroll {
             for i in 0..body_op.num_args() {
                 let arg = body_op.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    body_op.setarg(i, remapped_producer_box(ctx, new_ref));
+                    body_op.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped_producer_box(ctx, new_ref)));
                 }
             }
             if let Some(fa) = body_op.fail_args_mut() {
@@ -5790,7 +5800,7 @@ impl Optimization for OptUnroll {
             for i in 0..jump.num_args() {
                 let arg = jump.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    jump.setarg(i, remapped_producer_box(ctx, new_ref));
+                    jump.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped_producer_box(ctx, new_ref)));
                 }
             }
             // Reserve the Jump's own position so it lands above any
@@ -5825,6 +5835,7 @@ mod tests {
     use super::*;
     use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
     use crate::optimizeopt::optimizer::Optimizer;
+    use majit_ir::operand::Operand;
     use majit_ir::GcRef;
 
     /// Assign sequential positions to ops starting from `base`.
@@ -5890,11 +5901,14 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
-            Op::new(OpCode::Finish, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(
+                OpCode::Finish,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
         ];
         assign_positions(&mut ops, 0);
 
@@ -5928,8 +5942,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 0),
-                        rooted_resop_box(Type::Int, 1),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(2));
@@ -5938,9 +5952,9 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 2),
-                    rooted_resop_box(Type::Int, 50),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 2)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 50)),
                 ],
             ),
         ];
@@ -5983,14 +5997,17 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             );
             op.pos.set(OpRef::int_op(2));
             op
         }];
-        let mut jump = Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]);
+        let mut jump = Op::new(
+            OpCode::Jump,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))],
+        );
         jump.setdescr(TargetToken::new_preamble(7).as_jump_target_descr());
 
         let body_ops: Vec<majit_ir::OpRc> = body_ops.into_iter().map(std::rc::Rc::new).collect();
@@ -6090,7 +6107,10 @@ mod tests {
             VirtualState::new(vec![VirtualStateInfo::Constant(Value::Ref(old))]),
             exported_infos,
             vec![PreambleOp {
-                op: std::rc::Rc::new(Op::new(OpCode::SameAsR, &[BoxRef::from_opref(old_ref)])),
+                op: std::rc::Rc::new(Op::new(
+                    OpCode::SameAsR,
+                    &[Operand::from_boxref(&BoxRef::from_opref(old_ref))],
+                )),
                 res: BoxRef::from_opref(old_ref),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
@@ -6110,7 +6130,7 @@ mod tests {
                 res: BoxRef::from_opref(old_ref),
                 preamble_op: std::rc::Rc::new(Op::new(
                     OpCode::SameAsR,
-                    &[BoxRef::from_opref(old_ref)],
+                    &[Operand::from_boxref(&BoxRef::from_opref(old_ref))],
                 )),
                 invented_name: false,
                 same_as_source: Some(BoxRef::from_opref(old_ref)),
@@ -6120,7 +6140,10 @@ mod tests {
         state.short_box_const_values = short_box_const_values;
         state.short_preamble = Some(ShortPreamble {
             ops: vec![ShortPreambleOp {
-                op: Op::new(OpCode::GuardNonnull, &[BoxRef::from_opref(old_ref)]),
+                op: Op::new(
+                    OpCode::GuardNonnull,
+                    &[Operand::from_boxref(&BoxRef::from_opref(old_ref))],
+                ),
                 arg_mapping: Vec::new(),
                 fail_arg_mapping: Vec::new(),
             }],
@@ -6137,7 +6160,7 @@ mod tests {
         state.runtime_boxes.push(BoxRef::from_opref(old_ref));
         state.patchguardop = Some(Op::new(
             OpCode::GuardNonnull,
-            &[BoxRef::from_opref(old_ref)],
+            &[Operand::from_boxref(&BoxRef::from_opref(old_ref))],
         ));
 
         state.walk_const_ptr_refs_mut(&mut |slot| {
@@ -6202,8 +6225,8 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6229,15 +6252,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(
                 OpCode::IntSub,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6283,15 +6306,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(
                 OpCode::IntMul,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ), // references op0
             Op::new(OpCode::Jump, &[]),
@@ -6329,8 +6352,8 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6354,12 +6377,12 @@ mod tests {
     fn test_guards_duplicated_in_peel() {
         // Guards in the preamble serve as type checks.
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]),
+            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6388,12 +6411,12 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             {
-                let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 100)]);
+                let mut guard = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]);
                 guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into()); // refs op0
                 guard
             },
@@ -6433,11 +6456,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]), // carries v0 (the add result)
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]), // carries v0 (the add result)
         ];
         assign_positions(&mut ops, 0);
 
@@ -6464,15 +6487,15 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
                 ],
             ),
         ];
@@ -6501,26 +6524,26 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(
                 OpCode::IntSub,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(
                 OpCode::IntMul,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 2)]),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]),
+            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6550,7 +6573,7 @@ mod tests {
 
         // Simulate some state.
         pass.buffer
-            .push(Op::new(OpCode::IntAdd, &[rooted_resop_box(Type::Int, 0)]));
+            .push(Op::new(OpCode::IntAdd, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]));
         pass.seen_jump = true;
 
         pass.setup();
@@ -6568,12 +6591,12 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 0)]),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6610,7 +6633,7 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::GuardTrue,
-                &[rooted_resop_box(Type::Int, 100)],
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))],
                 descr.clone(),
             ),
             Op::new(OpCode::Jump, &[]),
@@ -6658,25 +6681,25 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 100),
-                    rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 100)),
                 ],
             ),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 1),
-                    rooted_resop_box(Type::Int, 0),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 2)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6747,11 +6770,11 @@ mod tests {
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_inputarg_box(Type::Int, 0),
-                    rooted_inputarg_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_inputarg_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[rooted_inputarg_box(Type::Int, 0)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_inputarg_box(Type::Int, 0))]),
         ];
         assign_positions(&mut ops, 2);
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -6764,16 +6787,16 @@ mod tests {
     #[test]
     fn test_unroll_optimizer_count_guards() {
         let ops = vec![
-            Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
             Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[rooted_resop_box(Type::Int, 0)]),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
         ];
         assert_eq!(UnrollOptimizer::count_guards(&ops), 2);
     }
@@ -6908,7 +6931,11 @@ mod tests {
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
-                    let mut op = Op::with_descr(OpCode::GetfieldGcI, &[si0], field_descr.clone());
+                    let mut op = Op::with_descr(
+                        OpCode::GetfieldGcI,
+                        &[Operand::from_boxref(&si0)],
+                        field_descr.clone(),
+                    );
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
@@ -6973,7 +7000,7 @@ mod tests {
                 op: {
                     let mut op = Op::with_descr(
                         OpCode::GetfieldGcPureI,
-                        &[BoxRef::from_opref(OpRef::const_ptr(ptr))],
+                        &[Operand::from_boxref(&BoxRef::from_opref(OpRef::const_ptr(ptr)))],
                         field_descr.clone(),
                     );
                     op.pos.set(OpRef::int_op(11));
@@ -7040,7 +7067,10 @@ mod tests {
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
-                    let mut op = Op::new(OpCode::CallLoopinvariantI, &[BoxRef::from_opref(func)]);
+                    let mut op = Op::new(
+                        OpCode::CallLoopinvariantI,
+                        &[Operand::from_boxref(&BoxRef::from_opref(func))],
+                    );
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
@@ -7105,7 +7135,10 @@ mod tests {
             crate::optimizeopt::vec_assoc::VecAssoc::new(),
             vec![crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
-                    let mut op = Op::new(OpCode::CallLoopinvariantI, &[BoxRef::from_opref(func)]);
+                    let mut op = Op::new(
+                        OpCode::CallLoopinvariantI,
+                        &[Operand::from_boxref(&BoxRef::from_opref(func))],
+                    );
                     op.pos.set(source);
                     std::rc::Rc::new(op)
                 },
@@ -7166,8 +7199,8 @@ mod tests {
                     let mut op = Op::new(
                         OpCode::IntAdd,
                         &[
-                            rooted_resop_box(Type::Int, 0),
-                            rooted_resop_box(Type::Int, 1),
+                            Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                            Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                         ],
                     );
                     op.pos.set(OpRef::int_op(20));
@@ -7269,7 +7302,7 @@ mod tests {
                 op: {
                     let mut op = Op::with_descr(
                         OpCode::GetfieldGcR,
-                        &[rooted_resop_box(Type::Ref, 3)],
+                        &[Operand::from_boxref(&rooted_resop_box(Type::Ref, 3))],
                         majit_ir::descr::make_field_descr_full(56, 0, 8, Type::Ref, false),
                     );
                     op.pos.set(OpRef::ref_op(19));
@@ -7378,7 +7411,10 @@ mod tests {
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
-                    let mut op = Op::new(OpCode::IntAdd, &[si0, si1]);
+                    let mut op = Op::new(
+                        OpCode::IntAdd,
+                        &[Operand::from_boxref(&si0), Operand::from_boxref(&si1)],
+                    );
                     op.pos.set(OpRef::int_op(30));
                     std::rc::Rc::new(op)
                 },
@@ -7439,8 +7475,8 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             );
             op.pos.set(OpRef::int_op(3));
@@ -7451,14 +7487,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntMul,
                     &[
-                        rooted_resop_box(Type::Int, 50),
-                        rooted_resop_box(Type::Int, 0),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 50)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(1));
                 op
             },
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 50)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))]),
         ];
 
         let combined = assemble_peeled_trace(
@@ -7502,8 +7538,8 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             );
             op.pos.set(OpRef::int_op(11));
@@ -7514,8 +7550,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntGe,
                     &[
-                        rooted_resop_box(Type::Int, 11),
-                        BoxRef::from_opref(OpRef::const_int(2)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 11)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(2))),
                     ],
                 );
                 op.pos.set(OpRef::int_op(4));
@@ -7525,14 +7561,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 11),
-                        BoxRef::from_opref(OpRef::const_int(1)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 11)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(1))),
                     ],
                 );
                 op.pos.set(OpRef::int_op(11));
                 op
             },
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 11)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 11))]),
         ];
 
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -7572,7 +7608,7 @@ mod tests {
     #[test]
     fn test_assemble_peeled_trace_preserves_visible_preamble_box_over_body_collision() {
         let p1_ops = vec![{
-            let mut op = Op::new(OpCode::GetfieldGcR, &[rooted_resop_box(Type::Int, 3)]);
+            let mut op = Op::new(OpCode::GetfieldGcR, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 3))]);
             op.pos.set(OpRef::int_op(19));
             op.setdescr(majit_ir::descr::make_field_descr_full(
                 56,
@@ -7588,8 +7624,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::SetfieldGc,
                     &[
-                        rooted_resop_box(Type::Int, 25),
-                        rooted_resop_box(Type::Int, 19),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 25)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 19)),
                     ],
                 );
                 op.setdescr(majit_ir::descr::make_field_descr_full(
@@ -7605,14 +7641,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 0),
-                        BoxRef::from_opref(OpRef::const_int(1)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(1))),
                     ],
                 );
                 op.pos.set(OpRef::int_op(19));
                 op
             },
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 19)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 19))]),
         ];
 
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -7651,8 +7687,8 @@ mod tests {
             let mut op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             );
             op.pos.set(OpRef::int_op(3));
@@ -7663,8 +7699,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntMul,
                     &[
-                        rooted_resop_box(Type::Int, 50),
-                        rooted_resop_box(Type::Int, 10),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 50)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(1));
@@ -7673,8 +7709,8 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 10),
-                    rooted_resop_box(Type::Int, 50),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 50)),
                 ],
             ),
         ];
@@ -7724,7 +7760,7 @@ mod tests {
         // immediate, and the box-namespace entries in the constants
         // snapshot must round-trip unchanged.
         let p1_ops = vec![{
-            let mut op = Op::new(OpCode::SameAsI, &[rooted_resop_box(Type::Int, 37)]);
+            let mut op = Op::new(OpCode::SameAsI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 37))]);
             op.pos.set(OpRef::void_op(857));
             op
         }];
@@ -7733,8 +7769,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::GuardValue,
                     &[
-                        rooted_resop_box(Type::Void, 857),
-                        BoxRef::from_opref(OpRef::const_int(2)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Void, 857)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(2))),
                     ],
                 );
                 op.setfailargs(vec![rooted_resop_box(Type::Void, 857)].into());
@@ -7743,10 +7779,10 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 10),
-                    rooted_resop_box(Type::Int, 853),
-                    rooted_resop_box(Type::Void, 857),
-                    rooted_resop_box(Type::Int, 850),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 853)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Void, 857)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 850)),
                 ],
             ),
         ];
@@ -7826,7 +7862,7 @@ mod tests {
         // pre-replaced with OpRef::int_op(10) (the corresponding label_arg).
         let p2_ops = vec![
             {
-                let mut op = Op::new(OpCode::GetfieldGcPureI, &[rooted_resop_box(Type::Int, 50)]);
+                let mut op = Op::new(OpCode::GetfieldGcPureI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))]);
                 op.pos.set(OpRef::int_op(1));
                 op.setdescr(majit_ir::make_field_descr(
                     0,
@@ -7839,8 +7875,8 @@ mod tests {
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 10),
-                    rooted_resop_box(Type::Int, 50),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 50)),
                 ],
             ),
         ];
@@ -7898,7 +7934,7 @@ mod tests {
         // it reaches the assembler. We mirror that here.
         let p2_ops = vec![
             {
-                let mut op = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Int, 64)]);
+                let mut op = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 64))]);
                 op.setfailargs(vec![rooted_resop_box(Type::Int, 64)].into());
                 op
             },
@@ -7906,14 +7942,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 10),
-                        BoxRef::from_opref(OpRef::const_int(1)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(1))),
                     ],
                 );
                 op.pos.set(OpRef::int_op(64));
                 op
             },
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 64)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 64))]),
         ];
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
@@ -7969,11 +8005,11 @@ mod tests {
             let mut jump = Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Int, 0),
-                    rooted_resop_box(Type::Int, 1),
-                    rooted_resop_box(Type::Int, 2),
-                    rooted_resop_box(Type::Int, 3),
-                    rooted_resop_box(Type::Int, 4),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 2)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 3)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 4)),
                 ],
             );
             jump.setdescr(start_descr.clone());
@@ -8032,8 +8068,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 0),
-                        rooted_resop_box(Type::Int, 1),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                     ],
                 );
                 op.pos.set(OpRef::int_op(2));
@@ -8043,8 +8079,8 @@ mod tests {
                 let mut jump = Op::new(
                     OpCode::Jump,
                     &[
-                        rooted_resop_box(Type::Int, 0),
-                        rooted_resop_box(Type::Int, 1),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                     ],
                 );
                 jump.setdescr(start_descr.clone());
@@ -8086,8 +8122,8 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 10),
-                        BoxRef::from_opref(OpRef::const_int(1)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(1))),
                     ],
                 );
                 op.pos.set(OpRef::int_op(20));
@@ -8097,9 +8133,9 @@ mod tests {
                 let mut jump = Op::new(
                     OpCode::Jump,
                     &[
-                        rooted_resop_box(Type::Int, 10),
-                        rooted_resop_box(Type::Int, 50),
-                        rooted_resop_box(Type::Int, 60),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 10)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 50)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 60)),
                     ],
                 );
                 jump.setdescr(start_descr.clone());
@@ -8161,11 +8197,11 @@ mod tests {
             Op::new(
                 OpCode::SetfieldGc,
                 &[
-                    rooted_resop_box(Type::Ref, 1),
-                    rooted_resop_box(Type::Int, 0),
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
         ];
         let constants = majit_ir::VecAssoc::from([
             (2_u32, majit_ir::Value::Int(606)),
@@ -8206,7 +8242,7 @@ mod tests {
         // sites). Mirrors `assemble_peeled_trace_with_jump_args`'s
         // `label_arg.is_constant()` predicate.
         let const_extra = OpRef::const_int(606);
-        let p2_ops = vec![Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 10)])];
+        let p2_ops = vec![Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 10))])];
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
         let combined = assemble_peeled_trace(
@@ -8248,14 +8284,14 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 200),
-                        BoxRef::from_opref(OpRef::const_int(1)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 200)),
+                        Operand::from_boxref(&BoxRef::from_opref(OpRef::const_int(1))),
                     ],
                 );
                 op.pos.set(OpRef::int_op(20));
                 op
             },
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 200)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 200))]),
         ];
 
         let combined = assemble_peeled_trace(
@@ -8301,26 +8337,26 @@ mod tests {
                 let mut op = Op::new(
                     OpCode::IntAdd,
                     &[
-                        rooted_resop_box(Type::Int, 0),
-                        rooted_resop_box(Type::Int, 1),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                        Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                     ],
                 );
                 op.pos.set(OpRef::void_op(3));
                 op
             },
-            Op::new(OpCode::Jump, &[rooted_resop_box(Type::Int, 0)]),
+            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
         ];
         let redirected_tail = vec![
             {
-                let mut op = Op::new(OpCode::GuardTrue, &[rooted_resop_box(Type::Void, 3)]);
+                let mut op = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Void, 3))]);
                 op.setfailargs(vec![rooted_resop_box(Type::Void, 3)].into());
                 op
             },
             Op::new(
                 OpCode::Jump,
                 &[
-                    rooted_resop_box(Type::Void, 3),
-                    rooted_resop_box(Type::Int, 4),
+                    Operand::from_boxref(&rooted_resop_box(Type::Void, 3)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, 4)),
                 ],
             ),
         ];
@@ -8348,9 +8384,9 @@ mod tests {
         let ops = vec![Op::new(
             OpCode::Jump,
             &[
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 1),
-                rooted_resop_box(Type::Int, 2),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
+                Operand::from_boxref(&rooted_resop_box(Type::Int, 2)),
             ],
         )];
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2028,8 +2028,8 @@ pub struct ExportedState {
     /// `short_inputarg_refs[i]`; keeping the strong Rc alive across the
     /// cross-peel export boundary lets the box resolve to a real bound
     /// `InputArg` in the rebuilt Phase-2 OptContext, so dependent operands
-    /// bind to `Operand::InputArg` rather than the position-only
-    /// `Operand::Box` catch-all.
+    /// bind to `Operand::InputArg` rather than an unbound position-only box
+    /// (which `from_boxref` rejects).
     pub short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// unroll.py: runtime_boxes — live values at the original jump point.
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
@@ -3049,8 +3049,8 @@ impl OptUnroll {
             // Each is DISTINCT from its `short_args[i]` original so the rename
             // is a real rename, not an identity no-op. Build the rooted
             // `InputArgRc` pool alongside (same shape as the preview pass) so
-            // the boxes stay bound to live `InputArg`s instead of shedding to
-            // the position-only `Operand::Box` catch-all.
+            // the boxes stay bound to live `InputArg`s instead of an unbound
+            // position-only box (which `from_boxref` rejects).
             let mut boxes = Vec::with_capacity(short_args.len());
             let mut refs = Vec::with_capacity(short_args.len());
             for &a in &short_args {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2969,7 +2969,7 @@ impl OptUnroll {
         ctx: &mut OptContext,
         exported_int_bounds: Option<
             &crate::optimizeopt::vec_assoc::VecAssoc<
-                BoxRef,
+                majit_ir::operand::Operand,
                 crate::optimizeopt::intutils::IntBound,
             >,
         >,
@@ -3263,7 +3263,7 @@ impl OptUnroll {
         ctx: &OptContext,
         exported_int_bounds: Option<
             &crate::optimizeopt::vec_assoc::VecAssoc<
-                BoxRef,
+                majit_ir::operand::Operand,
                 crate::optimizeopt::intutils::IntBound,
             >,
         >,
@@ -3314,7 +3314,7 @@ impl OptUnroll {
         ctx: &OptContext,
         exported_int_bounds: Option<
             &crate::optimizeopt::vec_assoc::VecAssoc<
-                BoxRef,
+                majit_ir::operand::Operand,
                 crate::optimizeopt::intutils::IntBound,
             >,
         >,
@@ -4409,7 +4409,7 @@ impl OptUnroll {
         ctx: &OptContext,
         exported_int_bounds: Option<
             &crate::optimizeopt::vec_assoc::VecAssoc<
-                BoxRef,
+                majit_ir::operand::Operand,
                 crate::optimizeopt::intutils::IntBound,
             >,
         >,
@@ -4483,8 +4483,11 @@ impl OptUnroll {
         if let Some(bound) = exported_int_bounds.and_then(|bounds| {
             // Same Phase-1 ctx as the export producer, so the canonical box for
             // `opref` is the memoized `Rc` the bound was keyed under (ptr_eq).
-            ctx.get_box_replacement_box(opref)
-                .and_then(|b| bounds.get(&b).cloned())
+            ctx.get_box_replacement_box(opref).and_then(|b| {
+                bounds
+                    .get(&majit_ir::operand::Operand::from_boxref(&b))
+                    .cloned()
+            })
         }) {
             return Some(OpInfo::int_bound(bound));
         }
@@ -4521,7 +4524,10 @@ pub(crate) fn export_state(
     optimizer: &mut crate::optimizeopt::optimizer::Optimizer,
     ctx: &mut OptContext,
     exported_int_bounds: Option<
-        &crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, crate::optimizeopt::intutils::IntBound>,
+        &crate::optimizeopt::vec_assoc::VecAssoc<
+            majit_ir::operand::Operand,
+            crate::optimizeopt::intutils::IntBound,
+        >,
     >,
 ) -> ExportedState {
     OptUnroll::new().export_state_with_bounds(
@@ -6753,8 +6759,10 @@ mod tests {
         use crate::optimizeopt::intutils::IntBound;
 
         let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(4, 0);
-        let mut exported_bounds: crate::optimizeopt::vec_assoc::VecAssoc<BoxRef, IntBound> =
-            crate::optimizeopt::vec_assoc::VecAssoc::new();
+        let mut exported_bounds: crate::optimizeopt::vec_assoc::VecAssoc<
+            majit_ir::operand::Operand,
+            IntBound,
+        > = crate::optimizeopt::vec_assoc::VecAssoc::new();
         // Bind the export-input position at its source (a forced end-arg is a
         // bound box in production); virtualstate.py:711-720 create_state
         // receives real AbstractValues.
@@ -6764,7 +6772,10 @@ mod tests {
         let box21 = ctx
             .get_box_replacement_box(OpRef::int_op(21))
             .expect("int_op(21) bound to a box");
-        exported_bounds.insert(box21, IntBound::bounded(10, 20));
+        exported_bounds.insert(
+            majit_ir::operand::Operand::from_boxref(&box21),
+            IntBound::bounded(10, 20),
+        );
 
         let exported = export_state(
             &[OpRef::int_op(21)],

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5569,7 +5569,7 @@ impl OptUnroll {
             for i in 0..peeled.num_args() {
                 let arg = peeled.arg(i);
                 if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                    peeled.setarg(i, BoxRef::from_opref(new_ref));
+                    peeled.setarg(i, remapped_producer_box(ctx, new_ref));
                 }
                 // Args referencing ops outside the buffer (e.g., input args)
                 // are kept as-is.
@@ -5577,8 +5577,8 @@ impl OptUnroll {
             if let Some(fa) = peeled.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                        *arg =
-                            majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(new_ref));
+                        let new_box = remapped_producer_box(ctx, new_ref);
+                        *arg = majit_ir::operand::Operand::from_boxref(&new_box);
                     }
                 }
             }
@@ -5619,14 +5619,14 @@ impl OptUnroll {
             for i in 0..body_op.num_args() {
                 let arg = body_op.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    body_op.setarg(i, BoxRef::from_opref(new_ref));
+                    body_op.setarg(i, remapped_producer_box(ctx, new_ref));
                 }
             }
             if let Some(fa) = body_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                        *arg =
-                            majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(new_ref));
+                        let new_box = remapped_producer_box(ctx, new_ref);
+                        *arg = majit_ir::operand::Operand::from_boxref(&new_box);
                     }
                 }
             }
@@ -5640,6 +5640,20 @@ impl OptUnroll {
             ctx.emit(body_op);
         }
         orig_ref_map
+    }
+}
+
+/// Resolve a remapped peel position to its canonical producer box, mirroring
+/// the import-path binding (`get_box_replacement_box`, else `materialize_box_at`
+/// — unroll.rs:2997-3024 / S10). The peeled / body producer emitted at
+/// `new_ref` precedes its consumers' arg writes (SSA def-before-use), so the
+/// read resolves to the bound `Op`; the `materialize_box_at` arm mints a
+/// registered stand-in that the producer's later `emit` catches up (mod.rs
+/// forward-reference path), never a position-only `Operand::Box`.
+fn remapped_producer_box(ctx: &mut OptContext, new_ref: OpRef) -> BoxRef {
+    match ctx.get_box_replacement_box(new_ref) {
+        Some(b) => b,
+        None => ctx.materialize_box_at(new_ref),
     }
 }
 
@@ -5738,7 +5752,7 @@ impl Optimization for OptUnroll {
             for i in 0..jump.num_args() {
                 let arg = jump.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    jump.setarg(i, BoxRef::from_opref(new_ref));
+                    jump.setarg(i, remapped_producer_box(ctx, new_ref));
                 }
             }
             // Reserve the Jump's own position so it lands above any

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3772,8 +3772,10 @@ impl OptUnroll {
             for a in &jump_args {
                 jump_args_box.push(ctx.materialize_box_at(*a));
             }
-            let jump_args_box_operand: Vec<majit_ir::operand::Operand> =
-                jump_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+            let jump_args_box_operand: Vec<majit_ir::operand::Operand> = jump_args_box
+                .iter()
+                .map(majit_ir::operand::Operand::from_boxref)
+                .collect();
             let mut jump = Op::new(OpCode::Jump, &jump_args_box_operand);
             jump.setdescr(target_token.as_jump_target_descr());
             // unroll.py:357 lets send_extra_operation raise InvalidLoop. This
@@ -4008,7 +4010,12 @@ impl OptUnroll {
                         // unroll.py:367: mapping values are the replayed op
                         // objects; bind to the registered producer (memoized
                         // on box_cache) rather than minting an unbound box.
-                        Some(&mapped) => new_op.setarg(i, majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(mapped))),
+                        Some(&mapped) => new_op.setarg(
+                            i,
+                            majit_ir::operand::Operand::from_boxref(
+                                &ctx.materialize_box_at(mapped),
+                            ),
+                        ),
                         None => {
                             // RPython: _map_args raises KeyError for unmapped
                             // args. This is equivalent to InvalidLoop — the
@@ -4767,7 +4774,12 @@ fn emit_alias_same_as_for_imports(
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
 ) {
     for alias in imported_short_aliases {
-        let mut op = Op::new(alias.same_as_opcode, &[majit_ir::operand::Operand::from_boxref(&alias.same_as_source.clone())]);
+        let mut op = Op::new(
+            alias.same_as_opcode,
+            &[majit_ir::operand::Operand::from_boxref(
+                &alias.same_as_source.clone(),
+            )],
+        );
         op.pos.set(alias.result);
         result.push(std::rc::Rc::new(op));
     }
@@ -4841,8 +4853,10 @@ fn assemble_peeled_trace_with_jump_args(
         for a in start_label_args {
             start_label_args_box.push(ctx.materialize_box_at(*a));
         }
-        let start_label_args_box_operand: Vec<majit_ir::operand::Operand> =
-            start_label_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let start_label_args_box_operand: Vec<majit_ir::operand::Operand> = start_label_args_box
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
         let mut start_label = Op::new(OpCode::Label, &start_label_args_box_operand);
         start_label.pos.set(OpRef::NONE);
         start_label.setdescr(start_label_descr);
@@ -5035,7 +5049,10 @@ fn assemble_peeled_trace_with_jump_args(
                         });
                     if tp != Type::Void {
                         let arg_source = ctx.materialize_box_at(source);
-                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[majit_ir::operand::Operand::from_boxref(&arg_source)]);
+                        let mut same_as = Op::new(
+                            OpCode::same_as_for_type(tp),
+                            &[majit_ir::operand::Operand::from_boxref(&arg_source)],
+                        );
                         same_as.pos.set(arg);
                         fallthrough_aliases.push(same_as);
                     }
@@ -5053,8 +5070,10 @@ fn assemble_peeled_trace_with_jump_args(
     for a in &full_label_args {
         full_label_args_box.push(ctx.materialize_box_at(*a));
     }
-    let full_label_args_box_operand: Vec<majit_ir::operand::Operand> =
-        full_label_args_box.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+    let full_label_args_box_operand: Vec<majit_ir::operand::Operand> = full_label_args_box
+        .iter()
+        .map(majit_ir::operand::Operand::from_boxref)
+        .collect();
     let mut label_op = Op::new(OpCode::Label, &full_label_args_box_operand);
     // resoperation.py:260 AbstractResOp.type = 'v' default — Label has no
     // result Box, so its OpRef position carries the Void tag rather than
@@ -5327,7 +5346,9 @@ fn assemble_peeled_trace_with_jump_args(
             let mut extended_args_box: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
                 smallvec::SmallVec::with_capacity(extended_args.len());
             for a in &extended_args {
-                extended_args_box.push(majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(*a)));
+                extended_args_box.push(majit_ir::operand::Operand::from_boxref(
+                    &ctx.materialize_box_at(*a),
+                ));
             }
             new_op.initarglist(extended_args_box);
         }
@@ -5407,7 +5428,9 @@ fn assemble_peeled_trace_with_jump_args(
             let mut jump_args_box: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
                 smallvec::SmallVec::with_capacity(jump_args.len());
             for a in &jump_args {
-                jump_args_box.push(majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(*a)));
+                jump_args_box.push(majit_ir::operand::Operand::from_boxref(
+                    &ctx.materialize_box_at(*a),
+                ));
             }
             new_op.initarglist(jump_args_box);
         }
@@ -5467,12 +5490,17 @@ fn assemble_peeled_trace_with_jump_args(
                     .collect();
                 let new_args_boxref = result[label_idx].getarglist_copy();
                 let mut new_args: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
-                    new_args_boxref.iter().map(majit_ir::operand::Operand::from_boxref).collect();
+                    new_args_boxref
+                        .iter()
+                        .map(majit_ir::operand::Operand::from_boxref)
+                        .collect();
                 new_args.extend(
                     extra_live_args
                         .into_iter()
                         .filter(|arg| !existing.contains(arg))
-                        .map(|arg| majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(arg))),
+                        .map(|arg| {
+                            majit_ir::operand::Operand::from_boxref(&ctx.materialize_box_at(arg))
+                        }),
                 );
                 result[label_idx].initarglist(new_args);
             }
@@ -5615,7 +5643,12 @@ impl OptUnroll {
             for i in 0..peeled.num_args() {
                 let arg = peeled.arg(i);
                 if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                    peeled.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped_producer_box(ctx, new_ref)));
+                    peeled.setarg(
+                        i,
+                        majit_ir::operand::Operand::from_boxref(&remapped_producer_box(
+                            ctx, new_ref,
+                        )),
+                    );
                 }
                 // Args referencing ops outside the buffer (e.g., input args)
                 // are kept as-is.
@@ -5641,8 +5674,11 @@ impl OptUnroll {
         // Emit Label between peeled and original body.
         // The Label's args match the Jump's args, forming the loop header.
         let label_pos = ctx.reserve_pos_typed(OpCode::Label.result_type());
-        let jump_label_args: Vec<majit_ir::operand::Operand> =
-            jump_op.getarglist().iter().map(majit_ir::operand::Operand::from_boxref).collect();
+        let jump_label_args: Vec<majit_ir::operand::Operand> = jump_op
+            .getarglist()
+            .iter()
+            .map(majit_ir::operand::Operand::from_boxref)
+            .collect();
         let mut label_op = Op::new(OpCode::Label, &jump_label_args);
         label_op.pos.set(label_pos);
         ctx.emit(label_op);
@@ -5667,7 +5703,12 @@ impl OptUnroll {
             for i in 0..body_op.num_args() {
                 let arg = body_op.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    body_op.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped_producer_box(ctx, new_ref)));
+                    body_op.setarg(
+                        i,
+                        majit_ir::operand::Operand::from_boxref(&remapped_producer_box(
+                            ctx, new_ref,
+                        )),
+                    );
                 }
             }
             if let Some(fa) = body_op.fail_args_mut() {
@@ -5800,7 +5841,12 @@ impl Optimization for OptUnroll {
             for i in 0..jump.num_args() {
                 let arg = jump.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    jump.setarg(i, majit_ir::operand::Operand::from_boxref(&remapped_producer_box(ctx, new_ref)));
+                    jump.setarg(
+                        i,
+                        majit_ir::operand::Operand::from_boxref(&remapped_producer_box(
+                            ctx, new_ref,
+                        )),
+                    );
                 }
             }
             // Reserve the Jump's own position so it lands above any
@@ -5835,8 +5881,8 @@ mod tests {
     use super::*;
     use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
     use crate::optimizeopt::optimizer::Optimizer;
-    use majit_ir::operand::Operand;
     use majit_ir::GcRef;
+    use majit_ir::operand::Operand;
 
     /// Assign sequential positions to ops starting from `base`.
     fn assign_positions(ops: &mut [Op], base: u32) {
@@ -6377,7 +6423,10 @@ mod tests {
     fn test_guards_duplicated_in_peel() {
         // Guards in the preamble serve as type checks.
         let mut ops = vec![
-            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]),
+            Op::new(
+                OpCode::GuardTrue,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))],
+            ),
             Op::new(
                 OpCode::IntAdd,
                 &[
@@ -6416,7 +6465,10 @@ mod tests {
                 ],
             ),
             {
-                let mut guard = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))]);
+                let mut guard = Op::new(
+                    OpCode::GuardTrue,
+                    &[Operand::from_boxref(&rooted_resop_box(Type::Int, 100))],
+                );
                 guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into()); // refs op0
                 guard
             },
@@ -6460,7 +6512,10 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]), // carries v0 (the add result)
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ), // carries v0 (the add result)
         ];
         assign_positions(&mut ops, 0);
 
@@ -6542,8 +6597,14 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
+            Op::new(
+                OpCode::GuardTrue,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))],
+            ),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6572,8 +6633,10 @@ mod tests {
         let mut pass = OptUnroll::new();
 
         // Simulate some state.
-        pass.buffer
-            .push(Op::new(OpCode::IntAdd, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]));
+        pass.buffer.push(Op::new(
+            OpCode::IntAdd,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+        ));
         pass.seen_jump = true;
 
         pass.setup();
@@ -6595,8 +6658,14 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 101)),
                 ],
             ),
-            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::GuardTrue,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6699,7 +6768,10 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))],
+            ),
         ];
         assign_positions(&mut ops, 0);
 
@@ -6774,7 +6846,10 @@ mod tests {
                     Operand::from_boxref(&rooted_inputarg_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_inputarg_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_inputarg_box(Type::Int, 0))],
+            ),
         ];
         assign_positions(&mut ops, 2);
         let mut constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -6787,7 +6862,10 @@ mod tests {
     #[test]
     fn test_unroll_optimizer_count_guards() {
         let ops = vec![
-            Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::GuardTrue,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
             Op::new(
                 OpCode::IntAdd,
                 &[
@@ -6795,8 +6873,14 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 1)),
                 ],
             ),
-            Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::GuardNonnull,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
         ];
         assert_eq!(UnrollOptimizer::count_guards(&ops), 2);
     }
@@ -7000,7 +7084,9 @@ mod tests {
                 op: {
                     let mut op = Op::with_descr(
                         OpCode::GetfieldGcPureI,
-                        &[Operand::from_boxref(&BoxRef::from_opref(OpRef::const_ptr(ptr)))],
+                        &[Operand::from_boxref(&BoxRef::from_opref(OpRef::const_ptr(
+                            ptr,
+                        )))],
                         field_descr.clone(),
                     );
                     op.pos.set(OpRef::int_op(11));
@@ -7494,7 +7580,10 @@ mod tests {
                 op.pos.set(OpRef::int_op(1));
                 op
             },
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))],
+            ),
         ];
 
         let combined = assemble_peeled_trace(
@@ -7568,7 +7657,10 @@ mod tests {
                 op.pos.set(OpRef::int_op(11));
                 op
             },
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 11))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 11))],
+            ),
         ];
 
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -7608,7 +7700,10 @@ mod tests {
     #[test]
     fn test_assemble_peeled_trace_preserves_visible_preamble_box_over_body_collision() {
         let p1_ops = vec![{
-            let mut op = Op::new(OpCode::GetfieldGcR, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 3))]);
+            let mut op = Op::new(
+                OpCode::GetfieldGcR,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 3))],
+            );
             op.pos.set(OpRef::int_op(19));
             op.setdescr(majit_ir::descr::make_field_descr_full(
                 56,
@@ -7648,7 +7743,10 @@ mod tests {
                 op.pos.set(OpRef::int_op(19));
                 op
             },
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 19))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 19))],
+            ),
         ];
 
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
@@ -7760,7 +7858,10 @@ mod tests {
         // immediate, and the box-namespace entries in the constants
         // snapshot must round-trip unchanged.
         let p1_ops = vec![{
-            let mut op = Op::new(OpCode::SameAsI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 37))]);
+            let mut op = Op::new(
+                OpCode::SameAsI,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 37))],
+            );
             op.pos.set(OpRef::void_op(857));
             op
         }];
@@ -7862,7 +7963,10 @@ mod tests {
         // pre-replaced with OpRef::int_op(10) (the corresponding label_arg).
         let p2_ops = vec![
             {
-                let mut op = Op::new(OpCode::GetfieldGcPureI, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))]);
+                let mut op = Op::new(
+                    OpCode::GetfieldGcPureI,
+                    &[Operand::from_boxref(&rooted_resop_box(Type::Int, 50))],
+                );
                 op.pos.set(OpRef::int_op(1));
                 op.setdescr(majit_ir::make_field_descr(
                     0,
@@ -7934,7 +8038,10 @@ mod tests {
         // it reaches the assembler. We mirror that here.
         let p2_ops = vec![
             {
-                let mut op = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 64))]);
+                let mut op = Op::new(
+                    OpCode::GuardTrue,
+                    &[Operand::from_boxref(&rooted_resop_box(Type::Int, 64))],
+                );
                 op.setfailargs(vec![rooted_resop_box(Type::Int, 64)].into());
                 op
             },
@@ -7949,7 +8056,10 @@ mod tests {
                 op.pos.set(OpRef::int_op(64));
                 op
             },
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 64))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 64))],
+            ),
         ];
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
@@ -8201,7 +8311,10 @@ mod tests {
                     Operand::from_boxref(&rooted_resop_box(Type::Int, 0)),
                 ],
             ),
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
         ];
         let constants = majit_ir::VecAssoc::from([
             (2_u32, majit_ir::Value::Int(606)),
@@ -8242,7 +8355,10 @@ mod tests {
         // sites). Mirrors `assemble_peeled_trace_with_jump_args`'s
         // `label_arg.is_constant()` predicate.
         let const_extra = OpRef::const_int(606);
-        let p2_ops = vec![Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 10))])];
+        let p2_ops = vec![Op::new(
+            OpCode::Jump,
+            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 10))],
+        )];
         let constants: majit_ir::VecAssoc<u32, majit_ir::Value> = majit_ir::VecAssoc::new();
 
         let combined = assemble_peeled_trace(
@@ -8291,7 +8407,10 @@ mod tests {
                 op.pos.set(OpRef::int_op(20));
                 op
             },
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 200))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 200))],
+            ),
         ];
 
         let combined = assemble_peeled_trace(
@@ -8344,11 +8463,17 @@ mod tests {
                 op.pos.set(OpRef::void_op(3));
                 op
             },
-            Op::new(OpCode::Jump, &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))]),
+            Op::new(
+                OpCode::Jump,
+                &[Operand::from_boxref(&rooted_resop_box(Type::Int, 0))],
+            ),
         ];
         let redirected_tail = vec![
             {
-                let mut op = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&rooted_resop_box(Type::Void, 3))]);
+                let mut op = Op::new(
+                    OpCode::GuardTrue,
+                    &[Operand::from_boxref(&rooted_resop_box(Type::Void, 3))],
+                );
                 op.setfailargs(vec![rooted_resop_box(Type::Void, 3)].into());
                 op
             },

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -724,6 +724,7 @@ impl UnrollOptimizer {
                         phase1_emit_high_water: self.next_global_opref,
                         partial_trace_inputargs: Vec::new(),
                         partial_trace_operations: Vec::new(),
+                        short_box_producer_roots: Vec::new(),
                         rooted_refs: Vec::new(),
                         rooted_const_ptr_slots: Vec::new(),
                         shadow_stack_base: 0,
@@ -2066,6 +2067,16 @@ pub struct ExportedState {
     /// preamble mutated `_forwarded` on must travel through here
     /// (resoperation.py:233-242 `_forwarded` host).
     pub(crate) partial_trace_operations: Vec<majit_ir::OpRc>,
+    /// #173 producer-rooting: keeps the Phase-1 producer `Op` that each
+    /// exported short-box `res` is bound to (`res.bound_op()`) alive into
+    /// Phase 2. A short-box `res` carries only a `Weak<Op>`; the Phase-1
+    /// OptContext that owns the strong `OpRc` drops at the peel boundary, so
+    /// without this carry `Operand::from_boxref(res)` upgrades a dead Weak →
+    /// None and panics (operand.rs:253). Populated at export from
+    /// `res.bound_op()` while still alive; InputArg-kind res (`bound_inputarg`,
+    /// not `bound_op`) contributes nothing here and is rooted via
+    /// `short_inputarg_refs` instead.
+    pub(crate) short_box_producer_roots: Vec<majit_ir::OpRc>,
     /// Shadow stack rooting for GcRef values in exported_infos.
     /// (BoxRef key, field kind, shadow stack index). The key is the
     /// `exported_infos` BoxRef key for `InfoPtrInfoConstant` entries; other
@@ -2160,6 +2171,7 @@ impl ExportedState {
             phase1_emit_high_water: 0,
             partial_trace_inputargs: Vec::new(),
             partial_trace_operations: Vec::new(),
+            short_box_producer_roots: Vec::new(),
             rooted_refs: Vec::new(),
             rooted_const_ptr_slots: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
@@ -2688,6 +2700,7 @@ impl Clone for ExportedState {
             phase1_emit_high_water: self.phase1_emit_high_water,
             partial_trace_inputargs: self.partial_trace_inputargs.clone(),
             partial_trace_operations: self.partial_trace_operations.clone(),
+            short_box_producer_roots: self.short_box_producer_roots.clone(),
             rooted_refs: Vec::new(),
             rooted_const_ptr_slots: Vec::new(),
             shadow_stack_base: majit_gc::shadow_stack::depth(),
@@ -3082,6 +3095,15 @@ impl OptUnroll {
             )
         };
         let exported_short_boxes = ctx.exported_short_boxes.clone();
+        // #173 producer-rooting: capture each exported short-box's Phase-1
+        // producer Op (`res.bound_op()`) while the Phase-1 ctx still owns the
+        // strong `OpRc`, so `res`'s Weak still upgrades after the peel boundary
+        // drops that ctx. InputArg-kind res is `bound_inputarg` (None here),
+        // rooted via `short_inputarg_refs` instead.
+        let short_box_producer_roots: Vec<majit_ir::OpRc> = exported_short_boxes
+            .iter()
+            .filter_map(|e| e.res.bound_op())
+            .collect();
         // unroll.py:466-473 line-by-line:
         //
         //   sb = ShortBoxes()
@@ -3161,6 +3183,9 @@ impl OptUnroll {
             short_inputargs,
             short_inputarg_refs,
         );
+        // #173: install the Phase-1 producer roots captured above. Kept off the
+        // positional `new` ctor (callers write fields post-construct).
+        state.short_box_producer_roots = short_box_producer_roots;
         // `OptContext::next_pos` is the strict upper bound on raw OpRefs
         // Phase 1 allocated, including intermediates folded / forwarded
         // away before any structure-stored field could observe them.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5187,9 +5187,16 @@ fn assemble_peeled_trace_with_jump_args(
                 &visible_before_label,
             );
             if mapped != arg {
+                // A remap hit whose target clone was already pushed binds to
+                // that producer; otherwise route through the canonical
+                // "box always exists" materializer (parity with the start_label
+                // / jump_source / extended_label_arg sites above) so the arg
+                // carries a bound `Operand::Op`/`InputArg` instead of a
+                // position-only box. `materialize_box_at(mapped).to_opref() ==
+                // mapped`, so the rewritten arg is OpRef-identical.
                 let boxed = match emitted_at.get(&mapped) {
                     Some(rc) => BoxRef::from_bound_op(rc),
-                    None => BoxRef::from_opref(mapped),
+                    None => ctx.materialize_box_at(mapped),
                 };
                 new_op.setarg(i, boxed);
             }

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -19,8 +19,8 @@
 ///   parity enforcement. They are re-exported here.
 use majit_ir::vec_set::VecSet;
 
-use majit_ir::{Op, OpCode, OpRc, OpRef};
 use majit_ir::operand::Operand;
+use majit_ir::{Op, OpCode, OpRc, OpRef};
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
@@ -1609,7 +1609,12 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
                     copied_op.setarg(
                         i,
-                        Operand::from_boxref(&bind_unroll(&produced, &original_body, &mut renamer, renamed)),
+                        Operand::from_boxref(&bind_unroll(
+                            &produced,
+                            &original_body,
+                            &mut renamer,
+                            renamed,
+                        )),
                     );
                 }
 
@@ -1633,7 +1638,8 @@ impl VectorLoop {
             // as the original label, then run the renamer over it so its
             // args track the rename state at this point.
             if align_unroll_once && u == 0 {
-                let label_args_ops: Vec<Operand> = label_args.iter().map(Operand::from_boxref).collect();
+                let label_args_ops: Vec<Operand> =
+                    label_args.iter().map(Operand::from_boxref).collect();
                 let mut minted = Op::new(OpCode::Label, &label_args_ops);
                 if let Some(descr) = self.label.getdescr() {
                     minted.setdescr(descr);
@@ -1642,7 +1648,12 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
                     minted.setarg(
                         i,
-                        Operand::from_boxref(&bind_unroll(&produced, &original_body, &mut renamer, renamed)),
+                        Operand::from_boxref(&bind_unroll(
+                            &produced,
+                            &original_body,
+                            &mut renamer,
+                            renamed,
+                        )),
                     );
                 }
                 new_label = minted;
@@ -1654,7 +1665,12 @@ impl VectorLoop {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
             self.jump.setarg(
                 i,
-                Operand::from_boxref(&bind_unroll(&produced, &original_body, &mut renamer, renamed)),
+                Operand::from_boxref(&bind_unroll(
+                    &produced,
+                    &original_body,
+                    &mut renamer,
+                    renamed,
+                )),
             );
         }
 

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1532,21 +1532,31 @@ impl VectorLoop {
         // (`Operand::from_bound_op`, no mint). A miss (label/inputarg/outer
         // position with no producer in this buffer) stays `from_opref`.
         let mut produced: VecAssoc<OpRef, OpRc> = VecAssoc::new();
-        let original_body_ref = &original_body;
-        let bind = |produced: &VecAssoc<OpRef, OpRc>, renamed: OpRef| -> BoxRef {
+        // Recover the producer box for a renamed position. A hit in `produced`
+        // (a copied op pushed to `unrolled`) or `original_body` (a
+        // first-iteration loop-carried producer) binds to that exact `OpRc`
+        // (`Operand::from_bound_op`, no mint). A miss is an inputarg / outer
+        // position with no producer in this buffer; it binds to a
+        // renamer-rooted producer box carrying the same `pos`
+        // (`Renamer::bound_box`), never a position-only `Operand::Box`.
+        // A nested `fn` (not a closure) so it can take `&mut renamer` without
+        // capturing it, leaving `renamer.rename_box` / `start_renaming` free.
+        fn bind_unroll(
+            produced: &VecAssoc<OpRef, OpRc>,
+            original_body: &[OpRc],
+            renamer: &mut Renamer,
+            renamed: OpRef,
+        ) -> BoxRef {
             if let Some(rc) = produced.get(&renamed) {
                 return BoxRef::from_bound_op(rc);
             }
-            // First-iteration loop-carried args resolve to ORIGINAL body
-            // positions (not yet copied into `produced`); their producer box
-            // lives in `original_body`. Bind there too before falling back.
             if !renamed.is_constant() && !renamed.is_none() {
-                if let Some(rc) = original_body_ref.iter().find(|op| op.pos.get() == renamed) {
+                if let Some(rc) = original_body.iter().find(|op| op.pos.get() == renamed) {
                     return BoxRef::from_bound_op(rc);
                 }
             }
-            BoxRef::from_opref(renamed)
-        };
+            renamer.bound_box(renamed)
+        }
         // vector.py:292 `new_label = loop.label` — the label install-target
         // is the existing label by default; the align-unroll arm overwrites
         // it with a freshly minted LABEL after the first body copy.
@@ -1588,7 +1598,7 @@ impl VectorLoop {
                 // vector.py:312-315: rename args
                 for i in 0..copied_op.num_args() {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
-                    copied_op.setarg(i, bind(&produced, renamed));
+                    copied_op.setarg(i, bind_unroll(&produced, &original_body, &mut renamer, renamed));
                 }
 
                 // vector.py:319-320: rename guard fail args
@@ -1617,7 +1627,7 @@ impl VectorLoop {
                 }
                 for i in 0..minted.num_args() {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
-                    minted.setarg(i, bind(&produced, renamed));
+                    minted.setarg(i, bind_unroll(&produced, &original_body, &mut renamer, renamed));
                 }
                 new_label = minted;
             }
@@ -1626,7 +1636,7 @@ impl VectorLoop {
         // vector.py:334-337: update jump args with final renaming
         for i in 0..self.jump.num_args() {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
-            self.jump.setarg(i, bind(&produced, renamed));
+            self.jump.setarg(i, bind_unroll(&produced, &original_body, &mut renamer, renamed));
         }
 
         // vector.py:339-344

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -20,6 +20,7 @@
 use majit_ir::vec_set::VecSet;
 
 use majit_ir::{Op, OpCode, OpRc, OpRef};
+use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
@@ -1608,7 +1609,7 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
                     copied_op.setarg(
                         i,
-                        bind_unroll(&produced, &original_body, &mut renamer, renamed),
+                        Operand::from_boxref(&bind_unroll(&produced, &original_body, &mut renamer, renamed)),
                     );
                 }
 
@@ -1632,7 +1633,8 @@ impl VectorLoop {
             // as the original label, then run the renamer over it so its
             // args track the rename state at this point.
             if align_unroll_once && u == 0 {
-                let mut minted = Op::new(OpCode::Label, &label_args);
+                let label_args_ops: Vec<Operand> = label_args.iter().map(Operand::from_boxref).collect();
+                let mut minted = Op::new(OpCode::Label, &label_args_ops);
                 if let Some(descr) = self.label.getdescr() {
                     minted.setdescr(descr);
                 }
@@ -1640,7 +1642,7 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
                     minted.setarg(
                         i,
-                        bind_unroll(&produced, &original_body, &mut renamer, renamed),
+                        Operand::from_boxref(&bind_unroll(&produced, &original_body, &mut renamer, renamed)),
                     );
                 }
                 new_label = minted;
@@ -1652,7 +1654,7 @@ impl VectorLoop {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
             self.jump.setarg(
                 i,
-                bind_unroll(&produced, &original_body, &mut renamer, renamed),
+                Operand::from_boxref(&bind_unroll(&produced, &original_body, &mut renamer, renamed)),
             );
         }
 
@@ -1739,7 +1741,7 @@ pub(crate) fn ensure_args_unpacked(
             seen.insert(unpacked);
             // The VecUnpack producer was just appended to `oplist`; bind the
             // arg to it (no position-only mint).
-            op.setarg(j, state.bound_arg_boxref(unpacked));
+            op.setarg(j, Operand::from_boxref(&state.bound_arg_boxref(unpacked)));
         }
     }
     // schedule.py:708-716: unpack guard failargs
@@ -1906,9 +1908,9 @@ mod tests {
     /// `assign_positions` / `to_opref`-keyed assertions are unchanged; constants and
     /// `None` shed to `Operand::Const` / none as before. Replaces the position-only
     /// `BoxRef::from_opref` that minted `Operand::Box` at `Op::new`.
-    fn bx(r: OpRef) -> BoxRef {
+    fn bx(r: OpRef) -> Operand {
         use crate::r#box::test_support::{rooted_inputarg_box, rooted_resop_box};
-        match r {
+        Operand::from_boxref(&match r {
             OpRef::InputArgInt(n) => rooted_inputarg_box(Type::Int, n),
             OpRef::InputArgFloat(n) => rooted_inputarg_box(Type::Float, n),
             OpRef::InputArgRef(n) => rooted_inputarg_box(Type::Ref, n),
@@ -1918,7 +1920,7 @@ mod tests {
             OpRef::VoidOp(n) => rooted_resop_box(Type::Void, n),
             // Const* / None shed to Operand::Const / none — no Operand::Box mint.
             _ => BoxRef::from_opref(r),
-        }
+        })
     }
 
     fn assign_positions(ops: &mut [Op], base: u32) {

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -87,7 +87,11 @@ impl VectorLoop {
     /// canonical producer box for its value; the buffer then carries
     /// producer identity (see `operations` field doc).
     pub fn new(label: Op, operations: Vec<Op>, jump: Op) -> Self {
-        Self::new_rc(label, operations.into_iter().map(std::rc::Rc::new).collect(), jump)
+        Self::new_rc(
+            label,
+            operations.into_iter().map(std::rc::Rc::new).collect(),
+            jump,
+        )
     }
 
     /// `new` variant taking already-`OpRc`-wrapped operations, so the
@@ -737,7 +741,9 @@ impl VectorizingOptimizer {
             let vec_create =
                 sched_state.create_vec_op(OpCode::VecI, &[], datatype, bytesize, signed, count);
             let zero_vec = vec_create.pos.get();
-            sched_state.invariant_oplist.push(std::rc::Rc::new(vec_create));
+            sched_state
+                .invariant_oplist
+                .push(std::rc::Rc::new(vec_create));
 
             let xor_op = sched_state.create_vec_op(
                 OpCode::VecIntXor,
@@ -1318,7 +1324,9 @@ impl VectorizingOptimizer {
             let vec_create =
                 sched_state.create_vec_op(OpCode::VecI, &[], datatype, bytesize, signed, count);
             let zero_vec = vec_create.pos.get();
-            sched_state.invariant_oplist.push(std::rc::Rc::new(vec_create));
+            sched_state
+                .invariant_oplist
+                .push(std::rc::Rc::new(vec_create));
 
             let xor_op = sched_state.create_vec_op(
                 OpCode::VecIntXor,
@@ -1598,7 +1606,10 @@ impl VectorLoop {
                 // vector.py:312-315: rename args
                 for i in 0..copied_op.num_args() {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
-                    copied_op.setarg(i, bind_unroll(&produced, &original_body, &mut renamer, renamed));
+                    copied_op.setarg(
+                        i,
+                        bind_unroll(&produced, &original_body, &mut renamer, renamed),
+                    );
                 }
 
                 // vector.py:319-320: rename guard fail args
@@ -1627,7 +1638,10 @@ impl VectorLoop {
                 }
                 for i in 0..minted.num_args() {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
-                    minted.setarg(i, bind_unroll(&produced, &original_body, &mut renamer, renamed));
+                    minted.setarg(
+                        i,
+                        bind_unroll(&produced, &original_body, &mut renamer, renamed),
+                    );
                 }
                 new_label = minted;
             }
@@ -1636,7 +1650,10 @@ impl VectorLoop {
         // vector.py:334-337: update jump args with final renaming
         for i in 0..self.jump.num_args() {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
-            self.jump.setarg(i, bind_unroll(&produced, &original_body, &mut renamer, renamed));
+            self.jump.setarg(
+                i,
+                bind_unroll(&produced, &original_body, &mut renamer, renamed),
+            );
         }
 
         // vector.py:339-344

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -19,11 +19,12 @@
 ///   parity enforcement. They are re-exported here.
 use majit_ir::vec_set::VecSet;
 
-use majit_ir::{Op, OpCode, OpRef};
+use majit_ir::{Op, OpCode, OpRc, OpRef};
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::dependency::DependencyGraph;
 use crate::optimizeopt::renamer::Renamer;
+use crate::optimizeopt::vec_assoc::VecAssoc;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 
 // Re-exports: these types live in schedule.rs but are defined in vector.py
@@ -42,6 +43,11 @@ pub use crate::optimizeopt::schedule::{
 /// In RPython, `get_forwarded()` returns VectorizationInfo if set on the
 /// op, and copy_resop re-attaches it to the clone. In Rust, `Op::clone()`
 /// already preserves the `vecinfo` field, so this is a trivial clone.
+///
+/// Returns an owned `Op`: the caller renames/retargets it, then wraps it
+/// into the canonical producer `OpRc` as it enters the buffer, so later
+/// ops in the same buffer bind their args to that exact `Rc`
+/// (`Operand::from_bound_op`) instead of a position-only `from_opref`.
 fn copy_resop(op: &Op) -> Op {
     op.clone()
 }
@@ -57,20 +63,36 @@ pub struct VectorLoop {
     /// vector.py:45: self.inputargs = label.getarglist_copy()
     pub inputargs: Vec<OpRef>,
     /// vector.py:46: self.prefix = []
-    pub prefix: Vec<Op>,
+    pub prefix: Vec<OpRc>,
     /// vector.py:47: self.prefix_label = None
     pub prefix_label: Option<Op>,
     /// vector.py:49: self.operations = oplist
-    pub operations: Vec<Op>,
+    ///
+    /// `Vec<OpRc>` (not `Vec<Op>`): each element is the canonical producer
+    /// box for its value, so a later op in the body binds its arg directly
+    /// to the producer `Rc` (`Operand::from_bound_op`) instead of minting a
+    /// position-only `Operand::Box` — parity with vector.py's box→box
+    /// renamer which carries box objects, not integer positions.
+    pub operations: Vec<OpRc>,
     /// vector.py:50: self.jump = jump
     pub jump: Op,
     /// vector.py:52: self.align_operations = []
-    pub align_operations: Vec<Op>,
+    pub align_operations: Vec<OpRc>,
 }
 
 impl VectorLoop {
     /// vector.py:43-52: __init__(self, label, oplist, jump)
+    ///
+    /// Each body op is wrapped into an `OpRc` on entry so it becomes the
+    /// canonical producer box for its value; the buffer then carries
+    /// producer identity (see `operations` field doc).
     pub fn new(label: Op, operations: Vec<Op>, jump: Op) -> Self {
+        Self::new_rc(label, operations.into_iter().map(std::rc::Rc::new).collect(), jump)
+    }
+
+    /// `new` variant taking already-`OpRc`-wrapped operations, so the
+    /// caller's producer boxes flow into the buffer without a re-clone.
+    pub fn new_rc(label: Op, operations: Vec<OpRc>, jump: Op) -> Self {
         debug_assert_eq!(label.opcode, OpCode::Label);
         debug_assert!(
             jump.opcode == OpCode::Jump,
@@ -187,12 +209,16 @@ impl VectorLoop {
         }
 
         // vector.py:80-84
+        // The producer buffers carry `OpRc`; the final emission boundary
+        // hands back owned `Op` (the ops leave the vectorizer's producer
+        // world here). Each op's args still bind to their producers — those
+        // are `Operand::Op(Rc)` inside the cloned `args` (see `Op::clone`).
         let mut oplist: Vec<Op> = Vec::new();
         if let Some(ref prefix_label) = self.prefix_label {
-            oplist.extend(self.prefix.iter().cloned());
+            oplist.extend(self.prefix.iter().map(|op| (**op).clone()));
             oplist.push(prefix_label.clone());
         } else if !self.prefix.is_empty() {
-            oplist.extend(self.prefix.iter().cloned());
+            oplist.extend(self.prefix.iter().map(|op| (**op).clone()));
         }
         // vector.py:85-86
         if label {
@@ -210,7 +236,7 @@ impl VectorLoop {
             state.clear_op_forwarded_vecinfo(self.jump.pos.get());
         }
         // vector.py:91
-        oplist.extend(self.operations.iter().cloned());
+        oplist.extend(self.operations.iter().map(|op| (**op).clone()));
         oplist.push(self.jump.clone());
         oplist
     }
@@ -218,33 +244,32 @@ impl VectorLoop {
     /// vector.py:94-120: clone — deep-clone the loop with renaming.
     pub fn clone_loop(&self) -> Self {
         let mut renamer = Renamer::new();
-        let _label = copy_resop(&self.label);
-        let mut prefix = Vec::new();
+        let mut prefix: Vec<OpRc> = Vec::new();
         for op in &self.prefix {
-            let mut newop = copy_resop(op);
+            let mut newop = (**op).clone();
             renamer.rename(&mut newop);
             if newop.opcode.result_type() != majit_ir::Type::Void {
                 renamer.start_renaming(op.pos.get(), newop.pos.get());
             }
-            prefix.push(newop);
+            prefix.push(std::rc::Rc::new(newop));
         }
         let prefix_label = self.prefix_label.as_ref().map(|pl| {
-            let mut newpl = copy_resop(pl);
+            let mut newpl = pl.clone();
             renamer.rename(&mut newpl);
             newpl
         });
-        let mut operations = Vec::new();
+        let mut operations: Vec<OpRc> = Vec::new();
         for op in &self.operations {
-            let mut newop = copy_resop(op);
+            let mut newop = (**op).clone();
             renamer.rename(&mut newop);
             if newop.opcode.result_type() != majit_ir::Type::Void {
                 renamer.start_renaming(op.pos.get(), newop.pos.get());
             }
-            operations.push(newop);
+            operations.push(std::rc::Rc::new(newop));
         }
-        let mut jump = copy_resop(&self.jump);
+        let mut jump = self.jump.clone();
         renamer.rename(&mut jump);
-        let mut loop_ = VectorLoop::new(copy_resop(&self.label), operations, jump);
+        let mut loop_ = VectorLoop::new_rc(self.label.clone(), operations, jump);
         loop_.prefix = prefix;
         loop_.prefix_label = prefix_label;
         loop_
@@ -253,6 +278,16 @@ impl VectorLoop {
     /// Number of ops in the loop body (excluding Label and Jump).
     pub fn body_len(&self) -> usize {
         self.operations.len()
+    }
+
+    /// Materialize an owned `Vec<Op>` view of the body for the read-only
+    /// `&[Op]` scanners (`DependencyGraph::build`, `LoopVersionInfo::snapshot`,
+    /// `GuardStrengthenOpt::propagate_all_forward`). These passes only inspect
+    /// the ops (structure / vecinfo) and never bind args to the scanned ops'
+    /// identity, so a deep clone at the call boundary is faithful; the canonical
+    /// producer `OpRc`s stay in `self.operations`.
+    fn operations_as_ops(&self) -> Vec<Op> {
+        self.operations.iter().map(|op| (**op).clone()).collect()
     }
 }
 
@@ -293,7 +328,7 @@ pub fn optimize_vector(
         .iter()
         .map(|a| a.to_opref())
         .collect();
-    info.snapshot(&loop_.operations, &label_args);
+    info.snapshot(&loop_.operations_as_ops(), &label_args);
     let version = loop_.clone_loop();
 
     let result = (|| {
@@ -392,7 +427,7 @@ pub fn apply_loop_vectorization(
                 prefix.len() + vloop.align_operations.len() + 1 + loop_ops.len(),
             );
             assembled.extend(prefix);
-            assembled.extend(vloop.align_operations.iter().cloned());
+            assembled.extend(vloop.align_operations.iter().map(|op| (**op).clone()));
             assembled.push(vloop.label.clone());
             assembled.extend(loop_ops);
             assembled
@@ -584,7 +619,9 @@ impl VectorizingOptimizer {
         if let Some(graph) = self.analyse_index_calculations(loop_, &constant_of) {
             let schedule = schedule_operations(&graph);
             if schedule.len() == loop_.operations.len() {
-                let scheduled: Vec<Op> = schedule
+                // Reorder by cheaply cloning the `OpRc`s — identity preserved
+                // (same producer boxes, new order), no op deep-clone.
+                let scheduled: Vec<OpRc> = schedule
                     .iter()
                     .map(|&i| loop_.operations[i].clone())
                     .collect();
@@ -604,7 +641,7 @@ impl VectorizingOptimizer {
         loop_.unroll_loop_iterations(self.unroll_count, align_unroll);
 
         // vector.py:250-253: vectorize — build graph, find adjacent memory refs
-        let graph = DependencyGraph::build(&loop_.operations, &constant_of);
+        let graph = DependencyGraph::build(&loop_.operations_as_ops(), &constant_of);
         // VecScheduleState is created before find_adjacent_memory_refs/
         // extend_packset because PackSet::can_be_packed now consults it via
         // isomorphic (vector.py: packset.can_be_packed reaches
@@ -700,7 +737,7 @@ impl VectorizingOptimizer {
             let vec_create =
                 sched_state.create_vec_op(OpCode::VecI, &[], datatype, bytesize, signed, count);
             let zero_vec = vec_create.pos.get();
-            sched_state.invariant_oplist.push(vec_create);
+            sched_state.invariant_oplist.push(std::rc::Rc::new(vec_create));
 
             let xor_op = sched_state.create_vec_op(
                 OpCode::VecIntXor,
@@ -711,7 +748,7 @@ impl VectorizingOptimizer {
                 count,
             );
             let zeroed_vec = xor_op.pos.get();
-            sched_state.invariant_oplist.push(xor_op);
+            sched_state.invariant_oplist.push(std::rc::Rc::new(xor_op));
 
             // VEC_PACK_I args are [vector, scalar, index, count]; index/count
             // are inline ConstInt (history.py:227), not pool indices.
@@ -726,7 +763,7 @@ impl VectorizingOptimizer {
                 count,
             );
             let seed_vec = pack_op.pos.get();
-            sched_state.invariant_oplist.push(pack_op);
+            sched_state.invariant_oplist.push(std::rc::Rc::new(pack_op));
 
             sched_state.accumulation.insert(
                 seed,
@@ -762,24 +799,32 @@ impl VectorizingOptimizer {
                 if all_ready && !pack_emitted[pack_idx] {
                     pack_emitted[pack_idx] = true;
                     for &member_idx in &pack.members {
-                        let mut member_op = loop_.operations[member_idx].clone();
+                        let mut member_op = (*loop_.operations[member_idx]).clone();
                         pre_emit_guard_accum(&sched_state, &mut member_op);
                         sched_state.renamer.rename(&mut member_op);
+                        // Bind the renamed args (e.g. accumulation-renamed vec
+                        // ops) to their producers already in `oplist`.
+                        sched_state.rebind_op_args(&member_op);
                         // schedule.py:677-680: packed members are emitted via
                         // mark_emitted(node, unpack=False) — renamed but NOT
                         // recorded in `seen`. They live only in box_to_vbox
                         // (turn_into_vector → setvector_of_box) so a later
                         // ensure_args_unpacked materializes a VecUnpack when the
                         // result is used as a scalar (e.g. carried by the jump).
-                        loop_.operations[member_idx] = member_op;
+                        // The renamed op becomes the new canonical producer box
+                        // at this slot, so later consumers bind to this `Rc`.
+                        loop_.operations[member_idx] = std::rc::Rc::new(member_op);
                     }
                     turn_into_vector(&mut sched_state, pack, &loop_.operations);
                 }
             } else {
-                let mut scalar_op = loop_.operations[node_idx].clone();
+                let mut scalar_op = (*loop_.operations[node_idx]).clone();
                 pre_emit_guard_accum(&sched_state, &mut scalar_op);
                 sched_state.renamer.rename(&mut scalar_op);
                 ensure_args_unpacked(&mut sched_state, &mut scalar_op, &mut seen);
+                // Bind the renamed / unpacked args to their producer boxes in
+                // the already-emitted oplist (no position-only mint).
+                sched_state.rebind_op_args(&scalar_op);
                 seen.insert(scalar_op.pos.get());
                 sched_state.append_to_oplist(scalar_op);
             }
@@ -816,8 +861,10 @@ impl VectorizingOptimizer {
             .map(|a| a.to_opref())
             .collect();
         let (strengthened, gso_consts) =
-            gso.propagate_all_forward(&loop_.operations, info, &gso_label_args, user_code);
-        loop_.operations = strengthened;
+            gso.propagate_all_forward(&loop_.operations_as_ops(), info, &gso_label_args, user_code);
+        // The guard-strengthened body is a fresh op list; wrap each into the
+        // canonical producer `OpRc` as it re-enters the buffer.
+        loop_.operations = strengthened.into_iter().map(std::rc::Rc::new).collect();
 
         // vector.py:262-265: re-schedule the trace to drop pure operations left
         // dead by guard strengthening (graph = DependencyGraph(loop);
@@ -1188,10 +1235,11 @@ impl VectorizingOptimizer {
         loop_.setup_vectorization(&mut sched_state, &constant_of);
 
         // First schedule operations for ILP before packing.
-        let dep_graph = DependencyGraph::build(&loop_.operations, &constant_of);
+        let dep_graph = DependencyGraph::build(&loop_.operations_as_ops(), &constant_of);
         let schedule = schedule_operations(&dep_graph);
         if schedule.len() == loop_.operations.len() {
-            let scheduled: Vec<Op> = schedule
+            // Reorder by cheaply cloning the `OpRc`s (identity preserved).
+            let scheduled: Vec<OpRc> = schedule
                 .iter()
                 .map(|&i| loop_.operations[i].clone())
                 .collect();
@@ -1200,7 +1248,7 @@ impl VectorizingOptimizer {
         }
 
         // Then rebuild the dependency graph and find packs.
-        let dep_graph = DependencyGraph::build(&loop_.operations, &constant_of);
+        let dep_graph = DependencyGraph::build(&loop_.operations_as_ops(), &constant_of);
         let seed_packs = dep_graph.find_packable_groups();
         if seed_packs.is_empty() {
             return None;
@@ -1270,7 +1318,7 @@ impl VectorizingOptimizer {
             let vec_create =
                 sched_state.create_vec_op(OpCode::VecI, &[], datatype, bytesize, signed, count);
             let zero_vec = vec_create.pos.get();
-            sched_state.invariant_oplist.push(vec_create);
+            sched_state.invariant_oplist.push(std::rc::Rc::new(vec_create));
 
             let xor_op = sched_state.create_vec_op(
                 OpCode::VecIntXor,
@@ -1281,7 +1329,7 @@ impl VectorizingOptimizer {
                 count,
             );
             let zeroed_vec = xor_op.pos.get();
-            sched_state.invariant_oplist.push(xor_op);
+            sched_state.invariant_oplist.push(std::rc::Rc::new(xor_op));
 
             // vector.py:866-869: pack the seed scalar into position 0
             let zero_const = OpRef::const_int(0);
@@ -1295,7 +1343,7 @@ impl VectorizingOptimizer {
                 count,
             );
             let seed_vec = pack_op.pos.get();
-            sched_state.invariant_oplist.push(pack_op);
+            sched_state.invariant_oplist.push(std::rc::Rc::new(pack_op));
 
             sched_state.accumulation.insert(
                 seed,
@@ -1331,24 +1379,32 @@ impl VectorizingOptimizer {
                 if all_ready && !pack_emitted[pack_idx] {
                     pack_emitted[pack_idx] = true;
                     for &member_idx in &pack.members {
-                        let mut member_op = loop_.operations[member_idx].clone();
+                        let mut member_op = (*loop_.operations[member_idx]).clone();
                         pre_emit_guard_accum(&sched_state, &mut member_op);
                         sched_state.renamer.rename(&mut member_op);
+                        // Bind the renamed args (e.g. accumulation-renamed vec
+                        // ops) to their producers already in `oplist`.
+                        sched_state.rebind_op_args(&member_op);
                         // schedule.py:677-680: packed members are emitted via
                         // mark_emitted(node, unpack=False) — renamed but NOT
                         // recorded in `seen`. They live only in box_to_vbox
                         // (turn_into_vector → setvector_of_box) so a later
                         // ensure_args_unpacked materializes a VecUnpack when the
                         // result is used as a scalar (e.g. carried by the jump).
-                        loop_.operations[member_idx] = member_op;
+                        // The renamed op becomes the new canonical producer box
+                        // at this slot, so later consumers bind to this `Rc`.
+                        loop_.operations[member_idx] = std::rc::Rc::new(member_op);
                     }
                     turn_into_vector(&mut sched_state, pack, &loop_.operations);
                 }
             } else {
-                let mut scalar_op = loop_.operations[node_idx].clone();
+                let mut scalar_op = (*loop_.operations[node_idx]).clone();
                 pre_emit_guard_accum(&sched_state, &mut scalar_op);
                 sched_state.renamer.rename(&mut scalar_op);
                 ensure_args_unpacked(&mut sched_state, &mut scalar_op, &mut seen);
+                // Bind the renamed / unpacked args to their producer boxes in
+                // the already-emitted oplist (no position-only mint).
+                sched_state.rebind_op_args(&scalar_op);
                 seen.insert(scalar_op.pos.get());
                 sched_state.append_to_oplist(scalar_op);
             }
@@ -1467,7 +1523,30 @@ impl VectorLoop {
         ];
 
         let mut renamer = Renamer::new();
-        let mut unrolled = Vec::new();
+        let mut unrolled: Vec<OpRc> = Vec::new();
+        // vector.py's renamer maps box→box; pyre's args are integer positions,
+        // so this side map recovers the producer box for a renamed position:
+        // each copied op's NEW position → the `OpRc` actually pushed to
+        // `unrolled`. SSA guarantees a producer is pushed before its
+        // consumers, so a renamed arg resolves to the canonical producer box
+        // (`Operand::from_bound_op`, no mint). A miss (label/inputarg/outer
+        // position with no producer in this buffer) stays `from_opref`.
+        let mut produced: VecAssoc<OpRef, OpRc> = VecAssoc::new();
+        let original_body_ref = &original_body;
+        let bind = |produced: &VecAssoc<OpRef, OpRc>, renamed: OpRef| -> BoxRef {
+            if let Some(rc) = produced.get(&renamed) {
+                return BoxRef::from_bound_op(rc);
+            }
+            // First-iteration loop-carried args resolve to ORIGINAL body
+            // positions (not yet copied into `produced`); their producer box
+            // lives in `original_body`. Bind there too before falling back.
+            if !renamed.is_constant() && !renamed.is_none() {
+                if let Some(rc) = original_body_ref.iter().find(|op| op.pos.get() == renamed) {
+                    return BoxRef::from_bound_op(rc);
+                }
+            }
+            BoxRef::from_opref(renamed)
+        };
         // vector.py:292 `new_label = loop.label` — the label install-target
         // is the existing label by default; the align-unroll arm overwrites
         // it with a freshly minted LABEL after the first body copy.
@@ -1509,7 +1588,7 @@ impl VectorLoop {
                 // vector.py:312-315: rename args
                 for i in 0..copied_op.num_args() {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
-                    copied_op.setarg(i, BoxRef::from_opref(renamed));
+                    copied_op.setarg(i, bind(&produced, renamed));
                 }
 
                 // vector.py:319-320: rename guard fail args
@@ -1517,7 +1596,14 @@ impl VectorLoop {
                     VectorizingOptimizer::copy_guard_descr(&renamer, &mut copied_op);
                 }
 
-                unrolled.push(copied_op);
+                // The copied op becomes the canonical producer box for its
+                // (renamed) result position; register it before pushing so
+                // later ops in this body bind to it.
+                let rc: OpRc = std::rc::Rc::new(copied_op);
+                if !new_pos.is_none() {
+                    produced.insert(new_pos, std::rc::Rc::clone(&rc));
+                }
+                unrolled.push(rc);
             }
 
             // vector.py:324-328 — after the first iteration of an align
@@ -1531,7 +1617,7 @@ impl VectorLoop {
                 }
                 for i in 0..minted.num_args() {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
-                    minted.setarg(i, BoxRef::from_opref(renamed));
+                    minted.setarg(i, bind(&produced, renamed));
                 }
                 new_label = minted;
             }
@@ -1540,7 +1626,7 @@ impl VectorLoop {
         // vector.py:334-337: update jump args with final renaming
         for i in 0..self.jump.num_args() {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
-            self.jump.setarg(i, BoxRef::from_opref(renamed));
+            self.jump.setarg(i, bind(&produced, renamed));
         }
 
         // vector.py:339-344
@@ -1624,7 +1710,9 @@ pub(crate) fn ensure_args_unpacked(
             let unpacked = unpack_from_vector(state, vec_ref, pos, 1);
             state.renamer.start_renaming(arg, unpacked);
             seen.insert(unpacked);
-            op.setarg(j, BoxRef::from_opref(unpacked));
+            // The VecUnpack producer was just appended to `oplist`; bind the
+            // arg to it (no position-only mint).
+            op.setarg(j, state.bound_arg_boxref(unpacked));
         }
     }
     // schedule.py:708-716: unpack guard failargs
@@ -1641,7 +1729,7 @@ pub(crate) fn ensure_args_unpacked(
                     let unpacked = unpack_from_vector(state, vec_ref, pos, 1);
                     state.renamer.start_renaming(arg.to_opref(), unpacked);
                     seen.insert(unpacked);
-                    *arg = BoxRef::from_opref(unpacked);
+                    *arg = state.bound_arg_boxref(unpacked);
                 }
             }
             op.setfailargs(fail_args);
@@ -1907,9 +1995,9 @@ mod tests {
         // three invariant ops — zero vector, xor-zero, pack seed into lane 0.
         let vc = st.create_vec_op(OpCode::VecI, &[], 'i', 8, true, 2);
         let vc_ref = vc.pos.get();
-        st.invariant_oplist.push(vc);
+        st.invariant_oplist.push(std::rc::Rc::new(vc));
         let xor = st.create_vec_op(OpCode::VecIntXor, &[vc_ref, vc_ref], 'i', 8, true, 2);
-        st.invariant_oplist.push(xor);
+        st.invariant_oplist.push(std::rc::Rc::new(xor));
         let pack = st.create_vec_op(
             OpCode::VecPackI,
             &[
@@ -1924,13 +2012,13 @@ mod tests {
             2,
         );
         let seed_vec = pack.pos.get();
-        st.invariant_oplist.push(pack);
+        st.invariant_oplist.push(std::rc::Rc::new(pack));
         // expand() (schedule.py:554-555) registers the splat vector here.
         st.invariant_vector_vars.insert(seed_vec);
 
         // The scheduled body lives in oplist; the base post_schedule
         // (schedule.py:116) moves it into loop_.operations.
-        st.oplist = body.clone();
+        st.oplist = body.iter().cloned().map(std::rc::Rc::new).collect();
 
         let mut seen: VecSet<OpRef> = vloop
             .label
@@ -1989,7 +2077,7 @@ mod tests {
         let mut vloop = VectorLoop::new(label, body.clone(), jump);
 
         let mut st = VecScheduleState::new(100);
-        st.oplist = body.clone();
+        st.oplist = body.iter().cloned().map(std::rc::Rc::new).collect();
         let mut seen: VecSet<OpRef> = vloop
             .label
             .getarglist()
@@ -2110,7 +2198,7 @@ mod tests {
             // packed scalar to a lane via setvector_of_box.
             let vecop = st.create_vec_op(OpCode::VecIntAdd, &[], 'i', 8, true, 2);
             let vec_ref = vecop.pos.get();
-            st.oplist.push(vecop);
+            st.oplist.push(std::rc::Rc::new(vecop));
             st.setvector_of_box(member_ref, 0, vec_ref);
 
             // seen seeded as the scheduling loop leaves it: always the label

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use crate::r#box::BoxRef;
 use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
+use majit_ir::operand::Operand;
 
 use crate::optimizeopt::info::{
     PtrInfo, VirtualArrayInfo, VirtualArrayStructInfo, VirtualInfo, VirtualStructInfo,
@@ -315,9 +316,9 @@ impl VirtualizableTracker {
             return None;
         }
         // Terminal box of the GetfieldRaw receiver — the virtualizable frame.
-        let frame_box = ctx.resolve_box_box(&producer.arg(0));
+        let frame_box = ctx.resolve_box_box(&producer.arg(0).to_boxref());
         let is_standard = ctx
-            .resolve_box_box_opt(&producer.arg(0))
+            .resolve_box_box_opt(&producer.arg(0).to_boxref())
             .map_or(false, |b| self.is_standard_ref(&b, ctx));
         if !is_standard {
             return None;
@@ -589,7 +590,7 @@ impl OptVirtualize {
     ) -> OptimizationResult {
         let size_ref = op.arg(0).to_opref();
         if let Some(size) = ctx
-            .resolve_box_box_opt(&op.arg(0))
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             // virtualize.py:28-29 `if not info.reasonable_array_index(size):`
@@ -672,8 +673,8 @@ impl OptVirtualize {
     }
 
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let struct_box = ctx.resolve_box_box_opt(&op.arg(0));
-        let value_ref = ctx.resolve_box_box(&op.arg(1)).to_opref();
+        let struct_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
+        let value_ref = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
         let setfield_descr_arc = op
             .getdescr()
             .expect("optimize_setfield_gc: field op without FieldDescr");
@@ -798,7 +799,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let struct_box = ctx.resolve_box_box_opt(&op.arg(0));
+        let struct_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
         let field_descr_arc = op
             .getdescr()
             .expect("optimize_getfield_gc: field op without FieldDescr");
@@ -945,11 +946,11 @@ impl OptVirtualize {
     }
 
     fn optimize_setarrayitem_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_box = ctx.resolve_box_box_opt(&op.arg(0));
-        let value_ref = ctx.resolve_box_box(&op.arg(2)).to_opref();
+        let array_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
+        let value_ref = ctx.resolve_box_box(&op.arg(2).to_boxref()).to_opref();
 
         if let Some(index) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             let idx = index as usize;
@@ -1004,12 +1005,12 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_box = ctx.resolve_box_box_opt(&op.arg(0));
+        let array_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
 
         if let Some(info) = array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
             if let PtrInfo::VirtualArray(vinfo) = info {
                 if let Some(index) = ctx
-                    .resolve_box_box_opt(&op.arg(1))
+                    .resolve_box_box_opt(&op.arg(1).to_boxref())
                     .and_then(|b_| ctx.get_constant_int_box(&b_))
                 {
                     // info.py:580-582: getitem returns None for
@@ -1041,7 +1042,7 @@ impl OptVirtualize {
         // `optimize_getfield_gc`.  Read-only: the matching setarrayitem is
         // left emitted, so no heap write is dropped.
         if let Some(index) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             if let Some(item_ref) = self
@@ -1067,7 +1068,7 @@ impl OptVirtualize {
 
     /// virtualize.py:268-274 optimize_ARRAYLEN_GC
     fn optimize_arraylen_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_box = ctx.resolve_box_box_opt(&op.arg(0));
+        let array_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
 
         if let Some(PtrInfo::VirtualArray(vinfo)) =
             array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b))
@@ -1093,7 +1094,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_box = ctx.resolve_box_box_opt(&op.arg(0));
+        let array_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
         // `info.py:573-581 getinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Strip the surrounding
         // `InteriorFieldDescr` first (`descr.py:388 InteriorFieldDescr.
@@ -1110,7 +1111,7 @@ impl OptVirtualize {
             array_box.as_ref().and_then(|b| ctx.peek_ptr_info(b))
         {
             if let Some(index) = ctx
-                .resolve_box_box_opt(&op.arg(1))
+                .resolve_box_box_opt(&op.arg(1).to_boxref())
                 .and_then(|b_| ctx.get_constant_int_box(&b_))
             {
                 // info.py:651-656 _compute_index: negative or out-of-range → -1
@@ -1149,8 +1150,8 @@ impl OptVirtualize {
         op: &Op,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_box = ctx.resolve_box_box_opt(&op.arg(0));
-        let value_ref = ctx.resolve_box_box(&op.arg(2)).to_opref();
+        let array_box = ctx.resolve_box_box_opt(&op.arg(0).to_boxref());
+        let value_ref = ctx.resolve_box_box(&op.arg(2).to_boxref()).to_opref();
         // `info.py:583-594 setinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Same shape as the GET
         // counterpart — strip the outer `InteriorFieldDescr` first.
@@ -1163,7 +1164,7 @@ impl OptVirtualize {
             .expect("optimize_setinteriorfield_gc: op without InteriorFieldDescr");
 
         if let Some(index) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             let elem_idx = index as usize;
@@ -1228,14 +1229,14 @@ impl OptVirtualize {
         if op.num_args() < 2 {
             return OptimizationResult::PassOn;
         }
-        let arg0 = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let arg0 = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         let Some(offset) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b| ctx.get_constant_int_box(&b))
         else {
             return OptimizationResult::PassOn;
         };
-        let info = ctx.peek_ptr_info(&op.arg(0).get_box_replacement(false));
+        let info = ctx.peek_ptr_info(&op.arg(0).to_boxref().get_box_replacement(false));
         match info {
             Some(PtrInfo::VirtualRawBuffer(_)) | Some(PtrInfo::VirtualRawSlice(_)) => {
                 self.make_virtual_raw_slice(offset, arg0, op, op_rc, ctx);
@@ -1303,9 +1304,9 @@ impl OptVirtualize {
     }
 
     fn optimize_raw_store(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let buf_ref = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let buf_ref = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
         let offset_ref = op.arg(1).to_opref();
-        let value_ref = ctx.resolve_box_box(&op.arg(2)).to_opref();
+        let value_ref = ctx.resolve_box_box(&op.arg(2).to_boxref()).to_opref();
 
         if let Some(offset) = ctx
             .get_box_replacement_box(offset_ref)
@@ -1394,10 +1395,10 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_ref = ctx.resolve_box_box(&op.arg(0)).to_opref();
+        let array_ref = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
 
         if let Some(index) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             if let Some(descr) = op.getdescr() {
@@ -1523,11 +1524,11 @@ impl OptVirtualize {
     ///     return self.emit(op)
     /// ```
     fn optimize_setarrayitem_raw(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_ref = ctx.resolve_box_box(&op.arg(0)).to_opref();
-        let value_ref = ctx.resolve_box_box(&op.arg(2)).to_opref();
+        let array_ref = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+        let value_ref = ctx.resolve_box_box(&op.arg(2).to_boxref()).to_opref();
 
         if let Some(index) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             if let Some(descr) = op.getdescr() {
@@ -1723,8 +1724,8 @@ impl OptVirtualize {
     /// here on the VirtualStruct half and the setfield_gc emit path is
     /// taken only when the vref has already escaped.
     fn optimize_virtual_ref_finish(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let vref_ref = ctx.resolve_box_box(&op.arg(0)).to_opref();
-        let obj_ref = ctx.resolve_box_box(&op.arg(1)).to_opref();
+        let vref_ref = ctx.resolve_box_box(&op.arg(0).to_boxref()).to_opref();
+        let obj_ref = ctx.resolve_box_box(&op.arg(1).to_boxref()).to_opref();
 
         // virtualize.py:151: `CONST_NULL.same_constant(objbox)` — only a
         // Ref-typed null constant matches; a plain ConstInt(0) does not.
@@ -1780,7 +1781,7 @@ impl OptVirtualize {
         if !obj_is_null {
             let arg_vref = ctx.materialize_box_at(vref_ref);
             let arg_obj = ctx.materialize_box_at(obj_ref);
-            let mut set_forced = Op::new(OpCode::SetfieldGc, &[arg_vref, arg_obj]);
+            let mut set_forced = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_vref), Operand::from_boxref(&arg_obj)]);
             set_forced.setdescr(self.vrefinfo.descr_forced.clone());
             ctx.emit_extra(ctx.current_pass_idx, set_forced);
         }
@@ -1790,7 +1791,7 @@ impl OptVirtualize {
         let null_ref = ctx.emit_constant_ref(majit_ir::GcRef(0));
         let arg_vref = ctx.materialize_box_at(vref_ref);
         let arg_null = ctx.materialize_box_at(null_ref);
-        let mut set_token = Op::new(OpCode::SetfieldGc, &[arg_vref, arg_null]);
+        let mut set_token = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_vref), Operand::from_boxref(&arg_null)]);
         set_token.setdescr(self.vrefinfo.descr_virtual_token.clone());
         ctx.emit_extra(ctx.current_pass_idx, set_token);
 
@@ -1835,7 +1836,7 @@ impl OptVirtualize {
             return false;
         }
         // vref = getptrinfo(op.getarg(1)); if vref and vref.is_virtual():
-        let (token_ref, forced_ref) = match ctx.peek_ptr_info(&op.arg(1).get_box_replacement(false))
+        let (token_ref, forced_ref) = match ctx.peek_ptr_info(&op.arg(1).to_boxref().get_box_replacement(false))
         {
             Some(PtrInfo::Virtual(vinfo)) => {
                 // tokenop = vref.getfield(vrefinfo.descr_virtual_token, None)
@@ -2155,11 +2156,11 @@ impl Optimization for OptVirtualize {
                             //   self.last_emitted_operation = REMOVED
                             if op.num_args() >= 2 {
                                 if let Some(size) =
-                                    ctx.get_constant_int_box(&op.arg(1).get_box_replacement(false))
+                                    ctx.get_constant_int_box(&op.arg(1).to_boxref().get_box_replacement(false))
                                 {
                                     // virtualize.py:53 func = source_op.getarg(0).getint()
                                     let func =
-                                        op.arg(0).get_box_replacement(false).const_int().expect(
+                                        op.arg(0).to_boxref().get_box_replacement(false).const_int().expect(
                                             "virtualize.py:53 source_op.getarg(0) must be ConstInt",
                                         );
                                     self.make_virtual_raw_memory(
@@ -2835,14 +2836,14 @@ mod tests {
             // an unbound operand whose root is not a sentinel is minted and
             // registered via `materialize_box_at`, then walked to its
             // terminal — cloning the orig arg would skip canonicalization.
-            let canonical = match ctx.resolve_box_box_opt(&op.arg(i)) {
-                Some(b) => b,
+            let canonical = match ctx.resolve_box_box_opt(&op.arg(i).to_boxref()) {
+                Some(b) => Operand::from_boxref(&b),
                 None => {
                     let argref = op.arg(i).to_opref();
                     if argref.is_none() {
                         op.arg(i).clone()
                     } else {
-                        ctx.materialize_box_at(argref).get_box_replacement(false)
+                        Operand::from_boxref(&ctx.materialize_box_at(argref).get_box_replacement(false))
                     }
                 }
             };
@@ -3021,25 +3022,25 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Ref,
                 0,
-            )],
+            ))],
             field_descr,
         );
         let get_item = Op::with_descr(
             OpCode::GetarrayitemRawI,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr.clone(),
         );
         let get_item_again = Op::with_descr(
             OpCode::GetarrayitemRawI,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr,
         );
@@ -3054,8 +3055,8 @@ mod tests {
         // Int-typed so its result position is `OpRef::int_op(0)`.
         let array_ptr_box =
             crate::r#box::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
-        ops[1].setarg(0, array_ptr_box.clone());
-        ops[2].setarg(0, array_ptr_box.clone());
+        ops[1].setarg(0, Operand::from_boxref(&array_ptr_box));
+        ops[2].setarg(0, Operand::from_boxref(&array_ptr_box));
 
         for op in &ops {
             let mut resolved = op.clone();
@@ -3113,9 +3114,9 @@ mod tests {
         let mut call = Op::new(
             OpCode::CallMayForceI,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
             ],
         );
         call.setdescr(majit_ir::descr::make_call_descr(
@@ -3161,10 +3162,10 @@ mod tests {
 
         let mut get = Op::new(
             OpCode::GetfieldRawI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Ref,
                 0,
-            )],
+            ))],
         );
         get.setdescr(test_vable_field_descr(8, Type::Int, 1));
         get.pos.set(OpRef::int_op(10));
@@ -3193,8 +3194,8 @@ mod tests {
         let mut set = Op::new(
             OpCode::SetfieldRaw,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
             ],
         );
         set.setdescr(test_vable_field_descr(8, Type::Int, 1));
@@ -3270,10 +3271,10 @@ mod tests {
 
         let mut get_field = Op::new(
             OpCode::GetfieldRawI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Ref,
                 0,
-            )],
+            ))],
         );
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
@@ -3287,8 +3288,8 @@ mod tests {
         let mut get_item = Op::new(
             OpCode::GetarrayitemRawI,
             &[
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
-                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
             ],
         );
         get_item.setdescr(array_descr(24));
@@ -3316,10 +3317,10 @@ mod tests {
 
         let mut get_field = Op::new(
             OpCode::GetfieldRawI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Ref,
                 0,
-            )],
+            ))],
         );
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
@@ -3333,9 +3334,9 @@ mod tests {
         let mut set_item = Op::new(
             OpCode::SetarrayitemRaw,
             &[
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
-                crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 2),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 2)),
             ],
         );
         set_item.setdescr(array_descr(24));
@@ -3375,26 +3376,26 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Ref,
                 0,
-            )],
+            ))],
             field_descr,
         );
         let set_item = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
             ],
             arr_descr.clone(),
         );
         let get_item = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr,
         );
@@ -3407,8 +3408,8 @@ mod tests {
         // position is `OpRef::int_op(0)`.
         let array_ptr_box =
             crate::r#box::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
-        ops[1].setarg(0, array_ptr_box.clone());
-        ops[2].setarg(0, array_ptr_box.clone());
+        ops[1].setarg(0, Operand::from_boxref(&array_ptr_box));
+        ops[2].setarg(0, Operand::from_boxref(&array_ptr_box));
 
         for op in &ops {
             let mut resolved = op.clone();
@@ -3486,19 +3487,19 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Ref,
                 0,
-            )],
+            ))],
             field_descr,
         );
         // stack[0] = 42 (const index → tracked)
         let set_item_const = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
             ],
             arr_descr.clone(),
         );
@@ -3506,9 +3507,9 @@ mod tests {
         let set_item_var = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 60),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 52),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 60)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 52)),
             ],
             arr_descr.clone(),
         );
@@ -3516,8 +3517,8 @@ mod tests {
         let get_item = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr,
         );
@@ -3528,9 +3529,9 @@ mod tests {
         // `OpRef::int_op(0)`; bind the element ops to its result box.
         let array_ptr_box =
             crate::r#box::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
-        ops[1].setarg(0, array_ptr_box.clone());
-        ops[2].setarg(0, array_ptr_box.clone());
-        ops[3].setarg(0, array_ptr_box.clone());
+        ops[1].setarg(0, Operand::from_boxref(&array_ptr_box));
+        ops[2].setarg(0, Operand::from_boxref(&array_ptr_box));
+        ops[3].setarg(0, Operand::from_boxref(&array_ptr_box));
 
         for op in &ops {
             let mut resolved = op.clone();
@@ -3590,21 +3591,21 @@ mod tests {
             Op::new(
                 OpCode::Label,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 1),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 2),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 2)),
                 ],
             ),
             Op::new(
                 OpCode::GuardTrue,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 1)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 1))],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 1),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 2),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 2)),
                 ],
             ),
         ];
@@ -3657,14 +3658,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 fd.clone(),
             ),
         ];
@@ -3718,8 +3719,8 @@ mod tests {
         let mut set_op = Op::with_descr(
             OpCode::SetfieldGc,
             &[
-                crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
             ],
             fd,
         );
@@ -3772,14 +3773,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ),
         ];
         assign_positions(&mut ops);
@@ -3828,23 +3829,23 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
                 ad.clone(),
             ), // pos=0
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 52),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 52)),
                 ],
                 ad.clone(),
             ), // pos=1
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
                 ],
                 ad.clone(),
             ), // pos=2
@@ -3923,32 +3924,32 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArrayClear,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
                 arr.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
-                    crate::r#box::test_support::rooted_resop_box(Type::Float, 60),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Float, 60)),
                 ],
                 real.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
-                    crate::r#box::test_support::rooted_resop_box(Type::Float, 61),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Float, 61)),
                 ],
                 imag.clone(),
             ),
             Op::with_descr(
                 OpCode::GetinteriorfieldGcF,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
                 ],
                 real.clone(),
             ),
@@ -3985,30 +3986,30 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArrayClear,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
                 arr.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Float, 60),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Float, 60)),
                 ],
                 real.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 51),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Float, 61),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Float, 61)),
                 ],
                 imag.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4064,12 +4065,12 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 50)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::ArraylenGc,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 ad.clone(),
             ),
         ];
@@ -4106,8 +4107,8 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
             ),
         ];
@@ -4138,7 +4139,7 @@ mod tests {
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()),
             Op::new(
                 OpCode::GuardNonnull,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4173,22 +4174,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
                 ],
                 fd_ref.clone(),
             ), // pos=2
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd_int.clone(),
             ), // pos=3
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ), // pos=4
         ];
         assign_positions(&mut ops);
@@ -4238,14 +4239,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 fd.clone(),
             ),
         ];
@@ -4272,14 +4273,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4309,24 +4310,24 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd,
             ),
             Op::new(
                 OpCode::CallR,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
                 ],
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Int,
                     2,
-                )],
+                ))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4375,25 +4376,25 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Int,
                     2,
-                )],
+                ))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4432,25 +4433,25 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Int,
                     2,
-                )],
+                ))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4486,33 +4487,33 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 101)),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Int,
                     2,
-                )],
+                ))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4573,27 +4574,27 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
                 fd_b.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 fd_b.clone(),
             ),
         ];
@@ -4621,22 +4622,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ),
         ];
         assign_positions(&mut ops);
@@ -4671,15 +4672,15 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
             ),
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
             ),
         ];
@@ -4712,17 +4713,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Ref,
                     0,
-                )],
+                ))],
                 fd.clone(),
             ),
         ];
@@ -4746,15 +4747,15 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 102),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 102)),
                 ],
             ), // pos=1
         ];
@@ -4793,13 +4794,13 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ), // pos=1
         ];
         assign_positions(&mut ops);
@@ -4835,15 +4836,15 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
             ), // pos=1, non-null
         ];
@@ -4876,13 +4877,13 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
             ), // pos=1
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1))],
             ), // pos=2
         ];
         assign_positions(&mut ops);
@@ -4924,22 +4925,22 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Ref,
                     0,
-                )],
+                ))],
             ), // pos=1
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
             ), // pos=2
         ];
@@ -4973,13 +4974,13 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
             ), // pos=0
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 forced_descr,
             ), // pos=1
         ];
@@ -5072,17 +5073,17 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 ad,
             ),
@@ -5114,34 +5115,34 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 201),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 201)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
                 ad,
             ),
@@ -5174,26 +5175,26 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 201),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 201)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 ad,
             ),
@@ -5221,17 +5222,17 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 200),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 ad,
             ),
@@ -5295,30 +5296,30 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 100)),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 3)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 3))],
             ),
             Op::new(
                 OpCode::Jump,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Ref,
                     100,
-                )],
+                ))],
             ),
         ];
         assign_positions(&mut ops);
@@ -5368,17 +5369,17 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
                 ],
                 next_fd.clone(),
             ),
             Op::new(
                 OpCode::Jump,
-                &[crate::r#box::test_support::rooted_inputarg_box(
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                     Type::Ref,
                     0,
-                )],
+                ))],
             ),
         ];
         ops[0].pos.set(OpRef::ref_op(1));
@@ -5416,14 +5417,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Float, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Float, 100)),
                 ],
                 float_fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
                 call_descr,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5457,16 +5458,16 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 100),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
                 ],
                 value_fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
                 ],
                 next_fd.clone(),
             ),
@@ -5474,26 +5475,26 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 5),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 101),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 5)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
                 ],
                 value_fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 5),
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 5)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
                 ],
                 next_fd.clone(),
             ),
             Op::new(
                 OpCode::Finish,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 5),
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 2),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 5)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
                 ],
             ),
         ];
@@ -5570,10 +5571,10 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Int,
                 20,
-            )],
+            ))],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5581,8 +5582,8 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
                 ],
                 fd.clone(),
             ), // pos=1
@@ -5655,10 +5656,10 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Int,
                 20,
-            )],
+            ))],
         );
         guard.setfailargs(
             vec![
@@ -5674,8 +5675,8 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
                 ],
                 fd.clone(),
             ), // pos=1
@@ -5739,10 +5740,10 @@ mod tests {
         // Guard with no virtuals in fail_args should not have rd_numb.
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Int,
                 10,
-            )],
+            ))],
         );
         guard.setfailargs(
             vec![
@@ -5779,10 +5780,10 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Int,
                 20,
-            )],
+            ))],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5790,8 +5791,8 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
                 ],
                 fd.clone(),
             ),
@@ -5847,10 +5848,10 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Int,
                 30,
-            )],
+            ))],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5858,16 +5859,16 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
                 ],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20)),
                 ],
                 fd_b.clone(),
             ),
@@ -5930,10 +5931,10 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_inputarg_box(
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
                 Type::Int,
                 30,
-            )],
+            ))],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5942,16 +5943,16 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
-                    crate::r#box::test_support::rooted_inputarg_box(Type::Int, 40),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 40)),
                 ],
                 inner_fd,
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
                 ],
                 outer_fd,
             ),
@@ -6012,21 +6013,21 @@ mod tests {
         let ad = array_descr(30);
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[crate::r#box::test_support::rooted_resop_box(Type::Int, 20)],
+            &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 20))],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[crate::r#box::test_support::rooted_resop_box(Type::Int, 10)],
+                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10))],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 11),
-                    crate::r#box::test_support::rooted_resop_box(Type::Int, 12),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 11)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 12)),
                 ],
                 ad,
             ),

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -9,8 +9,8 @@
 use std::sync::Arc;
 
 use crate::r#box::BoxRef;
-use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
 use majit_ir::operand::Operand;
+use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
 
 use crate::optimizeopt::info::{
     PtrInfo, VirtualArrayInfo, VirtualArrayStructInfo, VirtualInfo, VirtualStructInfo,
@@ -1781,7 +1781,13 @@ impl OptVirtualize {
         if !obj_is_null {
             let arg_vref = ctx.materialize_box_at(vref_ref);
             let arg_obj = ctx.materialize_box_at(obj_ref);
-            let mut set_forced = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_vref), Operand::from_boxref(&arg_obj)]);
+            let mut set_forced = Op::new(
+                OpCode::SetfieldGc,
+                &[
+                    Operand::from_boxref(&arg_vref),
+                    Operand::from_boxref(&arg_obj),
+                ],
+            );
             set_forced.setdescr(self.vrefinfo.descr_forced.clone());
             ctx.emit_extra(ctx.current_pass_idx, set_forced);
         }
@@ -1791,7 +1797,13 @@ impl OptVirtualize {
         let null_ref = ctx.emit_constant_ref(majit_ir::GcRef(0));
         let arg_vref = ctx.materialize_box_at(vref_ref);
         let arg_null = ctx.materialize_box_at(null_ref);
-        let mut set_token = Op::new(OpCode::SetfieldGc, &[Operand::from_boxref(&arg_vref), Operand::from_boxref(&arg_null)]);
+        let mut set_token = Op::new(
+            OpCode::SetfieldGc,
+            &[
+                Operand::from_boxref(&arg_vref),
+                Operand::from_boxref(&arg_null),
+            ],
+        );
         set_token.setdescr(self.vrefinfo.descr_virtual_token.clone());
         ctx.emit_extra(ctx.current_pass_idx, set_token);
 
@@ -1836,21 +1848,21 @@ impl OptVirtualize {
             return false;
         }
         // vref = getptrinfo(op.getarg(1)); if vref and vref.is_virtual():
-        let (token_ref, forced_ref) = match ctx.peek_ptr_info(&op.arg(1).to_boxref().get_box_replacement(false))
-        {
-            Some(PtrInfo::Virtual(vinfo)) => {
-                // tokenop = vref.getfield(vrefinfo.descr_virtual_token, None)
-                // if tokenop is None: return False
-                let tok = match get_field(&vinfo.fields, VREF_VIRTUAL_TOKEN_FIELD_INDEX) {
-                    Some(r) => r,
-                    None => return false,
-                };
-                // forcedop = vref.getfield(vrefinfo.descr_forced, None)
-                let forced = get_field(&vinfo.fields, VREF_FORCED_FIELD_INDEX);
-                (tok, forced)
-            }
-            _ => return false,
-        };
+        let (token_ref, forced_ref) =
+            match ctx.peek_ptr_info(&op.arg(1).to_boxref().get_box_replacement(false)) {
+                Some(PtrInfo::Virtual(vinfo)) => {
+                    // tokenop = vref.getfield(vrefinfo.descr_virtual_token, None)
+                    // if tokenop is None: return False
+                    let tok = match get_field(&vinfo.fields, VREF_VIRTUAL_TOKEN_FIELD_INDEX) {
+                        Some(r) => r,
+                        None => return false,
+                    };
+                    // forcedop = vref.getfield(vrefinfo.descr_forced, None)
+                    let forced = get_field(&vinfo.fields, VREF_FORCED_FIELD_INDEX);
+                    (tok, forced)
+                }
+                _ => return false,
+            };
         // tokeninfo = getptrinfo(tokenop)
         // if tokeninfo is not None and tokeninfo.is_constant() and not tokeninfo.is_nonnull():
         // The token field is `llmemory.GCREF` upstream
@@ -2155,12 +2167,16 @@ impl Optimization for OptVirtualize {
                             //   self.make_virtual_raw_memory(sizebox.getint(), op)
                             //   self.last_emitted_operation = REMOVED
                             if op.num_args() >= 2 {
-                                if let Some(size) =
-                                    ctx.get_constant_int_box(&op.arg(1).to_boxref().get_box_replacement(false))
-                                {
+                                if let Some(size) = ctx.get_constant_int_box(
+                                    &op.arg(1).to_boxref().get_box_replacement(false),
+                                ) {
                                     // virtualize.py:53 func = source_op.getarg(0).getint()
-                                    let func =
-                                        op.arg(0).to_boxref().get_box_replacement(false).const_int().expect(
+                                    let func = op
+                                        .arg(0)
+                                        .to_boxref()
+                                        .get_box_replacement(false)
+                                        .const_int()
+                                        .expect(
                                             "virtualize.py:53 source_op.getarg(0) must be ConstInt",
                                         );
                                     self.make_virtual_raw_memory(
@@ -2843,7 +2859,9 @@ mod tests {
                     if argref.is_none() {
                         op.arg(i).clone()
                     } else {
-                        Operand::from_boxref(&ctx.materialize_box_at(argref).get_box_replacement(false))
+                        Operand::from_boxref(
+                            &ctx.materialize_box_at(argref).get_box_replacement(false),
+                        )
                     }
                 }
             };
@@ -3022,16 +3040,18 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+            )],
             field_descr,
         );
         let get_item = Op::with_descr(
             OpCode::GetarrayitemRawI,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr.clone(),
@@ -3039,7 +3059,10 @@ mod tests {
         let get_item_again = Op::with_descr(
             OpCode::GetarrayitemRawI,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr,
@@ -3114,9 +3137,18 @@ mod tests {
         let mut call = Op::new(
             OpCode::CallMayForceI,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                    Type::Int,
+                    100,
+                )),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    1,
+                )),
             ],
         );
         call.setdescr(majit_ir::descr::make_call_descr(
@@ -3162,10 +3194,9 @@ mod tests {
 
         let mut get = Op::new(
             OpCode::GetfieldRawI,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+            )],
         );
         get.setdescr(test_vable_field_descr(8, Type::Int, 1));
         get.pos.set(OpRef::int_op(10));
@@ -3194,8 +3225,14 @@ mod tests {
         let mut set = Op::new(
             OpCode::SetfieldRaw,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    1,
+                )),
             ],
         );
         set.setdescr(test_vable_field_descr(8, Type::Int, 1));
@@ -3271,10 +3308,9 @@ mod tests {
 
         let mut get_field = Op::new(
             OpCode::GetfieldRawI,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+            )],
         );
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
@@ -3289,7 +3325,10 @@ mod tests {
             OpCode::GetarrayitemRawI,
             &[
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10)),
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    1,
+                )),
             ],
         );
         get_item.setdescr(array_descr(24));
@@ -3317,10 +3356,9 @@ mod tests {
 
         let mut get_field = Op::new(
             OpCode::GetfieldRawI,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+            )],
         );
         get_field.setdescr(test_vable_field_descr(24, Type::Int, 1));
         get_field.pos.set(OpRef::int_op(10));
@@ -3335,7 +3373,10 @@ mod tests {
             OpCode::SetarrayitemRaw,
             &[
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10)),
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 1)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Int,
+                    1,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 2)),
             ],
         );
@@ -3376,16 +3417,18 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+            )],
             field_descr,
         );
         let set_item = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
             ],
@@ -3394,7 +3437,10 @@ mod tests {
         let get_item = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr,
@@ -3487,17 +3533,19 @@ mod tests {
 
         let get_array_ptr = Op::with_descr(
             OpCode::GetfieldRawI,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Ref,
-                0,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+            )],
             field_descr,
         );
         // stack[0] = 42 (const index → tracked)
         let set_item_const = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
             ],
@@ -3507,7 +3555,10 @@ mod tests {
         let set_item_var = Op::with_descr(
             OpCode::SetarrayitemGc,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 60)),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 52)),
             ],
@@ -3517,7 +3568,10 @@ mod tests {
         let get_item = Op::with_descr(
             OpCode::GetarrayitemGcI,
             &[
-                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                    Type::Ref,
+                    0,
+                )),
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
             ],
             arr_descr,
@@ -3591,21 +3645,41 @@ mod tests {
             Op::new(
                 OpCode::Label,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 1)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 2)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        1,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        2,
+                    )),
                 ],
             ),
             Op::new(
                 OpCode::GuardTrue,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 1))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 1),
+                )],
             ),
             Op::new(
                 OpCode::Jump,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 1)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 2)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        1,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        2,
+                    )),
                 ],
             ),
         ];
@@ -3658,14 +3732,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 fd.clone(),
             ),
         ];
@@ -3720,7 +3802,10 @@ mod tests {
             OpCode::SetfieldGc,
             &[
                 Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                    Type::Int,
+                    100,
+                )),
             ],
             fd,
         );
@@ -3773,14 +3858,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -3829,23 +3922,40 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                )],
                 ad.clone(),
             ), // pos=0
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 52)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        52,
+                    )),
                 ],
                 ad.clone(),
             ), // pos=1
             Op::with_descr(
                 OpCode::GetarrayitemGcI,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
                 ],
                 ad.clone(),
             ), // pos=2
@@ -3924,32 +4034,58 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArrayClear,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                )],
                 arr.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Float, 60)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Float,
+                        60,
+                    )),
                 ],
                 real.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Float, 61)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Float,
+                        61,
+                    )),
                 ],
                 imag.clone(),
             ),
             Op::with_descr(
                 OpCode::GetinteriorfieldGcF,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
                 ],
                 real.clone(),
             ),
@@ -3986,30 +4122,52 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArrayClear,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                )],
                 arr.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Float, 60)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Float,
+                        60,
+                    )),
                 ],
                 real.clone(),
             ),
             Op::with_descr(
                 OpCode::SetinteriorfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 51)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Float, 61)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        51,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Float,
+                        61,
+                    )),
                 ],
                 imag.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4065,12 +4223,16 @@ mod tests {
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 50),
+                )],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::ArraylenGc,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 ad.clone(),
             ),
         ];
@@ -4107,8 +4269,14 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
             ),
         ];
@@ -4139,7 +4307,9 @@ mod tests {
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()),
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4174,22 +4344,36 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        1,
+                    )),
                 ],
                 fd_ref.clone(),
             ), // pos=2
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        1,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd_int.clone(),
             ), // pos=3
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ), // pos=4
         ];
         assign_positions(&mut ops);
@@ -4239,14 +4423,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 fd.clone(),
             ),
         ];
@@ -4273,14 +4465,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4310,24 +4510,35 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd,
             ),
             Op::new(
                 OpCode::CallR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        200,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
                 ],
             ),
             Op::new(
                 OpCode::Finish,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Int,
-                    2,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 2),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4376,25 +4587,36 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        200,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Int,
-                    2,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 2),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4433,25 +4655,36 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        200,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Int,
-                    2,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 2),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4487,33 +4720,50 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        1,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
                 fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        200,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
                 ],
                 call_descr,
             ),
             Op::new(
                 OpCode::Finish,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Int,
-                    2,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 2),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4574,27 +4824,43 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 fd_b.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 fd_b.clone(),
             ),
         ];
@@ -4622,22 +4888,36 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -4672,15 +4952,27 @@ mod tests {
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
             ),
             Op::new(
                 OpCode::GuardClass,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
             ),
         ];
@@ -4713,17 +5005,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::with_descr(
                 OpCode::GetfieldGcI,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Ref,
-                    0,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                )],
                 fd.clone(),
             ),
         ];
@@ -4747,15 +5044,27 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 102)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        102,
+                    )),
                 ],
             ), // pos=1
         ];
@@ -4794,13 +5103,21 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ), // pos=1
         ];
         assign_positions(&mut ops);
@@ -4836,15 +5153,27 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
             ), // pos=1, non-null
         ];
@@ -4877,13 +5206,21 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
             ), // pos=1
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 1),
+                )],
             ), // pos=2
         ];
         assign_positions(&mut ops);
@@ -4925,22 +5262,33 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
             ), // pos=0
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Ref,
-                    0,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                )],
             ), // pos=1
             Op::new(
                 OpCode::VirtualRefFinish,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
             ), // pos=2
         ];
@@ -4974,13 +5322,21 @@ mod tests {
             Op::new(
                 OpCode::VirtualRefR,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
             ), // pos=0
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 forced_descr,
             ), // pos=1
         ];
@@ -5073,17 +5429,32 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 ad,
             ),
@@ -5115,34 +5486,64 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 201)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        201,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
                 ad,
             ),
@@ -5175,26 +5576,50 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 201)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        201,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 ad,
             ),
@@ -5222,17 +5647,32 @@ mod tests {
             Op::with_descr(
                 OpCode::RawStore,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 200)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        50,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        200,
+                    )),
                 ],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::RawLoadI,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 50)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        50,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 ad,
             ),
@@ -5296,30 +5736,41 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        100,
+                    )),
                 ],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
             ),
             Op::with_descr(
                 OpCode::GetfieldGcR,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 fd.clone(),
             ),
             Op::new(
                 OpCode::CallN,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 3))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 3),
+                )],
             ),
             Op::new(
                 OpCode::Jump,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Ref,
-                    100,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 100),
+                )],
             ),
         ];
         assign_positions(&mut ops);
@@ -5369,17 +5820,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        1,
+                    )),
                 ],
                 next_fd.clone(),
             ),
             Op::new(
                 OpCode::Jump,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                    Type::Ref,
-                    0,
-                ))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0),
+                )],
             ),
         ];
         ops[0].pos.set(OpRef::ref_op(1));
@@ -5417,14 +5873,22 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Float, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Float,
+                        100,
+                    )),
                 ],
                 float_fd,
             ),
             Op::with_descr(
                 OpCode::CallR,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Ref, 0),
+                )],
                 call_descr,
             ),
             Op::new(OpCode::Jump, &[]),
@@ -5458,16 +5922,28 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 100)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        2,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        100,
+                    )),
                 ],
                 value_fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        2,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
                 ],
                 next_fd.clone(),
             ),
@@ -5475,26 +5951,50 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 5)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 101)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        5,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        101,
+                    )),
                 ],
                 value_fd.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 5)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        5,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        2,
+                    )),
                 ],
                 next_fd.clone(),
             ),
             Op::new(
                 OpCode::Finish,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 5)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 2)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 1)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Ref, 0)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        5,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        2,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        1,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Ref,
+                        0,
+                    )),
                 ],
             ),
         ];
@@ -5571,10 +6071,9 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Int,
-                20,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20),
+            )],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5582,8 +6081,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        10,
+                    )),
                 ],
                 fd.clone(),
             ), // pos=1
@@ -5656,10 +6161,9 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Int,
-                20,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20),
+            )],
         );
         guard.setfailargs(
             vec![
@@ -5675,8 +6179,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        10,
+                    )),
                 ],
                 fd.clone(),
             ), // pos=1
@@ -5740,10 +6250,9 @@ mod tests {
         // Guard with no virtuals in fail_args should not have rd_numb.
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Int,
-                10,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10),
+            )],
         );
         guard.setfailargs(
             vec![
@@ -5780,10 +6289,9 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Int,
-                20,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20),
+            )],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5791,8 +6299,14 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        10,
+                    )),
                 ],
                 fd.clone(),
             ),
@@ -5848,10 +6362,9 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Int,
-                30,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 30),
+            )],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5859,16 +6372,28 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 10)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        10,
+                    )),
                 ],
                 fd_a.clone(),
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 20)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        20,
+                    )),
                 ],
                 fd_b.clone(),
             ),
@@ -5931,10 +6456,9 @@ mod tests {
 
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
-                Type::Int,
-                30,
-            ))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_inputarg_box(Type::Int, 30),
+            )],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
@@ -5943,16 +6467,28 @@ mod tests {
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(Type::Int, 40)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        1,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_inputarg_box(
+                        Type::Int,
+                        40,
+                    )),
                 ],
                 inner_fd,
             ),
             Op::with_descr(
                 OpCode::SetfieldGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 1)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        1,
+                    )),
                 ],
                 outer_fd,
             ),
@@ -6013,21 +6549,34 @@ mod tests {
         let ad = array_descr(30);
         let mut guard = Op::new(
             OpCode::GuardTrue,
-            &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 20))],
+            &[Operand::from_boxref(
+                &crate::r#box::test_support::rooted_resop_box(Type::Int, 20),
+            )],
         );
         guard.setfailargs(vec![crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,
-                &[Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 10))],
+                &[Operand::from_boxref(
+                    &crate::r#box::test_support::rooted_resop_box(Type::Int, 10),
+                )],
                 ad.clone(),
             ),
             Op::with_descr(
                 OpCode::SetarrayitemGc,
                 &[
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Ref, 0)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 11)),
-                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(Type::Int, 12)),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Ref,
+                        0,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        11,
+                    )),
+                    Operand::from_boxref(&crate::r#box::test_support::rooted_resop_box(
+                        Type::Int,
+                        12,
+                    )),
                 ],
                 ad,
             ),

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -26,8 +26,8 @@ use std::rc::Rc;
 use majit_ir::vec_set::VecSet;
 
 use majit_ir::descr::descr_identity;
-use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 use majit_ir::operand::Operand;
+use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 
 /// virtualstate.py: VirtualStatesCantMatch — raised when two virtual states
 /// are incompatible and cannot be merged for bridge compilation.
@@ -2325,7 +2325,10 @@ impl GuardRequirement {
                 let class_const = ctx.make_constant_int(*expected_class);
                 let arg_b = ctx.materialize_box_at(arg);
                 let class_b = ctx.materialize_box_at(class_const);
-                let mut op = Op::new(OpCode::GuardClass, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&class_b)]);
+                let mut op = Op::new(
+                    OpCode::GuardClass,
+                    &[Operand::from_boxref(&arg_b), Operand::from_boxref(&class_b)],
+                );
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2348,7 +2351,10 @@ impl GuardRequirement {
                 let class_const = ctx.make_constant_int(*expected_class);
                 let arg_b = ctx.materialize_box_at(arg);
                 let class_b = ctx.materialize_box_at(class_const);
-                let mut op = Op::new(OpCode::GuardNonnullClass, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&class_b)]);
+                let mut op = Op::new(
+                    OpCode::GuardNonnullClass,
+                    &[Operand::from_boxref(&arg_b), Operand::from_boxref(&class_b)],
+                );
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2364,7 +2370,10 @@ impl GuardRequirement {
                         None => return Vec::new(),
                     }
                 };
-                let mut op = Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&ctx.materialize_box_at(arg))]);
+                let mut op = Op::new(
+                    OpCode::GuardNonnull,
+                    &[Operand::from_boxref(&ctx.materialize_box_at(arg))],
+                );
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2395,7 +2404,10 @@ impl GuardRequirement {
                 };
                 let arg_b = ctx.materialize_box_at(arg);
                 let val_b = ctx.materialize_box_at(val_const);
-                let mut op = Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&val_b)]);
+                let mut op = Op::new(
+                    OpCode::GuardValue,
+                    &[Operand::from_boxref(&arg_b), Operand::from_boxref(&val_b)],
+                );
                 op.setfailargs(Default::default());
                 vec![op]
             }

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -2488,9 +2488,11 @@ pub(crate) struct ExportCache {
     // assert traps that as a bind-at-alloc gap rather than silently
     // mis-deduping. `VecAssoc`/`VecSet` are Vec-backed and compare by `Eq` only
     // (never hash), so no GC pointer is hashed here.
-    pub finished:
-        crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, Rc<VirtualStateInfoNode>>,
-    pub in_progress: majit_ir::vec_set::VecSet<crate::r#box::BoxRef>,
+    pub finished: crate::optimizeopt::vec_assoc::VecAssoc<
+        majit_ir::operand::Operand,
+        Rc<VirtualStateInfoNode>,
+    >,
+    pub in_progress: majit_ir::vec_set::VecSet<majit_ir::operand::Operand>,
 }
 
 impl ExportCache {
@@ -2549,7 +2551,10 @@ fn export_single_value(
          must be a bound box; virtualstate.py:711-720)"
     );
     // virtualstate.py:714-716: cache hit returns the cached state directly.
-    if let Some(cached) = cache.finished.get(&box_) {
+    if let Some(cached) = cache
+        .finished
+        .get(&majit_ir::operand::Operand::from_boxref(&box_))
+    {
         return Rc::clone(cached);
     }
     // Cycle: this opref is currently being exported on the parent stack.
@@ -2563,7 +2568,10 @@ fn export_single_value(
     // spectral_norm, inline_helper). The cyclic-virtual-graph regression
     // (RPython parity gap documented above) is therefore latent — no
     // benchmark constructs the necessary self-referential structures.
-    if cache.in_progress.contains(&box_) {
+    if cache
+        .in_progress
+        .contains(&majit_ir::operand::Operand::from_boxref(&box_))
+    {
         // Fallback to Ref for the cycle leaf: pyre's virtual DAGs only
         // form through ptr fields, so the only reachable cycles are on
         // Ref-typed nodes. Matches `not_virtual(cpu, 'r', None)` in
@@ -2571,12 +2579,13 @@ fn export_single_value(
         // with LEVEL_UNKNOWN.
         return VirtualStateInfoNode::new_rc(VirtualStateInfo::Unknown(Type::Ref));
     }
-    cache.in_progress.insert(box_.clone());
+    let key = majit_ir::operand::Operand::from_boxref(&box_);
+    cache.in_progress.insert(key.clone());
 
     let info = export_single_value_inner(box_.to_opref(), ctx, cache);
     let rc = VirtualStateInfoNode::new_rc(info);
-    cache.in_progress.remove(&box_);
-    cache.finished.insert(box_, Rc::clone(&rc));
+    cache.in_progress.remove(&key);
+    cache.finished.insert(key, Rc::clone(&rc));
     rc
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -27,6 +27,7 @@ use majit_ir::vec_set::VecSet;
 
 use majit_ir::descr::descr_identity;
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
+use majit_ir::operand::Operand;
 
 /// virtualstate.py: VirtualStatesCantMatch — raised when two virtual states
 /// are incompatible and cannot be merged for bridge compilation.
@@ -2324,7 +2325,7 @@ impl GuardRequirement {
                 let class_const = ctx.make_constant_int(*expected_class);
                 let arg_b = ctx.materialize_box_at(arg);
                 let class_b = ctx.materialize_box_at(class_const);
-                let mut op = Op::new(OpCode::GuardClass, &[arg_b, class_b]);
+                let mut op = Op::new(OpCode::GuardClass, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&class_b)]);
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2347,7 +2348,7 @@ impl GuardRequirement {
                 let class_const = ctx.make_constant_int(*expected_class);
                 let arg_b = ctx.materialize_box_at(arg);
                 let class_b = ctx.materialize_box_at(class_const);
-                let mut op = Op::new(OpCode::GuardNonnullClass, &[arg_b, class_b]);
+                let mut op = Op::new(OpCode::GuardNonnullClass, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&class_b)]);
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2363,7 +2364,7 @@ impl GuardRequirement {
                         None => return Vec::new(),
                     }
                 };
-                let mut op = Op::new(OpCode::GuardNonnull, &[ctx.materialize_box_at(arg)]);
+                let mut op = Op::new(OpCode::GuardNonnull, &[Operand::from_boxref(&ctx.materialize_box_at(arg))]);
                 op.setfailargs(Default::default());
                 vec![op]
             }
@@ -2394,7 +2395,7 @@ impl GuardRequirement {
                 };
                 let arg_b = ctx.materialize_box_at(arg);
                 let val_b = ctx.materialize_box_at(val_const);
-                let mut op = Op::new(OpCode::GuardValue, &[arg_b, val_b]);
+                let mut op = Op::new(OpCode::GuardValue, &[Operand::from_boxref(&arg_b), Operand::from_boxref(&val_b)]);
                 op.setfailargs(Default::default());
                 vec![op]
             }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1,6 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 use majit_ir::{EffectInfo, OopSpecIndex, Op, OpCode, OpRef, Value};
+use majit_ir::operand::Operand;
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::{
@@ -62,7 +63,7 @@ pub fn _int_add(box1: &BoxRef, box2: &BoxRef, ctx: &mut OptContext) -> BoxRef {
     }
     let arg1 = ctx.resolve_box_box(box1);
     let arg2 = ctx.resolve_box_box(box2);
-    let op = Op::new(OpCode::IntAdd, &[arg1, arg2]);
+    let op = Op::new(OpCode::IntAdd, &[Operand::from_boxref(&arg1), Operand::from_boxref(&arg2)]);
     let __r = ctx.emit_for_force(op);
     ctx.materialize_box_at(__r)
 }
@@ -144,7 +145,7 @@ pub fn copy_str_content(
                 let arg_target = ctx.resolve_box_box(targetbox);
                 let arg_dst_off = ctx.resolve_box_box(&dst_offset);
                 let arg_char = ctx.resolve_box_box(&charbox);
-                let setitem_op = Op::new(set_opcode, &[arg_target, arg_dst_off, arg_char]);
+                let setitem_op = Op::new(set_opcode, &[Operand::from_boxref(&arg_target), Operand::from_boxref(&arg_dst_off), Operand::from_boxref(&arg_char)]);
                 ctx.emit_for_force(setitem_op);
                 dst_offset = _int_add(&dst_offset, &one, ctx);
             }
@@ -170,7 +171,7 @@ pub fn copy_str_content(
     let arg_len = ctx.resolve_box_box(lengthbox);
     let copy_op = Op::new(
         copy_opcode,
-        &[arg_src, arg_target, arg_srcoff, arg_off, arg_len],
+        &[Operand::from_boxref(&arg_src), Operand::from_boxref(&arg_target), Operand::from_boxref(&arg_srcoff), Operand::from_boxref(&arg_off), Operand::from_boxref(&arg_len)],
     );
     ctx.emit_for_force(copy_op);
     next_offset
@@ -249,7 +250,7 @@ pub fn string_copy_parts(
                     let arg_char = ctx.resolve_box_box(ch_ref);
                     let arg_target = ctx.resolve_box_box(targetbox);
                     let arg_offset = ctx.resolve_box_box(&offset);
-                    let setitem_op = Op::new(set_opcode, &[arg_target, arg_offset, arg_char]);
+                    let setitem_op = Op::new(set_opcode, &[Operand::from_boxref(&arg_target), Operand::from_boxref(&arg_offset), Operand::from_boxref(&arg_char)]);
                     ctx.emit_for_force(setitem_op);
                 }
                 offset = _int_add(&offset, &one, ctx);
@@ -412,7 +413,7 @@ impl OptString {
     /// SameAsI(dummy) and record the constant in the context.
     fn emit_constant_int(&self, value: i64, ctx: &mut OptContext) -> OpRef {
         // Emit a dummy SameAsI to get an OpRef, then record the constant.
-        let op = Op::new(OpCode::SameAsI, &[BoxRef::from_opref(OpRef::NONE)]);
+        let op = Op::new(OpCode::SameAsI, &[Operand::from_boxref(&BoxRef::from_opref(OpRef::NONE))]);
         let opref = ctx.emit(op);
         let b = ctx.materialize_box_at(opref);
         ctx.make_constant_box(&b, Value::Int(value));
@@ -578,7 +579,7 @@ impl OptString {
         // and to emit_extra(current_pass_idx) during the pass — identical to
         // the previous emit_extra(current_pass_idx) for the pass-time
         // string-compare / dispatcher callers.
-        ctx.emit_for_force(Op::new(get_opcode, &[arg_str, arg_index]))
+        ctx.emit_for_force(Op::new(get_opcode, &[Operand::from_boxref(&arg_str), Operand::from_boxref(&arg_index)]))
     }
 
     /// vstring.py:486-517 strgetitem(None, s, index, mode) with a box-valued
@@ -636,7 +637,7 @@ impl OptString {
     ) -> OptimizationResult {
         let len_ref = op.arg(0).to_opref();
         if let Some(len) = ctx
-            .resolve_box_box_opt(&op.arg(0))
+            .resolve_box_box_opt(&op.arg(0).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             if len >= 0 && (len as usize) <= MAX_CONST_LEN {
@@ -679,12 +680,12 @@ impl OptString {
 
     /// Handle STRSETITEM: if target is virtual Plain and index is constant, track.
     fn optimize_strsetitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let str_ref = ctx.resolve_box_box(&op.arg(0));
+        let str_ref = ctx.resolve_box_box(&op.arg(0).to_boxref());
         let char_ref = op.arg(2).to_opref();
         let char_resolved = ctx.get_replacement_opref(char_ref);
 
         if let Some(idx) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             let i = idx as usize;
@@ -714,10 +715,10 @@ impl OptString {
         mode: u8,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let str_ref = ctx.resolve_box_box(&op.arg(0));
+        let str_ref = ctx.resolve_box_box(&op.arg(0).to_boxref());
 
         if let Some(idx) = ctx
-            .resolve_box_box_opt(&op.arg(1))
+            .resolve_box_box_opt(&op.arg(1).to_boxref())
             .and_then(|b_| ctx.get_constant_int_box(&b_))
         {
             if let Some(ch_ref) = self.strgetitem(&str_ref, idx, mode, ctx) {
@@ -734,7 +735,7 @@ impl OptString {
         // forcing only the target. The slice/concat is left unreferenced rather
         // than forced wholesale.
         if let Some((target, index_box)) =
-            self.strgetitem_rebase_residual(&str_ref, &op.arg(1), mode, ctx)
+            self.strgetitem_rebase_residual(&str_ref, &op.arg(1).to_boxref(), mode, ctx)
         {
             // PRE-EXISTING DIVERGENCE: vstring.py:404 `_strgetitem` only builds
             // the STRGETITEM and hands it to emit_extra; the operand is forced
@@ -750,7 +751,7 @@ impl OptString {
             } else {
                 OpCode::Strgetitem
             };
-            let mut getitem = Op::new(get_opcode, &[arg_s, arg_i]);
+            let mut getitem = Op::new(get_opcode, &[Operand::from_boxref(&arg_s), Operand::from_boxref(&arg_i)]);
             getitem.pos.set(op.pos.get());
             // vstring.py:407-409 `_strgetitem`: resbox = replace_op_with(resbox,
             // STRGETITEM, ...); emit_extra(resbox). emit_extra =
@@ -838,7 +839,7 @@ impl OptString {
         };
         // vstring.py:526-527
         let has_info = ctx
-            .getptrinfo(&op.arg(0).get_box_replacement(false))
+            .getptrinfo(&op.arg(0).to_boxref().get_box_replacement(false))
             .is_some();
         if has_info {
             // vstring.py:529: lgtop = opinfo.getstrlen(arg1, self, mode)
@@ -873,8 +874,8 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // copystrcontent(src, dst, src_start, dst_start, length)
-        let src_ref_box = ctx.resolve_box_box(&op.arg(0));
-        let dst_ref = ctx.resolve_box_box(&op.arg(1));
+        let src_ref_box = ctx.resolve_box_box(&op.arg(0).to_boxref());
+        let dst_ref = ctx.resolve_box_box(&op.arg(1).to_boxref());
         let src_info = ctx.getptrinfo(&src_ref_box);
         let src_is_virtual_or_constant = src_info
             .as_ref()
@@ -882,9 +883,9 @@ impl OptString {
         // vstring.py:564/568: dst = getptrinfo(op.getarg(1)) resolves once;
         // reuse the resolved box instead of re-walking the operand chain.
         let dst_virtual = self.is_virtual_plain(&dst_ref, ctx);
-        let src_start = self.get_constant_int_bound(&op.arg(2), ctx);
-        let dst_start = self.get_constant_int_bound(&op.arg(3), ctx);
-        let length = self.get_constant_int_bound(&op.arg(4), ctx);
+        let src_start = self.get_constant_int_bound(&op.arg(2).to_boxref(), ctx);
+        let dst_start = self.get_constant_int_bound(&op.arg(3).to_boxref(), ctx);
+        let length = self.get_constant_int_bound(&op.arg(4).to_boxref(), ctx);
 
         if length == Some(0) {
             return OptimizationResult::Remove;
@@ -919,7 +920,7 @@ impl OptString {
                         let arg_char = ctx.materialize_box_at(char_ref);
                         ctx.emit_extra(
                             pass_idx,
-                            Op::new(setitem_opcode, &[arg_dst, arg_dst_index, arg_char]),
+                            Op::new(setitem_opcode, &[Operand::from_boxref(&arg_dst), Operand::from_boxref(&arg_dst_index), Operand::from_boxref(&arg_char)]),
                         );
                     }
                 }
@@ -941,11 +942,11 @@ impl OptString {
         // which may still inline small constant-length copies.
         copy_str_content(
             ctx,
-            &op.arg(0),
-            &op.arg(1),
-            &op.arg(2),
-            &op.arg(3),
-            &op.arg(4),
+            &op.arg(0).to_boxref(),
+            &op.arg(1).to_boxref(),
+            &op.arg(2).to_boxref(),
+            &op.arg(3).to_boxref(),
+            &op.arg(4).to_boxref(),
             mode,
             false, // need_next_offset=False
         );
@@ -984,7 +985,7 @@ impl OptString {
         }
         let arg_a = ctx.resolve_box_box(a);
         let arg_b = ctx.resolve_box_box(b);
-        let op = Op::new(OpCode::IntSub, &[arg_a, arg_b]);
+        let op = Op::new(OpCode::IntSub, &[Operand::from_boxref(&arg_a), Operand::from_boxref(&arg_b)]);
         let __r = ctx.emit_for_force(op);
         ctx.materialize_box_at(__r)
     }
@@ -999,10 +1000,10 @@ impl OptString {
             1u8
         };
         // STRLEN postprocess updates PtrInfo on the resolved receiver box.
-        if let Some(arg0_box) = ctx.resolve_box_box_opt(&op.arg(0)) {
+        if let Some(arg0_box) = ctx.resolve_box_box_opt(&op.arg(0).to_boxref()) {
             ctx.make_nonnull_str(&arg0_box, mode);
         }
-        if let Some(len) = self.get_known_length(&op.arg(0), ctx) {
+        if let Some(len) = self.get_known_length(&op.arg(0).to_boxref(), ctx) {
             let _ = len;
         }
     }
@@ -1075,8 +1076,8 @@ impl OptString {
         if op.num_args() >= 3 {
             // vstring.py:654-655: make_nonnull_str on each concat operand,
             // unconditionally. The resolved string boxes are the PtrInfo hosts.
-            let vleft_box = ctx.resolve_box_box(&op.arg(1));
-            let vright_box = ctx.resolve_box_box(&op.arg(2));
+            let vleft_box = ctx.resolve_box_box(&op.arg(1).to_boxref());
+            let vright_box = ctx.resolve_box_box(&op.arg(2).to_boxref());
             ctx.make_nonnull_str(&vleft_box, mode);
             ctx.make_nonnull_str(&vright_box, mode);
             let b = BoxRef::from_bound_op(op_rc);
@@ -1112,10 +1113,10 @@ impl OptString {
     ) -> OptimizationResult {
         if op.num_args() >= 4 {
             // vstring.py:663: self.make_nonnull_str(op.getarg(1), mode)
-            let mut s = ctx.resolve_box_box(&op.arg(1));
+            let mut s = ctx.resolve_box_box(&op.arg(1).to_boxref());
             ctx.make_nonnull_str(&s, mode);
-            let mut start = ctx.resolve_box_box(&op.arg(2));
-            let stop = ctx.resolve_box_box(&op.arg(3));
+            let mut start = ctx.resolve_box_box(&op.arg(2).to_boxref());
+            let stop = ctx.resolve_box_box(&op.arg(3).to_boxref());
             let lgtop = self.int_sub(&stop, &start, ctx);
             // vstring.py:682-685: double slicing s[i:j][k:l]
             if let Some(info) = self.get_slice_info(&s, ctx) {
@@ -1161,8 +1162,8 @@ impl OptString {
             return OptimizationResult::PassOn;
         }
         // vstring.py:693-696
-        let arg1 = ctx.resolve_box_box(&op.arg(1));
-        let arg2 = ctx.resolve_box_box(&op.arg(2));
+        let arg1 = ctx.resolve_box_box(&op.arg(1).to_boxref());
+        let arg2 = ctx.resolve_box_box(&op.arg(2).to_boxref());
         let i1 = ctx.getptrinfo(&arg1).is_some();
         let i2 = ctx.getptrinfo(&arg2).is_some();
         // vstring.py:698-705: l1box = i1.getstrlen(arg1, self, mode)
@@ -1255,7 +1256,7 @@ impl OptString {
                     let zero = ctx.emit_constant_int(0);
                     let arg_len = ctx.materialize_box_at(lengthbox);
                     let arg_zero = ctx.materialize_box_at(zero);
-                    let mut eq_op = Op::new(OpCode::IntEq, &[arg_len, arg_zero]);
+                    let mut eq_op = Op::new(OpCode::IntEq, &[Operand::from_boxref(&arg_len), Operand::from_boxref(&arg_zero)]);
                     eq_op.pos.set(op.pos.get());
                     // vstring.py:751-754: replace_op_with(INT_EQ, [len, 0]) then
                     // seo(op) = send_extra_operation(op, opt=None) restarts from
@@ -1280,7 +1281,7 @@ impl OptString {
                     let c2 = self.strgetitem_emit(arg2, 0, mode, ctx);
                     let arg_ch1 = ctx.materialize_box_at(c1);
                     let arg_ch2 = ctx.materialize_box_at(c2);
-                    let mut eq_op = Op::new(OpCode::IntEq, &[arg_ch1, arg_ch2]);
+                    let mut eq_op = Op::new(OpCode::IntEq, &[Operand::from_boxref(&arg_ch1), Operand::from_boxref(&arg_ch2)]);
                     eq_op.pos.set(op.pos.get());
                     // vstring.py:765-767: replace_op_with(INT_EQ, [c1, c2]) then
                     // seo(op) = send_extra_operation(op, opt=None) restarts from
@@ -1318,7 +1319,7 @@ impl OptString {
             let null_const = ctx.emit_constant_ref(majit_ir::GcRef::NULL);
             let arg_a = ctx.materialize_box_at(arg1.to_opref());
             let arg_null = ctx.materialize_box_at(null_const);
-            let mut eq_op = Op::new(OpCode::PtrEq, &[arg_a, arg_null]);
+            let mut eq_op = Op::new(OpCode::PtrEq, &[Operand::from_boxref(&arg_a), Operand::from_boxref(&arg_null)]);
             eq_op.pos.set(op.pos.get());
             // vstring.py:785-786: replace_op_with(PTR_EQ, ...) then self.emit(op)
             // (Optimization.emit) — the op flows on to the passes after OptString.
@@ -1424,9 +1425,10 @@ impl OptString {
             call_args_box.push(ctx.materialize_box_at(*a));
         }
         // vstring.py:854: replace_op_with(result, rop.CALL_I, [...], descr=calldescr)
+        let call_args_operand: Vec<Operand> = call_args_box.iter().map(Operand::from_boxref).collect();
         let mut call_op = match calldescr {
-            Some(d) => Op::with_descr(OpCode::CallI, &call_args_box, d.clone()),
-            None => Op::new(OpCode::CallI, &call_args_box),
+            Some(d) => Op::with_descr(OpCode::CallI, &call_args_operand, d.clone()),
+            None => Op::new(OpCode::CallI, &call_args_operand),
         };
         call_op.pos.set(result_op.pos.get());
         // vstring.py:857: return self.emit(op) (Optimization.emit) — the CALL_I
@@ -1449,10 +1451,10 @@ impl OptString {
         }
         // vstring.py:819-822: bail out if either info is missing
         let i1 = ctx
-            .getptrinfo(&op.arg(1).get_box_replacement(false))
+            .getptrinfo(&op.arg(1).to_boxref().get_box_replacement(false))
             .is_some();
         let i2 = ctx
-            .getptrinfo(&op.arg(2).get_box_replacement(false))
+            .getptrinfo(&op.arg(2).to_boxref().get_box_replacement(false))
             .is_some();
         if !i1 || !i2 {
             self.force_args_if_virtual(op, ctx);
@@ -1473,11 +1475,11 @@ impl OptString {
             // a final Emit, which would skip every subsequent pass. Mirror that
             // with a new op whose pos is the original result position
             // (replace_op_with) and a Restart result (send_extra_operation).
-            let char1 = self.strgetitem_emit(&op.arg(1), 0, mode, ctx);
-            let char2 = self.strgetitem_emit(&op.arg(2), 0, mode, ctx);
+            let char1 = self.strgetitem_emit(&op.arg(1).to_boxref(), 0, mode, ctx);
+            let char2 = self.strgetitem_emit(&op.arg(2).to_boxref(), 0, mode, ctx);
             let arg_char1 = ctx.materialize_box_at(char1);
             let arg_char2 = ctx.materialize_box_at(char2);
-            let mut sub_op = Op::new(OpCode::IntSub, &[arg_char1, arg_char2]);
+            let mut sub_op = Op::new(OpCode::IntSub, &[Operand::from_boxref(&arg_char1), Operand::from_boxref(&arg_char2)]);
             sub_op.pos.set(op.pos.get());
             return OptimizationResult::Restart(sub_op);
         }
@@ -1525,9 +1527,9 @@ impl OptString {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         if op.num_args() >= 3 {
-            let arg1_box = ctx.resolve_box_box_opt(&op.arg(1));
+            let arg1_box = ctx.resolve_box_box_opt(&op.arg(1).to_boxref());
             let length = ctx
-                .resolve_box_box_opt(&op.arg(2))
+                .resolve_box_box_opt(&op.arg(2).to_boxref())
                 .and_then(|b| ctx.get_constant_int_box(&b));
             // vstring.py:844-845: i2.is_constant() && i1.is_virtual() &&
             // isinstance(i1, VStringPlainInfo)
@@ -1593,7 +1595,7 @@ impl Optimization for OptString {
 
             // vstring.py: STRHASH/UNICODEHASH — force virtual string and emit.
             OpCode::Strhash | OpCode::Unicodehash => {
-                let src = ctx.resolve_box_box(&op.arg(0));
+                let src = ctx.resolve_box_box(&op.arg(0).to_boxref());
                 self.force_if_virtual(&src, ctx);
                 OptimizationResult::PassOn
             }
@@ -1670,13 +1672,13 @@ mod tests {
     /// the constant-map / PtrInfo keys this trace seeds by absolute position
     /// still resolve. The OptString driver runs that single pass and resolves
     /// args by position, so the detached synthetic never diverges.
-    fn iop(n: u32) -> BoxRef {
-        rooted_resop_box(Type::Int, n)
+    fn iop(n: u32) -> Operand {
+        Operand::from_boxref(&rooted_resop_box(Type::Int, n))
     }
 
     /// Bound drop-in for `from_opref(OpRef::ref_op(n))` at an op-argument site.
-    fn rop(n: u32) -> BoxRef {
-        rooted_resop_box(Type::Ref, n)
+    fn rop(n: u32) -> Operand {
+        Operand::from_boxref(&rooted_resop_box(Type::Ref, n))
     }
 
     /// Assign sequential positions to ops and pre-seed constants in OptContext.
@@ -1744,7 +1746,7 @@ mod tests {
             // propagate_from_pass_range, so the pass reads PtrInfo/IntBound
             // directly off resolved_op.arg(i) instead of a fresh unbound box.
             for i in 0..resolved_op.num_args() {
-                resolved_op.setarg(i, ctx.resolve_box_box(&resolved_op.arg(i)));
+                resolved_op.setarg(i, majit_ir::operand::Operand::from_boxref(&ctx.resolve_box_box(&resolved_op.arg(i).to_boxref())));
             }
             let resolved_rc = std::rc::Rc::new(resolved_op.clone());
             ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
@@ -2141,7 +2143,7 @@ mod tests {
                 op.pos.get(),
                 op.opcode,
                 op.arg(0).to_opref(),
-                op.arg(1).get_box_replacement(false),
+                op.arg(1).to_boxref().get_box_replacement(false),
             )
         };
         assert_eq!(res, res_pos);
@@ -2253,7 +2255,7 @@ mod tests {
                 assert_eq!(emitted.arg(0).to_opref(), vright_ref);
                 // arg1 is the fully rebased index (1 + 1) - 2 = 0.
                 assert_eq!(
-                    ctx.get_constant_int_box(&emitted.arg(1).get_box_replacement(false)),
+                    ctx.get_constant_int_box(&emitted.arg(1).to_boxref().get_box_replacement(false)),
                     Some(0)
                 );
                 assert_eq!(emitted.pos.get(), pos);

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 
-use majit_ir::{EffectInfo, OopSpecIndex, Op, OpCode, OpRef, Value};
 use majit_ir::operand::Operand;
+use majit_ir::{EffectInfo, OopSpecIndex, Op, OpCode, OpRef, Value};
 
 use crate::r#box::BoxRef;
 use crate::optimizeopt::info::{
@@ -63,7 +63,10 @@ pub fn _int_add(box1: &BoxRef, box2: &BoxRef, ctx: &mut OptContext) -> BoxRef {
     }
     let arg1 = ctx.resolve_box_box(box1);
     let arg2 = ctx.resolve_box_box(box2);
-    let op = Op::new(OpCode::IntAdd, &[Operand::from_boxref(&arg1), Operand::from_boxref(&arg2)]);
+    let op = Op::new(
+        OpCode::IntAdd,
+        &[Operand::from_boxref(&arg1), Operand::from_boxref(&arg2)],
+    );
     let __r = ctx.emit_for_force(op);
     ctx.materialize_box_at(__r)
 }
@@ -145,7 +148,14 @@ pub fn copy_str_content(
                 let arg_target = ctx.resolve_box_box(targetbox);
                 let arg_dst_off = ctx.resolve_box_box(&dst_offset);
                 let arg_char = ctx.resolve_box_box(&charbox);
-                let setitem_op = Op::new(set_opcode, &[Operand::from_boxref(&arg_target), Operand::from_boxref(&arg_dst_off), Operand::from_boxref(&arg_char)]);
+                let setitem_op = Op::new(
+                    set_opcode,
+                    &[
+                        Operand::from_boxref(&arg_target),
+                        Operand::from_boxref(&arg_dst_off),
+                        Operand::from_boxref(&arg_char),
+                    ],
+                );
                 ctx.emit_for_force(setitem_op);
                 dst_offset = _int_add(&dst_offset, &one, ctx);
             }
@@ -171,7 +181,13 @@ pub fn copy_str_content(
     let arg_len = ctx.resolve_box_box(lengthbox);
     let copy_op = Op::new(
         copy_opcode,
-        &[Operand::from_boxref(&arg_src), Operand::from_boxref(&arg_target), Operand::from_boxref(&arg_srcoff), Operand::from_boxref(&arg_off), Operand::from_boxref(&arg_len)],
+        &[
+            Operand::from_boxref(&arg_src),
+            Operand::from_boxref(&arg_target),
+            Operand::from_boxref(&arg_srcoff),
+            Operand::from_boxref(&arg_off),
+            Operand::from_boxref(&arg_len),
+        ],
     );
     ctx.emit_for_force(copy_op);
     next_offset
@@ -250,7 +266,14 @@ pub fn string_copy_parts(
                     let arg_char = ctx.resolve_box_box(ch_ref);
                     let arg_target = ctx.resolve_box_box(targetbox);
                     let arg_offset = ctx.resolve_box_box(&offset);
-                    let setitem_op = Op::new(set_opcode, &[Operand::from_boxref(&arg_target), Operand::from_boxref(&arg_offset), Operand::from_boxref(&arg_char)]);
+                    let setitem_op = Op::new(
+                        set_opcode,
+                        &[
+                            Operand::from_boxref(&arg_target),
+                            Operand::from_boxref(&arg_offset),
+                            Operand::from_boxref(&arg_char),
+                        ],
+                    );
                     ctx.emit_for_force(setitem_op);
                 }
                 offset = _int_add(&offset, &one, ctx);
@@ -413,7 +436,10 @@ impl OptString {
     /// SameAsI(dummy) and record the constant in the context.
     fn emit_constant_int(&self, value: i64, ctx: &mut OptContext) -> OpRef {
         // Emit a dummy SameAsI to get an OpRef, then record the constant.
-        let op = Op::new(OpCode::SameAsI, &[Operand::from_boxref(&BoxRef::from_opref(OpRef::NONE))]);
+        let op = Op::new(
+            OpCode::SameAsI,
+            &[Operand::from_boxref(&BoxRef::from_opref(OpRef::NONE))],
+        );
         let opref = ctx.emit(op);
         let b = ctx.materialize_box_at(opref);
         ctx.make_constant_box(&b, Value::Int(value));
@@ -579,7 +605,13 @@ impl OptString {
         // and to emit_extra(current_pass_idx) during the pass — identical to
         // the previous emit_extra(current_pass_idx) for the pass-time
         // string-compare / dispatcher callers.
-        ctx.emit_for_force(Op::new(get_opcode, &[Operand::from_boxref(&arg_str), Operand::from_boxref(&arg_index)]))
+        ctx.emit_for_force(Op::new(
+            get_opcode,
+            &[
+                Operand::from_boxref(&arg_str),
+                Operand::from_boxref(&arg_index),
+            ],
+        ))
     }
 
     /// vstring.py:486-517 strgetitem(None, s, index, mode) with a box-valued
@@ -751,7 +783,10 @@ impl OptString {
             } else {
                 OpCode::Strgetitem
             };
-            let mut getitem = Op::new(get_opcode, &[Operand::from_boxref(&arg_s), Operand::from_boxref(&arg_i)]);
+            let mut getitem = Op::new(
+                get_opcode,
+                &[Operand::from_boxref(&arg_s), Operand::from_boxref(&arg_i)],
+            );
             getitem.pos.set(op.pos.get());
             // vstring.py:407-409 `_strgetitem`: resbox = replace_op_with(resbox,
             // STRGETITEM, ...); emit_extra(resbox). emit_extra =
@@ -920,7 +955,14 @@ impl OptString {
                         let arg_char = ctx.materialize_box_at(char_ref);
                         ctx.emit_extra(
                             pass_idx,
-                            Op::new(setitem_opcode, &[Operand::from_boxref(&arg_dst), Operand::from_boxref(&arg_dst_index), Operand::from_boxref(&arg_char)]),
+                            Op::new(
+                                setitem_opcode,
+                                &[
+                                    Operand::from_boxref(&arg_dst),
+                                    Operand::from_boxref(&arg_dst_index),
+                                    Operand::from_boxref(&arg_char),
+                                ],
+                            ),
                         );
                     }
                 }
@@ -985,7 +1027,10 @@ impl OptString {
         }
         let arg_a = ctx.resolve_box_box(a);
         let arg_b = ctx.resolve_box_box(b);
-        let op = Op::new(OpCode::IntSub, &[Operand::from_boxref(&arg_a), Operand::from_boxref(&arg_b)]);
+        let op = Op::new(
+            OpCode::IntSub,
+            &[Operand::from_boxref(&arg_a), Operand::from_boxref(&arg_b)],
+        );
         let __r = ctx.emit_for_force(op);
         ctx.materialize_box_at(__r)
     }
@@ -1256,7 +1301,13 @@ impl OptString {
                     let zero = ctx.emit_constant_int(0);
                     let arg_len = ctx.materialize_box_at(lengthbox);
                     let arg_zero = ctx.materialize_box_at(zero);
-                    let mut eq_op = Op::new(OpCode::IntEq, &[Operand::from_boxref(&arg_len), Operand::from_boxref(&arg_zero)]);
+                    let mut eq_op = Op::new(
+                        OpCode::IntEq,
+                        &[
+                            Operand::from_boxref(&arg_len),
+                            Operand::from_boxref(&arg_zero),
+                        ],
+                    );
                     eq_op.pos.set(op.pos.get());
                     // vstring.py:751-754: replace_op_with(INT_EQ, [len, 0]) then
                     // seo(op) = send_extra_operation(op, opt=None) restarts from
@@ -1281,7 +1332,13 @@ impl OptString {
                     let c2 = self.strgetitem_emit(arg2, 0, mode, ctx);
                     let arg_ch1 = ctx.materialize_box_at(c1);
                     let arg_ch2 = ctx.materialize_box_at(c2);
-                    let mut eq_op = Op::new(OpCode::IntEq, &[Operand::from_boxref(&arg_ch1), Operand::from_boxref(&arg_ch2)]);
+                    let mut eq_op = Op::new(
+                        OpCode::IntEq,
+                        &[
+                            Operand::from_boxref(&arg_ch1),
+                            Operand::from_boxref(&arg_ch2),
+                        ],
+                    );
                     eq_op.pos.set(op.pos.get());
                     // vstring.py:765-767: replace_op_with(INT_EQ, [c1, c2]) then
                     // seo(op) = send_extra_operation(op, opt=None) restarts from
@@ -1319,7 +1376,13 @@ impl OptString {
             let null_const = ctx.emit_constant_ref(majit_ir::GcRef::NULL);
             let arg_a = ctx.materialize_box_at(arg1.to_opref());
             let arg_null = ctx.materialize_box_at(null_const);
-            let mut eq_op = Op::new(OpCode::PtrEq, &[Operand::from_boxref(&arg_a), Operand::from_boxref(&arg_null)]);
+            let mut eq_op = Op::new(
+                OpCode::PtrEq,
+                &[
+                    Operand::from_boxref(&arg_a),
+                    Operand::from_boxref(&arg_null),
+                ],
+            );
             eq_op.pos.set(op.pos.get());
             // vstring.py:785-786: replace_op_with(PTR_EQ, ...) then self.emit(op)
             // (Optimization.emit) — the op flows on to the passes after OptString.
@@ -1425,7 +1488,8 @@ impl OptString {
             call_args_box.push(ctx.materialize_box_at(*a));
         }
         // vstring.py:854: replace_op_with(result, rop.CALL_I, [...], descr=calldescr)
-        let call_args_operand: Vec<Operand> = call_args_box.iter().map(Operand::from_boxref).collect();
+        let call_args_operand: Vec<Operand> =
+            call_args_box.iter().map(Operand::from_boxref).collect();
         let mut call_op = match calldescr {
             Some(d) => Op::with_descr(OpCode::CallI, &call_args_operand, d.clone()),
             None => Op::new(OpCode::CallI, &call_args_operand),
@@ -1479,7 +1543,13 @@ impl OptString {
             let char2 = self.strgetitem_emit(&op.arg(2).to_boxref(), 0, mode, ctx);
             let arg_char1 = ctx.materialize_box_at(char1);
             let arg_char2 = ctx.materialize_box_at(char2);
-            let mut sub_op = Op::new(OpCode::IntSub, &[Operand::from_boxref(&arg_char1), Operand::from_boxref(&arg_char2)]);
+            let mut sub_op = Op::new(
+                OpCode::IntSub,
+                &[
+                    Operand::from_boxref(&arg_char1),
+                    Operand::from_boxref(&arg_char2),
+                ],
+            );
             sub_op.pos.set(op.pos.get());
             return OptimizationResult::Restart(sub_op);
         }
@@ -1746,7 +1816,12 @@ mod tests {
             // propagate_from_pass_range, so the pass reads PtrInfo/IntBound
             // directly off resolved_op.arg(i) instead of a fresh unbound box.
             for i in 0..resolved_op.num_args() {
-                resolved_op.setarg(i, majit_ir::operand::Operand::from_boxref(&ctx.resolve_box_box(&resolved_op.arg(i).to_boxref())));
+                resolved_op.setarg(
+                    i,
+                    majit_ir::operand::Operand::from_boxref(
+                        &ctx.resolve_box_box(&resolved_op.arg(i).to_boxref()),
+                    ),
+                );
             }
             let resolved_rc = std::rc::Rc::new(resolved_op.clone());
             ctx.bind_input_resops(std::slice::from_ref(&resolved_rc));
@@ -2255,7 +2330,9 @@ mod tests {
                 assert_eq!(emitted.arg(0).to_opref(), vright_ref);
                 // arg1 is the fully rebased index (1 + 1) - 2 = 0.
                 assert_eq!(
-                    ctx.get_constant_int_box(&emitted.arg(1).to_boxref().get_box_replacement(false)),
+                    ctx.get_constant_int_box(
+                        &emitted.arg(1).to_boxref().get_box_replacement(false)
+                    ),
                     Some(0)
                 );
                 assert_eq!(emitted.pos.get(), pos);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -18,6 +18,7 @@ pub use frame::{MIFrame, MIFrameStack};
 use std::sync::Arc;
 
 use crate::r#box::BoxRef;
+use majit_ir::operand::Operand;
 use crate::optimizeopt::optimizer::{Optimizer, PendingBridgeRd};
 use majit_backend::{Backend, ExitRecoveryLayout, JitCellToken};
 #[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
@@ -5219,7 +5220,7 @@ impl<M: Clone> MetaInterp<M> {
                 &trace
                     .inputargs
                     .iter()
-                    .map(BoxRef::from_bound_inputarg)
+                    .map(|ia| Operand::from_boxref(&BoxRef::from_bound_inputarg(ia)))
                     .collect::<Vec<_>>(),
             );
             label_op.pos.set(majit_ir::OpRef::NONE);
@@ -5366,7 +5367,7 @@ impl<M: Clone> MetaInterp<M> {
                     &trace
                         .inputargs
                         .iter()
-                        .map(BoxRef::from_bound_inputarg)
+                        .map(|ia| Operand::from_boxref(&BoxRef::from_bound_inputarg(ia)))
                         .collect::<Vec<_>>(),
                 );
                 label_op.pos.set(majit_ir::OpRef::NONE);
@@ -7198,7 +7199,7 @@ impl<M: Clone> MetaInterp<M> {
             &trace
                 .inputargs
                 .iter()
-                .map(BoxRef::from_bound_inputarg)
+                .map(|ia| Operand::from_boxref(&BoxRef::from_bound_inputarg(ia)))
                 .collect::<Vec<_>>(),
         );
         label_op.pos.set(majit_ir::OpRef::NONE);
@@ -17914,7 +17915,8 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| bound_box(*a)).collect();
+        let args: Vec<majit_ir::operand::Operand> =
+            args.iter().map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a))).collect();
         let op = Op::new(opcode, &args);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE
@@ -17925,7 +17927,8 @@ mod tests {
     }
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
-        let args: Vec<BoxRef> = args.iter().map(|a| bound_box(*a)).collect();
+        let args: Vec<majit_ir::operand::Operand> =
+            args.iter().map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a))).collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -16157,10 +16157,7 @@ mod metainterp_static_data_tests {
             .expect("active trace")
             .recorder
             .record_input_arg(majit_ir::Type::Int);
-        let argboxes = [
-            (JitArgKind::Int, a0, 4),
-            (JitArgKind::Int, a1, 6),
-        ];
+        let argboxes = [(JitArgKind::Int, a0, 4), (JitArgKind::Int, a1, 6)];
 
         let result = meta.do_residual_call_full(
             funcbox,
@@ -16694,11 +16691,7 @@ mod metainterp_static_data_tests {
             .expect("active trace")
             .recorder
             .record_input_arg(majit_ir::Type::Int);
-        let argboxes = [
-            funcbox,
-            (JitArgKind::Int, a0, 5),
-            (JitArgKind::Int, a1, 9),
-        ];
+        let argboxes = [funcbox, (JitArgKind::Int, a0, 5), (JitArgKind::Int, a1, 9)];
         // Pre-set last_exc_value to verify clear_exception runs.
         meta.last_exc_value = 0xdead;
         let result = meta.miframe_execute_varargs(

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -18,7 +18,6 @@ pub use frame::{MIFrame, MIFrameStack};
 use std::sync::Arc;
 
 use crate::r#box::BoxRef;
-use majit_ir::operand::Operand;
 use crate::optimizeopt::optimizer::{Optimizer, PendingBridgeRd};
 use majit_backend::{Backend, ExitRecoveryLayout, JitCellToken};
 #[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
@@ -31,6 +30,7 @@ pub(crate) use majit_backend_cranelift::CraneliftBackend as BackendImpl;
 pub(crate) use majit_backend_dynasm::runner::DynasmBackend as BackendImpl;
 #[cfg(target_arch = "wasm32")]
 pub(crate) use majit_backend_wasm::WasmBackend as BackendImpl;
+use majit_ir::operand::Operand;
 
 #[cfg(not(any(feature = "cranelift", feature = "dynasm", target_arch = "wasm32")))]
 compile_error!("majit-metainterp requires a backend: enable feature \"cranelift\" or \"dynasm\"");
@@ -17915,8 +17915,10 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
-        let args: Vec<majit_ir::operand::Operand> =
-            args.iter().map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a))).collect();
+        let args: Vec<majit_ir::operand::Operand> = args
+            .iter()
+            .map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a)))
+            .collect();
         let op = Op::new(opcode, &args);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE
@@ -17927,8 +17929,10 @@ mod tests {
     }
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
-        let args: Vec<majit_ir::operand::Operand> =
-            args.iter().map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a))).collect();
+        let args: Vec<majit_ir::operand::Operand> = args
+            .iter()
+            .map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a)))
+            .collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -7189,11 +7189,16 @@ impl<M: Clone> MetaInterp<M> {
         if let Some(jump_op) = compiled_ops.last().filter(|op| op.opcode == OpCode::Jump) {
             jump_op.setdescr(target_token.as_jump_target_descr());
         }
+        // Bind the label args to the TreeLoop's canonical `InputArgRc`
+        // producers (the same slot-for-slot mirror used by the retry-path
+        // Label synthesis above) instead of re-minting position-only boxes:
+        // `inputargs` are value clones of `trace.inputargs`.
         let mut label_op = majit_ir::Op::new(
             majit_ir::OpCode::Label,
-            &inputargs
+            &trace
+                .inputargs
                 .iter()
-                .map(|ia| BoxRef::from_opref(ia.opref()))
+                .map(BoxRef::from_bound_inputarg)
                 .collect::<Vec<_>>(),
         );
         label_op.pos.set(majit_ir::OpRef::NONE);

--- a/majit/majit-metainterp/src/pyjitpl/mod.rs
+++ b/majit/majit-metainterp/src/pyjitpl/mod.rs
@@ -16144,9 +16144,22 @@ mod metainterp_static_data_tests {
         let fnaddr = execute_varargs_int_helper as *const () as i64;
         let funcbox_ref = meta.trace_ctx().expect("active trace").const_ref(fnaddr);
         let funcbox = (JitArgKind::Ref, funcbox_ref, fnaddr);
+        // Bind the int operands to recorded inputarg producers so the
+        // recorded CALL_I op carries `Operand::InputArg`, not a
+        // position-only `Operand::Box`.
+        let a0 = meta
+            .trace_ctx()
+            .expect("active trace")
+            .recorder
+            .record_input_arg(majit_ir::Type::Int);
+        let a1 = meta
+            .trace_ctx()
+            .expect("active trace")
+            .recorder
+            .record_input_arg(majit_ir::Type::Int);
         let argboxes = [
-            (JitArgKind::Int, OpRef::int_op(1), 4),
-            (JitArgKind::Int, OpRef::int_op(2), 6),
+            (JitArgKind::Int, a0, 4),
+            (JitArgKind::Int, a1, 6),
         ];
 
         let result = meta.do_residual_call_full(
@@ -16502,7 +16515,15 @@ mod metainterp_static_data_tests {
         );
         let fnaddr = cond_call_void_helper as *const () as i64;
         let funcbox_ref = meta.trace_ctx().expect("active trace").const_ref(fnaddr);
-        let condbox = (JitArgKind::Int, OpRef::int_op(50), 1);
+        // Bind the cond operand to a recorded inputarg producer so the
+        // recorded COND_CALL_N op carries `Operand::InputArg`, not a
+        // position-only `Operand::Box`.
+        let cond_ref = meta
+            .trace_ctx()
+            .expect("active trace")
+            .recorder
+            .record_input_arg(majit_ir::Type::Int);
+        let condbox = (JitArgKind::Int, cond_ref, 1);
         let funcbox = (JitArgKind::Ref, funcbox_ref, fnaddr);
         let result = meta.do_conditional_call(
             condbox,
@@ -16555,8 +16576,17 @@ mod metainterp_static_data_tests {
             majit_ir::Type::Int,
             majit_ir::EffectInfo::default(),
         );
-        let condbox = (JitArgKind::Int, OpRef::int_op(50), 0);
-        let funcbox = (JitArgKind::Ref, OpRef::ref_op(0), fnaddr);
+        // Bind cond to a recorded Int inputarg producer and funcbox to the
+        // live Ref inputarg seeded by `live_values` (position 0) so the
+        // recorded COND_CALL_VALUE_I op carries `Operand::InputArg` for both
+        // operands, not a position-only `Operand::Box`.
+        let cond_ref = meta
+            .trace_ctx()
+            .expect("active trace")
+            .recorder
+            .record_input_arg(majit_ir::Type::Int);
+        let condbox = (JitArgKind::Int, cond_ref, 0);
+        let funcbox = (JitArgKind::Ref, OpRef::input_arg_ref(0), fnaddr);
         let result = meta.do_conditional_call(
             condbox,
             funcbox,
@@ -16651,10 +16681,23 @@ mod metainterp_static_data_tests {
         let fnaddr = execute_varargs_int_helper as *const () as i64;
         let funcbox_ref = meta.trace_ctx().expect("active trace").const_ref(fnaddr);
         let funcbox = (JitArgKind::Ref, funcbox_ref, fnaddr);
+        // Bind the int operands to recorded inputarg producers so the
+        // recorded CALL_I op carries `Operand::InputArg`, not a
+        // position-only `Operand::Box`.
+        let a0 = meta
+            .trace_ctx()
+            .expect("active trace")
+            .recorder
+            .record_input_arg(majit_ir::Type::Int);
+        let a1 = meta
+            .trace_ctx()
+            .expect("active trace")
+            .recorder
+            .record_input_arg(majit_ir::Type::Int);
         let argboxes = [
             funcbox,
-            (JitArgKind::Int, OpRef::int_op(1), 5),
-            (JitArgKind::Int, OpRef::int_op(2), 9),
+            (JitArgKind::Int, a0, 5),
+            (JitArgKind::Int, a1, 9),
         ];
         // Pre-set last_exc_value to verify clear_exception runs.
         meta.last_exc_value = 0xdead;
@@ -16697,6 +16740,17 @@ mod metainterp_static_data_tests {
         let fnaddr = execute_varargs_int_helper as *const () as i64;
         let funcbox_ref = meta.trace_ctx().expect("active trace").const_ref(fnaddr);
         let funcbox = (JitArgKind::Ref, funcbox_ref, fnaddr);
+        // Record producer ops at positions 1 and 2 (after one inputarg at
+        // position 0) so the int operands `OpRef::int_op(1)`/`int_op(2)`
+        // bind to those `Operand::Op` producers instead of minting a
+        // position-only `Operand::Box`. Their `to_opref()` still round-trips
+        // to `int_op(1)`/`int_op(2)`, preserving the arg-identity asserts.
+        {
+            let rec = &mut meta.trace_ctx().expect("active trace").recorder;
+            let i0 = rec.record_input_arg(majit_ir::Type::Int);
+            assert_eq!(rec.record_op(OpCode::IntAdd, &[i0, i0]), OpRef::int_op(1));
+            assert_eq!(rec.record_op(OpCode::IntAdd, &[i0, i0]), OpRef::int_op(2));
+        }
         let argboxes = [
             funcbox,
             (JitArgKind::Int, OpRef::int_op(1), 7),

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -342,7 +342,12 @@ impl Trace {
             None => Op::new(opcode, &self.box_args(args)),
         };
         op.pos.set(opref);
-        op.setfailargs(self.box_args(fail_args).iter().map(Operand::to_boxref).collect());
+        op.setfailargs(
+            self.box_args(fail_args)
+                .iter()
+                .map(Operand::to_boxref)
+                .collect(),
+        );
         self.ops.push(OpRc::new(op));
         self.op_count += 1;
         if opcode.result_type() != Type::Void {
@@ -403,7 +408,12 @@ impl Trace {
             .rev()
             .find(|op| op.pos.get() == opref)
             .unwrap_or_else(|| panic!("set_op_fail_args: no op with pos {:?}", opref));
-        op.setfailargs(self.box_args(fail_args).iter().map(Operand::to_boxref).collect());
+        op.setfailargs(
+            self.box_args(fail_args)
+                .iter()
+                .map(Operand::to_boxref)
+                .collect(),
+        );
     }
 
     /// Set `fail_arg_types` on the last recorded op. Used by

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -12,6 +12,7 @@
 /// `MetaInterp.history.record*` mirroring
 /// `pyjitpl.py:2455+ self.history.record2(...)`.
 use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, InputArg, InputArgRc, Op, OpCode, OpRc, OpRef, Type, Value};
 
 /// opencoder.py:567-568 `cut_point()` — RPython 5-tuple
@@ -199,8 +200,10 @@ impl Trace {
     /// Frame registers and the public `record_*` API stay OpRef; the optimizer
     /// bridges back with `BoxRef::to_opref`, which round-trips to the same
     /// `OpRef` the frozen `from_opref` view produced.
-    fn box_args(&self, args: &[OpRef]) -> smallvec::SmallVec<[BoxRef; 3]> {
-        args.iter().map(|&a| self.box_for_operand(a)).collect()
+    fn box_args(&self, args: &[OpRef]) -> smallvec::SmallVec<[Operand; 3]> {
+        args.iter()
+            .map(|&a| Operand::from_boxref(&self.box_for_operand(a)))
+            .collect()
     }
 
     /// Resolve one operand `OpRef` to its canonical `BoxRef`. Const operands
@@ -339,7 +342,7 @@ impl Trace {
             None => Op::new(opcode, &self.box_args(args)),
         };
         op.pos.set(opref);
-        op.setfailargs(self.box_args(fail_args));
+        op.setfailargs(self.box_args(fail_args).iter().map(Operand::to_boxref).collect());
         self.ops.push(OpRc::new(op));
         self.op_count += 1;
         if opcode.result_type() != Type::Void {
@@ -400,7 +403,7 @@ impl Trace {
             .rev()
             .find(|op| op.pos.get() == opref)
             .unwrap_or_else(|| panic!("set_op_fail_args: no op with pos {:?}", opref));
-        op.setfailargs(self.box_args(fail_args));
+        op.setfailargs(self.box_args(fail_args).iter().map(Operand::to_boxref).collect());
     }
 
     /// Set `fail_arg_types` on the last recorded op. Used by

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3176,8 +3176,8 @@ pub struct ResumeDataLoopMemo {
     /// Becomes storage.rd_consts (resume.py:467).
     ///
     /// resume.py:150-151 — cached box/virtual numbering.
-    pub cached_boxes: crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, i32>,
-    pub cached_virtuals: crate::optimizeopt::vec_assoc::VecAssoc<crate::r#box::BoxRef, i32>,
+    pub cached_boxes: crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::operand::Operand, i32>,
+    pub cached_virtuals: crate::optimizeopt::vec_assoc::VecAssoc<majit_ir::operand::Operand, i32>,
     /// resume.py:153-155 — statistics.
     pub nvirtuals: usize,
     pub nvholes: usize,
@@ -3362,7 +3362,7 @@ impl ResumeDataLoopMemo {
         b: &crate::r#box::BoxRef,
         boxes: &mut Vec<OpRef>,
     ) -> i32 {
-        if let Some(&num) = self.cached_boxes.get(b) {
+        if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(b)) {
             // resume.py:268: boxes[-num - 1] = box
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
@@ -3373,7 +3373,8 @@ impl ResumeDataLoopMemo {
         // resume.py:270-271: boxes.append(box); num = -len(boxes)
         boxes.push(b.to_opref());
         let num = -(boxes.len() as i32);
-        self.cached_boxes.insert(b.clone(), num);
+        self.cached_boxes
+            .insert(majit_ir::operand::Operand::from_boxref(b), num);
         num
     }
 
@@ -3384,7 +3385,7 @@ impl ResumeDataLoopMemo {
         b: &crate::r#box::BoxRef,
         boxes: &mut Vec<Option<OpRef>>,
     ) -> i32 {
-        if let Some(&num) = self.cached_boxes.get(b) {
+        if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(b)) {
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
                 boxes[idx] = Some(b.to_opref());
@@ -3393,18 +3394,20 @@ impl ResumeDataLoopMemo {
         }
         boxes.push(Some(b.to_opref()));
         let num = -(boxes.len() as i32);
-        self.cached_boxes.insert(b.clone(), num);
+        self.cached_boxes
+            .insert(majit_ir::operand::Operand::from_boxref(b), num);
         num
     }
 
     /// resume.py:278 assign_number_to_virtual — returns a negative number.
     pub fn assign_number_to_virtual(&mut self, b: &crate::r#box::BoxRef) -> i32 {
-        if let Some(&num) = self.cached_virtuals.get(b) {
+        if let Some(&num) = self.cached_virtuals.get(&majit_ir::operand::Operand::from_boxref(b)) {
             return num;
         }
         // resume.py:283: num = self.cached_virtuals[box] = -len(self.cached_virtuals) - 1
         let num = -(self.num_cached_virtuals() as i32) - 1;
-        self.cached_virtuals.insert(b.clone(), num);
+        self.cached_virtuals
+            .insert(majit_ir::operand::Operand::from_boxref(b), num);
         num
     }
 
@@ -3624,12 +3627,12 @@ impl ResumeDataLoopMemo {
                             }
                             if let Some(t) = new_liveboxes.get(&b) {
                                 if tagged_eq(t, UNASSIGNED) {
-                                    if let Some(&num) = self.cached_boxes.get(&b) {
+                                    if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(&b)) {
                                         return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                                     }
                                 }
                                 if tagged_eq(t, UNASSIGNEDVIRTUAL) {
-                                    if let Some(&num) = self.cached_virtuals.get(&b) {
+                                    if let Some(&num) = self.cached_virtuals.get(&majit_ir::operand::Operand::from_boxref(&b)) {
                                         return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                                     }
                                 }
@@ -3767,12 +3770,12 @@ impl ResumeDataLoopMemo {
         if let Some(tagged) = new_liveboxes.get(&b) {
             // Resolve UNASSIGNED to real cached number
             if tagged_eq(tagged, UNASSIGNED) {
-                if let Some(&num) = self.cached_boxes.get(&b) {
+                if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(&b)) {
                     return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                 }
             }
             if tagged_eq(tagged, UNASSIGNEDVIRTUAL) {
-                if let Some(&num) = self.cached_virtuals.get(&b) {
+                if let Some(&num) = self.cached_virtuals.get(&majit_ir::operand::Operand::from_boxref(&b)) {
                     return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                 }
             }

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -3373,7 +3373,10 @@ impl ResumeDataLoopMemo {
         b: &crate::r#box::BoxRef,
         boxes: &mut Vec<OpRef>,
     ) -> i32 {
-        if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(b)) {
+        if let Some(&num) = self
+            .cached_boxes
+            .get(&majit_ir::operand::Operand::from_boxref(b))
+        {
             // resume.py:268: boxes[-num - 1] = box
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
@@ -3396,7 +3399,10 @@ impl ResumeDataLoopMemo {
         b: &crate::r#box::BoxRef,
         boxes: &mut Vec<Option<OpRef>>,
     ) -> i32 {
-        if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(b)) {
+        if let Some(&num) = self
+            .cached_boxes
+            .get(&majit_ir::operand::Operand::from_boxref(b))
+        {
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
                 boxes[idx] = Some(b.to_opref());
@@ -3412,7 +3418,10 @@ impl ResumeDataLoopMemo {
 
     /// resume.py:278 assign_number_to_virtual — returns a negative number.
     pub fn assign_number_to_virtual(&mut self, b: &crate::r#box::BoxRef) -> i32 {
-        if let Some(&num) = self.cached_virtuals.get(&majit_ir::operand::Operand::from_boxref(b)) {
+        if let Some(&num) = self
+            .cached_virtuals
+            .get(&majit_ir::operand::Operand::from_boxref(b))
+        {
             return num;
         }
         // resume.py:283: num = self.cached_virtuals[box] = -len(self.cached_virtuals) - 1
@@ -3638,12 +3647,18 @@ impl ResumeDataLoopMemo {
                             }
                             if let Some(t) = new_liveboxes.get(&b) {
                                 if tagged_eq(t, UNASSIGNED) {
-                                    if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(&b)) {
+                                    if let Some(&num) = self
+                                        .cached_boxes
+                                        .get(&majit_ir::operand::Operand::from_boxref(&b))
+                                    {
                                         return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                                     }
                                 }
                                 if tagged_eq(t, UNASSIGNEDVIRTUAL) {
-                                    if let Some(&num) = self.cached_virtuals.get(&majit_ir::operand::Operand::from_boxref(&b)) {
+                                    if let Some(&num) = self
+                                        .cached_virtuals
+                                        .get(&majit_ir::operand::Operand::from_boxref(&b))
+                                    {
                                         return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                                     }
                                 }
@@ -3781,12 +3796,18 @@ impl ResumeDataLoopMemo {
         if let Some(tagged) = new_liveboxes.get(&b) {
             // Resolve UNASSIGNED to real cached number
             if tagged_eq(tagged, UNASSIGNED) {
-                if let Some(&num) = self.cached_boxes.get(&majit_ir::operand::Operand::from_boxref(&b)) {
+                if let Some(&num) = self
+                    .cached_boxes
+                    .get(&majit_ir::operand::Operand::from_boxref(&b))
+                {
                     return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                 }
             }
             if tagged_eq(tagged, UNASSIGNEDVIRTUAL) {
-                if let Some(&num) = self.cached_virtuals.get(&majit_ir::operand::Operand::from_boxref(&b)) {
+                if let Some(&num) = self
+                    .cached_virtuals
+                    .get(&majit_ir::operand::Operand::from_boxref(&b))
+                {
                     return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                 }
             }
@@ -4600,7 +4621,8 @@ mod tests {
         // bound to a rooted producer so they shed to Operand::InputArg / Op.
         // Under ptr_eq keying they stay distinct keys (PyPy `box is box`),
         // never collapsed by a shared raw slot index.
-        let input = crate::r#box::test_support::rooted_box_from_opref(majit_ir::OpRef::input_arg_int(0));
+        let input =
+            crate::r#box::test_support::rooted_box_from_opref(majit_ir::OpRef::input_arg_int(0));
         let op = crate::r#box::test_support::rooted_box_from_opref(majit_ir::OpRef::int_op(0));
 
         liveboxes.insert(input.clone(), UNASSIGNED);

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -105,7 +105,7 @@ pub const TAG_CONST_OFFSET: i32 = 0;
 /// debug builds rather than silently producing an out-of-RPython-shape
 /// numbering state.
 pub struct LiveboxMap {
-    entries: majit_ir::vec_assoc::VecAssoc<crate::r#box::BoxRef, i16>,
+    entries: majit_ir::vec_assoc::VecAssoc<majit_ir::operand::Operand, i16>,
 }
 
 impl LiveboxMap {
@@ -117,7 +117,9 @@ impl LiveboxMap {
 
     #[inline(always)]
     pub fn get(&self, b: &crate::r#box::BoxRef) -> Option<i16> {
-        self.entries.get(b).copied()
+        self.entries
+            .get(&majit_ir::operand::Operand::from_boxref(b))
+            .copied()
     }
 
     #[inline(always)]
@@ -128,18 +130,20 @@ impl LiveboxMap {
              `_number_boxes` invariant — `isinstance(box, Const)` is encoded \
              via `getconst(box)` and never enters numb_state.liveboxes",
         );
-        self.entries.insert(b, value);
+        self.entries
+            .insert(majit_ir::operand::Operand::from_boxref(&b), value);
     }
 
     #[inline(always)]
     pub fn contains_key(&self, b: &crate::r#box::BoxRef) -> bool {
-        self.entries.contains_key(b)
+        self.entries
+            .contains_key(&majit_ir::operand::Operand::from_boxref(b))
     }
 
     /// Iterate over all (canonical box, tag) pairs in RPython dict insertion
     /// order (Rc::ptr_eq identity = PyPy `box is box`).
     pub fn iter(&self) -> impl Iterator<Item = (crate::r#box::BoxRef, i16)> + '_ {
-        self.entries.iter().map(|(b, v)| (b.clone(), *v))
+        self.entries.iter().map(|(op, v)| (op.to_boxref(), *v))
     }
 }
 
@@ -459,6 +463,13 @@ impl BoxEnv for SimpleBoxEnv {
         if let Some(b) = self.box_cache.borrow().get(&root) {
             return b.clone();
         }
+        // This env holds no producer Ops; in tests, synthesize a rooted bound
+        // producer so the box sheds to `Operand::Op`/`InputArg` (the Operand-
+        // keyed liveboxes/cached maps reject a position-only box). The method
+        // is never reached in non-test builds, where `from_opref` is retained.
+        #[cfg(test)]
+        let b = crate::r#box::test_support::rooted_box_from_opref(root);
+        #[cfg(not(test))]
         let b = crate::r#box::BoxRef::from_opref(root);
         self.box_cache.borrow_mut().insert(root, b.clone());
         b
@@ -4585,20 +4596,29 @@ mod tests {
     #[test]
     fn livebox_map_preserves_box_identity_and_insertion_order() {
         let mut liveboxes = LiveboxMap::new();
-        // Two distinct logical boxes — an InputArg and a ResOp result. Under
-        // Rc::ptr_eq keying they stay distinct keys (PyPy `box is box`), never
-        // collapsed by a shared raw slot index.
-        let input = crate::r#box::BoxRef::from_opref(majit_ir::OpRef::input_arg_int(0));
-        let op = crate::r#box::BoxRef::from_opref(majit_ir::OpRef::int_op(0));
+        // Two distinct logical boxes — an InputArg and a ResOp result, each
+        // bound to a rooted producer so they shed to Operand::InputArg / Op.
+        // Under ptr_eq keying they stay distinct keys (PyPy `box is box`),
+        // never collapsed by a shared raw slot index.
+        let input = crate::r#box::test_support::rooted_box_from_opref(majit_ir::OpRef::input_arg_int(0));
+        let op = crate::r#box::test_support::rooted_box_from_opref(majit_ir::OpRef::int_op(0));
 
         liveboxes.insert(input.clone(), UNASSIGNED);
         liveboxes.insert(op.clone(), UNASSIGNEDVIRTUAL);
 
         assert_eq!(liveboxes.get(&input), Some(UNASSIGNED));
         assert_eq!(liveboxes.get(&op), Some(UNASSIGNEDVIRTUAL));
+        // iter() reconstructs each key's bound BoxRef view via to_boxref, so
+        // compare by the stable (type, position) OpRef identity + order.
         assert_eq!(
-            liveboxes.iter().collect::<Vec<_>>(),
-            vec![(input, UNASSIGNED), (op, UNASSIGNEDVIRTUAL)]
+            liveboxes
+                .iter()
+                .map(|(b, t)| (b.to_opref(), t))
+                .collect::<Vec<_>>(),
+            vec![
+                (input.to_opref(), UNASSIGNED),
+                (op.to_opref(), UNASSIGNEDVIRTUAL)
+            ]
         );
     }
 
@@ -4948,7 +4968,9 @@ mod tests {
                 if let Some(b) = self.box_cache.borrow().get(&root) {
                     return b.clone();
                 }
-                let b = crate::r#box::BoxRef::from_opref(root);
+                // Synthesize a rooted bound producer so the box sheds to
+                // `Operand::Op`/`InputArg` for the Operand-keyed liveboxes map.
+                let b = crate::r#box::test_support::rooted_box_from_opref(root);
                 self.box_cache.borrow_mut().insert(root, b.clone());
                 b
             }

--- a/pyre/pyre-jit-trace/Cargo.toml
+++ b/pyre/pyre-jit-trace/Cargo.toml
@@ -48,4 +48,5 @@ syn = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]
+majit-ir = { workspace = true, features = ["test-support"] }
 insta = { workspace = true }

--- a/pyre/pyre-jit-trace/src/shadow_walker.rs
+++ b/pyre/pyre-jit-trace/src/shadow_walker.rs
@@ -447,7 +447,10 @@ mod tests {
     use majit_ir::{DescrRef, OpCode, OpRef};
 
     fn op(opcode: OpCode, args: &[OpRef], descr: Option<DescrRef>) -> Op {
-        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
+        let bx: Vec<majit_ir::operand::Operand> = args
+            .iter()
+            .map(|a| majit_ir::operand::Operand::from_boxref(&rb(*a)))
+            .collect();
         let mut op = match descr {
             Some(d) => Op::with_descr(opcode, &bx, d),
             None => Op::new(opcode, &bx),

--- a/pyre/pyre-jit-trace/src/shadow_walker.rs
+++ b/pyre/pyre-jit-trace/src/shadow_walker.rs
@@ -456,44 +456,7 @@ mod tests {
         op
     }
 
-    /// Test-only operand-source for op args / failargs: bind `a` to a
-    /// synthetic producer carrying the same position so the box sheds to
-    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
-    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
-    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
-    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
-    /// producer graph); `to_opref()` is unchanged, so position-based
-    /// assertions are identical.
-    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-        use majit_ir::box_ref::BoxRef;
-        use majit_ir::resoperation::{Op, OpCode};
-        use majit_ir::{OpRef, Type};
-        if a.is_none() || a.is_constant() {
-            return BoxRef::from_opref(a);
-        }
-        let ty = a.ty().unwrap_or(Type::Void);
-        match a {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
-                let b = BoxRef::from_bound_inputarg(&ia);
-                std::mem::forget(ia);
-                b
-            }
-            _ => {
-                let opcode = match ty {
-                    Type::Int => OpCode::SameAsI,
-                    Type::Float => OpCode::SameAsF,
-                    Type::Ref => OpCode::SameAsR,
-                    Type::Void => OpCode::Jump,
-                };
-                let p = std::rc::Rc::new(Op::new(opcode, &[]));
-                p.pos.set(a);
-                let b = BoxRef::from_bound_op(&p);
-                std::mem::forget(p);
-                b
-            }
-        }
-    }
+    use majit_ir::box_ref::bound_box_from_opref as rb;
 
     #[test]
     fn shadow_walker_enabled_defaults_off() {

--- a/pyre/pyre-jit-trace/src/shadow_walker.rs
+++ b/pyre/pyre-jit-trace/src/shadow_walker.rs
@@ -447,13 +447,52 @@ mod tests {
     use majit_ir::{DescrRef, OpCode, OpRef};
 
     fn op(opcode: OpCode, args: &[OpRef], descr: Option<DescrRef>) -> Op {
-        let bx: Vec<BoxRef> = args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+        let bx: Vec<BoxRef> = args.iter().map(|a| rb(*a)).collect();
         let mut op = match descr {
             Some(d) => Op::with_descr(opcode, &bx, d),
             None => Op::new(opcode, &bx),
         };
         op.pos.set(OpRef::op_typed(0, opcode.result_type()));
         op
+    }
+
+    /// Test-only operand-source for op args / failargs: bind `a` to a
+    /// synthetic producer carrying the same position so the box sheds to
+    /// `Operand::Op` / `Operand::InputArg` (the deleted position-only operand
+    /// is rejected by `from_boxref`, #9). Const / None shed via `from_opref`.
+    /// The synthetic producer is intentionally leaked (`mem::forget`) so the
+    /// box's `Weak` upgrades for the life of the test process (fixtures hold no
+    /// producer graph); `to_opref()` is unchanged, so position-based
+    /// assertions are identical.
+    fn rb(a: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
+        use majit_ir::box_ref::BoxRef;
+        use majit_ir::resoperation::{Op, OpCode};
+        use majit_ir::{OpRef, Type};
+        if a.is_none() || a.is_constant() {
+            return BoxRef::from_opref(a);
+        }
+        let ty = a.ty().unwrap_or(Type::Void);
+        match a {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia = std::rc::Rc::new(majit_ir::value::InputArg::from_type(ty, a.raw()));
+                let b = BoxRef::from_bound_inputarg(&ia);
+                std::mem::forget(ia);
+                b
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let p = std::rc::Rc::new(Op::new(opcode, &[]));
+                p.pos.set(a);
+                let b = BoxRef::from_bound_op(&p);
+                std::mem::forget(p);
+                b
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
#47

## Summary

Advances the #47 box-identity program: the optimizer keys its state on the
producer object (`Rc<Op>` / `Rc<InputArg>` / `Const`) the way RPython keys
`{box: value}` dicts by Python `is`, and the `Operand::Box` flat-OpRef
compensation carrier is removed.

- **Drain `Operand::Box` mints to zero.** Every op-argument source now carries
  a *bound* producer instead of a position-only box: peel-iteration remap
  (E1), the vectorizer op-arg / fallback / renamer / IndexVar minters (E2),
  `ByteTraceIter` decode, and the recorder/heap test fixtures. An unbound
  position-only box no longer reaches operand construction.
- **Delete the `Operand::Box` variant** (E3). `Operand::from_boxref` now
  panics on a position-only box (debug tripwire), enforcing that every
  `_args[i]` is a bound producer or a constant.
- **Re-home `Operand::Const`** onto `Rc<Cell<Value>>` (E7a): the `Cell` keeps
  the in-place `&self` GC forward, the `Rc` gives a constant object identity
  so `Operand`'s `PartialEq`/`Hash` is a uniform `Rc::ptr_eq`, matching
  `BoxRef` exactly.
- **Re-key producer side-tables to `Operand`** (slice 3a): `replaces_guard`,
  `emitted_operations`, the rec dedup set, `unescaped`, `heapc_deps`, and the
  `export_arg_int_bounds` map. Keys come from `from_bound_op` or a
  `get_box_replacement_box` result (bound-or-None, never position-only), so
  the lookups are preserved by object identity.

Gate per change: `cargo test` (majit-ir + metainterp dynasm/cranelift libs)
and `python ./pyre/check.py` 139/139 on both the dynasm and cranelift
backends.

A step toward deleting the `Box` / `BoxKind` / `BoxRef` wrapper entirely
(#9 / S-11); the remaining boundary-crossing maps (short-preamble import,
resume numbering) carry position-only boxes across the peel boundary and are
tracked separately.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
