### PR TITLE
jit: retire off-GC code-globals DictStorage proxy; deadframe Constant-type and vable-identity fixes

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -680,11 +680,11 @@ fn caller_prefix_recovery_layout(
             slots: slot_types
                 .iter()
                 .enumerate()
-                .map(|(slot, _)| {
+                .map(|(slot, ty)| {
                     inputs
                         .get(slot)
                         .copied()
-                        .map(ExitValueSourceLayout::Constant)
+                        .map(|v| ExitValueSourceLayout::Constant(v, *ty))
                         .unwrap_or(ExitValueSourceLayout::Unavailable)
                 })
                 .collect(),
@@ -14055,7 +14055,9 @@ fn collect_guards(
                             vidx_to_slot.insert(*vidx, new_slots.len());
                             ExitValueSourceLayout::Virtual(*vidx)
                         }
-                        RebuiltValue::Const(c) => ExitValueSourceLayout::Constant(c.as_raw_i64()),
+                        RebuiltValue::Const(c) => {
+                            ExitValueSourceLayout::Constant(c.as_raw_i64(), c.get_type())
+                        }
                         RebuiltValue::Unassigned => ExitValueSourceLayout::Uninitialized,
                     });
                 }
@@ -14070,6 +14072,7 @@ fn collect_guards(
                         ExitValueSourceLayout::ExitValue(idx) => {
                             fail_arg_types.get(*idx).copied().unwrap_or(Type::Ref)
                         }
+                        ExitValueSourceLayout::Constant(_, ty) => *ty,
                         _ => Type::Ref,
                     })
                     .collect();
@@ -14115,16 +14118,18 @@ fn collect_guards(
                         };
                         ExitValueSourceLayout::Virtual(idx)
                     }
-                    resumedata::TAGINT => ExitValueSourceLayout::Constant(val as i64),
+                    resumedata::TAGINT => {
+                        ExitValueSourceLayout::Constant(val as i64, Type::Int)
+                    }
                     resumedata::TAGCONST => {
                         let idx = (val - resumedata::TAG_CONST_OFFSET) as usize;
                         let c = rd_consts_ref
                             .get(idx)
                             .copied()
                             .unwrap_or(majit_ir::Const::Int(0));
-                        ExitValueSourceLayout::Constant(c.as_raw_i64())
+                        ExitValueSourceLayout::Constant(c.as_raw_i64(), c.get_type())
                     }
-                    _ => ExitValueSourceLayout::Constant(0),
+                    _ => ExitValueSourceLayout::Constant(0, Type::Int),
                 }
             };
             let resolve_fieldnums = |fieldnums: &[i16],
@@ -14256,7 +14261,7 @@ fn collect_guards(
                                 base: fieldnums
                                     .first()
                                     .map(|&fnum| resolve_fieldnum(fnum))
-                                    .unwrap_or(ExitValueSourceLayout::Constant(0)),
+                                    .unwrap_or(ExitValueSourceLayout::Constant(0, Type::Int)),
                             }
                         }
                         // resume.py:763 VStrPlainInfo / resume.py:817
@@ -17432,7 +17437,10 @@ mod tests {
                 source_guard: None,
                 pc: 4242,
                 jitcode_index: 0,
-                slots: vec![majit_backend::ExitValueSourceLayout::Constant(99)],
+                slots: vec![majit_backend::ExitValueSourceLayout::Constant(
+                    99,
+                    majit_ir::Type::Int,
+                )],
                 slot_types: Some(vec![Type::Int]),
             }],
             virtual_layouts: Vec::new(),
@@ -17603,7 +17611,7 @@ mod tests {
                 kind: 1,
                 items: vec![
                     majit_backend::ExitValueSourceLayout::ExitValue(0),
-                    majit_backend::ExitValueSourceLayout::Constant(44),
+                    majit_backend::ExitValueSourceLayout::Constant(44, majit_ir::Type::Int),
                 ],
             }],
             pending_field_layouts: vec![majit_backend::ExitPendingFieldLayout {
@@ -17832,7 +17840,7 @@ mod tests {
                 kind: 1,
                 items: vec![
                     majit_backend::ExitValueSourceLayout::ExitValue(0),
-                    majit_backend::ExitValueSourceLayout::Constant(55),
+                    majit_backend::ExitValueSourceLayout::Constant(55, majit_ir::Type::Int),
                 ],
             }],
             pending_field_layouts: vec![majit_backend::ExitPendingFieldLayout {

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -14118,9 +14118,7 @@ fn collect_guards(
                         };
                         ExitValueSourceLayout::Virtual(idx)
                     }
-                    resumedata::TAGINT => {
-                        ExitValueSourceLayout::Constant(val as i64, Type::Int)
-                    }
+                    resumedata::TAGINT => ExitValueSourceLayout::Constant(val as i64, Type::Int),
                     resumedata::TAGCONST => {
                         let idx = (val - resumedata::TAG_CONST_OFFSET) as usize;
                         let c = rd_consts_ref

--- a/majit/majit-backend-cranelift/tests/integration.rs
+++ b/majit/majit-backend-cranelift/tests/integration.rs
@@ -2188,7 +2188,7 @@ fn test_compiled_bridge_guard_failure_has_frame_stack() {
                 source_guard: None,
                 pc: 500,
                 jitcode_index: 0,
-                slots: vec![ExitValueSourceLayout::Constant(0)],
+                slots: vec![ExitValueSourceLayout::Constant(0, Type::Int)],
                 slot_types: Some(vec![Type::Int]),
             },
             ExitFrameLayout {

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -150,8 +150,13 @@ pub struct CompiledTraceInfo {
 pub enum ExitValueSourceLayout {
     /// Slot is sourced from a raw exit slot.
     ExitValue(usize),
-    /// Slot is a constant value embedded in the layout.
-    Constant(i64),
+    /// Slot is a constant value embedded in the layout — `(raw i64 bits,
+    /// declared type)`. The type is retained so the resume reader can
+    /// reconstruct a typed `Const` rather than assuming `Int`
+    /// (resume.py:1017-1038 `decode_box(tagged, kind)`: a slot's type is the
+    /// declared type of the variable, so a constant GC pointer decodes as a
+    /// `Ref`, not a boxed integer).
+    Constant(i64, Type),
     /// Slot refers to a materialized virtual object.
     Virtual(usize),
     /// Slot exists but remains uninitialized.

--- a/majit/majit-backend/src/resume_value.rs
+++ b/majit/majit-backend/src/resume_value.rs
@@ -138,9 +138,10 @@ impl ResumeValueLayoutSummaryExt for ResumeValueLayoutSummary {
             ResumeValueKind::FailArg => {
                 ExitValueSourceLayout::ExitValue(self.raw_fail_arg_position_or_fallback())
             }
-            ResumeValueKind::Constant => {
-                ExitValueSourceLayout::Constant(self.constant.expect("missing constant value"))
-            }
+            ResumeValueKind::Constant => ExitValueSourceLayout::Constant(
+                self.constant.expect("missing constant value"),
+                self.constant_type.expect("missing constant type"),
+            ),
             ResumeValueKind::Virtual => ExitValueSourceLayout::Virtual(
                 self.virtual_index.expect("missing virtual index") + virtual_offset,
             ),
@@ -193,12 +194,12 @@ pub fn resume_value_layout_summary_from_exit_value_source(
             constant_type: None,
             virtual_index: None,
         },
-        ExitValueSourceLayout::Constant(value) => ResumeValueLayoutSummary {
+        ExitValueSourceLayout::Constant(value, ty) => ResumeValueLayoutSummary {
             kind: ResumeValueKind::Constant,
             fail_arg_index: 0,
             raw_fail_arg_position: None,
             constant: Some(*value),
-            constant_type: Some(Type::Int),
+            constant_type: Some(*ty),
             virtual_index: None,
         },
         ExitValueSourceLayout::Virtual(index) => ResumeValueLayoutSummary {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -96,9 +96,10 @@ fn fail_arg_type(opref: &OpRef) -> Type {
 }
 
 /// Derive slot_types from ExitValueSourceLayout + exit_types.
-/// RPython resume.py:1410 load_next_value_of_type parity:
-/// slot type is the DECLARED type of the variable.
-/// ExitValue(idx) → exit_types[idx]; Constant → Int; others → Ref.
+/// resume.py:1017-1038 decode_box(tagged, kind) parity: a slot's type
+/// is the declared type of the variable, so a constant carries its own
+/// declared type rather than being assumed an integer.
+/// ExitValue(idx) → exit_types[idx]; Constant(_, ty) → ty; others → Ref.
 fn derive_slot_types(
     slots: &[majit_backend::ExitValueSourceLayout],
     exit_types: &[Type],
@@ -109,7 +110,7 @@ fn derive_slot_types(
             majit_backend::ExitValueSourceLayout::ExitValue(idx) => {
                 exit_types.get(*idx).copied().unwrap_or(Type::Ref)
             }
-            majit_backend::ExitValueSourceLayout::Constant(_) => Type::Int,
+            majit_backend::ExitValueSourceLayout::Constant(_, ty) => *ty,
             _ => Type::Ref,
         })
         .collect()
@@ -678,7 +679,9 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                     let to_exit_source = |val: &RebuiltValue| match val {
                         RebuiltValue::Box(idx, _) => ExitValueSourceLayout::ExitValue(*idx),
                         RebuiltValue::Virtual(vidx) => ExitValueSourceLayout::Virtual(*vidx),
-                        RebuiltValue::Const(c) => ExitValueSourceLayout::Constant(c.as_raw_i64()),
+                        RebuiltValue::Const(c) => {
+                            ExitValueSourceLayout::Constant(c.as_raw_i64(), c.get_type())
+                        }
                         RebuiltValue::Unassigned => ExitValueSourceLayout::Uninitialized,
                     };
                     (
@@ -741,13 +744,15 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                         };
                         ExitValueSourceLayout::Virtual(idx)
                     }
-                    majit_ir::resumedata::TAGINT => ExitValueSourceLayout::Constant(val as i64),
+                    majit_ir::resumedata::TAGINT => {
+                        ExitValueSourceLayout::Constant(val as i64, Type::Int)
+                    }
                     majit_ir::resumedata::TAGCONST => {
                         let idx = (val - majit_ir::resumedata::TAG_CONST_OFFSET) as usize;
                         let c = rd_consts_ref.get(idx).copied().unwrap_or(Const::Int(0));
-                        ExitValueSourceLayout::Constant(c.as_raw_i64())
+                        ExitValueSourceLayout::Constant(c.as_raw_i64(), c.get_type())
                     }
-                    _ => ExitValueSourceLayout::Constant(0),
+                    _ => ExitValueSourceLayout::Constant(0, Type::Int),
                 }
             };
             let resolve_fieldnums = |fieldnums: &[i16],
@@ -889,7 +894,7 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                                     let base = fieldnums
                                         .first()
                                         .map(|&fnum| resolve_tagged_source(fnum))
-                                        .unwrap_or(ExitValueSourceLayout::Constant(0));
+                                        .unwrap_or(ExitValueSourceLayout::Constant(0, Type::Int));
                                     majit_backend::ExitVirtualLayout::RawSlice {
                                         offset: *offset,
                                         base,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -51,12 +51,12 @@ fn materialize_pending_fields(exit_layout: &CompiledExitLayout, raw_values: &[i6
             ExitValueSourceLayout::ExitValue(slot) if *slot < raw_values.len() => {
                 raw_values[*slot] as *mut u8
             }
-            ExitValueSourceLayout::Constant(c) => *c as *mut u8,
+            ExitValueSourceLayout::Constant(c, _) => *c as *mut u8,
             _ => std::ptr::null_mut(),
         };
         let value = match &pf.value {
             ExitValueSourceLayout::ExitValue(slot) if *slot < raw_values.len() => raw_values[*slot],
-            ExitValueSourceLayout::Constant(c) => *c,
+            ExitValueSourceLayout::Constant(c, _) => *c,
             _ => 0,
         };
         if struct_ptr.is_null() {

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1857,6 +1857,20 @@ impl TraceCtx {
             .and_then(|boxes| boxes.get(index).copied())
     }
 
+    /// The vable identity OpRef — `virtualizable_boxes[-1]`, seeded ONCE from
+    /// the portal/owner frame in `init_virtualizable_boxes`. The snapshot's
+    /// vable section identity (`_list_of_boxes_virtualizable`'s front pointer)
+    /// must be this owner frame, never the current (possibly inlined-callee)
+    /// frame: the decoder's `get_total_size(virtualizable)` reads the heap
+    /// array length off this pointer and asserts it equals the owner-sourced
+    /// field count. Returns `None` when no standard virtualizable is seeded
+    /// (test fixtures), so callers fall back to the current frame.
+    pub fn virtualizable_owner_identity(&self) -> Option<OpRef> {
+        self.virtualizable_boxes
+            .as_ref()
+            .and_then(|boxes| boxes.last().copied())
+    }
+
     /// Read a standard virtualizable slot as (OpRef, concrete Value) — RPython
     /// `virtualizable_boxes[index]` parity: a Box carries both the traced
     /// reference and its concrete value. Callers that need to seed a register

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4306,17 +4306,17 @@ fn exec_or_eval(
     ///
     /// The storage is owned by the dict for its lifetime — functions
     /// defined during the run capture the dict OBJECT as `__globals__` and
-    /// recover this storage via `get_w_globals()` — so it is intentionally
+    /// recover this storage via `get_w_globals_storage()` — so it is intentionally
     /// leaked alongside the dict rather than freed.  Retires with the
     /// `dict_storage_proxy` bridge when the dict becomes the single store.
-    fn ensure_globals_storage_proxy(w_globals_obj: pyre_object::PyObjectRef) {
-        if w_globals_obj.is_null() {
+    fn ensure_globals_storage_proxy(w_globals: pyre_object::PyObjectRef) {
+        if w_globals.is_null() {
             return;
         }
         // Dispatch storage on `resolve_dict_backing` (a dict subclass
         // resolves to itself; a dict-proxy / mapping to its inner dict),
         // mirroring PyPy's storage-vs-original split.
-        let backing = unsafe { crate::type_methods::resolve_dict_backing(w_globals_obj) };
+        let backing = unsafe { crate::type_methods::resolve_dict_backing(w_globals) };
         if backing.is_null() {
             return;
         }
@@ -4345,7 +4345,7 @@ fn exec_or_eval(
     }
 
     fn ensure_eval_builtins(
-        w_globals_obj: pyre_object::PyObjectRef,
+        w_globals: pyre_object::PyObjectRef,
         exec_ctx: *const crate::PyExecutionContext,
     ) -> Result<(), crate::PyError> {
         // pypy/module/__builtin__/compiling.py:109-110 eval:
@@ -4362,18 +4362,18 @@ fn exec_or_eval(
         } else {
             pyre_object::PY_NULL
         };
-        if w_builtin.is_null() || w_globals_obj.is_null() {
+        if w_builtin.is_null() || w_globals.is_null() {
             return Ok(());
         }
         let key = pyre_object::w_str_new("__builtins__");
-        if !crate::baseobjspace::contains(w_globals_obj, key)? {
-            crate::baseobjspace::setitem(w_globals_obj, key, w_builtin)?;
+        if !crate::baseobjspace::contains(w_globals, key)? {
+            crate::baseobjspace::setitem(w_globals, key, w_builtin)?;
         }
         Ok(())
     }
 
     fn ensure_exec_builtins(
-        w_globals_obj: pyre_object::PyObjectRef,
+        w_globals: pyre_object::PyObjectRef,
         caller_frame: *const crate::PyFrame,
         exec_ctx: *const crate::PyExecutionContext,
     ) -> Result<(), crate::PyError> {
@@ -4394,11 +4394,11 @@ fn exec_or_eval(
         } else {
             pyre_object::PY_NULL
         };
-        if w_builtin.is_null() || w_globals_obj.is_null() {
+        if w_builtin.is_null() || w_globals.is_null() {
             return Ok(());
         }
         let key = pyre_object::w_str_new("__builtins__");
-        let setdefault = crate::baseobjspace::getattr_str(w_globals_obj, "setdefault")?;
+        let setdefault = crate::baseobjspace::getattr_str(w_globals, "setdefault")?;
         crate::call_and_check(setdefault, &[key, w_builtin])?;
         Ok(())
     }
@@ -4433,26 +4433,26 @@ fn exec_or_eval(
     // pyopcode.py:2005-2009 ensure_ns — the globals object is the
     // user-supplied dict, else the caller frame's globals, else a fresh
     // empty dict (`exec(src)` outside any frame, PyPy `newdict('module')`).
-    let w_globals_obj = if !is_none_or_null(globals_arg) {
+    let w_globals = if !is_none_or_null(globals_arg) {
         globals_arg
     } else if !caller_frame.is_null() {
-        unsafe { (*caller_frame).get_w_globals_obj() }
+        unsafe { (*caller_frame).get_w_globals() }
     } else {
         pyre_object::w_dict_new()
     };
     // Seed the str-keyed storage proxy that the LOAD_GLOBAL / STORE_GLOBAL
     // bytecode fastpath reads, mirroring the dict's str entries.  A dict
     // already backing a frame (module.__dict__ / globals()) keeps its proxy.
-    ensure_globals_storage_proxy(w_globals_obj);
+    ensure_globals_storage_proxy(w_globals);
     // pyopcode.py:773-774 `space.call_method(w_globals, 'setdefault', ...)`
     // (exec) and compiling.py:109-110 `space.setitem_str(w_globals, ...)`
     // (eval) dispatch on the ORIGINAL `w_globals` object so a dict-subclass
     // `setdefault` / `__contains__` / `__setitem__` override fires; the
     // str-keyed write fans into the storage proxy seeded above.
     if is_eval {
-        ensure_eval_builtins(w_globals_obj, exec_ctx)?;
+        ensure_eval_builtins(w_globals, exec_ctx)?;
     } else {
-        ensure_exec_builtins(w_globals_obj, caller_frame, exec_ctx)?;
+        ensure_exec_builtins(w_globals, caller_frame, exec_ctx)?;
     }
 
     // pypy/interpreter/pyopcode.py:771-776 — `code.exec_code(space,
@@ -4509,7 +4509,7 @@ fn exec_or_eval(
     // object may not contain free variables" directly — exec()'s
     // closure-mismatch TypeError was already raised above.
     let mut frame =
-        match crate::createframe_obj(code_obj_ref as *const (), w_globals_obj, exec_ctx, None) {
+        match crate::createframe_obj(code_obj_ref as *const (), w_globals, exec_ctx, None) {
             Ok(frame) => frame,
             Err(err) => {
                 let _ = raw_code;
@@ -4529,7 +4529,7 @@ fn exec_or_eval(
         // resolved object is the caller's globals (module-level exec
         // collapses to locals=globals — same-dict shape kept by the
         // module-frame's initialize_frame_scopes binding).
-        let caller_globals_obj = unsafe { (*caller_frame).get_w_globals_obj() };
+        let caller_globals_obj = unsafe { (*caller_frame).get_w_globals() };
         let same_as_globals = !caller_globals_obj.is_null()
             && std::ptr::eq(implicit_caller_locals, caller_globals_obj);
         if !same_as_globals {
@@ -4566,18 +4566,18 @@ fn builtin_globals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             ));
         }
         // `pypy/module/__builtin__/interp_inspect.py:5 globals_w` →
-        // `caller.get_w_globals()` returns the dict directly without
+        // `caller.get_w_globals_storage()` returns the dict directly without
         // wrapping.  PyPy keeps a single dict per module so subsequent
         // `globals()` / `frame.f_globals` / `f.__globals__` /
         // `module.__dict__` accesses on the same module share one
         // identity.  Pyre routes through the lazy cached
-        // `get_w_globals_obj` (Step 1 of the w_globals type
+        // `get_w_globals` (Step 1 of the w_globals type
         // migration) which returns the canonical W_DictObject paired
         // with the frame's storage — same identity invariant via
         // `dict_storage_to_dict`'s mirror_target.  Returning a fresh
         // wrapper per call (as the previous shape did) silently
         // diverged on `globals() is module.__dict__`.
-        let dict = unsafe { (*frame).get_w_globals_obj() };
+        let dict = unsafe { (*frame).get_w_globals() };
         if dict.is_null() {
             return Err(crate::PyError::runtime_error(
                 "globals() requires an active frame",

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2160,12 +2160,7 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
 
     let mut frame =
         crate::pyframe::FrameBox::new(PyFrame::new_for_call_with_closure_and_globals_obj(
-            w_code,
-            args,
-            globals,
-            w_globals,
-            exec_ctx,
-            closure,
+            w_code, args, globals, w_globals, exec_ctx, closure,
         ));
     frame.fix_array_ptrs();
     if crate::pyframe::code_flags_make_generator(code_ref.flags) {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -433,9 +433,9 @@ fn call_user_function_with_eval(
     eval_fn: EvalFn,
 ) -> PyResult {
     let w_code = unsafe { crate::getcode(callable) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(callable) };
+    let w_globals = unsafe { function_get_globals_obj(callable) };
     let closure = unsafe { function_get_closure(callable) };
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
@@ -452,7 +452,7 @@ fn call_user_function_with_eval(
                 w_code,
                 &final_args,
                 globals,
-                w_globals_obj,
+                w_globals,
                 frame.execution_context,
                 closure,
             )?);
@@ -464,7 +464,7 @@ fn call_user_function_with_eval(
             w_code,
             &final_args,
             globals,
-            w_globals_obj,
+            w_globals,
             frame.execution_context,
             closure,
         )?);
@@ -486,9 +486,9 @@ pub fn call_user_function_resolved(
     let _depth_guard = increment_call_depth();
 
     let w_code = unsafe { crate::getcode(callable) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(callable) };
+    let w_globals = unsafe { function_get_globals_obj(callable) };
     let closure = unsafe { function_get_closure(callable) };
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
@@ -502,7 +502,7 @@ pub fn call_user_function_resolved(
                 w_code,
                 args,
                 globals,
-                w_globals_obj,
+                w_globals,
                 frame.execution_context,
                 closure,
             )?);
@@ -516,7 +516,7 @@ pub fn call_user_function_resolved(
             w_code,
             args,
             globals,
-            w_globals_obj,
+            w_globals,
             frame.execution_context,
             closure,
         )?);
@@ -744,9 +744,9 @@ pub fn call_user_function_plain_with_ctx(
     args: &[PyObjectRef],
 ) -> PyResult {
     let w_code = unsafe { crate::getcode(callable) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(callable) };
+    let w_globals = unsafe { function_get_globals_obj(callable) };
     let closure = unsafe { function_get_closure(callable) };
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
@@ -760,7 +760,7 @@ pub fn call_user_function_plain_with_ctx(
                 w_code,
                 &final_args,
                 globals,
-                w_globals_obj,
+                w_globals,
                 execution_context,
                 closure,
             )?);
@@ -772,7 +772,7 @@ pub fn call_user_function_plain_with_ctx(
             w_code,
             &final_args,
             globals,
-            w_globals_obj,
+            w_globals,
             execution_context,
             closure,
         )?);
@@ -1582,16 +1582,16 @@ pub fn call_with_kwargs(
             }
 
             // Create frame and execute
-            // Raw storage is recovered from `w_globals_obj` by the frame builder.
+            // Raw storage is recovered from `w_globals` by the frame builder.
             let globals = std::ptr::null_mut();
-            let w_globals_obj = unsafe { function_get_globals_obj(callable) };
+            let w_globals = unsafe { function_get_globals_obj(callable) };
             let closure = unsafe { function_get_closure(callable) };
             let mut func_frame = crate::pyframe::FrameBox::new(
                 crate::pyframe::PyFrame::try_new_for_call_with_closure_and_globals_obj(
                     w_code,
                     &final_args,
                     globals,
-                    w_globals_obj,
+                    w_globals,
                     frame.execution_context,
                     closure,
                 )?,
@@ -2059,9 +2059,9 @@ fn issubtype_ptr(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
 /// Helper: call a user function with arbitrary args from descriptor context.
 fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
     let w_code = unsafe { crate::getcode(func) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(func) };
+    let w_globals = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
@@ -2089,7 +2089,7 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
                 w_code,
                 &final_args,
                 globals,
-                w_globals_obj,
+                w_globals,
                 exec_ctx,
                 closure,
             ) {
@@ -2114,7 +2114,7 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
             w_code,
             &final_args,
             globals,
-            w_globals_obj,
+            w_globals,
             exec_ctx,
             closure,
         ) {
@@ -2143,9 +2143,9 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
 /// packed `*args` / `**kwargs` slots as extra positionals.
 fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRef {
     let w_code = unsafe { crate::getcode(func) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(func) };
+    let w_globals = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
@@ -2163,7 +2163,7 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
             w_code,
             args,
             globals,
-            w_globals_obj,
+            w_globals,
             exec_ctx,
             closure,
         ));
@@ -2559,9 +2559,9 @@ fn build_class_inner(
     w_orig_bases: Option<PyObjectRef>,
 ) -> PyResult {
     let w_code = unsafe { crate::getcode(body_fn) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(body_fn) };
+    let w_globals = unsafe { function_get_globals_obj(body_fn) };
     let closure = unsafe { function_get_closure(body_fn) };
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
@@ -2732,7 +2732,7 @@ fn build_class_inner(
             w_code,
             &[],
             globals,
-            w_globals_obj,
+            w_globals,
             exec_ctx,
             closure,
         )?);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -462,15 +462,15 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                     visitor(&mut *(w_f_trace_slot as *mut majit_ir::GcRef));
                 }
                 // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Visit
-                // the canonical `w_globals_obj` slot first so the visitor
+                // the canonical `w_globals` slot first so the visitor
                 // forwards it (and resolves any forwarding marker a sibling
                 // frame sharing the same module globals already left); only
                 // then is the object's `dict_storage_proxy` safe to chase for
                 // the backing storage.  Reading the proxy off a not-yet-
                 // forwarded object would dereference a stale nursery address.
-                let w_globals_obj_slot = &mut (*frame).w_globals_obj as *mut PyObjectRef;
+                let w_globals_obj_slot = &mut (*frame).w_globals as *mut PyObjectRef;
                 visitor(&mut *(w_globals_obj_slot as *mut majit_ir::GcRef));
-                let live_obj = (*frame).w_globals_obj;
+                let live_obj = (*frame).w_globals;
                 if !live_obj.is_null() {
                     let globals_ptr =
                         pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(live_obj)
@@ -640,7 +640,7 @@ pub fn walk_suspended_generator_frame(
 
         // Forward the globals/builtin object pointers (their dict values
         // are rooted elsewhere as noted above).
-        let w_globals_obj_slot = &mut (*frame).w_globals_obj as *mut PyObjectRef;
+        let w_globals_obj_slot = &mut (*frame).w_globals as *mut PyObjectRef;
         visitor(&mut *(w_globals_obj_slot as *mut majit_ir::GcRef));
         let w_builtin_slot = &mut (*frame).w_builtin as *mut PyObjectRef;
         visitor(&mut *(w_builtin_slot as *mut majit_ir::GcRef));
@@ -1305,12 +1305,12 @@ impl SharedOpcodeHandler for PyFrame {
         // `pypy/interpreter/pyopcode.py:1457 MAKE_FUNCTION` stamps
         // `func.w_func_globals = self.w_globals` from the running
         // frame's dict object directly.  Pyre resolves the same
-        // canonical sibling via `get_w_globals_obj()` and threads it
+        // canonical sibling via `get_w_globals()` and threads it
         // through `make_function_from_code_obj_with_globals_obj` so
         // the freshly-created function's `__globals__` identity IS
         // the frame's view — no lazy `dict_storage_to_dict` second
         // resolution that could surface a different W_DictObject.
-        let w_globals_obj = self.get_w_globals_obj();
+        let w_globals = self.get_w_globals();
         // Capture the globals OBJECT only; the raw `*mut DictStorage` is
         // recovered from the object via the proxy back-link wherever a frame
         // built from this function still needs it.  Threading a raw here is
@@ -1319,7 +1319,7 @@ impl SharedOpcodeHandler for PyFrame {
         Ok(
             crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
                 code_obj,
-                w_globals_obj,
+                w_globals,
             ),
         )
     }
@@ -1476,13 +1476,13 @@ impl NamespaceOpcodeHandler for PyFrame {
         _nameindex: usize,
         value: Self::Value,
     ) -> Result<(), PyError> {
-        let w_globals_obj = self.get_w_globals_obj();
-        if !w_globals_obj.is_null() {
+        let w_globals = self.get_w_globals();
+        if !w_globals.is_null() {
             unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str(w_globals_obj, name, value);
+                pyre_object::dictmultiobject::w_dict_setitem_str(w_globals, name, value);
             }
         } else {
-            let ns = unsafe { &mut *self.get_w_globals() };
+            let ns = unsafe { &mut *self.get_w_globals_storage() };
             dict_storage_store(ns, name, value);
         }
         Ok(())
@@ -1496,18 +1496,18 @@ impl NamespaceOpcodeHandler for PyFrame {
     /// so `exec("x = len", {"__builtins__": {}})` raises `NameError`
     /// because the empty dict is the picked builtin.
     fn load_global_value(&mut self, name: &str, nameindex: usize) -> Result<Self::Value, PyError> {
-        // `pyframe.py:128-132 get_w_globals` returns the W_DictObject
-        // directly; pyre's `w_globals_obj` slot (eagerly resolved at
+        // `pyframe.py:128-132 get_w_globals_storage` returns the W_DictObject
+        // directly; pyre's `w_globals` slot (eagerly resolved at
         // frame construction per `pyframe.py:98 __init__`) carries
         // that identity.  Route the primary lookup through the strategy
         // dispatch (`dictmultiobject.py:111-112 setitem_str` /
         // `:113-115 getitem_str`) so dict-subclass overrides resolve
         // properly and the W_ModuleDictObject path consults its cell
         // map directly instead of walking the back-mirror storage.
-        let w_globals_obj = self.get_w_globals_obj();
-        if !w_globals_obj.is_null() {
+        let w_globals = self.get_w_globals();
+        if !w_globals.is_null() {
             if let Some(value) =
-                unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals_obj, name) }
+                unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals, name) }
             {
                 return Ok(value);
             }
@@ -1525,19 +1525,19 @@ impl NamespaceOpcodeHandler for PyFrame {
         // strategy-level `get_global_cache(varname)` install are
         // skipped, because both would attach a cache to a module that
         // is not the one being executed.  Identity is `pycode.w_globals
-        // is self.get_w_globals()` — the wrapped dict OBJECT on both
-        // sides (`w_code_get_w_globals_obj` vs the frame's `w_globals_obj`).
+        // is self.get_w_globals_storage()` — the wrapped dict OBJECT on both
+        // sides (`w_code_get_w_globals` vs the frame's `w_globals`).
         let pycode_matches_frame: bool = unsafe {
-            let cwo = crate::pycode::w_code_get_w_globals_obj(self.pycode as PyObjectRef);
-            !cwo.is_null() && std::ptr::eq(cwo, w_globals_obj)
+            let cwo = crate::pycode::w_code_get_w_globals(self.pycode as PyObjectRef);
+            !cwo.is_null() && std::ptr::eq(cwo, w_globals)
         };
         if pycode_matches_frame
-            && !w_globals_obj.is_null()
-            && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals_obj) }
+            && !w_globals.is_null()
+            && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals) }
         {
             let cache_hit: Option<PyObjectRef> = unsafe {
                 load_global_via_cache(
-                    w_globals_obj,
+                    w_globals,
                     self.w_builtin,
                     name,
                     self.pycode as PyObjectRef,
@@ -2639,7 +2639,7 @@ impl OpcodeStepExecutor for PyFrame {
         }
         crate::importing::importhook(
             name,
-            self.get_w_globals_obj(),
+            self.get_w_globals(),
             pyre_object::w_none(),
             0,
             self.execution_context,
@@ -2657,7 +2657,7 @@ impl OpcodeStepExecutor for PyFrame {
 
         let module = crate::importing::importhook(
             name,
-            self.get_w_globals_obj(), // for relative imports: __name__/__package__
+            self.get_w_globals(), // for relative imports: __name__/__package__
             w_fromlist,
             level,
             self.execution_context,
@@ -2921,17 +2921,17 @@ impl OpcodeStepExecutor for PyFrame {
             return Ok(());
         }
         // Fall back to globals
-        let w_globals_obj = self.get_w_globals_obj();
-        if !w_globals_obj.is_null() {
+        let w_globals = self.get_w_globals();
+        if !w_globals.is_null() {
             if let Some(val) =
-                unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals_obj, name) }
+                unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals, name) }
             {
                 self.push(val);
                 return Ok(());
             }
         } else {
             unsafe {
-                if let Some(&val) = (*self.get_w_globals()).get(name) {
+                if let Some(&val) = (*self.get_w_globals_storage()).get(name) {
                     self.push(val);
                     return Ok(());
                 }
@@ -3098,20 +3098,20 @@ impl OpcodeStepExecutor for PyFrame {
             return Ok(());
         }
         let w_locals = self.get_w_locals();
-        let w_globals_obj = self.get_w_globals_obj();
+        let w_globals = self.get_w_globals();
         let found: bool = if !w_locals.is_null() {
             // No `get_w_locals_obj` accessor yet — locals DictStorage
             // doesn't have a canonical W_DictObject sibling for routing.
             unsafe { crate::dict_storage_delete(&mut *w_locals, name) }
-        } else if w_globals_obj.is_null() {
-            let ns = self.get_w_globals();
+        } else if w_globals.is_null() {
+            let ns = self.get_w_globals_storage();
             unsafe { crate::dict_storage_delete(&mut *ns, name) }
         } else {
             // Globals fallback: route through `w_dict_delitem_str` on
             // the canonical W_DictObject so the W_ModuleDictObject
             // strategy and mirror `DictStorage` stay coherent via
             // `maybe_sync_dict_storage_delete`.
-            unsafe { pyre_object::w_dict_delitem_str(w_globals_obj, name) }
+            unsafe { pyre_object::w_dict_delitem_str(w_globals, name) }
         };
         if !found {
             return Err(PyError::name_error_with_name(
@@ -3124,19 +3124,19 @@ impl OpcodeStepExecutor for PyFrame {
 
     // ── delete_global ──
     // pypy/interpreter/pyopcode.py:901-903 DELETE_GLOBAL —
-    //   `self.space.delitem(self.get_w_globals(), w_varname)`.
+    //   `self.space.delitem(self.get_w_globals_storage(), w_varname)`.
     // `space.delitem` on a dict raises `KeyError(w_varname)` when the
     // key is missing; pyre routes through `w_dict_delitem_str` on the
     // canonical W_DictObject so the W_ModuleDictObject's strategy and
     // its mirror `DictStorage` stay coherent via
     // `maybe_sync_dict_storage_delete`.
     fn delete_global(&mut self, name: &str) -> Result<(), PyError> {
-        let w_globals_obj = self.get_w_globals_obj();
-        let found: bool = if w_globals_obj.is_null() {
-            let ns = self.get_w_globals();
+        let w_globals = self.get_w_globals();
+        let found: bool = if w_globals.is_null() {
+            let ns = self.get_w_globals_storage();
             unsafe { crate::dict_storage_delete(&mut *ns, name) }
         } else {
-            unsafe { pyre_object::w_dict_delitem_str(w_globals_obj, name) }
+            unsafe { pyre_object::w_dict_delitem_str(w_globals, name) }
         };
         if !found {
             return Err(PyError::key_error(format!("'{name}'")));
@@ -3699,17 +3699,17 @@ impl OpcodeStepExecutor for PyFrame {
                         pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), value);
                     }
                 }
-                let w_globals_obj = self.get_w_globals_obj();
-                if self.nlocals() == 0 && !w_globals_obj.is_null() {
+                let w_globals = self.get_w_globals();
+                if self.nlocals() == 0 && !w_globals.is_null() {
                     for (key, value) in
-                        unsafe { pyre_object::dictmultiobject::w_dict_items(w_globals_obj) }
+                        unsafe { pyre_object::dictmultiobject::w_dict_items(w_globals) }
                     {
                         if !value.is_null() {
                             pyre_object::w_dict_store(dict, key, value);
                         }
                     }
                 } else {
-                    let w_globals = self.get_w_globals();
+                    let w_globals = self.get_w_globals_storage();
                     if self.nlocals() == 0 && !w_globals.is_null() {
                         for (key, &value) in (*w_globals).entries() {
                             if !value.is_null() {
@@ -3884,7 +3884,7 @@ mod tests {
     #[test]
     fn test_exception_is_valid_obj_as_class_w_matches_baseexception_subclass_rule() {
         let (_result, frame) = run_exec_frame("good = ValueError\nbad = int");
-        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
         let good = *w_globals.get("good").expect("missing good");
         let bad = *w_globals.get("bad").expect("missing bad");
 
@@ -3910,7 +3910,7 @@ mod tests {
         let (_result, frame) = run_exec_frame(
             "def make_adder(n):\n    def add(x):\n        return x + n\n    return add\nresult = make_adder(10)(5)",
         );
-        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
         let result = *w_globals.get("result").expect("missing result");
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 15);
     }
@@ -3925,7 +3925,7 @@ mod tests {
         let (_result, frame) = run_exec_frame(
             "class A:\n    def f(self):\n        return 1\nclass B(A):\n    def f(self):\n        return 10 + super().f()\nresult = B().f()",
         );
-        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
         let result = *w_globals.get("result").expect("missing result");
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 11);
     }
@@ -3944,15 +3944,15 @@ mod tests {
     #[test]
     fn test_raise_from_sets_cause_attribute() {
         let (_result, frame) = run_exec_frame("exc = ValueError()\ncause = KeyError()");
-        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
         let exc = *w_globals.get("exc").expect("missing exc");
         let cause = *w_globals.get("cause").expect("missing cause");
 
         let code = compile_exec("raise exc from cause").expect("compile failed");
         let mut raise_frame = PyFrame::new(code);
         unsafe {
-            (*raise_frame.fget_w_globals()).insert("exc".to_string(), exc);
-            (*raise_frame.fget_w_globals()).insert("cause".to_string(), cause);
+            (*raise_frame.fget_w_globals_storage()).insert("exc".to_string(), exc);
+            (*raise_frame.fget_w_globals_storage()).insert("cause".to_string(), cause);
         }
 
         let err = raise_frame
@@ -4014,8 +4014,8 @@ mod tests {
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
-            let y = w_dict_getitem_str(frame.w_globals_obj, "y").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
+            let y = w_dict_getitem_str(frame.w_globals, "y").unwrap();
             assert_eq!(w_int_get_value(x), 5);
             assert_eq!(w_int_get_value(y), 25);
         }
@@ -4028,7 +4028,7 @@ mod tests {
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
             assert_eq!(w_int_get_value(i), 10);
         }
     }
@@ -4063,7 +4063,7 @@ r = acc",
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "r").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "r").unwrap();
             assert_eq!(w_int_get_value(r), 6);
         }
     }
@@ -4207,7 +4207,7 @@ r = acc",
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let s = w_dict_getitem_str(frame.w_globals_obj, "s").unwrap();
+            let s = w_dict_getitem_str(frame.w_globals, "s").unwrap();
             assert_eq!(w_int_get_value(s), 45);
         }
     }
@@ -4220,7 +4220,7 @@ r = acc",
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let s = w_dict_getitem_str(frame.w_globals_obj, "s").unwrap();
+            let s = w_dict_getitem_str(frame.w_globals, "s").unwrap();
             assert_eq!(w_int_get_value(s), 4_498_500);
         }
     }
@@ -4241,8 +4241,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 4500);
         }
@@ -4262,8 +4262,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 4_501_500);
         }
@@ -4284,9 +4284,9 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
-            let lst = w_dict_getitem_str(frame.w_globals_obj, "lst").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
+            let lst = w_dict_getitem_str(frame.w_globals, "lst").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 4_498_500);
             assert_eq!(w_int_get_value(w_list_getitem(lst, 0).unwrap()), 2999);
@@ -4306,8 +4306,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 4095);
         }
@@ -4326,8 +4326,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), -4_501_500);
         }
@@ -4346,8 +4346,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 1_498_500);
         }
@@ -4366,8 +4366,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 8_994);
         }
@@ -4386,8 +4386,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 2_250_000);
         }
@@ -4408,8 +4408,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4432,8 +4432,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4456,8 +4456,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4478,8 +4478,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4500,8 +4500,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4524,8 +4524,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4546,8 +4546,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4567,8 +4567,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 12_000);
         }
@@ -4588,8 +4588,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 6_000);
         }
@@ -4610,8 +4610,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4634,8 +4634,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 6000);
         }
@@ -4656,8 +4656,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4676,8 +4676,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 6426);
         }
@@ -4696,8 +4696,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 11568);
         }
@@ -4720,8 +4720,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 3000);
         }
@@ -4742,9 +4742,9 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
-            let lst = w_dict_getitem_str(frame.w_globals_obj, "lst").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
+            let lst = w_dict_getitem_str(frame.w_globals, "lst").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 4_498_500);
             assert_eq!(w_int_get_value(w_list_getitem(lst, -1).unwrap()), 2999);
@@ -4765,8 +4765,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 15_000);
         }
@@ -4787,8 +4787,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let i = w_dict_getitem_str(frame.w_globals_obj, "i").unwrap();
-            let acc = w_dict_getitem_str(frame.w_globals_obj, "acc").unwrap();
+            let i = w_dict_getitem_str(frame.w_globals, "i").unwrap();
+            let acc = w_dict_getitem_str(frame.w_globals, "acc").unwrap();
             assert_eq!(w_int_get_value(i), 3000);
             assert_eq!(w_int_get_value(acc), 4_501_500);
         }
@@ -4801,7 +4801,7 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let s = w_dict_getitem_str(frame.w_globals_obj, "s").unwrap();
+            let s = w_dict_getitem_str(frame.w_globals, "s").unwrap();
             assert_eq!(w_int_get_value(s), 35);
         }
     }
@@ -4813,7 +4813,7 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let s = w_dict_getitem_str(frame.w_globals_obj, "s").unwrap();
+            let s = w_dict_getitem_str(frame.w_globals, "s").unwrap();
             // 0 + 2 + 4 + 6 + 8 = 20
             assert_eq!(w_int_get_value(s), 20);
         }
@@ -4826,7 +4826,7 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let s = w_dict_getitem_str(frame.w_globals_obj, "s").unwrap();
+            let s = w_dict_getitem_str(frame.w_globals, "s").unwrap();
             assert_eq!(w_int_get_value(s), 42);
         }
     }
@@ -4838,7 +4838,7 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let s = w_dict_getitem_str(frame.w_globals_obj, "s").unwrap();
+            let s = w_dict_getitem_str(frame.w_globals, "s").unwrap();
             // 0 + 1 + 2 + 3 + 4 = 10
             assert_eq!(w_int_get_value(s), 10);
         }
@@ -4853,7 +4853,7 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
             assert_eq!(w_int_get_value(x), 3);
         }
     }
@@ -4865,7 +4865,7 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
             assert_eq!(w_int_get_value(x), 5);
         }
     }
@@ -4877,8 +4877,8 @@ while i < 3000:
         let mut frame = PyFrame::new(code);
         let _ = frame.execute_frame(None, None);
         unsafe {
-            let a = w_dict_getitem_str(frame.w_globals_obj, "a").unwrap();
-            let b = w_dict_getitem_str(frame.w_globals_obj, "b").unwrap();
+            let a = w_dict_getitem_str(frame.w_globals, "a").unwrap();
+            let b = w_dict_getitem_str(frame.w_globals, "b").unwrap();
             assert_eq!(w_int_get_value(a), 3);
             assert_eq!(w_int_get_value(b), 7);
         }
@@ -4891,7 +4891,7 @@ while i < 3000:
         let source = "x = [1, 2, 3]";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
             assert!(is_list(x));
             assert_eq!(w_list_len(x), 3);
             assert_eq!(w_int_get_value(w_list_getitem(x, 0).unwrap()), 1);
@@ -4905,8 +4905,8 @@ while i < 3000:
         let source = "a, b = 1, 2";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let a = w_dict_getitem_str(frame.w_globals_obj, "a").unwrap();
-            let b = w_dict_getitem_str(frame.w_globals_obj, "b").unwrap();
+            let a = w_dict_getitem_str(frame.w_globals, "a").unwrap();
+            let b = w_dict_getitem_str(frame.w_globals, "b").unwrap();
             assert_eq!(w_int_get_value(a), 1);
             assert_eq!(w_int_get_value(b), 2);
         }
@@ -4917,7 +4917,7 @@ while i < 3000:
         let source = "lst = [10, 20, 30]\nx = lst[1]";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
             assert_eq!(w_int_get_value(x), 20);
         }
     }
@@ -4927,7 +4927,7 @@ while i < 3000:
         let source = "lst = [1, 2, 3]\nlst[0] = 99\nx = lst[0]";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
             assert_eq!(w_int_get_value(x), 99);
         }
     }
@@ -4937,7 +4937,7 @@ while i < 3000:
         let source = "d = {1: 10, 2: 20}\nx = d[1]";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let x = w_dict_getitem_str(frame.w_globals_obj, "x").unwrap();
+            let x = w_dict_getitem_str(frame.w_globals, "x").unwrap();
             assert_eq!(w_int_get_value(x), 10);
         }
     }
@@ -4949,7 +4949,7 @@ while i < 3000:
         let source = "def double(x):\n    return x * 2\nresult = double(21)";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 42);
         }
     }
@@ -4964,7 +4964,7 @@ def add_squares(a, b):
 result = add_squares(3, 4)";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 25);
         }
     }
@@ -4979,7 +4979,7 @@ def factorial(n):
 result = factorial(5)";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 120);
         }
     }
@@ -4996,7 +4996,7 @@ f.x = 42
 result = f.x";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 42);
         }
     }
@@ -5012,7 +5012,7 @@ f.b = 20
 result = f.a + f.b";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 30);
         }
     }
@@ -5028,7 +5028,7 @@ f.x = 2
 result = f.x";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 2);
         }
     }
@@ -5046,7 +5046,7 @@ g.x = 20
 result = f.x + g.x";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 30);
         }
     }
@@ -5059,7 +5059,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("exec failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(result), "1 in [1,2,3] should be True");
         }
     }
@@ -5069,7 +5069,7 @@ result = f.x + g.x";
         let source = "result = 4 not in [1, 2, 3]";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(result));
         }
     }
@@ -5095,7 +5095,7 @@ result = f.x + g.x";
         let source = "x = 42\nresult = f'val={x}'";
         let (_, frame) = run_exec_frame(source);
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_str_get_value(result), "val=42");
         }
     }
@@ -5106,7 +5106,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert!(is_list(result), "slice result should be list");
                 assert_eq!(w_list_len(result), 2);
                 assert_eq!(w_int_get_value(w_list_getitem(result, 0).unwrap()), 2);
@@ -5148,7 +5148,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("f-string exec failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_str_get_value(result), "10 + 20 = 30");
         }
     }
@@ -5159,7 +5159,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("string contains failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(result));
         }
     }
@@ -5170,7 +5170,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("tuple contains failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(result));
         }
     }
@@ -5181,7 +5181,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("not in failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(result));
         }
     }
@@ -5192,7 +5192,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("is not None failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(result));
         }
     }
@@ -5203,7 +5203,7 @@ result = f.x + g.x";
         let (res, frame) = run_exec_frame(source);
         res.expect("negative slice failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(is_list(result));
             assert_eq!(w_list_len(result), 3);
         }
@@ -5218,7 +5218,7 @@ result = add(add(1, 2), add(3, 4))";
         let (res, frame) = run_exec_frame(source);
         res.expect("nested call failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 10);
         }
     }
@@ -5235,7 +5235,7 @@ result = x";
         let (res, frame) = run_exec_frame(source);
         res.expect("while+break failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 5);
         }
     }
@@ -5246,7 +5246,7 @@ result = x";
         let (res, frame) = run_exec_frame(source);
         res.expect("inplace add failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 15);
         }
     }
@@ -5261,7 +5261,7 @@ for c in 'hello':
         let (res, frame) = run_exec_frame(source);
         res.expect("string iteration failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_str_get_value(result), "hello");
         }
     }
@@ -5277,7 +5277,7 @@ result = count";
         let (res, frame) = run_exec_frame(source);
         res.expect("enumerate style failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 3);
         }
     }
@@ -5293,7 +5293,7 @@ for i in [1, 2, 3]:
         let (res, frame) = run_exec_frame(source);
         res.expect("nested for failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             // 1*10 + 1*20 + 2*10 + 2*20 + 3*10 + 3*20 = 10+20+20+40+30+60 = 180
             assert_eq!(w_int_get_value(result), 180);
         }
@@ -5311,7 +5311,7 @@ result = x";
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert_eq!(w_int_get_value(result), 42);
             },
             Err(e) => panic!("try/except failed: {} ({:?})", e.message, e.kind),
@@ -5329,7 +5329,7 @@ result = fib(10)";
         let (res, frame) = run_exec_frame(source);
         res.expect("fib failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(r), 55);
         }
     }
@@ -5357,7 +5357,7 @@ result = fib(10)";
         let (res, frame) = run_exec_frame(source);
         res.expect("negative index failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(r), 30);
         }
     }
@@ -5368,7 +5368,7 @@ result = fib(10)";
         let (res, frame) = run_exec_frame(source);
         res.expect("boolean and failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(!crate::baseobjspace::is_true(r).unwrap());
         }
     }
@@ -5379,7 +5379,7 @@ result = fib(10)";
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert!(w_bool_get_value(r));
             },
             Err(e) => eprintln!("chained comparison: {}", e.message),
@@ -5398,7 +5398,7 @@ except ZeroDivisionError:
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert_eq!(w_int_get_value(r), 99);
             },
             Err(e) => panic!("specific except failed: {} ({:?})", e.message, e.kind),
@@ -5489,7 +5489,7 @@ except (ValueError, 42):
         let (_result, frame) = run_exec_frame(
             "exc = ValueError(\"boom\")\nplain = 5\nvalue_error = ValueError\ntype_error = TypeError",
         );
-        let w_globals = unsafe { &*frame.fget_w_globals() };
+        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
         let exc = *w_globals.get("exc").expect("missing exc");
         let plain = *w_globals.get("plain").expect("missing plain");
         let value_error = *w_globals.get("value_error").expect("missing value_error");
@@ -5512,7 +5512,7 @@ finally:
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert_eq!(w_int_get_value(r), 11);
             },
             Err(e) => panic!("try/finally failed: {} ({:?})", e.message, e.kind),
@@ -5532,7 +5532,7 @@ result = result + 10
         let (res, frame) = run_exec_frame(source);
         res.expect("multiple except failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(r), 11);
         }
     }
@@ -5549,7 +5549,7 @@ for x in [1, 2, 3, 4, 5]:
         let (res, frame) = run_exec_frame(source);
         res.expect("for+continue failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             // 1 + 2 + 4 + 5 = 12 (skips 3)
             assert_eq!(w_int_get_value(r), 12);
         }
@@ -5565,7 +5565,7 @@ result = greet('world')
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert_eq!(w_str_get_value(r), "hello");
             },
             Err(e) => {
@@ -5581,7 +5581,7 @@ result = greet('world')
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert!(is_list(result));
                 // After += [3], x should have 3 elements
                 assert_eq!(w_list_len(result), 3);
@@ -5600,7 +5600,7 @@ result = total";
         let (res, frame) = run_exec_frame(source);
         res.expect("for loop failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 15);
         }
     }
@@ -5614,7 +5614,7 @@ for c in 'abc':
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert_eq!(w_int_get_value(result), 3);
             },
             Err(e) => {
@@ -5630,7 +5630,7 @@ for c in 'abc':
         let (res, frame) = run_exec_frame(source);
         res.expect("multiple assign failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 84);
         }
     }
@@ -5647,7 +5647,7 @@ result = add5(10)";
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert_eq!(w_int_get_value(r), 15);
             },
             Err(e) => panic!("closure failed: {} ({:?})", e.message, e.kind),
@@ -5660,7 +5660,7 @@ result = add5(10)";
         let (res, frame) = run_exec_frame(source);
         res.expect("tuple unpack failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(r), 6);
         }
     }
@@ -5671,7 +5671,7 @@ result = add5(10)";
         let (res, frame) = run_exec_frame(source);
         res.expect("dict access failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(r), 30);
         }
     }
@@ -5682,7 +5682,7 @@ result = add5(10)";
         let (res, frame) = run_exec_frame(source);
         res.expect("string len failed");
         unsafe {
-            let r = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let r = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(r), 5);
         }
     }
@@ -5732,7 +5732,7 @@ for x in [1, 2, 3]:
         let (res, frame) = run_exec_frame(source);
         match res {
             Ok(_) => unsafe {
-                let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+                let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
                 assert!(is_list(result));
                 assert_eq!(w_list_len(result), 3);
                 assert_eq!(w_int_get_value(w_list_getitem(result, 0).unwrap()), 2);
@@ -5749,7 +5749,7 @@ for x in [1, 2, 3]:
         let (res, frame) = run_exec_frame(source);
         res.expect("globals() failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 42);
         }
     }
@@ -5764,7 +5764,7 @@ result = f(2, 3)";
         let (res, frame) = run_exec_frame(source);
         res.expect("locals() in function failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 10);
         }
     }
@@ -5780,7 +5780,7 @@ result = C.snap['y'] + globals()['x']";
         let (res, frame) = run_exec_frame(source);
         res.expect("locals() in class failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 3);
         }
     }
@@ -5798,7 +5798,7 @@ result = m(41)";
         let (res, frame) = run_exec_frame(source);
         res.expect("bound method lookup failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 42);
         }
     }
@@ -5815,8 +5815,8 @@ m = c.add";
         let (res, frame) = run_exec_frame(source);
         res.expect("bound method lookup setup failed");
         unsafe {
-            let c_obj = w_dict_getitem_str(frame.w_globals_obj, "c").unwrap();
-            let m_obj = w_dict_getitem_str(frame.w_globals_obj, "m").unwrap();
+            let c_obj = w_dict_getitem_str(frame.w_globals, "c").unwrap();
+            let m_obj = w_dict_getitem_str(frame.w_globals, "m").unwrap();
             assert!(pyre_object::is_method(m_obj));
             assert!(std::ptr::eq(pyre_object::w_method_get_self(m_obj), c_obj));
         }
@@ -5832,7 +5832,7 @@ result = len(xs)";
         let (res, frame) = run_exec_frame(source);
         res.expect("builtin type method lookup failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 1);
         }
     }
@@ -5847,7 +5847,7 @@ result = c.f([1, 2, 3])";
         let (res, frame) = run_exec_frame(source);
         res.expect("builtin function descriptor semantics failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 3);
         }
     }
@@ -5894,12 +5894,12 @@ except AttributeError as e:
         let (res, frame) = run_exec_frame(source);
         res.expect("builtin_function typedef overrides failed");
         unsafe {
-            let _doc_value = w_dict_getitem_str(frame.w_globals_obj, "doc_value").unwrap();
-            let self_is_none = w_dict_getitem_str(frame.w_globals_obj, "self_is_none").unwrap();
-            let repr_result = w_dict_getitem_str(frame.w_globals_obj, "repr_result").unwrap();
-            let new_err = w_dict_getitem_str(frame.w_globals_obj, "new_err").unwrap();
-            let set_err = w_dict_getitem_str(frame.w_globals_obj, "set_err").unwrap();
-            let del_err = w_dict_getitem_str(frame.w_globals_obj, "del_err").unwrap();
+            let _doc_value = w_dict_getitem_str(frame.w_globals, "doc_value").unwrap();
+            let self_is_none = w_dict_getitem_str(frame.w_globals, "self_is_none").unwrap();
+            let repr_result = w_dict_getitem_str(frame.w_globals, "repr_result").unwrap();
+            let new_err = w_dict_getitem_str(frame.w_globals, "new_err").unwrap();
+            let set_err = w_dict_getitem_str(frame.w_globals, "set_err").unwrap();
+            let del_err = w_dict_getitem_str(frame.w_globals, "del_err").unwrap();
             assert!(w_bool_get_value(self_is_none));
             assert_eq!(w_str_get_value(repr_result), "<built-in function len>");
             assert_eq!(
@@ -5933,9 +5933,9 @@ manual_result = len(manual)";
         let (res, frame) = run_exec_frame(source);
         res.expect("set constructor parity failed");
         unsafe {
-            let is_subtype = w_dict_getitem_str(frame.w_globals_obj, "is_subtype").unwrap();
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
-            let manual_result = w_dict_getitem_str(frame.w_globals_obj, "manual_result").unwrap();
+            let is_subtype = w_dict_getitem_str(frame.w_globals, "is_subtype").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
+            let manual_result = w_dict_getitem_str(frame.w_globals, "manual_result").unwrap();
             assert!(w_bool_get_value(is_subtype));
             assert_eq!(w_int_get_value(result), 3);
             assert_eq!(w_int_get_value(manual_result), 2);
@@ -5955,9 +5955,9 @@ result = len(sub)";
         let (res, frame) = run_exec_frame(source);
         res.expect("frozenset constructor parity failed");
         unsafe {
-            let same = w_dict_getitem_str(frame.w_globals_obj, "same").unwrap();
-            let is_subtype = w_dict_getitem_str(frame.w_globals_obj, "is_subtype").unwrap();
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let same = w_dict_getitem_str(frame.w_globals, "same").unwrap();
+            let is_subtype = w_dict_getitem_str(frame.w_globals, "is_subtype").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert!(w_bool_get_value(same));
             assert!(w_bool_get_value(is_subtype));
             assert_eq!(w_int_get_value(result), 3);
@@ -6003,11 +6003,11 @@ except TypeError as e:
         let (res, frame) = run_exec_frame(source);
         res.expect("set/frozenset arity enforcement failed");
         unsafe {
-            let init_err = w_dict_getitem_str(frame.w_globals_obj, "init_err").unwrap();
+            let init_err = w_dict_getitem_str(frame.w_globals, "init_err").unwrap();
             let init_direct_err =
-                w_dict_getitem_str(frame.w_globals_obj, "init_direct_err").unwrap();
-            let frozen_err = w_dict_getitem_str(frame.w_globals_obj, "frozen_err").unwrap();
-            let frozen_new_err = w_dict_getitem_str(frame.w_globals_obj, "frozen_new_err").unwrap();
+                w_dict_getitem_str(frame.w_globals, "init_direct_err").unwrap();
+            let frozen_err = w_dict_getitem_str(frame.w_globals, "frozen_err").unwrap();
+            let frozen_new_err = w_dict_getitem_str(frame.w_globals, "frozen_new_err").unwrap();
             assert!(
                 !w_str_get_value(init_err).is_empty(),
                 "set([1], 2) should raise TypeError"
@@ -6055,8 +6055,8 @@ except TypeError as e:
         let (res, frame) = run_exec_frame(source);
         res.expect("layout safety check failed");
         unsafe {
-            let err = w_dict_getitem_str(frame.w_globals_obj, "err").unwrap();
-            let frozen_err = w_dict_getitem_str(frame.w_globals_obj, "frozen_err").unwrap();
+            let err = w_dict_getitem_str(frame.w_globals, "err").unwrap();
+            let frozen_err = w_dict_getitem_str(frame.w_globals, "frozen_err").unwrap();
             assert!(
                 !w_str_get_value(err).is_empty(),
                 "set.__new__(int) should raise TypeError"
@@ -6081,8 +6081,8 @@ bound = C.pick
 result = bound()";
         let (res, frame) = run_exec_frame(source);
         res.expect("metaclass descriptor lookup failed");
-        let result = unsafe { w_dict_getitem_str(frame.w_globals_obj, "result").unwrap() };
-        let c_obj = unsafe { w_dict_getitem_str(frame.w_globals_obj, "C").unwrap() };
+        let result = unsafe { w_dict_getitem_str(frame.w_globals, "result").unwrap() };
+        let c_obj = unsafe { w_dict_getitem_str(frame.w_globals, "C").unwrap() };
         assert!(std::ptr::eq(result, c_obj));
     }
 
@@ -6100,7 +6100,7 @@ result = C.value";
         let (res, frame) = run_exec_frame(source);
         res.expect("__prepare__ lookup failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 42);
         }
     }
@@ -6116,8 +6116,8 @@ g = f.__globals__
 code = f.__code__";
         let (res, frame) = run_exec_frame(source);
         res.expect("function dunder lookup failed");
-        let globals = unsafe { w_dict_getitem_str(frame.w_globals_obj, "g").unwrap() };
-        let code = unsafe { w_dict_getitem_str(frame.w_globals_obj, "code").unwrap() };
+        let globals = unsafe { w_dict_getitem_str(frame.w_globals, "g").unwrap() };
+        let code = unsafe { w_dict_getitem_str(frame.w_globals, "code").unwrap() };
         unsafe {
             let x = pyre_object::w_dict_lookup(globals, pyre_object::w_str_new("x")).unwrap();
             assert_eq!(w_int_get_value(x), 7);
@@ -6144,7 +6144,7 @@ except TypeError:
         let (res, frame) = run_exec_frame(source);
         res.expect("vars() exception path failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 1);
         }
     }
@@ -6160,7 +6160,7 @@ except TypeError:
         let (res, frame) = run_exec_frame(source);
         res.expect("type() exception path failed");
         unsafe {
-            let result = w_dict_getitem_str(frame.w_globals_obj, "result").unwrap();
+            let result = w_dict_getitem_str(frame.w_globals, "result").unwrap();
             assert_eq!(w_int_get_value(result), 1);
         }
     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1316,12 +1316,7 @@ impl SharedOpcodeHandler for PyFrame {
         // built from this function still needs it.  Threading a raw here is
         // what dangled exec-defined functions when the exec temp storage was
         // freed (the `GlobalsBinding` leak), so it is dropped.
-        Ok(
-            crate::runtime_ops::make_function_from_code_obj_with_globals_obj(
-                code_obj,
-                w_globals,
-            ),
-        )
+        Ok(crate::runtime_ops::make_function_from_code_obj_with_globals_obj(code_obj, w_globals))
     }
 
     fn call_callable(
@@ -6004,8 +5999,7 @@ except TypeError as e:
         res.expect("set/frozenset arity enforcement failed");
         unsafe {
             let init_err = w_dict_getitem_str(frame.w_globals, "init_err").unwrap();
-            let init_direct_err =
-                w_dict_getitem_str(frame.w_globals, "init_direct_err").unwrap();
+            let init_direct_err = w_dict_getitem_str(frame.w_globals, "init_direct_err").unwrap();
             let frozen_err = w_dict_getitem_str(frame.w_globals, "frozen_err").unwrap();
             let frozen_new_err = w_dict_getitem_str(frame.w_globals, "frozen_new_err").unwrap();
             assert!(

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1524,17 +1524,12 @@ impl NamespaceOpcodeHandler for PyFrame {
         // the per-pycode `_globals_caches[nameindex]` slot AND the
         // strategy-level `get_global_cache(varname)` install are
         // skipped, because both would attach a cache to a module that
-        // is not the one being executed.  Identity is checked via
-        // `pycode.w_globals == frame.get_w_globals()` (raw pointer
-        // equality mirrors PyPy's `is` on the wrapped dict).
-        // `get_w_globals()` recovers the raw storage from the frame's
-        // canonical `w_globals_obj`; `dict_storage_to_dict` /
-        // `w_dict_get_dict_storage_proxy` are mutual inverses under the
-        // `mirror_target` invariant, so this raw comparison agrees with
-        // the object `is` check.
+        // is not the one being executed.  Identity is `pycode.w_globals
+        // is self.get_w_globals()` — the wrapped dict OBJECT on both
+        // sides (`w_code_get_w_globals_obj` vs the frame's `w_globals_obj`).
         let pycode_matches_frame: bool = unsafe {
-            let cw = crate::pycode::w_code_get_w_globals(self.pycode as PyObjectRef);
-            !cw.is_null() && std::ptr::eq(cw, self.get_w_globals())
+            let cwo = crate::pycode::w_code_get_w_globals_obj(self.pycode as PyObjectRef);
+            !cwo.is_null() && std::ptr::eq(cwo, w_globals_obj)
         };
         if pycode_matches_frame
             && !w_globals_obj.is_null()

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -123,10 +123,10 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
     unsafe {
         let frame_ref = &mut *frame;
         // `pyframe.py:766 fget_f_globals` returns `self.w_globals`
-        // (already a W_DictObject).  Pyre's eager `w_globals_obj` slot
+        // (already a W_DictObject).  Pyre's eager `w_globals` slot
         // matches that identity; reading it here avoids a second
         // `dict_storage_to_dict` round-trip below.
-        let w_globals_obj = frame_ref.get_w_globals_obj();
+        let w_globals = frame_ref.get_w_globals();
         let w_locals = frame_ref.get_w_locals();
         let w_trace = frame_ref.get_w_f_trace();
         // pypy/interpreter/pyframe.py:154 fget_f_back walks the
@@ -157,10 +157,10 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
         let _ = crate::baseobjspace::setattr_str(
             w_frame,
             "f_globals",
-            if w_globals_obj.is_null() {
+            if w_globals.is_null() {
                 pyre_object::w_none()
             } else {
-                w_globals_obj
+                w_globals
             },
         );
         let _ = crate::baseobjspace::setattr_str(

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1418,14 +1418,14 @@ pub unsafe fn fget___module__(obj: PyObjectRef) -> PyObjectRef {
         if (*func).w_module.is_null() {
             // function.py:505-506: space.call_method(self.w_func_globals,
             // "get", space.newtext("__name__"))
-            let w_globals_obj = (*func).w_func_globals_obj;
-            if !w_globals_obj.is_null() && !pyre_object::is_none(w_globals_obj) {
+            let w_globals = (*func).w_func_globals_obj;
+            if !w_globals.is_null() && !pyre_object::is_none(w_globals) {
                 // Dispatch through `dict.get` so dict subclasses that
                 // override `get` are observed.  When the lookup yields
                 // PY_NULL we fall back to `space.w_None` per the
                 // upstream attribute-not-found branch.
                 let name_key = pyre_object::w_str_new("__name__");
-                let result = crate::baseobjspace::call_method(w_globals_obj, "get", &[name_key]);
+                let result = crate::baseobjspace::call_method(w_globals, "get", &[name_key]);
                 function_write_barrier(obj);
                 (*func).w_module = if result.is_null() {
                     pyre_object::w_none()
@@ -2121,7 +2121,7 @@ fn _flat_pycall(
 ) -> PyObjectRef {
     // call.rs:423-424 parity — increment call depth for JIT depth tracking.
     let _depth_guard = crate::call::increment_call_depth();
-    let w_globals_obj = unsafe { function_get_globals_obj(func) };
+    let w_globals = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
 
     // function.py:208-209 — createframe(code, w_func_globals, self)
@@ -2133,7 +2133,7 @@ fn _flat_pycall(
             code,
             &[], // locals filled below directly from stack
             std::ptr::null_mut(),
-            w_globals_obj,
+            w_globals,
             frame.execution_context,
             closure,
         ) {
@@ -2195,7 +2195,7 @@ fn _flat_pycall_defaults(
     dropvalues: usize,
 ) -> PyObjectRef {
     let _depth_guard = crate::call::increment_call_depth();
-    let w_globals_obj = unsafe { function_get_globals_obj(func) };
+    let w_globals = unsafe { function_get_globals_obj(func) };
     let closure = unsafe { function_get_closure(func) };
 
     // FrameBox: header-bearing heap frame for the JIT write barrier.
@@ -2204,7 +2204,7 @@ fn _flat_pycall_defaults(
             code,
             &[], // locals filled below
             std::ptr::null_mut(),
-            w_globals_obj,
+            w_globals,
             frame.execution_context,
             closure,
         ) {
@@ -2270,14 +2270,14 @@ mod tests {
         let raw_code = 0xDEAD_BEEF as *const ();
         let w_code = crate::w_code_new(raw_code);
         let mut ns = DictStorage::new();
-        let w_globals_obj = crate::baseobjspace::dict_storage_to_dict(&mut ns as *mut DictStorage);
-        let obj = function_new(w_code as *const (), "myfunc".to_string(), w_globals_obj);
+        let w_globals = crate::baseobjspace::dict_storage_to_dict(&mut ns as *mut DictStorage);
+        let obj = function_new(w_code as *const (), "myfunc".to_string(), w_globals);
         unsafe {
             assert!(is_function(obj));
             assert!(!is_int(obj));
             assert_eq!(function_get_code(obj), w_code as *const ());
             assert_eq!(function_get_name(obj), "myfunc");
-            assert_eq!(function_get_globals_obj(obj), w_globals_obj);
+            assert_eq!(function_get_globals_obj(obj), w_globals);
             assert!(function_get_closure(obj).is_null());
         }
     }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -834,7 +834,7 @@ pub fn remove_sys_module(name: &str) {
 /// module-level list / instance — would otherwise be read back stale
 /// after a collection relocates it.  Treat each loaded module's dict as
 /// a pinned root source so those slots stay forwarded.  This complements
-/// the per-frame `w_globals_obj` walk in `eval::walk_pyframe_roots`,
+/// the per-frame `w_globals` walk in `eval::walk_pyframe_roots`,
 /// which additionally covers `exec`/`eval` globals dicts that are not
 /// registered in `sys.modules`.
 ///

--- a/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
+++ b/pyre/pyre-interpreter/src/module/sys/interp_sys.rs
@@ -73,19 +73,19 @@ fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
         // `f_locals` by running `fast2locals()` and exposing the
         // resulting `debugdata.w_locals` dict.
         let w_locals_obj = frame_ref.getdictscope_w().unwrap_or(pyre_object::PY_NULL);
-        // pyframe.py:128 get_w_globals returns the globals dict object.  The
-        // canonical `w_globals_obj` is seeded by every frame constructor and
+        // pyframe.py:128 get_w_globals_storage returns the globals dict object.  The
+        // canonical `w_globals` is seeded by every frame constructor and
         // is the source of truth for the frame's globals.
-        let w_globals_obj = frame_ref.get_w_globals_obj();
+        let w_globals = frame_ref.get_w_globals();
         let pycode = frame_ref.pycode as pyre_object::PyObjectRef;
         let lineno = frame_ref.fget_f_lineno() as i64;
         let _ = crate::baseobjspace::setattr_str(
             stub,
             "f_globals",
-            if w_globals_obj.is_null() {
+            if w_globals.is_null() {
                 pyre_object::w_none()
             } else {
-                w_globals_obj
+                w_globals
             },
         );
         let _ = crate::baseobjspace::setattr_str(

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -40,14 +40,11 @@ pub struct W_CodeObject {
     pub ob_header: PyObject,
     /// Opaque pointer to a `CodeObject` (owned via Box::into_raw).
     pub code_ptr: *const (),
-    /// PyPy: `PyCode.w_globals`.
-    pub w_globals: *mut crate::DictStorage,
-    /// The globals dict OBJECT (`W_DictMultiObject`) — PyPy's `PyCode.w_globals`
-    /// IS the wrapped dict object (`pycode.py:105 "w_globals?"`). Pyre keeps
-    /// `w_globals` as the off-GC proxy `DictStorage`; this holds the canonical
-    /// object (`dict_storage_to_dict(w_globals)`, a `malloc_typed`-immortal
-    /// wrapper), stamped alongside the proxy. The JIT codewriter/bridge read
-    /// this so the off-GC proxy can be retired. Null until first stamped.
+    /// PyPy: `PyCode.w_globals` — the globals dict OBJECT (`W_DictMultiObject`,
+    /// `pycode.py:105 "w_globals?"`).  A `malloc_typed`-immortal wrapper, so
+    /// the pointer never moves.  Null until first stamped by
+    /// `frame_stores_global`.  (Named `w_globals_obj` while the legacy raw
+    /// `DictStorage` storage is recovered on demand via `w_globals_obj_storage`.)
     pub w_globals_obj: PyObjectRef,
     /// PyPy: `PyCode.hidden_applevel` (`pycode.py:111, 147`). Set by
     /// `pycompiler.compile(hidden_applevel=True)` for PyPy gateway/
@@ -94,8 +91,6 @@ pub struct W_CodeObject {
 
 /// Field offset of `code_ptr` within `W_CodeObject`.
 pub const CODE_PTR_OFFSET: usize = std::mem::offset_of!(W_CodeObject, code_ptr);
-/// Field offset of `w_globals` within `W_CodeObject`.
-pub const CODE_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(W_CodeObject, w_globals);
 
 /// GC type id assigned to `W_CodeObject`.
 ///
@@ -230,7 +225,6 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
             w_class: pyre_object::pyobject::get_instantiate(&CODE_TYPE),
         },
         code_ptr,
-        w_globals: std::ptr::null_mut(),
         w_globals_obj: pyre_object::PY_NULL,
         hidden_applevel,
         fast_natural_arity,
@@ -339,10 +333,9 @@ pub unsafe fn w_code_hidden_applevel(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const W_CodeObject)).hidden_applevel }
 }
 
-/// The globals dict OBJECT stamped alongside `w_globals`. PyPy's
-/// `PyCode.w_globals` IS this object; pyre keeps the proxy in `w_globals` and
-/// the canonical object here so the JIT codewriter/bridge can read globals
-/// without the off-GC proxy.
+/// PyPy: `PyCode.w_globals` — the globals dict OBJECT. The JIT
+/// codewriter/bridge read this to fold globals lookups without an off-GC
+/// proxy.
 #[inline]
 pub unsafe fn w_code_get_w_globals_obj(obj: PyObjectRef) -> PyObjectRef {
     if obj.is_null() {
@@ -351,45 +344,29 @@ pub unsafe fn w_code_get_w_globals_obj(obj: PyObjectRef) -> PyObjectRef {
     unsafe { (*(obj as *const W_CodeObject)).w_globals_obj }
 }
 
-/// Stamp `code.w_globals_obj` from the proxy `w_globals` (its `mirror_target`
-/// object via `dict_storage_to_dict`) when not already set. The wrapper is a
-/// `malloc_typed`-immortal object, so the stamped pointer never moves.
-#[inline]
-unsafe fn stamp_w_globals_obj(code: &mut W_CodeObject, w_globals: *mut crate::DictStorage) {
-    if code.w_globals_obj.is_null() && !w_globals.is_null() {
-        code.w_globals_obj = crate::baseobjspace::dict_storage_to_dict(w_globals);
-    }
-}
-
 /// PyPy: `PyCode.w_globals = w_globals`.
 #[inline]
-pub unsafe fn w_code_set_w_globals(obj: PyObjectRef, w_globals: *mut crate::DictStorage) {
+pub unsafe fn w_code_set_w_globals_obj(obj: PyObjectRef, w_globals_obj: PyObjectRef) {
     if obj.is_null() {
         return;
     }
     unsafe {
-        let code = &mut *(obj as *mut W_CodeObject);
-        code.w_globals = w_globals;
-        stamp_w_globals_obj(code, w_globals);
+        (*(obj as *mut W_CodeObject)).w_globals_obj = w_globals_obj;
     }
 }
 
 /// PyPy: `PyCode.frame_stores_global(w_globals)`.
 #[inline]
-pub unsafe fn w_code_frame_stores_global(
-    obj: PyObjectRef,
-    w_globals: *mut crate::DictStorage,
-) -> bool {
+pub unsafe fn w_code_frame_stores_global(obj: PyObjectRef, w_globals_obj: PyObjectRef) -> bool {
     if obj.is_null() {
         return false;
     }
     let code = unsafe { &mut *(obj as *mut W_CodeObject) };
-    if code.w_globals.is_null() {
-        code.w_globals = w_globals;
-        unsafe { stamp_w_globals_obj(code, w_globals) };
+    if code.w_globals_obj.is_null() {
+        code.w_globals_obj = w_globals_obj;
         return false;
     }
-    !std::ptr::eq(code.w_globals, w_globals)
+    !std::ptr::eq(code.w_globals_obj, w_globals_obj)
 }
 
 /// pycode.py:226-238 `_compute_flatcall`.

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -339,15 +339,6 @@ pub unsafe fn w_code_hidden_applevel(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const W_CodeObject)).hidden_applevel }
 }
 
-/// PyPy: `PyCode.w_globals`.
-#[inline]
-pub unsafe fn w_code_get_w_globals(obj: PyObjectRef) -> *mut crate::DictStorage {
-    if obj.is_null() {
-        return std::ptr::null_mut();
-    }
-    unsafe { (*(obj as *const W_CodeObject)).w_globals }
-}
-
 /// The globals dict OBJECT stamped alongside `w_globals`. PyPy's
 /// `PyCode.w_globals` IS this object; pyre keeps the proxy in `w_globals` and
 /// the canonical object here so the JIT codewriter/bridge can read globals

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -42,6 +42,13 @@ pub struct W_CodeObject {
     pub code_ptr: *const (),
     /// PyPy: `PyCode.w_globals`.
     pub w_globals: *mut crate::DictStorage,
+    /// The globals dict OBJECT (`W_DictMultiObject`) — PyPy's `PyCode.w_globals`
+    /// IS the wrapped dict object (`pycode.py:105 "w_globals?"`). Pyre keeps
+    /// `w_globals` as the off-GC proxy `DictStorage`; this holds the canonical
+    /// object (`dict_storage_to_dict(w_globals)`, a `malloc_typed`-immortal
+    /// wrapper), stamped alongside the proxy. The JIT codewriter/bridge read
+    /// this so the off-GC proxy can be retired. Null until first stamped.
+    pub w_globals_obj: PyObjectRef,
     /// PyPy: `PyCode.hidden_applevel` (`pycode.py:111, 147`). Set by
     /// `pycompiler.compile(hidden_applevel=True)` for PyPy gateway/
     /// app_main bridge code.  Pyre has no such call site yet, so this
@@ -224,6 +231,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         },
         code_ptr,
         w_globals: std::ptr::null_mut(),
+        w_globals_obj: pyre_object::PY_NULL,
         hidden_applevel,
         fast_natural_arity,
         globals_caches,
@@ -340,6 +348,28 @@ pub unsafe fn w_code_get_w_globals(obj: PyObjectRef) -> *mut crate::DictStorage 
     unsafe { (*(obj as *const W_CodeObject)).w_globals }
 }
 
+/// The globals dict OBJECT stamped alongside `w_globals`. PyPy's
+/// `PyCode.w_globals` IS this object; pyre keeps the proxy in `w_globals` and
+/// the canonical object here so the JIT codewriter/bridge can read globals
+/// without the off-GC proxy.
+#[inline]
+pub unsafe fn w_code_get_w_globals_obj(obj: PyObjectRef) -> PyObjectRef {
+    if obj.is_null() {
+        return pyre_object::PY_NULL;
+    }
+    unsafe { (*(obj as *const W_CodeObject)).w_globals_obj }
+}
+
+/// Stamp `code.w_globals_obj` from the proxy `w_globals` (its `mirror_target`
+/// object via `dict_storage_to_dict`) when not already set. The wrapper is a
+/// `malloc_typed`-immortal object, so the stamped pointer never moves.
+#[inline]
+unsafe fn stamp_w_globals_obj(code: &mut W_CodeObject, w_globals: *mut crate::DictStorage) {
+    if code.w_globals_obj.is_null() && !w_globals.is_null() {
+        code.w_globals_obj = crate::baseobjspace::dict_storage_to_dict(w_globals);
+    }
+}
+
 /// PyPy: `PyCode.w_globals = w_globals`.
 #[inline]
 pub unsafe fn w_code_set_w_globals(obj: PyObjectRef, w_globals: *mut crate::DictStorage) {
@@ -347,7 +377,9 @@ pub unsafe fn w_code_set_w_globals(obj: PyObjectRef, w_globals: *mut crate::Dict
         return;
     }
     unsafe {
-        (*(obj as *mut W_CodeObject)).w_globals = w_globals;
+        let code = &mut *(obj as *mut W_CodeObject);
+        code.w_globals = w_globals;
+        stamp_w_globals_obj(code, w_globals);
     }
 }
 
@@ -363,6 +395,7 @@ pub unsafe fn w_code_frame_stores_global(
     let code = unsafe { &mut *(obj as *mut W_CodeObject) };
     if code.w_globals.is_null() {
         code.w_globals = w_globals;
+        unsafe { stamp_w_globals_obj(code, w_globals) };
         return false;
     }
     !std::ptr::eq(code.w_globals, w_globals)

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -43,9 +43,9 @@ pub struct W_CodeObject {
     /// PyPy: `PyCode.w_globals` — the globals dict OBJECT (`W_DictMultiObject`,
     /// `pycode.py:105 "w_globals?"`).  A `malloc_typed`-immortal wrapper, so
     /// the pointer never moves.  Null until first stamped by
-    /// `frame_stores_global`.  (Named `w_globals_obj` while the legacy raw
-    /// `DictStorage` storage is recovered on demand via `w_globals_obj_storage`.)
-    pub w_globals_obj: PyObjectRef,
+    /// `frame_stores_global`.  The off-GC `DictStorage` storage is recovered
+    /// on demand via `w_globals_storage`.
+    pub w_globals: PyObjectRef,
     /// PyPy: `PyCode.hidden_applevel` (`pycode.py:111, 147`). Set by
     /// `pycompiler.compile(hidden_applevel=True)` for PyPy gateway/
     /// app_main bridge code.  Pyre has no such call site yet, so this
@@ -225,7 +225,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
             w_class: pyre_object::pyobject::get_instantiate(&CODE_TYPE),
         },
         code_ptr,
-        w_globals_obj: pyre_object::PY_NULL,
+        w_globals: pyre_object::PY_NULL,
         hidden_applevel,
         fast_natural_arity,
         globals_caches,
@@ -337,36 +337,36 @@ pub unsafe fn w_code_hidden_applevel(obj: PyObjectRef) -> bool {
 /// codewriter/bridge read this to fold globals lookups without an off-GC
 /// proxy.
 #[inline]
-pub unsafe fn w_code_get_w_globals_obj(obj: PyObjectRef) -> PyObjectRef {
+pub unsafe fn w_code_get_w_globals(obj: PyObjectRef) -> PyObjectRef {
     if obj.is_null() {
         return pyre_object::PY_NULL;
     }
-    unsafe { (*(obj as *const W_CodeObject)).w_globals_obj }
+    unsafe { (*(obj as *const W_CodeObject)).w_globals }
 }
 
 /// PyPy: `PyCode.w_globals = w_globals`.
 #[inline]
-pub unsafe fn w_code_set_w_globals_obj(obj: PyObjectRef, w_globals_obj: PyObjectRef) {
+pub unsafe fn w_code_set_w_globals(obj: PyObjectRef, w_globals: PyObjectRef) {
     if obj.is_null() {
         return;
     }
     unsafe {
-        (*(obj as *mut W_CodeObject)).w_globals_obj = w_globals_obj;
+        (*(obj as *mut W_CodeObject)).w_globals = w_globals;
     }
 }
 
 /// PyPy: `PyCode.frame_stores_global(w_globals)`.
 #[inline]
-pub unsafe fn w_code_frame_stores_global(obj: PyObjectRef, w_globals_obj: PyObjectRef) -> bool {
+pub unsafe fn w_code_frame_stores_global(obj: PyObjectRef, w_globals: PyObjectRef) -> bool {
     if obj.is_null() {
         return false;
     }
     let code = unsafe { &mut *(obj as *mut W_CodeObject) };
-    if code.w_globals_obj.is_null() {
-        code.w_globals_obj = w_globals_obj;
+    if code.w_globals.is_null() {
+        code.w_globals = w_globals;
         return false;
     }
-    !std::ptr::eq(code.w_globals_obj, w_globals_obj)
+    !std::ptr::eq(code.w_globals, w_globals)
 }
 
 /// pycode.py:226-238 `_compute_flatcall`.

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -927,12 +927,6 @@ impl PyFrame {
             clear_debugdata_ptr(&mut self.debugdata);
             clear_block_chain(&mut self.lastblock);
         }
-        // pyframe.py:103 — stamp `pycode.w_globals` (the first-globals cache
-        // the LOAD_GLOBAL fast path keys on); side effect only, since the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`.
-        unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
-        }
         // `pyframe.py:114-115` — `self.builtin = space.builtin.pick_builtin(
         // w_globals)`.  pyre keeps the picked builtin and the canonical
         // `w_globals` W_DictObject (the `get_w_globals` resolution of
@@ -946,6 +940,12 @@ impl PyFrame {
         } else {
             crate::baseobjspace::dict_storage_to_dict(w_globals)
         };
+        // pyframe.py:103 — stamp `pycode.w_globals` (the first-globals cache
+        // the LOAD_GLOBAL fast path keys on); side effect only, since the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`.
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, self.w_globals_obj);
+        }
         // pyframe.py:118 — final step of __init__.
         self.initialize_frame_scopes(outer_func, code).expect(
             "PyFrame::__init__: initialize_frame_scopes raised — caller should use createframe",
@@ -1161,11 +1161,6 @@ impl PyFrame {
         let nlocals = unsafe { (&*raw).varnames.len() };
         let ncells = unsafe { ncells(&*raw) };
         let size = nlocals + ncells + 16; // small stack
-        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`).
-        unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
-        }
         let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
         // `pyframe.py:98 __init__(self, space, code, w_globals, ...)`
         // stores `w_globals` as the canonical W_DictObject directly.
@@ -1178,6 +1173,11 @@ impl PyFrame {
         } else {
             crate::baseobjspace::dict_storage_to_dict(w_globals)
         };
+        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
+        }
         let mut frame = PyFrame {
             execution_context,
             pycode: code,
@@ -1254,7 +1254,10 @@ impl PyFrame {
         let code_ptr = Box::into_raw(Box::new(code));
         let w_code = crate::w_code_new(code_ptr as *const ());
         unsafe {
-            crate::w_code_set_w_globals(w_code, w_globals);
+            crate::w_code_set_w_globals_obj(
+                w_code,
+                crate::baseobjspace::dict_storage_to_dict(w_globals),
+            );
         }
         let ctx_ptr = Rc::into_raw(execution_context);
         crate::createframe(w_code as *const (), w_globals, ctx_ptr, None)
@@ -1277,11 +1280,6 @@ impl PyFrame {
         let num_cells = ncells(code_ref);
         let max_stack = code_ref.max_stackdepth as usize;
 
-        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`).
-        unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
-        }
         let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
         // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores
         // the W_DictObject directly; eager `dict_storage_to_dict`
@@ -1291,6 +1289,11 @@ impl PyFrame {
         } else {
             crate::baseobjspace::dict_storage_to_dict(w_globals)
         };
+        // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
+        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        unsafe {
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
+        }
         let mut frame = PyFrame {
             execution_context,
             pycode: code,
@@ -2396,7 +2399,6 @@ impl PyFrame {
         Ok(Self::finish_for_call_with_globals_obj(
             code,
             args,
-            globals,
             w_globals_obj,
             execution_context,
             closure,
@@ -2431,7 +2433,6 @@ impl PyFrame {
         Self::finish_for_call_with_globals_obj(
             code,
             args,
-            globals,
             w_globals_obj,
             execution_context,
             closure,
@@ -2445,23 +2446,11 @@ impl PyFrame {
     fn finish_for_call_with_globals_obj(
         code: *const (),
         args: &[PyObjectRef],
-        globals: *mut DictStorage,
         w_globals_obj: PyObjectRef,
         execution_context: *const PyExecutionContext,
         closure: PyObjectRef,
         w_builtin: PyObjectRef,
     ) -> Self {
-        // Recover the legacy raw storage from the object (the `mirror_target`
-        // inverse of `dict_storage_to_dict`) so the `frame_stores_global`
-        // stamp and the debug-data snapshot see the canonical storage even
-        // when the caller threads a null raw (obj-only functions, e.g.
-        // MAKE_FUNCTION).  A null `w_globals_obj` (test stubs) keeps the
-        // passed raw.
-        let globals = if w_globals_obj.is_null() {
-            globals
-        } else {
-            unsafe { pyre_object::w_dict_get_dict_storage_proxy(w_globals_obj) as *mut DictStorage }
-        };
         let code_ref = unsafe {
             &*(crate::w_code_get_ptr(code as pyre_object::PyObjectRef) as *const CodeObject)
         };
@@ -2505,7 +2494,7 @@ impl PyFrame {
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
         // gated debugdata snapshot retired in favour of `w_globals_obj`).
         unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, globals);
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
         }
 
         let mut frame = PyFrame {
@@ -2809,13 +2798,10 @@ pub fn createframe_obj(
     let num_locals = code_ref.varnames.len();
     let num_cells = ncells(code_ref);
     let max_stack = code_ref.max_stackdepth as usize;
-    // The `frame_stores_global` check and the debug-data snapshot still read
-    // the raw storage; recover it from the object via the proxy back-link.
-    let w_globals = w_globals_obj_storage(w_globals_obj);
     // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the gated
     // debugdata snapshot retired in favour of `w_globals_obj`).
     unsafe {
-        crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
+        crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
     }
 
     let size = num_locals + num_cells + max_stack;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -118,11 +118,11 @@ pub struct PyFrame {
     /// constructor (or threaded through directly by the obj-taking
     /// constructors), so every reader after construction observes the same
     /// W_DictObject across the frame's lifetime.  This is the source of
-    /// truth: `get_w_globals_obj()` returns it directly and
-    /// `get_w_globals()` recovers the raw storage from it via
+    /// truth: `get_w_globals()` returns it directly and
+    /// `get_w_globals_storage()` recovers the raw storage from it via
     /// `w_dict_get_dict_storage_proxy`.  Synthetic test stubs that
     /// hand-build PyFrame without a real globals leave it `PY_NULL`.
-    pub w_globals_obj: PyObjectRef,
+    pub w_globals: PyObjectRef,
 }
 
 /// GC type id for `PyFrame`. Reserved ahead of any callsite that allocates
@@ -516,7 +516,7 @@ pub struct FrameDebugData {
 impl FrameDebugData {
     // `_pycode` keeps the constructor shape of `pyframe.py:48
     // FrameDebugData.__init__(self, pycode, init_lineno)`.  The frame's
-    // globals object now lives in `PyFrame.w_globals_obj`, so debugdata no
+    // globals object now lives in `PyFrame.w_globals`, so debugdata no
     // longer snapshots `pycode.w_globals`.
     pub fn new(_pycode: *const (), init_lineno: isize) -> Self {
         Self {
@@ -646,12 +646,12 @@ pub const PYFRAME_F_BACKREF_OFFSET: usize = std::mem::offset_of!(PyFrame, f_back
 /// guard exit / re-entry edge.
 pub const PYFRAME_W_BUILTIN_OFFSET: usize = std::mem::offset_of!(PyFrame, w_builtin);
 
-/// Byte offset of `w_globals_obj` in `PyFrame` — the canonical
+/// Byte offset of `w_globals` in `PyFrame` — the canonical
 /// W_DictObject paired with the storage in `w_globals`.  Registered
 /// as a GC-traceable slot so a minor collection forwards the pointer
 /// when the dict survives.  The slot is lazy: `PY_NULL` until
-/// `get_w_globals_obj` resolves it.
-pub const PYFRAME_W_GLOBALS_OBJ_OFFSET: usize = std::mem::offset_of!(PyFrame, w_globals_obj);
+/// `get_w_globals` resolves it.
+pub const PYFRAME_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(PyFrame, w_globals);
 
 // Backward-compat aliases used by JIT code.
 pub const PYFRAME_STACK_DEPTH_OFFSET: usize = PYFRAME_VALUESTACKDEPTH_OFFSET;
@@ -827,20 +827,20 @@ impl PyFrame {
         self.code()
     }
 
-    /// pyframe.py:129-133 get_w_globals — the raw `*mut DictStorage`
+    /// pyframe.py:129-133 get_w_globals_storage — the raw `*mut DictStorage`
     /// backing this frame's globals.  `pyframe.py:49 self.w_globals =
     /// w_globals` keeps the canonical W_DictObject as the single field;
-    /// pyre's split layout makes `w_globals_obj` that source of truth and
+    /// pyre's split layout makes `w_globals` that source of truth and
     /// recovers the raw storage from it via `w_dict_get_dict_storage_proxy`
     /// (the inverse of `dict_storage_to_dict`).
     #[inline]
-    pub fn get_w_globals(&self) -> *mut DictStorage {
-        w_globals_obj_storage(self.w_globals_obj)
+    pub fn get_w_globals_storage(&self) -> *mut DictStorage {
+        w_globals_storage(self.w_globals)
     }
 
     /// The canonical W_DictObject for this frame's globals
     /// (`pyframe.py:49 self.w_globals = w_globals`).  Every frame
-    /// constructor seeds `w_globals_obj` eagerly, so this is a plain
+    /// constructor seeds `w_globals` eagerly, so this is a plain
     /// field read; callers wanting object identity
     /// (`function.__globals__ is frame.f_globals`, `globals() is
     /// module.__dict__`, etc.) read it directly.
@@ -848,8 +848,8 @@ impl PyFrame {
     /// Returns `PY_NULL` when the frame has no globals (test stubs);
     /// callers that expect a dict should null-check before dereferencing.
     #[inline]
-    pub fn get_w_globals_obj(&self) -> PyObjectRef {
-        self.w_globals_obj
+    pub fn get_w_globals(&self) -> PyObjectRef {
+        self.w_globals
     }
 
     /// pyframe.py:135 get_w_f_trace
@@ -902,7 +902,7 @@ impl PyFrame {
     pub fn __init__(
         &mut self,
         code: *const (),
-        w_globals: *mut DictStorage,
+        w_globals_storage: *mut DictStorage,
         outer_func: PyObjectRef,
     ) {
         let _ = outer_func;
@@ -929,22 +929,23 @@ impl PyFrame {
         }
         // `pyframe.py:114-115` — `self.builtin = space.builtin.pick_builtin(
         // w_globals)`.  pyre keeps the picked builtin and the canonical
-        // `w_globals` W_DictObject (the `get_w_globals` resolution of
-        // `pyframe.py:128-132`) in the adjacent `w_builtin` / `w_globals_obj`
+        // `w_globals` W_DictObject (the `get_w_globals_storage` resolution of
+        // `pyframe.py:128-132`) in the adjacent `w_builtin` / `w_globals`
         // slots, resolved eagerly here exactly as `new_minimal` does, so a
         // frame built through this hook is left in the same state as one
         // built by `createframe`.
-        self.w_builtin = crate::baseobjspace::frame_builtin(w_globals, self.execution_context);
-        self.w_globals_obj = if w_globals.is_null() {
+        self.w_builtin =
+            crate::baseobjspace::frame_builtin(w_globals_storage, self.execution_context);
+        self.w_globals = if w_globals_storage.is_null() {
             PY_NULL
         } else {
-            crate::baseobjspace::dict_storage_to_dict(w_globals)
+            crate::baseobjspace::dict_storage_to_dict(w_globals_storage)
         };
         // pyframe.py:103 — stamp `pycode.w_globals` (the first-globals cache
         // the LOAD_GLOBAL fast path keys on); side effect only, since the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`.
+        // gated debugdata snapshot retired in favour of `w_globals`.
         unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, self.w_globals_obj);
+            crate::w_code_frame_stores_global(code as PyObjectRef, self.w_globals);
         }
         // pyframe.py:118 — final step of __init__.
         self.initialize_frame_scopes(outer_func, code).expect(
@@ -973,10 +974,10 @@ impl PyFrame {
         self.getdictscope()
     }
 
-    /// PyPy-compatible `fget_w_globals`.
+    /// PyPy-compatible `fget_w_globals_storage`.
     #[inline]
-    pub fn fget_w_globals(&self) -> *mut DictStorage {
-        self.get_w_globals()
+    pub fn fget_w_globals_storage(&self) -> *mut DictStorage {
+        self.get_w_globals_storage()
     }
 
     /// PyPy-compatible `_getcell`.
@@ -1014,7 +1015,7 @@ impl PyFrame {
             let w_locals = if flags.contains(CodeFlags::NEWLOCALS) {
                 pyre_object::lltype::malloc_raw(DictStorage::new())
             } else {
-                self.get_w_globals()
+                self.get_w_globals_storage()
             };
             self.getorcreate_debug_data(-1).w_locals = w_locals;
         }
@@ -1153,7 +1154,7 @@ impl PyFrame {
     /// Used by MIFrame Box tracking when concrete_frame is unavailable.
     pub fn new_minimal(
         code: *const (),
-        w_globals: *mut crate::DictStorage,
+        w_globals_storage: *mut crate::DictStorage,
         execution_context: *const PyExecutionContext,
     ) -> Self {
         let raw =
@@ -1161,22 +1162,22 @@ impl PyFrame {
         let nlocals = unsafe { (&*raw).varnames.len() };
         let ncells = unsafe { ncells(&*raw) };
         let size = nlocals + ncells + 16; // small stack
-        let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
+        let w_builtin = crate::baseobjspace::frame_builtin(w_globals_storage, execution_context);
         // `pyframe.py:98 __init__(self, space, code, w_globals, ...)`
         // stores `w_globals` as the canonical W_DictObject directly.
-        // Pyre carries both the raw storage pointer (`w_globals`) and
-        // the W_DictObject (`w_globals_obj`); eager resolution at
+        // Pyre carries both the raw storage pointer (`w_globals_storage`) and
+        // the W_DictObject (`w_globals`); eager resolution at
         // frame construction matches PyPy's `self.w_globals = w_globals`
         // identity invariant without waiting for the first reader.
-        let w_globals_obj = if w_globals.is_null() {
+        let w_globals = if w_globals_storage.is_null() {
             PY_NULL
         } else {
-            crate::baseobjspace::dict_storage_to_dict(w_globals)
+            crate::baseobjspace::dict_storage_to_dict(w_globals_storage)
         };
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
         }
         let mut frame = PyFrame {
             execution_context,
@@ -1195,7 +1196,7 @@ impl PyFrame {
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
             w_builtin,
-            w_globals_obj,
+            w_globals,
         };
         frame
     }
@@ -1254,7 +1255,7 @@ impl PyFrame {
         let code_ptr = Box::into_raw(Box::new(code));
         let w_code = crate::w_code_new(code_ptr as *const ());
         unsafe {
-            crate::w_code_set_w_globals_obj(
+            crate::w_code_set_w_globals(
                 w_code,
                 crate::baseobjspace::dict_storage_to_dict(w_globals),
             );
@@ -1271,7 +1272,7 @@ impl PyFrame {
     pub(crate) fn new_with_namespace(
         code: *const (),
         execution_context: *const PyExecutionContext,
-        w_globals: *mut DictStorage,
+        w_globals_storage: *mut DictStorage,
     ) -> Self {
         let raw =
             unsafe { crate::w_code_get_ptr(code as pyre_object::PyObjectRef) as *const CodeObject };
@@ -1280,19 +1281,19 @@ impl PyFrame {
         let num_cells = ncells(code_ref);
         let max_stack = code_ref.max_stackdepth as usize;
 
-        let w_builtin = crate::baseobjspace::frame_builtin(w_globals, execution_context);
+        let w_builtin = crate::baseobjspace::frame_builtin(w_globals_storage, execution_context);
         // `pyframe.py:98 __init__` — `self.w_globals = w_globals` stores
         // the W_DictObject directly; eager `dict_storage_to_dict`
         // mirrors the identity invariant on pyre's split layout.
-        let w_globals_obj = if w_globals.is_null() {
+        let w_globals = if w_globals_storage.is_null() {
             PY_NULL
         } else {
-            crate::baseobjspace::dict_storage_to_dict(w_globals)
+            crate::baseobjspace::dict_storage_to_dict(w_globals_storage)
         };
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
         }
         let mut frame = PyFrame {
             execution_context,
@@ -1311,7 +1312,7 @@ impl PyFrame {
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
             w_builtin,
-            w_globals_obj,
+            w_globals,
         };
         // Module-level w_locals = w_globals binding flows naturally
         // through `createframe → initialize_frame_scopes` since RustPython
@@ -1319,7 +1320,7 @@ impl PyFrame {
         // (pyframe.py:233-235).  This constructor bypasses
         // initialize_frame_scopes, so still bind w_locals to w_globals
         // explicitly to match what `createframe` would observe.
-        frame.getorcreate_debug_data(-1).w_locals = w_globals;
+        frame.getorcreate_debug_data(-1).w_locals = w_globals_storage;
         frame
     }
 
@@ -1331,7 +1332,7 @@ impl PyFrame {
     pub fn snapshot_for_tracing(&self) -> FrameBox {
         // Frame-LOCAL state (locals_cells_stack_w / valuestackdepth / last_instr)
         // is COPIED, so snapshot mutations to locals/stack are discarded — that
-        // is the abort-safety the snapshot exists for.  But `w_globals_obj`
+        // is the abort-safety the snapshot exists for.  But `w_globals`
         // (below) is the SAME dict ptr: SHARED-heap mutations during recording
         // (inline-frame STORE_GLOBAL via `concrete_execute_step`) leak to the
         // real heap and are re-applied by the compiled loop's re-run.  This is
@@ -1352,7 +1353,7 @@ impl PyFrame {
             w_yielding_from: self.w_yielding_from,
             f_backref: self.f_backref,
             w_builtin: self.w_builtin,
-            w_globals_obj: self.w_globals_obj,
+            w_globals: self.w_globals,
         });
         // fix_array_ptrs AFTER Box allocation: inline_buf ptr must
         // point to the heap-allocated frame, not a stale stack address.
@@ -2343,14 +2344,14 @@ impl PyFrame {
         code: *const (),
         args: &[PyObjectRef],
         globals: *mut DictStorage,
-        w_globals_obj: PyObjectRef,
+        w_globals: PyObjectRef,
         execution_context: *const PyExecutionContext,
     ) -> Self {
         Self::new_for_call_with_closure_and_globals_obj(
             code,
             args,
             globals,
-            w_globals_obj,
+            w_globals,
             execution_context,
             PY_NULL,
         )
@@ -2364,7 +2365,7 @@ impl PyFrame {
         execution_context: *const PyExecutionContext,
         closure: PyObjectRef,
     ) -> Self {
-        let w_globals_obj = if globals.is_null() {
+        let w_globals = if globals.is_null() {
             PY_NULL
         } else {
             crate::baseobjspace::dict_storage_to_dict(globals)
@@ -2373,7 +2374,7 @@ impl PyFrame {
             code,
             args,
             globals,
-            w_globals_obj,
+            w_globals,
             execution_context,
             closure,
         )
@@ -2387,19 +2388,19 @@ impl PyFrame {
         code: *const (),
         args: &[PyObjectRef],
         globals: *mut DictStorage,
-        w_globals_obj: PyObjectRef,
+        w_globals: PyObjectRef,
         execution_context: *const PyExecutionContext,
         closure: PyObjectRef,
     ) -> Result<Self, crate::PyError> {
-        let w_builtin = if w_globals_obj.is_null() {
+        let w_builtin = if w_globals.is_null() {
             crate::baseobjspace::frame_builtin(globals, execution_context)
         } else {
-            crate::baseobjspace::frame_builtin_obj_checked(w_globals_obj, execution_context)?
+            crate::baseobjspace::frame_builtin_obj_checked(w_globals, execution_context)?
         };
         Ok(Self::finish_for_call_with_globals_obj(
             code,
             args,
-            w_globals_obj,
+            w_globals,
             execution_context,
             closure,
             w_builtin,
@@ -2421,19 +2422,19 @@ impl PyFrame {
         code: *const (),
         args: &[PyObjectRef],
         globals: *mut DictStorage,
-        w_globals_obj: PyObjectRef,
+        w_globals: PyObjectRef,
         execution_context: *const PyExecutionContext,
         closure: PyObjectRef,
     ) -> Self {
-        let w_builtin = if w_globals_obj.is_null() {
+        let w_builtin = if w_globals.is_null() {
             crate::baseobjspace::frame_builtin(globals, execution_context)
         } else {
-            crate::baseobjspace::frame_builtin_obj(w_globals_obj, execution_context)
+            crate::baseobjspace::frame_builtin_obj(w_globals, execution_context)
         };
         Self::finish_for_call_with_globals_obj(
             code,
             args,
-            w_globals_obj,
+            w_globals,
             execution_context,
             closure,
             w_builtin,
@@ -2446,7 +2447,7 @@ impl PyFrame {
     fn finish_for_call_with_globals_obj(
         code: *const (),
         args: &[PyObjectRef],
-        w_globals_obj: PyObjectRef,
+        w_globals: PyObjectRef,
         execution_context: *const PyExecutionContext,
         closure: PyObjectRef,
         w_builtin: PyObjectRef,
@@ -2492,9 +2493,9 @@ impl PyFrame {
         }
 
         // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the
-        // gated debugdata snapshot retired in favour of `w_globals_obj`).
+        // gated debugdata snapshot retired in favour of `w_globals`).
         unsafe {
-            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
+            crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
         }
 
         let mut frame = PyFrame {
@@ -2512,7 +2513,7 @@ impl PyFrame {
             w_yielding_from: PY_NULL,
             f_backref: std::ptr::null_mut(),
             w_builtin,
-            w_globals_obj,
+            w_globals,
         };
         frame.init_cells();
         frame
@@ -2742,12 +2743,12 @@ pub fn createframe(
     // and delegate to `createframe_obj`.  `dict_storage_to_dict` and
     // `w_dict_get_dict_storage_proxy` are mutual inverses under the
     // `mirror_target` invariant, so the round-trip preserves identity.
-    let w_globals_obj = if w_globals.is_null() {
+    let w_globals = if w_globals.is_null() {
         PY_NULL
     } else {
         crate::baseobjspace::dict_storage_to_dict(w_globals)
     };
-    createframe_obj(code, w_globals_obj, execution_context, outer_func)
+    createframe_obj(code, w_globals, execution_context, outer_func)
 }
 
 /// `baseobjspace.py:796 createframe` with the globals passed as the dict
@@ -2757,7 +2758,7 @@ pub fn createframe(
 /// FrameDebugData.w_globals snapshot, both of which retire in later steps.
 pub fn createframe_obj(
     code: *const (),
-    w_globals_obj: PyObjectRef,
+    w_globals: PyObjectRef,
     execution_context: *const PyExecutionContext,
     outer_func: Option<PyObjectRef>,
 ) -> Result<FrameBox, crate::PyError> {
@@ -2777,18 +2778,18 @@ pub fn createframe_obj(
     // Normalize a dict-subclass globals (`exec(src, G())`) to its inner
     // `__dict_data__` dict.  The storage proxy that LOAD_GLOBAL reads lives
     // on the `W_DictObject`, and downstream readers key off this object —
-    // `get_w_globals`, MAKE_FUNCTION's `function.__globals__`, and the JIT
+    // `get_w_globals_storage`, MAKE_FUNCTION's `function.__globals__`, and the JIT
     // inline / callee globals readers — so the frame must hold the
     // `W_DictObject`, not the subclass instance whose layout has no proxy
     // slot.  No-op for a plain dict / module dict (`resolve_dict_backing`
     // returns the argument).  Converges to holding the object directly when
     // the raw `DictStorage` proxy retires.
-    let w_globals_obj = if w_globals_obj.is_null() {
-        w_globals_obj
+    let w_globals = if w_globals.is_null() {
+        w_globals
     } else {
-        let backing = crate::type_methods::resolve_dict_backing(w_globals_obj);
+        let backing = crate::type_methods::resolve_dict_backing(w_globals);
         if backing.is_null() {
-            w_globals_obj
+            w_globals
         } else {
             backing
         }
@@ -2799,13 +2800,13 @@ pub fn createframe_obj(
     let num_cells = ncells(code_ref);
     let max_stack = code_ref.max_stackdepth as usize;
     // pyframe.py:103 — stamp `pycode.w_globals`; side effect only (the gated
-    // debugdata snapshot retired in favour of `w_globals_obj`).
+    // debugdata snapshot retired in favour of `w_globals`).
     unsafe {
-        crate::w_code_frame_stores_global(code as PyObjectRef, w_globals_obj);
+        crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
     }
 
     let size = num_locals + num_cells + max_stack;
-    let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals_obj, execution_context);
+    let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, execution_context);
     let mut frame = FrameBox::new(PyFrame {
         execution_context,
         pycode: code,
@@ -2821,7 +2822,7 @@ pub fn createframe_obj(
         w_yielding_from: PY_NULL,
         f_backref: std::ptr::null_mut(),
         w_builtin,
-        w_globals_obj,
+        w_globals,
     });
     // pyframe.py:119 — final step of __init__.  PY_NULL plays the role of
     // Python `None` per the existing `initialize_frame_scopes` convention
@@ -2846,11 +2847,11 @@ pub fn createframe_obj(
 /// a dict subclass to its inner `__dict_data__` dict first: the proxy lives
 /// on the `W_DictObject`, so reading it straight off the subclass instance
 /// would dereference an unrelated offset.
-pub(crate) fn w_globals_obj_storage(w_globals_obj: PyObjectRef) -> *mut DictStorage {
-    if w_globals_obj.is_null() {
+pub(crate) fn w_globals_storage(w_globals: PyObjectRef) -> *mut DictStorage {
+    if w_globals.is_null() {
         return std::ptr::null_mut();
     }
-    let backing = crate::type_methods::resolve_dict_backing(w_globals_obj);
+    let backing = crate::type_methods::resolve_dict_backing(w_globals);
     if backing.is_null() {
         return std::ptr::null_mut();
     }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -102,9 +102,7 @@ pub extern "C" fn jit_load_name_from_namespace(
     } else {
         std::ptr::null_mut()
     };
-    if !w_globals.is_null()
-        && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals) }
-    {
+    if !w_globals.is_null() && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals) } {
         if let Some(v) =
             unsafe { crate::eval::load_global_via_cache_extern(w_globals, w_builtin, name) }
         {
@@ -140,11 +138,7 @@ pub extern "C" fn jit_store_name_to_namespace(
     // dicts (cells) and plain dicts (exec/eval globals) uniformly.
     if !w_globals.is_null() {
         unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str(
-                w_globals,
-                name,
-                value as PyObjectRef,
-            );
+            pyre_object::dictmultiobject::w_dict_setitem_str(w_globals, name, value as PyObjectRef);
         }
     }
     0

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -18,11 +18,11 @@ use crate::{
 /// `pypy/interpreter/pyopcode.py:1457 MAKE_FUNCTION` stamps the new
 /// function's `w_func_globals = self.w_globals` directly from the
 /// running frame's dict object.  This entry point accepts the canonical
-/// PyObjectRef (`w_globals_obj`) so the freshly-created function inherits
+/// PyObjectRef (`w_globals`) so the freshly-created function inherits
 /// the frame's exact `__globals__` identity.
 pub fn make_function_from_code_obj_with_globals_obj(
     code_obj: PyObjectRef,
-    w_globals_obj: PyObjectRef,
+    w_globals: PyObjectRef,
 ) -> PyObjectRef {
     let code_ptr = unsafe { w_code_get_ptr(code_obj) };
     let code = unsafe { &*(code_ptr as *const crate::CodeObject) };
@@ -36,7 +36,7 @@ pub fn make_function_from_code_obj_with_globals_obj(
     let func = crate::function::function_new_with_closure(
         code_obj as *const (),
         code.obj_name.to_string(),
-        w_globals_obj,
+        w_globals,
         pyre_object::PY_NULL,
     );
     let qualname_obj = pyre_object::w_str_new(code.qualname.as_ref());
@@ -55,10 +55,10 @@ fn decode_name(name_ptr: i64, name_len: i64) -> Option<&'static str> {
 #[majit_macros::dont_look_inside]
 pub extern "C" fn jit_make_function_from_globals(globals: i64, code_obj: i64) -> i64 {
     // `globals` is the globals OBJECT (the JIT threads the vable
-    // `w_globals_obj` slot).  Capture it directly; the raw `*mut DictStorage`
+    // `w_globals` slot).  Capture it directly; the raw `*mut DictStorage`
     // is recovered from the object wherever a frame still needs it.
-    let w_globals_obj = globals as PyObjectRef;
-    make_function_from_code_obj_with_globals_obj(code_obj as PyObjectRef, w_globals_obj) as i64
+    let w_globals = globals as PyObjectRef;
+    make_function_from_code_obj_with_globals_obj(code_obj as PyObjectRef, w_globals) as i64
 }
 
 #[majit_macros::dont_look_inside]
@@ -68,19 +68,19 @@ pub extern "C" fn jit_load_name_from_namespace(
     name_ptr: i64,
     name_len: i64,
 ) -> i64 {
-    let w_globals_obj = namespace_ptr as PyObjectRef;
+    let w_globals = namespace_ptr as PyObjectRef;
     let Some(name) = decode_name(name_ptr, name_len) else {
         return 0;
     };
-    // `pyopcode.py:959 _load_global`: `space.finditem_str(get_w_globals(),
+    // `pyopcode.py:959 _load_global`: `space.finditem_str(get_w_globals_storage(),
     // varname)`.  Dispatch through the dict strategy on the object
     // (`dictmultiobject.py:113-115 getitem_str`) so module dicts
     // (celldict cells) and plain dicts (exec/eval globals) are both
     // handled without requiring a dict_storage_proxy.  Mirrors the
     // interpreter `load_global_value` (eval.rs).
-    if !w_globals_obj.is_null() {
+    if !w_globals.is_null() {
         if let Some(v) =
-            unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals_obj, name) }
+            unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(w_globals, name) }
         {
             return v as i64;
         }
@@ -102,11 +102,11 @@ pub extern "C" fn jit_load_name_from_namespace(
     } else {
         std::ptr::null_mut()
     };
-    if !w_globals_obj.is_null()
-        && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals_obj) }
+    if !w_globals.is_null()
+        && unsafe { pyre_object::dictmultiobject::is_module_dict(w_globals) }
     {
         if let Some(v) =
-            unsafe { crate::eval::load_global_via_cache_extern(w_globals_obj, w_builtin, name) }
+            unsafe { crate::eval::load_global_via_cache_extern(w_globals, w_builtin, name) }
         {
             return v as i64;
         }
@@ -130,18 +130,18 @@ pub extern "C" fn jit_store_name_to_namespace(
     name_len: i64,
     value: i64,
 ) -> i64 {
-    let w_globals_obj = namespace_ptr as PyObjectRef;
+    let w_globals = namespace_ptr as PyObjectRef;
     let Some(name) = decode_name(name_ptr, name_len) else {
         return 0;
     };
     // `celldict.py:332 STORE_GLOBAL_cached` (jitted): `space.setitem_str(
-    // get_w_globals(), varname, w_newvalue)`.  Strategy dispatch on the
+    // get_w_globals_storage(), varname, w_newvalue)`.  Strategy dispatch on the
     // object (`dictmultiobject.py:111-112 setitem_str`) handles module
     // dicts (cells) and plain dicts (exec/eval globals) uniformly.
-    if !w_globals_obj.is_null() {
+    if !w_globals.is_null() {
         unsafe {
             pyre_object::dictmultiobject::w_dict_setitem_str(
-                w_globals_obj,
+                w_globals,
                 name,
                 value as PyObjectRef,
             );

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1358,7 +1358,7 @@ static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
             ),
             (
                 "PyFrame.w_globals",
-                crate::frame_layout::PYFRAME_W_GLOBALS_OBJ_OFFSET,
+                crate::frame_layout::PYFRAME_W_GLOBALS_OFFSET,
                 8,
                 Type::Ref,
                 false,
@@ -1441,8 +1441,8 @@ static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
             // adjacent raw `PyFrame.w_globals` entry above and rename
             // this one to fully match PyPy's pyframe.py:49 shape.
             (
-                "PyFrame.w_globals_obj",
-                crate::frame_layout::PYFRAME_W_GLOBALS_OBJ_OFFSET,
+                "PyFrame.w_globals",
+                crate::frame_layout::PYFRAME_W_GLOBALS_OFFSET,
                 8,
                 Type::Ref,
                 false,
@@ -2218,8 +2218,8 @@ pub fn pyframe_dict_storage_descr() -> DescrRef {
     field_descr_from_group(&PYFRAME_DESCR_GROUP, 4)
 }
 
-/// R3.3b prep: canonical `PyFrame.w_globals_obj` slot
-/// (PYFRAME_W_GLOBALS_OBJ_OFFSET).  Used by
+/// R3.3b prep: canonical `PyFrame.w_globals` slot
+/// (PYFRAME_W_GLOBALS_OFFSET).  Used by
 /// `emit_new_pyframe_inline_self_recursive` to populate the
 /// W_DictObject sibling so trace-time chases observe a non-null
 /// PyObjectRef.  R3.3 cutover will fold `pyframe_dict_storage_descr`
@@ -2231,7 +2231,7 @@ pub fn pyframe_w_globals_obj_descr() -> DescrRef {
 /// R3.3-b: `W_ModuleDictObject.dict_storage_proxy` field — a raw
 /// `*mut DictStorage` pointer set during module init and stable
 /// for the object's lifetime.  Used by `frame_get_namespace` to
-/// chase from `w_globals_obj` (a W_ModuleDictObject) to the
+/// chase from `w_globals` (a W_ModuleDictObject) to the
 /// DictStorage that `load/store_namespace_value` reads.
 pub fn module_dict_storage_proxy_descr() -> DescrRef {
     make_immutable_field_descr(

--- a/pyre/pyre-jit-trace/src/frame_layout.rs
+++ b/pyre/pyre-jit-trace/src/frame_layout.rs
@@ -52,14 +52,14 @@ pub const PYFRAME_F_BACKREF_OFFSET: usize = std::mem::offset_of!(PyFrame, f_back
 /// pointer.
 pub const PYFRAME_W_BUILTIN_OFFSET: usize = std::mem::offset_of!(PyFrame, w_builtin);
 
-/// Byte offset of `w_globals_obj` in `PyFrame`.
+/// Byte offset of `w_globals` in `PyFrame`.
 ///
 /// Lazy-cached canonical W_DictObject sibling for `frame.w_globals`.
 /// The slot is a GCREF and must be visible to the descr / nursery GC
 /// walkers so the cached dict survives across minor collections; once
 /// populated it remains the same identity for the frame's lifetime
 /// (guaranteed by `dict_storage_to_dict`'s `mirror_target` invariant).
-pub const PYFRAME_W_GLOBALS_OBJ_OFFSET: usize = std::mem::offset_of!(PyFrame, w_globals_obj);
+pub const PYFRAME_W_GLOBALS_OFFSET: usize = std::mem::offset_of!(PyFrame, w_globals);
 
 // Backward-compat aliases used by JIT descriptor helpers.
 pub const PYFRAME_STACK_DEPTH_OFFSET: usize = PYFRAME_VALUESTACKDEPTH_OFFSET;
@@ -89,7 +89,7 @@ const _: () = {
     assert!(PYFRAME_F_BACKREF_OFFSET == pyre_interpreter::pyframe::PYFRAME_F_BACKREF_OFFSET);
     assert!(PYFRAME_W_BUILTIN_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_BUILTIN_OFFSET);
     assert!(
-        PYFRAME_W_GLOBALS_OBJ_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OBJ_OFFSET
+        PYFRAME_W_GLOBALS_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OFFSET
     );
 };
 

--- a/pyre/pyre-jit-trace/src/frame_layout.rs
+++ b/pyre/pyre-jit-trace/src/frame_layout.rs
@@ -88,9 +88,7 @@ const _: () = {
     );
     assert!(PYFRAME_F_BACKREF_OFFSET == pyre_interpreter::pyframe::PYFRAME_F_BACKREF_OFFSET);
     assert!(PYFRAME_W_BUILTIN_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_BUILTIN_OFFSET);
-    assert!(
-        PYFRAME_W_GLOBALS_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OFFSET
-    );
+    assert!(PYFRAME_W_GLOBALS_OFFSET == pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OFFSET);
 };
 
 /// Build the virtualizable layout description for `PyFrame`.

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -142,23 +142,23 @@ pub fn emit_trace_call_ref_typed_elidable_cannot_raise(
 /// `GetfieldGcR`.  Null on a non-module dict, missing slot, or after
 /// `switch_to_object_strategy`.
 pub(crate) extern "C" fn jit_namespace_cell_lookup(namespace_ptr: i64, slot: i64) -> i64 {
-    let w_globals_obj = namespace_ptr as pyre_object::PyObjectRef;
-    if w_globals_obj.is_null() || slot < 0 {
+    let w_globals = namespace_ptr as pyre_object::PyObjectRef;
+    if w_globals.is_null() || slot < 0 {
         return PY_NULL as i64;
     }
     let cell =
-        unsafe { pyre_object::dictmultiobject::module_dict_cell_at(w_globals_obj, slot as usize) };
+        unsafe { pyre_object::dictmultiobject::module_dict_cell_at(w_globals, slot as usize) };
     cell.unwrap_or(PY_NULL) as i64
 }
 
 pub(crate) fn namespace_slot_lookup_values(
     func_ptr: *const (),
-    w_globals_obj: pyre_object::PyObjectRef,
+    w_globals: pyre_object::PyObjectRef,
     slot: usize,
 ) -> [Value; 3] {
     [
         Value::Int(func_ptr as usize as i64),
-        Value::Ref(GcRef(w_globals_obj as usize)),
+        Value::Ref(GcRef(w_globals as usize)),
         Value::Int(slot as i64),
     ]
 }
@@ -1025,7 +1025,7 @@ pub fn emit_new_pyframe_inline_with_params(
     array_size: usize,
     valuestackdepth: usize,
     pycode: OpRef,
-    w_globals_obj: OpRef,
+    w_globals: OpRef,
     ec: OpRef,
 ) -> OpRef {
     use crate::descr::{
@@ -1070,10 +1070,10 @@ pub fn emit_new_pyframe_inline_with_params(
     let globals_obj_idx = globals_obj_descr.index();
     ctx.record_op_with_descr(
         OpCode::SetfieldGc,
-        &[new_frame, w_globals_obj],
+        &[new_frame, w_globals],
         globals_obj_descr,
     );
-    ctx.heapcache_setfield_cached(new_frame, globals_obj_idx, w_globals_obj);
+    ctx.heapcache_setfield_cached(new_frame, globals_obj_idx, w_globals);
 
     let locals_descr = pyframe_locals_cells_stack_descr();
     let locals_idx = locals_descr.index();
@@ -1118,7 +1118,7 @@ pub fn emit_new_pyframe_inline_self_recursive(
     array_size: usize,
     valuestackdepth: usize,
     pycode: OpRef,
-    w_globals_obj: OpRef,
+    w_globals: OpRef,
     ec: OpRef,
 ) -> OpRef {
     use crate::descr::{
@@ -1174,16 +1174,16 @@ pub fn emit_new_pyframe_inline_self_recursive(
     ctx.heapcache_setfield_cached(new_frame, code_idx, pycode);
 
     // pyframe.py:49 `self.w_globals = w_globals` — store the canonical
-    // W_DictObject (w_globals_obj).  frame_get_namespace chases through
+    // W_DictObject (w_globals).  frame_get_namespace chases through
     // dict_storage_proxy to reach the underlying DictStorage.
     let globals_obj_descr = pyframe_w_globals_obj_descr();
     let globals_obj_idx = globals_obj_descr.index();
     ctx.record_op_with_descr(
         OpCode::SetfieldGc,
-        &[new_frame, w_globals_obj],
+        &[new_frame, w_globals],
         globals_obj_descr,
     );
-    ctx.heapcache_setfield_cached(new_frame, globals_obj_idx, w_globals_obj);
+    ctx.heapcache_setfield_cached(new_frame, globals_obj_idx, w_globals);
 
     // `locals_array` is a fresh `NewArrayClear` op result.  PyPy's
     // executor-while-trace model would have `Box.value` carry the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8162,23 +8162,13 @@ fn try_walker_call_assembler_self_recursive(
     if pyre_interpreter::ncells(callee_code) != 0 {
         return Ok(None);
     }
-    // Recover the legacy raw storage from the object via the proxy back-link
-    // for the `frame_stores_global` stamp; the function's own raw slot is
-    // null (MAKE_FUNCTION captures the object only), so reading it would
-    // mis-stamp `pycode.w_globals`.
+    // The callee's globals OBJECT (`function.w_func_globals_obj`) for the
+    // `frame_stores_global` stamp.
     let callee_globals_obj = unsafe { pyre_interpreter::function_get_globals_obj(callable) };
-    let callee_globals = if callee_globals_obj.is_null() {
-        std::ptr::null_mut()
-    } else {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(callee_globals_obj)
-                as *mut pyre_interpreter::DictStorage
-        }
-    };
     if unsafe {
         pyre_interpreter::w_code_frame_stores_global(
             w_code as pyre_object::PyObjectRef,
-            callee_globals,
+            callee_globals_obj,
         )
     } {
         return Ok(None);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2934,7 +2934,7 @@ fn try_resolve_inline_callee_static_field(
         }
     };
     let const_ptr = match field_idx {
-        VABLE_NAMESPACE_FIELD_IDX => consts.w_globals_obj,
+        VABLE_NAMESPACE_FIELD_IDX => consts.w_globals,
         VABLE_CODE_FIELD_IDX => consts.w_code,
         _ => return Ok(None),
     };
@@ -5667,7 +5667,7 @@ thread_local! {
 struct InlineCalleeConsts {
     /// `frame.w_globals` object (`VABLE_NAMESPACE_FIELD_IDX` = 5): the
     /// callee function's `__globals__` as a `PyObjectRef`.
-    w_globals_obj: usize,
+    w_globals: usize,
     /// `frame.pycode` (`VABLE_CODE_FIELD_IDX` = 1): the callee's `W_Code`
     /// pointer.
     w_code: usize,
@@ -8532,7 +8532,7 @@ fn try_walker_inline_user_call(
     // `try_resolve_inline_callee_static_field` instead of aborting
     // `VableBoxNotSeeded`.  Mirror of the codewriter non-portal branch.
     let inline_consts = InlineCalleeConsts {
-        w_globals_obj: unsafe { pyre_interpreter::function_get_globals_obj(callable) } as usize,
+        w_globals: unsafe { pyre_interpreter::function_get_globals_obj(callable) } as usize,
         w_code: callee_code_key,
     };
 
@@ -8642,7 +8642,7 @@ fn try_walker_inline_user_call(
         };
 
         let pycode_const = ctx.trace_ctx.const_ref(w_code as i64);
-        let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals_obj as i64);
+        let w_globals_obj_const = ctx.trace_ctx.const_ref(inline_consts.w_globals as i64);
         let param_boxes: Vec<OpRef> = (0..nparams).map(|i| r_args[2 + i]).collect();
         let callee_frame = crate::helpers::emit_new_pyframe_inline_with_params(
             ctx.trace_ctx,

--- a/pyre/pyre-jit-trace/src/metainterp.rs
+++ b/pyre/pyre-jit-trace/src/metainterp.rs
@@ -929,7 +929,7 @@ impl PyreMetaInterp {
     /// never concrete-steps.  For a residual SHARED-heap STORE (STORE_GLOBAL /
     /// STORE_SUBSCR / LIST_APPEND on a caller-shared object) `execute_opcode_step`
     /// mutates the live heap during recording, because `snapshot_for_tracing`
-    /// shares `w_globals_obj` (pyframe.rs).  The compiled loop then re-runs the
+    /// shares `w_globals` (pyframe.rs).  The compiled loop then re-runs the
     /// traced iteration from the loop header (the real frame never advanced),
     /// re-applying the store → one-time over-commit scaling with inline depth.
     /// RPython advances the single real frame as it records (so the store

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls_post.template.rs
@@ -238,7 +238,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         _nameindex: usize,
     ) -> Result<Self::Value, pyre_interpreter::PyError> {
         use crate::helpers::TraceHelperAccess;
-        let w_globals_obj = self.sym().concrete_namespace;
+        let w_globals = self.sym().concrete_namespace;
         // `celldict.py:285-322 _LOAD_GLOBAL_cached` + `:42-54
         // getdictvalue_no_unwrapping`: the JIT global fast path promotes
         // the module dict's `version?` quasi-immutable, folds the stored
@@ -250,9 +250,9 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         // `IntMutableCell` slots (which need `w_int_new` boxing of
         // `intvalue`) fall through to the layout-agnostic name-based path
         // (`_load_global` -> `space.finditem_str`).
-        let cell_path = crate::state::module_dict_cell_slot_direct(w_globals_obj, name).and_then(
+        let cell_path = crate::state::module_dict_cell_slot_direct(w_globals, name).and_then(
             |slot| {
-                let stored = crate::state::module_dict_cell_value_direct(w_globals_obj, slot)?;
+                let stored = crate::state::module_dict_cell_value_direct(w_globals, slot)?;
                 if stored.is_null()
                     || unsafe { pyre_object::celldict::is_int_mutable_cell(stored) }
                 {
@@ -278,7 +278,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
             let name_bytes = name.as_bytes();
             let obj = crate::helpers::jit_load_name_from_namespace(
                 frame_ptr,
-                w_globals_obj as i64,
+                w_globals as i64,
                 name_bytes.as_ptr() as i64,
                 name_bytes.len() as i64,
             ) as pyre_object::PyObjectRef;
@@ -291,7 +291,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         let result_obj = unsafe { pyre_object::celldict::unwrap_cell(stored) };
         let result_concrete = crate::state::ConcreteValue::from_pyobj(result_obj);
         let opref = self.with_ctx(|_this, ctx| {
-            let ns_const = ctx.const_ref(w_globals_obj as i64);
+            let ns_const = ctx.const_ref(w_globals as i64);
             let slot_const = ctx.const_int(slot as i64);
             // `quasiimmut.py` + `celldict.py:34 _immutable_fields_=["version?"]`:
             // 1. QUASIIMMUT_FIELD(ns, slot) — recorded as a version dep +
@@ -314,7 +314,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
                 majit_metainterp::EffectInfoSlot::ElidableCannotRaise,
             );
             let concrete_args =
-                crate::helpers::namespace_slot_lookup_values(lookup_fn, w_globals_obj, slot);
+                crate::helpers::namespace_slot_lookup_values(lookup_fn, w_globals, slot);
             let concrete_cell = crate::helpers::namespace_slot_lookup_result(stored);
             let cell_opref = crate::helpers::emit_trace_call_ref_typed_elidable_cannot_raise(
                 ctx,
@@ -351,7 +351,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         use crate::helpers::TraceHelperAccess;
         // `celldict.py:328-333 STORE_GLOBAL_cached`: under the JIT the
         // cell/slot path is bypassed entirely —
-        // `self.space.setitem_str(self.get_w_globals(), varname, w_newvalue)`.
+        // `self.space.setitem_str(self.get_w_globals_storage(), varname, w_newvalue)`.
         // The emitted IR is layout-agnostic: `w_dict_setitem_str` on the
         // globals dict object runs the full ModuleDictStrategy.setitem_str
         // (write_cell + version mutated()) and mirrors the str-keyed write

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11396,15 +11396,12 @@ pub(crate) fn assemble_bridge_inline_pending(
 
     // pyframe.py:128-132 get_w_globals(): a frame's globals come from its OWN
     // pycode (`jit.promote(self.pycode).w_globals`), not the caller. Resolve
-    // the callee's globals from `recipe.w_code` — the same `pycode.w_globals`
-    // the callee module exposes through its function's `w_func_globals_obj` —
-    // so a cross-module inlined callee's LOAD_GLOBAL sees the callee module's
-    // namespace. `reconstruct_inline_recipe` aborts the multi-frame path when
-    // the callee code has no resolved globals, so `globals` is non-null here.
-    let globals = unsafe { pyre_interpreter::w_code_get_w_globals(recipe.w_code as PyObjectRef) };
-    // pycode.w_globals OBJECT — stamped alongside the proxy, the same
-    // `dict_storage_to_dict(globals)` wrapper but read off the code object
-    // rather than re-derived from the off-GC proxy.
+    // the callee's globals OBJECT from `recipe.w_code` — the same
+    // `pycode.w_globals` the callee module exposes through its function's
+    // `w_func_globals_obj` — so a cross-module inlined callee's LOAD_GLOBAL
+    // sees the callee module's namespace. `reconstruct_inline_recipe` aborts
+    // the multi-frame path when the callee code has no resolved globals
+    // object, so this is non-null here.
     let w_globals_obj =
         unsafe { pyre_interpreter::w_code_get_w_globals_obj(recipe.w_code as PyObjectRef) };
 
@@ -11412,11 +11409,14 @@ pub(crate) fn assemble_bridge_inline_pending(
     // `recipe.w_code` and seed `locals_cells_stack_w[0..valuestackdepth]` from
     // the decoded boxes. The callee has no cells/freevars (gated in
     // `reconstruct_inline_recipe`), so `closure = PY_NULL` and the array
-    // layout is `[locals | stack]` with `stack_base() == nlocals`.
+    // layout is `[locals | stack]` with `stack_base() == nlocals`. The builder
+    // re-derives the storage proxy from the (non-null) globals object, so the
+    // raw `globals` arg is unused — pass null rather than reading the off-GC
+    // `code.w_globals` proxy.
     let mut concrete_frame = PyFrame::new_for_call_with_closure_and_globals_obj(
         recipe.w_code,
         &[],
-        globals,
+        std::ptr::null_mut(),
         w_globals_obj,
         execution_context,
         pyre_object::PY_NULL,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11402,8 +11402,7 @@ pub(crate) fn assemble_bridge_inline_pending(
     // sees the callee module's namespace. `reconstruct_inline_recipe` aborts
     // the multi-frame path when the callee code has no resolved globals
     // object, so this is non-null here.
-    let w_globals =
-        unsafe { pyre_interpreter::w_code_get_w_globals(recipe.w_code as PyObjectRef) };
+    let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(recipe.w_code as PyObjectRef) };
 
     // resume.py:1042-1057 newframe + reload: build a fresh concrete frame for
     // `recipe.w_code` and seed `locals_cells_stack_w[0..valuestackdepth]` from

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1865,7 +1865,7 @@ use crate::descr::{
 };
 use crate::frame_layout::{
     PYFRAME_DEBUGDATA_OFFSET, PYFRAME_LASTBLOCK_OFFSET, PYFRAME_LOCALS_CELLS_STACK_OFFSET,
-    PYFRAME_PYCODE_OFFSET, PYFRAME_VALUESTACKDEPTH_OFFSET, PYFRAME_W_GLOBALS_OBJ_OFFSET,
+    PYFRAME_PYCODE_OFFSET, PYFRAME_VALUESTACKDEPTH_OFFSET, PYFRAME_W_GLOBALS_OFFSET,
 };
 use crate::helpers::emit_box_float_inline;
 
@@ -2393,7 +2393,7 @@ pub(crate) fn frame_locals_cells_stack_descr() -> DescrRef {
 }
 
 // R3.3: frame_dict_storage_descr retired — frame_get_namespace now
-// reads through w_globals_obj → dict_storage_proxy.
+// reads through w_globals → dict_storage_proxy.
 
 pub(crate) fn wrapint(ctx: &mut TraceCtx, value: OpRef) -> OpRef {
     crate::helpers::emit_box_int_inline(ctx, value, w_int_size_descr(), int_intval_descr())
@@ -3278,7 +3278,7 @@ pub(crate) fn frame_get_globals_obj(ctx: &mut TraceCtx, frame: OpRef) -> OpRef {
     )
 }
 
-/// Read through w_globals_obj → dict_storage_proxy to reach the raw
+/// Read through w_globals → dict_storage_proxy to reach the raw
 /// DictStorage* for slot-based namespace reads (celldict quasiimmut
 /// path).  Only valid when globals is a W_ModuleDictObject.
 /// Read a value from the unified `locals_cells_stack_w` at the given absolute index.
@@ -4117,7 +4117,7 @@ impl PyreSym {
         if concrete_frame != 0 {
             let frame = unsafe { &*(concrete_frame as *const pyre_interpreter::pyframe::PyFrame) };
             self.jitcode = jitcode_for(frame.pycode);
-            self.concrete_namespace = frame.w_globals_obj;
+            self.concrete_namespace = frame.w_globals;
             self.concrete_execution_context = frame.execution_context;
             self.concrete_vable_ptr = concrete_frame as *mut u8;
             // pyjitpl.py:74-90 MIFrame.setup parity for the per-kind banks
@@ -4591,10 +4591,10 @@ impl PyreJitState {
         let Some(frame_ptr) = self.frame_ptr() else {
             return 0;
         };
-        let w_globals_obj = unsafe {
-            *(frame_ptr.add(PYFRAME_W_GLOBALS_OBJ_OFFSET) as *const pyre_object::PyObjectRef)
+        let w_globals = unsafe {
+            *(frame_ptr.add(PYFRAME_W_GLOBALS_OFFSET) as *const pyre_object::PyObjectRef)
         };
-        if w_globals_obj.is_null() {
+        if w_globals.is_null() {
             return 0;
         }
         // `dictmultiobject.py:107-109 W_DictMultiObject.length`. The common
@@ -4603,8 +4603,8 @@ impl PyreJitState {
         // per-portal-entry path. Plain dict globals (exec/eval) fall back to
         // the polymorphic strategy length.
         unsafe {
-            pyre_object::dictmultiobject::module_dict_storage_len(w_globals_obj)
-                .unwrap_or_else(|| pyre_object::dictmultiobject::w_dict_len(w_globals_obj))
+            pyre_object::dictmultiobject::module_dict_storage_len(w_globals)
+                .unwrap_or_else(|| pyre_object::dictmultiobject::w_dict_len(w_globals))
         }
     }
 
@@ -4746,9 +4746,9 @@ impl PyreJitState {
             .expect("PyreJitState.frame must point to a valid PyFrame")
     }
 
-    /// Read the w_globals_obj pointer from the heap frame.
+    /// Read the w_globals pointer from the heap frame.
     pub fn w_globals_as_usize(&self) -> usize {
-        self.read_frame_usize(PYFRAME_W_GLOBALS_OBJ_OFFSET)
+        self.read_frame_usize(PYFRAME_W_GLOBALS_OFFSET)
             .expect("PyreJitState.frame must point to a valid PyFrame")
     }
 
@@ -4795,10 +4795,10 @@ impl PyreJitState {
         );
     }
 
-    /// Write the w_globals_obj pointer to the heap frame.
+    /// Write the w_globals pointer to the heap frame.
     pub fn set_w_globals(&mut self, value: usize) {
         assert!(
-            self.write_frame_usize(PYFRAME_W_GLOBALS_OBJ_OFFSET, value),
+            self.write_frame_usize(PYFRAME_W_GLOBALS_OFFSET, value),
             "PyreJitState.frame must point to a valid PyFrame"
         );
     }
@@ -5101,13 +5101,13 @@ fn reconstruct_inline_recipe(
     if !code_ref.freevars.is_empty() || pyre_interpreter::pyframe::ncells(code_ref) != 0 {
         return None;
     }
-    // pyframe.py:128-132 get_w_globals(): the reconstructed callee frame's
+    // pyframe.py:128-132 get_w_globals_storage(): the reconstructed callee frame's
     // globals come from its own pycode (`assemble_bridge_inline_pending`
-    // resolves them via `w_code_get_w_globals_obj`). If the callee code never
+    // resolves them via `w_code_get_w_globals`). If the callee code never
     // ran under known globals (the globals object is null), there is no
     // namespace to restore, so abort to the single-frame bridge — the forward
     // inline path declines the same way.
-    if unsafe { pyre_interpreter::w_code_get_w_globals_obj(w_code as pyre_object::PyObjectRef) }
+    if unsafe { pyre_interpreter::w_code_get_w_globals(w_code as pyre_object::PyObjectRef) }
         .is_null()
     {
         return None;
@@ -9294,7 +9294,7 @@ mod tests {
             .execute_frame(None, None)
             .expect("module body should execute");
         let ty = unsafe {
-            (*frame.fget_w_globals())
+            (*frame.fget_w_globals_storage())
                 .get("x")
                 .copied()
                 .expect("namespace should contain x")
@@ -9340,7 +9340,7 @@ mod tests {
             .execute_frame(None, None)
             .expect("module body should execute");
         let callable = unsafe {
-            (*frame.fget_w_globals())
+            (*frame.fget_w_globals_storage())
                 .get("x")
                 .copied()
                 .expect("namespace should contain x")
@@ -9476,7 +9476,7 @@ mod tests {
             .execute_frame(None, None)
             .expect("lookup module should execute");
         let int_type = unsafe {
-            (*lookup_frame.fget_w_globals())
+            (*lookup_frame.fget_w_globals_storage())
                 .get("x")
                 .copied()
                 .expect("globals should contain int")
@@ -10003,7 +10003,7 @@ mod tests {
             .execute_frame(None, None)
             .expect("class body should execute");
         let instance = unsafe {
-            (*frame.fget_w_globals())
+            (*frame.fget_w_globals_storage())
                 .get("c")
                 .copied()
                 .expect("namespace should contain c")
@@ -11374,7 +11374,7 @@ fn recipe_slot_to_pyobj(v: majit_ir::Value) -> PyObjectRef {
 /// call; a reconstructed suspended frame is simply pushed.
 ///
 /// The callee frame's globals come from its OWN pycode (`recipe.w_code`),
-/// matching `pyframe.py:128-132 get_w_globals()` where a frame's globals
+/// matching `pyframe.py:128-132 get_w_globals_storage()` where a frame's globals
 /// derive from its promoted pycode rather than the caller; a cross-module
 /// inlined callee's LOAD_GLOBAL then resolves against the callee module's
 /// namespace. `execution_context` is the per-thread singleton and comes from
@@ -11394,7 +11394,7 @@ pub(crate) fn assemble_bridge_inline_pending(
     let nlocals = recipe.nlocals;
     let valuestackdepth = recipe.valuestackdepth;
 
-    // pyframe.py:128-132 get_w_globals(): a frame's globals come from its OWN
+    // pyframe.py:128-132 get_w_globals_storage(): a frame's globals come from its OWN
     // pycode (`jit.promote(self.pycode).w_globals`), not the caller. Resolve
     // the callee's globals OBJECT from `recipe.w_code` — the same
     // `pycode.w_globals` the callee module exposes through its function's
@@ -11402,8 +11402,8 @@ pub(crate) fn assemble_bridge_inline_pending(
     // sees the callee module's namespace. `reconstruct_inline_recipe` aborts
     // the multi-frame path when the callee code has no resolved globals
     // object, so this is non-null here.
-    let w_globals_obj =
-        unsafe { pyre_interpreter::w_code_get_w_globals_obj(recipe.w_code as PyObjectRef) };
+    let w_globals =
+        unsafe { pyre_interpreter::w_code_get_w_globals(recipe.w_code as PyObjectRef) };
 
     // resume.py:1042-1057 newframe + reload: build a fresh concrete frame for
     // `recipe.w_code` and seed `locals_cells_stack_w[0..valuestackdepth]` from
@@ -11417,7 +11417,7 @@ pub(crate) fn assemble_bridge_inline_pending(
         recipe.w_code,
         &[],
         std::ptr::null_mut(),
-        w_globals_obj,
+        w_globals,
         execution_context,
         pyre_object::PY_NULL,
     );
@@ -11455,7 +11455,7 @@ pub(crate) fn assemble_bridge_inline_pending(
     sym.concrete_stack = (nlocals..valuestackdepth)
         .map(|k| ConcreteValue::from_pyobj(recipe_slot_to_pyobj(recipe.concrete_r[k])))
         .collect();
-    sym.concrete_namespace = w_globals_obj;
+    sym.concrete_namespace = w_globals;
     sym.concrete_execution_context = execution_context;
     // pyjitpl.py:74-90 MIFrame.setup: size the per-kind banks + copy_constants.
     // The constant tail lands at `[num_regs_X..]`, beyond the live

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5103,11 +5103,11 @@ fn reconstruct_inline_recipe(
     }
     // pyframe.py:128-132 get_w_globals(): the reconstructed callee frame's
     // globals come from its own pycode (`assemble_bridge_inline_pending`
-    // resolves them via `w_code_get_w_globals`). If the callee code never ran
-    // under known globals (`w_globals` null), there is no namespace to restore,
-    // so abort to the single-frame bridge — the forward inline path declines
-    // the same way.
-    if unsafe { pyre_interpreter::w_code_get_w_globals(w_code as pyre_object::PyObjectRef) }
+    // resolves them via `w_code_get_w_globals_obj`). If the callee code never
+    // ran under known globals (the globals object is null), there is no
+    // namespace to restore, so abort to the single-frame bridge — the forward
+    // inline path declines the same way.
+    if unsafe { pyre_interpreter::w_code_get_w_globals_obj(w_code as pyre_object::PyObjectRef) }
         .is_null()
     {
         return None;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -11402,11 +11402,11 @@ pub(crate) fn assemble_bridge_inline_pending(
     // namespace. `reconstruct_inline_recipe` aborts the multi-frame path when
     // the callee code has no resolved globals, so `globals` is non-null here.
     let globals = unsafe { pyre_interpreter::w_code_get_w_globals(recipe.w_code as PyObjectRef) };
-    let w_globals_obj = if globals.is_null() {
-        pyre_object::PY_NULL
-    } else {
-        pyre_interpreter::baseobjspace::dict_storage_to_dict(globals)
-    };
+    // pycode.w_globals OBJECT — stamped alongside the proxy, the same
+    // `dict_storage_to_dict(globals)` wrapper but read off the code object
+    // rather than re-derived from the off-GC proxy.
+    let w_globals_obj =
+        unsafe { pyre_interpreter::w_code_get_w_globals_obj(recipe.w_code as PyObjectRef) };
 
     // resume.py:1042-1057 newframe + reload: build a fresh concrete frame for
     // `recipe.w_code` and seed `locals_cells_stack_w[0..valuestackdepth]` from

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -447,7 +447,7 @@ fn emit_call_assembler_callee_frame(
             let ncells = pyre_interpreter::ncells(callee_code);
             let max_stack = callee_code.max_stackdepth as usize;
             // The callee's globals OBJECT (`function.w_func_globals_obj`)
-            // populates `PyFrame.w_globals_obj` and feeds the
+            // populates `PyFrame.w_globals` and feeds the
             // `frame_stores_global` stamp.
             let callee_globals_obj =
                 unsafe { pyre_interpreter::function_get_globals_obj(concrete_callable) };
@@ -7406,7 +7406,7 @@ impl MIFrame {
                     null, // debugdata = None
                     null, // lastblock = None
                     // pyframe.py:128 self.w_globals is the dict OBJECT; the
-                    // vable slot is PYFRAME_W_GLOBALS_OBJ_OFFSET, so seed the
+                    // vable slot is PYFRAME_W_GLOBALS_OFFSET, so seed the
                     // W_DictObject sibling, not the raw DictStorage*.
                     ctx.const_ref(callee_globals_obj as i64),
                 )
@@ -11595,7 +11595,7 @@ mod tests {
             .execute_frame(None, None)
             .expect("module body should execute");
         let exc_class = unsafe {
-            (*frame.fget_w_globals())
+            (*frame.fget_w_globals_storage())
                 .get("x")
                 .copied()
                 .expect("namespace should contain ValueError")

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -446,26 +446,15 @@ fn emit_call_assembler_callee_frame(
             let nlocals = callee_code.varnames.len();
             let ncells = pyre_interpreter::ncells(callee_code);
             let max_stack = callee_code.max_stackdepth as usize;
-            // Resolve the canonical W_DictObject sibling so the inline
-            // new-PyFrame helper populates `PyFrame.w_globals_obj`, and
-            // recover the legacy raw storage from it via the proxy back-link
-            // for the `frame_stores_global` stamp.  The function's own raw
-            // slot is null (MAKE_FUNCTION captures the object only), so
-            // reading it here would mis-stamp `pycode.w_globals`.
+            // The callee's globals OBJECT (`function.w_func_globals_obj`)
+            // populates `PyFrame.w_globals_obj` and feeds the
+            // `frame_stores_global` stamp.
             let callee_globals_obj =
                 unsafe { pyre_interpreter::function_get_globals_obj(concrete_callable) };
-            let callee_globals = if callee_globals_obj.is_null() {
-                std::ptr::null_mut()
-            } else {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(callee_globals_obj)
-                        as *mut pyre_interpreter::DictStorage
-                }
-            };
             let stores_global = unsafe {
                 pyre_interpreter::w_code_frame_stores_global(
                     w_callee_code as PyObjectRef,
-                    callee_globals,
+                    callee_globals_obj,
                 )
             };
             if ncells == 0 && !stores_global {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -4698,8 +4698,21 @@ impl MIFrame {
         let mut boxes = Vec::new();
         // opencoder.py:722: virtualizable_ptr FIRST.
         // The virtualizable frame pointer is always a GCREF.
+        //
+        // RPython parity: the vable identity is the virtualizable OWNER
+        // (portal) frame — `metainterp.virtualizable_boxes[-1]` — recorded once
+        // at toplevel, NOT the current frame. For an inlined callee `sym` (the
+        // separate-inline-frame path), `sym.frame` is the callee frame, whose
+        // heap `locals_cells_stack_w` length differs from the owner frame's;
+        // the static-field count and array length below are sourced from the
+        // owner (`ctx.virtualizable_*`), so using `sym.frame` here makes the
+        // decoder's `get_total_size(virtualizable)` read the callee's shorter
+        // array and trip `consume_vable_info` (vable_size-1 mismatch). Source
+        // the identity from the seeded owner; fall back to `sym.frame` only in
+        // the unseeded test path.
+        let identity_opref = ctx.virtualizable_owner_identity().unwrap_or(sym.frame);
         boxes.push(Self::opref_to_snapshot_tagged_for_slot(
-            sym.frame,
+            identity_opref,
             ctx,
             Some(majit_ir::Type::Ref),
         ));

--- a/pyre/pyre-jit-trace/src/virtualizable_gen.rs
+++ b/pyre/pyre-jit-trace/src/virtualizable_gen.rs
@@ -7,7 +7,7 @@
 use crate::frame_layout::{
     PYFRAME_DEBUGDATA_OFFSET, PYFRAME_LAST_INSTR_OFFSET, PYFRAME_LASTBLOCK_OFFSET,
     PYFRAME_LOCALS_CELLS_STACK_OFFSET, PYFRAME_PYCODE_OFFSET, PYFRAME_VABLE_TOKEN_OFFSET,
-    PYFRAME_VALUESTACKDEPTH_OFFSET, PYFRAME_W_GLOBALS_OBJ_OFFSET,
+    PYFRAME_VALUESTACKDEPTH_OFFSET, PYFRAME_W_GLOBALS_OFFSET,
 };
 use crate::state::PyreJitState;
 use pyre_object::{FIXED_ARRAY_ITEMS_OFFSET, FIXED_ARRAY_LEN_OFFSET};
@@ -56,7 +56,7 @@ majit_macros::virtualizable! {
         valuestackdepth: int @ PYFRAME_VALUESTACKDEPTH_OFFSET,
         debugdata: ref @ PYFRAME_DEBUGDATA_OFFSET,
         lastblock: ref @ PYFRAME_LASTBLOCK_OFFSET,
-        w_globals: ref @ PYFRAME_W_GLOBALS_OBJ_OFFSET,
+        w_globals: ref @ PYFRAME_W_GLOBALS_OFFSET,
     },
 
     // RPython virtualizable.py:28 parity: the array field holds a pointer

--- a/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
+++ b/pyre/pyre-jit-trace/tests/snapshots/opcode_handler_impls.snap
@@ -759,7 +759,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         _nameindex: usize,
     ) -> Result<Self::Value, pyre_interpreter::PyError> {
         use crate::helpers::TraceHelperAccess;
-        let w_globals_obj = self.sym().concrete_namespace;
+        let w_globals = self.sym().concrete_namespace;
         // `celldict.py:285-322 _LOAD_GLOBAL_cached` + `:42-54
         // getdictvalue_no_unwrapping`: the JIT global fast path promotes
         // the module dict's `version?` quasi-immutable, folds the stored
@@ -771,9 +771,9 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         // `IntMutableCell` slots (which need `w_int_new` boxing of
         // `intvalue`) fall through to the layout-agnostic name-based path
         // (`_load_global` -> `space.finditem_str`).
-        let cell_path = crate::state::module_dict_cell_slot_direct(w_globals_obj, name).and_then(
+        let cell_path = crate::state::module_dict_cell_slot_direct(w_globals, name).and_then(
             |slot| {
-                let stored = crate::state::module_dict_cell_value_direct(w_globals_obj, slot)?;
+                let stored = crate::state::module_dict_cell_value_direct(w_globals, slot)?;
                 if stored.is_null()
                     || unsafe { pyre_object::celldict::is_int_mutable_cell(stored) }
                 {
@@ -799,7 +799,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
             let name_bytes = name.as_bytes();
             let obj = crate::helpers::jit_load_name_from_namespace(
                 frame_ptr,
-                w_globals_obj as i64,
+                w_globals as i64,
                 name_bytes.as_ptr() as i64,
                 name_bytes.len() as i64,
             ) as pyre_object::PyObjectRef;
@@ -812,7 +812,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         let result_obj = unsafe { pyre_object::celldict::unwrap_cell(stored) };
         let result_concrete = crate::state::ConcreteValue::from_pyobj(result_obj);
         let opref = self.with_ctx(|_this, ctx| {
-            let ns_const = ctx.const_ref(w_globals_obj as i64);
+            let ns_const = ctx.const_ref(w_globals as i64);
             let slot_const = ctx.const_int(slot as i64);
             // `quasiimmut.py` + `celldict.py:34 _immutable_fields_=["version?"]`:
             // 1. QUASIIMMUT_FIELD(ns, slot) — recorded as a version dep +
@@ -835,7 +835,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
                 majit_metainterp::EffectInfoSlot::ElidableCannotRaise,
             );
             let concrete_args =
-                crate::helpers::namespace_slot_lookup_values(lookup_fn, w_globals_obj, slot);
+                crate::helpers::namespace_slot_lookup_values(lookup_fn, w_globals, slot);
             let concrete_cell = crate::helpers::namespace_slot_lookup_result(stored);
             let cell_opref = crate::helpers::emit_trace_call_ref_typed_elidable_cannot_raise(
                 ctx,
@@ -872,7 +872,7 @@ impl pyre_interpreter::NamespaceOpcodeHandler for crate::state::MIFrame {
         use crate::helpers::TraceHelperAccess;
         // `celldict.py:328-333 STORE_GLOBAL_cached`: under the JIT the
         // cell/slot path is bypassed entirely —
-        // `self.space.setitem_str(self.get_w_globals(), varname, w_newvalue)`.
+        // `self.space.setitem_str(self.get_w_globals_storage(), varname, w_newvalue)`.
         // The emitted IR is layout-agnostic: `w_dict_setitem_str` on the
         // globals dict object runs the full ModuleDictStrategy.setitem_str
         // (write_cell + version mutated()) and mirrors the str-keyed write

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -406,7 +406,7 @@ unsafe fn visit_callee_frame_roots(frame: *mut PyFrame, visitor: &mut dyn FnMut(
     }
     visitor(unsafe { &mut *(&mut frame.f_generator_nowref as *mut PyObjectRef as *mut GcRef) });
     visitor(unsafe { &mut *(&mut frame.w_yielding_from as *mut PyObjectRef as *mut GcRef) });
-    visitor(unsafe { &mut *(&mut frame.w_globals_obj as *mut PyObjectRef as *mut GcRef) });
+    visitor(unsafe { &mut *(&mut frame.w_globals as *mut PyObjectRef as *mut GcRef) });
 }
 
 /// Extra GC root walker for JIT-created callee frames (frame arena +
@@ -551,21 +551,21 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
     // warmspot.py:1021 assembler_call_helper parity: the callee frame
     // (deadframe) may be a nursery-allocated JitFrame-like block. We
     // reconstruct a proper interpreter frame from its raw fields.
-    let (code, w_globals_obj, exec_ctx) = unsafe {
+    let (code, w_globals, exec_ctx) = unsafe {
         use pyre_interpreter::pyframe::*;
         let p = frame_ptr as *const u8;
         let code = *(p.add(PYFRAME_PYCODE_OFFSET) as *const *const ());
-        let w_globals_obj =
-            *(p.add(PYFRAME_W_GLOBALS_OBJ_OFFSET) as *const pyre_object::PyObjectRef);
+        let w_globals =
+            *(p.add(PYFRAME_W_GLOBALS_OFFSET) as *const pyre_object::PyObjectRef);
         let ec = *(p.add(std::mem::offset_of!(PyFrame, execution_context))
             as *const *const pyre_interpreter::PyExecutionContext);
-        (code, w_globals_obj, ec)
+        (code, w_globals, ec)
     };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let namespace = std::ptr::null_mut();
 
     let mut func_frame =
-        PyFrame::new_for_call_with_globals_obj(code, &[], namespace, w_globals_obj, exec_ctx);
+        PyFrame::new_for_call_with_globals_obj(code, &[], namespace, w_globals, exec_ctx);
     func_frame.fix_array_ptrs();
 
     // warmspot.py:1021-1028 assembler_call_helper:
@@ -636,7 +636,7 @@ fn resolve_field_offset(owner: &str, field_name: &str) -> usize {
         "locals_cells_stack_w" => std::mem::offset_of!(PyFrame, locals_cells_stack_w),
         "valuestackdepth" => std::mem::offset_of!(PyFrame, valuestackdepth),
         "next_instr" | "f_lasti" | "last_instr" => std::mem::offset_of!(PyFrame, last_instr),
-        "namespace" | "w_globals" => std::mem::offset_of!(PyFrame, w_globals_obj),
+        "namespace" | "w_globals" => std::mem::offset_of!(PyFrame, w_globals),
         "vable_token" => std::mem::offset_of!(PyFrame, vable_token),
         // #171 codewriter descr-bridge (blackhole side): the dotted nested
         // `int_items.{len,heap_cap,block}` leaves `_handle_list_call`
@@ -2698,9 +2698,9 @@ fn create_callee_frame_impl_1_boxed(
 ) -> i64 {
     let w_code = unsafe { pyre_interpreter::getcode(callable) };
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(callable) };
+    let w_globals = unsafe { function_get_globals_obj(callable) };
     let one_arg = [boxed_arg];
     let args = fill_positional_defaults_for_jit_call(callable, w_code, &one_arg);
     let args = args.as_ref();
@@ -2710,7 +2710,7 @@ fn create_callee_frame_impl_1_boxed(
         if was_init {
             let f = unsafe { &mut *ptr };
             if f.pycode == w_code
-                && f.w_globals_obj == w_globals_obj
+                && f.w_globals == w_globals
                 && f.execution_context == caller.execution_context
             {
                 reset_reused_call_frame(f, args);
@@ -2726,7 +2726,7 @@ fn create_callee_frame_impl_1_boxed(
                             w_code,
                             args,
                             globals,
-                            w_globals_obj,
+                            w_globals,
                             caller.execution_context,
                         ),
                     );
@@ -2741,7 +2741,7 @@ fn create_callee_frame_impl_1_boxed(
                         w_code,
                         args,
                         globals,
-                        w_globals_obj,
+                        w_globals,
                         caller.execution_context,
                     ),
                 );
@@ -2757,7 +2757,7 @@ fn create_callee_frame_impl_1_boxed(
         w_code,
         args,
         globals,
-        w_globals_obj,
+        w_globals,
         caller.execution_context,
     ));
     unsafe { &mut *frame_ptr }.fix_array_ptrs();
@@ -2770,8 +2770,8 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
 ) -> i64 {
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
     let func_code = caller.pycode;
-    let w_globals_obj = caller.w_globals_obj;
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let w_globals = caller.w_globals;
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
     let execution_context = caller.execution_context;
 
@@ -2780,7 +2780,7 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
         if was_init {
             let f = unsafe { &mut *ptr };
             if f.pycode == func_code
-                && f.w_globals_obj == w_globals_obj
+                && f.w_globals == w_globals
                 && f.execution_context == execution_context
             {
                 // Reuse: same code/globals/ec — full reset matching
@@ -2796,7 +2796,7 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
                             func_code,
                             &[boxed_arg],
                             globals,
-                            w_globals_obj,
+                            w_globals,
                             execution_context,
                         ),
                     );
@@ -2811,7 +2811,7 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
                         func_code,
                         &[boxed_arg],
                         globals,
-                        w_globals_obj,
+                        w_globals,
                         execution_context,
                     ),
                 );
@@ -2834,7 +2834,7 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
         func_code,
         &[boxed_arg],
         globals,
-        w_globals_obj,
+        w_globals,
         execution_context,
     ));
     unsafe { &mut *frame_ptr }.fix_array_ptrs();
@@ -2852,9 +2852,9 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
     let callable = callable as PyObjectRef;
     let w_code = unsafe { pyre_interpreter::getcode(callable) };
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
-    let w_globals_obj = unsafe { function_get_globals_obj(callable) };
+    let w_globals = unsafe { function_get_globals_obj(callable) };
     let args = fill_positional_defaults_for_jit_call(callable, w_code, args);
     let args = args.as_ref();
 
@@ -2866,7 +2866,7 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
             // are stable for self-recursion (same function, same module).
             let f = unsafe { &mut *ptr };
             if f.pycode == w_code
-                && f.w_globals_obj == w_globals_obj
+                && f.w_globals == w_globals
                 && f.execution_context == caller.execution_context
             {
                 reset_reused_call_frame(f, args);
@@ -2880,7 +2880,7 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
                             w_code,
                             args,
                             globals,
-                            w_globals_obj,
+                            w_globals,
                             caller.execution_context,
                         ),
                     );
@@ -2896,7 +2896,7 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
                         w_code,
                         args,
                         globals,
-                        w_globals_obj,
+                        w_globals,
                         caller.execution_context,
                     ),
                 );
@@ -2913,7 +2913,7 @@ fn create_callee_frame_impl(caller_frame: i64, callable: i64, args: &[PyObjectRe
         w_code,
         args,
         globals,
-        w_globals_obj,
+        w_globals,
         caller.execution_context,
     ));
     unsafe { &mut *frame_ptr }.fix_array_ptrs();
@@ -2965,8 +2965,8 @@ pub extern "C" fn jit_create_self_recursive_callee_frame_1_raw_int(
 ) -> i64 {
     let caller = unsafe { &*(caller_frame as *const PyFrame) };
     let func_code = caller.pycode;
-    let w_globals_obj = caller.w_globals_obj;
-    // Raw storage is recovered from `w_globals_obj` by the frame builder.
+    let w_globals = caller.w_globals;
+    // Raw storage is recovered from `w_globals` by the frame builder.
     let globals = std::ptr::null_mut();
     let execution_context = caller.execution_context;
 
@@ -2977,7 +2977,7 @@ pub extern "C" fn jit_create_self_recursive_callee_frame_1_raw_int(
         let f = unsafe { &mut *ptr };
         if was_init
             && f.pycode == func_code
-            && f.w_globals_obj == w_globals_obj
+            && f.w_globals == w_globals
             && f.execution_context == execution_context
         {
             // Reuse: full reset matching new_for_call semantics.
@@ -2993,7 +2993,7 @@ pub extern "C" fn jit_create_self_recursive_callee_frame_1_raw_int(
                         func_code,
                         &[boxed],
                         globals,
-                        w_globals_obj,
+                        w_globals,
                         execution_context,
                     ),
                 );
@@ -3022,7 +3022,7 @@ pub extern "C" fn jit_create_self_recursive_callee_frame_1_raw_int(
         func_code,
         &[boxed],
         globals,
-        w_globals_obj,
+        w_globals,
         execution_context,
     ));
     unsafe { &mut *frame_ptr }.fix_array_ptrs();
@@ -3538,7 +3538,7 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
 }
 
 /// `_load_global` residual (pyopcode.py:958-969).  Resolves the namespace via
-/// the executing frame's `get_w_globals()` when the live frame OWNS this
+/// the executing frame's `get_w_globals_storage()` when the live frame OWNS this
 /// `w_code` (`frame.pycode == w_code`) — honoring an `exec(code, ns)`
 /// frame-specific namespace — and falls back to the callee's own promoted
 /// `w_code` globals otherwise (an inlined / chained callee's frame register
@@ -3569,13 +3569,13 @@ pub extern "C" fn bh_load_global_fn(
     let _ = namespace_ptr;
     let parent_frame_ptr = frame_ptr as *const PyFrame;
     // pypy/interpreter/pyopcode.py:958-969 `_load_global`:
-    //   w_value = self.space.finditem_str(self.get_w_globals(), varname)
+    //   w_value = self.space.finditem_str(self.get_w_globals_storage(), varname)
     //   if w_value is None:
     //       w_value = self.get_builtin().getdictvalue(self.space, varname)
     //       if w_value is None:
     //           self._load_global_failed(w_varname)
     //
-    // `self.get_w_globals_obj()` (pyframe.py:49) is the executing frame's own
+    // `self.get_w_globals()` (pyframe.py:49) is the executing frame's own
     // globals object: the per-frame globals an `exec(code, ns)` installs,
     // falling back to the code's bound globals when there is no override.
     // Use it whenever the live frame OWNS this `w_code`
@@ -3586,19 +3586,21 @@ pub extern "C" fn bh_load_global_fn(
     // A frame that does NOT own this `w_code` is an aliased OUTER frame on a
     // chained blackhole / inlined-callee resume (the same aliasing makes the
     // `namespace_ptr` operand unusable, hence ignored above).  Resolve from
-    // the callee's own promoted `w_code` constant: reading `w_globals_obj`
+    // the callee's own promoted `w_code` constant: reading `w_globals`
     // from it yields the current module dict object the const-folding
     // `frontend_global_flow_value` resolved statically, but live, so a
     // relocated dict (a growing `memo`) is followed instead of dangling.
-    let w_globals_obj = if !parent_frame_ptr.is_null()
+    let w_globals = if !parent_frame_ptr.is_null()
         && unsafe { (*parent_frame_ptr).pycode } as usize == w_code_ptr as usize
     {
-        unsafe { (*parent_frame_ptr).get_w_globals_obj() }
+        unsafe { (*parent_frame_ptr).get_w_globals() }
     } else {
-        unsafe { pyre_interpreter::w_code_get_w_globals_obj(w_code_ptr as pyre_object::PyObjectRef) }
+        unsafe {
+            pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef)
+        }
     };
-    if !w_globals_obj.is_null() {
-        match pyre_interpreter::baseobjspace::finditem_str(w_globals_obj, varname) {
+    if !w_globals.is_null() {
+        match pyre_interpreter::baseobjspace::finditem_str(w_globals, varname) {
             Ok(Some(w_value)) => return w_value as i64,
             Ok(None) => {}
             Err(err) => {
@@ -3816,12 +3818,12 @@ pub extern "C" fn bh_import_name_fn(
     // which collapses to the wrong frame for an inlined non-portal callee.
     // `w_globals` must be the wrapped dict object `resolve_package_name` does
     // `finditem_str` against (not the raw DictStorage), so resolve it through
-    // `get_w_globals_obj`.
+    // `get_w_globals`.
     let frame = frame_ptr as *mut PyFrame;
     let w_globals = if frame.is_null() {
         pyre_object::PY_NULL
     } else {
-        unsafe { (*frame).get_w_globals_obj() }
+        unsafe { (*frame).get_w_globals() }
     };
     let ec = pyre_interpreter::call::getexecutioncontext();
     let w_level = level as pyre_object::PyObjectRef;
@@ -4064,7 +4066,7 @@ pub extern "C" fn bh_load_method_self_fn(
 
 /// `LOAD_NAME` residual for the standalone (blackhole / deopt)
 /// per-CodeObject jitcode.  `pyopcode.py:945-955 LOAD_NAME` — when
-/// `getorcreatedebug().w_locals is not get_w_globals()` the lookup
+/// `getorcreatedebug().w_locals is not get_w_globals_storage()` the lookup
 /// tries `finditem_str(w_locals, varname)` first, then falls through
 /// to the `LOAD_GLOBAL` globals → builtins chain.  Delegates to the
 /// interpreter trait impl (`eval.rs load_name_checked_value`) so the
@@ -4133,7 +4135,7 @@ pub extern "C" fn bh_store_name_fn(frame_ptr: i64, w_name: i64, value: i64) -> i
 /// value directly into `w_globals`, bypassing `w_locals`.  Delegates to
 /// the interpreter trait impl (`eval.rs store_global_value`), which
 /// routes through `w_dict_setitem_str` on the eagerly-resolved
-/// `w_globals_obj` (or the back-mirror dict storage when null).  Same
+/// `w_globals` (or the back-mirror dict storage when null).  Same
 /// blackhole-only execution contract and `w_name` ABI as
 /// `bh_store_name_fn`.  `STORE_GLOBAL` carries no nameindex-keyed cache,
 /// so the trait's `nameindex` argument is passed as 0.  Returns 1 on
@@ -5003,7 +5005,7 @@ mod tests_bh_normalize_raise {
             .execute_frame(None, None)
             .expect("module body should execute");
         let callable = unsafe {
-            (*frame.fget_w_globals())
+            (*frame.fget_w_globals_storage())
                 .get("x")
                 .copied()
                 .expect("namespace should contain x")

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -555,8 +555,7 @@ pub extern "C" fn jit_force_callee_frame(frame_ptr: i64) -> i64 {
         use pyre_interpreter::pyframe::*;
         let p = frame_ptr as *const u8;
         let code = *(p.add(PYFRAME_PYCODE_OFFSET) as *const *const ());
-        let w_globals =
-            *(p.add(PYFRAME_W_GLOBALS_OFFSET) as *const pyre_object::PyObjectRef);
+        let w_globals = *(p.add(PYFRAME_W_GLOBALS_OFFSET) as *const pyre_object::PyObjectRef);
         let ec = *(p.add(std::mem::offset_of!(PyFrame, execution_context))
             as *const *const pyre_interpreter::PyExecutionContext);
         (code, w_globals, ec)
@@ -3595,9 +3594,7 @@ pub extern "C" fn bh_load_global_fn(
     {
         unsafe { (*parent_frame_ptr).get_w_globals() }
     } else {
-        unsafe {
-            pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef)
-        }
+        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) }
     };
     if !w_globals.is_null() {
         match pyre_interpreter::baseobjspace::finditem_str(w_globals, varname) {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3575,32 +3575,37 @@ pub extern "C" fn bh_load_global_fn(
     //       if w_value is None:
     //           self._load_global_failed(w_varname)
     //
-    // `self.get_w_globals()` (pyframe.py:129-133) is the executing frame's
-    // own namespace: the per-frame `w_globals` an `exec(code, ns)` installs
-    // in `debug_data`, falling back to the code's bound `w_globals` when
-    // there is no override.  Use it whenever the live frame OWNS this
-    // `w_code` (`frame.pycode == w_code`), so a compiled `LOAD_GLOBAL`
-    // resolves against the executing frame's globals — not the code's
-    // original module dict — exactly as the interpreter does.
+    // `self.get_w_globals_obj()` (pyframe.py:49) is the executing frame's own
+    // globals object: the per-frame globals an `exec(code, ns)` installs,
+    // falling back to the code's bound globals when there is no override.
+    // Use it whenever the live frame OWNS this `w_code`
+    // (`frame.pycode == w_code`), so a compiled `LOAD_GLOBAL` resolves
+    // against the executing frame's globals — not the code's original module
+    // dict — exactly as the interpreter does.
     //
     // A frame that does NOT own this `w_code` is an aliased OUTER frame on a
     // chained blackhole / inlined-callee resume (the same aliasing makes the
     // `namespace_ptr` operand unusable, hence ignored above).  Resolve from
-    // the callee's own promoted `w_code` constant: reading `w_globals` from
-    // it yields the current (GC-forwarded) module dict the const-folding
+    // the callee's own promoted `w_code` constant: reading `w_globals_obj`
+    // from it yields the current module dict object the const-folding
     // `frontend_global_flow_value` resolved statically, but live, so a
     // relocated dict (a growing `memo`) is followed instead of dangling.
-    let w_globals = if !parent_frame_ptr.is_null()
+    let w_globals_obj = if !parent_frame_ptr.is_null()
         && unsafe { (*parent_frame_ptr).pycode } as usize == w_code_ptr as usize
     {
-        unsafe { (*parent_frame_ptr).get_w_globals() }
+        unsafe { (*parent_frame_ptr).get_w_globals_obj() }
     } else {
-        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) }
+        unsafe { pyre_interpreter::w_code_get_w_globals_obj(w_code_ptr as pyre_object::PyObjectRef) }
     };
-    if !w_globals.is_null() {
-        let globals = unsafe { &*w_globals };
-        if let Some(w_value) = pyre_interpreter::dict_storage_get(globals, varname) {
-            return w_value as i64;
+    if !w_globals_obj.is_null() {
+        match pyre_interpreter::baseobjspace::finditem_str(w_globals_obj, varname) {
+            Ok(Some(w_value)) => return w_value as i64,
+            Ok(None) => {}
+            Err(err) => {
+                let exc_obj = err.to_exc_object();
+                publish_residual_call_exception(exc_obj as i64);
+                return 0;
+            }
         }
     }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7714,13 +7714,13 @@ mod tests {
 
         let ec_value = unsafe { (*(frame_ptr as *const PyFrame)).execution_context as usize };
         let mut values = vec![
-            Value::Ref(GcRef(frame_ptr)),                    // frame
-            Value::Ref(GcRef(ec_value)),                     // ec extra red
-            Value::Int(8),                                   // last_instr
-            Value::Ref(GcRef(frame.pycode as usize)),        // pycode
-            Value::Int(4),                                   // valuestackdepth
-            Value::Ref(GcRef(0)),                            // debugdata
-            Value::Ref(GcRef(0)),                            // lastblock
+            Value::Ref(GcRef(frame_ptr)),                // frame
+            Value::Ref(GcRef(ec_value)),                 // ec extra red
+            Value::Int(8),                               // last_instr
+            Value::Ref(GcRef(frame.pycode as usize)),    // pycode
+            Value::Int(4),                               // valuestackdepth
+            Value::Ref(GcRef(0)),                        // debugdata
+            Value::Ref(GcRef(0)),                        // lastblock
             Value::Ref(GcRef(frame.w_globals as usize)), // w_globals
         ];
         for reg in live_regs.iter() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1258,7 +1258,7 @@ thread_local! {
                 pyre_interpreter::pyframe::PYFRAME_W_YIELDING_FROM_OFFSET,
                 pyre_interpreter::pyframe::PYFRAME_F_BACKREF_OFFSET,
                 // Lazy-cached canonical W_DictObject sibling for
-                // `frame.w_globals`.  Once `get_w_globals_obj` resolves
+                // `frame.w_globals`.  Once `get_w_globals` resolves
                 // the pointer it stays alive for the frame's lifetime
                 // (`dict_storage_to_dict` mirror_target invariant), so
                 // the slot must be visited by the nursery tracer to
@@ -1267,7 +1267,7 @@ thread_local! {
                 // `execution_context`, `pycode`, `debugdata`,
                 // `lastblock`) all point at non-nursery memory and
                 // remain off-list.
-                pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OBJ_OFFSET,
+                pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OFFSET,
             ],
         ));
         debug_assert_eq!(pyframe_tid, PYFRAME_GC_TYPE_ID);
@@ -1371,7 +1371,7 @@ thread_local! {
         // hardcoded tid shifts.  `W_CodeObject` carries only raw /
         // non-GC pointers today (`code_ptr`, `w_globals`,
         // `globals_caches`), so it registers with empty gc_ptr offsets;
-        // it has no `w_globals_obj` PyObjectRef slot to trace.
+        // it has no `w_globals` PyObjectRef slot to trace.
         // Allocation still routes through `Box::into_raw`
         // (`w_code_new` → `malloc_typed`), so this registration is inert
         // — the collector never reaches a code object until `w_code_new`
@@ -3076,7 +3076,7 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
 
 fn log_named_global_result(frame: &PyFrame, label: &str) {
     unsafe {
-        let ns = frame.get_w_globals();
+        let ns = frame.get_w_globals_storage();
         if ns.is_null() {
             return;
         }
@@ -6627,7 +6627,7 @@ fn build_resumed_frames(
                     f.next_instr(),
                     f.valuestackdepth,
                     f.pycode,
-                    f.w_globals_obj,
+                    f.w_globals,
                     f.debugdata,
                     f.lastblock,
                     f.vable_token,
@@ -6709,7 +6709,7 @@ fn build_resumed_frames(
             if !vable_ns.is_null() {
                 vable_ns
             } else if !vable_frame_ptr.is_null() {
-                unsafe { (*vable_frame_ptr).w_globals_obj as *const () }
+                unsafe { (*vable_frame_ptr).w_globals as *const () }
             } else {
                 std::ptr::null()
             }
@@ -7358,9 +7358,9 @@ mod tests {
     use super::*;
 
     /// The frame's globals `DictStorage`, resolved through the canonical
-    /// `w_globals_obj`'s `dict_storage_proxy`.
+    /// `w_globals`'s `dict_storage_proxy`.
     unsafe fn frame_globals_storage(frame: &PyFrame) -> *const pyre_interpreter::DictStorage {
-        pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(frame.w_globals_obj)
+        pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(frame.w_globals)
             as *const pyre_interpreter::DictStorage
     }
 
@@ -7606,13 +7606,13 @@ mod tests {
             symbolic_stack_types: vec![],
             registers_r: vec![local],
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(resume_pc as i64 - 1),
             vable_pycode: ctx.const_ref(frame.pycode as usize as i64),
             vable_valuestackdepth: ctx.const_int(1),
             vable_debugdata: ctx.const_ref(frame.debugdata as usize as i64),
             vable_lastblock: ctx.const_ref(frame.lastblock as usize as i64),
-            vable_w_globals: ctx.const_ref(frame.w_globals_obj as usize as i64),
+            vable_w_globals: ctx.const_ref(frame.w_globals as usize as i64),
         }
     }
 
@@ -7721,7 +7721,7 @@ mod tests {
             Value::Int(4),                                   // valuestackdepth
             Value::Ref(GcRef(0)),                            // debugdata
             Value::Ref(GcRef(0)),                            // lastblock
-            Value::Ref(GcRef(frame.w_globals_obj as usize)), // w_globals
+            Value::Ref(GcRef(frame.w_globals as usize)), // w_globals
         ];
         for reg in live_regs.iter() {
             match *reg {
@@ -7811,7 +7811,7 @@ mod tests {
             symbolic_stack_types: vec![Type::Ref, Type::Int],
             registers_r: vec![OpRef::NONE; max_color + 1],
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(999),
             vable_pycode: ctx.const_ref(0xdead),
             vable_valuestackdepth: ctx.const_int(111),
@@ -7926,7 +7926,7 @@ mod tests {
             symbolic_stack_types: vec![Type::Ref, Type::Int],
             registers_r,
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(0),
             vable_pycode: ctx.const_ref(0),
             vable_valuestackdepth: ctx.const_int(0),
@@ -8040,13 +8040,13 @@ mod tests {
                     r
                 },
                 concrete_stack: vec![],
-                concrete_namespace: frame.w_globals_obj,
+                concrete_namespace: frame.w_globals,
                 vable_last_instr: ctx.const_int(resume_pc as i64 - 1),
                 vable_pycode: ctx.const_ref(frame.pycode as usize as i64),
                 vable_valuestackdepth: ctx.const_int(1),
                 vable_debugdata: ctx.const_ref(frame.debugdata as usize as i64),
                 vable_lastblock: ctx.const_ref(frame.lastblock as usize as i64),
-                vable_w_globals: ctx.const_ref(frame.w_globals_obj as usize as i64),
+                vable_w_globals: ctx.const_ref(frame.w_globals as usize as i64),
             });
             let mut state = MIFrame::from_sym(&mut ctx, &mut sym, frame_ptr, resume_pc, resume_pc);
 
@@ -8121,7 +8121,7 @@ mod tests {
             symbolic_stack_types: vec![Type::Ref, Type::Int],
             registers_r: vec![OpRef::NONE; max_color + 1],
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(0),
             vable_pycode: ctx.const_ref(0),
             vable_valuestackdepth: ctx.const_int(0),
@@ -8189,7 +8189,7 @@ mod tests {
             symbolic_stack_types: vec![Type::Ref, Type::Int],
             registers_r: vec![OpRef::NONE; max_color + 1],
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(0),
             vable_pycode: ctx.const_ref(0),
             vable_valuestackdepth: ctx.const_int(0),
@@ -8309,13 +8309,13 @@ mod tests {
                 symbolic_stack_types: vec![Type::Ref, Type::Ref, Type::Ref, Type::Ref],
                 registers_r: vec![OpRef::NONE; 8],
                 concrete_stack: vec![],
-                concrete_namespace: frame.w_globals_obj,
+                concrete_namespace: frame.w_globals,
                 vable_last_instr: ctx.const_int(resume_pc as i64 - 1),
                 vable_pycode: ctx.const_ref(frame.pycode as usize as i64),
                 vable_valuestackdepth: ctx.const_int(7),
                 vable_debugdata: ctx.const_ref(frame.debugdata as usize as i64),
                 vable_lastblock: ctx.const_ref(frame.lastblock as usize as i64),
-                vable_w_globals: ctx.const_ref(frame.w_globals_obj as usize as i64),
+                vable_w_globals: ctx.const_ref(frame.w_globals as usize as i64),
             });
             trace_state::seed_compiled_trace_jitcode_test_state(
                 &mut sym,
@@ -8465,13 +8465,13 @@ mod tests {
             symbolic_stack_types: vec![Type::Ref, Type::Ref, Type::Ref, Type::Ref],
             registers_r: vec![OpRef::NONE; 8],
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(resume_pc as i64 - 1),
             vable_pycode: ctx.const_ref(frame.pycode as usize as i64),
             vable_valuestackdepth: ctx.const_int(7),
             vable_debugdata: ctx.const_ref(frame.debugdata as usize as i64),
             vable_lastblock: ctx.const_ref(frame.lastblock as usize as i64),
-            vable_w_globals: ctx.const_ref(frame.w_globals_obj as usize as i64),
+            vable_w_globals: ctx.const_ref(frame.w_globals as usize as i64),
         });
         trace_state::seed_compiled_trace_jitcode_test_state(
             &mut sym,
@@ -8589,13 +8589,13 @@ mod tests {
             symbolic_stack_types: vec![Type::Ref, Type::Ref],
             registers_r: vec![local0, stack0, stack1],
             concrete_stack: vec![],
-            concrete_namespace: frame.w_globals_obj,
+            concrete_namespace: frame.w_globals,
             vable_last_instr: ctx.const_int(target_pc as i64 - 1),
             vable_pycode: ctx.const_ref(frame.pycode as usize as i64),
             vable_valuestackdepth: ctx.const_int(3),
             vable_debugdata: ctx.const_ref(frame.debugdata as usize as i64),
             vable_lastblock: ctx.const_ref(frame.lastblock as usize as i64),
-            vable_w_globals: ctx.const_ref(frame.w_globals_obj as usize as i64),
+            vable_w_globals: ctx.const_ref(frame.w_globals as usize as i64),
         });
         let mut state = MIFrame::from_sym(&mut ctx, &mut sym, frame_ptr, target_pc, target_pc);
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6829,7 +6829,7 @@ fn replay_pending_fields(
             majit_backend::ExitValueSourceLayout::ExitValue(idx) => {
                 dead_frame_typed.get(*idx).cloned().map(value_to_raw_bits)
             }
-            majit_backend::ExitValueSourceLayout::Constant(c) => Some(*c),
+            majit_backend::ExitValueSourceLayout::Constant(c, _) => Some(*c),
             majit_backend::ExitValueSourceLayout::Virtual(vidx) => {
                 Some(value_to_raw_bits(materialize_virtual_from_rd(
                     *vidx,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3215,15 +3215,22 @@ fn frontend_global_object(w_code: *const (), name: &str) -> Option<pyre_object::
     if w_code.is_null() {
         return None;
     }
-    let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(w_code) };
-    if w_globals.is_null() {
+    // pyopcode.py:957 `_load_global`: `finditem_str(self.get_w_globals(),
+    // varname)` then the builtins fallback. Read the globals OBJECT
+    // (`pycode.w_globals`) rather than the off-GC proxy storage.
+    let w_globals_obj = unsafe { pyre_interpreter::w_code_get_w_globals_obj(w_code) };
+    if w_globals_obj.is_null() {
         return None;
     }
-    let globals = unsafe { &*w_globals };
-    if let Some(w_value) = pyre_interpreter::dict_storage_get(globals, name) {
+    if let Some(w_value) = pyre_interpreter::baseobjspace::finditem_str(w_globals_obj, name)
+        .ok()
+        .flatten()
+    {
         return Some(w_value);
     }
-    let w_builtin = pyre_interpreter::dict_storage_get(globals, "__builtins__")?;
+    let w_builtin = pyre_interpreter::baseobjspace::finditem_str(w_globals_obj, "__builtins__")
+        .ok()
+        .flatten()?;
     let lookup_obj = if unsafe { pyre_object::is_module(w_builtin) } {
         unsafe { pyre_object::w_module_get_w_dict(w_builtin) }
     } else if unsafe { pyre_object::is_dict(w_builtin) } {
@@ -7448,11 +7455,6 @@ impl CodeWriter {
                             } else {
                                 let name_idx = raw_namei as usize >> 1;
                                 let name = code.names.get(name_idx).map(|name| name.as_str());
-                                let w_globals = unsafe {
-                                    pyre_interpreter::w_code_get_w_globals(
-                                        w_code as pyre_object::PyObjectRef,
-                                    )
-                                };
                                 // Classify the FINAL resolved global — module
                                 // globals OR `__builtins__`, the same lookup
                                 // `frontend_global_flow_value` const-folds.  A
@@ -7470,21 +7472,24 @@ impl CodeWriter {
                                     });
                                 if global_is_relocatable_container {
                                     // The namespace operand is the callee's
-                                    // module dict OBJECT.  `PyFrame.__init__`
-                                    // builds `w_globals_obj` eagerly
-                                    // (`dict_storage_to_dict`), so by jitcode
-                                    // build time it is already in the non-moving
-                                    // oldgen and const-folding ITS pointer is
-                                    // GC-safe.  `try_walker_load_global_cell_fold`
-                                    // reads the container VALUE live through it
-                                    // each iteration, so the relocating value is
+                                    // module dict OBJECT (`pycode.w_globals`).
+                                    // `PyFrame.__init__` stamps it eagerly
+                                    // (`w_code_get_w_globals_obj`), a
+                                    // `malloc_typed`-immortal wrapper, so by
+                                    // jitcode build time it is already in the
+                                    // non-moving oldgen and const-folding ITS
+                                    // pointer is GC-safe.
+                                    // `try_walker_load_global_cell_fold` reads
+                                    // the container VALUE live through it each
+                                    // iteration, so the relocating value is
                                     // never baked.  A container is never a call
                                     // target, so the cell-fold's deep-inline
                                     // call mis-resolution does not apply.
-                                    let ns_obj =
-                                        pyre_interpreter::baseobjspace::dict_storage_to_dict(
-                                            w_globals,
-                                        );
+                                    let ns_obj = unsafe {
+                                        pyre_interpreter::w_code_get_w_globals_obj(
+                                            w_code as pyre_object::PyObjectRef,
+                                        )
+                                    };
                                     let ns_const: super::flow::FlowValue =
                                         super::flow::Constant::new(
                                             super::flow::ConstantValue::Signed(ns_obj as i64),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3215,20 +3215,20 @@ fn frontend_global_object(w_code: *const (), name: &str) -> Option<pyre_object::
     if w_code.is_null() {
         return None;
     }
-    // pyopcode.py:957 `_load_global`: `finditem_str(self.get_w_globals(),
+    // pyopcode.py:957 `_load_global`: `finditem_str(self.get_w_globals_storage(),
     // varname)` then the builtins fallback. Read the globals OBJECT
     // (`pycode.w_globals`) rather than the off-GC proxy storage.
-    let w_globals_obj = unsafe { pyre_interpreter::w_code_get_w_globals_obj(w_code) };
-    if w_globals_obj.is_null() {
+    let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(w_code) };
+    if w_globals.is_null() {
         return None;
     }
-    if let Some(w_value) = pyre_interpreter::baseobjspace::finditem_str(w_globals_obj, name)
+    if let Some(w_value) = pyre_interpreter::baseobjspace::finditem_str(w_globals, name)
         .ok()
         .flatten()
     {
         return Some(w_value);
     }
-    let w_builtin = pyre_interpreter::baseobjspace::finditem_str(w_globals_obj, "__builtins__")
+    let w_builtin = pyre_interpreter::baseobjspace::finditem_str(w_globals, "__builtins__")
         .ok()
         .flatten()?;
     let lookup_obj = if unsafe { pyre_object::is_module(w_builtin) } {
@@ -7384,7 +7384,7 @@ impl CodeWriter {
                             // (e.g. a `memo` dict mutated in the loop) leaves a
                             // dangling pointer the blackhole resume then reads.
                             // The register-form namespace (`getfield_vable_r`,
-                            // field 5 = the live `w_globals_obj`) lets
+                            // field 5 = the live `w_globals`) lets
                             // `try_walker_load_global_cell_fold` hoist the lookup
                             // to a GC-safe live cell read (`QuasiimmutField` +
                             // `jit_namespace_cell_lookup`), so the value is read
@@ -7474,7 +7474,7 @@ impl CodeWriter {
                                     // The namespace operand is the callee's
                                     // module dict OBJECT (`pycode.w_globals`).
                                     // `PyFrame.__init__` stamps it eagerly
-                                    // (`w_code_get_w_globals_obj`), a
+                                    // (`w_code_get_w_globals`), a
                                     // `malloc_typed`-immortal wrapper, so by
                                     // jitcode build time it is already in the
                                     // non-moving oldgen and const-folding ITS
@@ -7486,7 +7486,7 @@ impl CodeWriter {
                                     // target, so the cell-fold's deep-inline
                                     // call mis-resolution does not apply.
                                     let ns_obj = unsafe {
-                                        pyre_interpreter::w_code_get_w_globals_obj(
+                                        pyre_interpreter::w_code_get_w_globals(
                                             w_code as pyre_object::PyObjectRef,
                                         )
                                     };
@@ -12209,7 +12209,7 @@ mod tests {
         pyre_interpreter::dict_storage_store(globals.as_mut(), "x", w_value);
         let globals_ptr = Box::into_raw(globals);
         unsafe {
-            pyre_interpreter::w_code_set_w_globals_obj(
+            pyre_interpreter::w_code_set_w_globals(
                 w_code,
                 pyre_interpreter::baseobjspace::dict_storage_to_dict(globals_ptr),
             );

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -12209,7 +12209,10 @@ mod tests {
         pyre_interpreter::dict_storage_store(globals.as_mut(), "x", w_value);
         let globals_ptr = Box::into_raw(globals);
         unsafe {
-            pyre_interpreter::w_code_set_w_globals(w_code, globals_ptr);
+            pyre_interpreter::w_code_set_w_globals_obj(
+                w_code,
+                pyre_interpreter::baseobjspace::dict_storage_to_dict(globals_ptr),
+            );
         }
 
         let value = frontend_global_flow_value(w_code as *const (), "x").expect("global constant");

--- a/pyre/pyre-jit/tests/instance_gc_stress.rs
+++ b/pyre/pyre-jit/tests/instance_gc_stress.rs
@@ -104,7 +104,7 @@ fn run_harness() -> Result<(), String> {
     // Reuse the canonical globals dict as the __main__ module's dict so
     // `globals()` / `function.__globals__` share one identity
     // (`run_source` parity).
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyre-jit/tests/list_elements_gc_stress.rs
+++ b/pyre/pyre-jit/tests/list_elements_gc_stress.rs
@@ -89,7 +89,7 @@ fn run_harness() -> Result<(), String> {
     let mut frame = PyFrame::new_with_context(code, execution_context)
         .map_err(|e| format!("frame setup error: {}", e.message))?;
 
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyre-jit/tests/list_young_dict_gc_stress.rs
+++ b/pyre/pyre-jit/tests/list_young_dict_gc_stress.rs
@@ -105,7 +105,7 @@ fn run_harness() -> Result<(), String> {
     let mut frame = PyFrame::new_with_context(code, execution_context)
         .map_err(|e| format!("frame setup error: {}", e.message))?;
 
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyre-jit/tests/method_cache_gc_stress.rs
+++ b/pyre/pyre-jit/tests/method_cache_gc_stress.rs
@@ -99,7 +99,7 @@ fn run_harness() -> Result<(), String> {
     let mut frame = PyFrame::new_with_context(code, execution_context)
         .map_err(|e| format!("frame setup error: {}", e.message))?;
 
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyre-jit/tests/type_namespace_gc_stress.rs
+++ b/pyre/pyre-jit/tests/type_namespace_gc_stress.rs
@@ -88,7 +88,7 @@ fn run_harness() -> Result<(), String> {
     // Reuse the canonical globals dict as the __main__ module's dict so
     // `globals()` / `function.__globals__` share one identity
     // (`run_source` parity).
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyre-jit/tests/weak_subclasses_gc_stress.rs
+++ b/pyre/pyre-jit/tests/weak_subclasses_gc_stress.rs
@@ -100,7 +100,7 @@ fn run_harness() -> Result<(), String> {
     let mut frame = PyFrame::new_with_context(code, execution_context)
         .map_err(|e| format!("frame setup error: {}", e.message))?;
 
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyre-wasm/Cargo.toml
+++ b/pyre/pyre-wasm/Cargo.toml
@@ -11,7 +11,11 @@ description = "pyre Python interpreter compiled to WebAssembly"
 crate-type = ["cdylib"]
 
 [features]
-default = ["web"]
+# No default: `web`/`wasmi` are selected explicitly (both build paths pass
+# `--no-default-features --features <binding>`). Defaulting to `web` would
+# pull `pyre-jit/wasm-web` into a host `cargo build/test --all` via feature
+# unification and trip pyre-jit's non-wasm32 compile_error guard.
+default = []
 # Browser / JS host: `run_python` is exported through wasm-bindgen and the
 # JIT instantiates trace modules via the `WebAssembly` API (`jit_glue.js`).
 # The browser has no filesystem, so the stdlib `import re` needs is embedded

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -269,7 +269,7 @@ fn run_python_impl(source: &str) -> String {
     // same), reusing the canonical globals dict so `__main__.__dict__`,
     // `globals()`, and `function.__globals__` share one identity. Without this,
     // `sys.modules['__main__']` / `import __main__` raise KeyError.
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::moduleobject::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -343,7 +343,7 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
     // module's `w_dict` shares one identity with `globals()` /
     // `function.__globals__` (PyPy `module.py:77 Module.getdict()`
     // parity).
-    let canonical = frame.get_w_globals_obj();
+    let canonical = frame.get_w_globals();
     let main_module = pyre_object::moduleobject::w_module_new_aliasing_dict(
         "__main__",
         unsafe { pyre_object::w_dict_get_dict_storage_proxy(canonical) },


### PR DESCRIPTION
#128

## Summary

Retires the pyre-only off-GC `W_CodeObject.w_globals: *mut DictStorage` proxy and routes module-globals access through the globals object, plus two JIT correctness fixes that landed on the way.

### Globals: key on the code object, drop the off-GC proxy

- Add `W_CodeObject.w_globals_obj` (the wrapped globals dict object). The codewriter `frontend_global_object`, the relocatable-container namespace operand, and the bridge inline-frame builder read it via `finditem_str` / `w_code_get_w_globals_obj` instead of deriving it from the proxy `DictStorage`. PyPy's `PyCode.w_globals` is the wrapped dict object.
- Re-source the remaining `LOAD_GLOBAL` readers from the proxy to the object: the `call_jit.rs` residual fold (`get_w_globals_obj` + `finditem_str`), the `eval.rs` `_load_global` cache-identity test (pointer identity against the frame's globals object), and the `reconstruct_inline_recipe` null-gate.
- `assemble_bridge_inline_pending` passes null storage to `new_for_call_with_closure_and_globals_obj`, which re-derives the proxy from the non-null globals object.
- Drop the `w_globals: *mut DictStorage` field, `stamp_w_globals_obj`, `CODE_W_GLOBALS_OFFSET`, and the now-dead raw globals parameter of `finish_for_call_with_globals_obj`. `w_code_frame_stores_global` / `w_code_set_w_globals_obj` now take and compare the globals object.
- Rename the globals-object symbols to the PyPy names: `w_globals_obj` → `w_globals`, `w_code_get/set_w_globals_obj` → `w_code_get/set_w_globals`, `get_w_globals_obj` → `get_w_globals`, `PYFRAME_W_GLOBALS_OBJ_OFFSET` → `PYFRAME_W_GLOBALS_OFFSET`. The proxy-storage accessors keep distinct `*_storage` names.

### Deadframe `Constant` carries its declared type

`ExitValueSourceLayout::Constant` held a bare `i64` and `derive_slot_types` mapped every `Constant` slot to `Type::Int`, so a const-folded inlined argument whose deadframe slot holds a live boxed reference was typed `Int` and `decode_ref`'s TAGBOX `Int` branch re-boxed the pointer bits into a garbage integer. `Constant` now carries `(i64, Type)` threaded through every construction site (TAGINT → `Int`, TAGCONST/Const → `Const::get_type`); `derive_slot_types` returns the carried type, and the cranelift `new_slot_types` block gains a `Constant -> ty` arm replacing the `_ -> Type::Ref` catch-all that rooted integer-valued deadframe cells during GC. (resume.py:1017-1038)

### Vable snapshot identity from the owner frame

`build_virtualizable_boxes_snapshot` used `sym.frame` (the inlined callee on the separate-inline-frame path) for the vable section identity, while the static-field count and array length in the same snapshot came from the owner frame. An inlined callee whose `locals_cells_stack_w` is shorter than the owner's therefore tripped `consume_vable_info` on a `vable_size-1` mismatch. Added `TraceCtx::virtualizable_owner_identity` (seeded once from the owner frame) for the identity OpRef, falling back to `sym.frame` only when no standard virtualizable is seeded. (opencoder.py:722)

## Self-review

This patch is AI-assisted; all commits carry the `Assisted-by: Claude` trailer.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
