### PR TITLE
front/rtyper: dead-aggregate sweep, bool/str lowering, ll_str helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,57 @@ locals) is one root cause — a *frame-identity collapse*. Fix it by restoring
 the per-frame red frame (converging on RPython's 1-red-arg frame shape), never
 by baking a single anchor's value as a constant.
 
+## Charon LLBC extraction — the prepass/census input
+
+The annotator/rtyper prepass (and the `PYRE_RTYPER_VERBOSE` census) does **not**
+read the interpreter's Rust source directly — it reads pre-extracted Charon
+`.ullbc` artefacts under `build/llbc/*.ullbc`. **These are frozen snapshots: a
+change to `pyre-interpreter` / `pyre-object` / `pyre-jit` *source* is invisible
+to the prepass until the `.ullbc` is re-extracted.** Only `majit-translate`
+(translator) changes take effect without re-extraction, because the translator
+runs live over the frozen `.ullbc` bodies.
+
+Charon is a **shared, pre-installed** dependency — it lives in the communal
+build cache (`../.pyre-build/charon/<platform>/charon`, pinned
+`nightly-2026.05.29`), **not** on `PATH`. So `which charon` finds nothing, yet
+the scripts below work because they resolve that cache path directly. Do **not**
+conclude "charon is missing" from `which charon`; check
+`../.pyre-build/charon/<platform>/` (override with `PYRE_SHARED_BUILD` /
+`CHARON_DEST`).
+
+Two scripts manage this (both `python3`, run from repo root):
+
+- **`scripts/install-charon.py`** — fetch/build the pinned Charon into the
+  shared cache. Idempotent: prints "already installed" and exits if the stamped
+  version matches. Usually a no-op since the cache is communal.
+- **`scripts/extract-llbc.py [crates…]`** — (re)extract `.ullbc`. No args ⇒
+  `DEFAULT_CRATES` (`pyre-object pyre-interpreter pyre-jit`); known crates are
+  `corpus pyre-object pyre-module pyre-interpreter pyre-jit`. It has
+  **source-fingerprint skip logic**: a crate whose tracked source is unchanged
+  prints `=== skipping <crate> … (fingerprint unchanged) ===` and is *not*
+  rewritten. Force a full rebuild with `--force` (or `LLBC_FORCE_REEXTRACT=1`).
+  `pyre-interpreter.ullbc` is ~300 MB and a forced re-extract takes minutes.
+
+```bash
+python3 scripts/install-charon.py                 # ensure charon (usually no-op)
+python3 scripts/extract-llbc.py                   # re-extract the 3 default crates
+```
+
+After re-extraction, **rebuild the prepass** to re-run it against the new
+`.ullbc`, then bucket the census:
+
+```bash
+touch pyre/pyre-jit-trace/build.rs
+PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace   # build.rs runs the prepass
+# newest stderr: target/release/build/pyre-jit-trace-*/stderr
+#   rg -c 'PREPASS phaseA fail' <stderr>   # / phaseB
+```
+
+So: interpreter-source work that should move the census ⇒ `extract-llbc.py`
+first, then the prepass rebuild. Translator-only work ⇒ just the prepass
+rebuild. (`rg` note: a stray `--replace` in user config can mangle these long
+lines, e.g. `GcType`→`n`; pass `rg --no-config` when bucketing.)
+
 ## Data structure parity with RPython/PyPy
 
 **Do not casually introduce `HashMap` (or any Rust-native collection) when porting RPython/PyPy code.**

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -10258,6 +10258,60 @@ fn resolve_to_producer_op(
     }
 }
 
+/// Whether `dom` dominates `target`: every path from the graph entry to
+/// `target` passes through `dom`.  Computed as "with `dom` removed, is
+/// `target` unreachable from `startblock`" (the standard reachability
+/// formulation; a block dominates itself).  Used to prove a value defined
+/// in `dom` is available at every op in `target`.
+fn block_dominates(graph: &FunctionGraph, dom: BlockId, target: BlockId) -> bool {
+    if dom == target {
+        return true;
+    }
+    let mut seen: Vec<BlockId> = vec![graph.startblock];
+    let mut stack = vec![graph.startblock];
+    while let Some(b) = stack.pop() {
+        if b == dom {
+            continue; // cut: do not traverse through the candidate dominator
+        }
+        if b == target {
+            return false; // reached target without passing through dom
+        }
+        if let Some(block) = graph.blocks.iter().find(|x| x.id == b) {
+            for l in &block.exits {
+                if !seen.contains(&l.target) {
+                    seen.push(l.target);
+                    stack.push(l.target);
+                }
+            }
+        }
+    }
+    // `target` unreachable once `dom` is cut ⇒ `dom` dominates `target`.
+    // Guard against an unreachable `target` (vacuously "dominated"): only
+    // treat as dominated when `target` is genuinely reachable in the full
+    // graph.
+    block_reachable(graph, target)
+}
+
+/// Whether `target` is reachable from `startblock` following exits.
+fn block_reachable(graph: &FunctionGraph, target: BlockId) -> bool {
+    let mut seen: Vec<BlockId> = vec![graph.startblock];
+    let mut stack = vec![graph.startblock];
+    while let Some(b) = stack.pop() {
+        if b == target {
+            return true;
+        }
+        if let Some(block) = graph.blocks.iter().find(|x| x.id == b) {
+            for l in &block.exits {
+                if !seen.contains(&l.target) {
+                    seen.push(l.target);
+                    stack.push(l.target);
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Decode the packed format-string template that `format_args!` lowers
 /// its `&[&str]` pieces into.  The pieces argument to `fmt::Arguments::new`
 /// is a `[u8; N]` byte buffer (charon lowers it as an `Array` of `U8`
@@ -11010,11 +11064,320 @@ struct FmtCollapseMulti {
     /// inputarg that, after the link rewrite, carries the folded String).
     fmt_args: Variable,
     /// Op result var ids to delete (args/pieces array ctors, packed byte
-    /// consts, `Arguments::new`).
+    /// consts, `Arguments::new`, and — when the argument-Tuple round-trip is
+    /// eliminated — the Tuple ctor + its `__pos_N` `FieldRead`s).
     dead_results: Vec<u64>,
     /// Aggregate base var ids whose `FieldWrite`s are deleted (the args and
-    /// pieces arrays).
+    /// pieces arrays, plus the argument-Tuple base when eliminated).
     dead_bases: Vec<u64>,
+    /// `(block, exit_idx, arg_pos, value)` link-arg rebinds applied before
+    /// deletion: a `format_args!` Tuple ref threaded to a placeholder's block
+    /// is replaced by the rendered value, so the threaded inputarg `str`
+    /// reads now carries the value rather than the Tuple field. Empty unless
+    /// the Tuple round-trip is eliminated ([`attempt_fmt_tuple_elimination`]).
+    link_rebinds: Vec<(BlockId, usize, usize, Variable)>,
+}
+
+/// True if `op` reads `var` in any operand position.  Covers the front-end
+/// operand-bearing `OpKind` variants present during `finish` — the fmt
+/// collapse runs pre-`jtransform`, so the JIT-only call / vable / guard-value
+/// families never appear and cannot carry the on-stack `format_args!` Tuple
+/// ref; other variants default to `false`.
+fn op_reads_var(op: &crate::model::SpaceOperation, var: &Variable) -> bool {
+    use crate::model::{LinkArg, OpKind};
+    let v = var.id();
+    let is = |x: &Variable| x.id() == v;
+    let arg_is = |a: &LinkArg| matches!(a, LinkArg::Value(x) if x.id() == v);
+    match &op.kind {
+        OpKind::FieldRead { base, .. } => is(base),
+        OpKind::FieldWrite { base, value, .. } => is(base) || arg_is(value),
+        OpKind::ArrayRead { base, index, .. } => is(base) || is(index),
+        OpKind::ArrayWrite {
+            base, index, value, ..
+        } => is(base) || is(index) || arg_is(value),
+        OpKind::InteriorFieldRead { base, index, .. } => is(base) || is(index),
+        OpKind::InteriorFieldWrite {
+            base, index, value, ..
+        } => is(base) || is(index) || is(value),
+        OpKind::Call { args, .. } => args.iter().any(is),
+        OpKind::BinOp { lhs, rhs, .. } => is(lhs) || is(rhs),
+        OpKind::UnaryOp { operand, .. } => is(operand),
+        OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => is(cond),
+        _ => false,
+    }
+}
+
+/// The plan to also delete the `format_args!` argument-Tuple round-trip in a
+/// multi-arg chain — the deletion the single-arg [`collect_fmt_collapse`]
+/// always performs but the multi-arg path historically skipped.  Without it
+/// the Tuple ctor + its `__pos_N` `FieldWrite`/`FieldRead`s survive, and a
+/// placeholder value (a `StringRepr`) written into the Tuple's
+/// PyObject-erased `__pos_N` field walls the rtyper (`convertvar(StringRepr →
+/// InstanceRepr PyObject)`, no pairtype arm) when the Tuple is pinned by a
+/// field read-back.  The Tuple is a Rust `format_args!` artifact with no PyPy
+/// counterpart (PyPy joins the message flat, then boxes once at the exception
+/// boundary), so deleting it is the parity-correct collapse.
+///
+/// Resolves each placeholder to its rendered value (`chain.args[i].value`,
+/// already unwrapped through the Tuple by `extract_fmt_chain`) so `str` reads
+/// the value, not the Tuple field.  A placeholder whose `new_display` sits in
+/// the Tuple-construction block reads the value directly; one in a successor
+/// block (the common Charon call-boundary split) reads it through a slot
+/// rebind on the single incoming link that forwards the Tuple ref.  Returns
+/// `None` (leaving the historic in-place `str(field-read)` collapse, which
+/// keeps the residual Tuple but never reintroduces the `fmt` extern) for any
+/// shape outside this set, so the change is strictly additive and a hard
+/// shape bails rather than half-deleting.
+struct FmtTupleElim {
+    /// Per placeholder (chain order): the var `str` should read.
+    str_inputs: Vec<Variable>,
+    /// `(block, exit_idx, arg_pos, value)` Tuple-ref slot rebinds.
+    link_rebinds: Vec<(BlockId, usize, usize, Variable)>,
+    /// Tuple ctor + per-placeholder `FieldRead` result ids to delete.
+    dead_results: Vec<u64>,
+    /// Tuple base id whose `FieldWrite`s are deleted.
+    dead_bases: Vec<u64>,
+}
+
+/// Whether every `FieldWrite` storing into the argument `Tuple` `tv` lives
+/// in `bc` (the ctor block).  Matches a write by Variable id or by producer
+/// identity (a threaded copy of the ref carries a different id but the same
+/// producing ctor op), mirroring [`unwrap_fmt_arg_tuple_ref`].  When true,
+/// every field value is in scope at `bc`, hence at any block `bc`
+/// dominates — so an in-place `str(value)` rewrite at a cross-block reader
+/// is sound.
+fn all_tuple_writes_in_block(graph: &FunctionGraph, tv: &Variable, bc: BlockId) -> bool {
+    use crate::model::OpKind;
+    let tv_producer = resolve_to_producer_op(graph, tv);
+    for b in &graph.blocks {
+        for op in &b.operations {
+            if let OpKind::FieldWrite { base, .. } = &op.kind {
+                let denotes_tuple = base.id() == tv.id()
+                    || (tv_producer.is_some()
+                        && resolve_to_producer_op(graph, base) == tv_producer);
+                if denotes_tuple && b.id != bc {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+fn attempt_fmt_tuple_elimination(
+    graph: &FunctionGraph,
+    chain: &FmtChain,
+    new_display_ops: &[(BlockId, usize, Variable)],
+) -> Option<FmtTupleElim> {
+    use crate::model::{ExitSwitch, LinkArg, OpKind};
+    if chain.args.len() != new_display_ops.len() {
+        return None;
+    }
+
+    // The shared argument-Tuple ctor, resolved from each placeholder's
+    // `new_display` arg `FieldRead` base; all placeholders must read the same
+    // Tuple, or the chain is not the single private `format_args!` Tuple.
+    let mut tuple_var: Option<Variable> = None;
+    let mut ctor_block: Option<BlockId> = None;
+
+    enum Plan {
+        Local {
+            value: Variable,
+            getattr_result: u64,
+        },
+        Threaded {
+            carrier: Variable,
+            getattr_result: u64,
+            rebind: (BlockId, usize, usize, Variable),
+        },
+    }
+    let mut plans: Vec<Plan> = Vec::with_capacity(new_display_ops.len());
+
+    for (i, (nd_block, _nd_idx, inner)) in new_display_ops.iter().enumerate() {
+        let value = chain.args.get(i)?.value.clone();
+        // `inner` is a `FieldRead` of the Tuple's `__pos_i` field; co-located
+        // with its `new_display` (the Charon array lowering keeps them in one
+        // block).
+        let (fr_block, fr_idx) = resolve_to_producer_op(graph, inner)?;
+        if fr_block != *nd_block {
+            return None;
+        }
+        let frb = graph.blocks.iter().find(|b| b.id == fr_block)?;
+        let carrier = match &frb.operations.get(fr_idx)?.kind {
+            OpKind::FieldRead { base, .. } => base.clone(),
+            _ => return None,
+        };
+        let getattr_result = inner.id();
+
+        // The Tuple ctor: the carrier resolves to it (directly for the local
+        // placeholder, through the forwarding link for a threaded copy).
+        let (cb, ci) = resolve_to_producer_op(graph, &carrier)?;
+        let ctor_result = graph
+            .blocks
+            .iter()
+            .find(|b| b.id == cb)?
+            .operations
+            .get(ci)?
+            .result
+            .as_ref()?
+            .clone();
+        match (&tuple_var, &ctor_block) {
+            (Some(tv), Some(bc)) if tv.id() != ctor_result.id() || *bc != cb => return None,
+            _ => {
+                tuple_var = Some(ctor_result.clone());
+                ctor_block = Some(cb);
+            }
+        }
+        let tv = tuple_var.clone()?;
+        let bc = ctor_block?;
+
+        if carrier.id() == tv.id() {
+            // Local: the value is in scope where the Tuple is built.  A
+            // cross-block reader (`format_args!` splits the placeholder
+            // field reads across a straight-line block boundary) is still
+            // sound when `bc` dominates the reader and every Tuple write
+            // lives in `bc`, so each field value is available at the reader.
+            if *nd_block != bc
+                && !(block_dominates(graph, bc, *nd_block)
+                    && all_tuple_writes_in_block(graph, &tv, bc))
+            {
+                return None;
+            }
+            plans.push(Plan::Local {
+                value,
+                getattr_result,
+            });
+            continue;
+        }
+
+        // Threaded: the carrier is an inputarg at position `pos`, fed by a
+        // single incoming link from the ctor block that forwards the Tuple
+        // ref at that position; rebind that slot to the value.  The carrier
+        // must be used in this block only by this one `FieldRead` (never
+        // forwarded onward / read again / used in the exit switch) so the
+        // rebind is sound.  `LinkArg`s hold the predecessor's source vars,
+        // which correspond positionally to the target's inputargs.
+        let nd_blk = graph.blocks.iter().find(|b| b.id == *nd_block)?;
+        let pos = nd_blk
+            .inputargs
+            .iter()
+            .position(|a| a.id() == carrier.id())?;
+        let incoming: Vec<(BlockId, usize)> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| {
+                b.exits
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(ei, l)| (l.target == *nd_block).then_some((b.id, ei)))
+            })
+            .collect();
+        if incoming.len() != 1 {
+            return None; // phi merge: no single forwarding slot to rebind
+        }
+        let (pred, ei) = incoming[0];
+        if pred != bc {
+            return None;
+        }
+        let forwards_tuple = matches!(
+            graph
+                .blocks
+                .iter()
+                .find(|b| b.id == pred)?
+                .exits
+                .get(ei)
+                .and_then(|l| l.args.get(pos)),
+            Some(LinkArg::Value(x)) if x.id() == tv.id()
+        );
+        if !forwards_tuple {
+            return None;
+        }
+        let used_elsewhere = nd_blk
+            .operations
+            .iter()
+            .enumerate()
+            .any(|(idx, op)| idx != fr_idx && op_reads_var(op, &carrier))
+            || nd_blk.exits.iter().any(|l| {
+                l.args
+                    .iter()
+                    .any(|a| matches!(a, LinkArg::Value(x) if x.id() == carrier.id()))
+            })
+            || matches!(&nd_blk.exitswitch, Some(ExitSwitch::Value(x)) if x.id() == carrier.id());
+        if used_elsewhere {
+            return None;
+        }
+        plans.push(Plan::Threaded {
+            carrier: carrier.clone(),
+            getattr_result,
+            rebind: (pred, ei, pos, value.clone()),
+        });
+    }
+
+    let tuple_var = tuple_var?;
+    let link_rebinds: Vec<(BlockId, usize, usize, Variable)> = plans
+        .iter()
+        .filter_map(|p| match p {
+            Plan::Threaded { rebind, .. } => Some(rebind.clone()),
+            Plan::Local { .. } => None,
+        })
+        .collect();
+
+    let mut dead_results = vec![tuple_var.id()];
+    let mut str_inputs = Vec::with_capacity(plans.len());
+    for p in &plans {
+        match p {
+            Plan::Local {
+                value,
+                getattr_result,
+            } => {
+                str_inputs.push(value.clone());
+                dead_results.push(*getattr_result);
+            }
+            Plan::Threaded {
+                carrier,
+                getattr_result,
+                ..
+            } => {
+                str_inputs.push(carrier.clone());
+                dead_results.push(*getattr_result);
+            }
+        }
+    }
+
+    // Deleting the ctor, its `FieldWrite`s, and the placeholder `FieldRead`s
+    // leaves the framestate forwards of the (now dead) Tuple ref for the
+    // post-collapse `prune_dead_phis` in `finish` to clean up (it trims dead
+    // `Link.args` + inputargs).  That is sound only when the Tuple ref has no
+    // *surviving* op reader: every op that reads it must be one we delete (a
+    // placeholder `FieldRead` whose result is in `dead_results`, or a
+    // `FieldWrite` into it).  Threaded slots are redirected to the value by
+    // `link_rebinds`; any remaining forward of a fully-dead Tuple ref is what
+    // `prune_dead_phis` removes.  A surviving reader (the ref escapes the
+    // chain) would dangle, so bail to the historic in-place `str(field-read)`
+    // collapse (residual Tuple, no regression).
+    let tuple_has_live_reader = graph.blocks.iter().any(|b| {
+        b.operations.iter().any(|op| {
+            let deleted = op
+                .result
+                .as_ref()
+                .is_some_and(|r| dead_results.contains(&r.id()))
+                || matches!(&op.kind, OpKind::FieldWrite { base, .. } if base.id() == tuple_var.id());
+            !deleted
+                && crate::inline::op_variable_refs(&op.kind)
+                    .iter()
+                    .any(|v| v.id() == tuple_var.id())
+        }) || matches!(&b.exitswitch, Some(ExitSwitch::Value(x)) if x.id() == tuple_var.id())
+    });
+    if tuple_has_live_reader {
+        return None;
+    }
+
+    Some(FmtTupleElim {
+        str_inputs,
+        link_rebinds,
+        dead_results,
+        dead_bases: vec![tuple_var.id()],
+    })
 }
 
 /// Recognize a multi-argument `format!` chain terminating at the
@@ -11095,7 +11458,22 @@ fn collect_fmt_collapse_multi(
 
     let mut dead_results = vec![arguments_var, pieces_var.id(), args_var.id()];
     dead_results.extend(piece_byte_vars.iter().map(|v| v.id()));
-    let dead_bases = vec![pieces_var.id(), args_var.id()];
+    let mut dead_bases = vec![pieces_var.id(), args_var.id()];
+
+    // Also delete the `format_args!` argument-Tuple round-trip when the shape
+    // permits (mirroring the single-arg path).  On success each placeholder's
+    // `str` reads the rendered value instead of the Tuple field, so the Tuple
+    // ctor + its writes/reads become dead.  On `None` the historic in-place
+    // `str(field-read)` collapse stands (residual Tuple, no `fmt` extern).
+    let mut link_rebinds = Vec::new();
+    if let Some(elim) = attempt_fmt_tuple_elimination(graph, &chain, &new_display_ops) {
+        for (slot, value) in new_display_ops.iter_mut().zip(elim.str_inputs) {
+            slot.2 = value;
+        }
+        dead_results.extend(elim.dead_results);
+        dead_bases.extend(elim.dead_bases);
+        link_rebinds = elim.link_rebinds;
+    }
 
     Some(FmtCollapseMulti {
         args_block,
@@ -11108,6 +11486,7 @@ fn collect_fmt_collapse_multi(
         fmt_args,
         dead_results,
         dead_bases,
+        link_rebinds,
     })
 }
 
@@ -11156,6 +11535,16 @@ fn collapse_fmt_chains_multi(graph: &mut FunctionGraph) -> usize {
                     operand: inner.clone(),
                     result_ty: ValueType::Ref(None),
                 };
+            }
+        }
+        // 1b. Rebind any `format_args!` Tuple-ref slots to the rendered value
+        //     (Tuple round-trip elimination): the threaded inputarg a `str`
+        //     now reads carries the value instead of the deleted Tuple field.
+        for (bid, ei, pos, value) in &site.link_rebinds {
+            if let Some(link) = graph.block_mut(*bid).exits.get_mut(*ei) {
+                if let Some(arg) = link.args.get_mut(*pos) {
+                    *arg = LinkArg::Value(value.clone());
+                }
             }
         }
         // 2. Replace the `alloc::fmt::format` op with `same_as(fmt_args)`:
@@ -12213,8 +12602,16 @@ mod tests {
                     _ => None,
                 })
         };
-        assert_eq!(find_str(b0), Some(ar0.id()), "B0 new_display→str(ar0)");
-        assert_eq!(find_str(b1), Some(ar1.id()), "B1 new_display→str(ar1)");
+        // The argument-Tuple round-trip is eliminated: the local placeholder
+        // reads its value `x` directly; the threaded placeholder reads the
+        // rebound carrier (`tuple_in`, now forwarding `y`), not the Tuple
+        // field.
+        assert_eq!(find_str(b0), Some(x.id()), "B0 new_display→str(x)");
+        assert_eq!(
+            find_str(b1),
+            Some(tuple_in.id()),
+            "B1 new_display→str(rebound carrier)"
+        );
 
         // No `fmt` externs survive anywhere in the graph.
         for b in &graph.blocks {
@@ -12231,6 +12628,28 @@ mod tests {
                 }
             }
         }
+
+        // The Tuple ctor, its `__pos_N` writes, and the field read-backs are
+        // all deleted — no StringRepr→PyObject-erased-field setattr survives.
+        for b in &graph.blocks {
+            for op in &b.operations {
+                if let Some(r) = &op.result {
+                    assert_ne!(r.id(), tuple.id(), "Tuple ctor survived");
+                    assert_ne!(r.id(), ar0.id(), "__pos_0 FieldRead survived");
+                    assert_ne!(r.id(), ar1.id(), "__pos_1 FieldRead survived");
+                }
+                if let OpKind::FieldWrite { base, .. } = &op.kind {
+                    assert_ne!(base.id(), tuple.id(), "Tuple __pos_N FieldWrite survived");
+                }
+            }
+        }
+        // The B0→B1 link slot that forwarded the Tuple ref now forwards `y`.
+        let b0_block = graph.blocks.iter().find(|b| b.id == b0).unwrap();
+        assert_eq!(
+            b0_block.exits[0].args[0].as_variable().map(|v| v.id()),
+            Some(y.id()),
+            "B0→B1 Tuple slot rebound to y"
+        );
 
         // Bf's format op became `same_as(fmt_args_in)`, keeping `formatted`.
         let bf_block = graph.blocks.iter().find(|b| b.id == bf).unwrap();
@@ -12263,6 +12682,251 @@ mod tests {
             fmt_args.id(),
             "Bp must forward the folded String, not Arguments"
         );
+    }
+
+    #[test]
+    fn collapse_fmt_chains_multi_eliminates_cross_block_local_tuple() {
+        use super::{collapse_fmt_chains_multi, fmt_path_ends_with, is_arguments_new_path};
+        use crate::flowspace::model::Variable;
+        use crate::model::{
+            CallTarget, FieldDescriptor, FunctionGraph, Link, LinkArg, OpKind, SpaceOperation,
+            ValueType,
+        };
+
+        // The `index_type_error` shape: `format!` splits the two placeholder
+        // field reads across a straight-line block boundary, but B1 reads the
+        // 2nd field off the *same* Tuple ref id (referenced cross-block by
+        // dominance), not a threaded inputarg copy.  Both placeholders are
+        // Local; the cross-block reader is admitted because B0 dominates B1
+        // and every Tuple write lives in B0.
+        let mut graph = FunctionGraph::new("fmt_collapse_cross_block_local");
+        let b0 = graph.create_block();
+        let b1 = graph.create_block();
+        let bp = graph.create_block();
+        let bf = graph.create_block();
+        let bret = graph.create_block();
+        // B0 is the entry so `block_dominates(b0, b1)` holds (b1 reachable
+        // only through b0), mirroring the real `index_type_error` CFG.
+        graph.startblock = b0;
+
+        let fpath = |segs: &[&str]| CallTarget::FunctionPath {
+            segments: segs.iter().map(|s| s.to_string()).collect(),
+        };
+
+        // ── B0: Tuple{x, y} + both FieldWrites + FieldRead __pos_0 + new_display ──
+        let x = Variable::new();
+        let y = Variable::new();
+        graph.block_mut(b0).inputargs = vec![x.clone(), y.clone()];
+        let tuple = Variable::new();
+        graph.block_mut(b0).operations.push(SpaceOperation {
+            result: Some(tuple.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Tuple".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Tuple".to_string())),
+            },
+        });
+        for (i, v) in [&x, &y].iter().enumerate() {
+            graph.block_mut(b0).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: tuple.clone(),
+                    field: FieldDescriptor::new(format!("__pos_{i}"), Some("Tuple".to_string())),
+                    value: LinkArg::Value((*v).clone()),
+                    ty: ValueType::Ref(None),
+                },
+            });
+        }
+        let ar0 = Variable::new();
+        graph.block_mut(b0).operations.push(SpaceOperation {
+            result: Some(ar0.clone()),
+            kind: OpKind::FieldRead {
+                base: tuple.clone(),
+                field: FieldDescriptor::new("__pos_0", Some("Tuple".to_string())),
+                ty: ValueType::Ref(None),
+                pure: false,
+            },
+        });
+        let nd0 = Variable::new();
+        graph.block_mut(b0).operations.push(SpaceOperation {
+            result: Some(nd0.clone()),
+            kind: OpKind::Call {
+                target: fpath(&["fmt", "rt", "Argument", "new_display"]),
+                args: vec![ar0.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        // B0 → B1 forwards only the first new_display; the Tuple ref is NOT a
+        // link arg — B1 references it directly by id (dominance carry).
+        let nd0_in = Variable::new();
+        graph.block_mut(b1).inputargs = vec![nd0_in.clone()];
+        graph.block_mut(b0).exits =
+            vec![Link::from_variables(&graph, vec![nd0], b1, None).with_prevblock(b0)];
+
+        // ── B1: FieldRead __pos_1 off the *same* tuple id + new_display(&y) ──
+        let ar1 = Variable::new();
+        graph.block_mut(b1).operations.push(SpaceOperation {
+            result: Some(ar1.clone()),
+            kind: OpKind::FieldRead {
+                base: tuple.clone(),
+                field: FieldDescriptor::new("__pos_1", Some("Tuple".to_string())),
+                ty: ValueType::Ref(None),
+                pure: false,
+            },
+        });
+        let nd1 = Variable::new();
+        graph.block_mut(b1).operations.push(SpaceOperation {
+            result: Some(nd1.clone()),
+            kind: OpKind::Call {
+                target: fpath(&["fmt", "rt", "Argument", "new_display"]),
+                args: vec![ar1.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        let nd0_p = Variable::new();
+        let nd1_p = Variable::new();
+        graph.block_mut(bp).inputargs = vec![nd0_p.clone(), nd1_p.clone()];
+        graph.block_mut(b1).exits =
+            vec![Link::from_variables(&graph, vec![nd0_in, nd1], bp, None).with_prevblock(b1)];
+
+        // ── Bp: args array, pieces array, Arguments::new ──
+        let args_arr = Variable::new();
+        graph.block_mut(bp).operations.push(SpaceOperation {
+            result: Some(args_arr.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Array".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Array".to_string())),
+            },
+        });
+        for (i, v) in [&nd0_p, &nd1_p].iter().enumerate() {
+            graph.block_mut(bp).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: args_arr.clone(),
+                    field: FieldDescriptor::new(format!("__pos_{i}"), Some("Array".to_string())),
+                    value: LinkArg::Value((*v).clone()),
+                    ty: ValueType::Ref(None),
+                },
+            });
+        }
+        let pieces_arr = Variable::new();
+        graph.block_mut(bp).operations.push(SpaceOperation {
+            result: Some(pieces_arr.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor {
+                    name: "Array".to_string(),
+                    owner_path: vec![],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(Some("Array".to_string())),
+            },
+        });
+        for (i, byte) in [1i64, 97, 0xC0, 1, 98, 0xC0, 1, 99, 0].iter().enumerate() {
+            let v = Variable::new();
+            graph.block_mut(bp).operations.push(SpaceOperation {
+                result: Some(v.clone()),
+                kind: OpKind::ConstInt(*byte),
+            });
+            graph.block_mut(bp).operations.push(SpaceOperation {
+                result: None,
+                kind: OpKind::FieldWrite {
+                    base: pieces_arr.clone(),
+                    field: FieldDescriptor::new(format!("__pos_{i}"), Some("Array".to_string())),
+                    value: LinkArg::Value(v),
+                    ty: ValueType::Int,
+                },
+            });
+        }
+        let fmt_args = Variable::new();
+        graph.block_mut(bp).operations.push(SpaceOperation {
+            result: Some(fmt_args.clone()),
+            kind: OpKind::Call {
+                target: fpath(&["fmt", "Arguments", "new"]),
+                args: vec![pieces_arr, args_arr],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        let fmt_args_in = Variable::new();
+        graph.block_mut(bf).inputargs = vec![fmt_args_in.clone()];
+        graph.block_mut(bp).exits =
+            vec![Link::from_variables(&graph, vec![fmt_args.clone()], bf, None).with_prevblock(bp)];
+
+        // ── Bf: alloc::fmt::format(args) → String ──
+        let formatted = Variable::new();
+        graph.block_mut(bf).operations.push(SpaceOperation {
+            result: Some(formatted.clone()),
+            kind: OpKind::Call {
+                target: fpath(&["alloc", "fmt", "format"]),
+                args: vec![fmt_args_in.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        });
+        let ret = Variable::new();
+        graph.block_mut(bret).inputargs = vec![ret];
+        graph.block_mut(bf).exits = vec![
+            Link::from_variables(&graph, vec![formatted.clone()], bret, None).with_prevblock(bf),
+        ];
+
+        collapse_fmt_chains_multi(&mut graph);
+
+        let find_str = |bid| {
+            graph
+                .blocks
+                .iter()
+                .find(|b| b.id == bid)
+                .unwrap()
+                .operations
+                .iter()
+                .find_map(|op| match &op.kind {
+                    OpKind::UnaryOp { op: o, operand, .. } if o == "str" => Some(operand.id()),
+                    _ => None,
+                })
+        };
+        // Both placeholders are Local and read their values directly — the
+        // cross-block reader in B1 reads `y`, not a Tuple field.
+        assert_eq!(find_str(b0), Some(x.id()), "B0 new_display→str(x)");
+        assert_eq!(
+            find_str(b1),
+            Some(y.id()),
+            "B1 cross-block new_display→str(y)"
+        );
+
+        // No `fmt` externs survive.
+        for b in &graph.blocks {
+            for op in &b.operations {
+                if let OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } = &op.kind
+                {
+                    let bad = fmt_path_ends_with(segments, &["Argument", "new_display"])
+                        || is_arguments_new_path(segments)
+                        || fmt_path_ends_with(segments, &["fmt", "format"]);
+                    assert!(!bad, "residual fmt extern survived: {segments:?}");
+                }
+            }
+        }
+
+        // Tuple ctor, both writes, and both field read-backs are gone.
+        for b in &graph.blocks {
+            for op in &b.operations {
+                if let Some(r) = &op.result {
+                    assert_ne!(r.id(), tuple.id(), "Tuple ctor survived");
+                    assert_ne!(r.id(), ar0.id(), "__pos_0 FieldRead survived");
+                    assert_ne!(r.id(), ar1.id(), "__pos_1 FieldRead survived");
+                }
+                if let OpKind::FieldWrite { base, .. } = &op.kind {
+                    assert_ne!(base.id(), tuple.id(), "Tuple __pos_N FieldWrite survived");
+                }
+            }
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1554,6 +1554,17 @@ impl<'a> Lowering<'a> {
             // (`pyre_trait_unique_impls`, keyed by qualified path).
             let class_root = match &ty {
                 ValueType::Ref(_) => tyref_class_root(&local.ty, llbc)
+                    // A `&str` / `str` param strips to the `str` builtin
+                    // (not an ADT), so `tyref_class_root` answers `None`;
+                    // name it `"str"` so `derive_subject_inputcells` seeds
+                    // the byte `SomeString` (`s_str0`) instead of the
+                    // abstract `SomeInstance(None)` a `Ref(None)` projects
+                    // to.  A string param compared against a string literal
+                    // then rtypes as `pair(StringRepr, StringRepr)` rather
+                    // than walling at `pair(InstanceRepr, StringRepr)`.
+                    .or_else(|| {
+                        tyref_strips_to_str(&local.ty, llbc).then(|| "str".to_string())
+                    })
                     .or_else(|| tyref_generic_trait_bound_root(&local.ty, llbc, generics)),
                 _ => None,
             };

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1331,7 +1331,12 @@ pub fn lower_fun_decl_with_static_addrs(
 ///   removal to keep untouched graphs byte-identical.
 fn simplify_lowered_graph(graph: &mut FunctionGraph) {
     crate::model::eliminate_empty_blocks(graph);
-    let mut dirty = crate::model::remove_assertion_errors(graph) > 0;
+    // Drop dead aggregate constructions (malloc + field stores whose
+    // result is never read) before the dead-op sweep — `prune_dead_phis`
+    // keeps them because a `FieldWrite` is side-effecting, so its `base`
+    // pins the aggregate (`remove_simple_mallocs`, malloc.py).
+    let mut dirty = crate::model::remove_dead_aggregates(graph) > 0;
+    dirty |= crate::model::remove_assertion_errors(graph) > 0;
     // Constant-condition arms (`if WITHPREBUILTINT { … }` with the
     // config const folded by `const_eval_global`) collapse to the
     // taken link and the dead arm is emptied — the registry lift

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1567,9 +1567,7 @@ impl<'a> Lowering<'a> {
                     // to.  A string param compared against a string literal
                     // then rtypes as `pair(StringRepr, StringRepr)` rather
                     // than walling at `pair(InstanceRepr, StringRepr)`.
-                    .or_else(|| {
-                        tyref_strips_to_str(&local.ty, llbc).then(|| "str".to_string())
-                    })
+                    .or_else(|| tyref_strips_to_str(&local.ty, llbc).then(|| "str".to_string()))
                     .or_else(|| tyref_generic_trait_bound_root(&local.ty, llbc, generics)),
                 _ => None,
             };

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -84,6 +84,8 @@ const RESULT_EXC_LOWERING_SCOPE: &[&str] = &[
     "store_fast",
     "opcode_store_fast_store_fast",
     "store_fast_store_fast",
+    "close_loop_args",
+    "null_value",
 ];
 
 /// Dispatch-wrapper family rule: every `pyopcode::execute_*` wrapper —

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2452,12 +2452,15 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
                 if real_read.contains(result) {
                     continue;
                 }
-                let stores_clean = graph.blocks.iter().flat_map(|b| &b.operations).all(|o| {
-                    match &o.kind {
-                        OpKind::FieldWrite { base, .. } if base == result => o.result.is_none(),
-                        _ => true,
-                    }
-                });
+                let stores_clean =
+                    graph
+                        .blocks
+                        .iter()
+                        .flat_map(|b| &b.operations)
+                        .all(|o| match &o.kind {
+                            OpKind::FieldWrite { base, .. } if base == result => o.result.is_none(),
+                            _ => true,
+                        });
                 if stores_clean {
                     dead.insert(result.clone());
                 }
@@ -4818,8 +4821,12 @@ mod tests {
         // field stores are dead (`remove_simple_mallocs`).
         let mut graph = FunctionGraph::new("test");
         let entry = graph.startblock;
-        let b0 = graph.push_op_var(entry, OpKind::ConstBool(true), true).unwrap();
-        let b1 = graph.push_op_var(entry, OpKind::ConstBool(false), true).unwrap();
+        let b0 = graph
+            .push_op_var(entry, OpKind::ConstBool(true), true)
+            .unwrap();
+        let b1 = graph
+            .push_op_var(entry, OpKind::ConstBool(false), true)
+            .unwrap();
         let tmp = graph
             .push_op_var(
                 entry,
@@ -4861,7 +4868,10 @@ mod tests {
                 } | OpKind::FieldWrite { .. }
             )
         });
-        assert!(!has_ctor_or_store, "dead aggregate ctor + stores must be gone");
+        assert!(
+            !has_ctor_or_store,
+            "dead aggregate ctor + stores must be gone"
+        );
     }
 
     #[test]
@@ -4870,7 +4880,9 @@ mod tests {
         // read, so neither the ctor nor its stores may be removed.
         let mut graph = FunctionGraph::new("test");
         let entry = graph.startblock;
-        let b0 = graph.push_op_var(entry, OpKind::ConstBool(true), true).unwrap();
+        let b0 = graph
+            .push_op_var(entry, OpKind::ConstBool(true), true)
+            .unwrap();
         let tmp = graph
             .push_op_var(
                 entry,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2358,6 +2358,141 @@ pub fn clear_unreachable_blocks(graph: &mut FunctionGraph) {
     }
 }
 
+/// Remove dead aggregate constructions — a `SyntheticTransparentCtor`
+/// call whose result escapes *only* into its own `FieldWrite` field
+/// stores (never read, returned, or passed) — along with those stores.
+///
+/// This is the `remove_simple_mallocs` shape from
+/// `rpython/translator/backendopt/malloc.py`: a `malloc` whose result
+/// flows only into `setfield` stores and is never read is dead, so the
+/// malloc and its stores are dropped.  `prune_dead_phis`
+/// (`transform_dead_op_vars`) cannot do this on its own because a
+/// `FieldWrite` is side-effecting (not a pure op), so it pins its
+/// `base` operand in `read_vars` and the aggregate survives.
+///
+/// The construction only reaches the front-end as a malloc + store
+/// chain (`OpKind::Call { SyntheticTransparentCtor }` +
+/// `OpKind::FieldWrite`) for the heterogeneous tuple/struct path; the
+/// pure `OpKind::NewTuple` form is already swept by `prune_dead_phis`.
+/// A discarded `(a, b)` pair (e.g. `let _ = (truth, expect_true);`)
+/// lowers to this chain, and its dead field stores otherwise force a
+/// primitive→object store whose `(BoolRepr|IntegerRepr, InstanceRepr)`
+/// convert the rtyper rejects.
+///
+/// Conservative by construction: a constructor result is treated as
+/// dead only when its *every* use is as a `FieldWrite.base` (the one
+/// read site this pass exempts) and every such store has no result of
+/// its own.  Any other reference — a `FieldRead`/`InteriorFieldWrite`
+/// base, a `FieldWrite` *value*, a call argument, an exitswitch, a
+/// `Link.arg`, a terminal-block inputarg — pins the result and the
+/// chain is kept.  Runs to a fixpoint so a store of one dead aggregate
+/// into another exposes the inner one once the outer store is gone.
+pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
+    use crate::flowspace::model::Variable;
+
+    let is_synthetic_ctor = |kind: &OpKind| {
+        matches!(
+            kind,
+            OpKind::Call {
+                target: CallTarget::SyntheticTransparentCtor { .. },
+                ..
+            }
+        )
+    };
+
+    let mut total_removed = 0usize;
+    loop {
+        // Pass 1: gather every "real" read.  A `FieldWrite.base` is the
+        // store *target*, not a value read, so it is the single ref this
+        // pass does not count; `FieldWrite.value` (if a Variable) is a
+        // genuine read and every other op contributes its full
+        // `op_variable_refs` set.
+        let mut real_read: HashSet<Variable> = HashSet::new();
+        for block in &graph.blocks {
+            for op in &block.operations {
+                if let OpKind::FieldWrite { value, .. } = &op.kind {
+                    if let Some(var) = value.as_variable() {
+                        real_read.insert(var.clone());
+                    }
+                } else {
+                    for var in crate::inline::op_variable_refs(&op.kind) {
+                        real_read.insert(var);
+                    }
+                }
+            }
+            if let Some(ExitSwitch::Value(var)) = &block.exitswitch {
+                real_read.insert(var.clone());
+            }
+            for link in &block.exits {
+                for arg in &link.args {
+                    if let Some(var) = arg.as_variable() {
+                        real_read.insert(var.clone());
+                    }
+                }
+            }
+            // A terminal block (no exits) implicitly uses every inputarg
+            // — the same return-value pin `prune_dead_phis` Step 1 makes.
+            if block.exits.is_empty() {
+                for iarg in &block.inputargs {
+                    real_read.insert(iarg.clone());
+                }
+            }
+        }
+
+        // Pass 2: a constructor result is dead when it is not read and
+        // every store into it is result-less (so dropping the store
+        // leaves no dangling definition).
+        let mut dead: HashSet<Variable> = HashSet::new();
+        for block in &graph.blocks {
+            for op in &block.operations {
+                if !is_synthetic_ctor(&op.kind) {
+                    continue;
+                }
+                let Some(result) = &op.result else { continue };
+                if real_read.contains(result) {
+                    continue;
+                }
+                let stores_clean = graph.blocks.iter().flat_map(|b| &b.operations).all(|o| {
+                    match &o.kind {
+                        OpKind::FieldWrite { base, .. } if base == result => o.result.is_none(),
+                        _ => true,
+                    }
+                });
+                if stores_clean {
+                    dead.insert(result.clone());
+                }
+            }
+        }
+        if dead.is_empty() {
+            break;
+        }
+
+        // Pass 3: drop the dead constructors and their field stores.
+        let mut removed = 0usize;
+        for block in &mut graph.blocks {
+            block.operations.retain(|op| {
+                let drop = match &op.kind {
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor { .. },
+                        ..
+                    } => op.result.as_ref().is_some_and(|r| dead.contains(r)),
+                    OpKind::FieldWrite { base, .. } => dead.contains(base),
+                    _ => false,
+                };
+                if drop {
+                    removed += 1;
+                }
+                !drop
+            });
+        }
+        total_removed += removed;
+        if removed == 0 {
+            break;
+        }
+    }
+    total_removed
+}
+
 /// Remove dead operations and dead inputargs from `graph` per
 /// backward dataflow over operation operands + exitswitches +
 /// `Link.args`-as-dependencies.  Line-by-line port of
@@ -4672,6 +4807,107 @@ mod tests {
         assert!(
             entry_exit.args.is_empty(),
             "predecessor link arg matching the pruned phi must be removed"
+        );
+    }
+
+    #[test]
+    fn remove_dead_aggregates_drops_discarded_ctor_and_its_field_stores() {
+        // entry: tmp = SyntheticTransparentCtor("Tuple");
+        //        setfield(tmp.__pos_0 = b0); setfield(tmp.__pos_1 = b1);
+        //        return void.  `tmp` is never read, so the ctor and both
+        // field stores are dead (`remove_simple_mallocs`).
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let b0 = graph.push_op_var(entry, OpKind::ConstBool(true), true).unwrap();
+        let b1 = graph.push_op_var(entry, OpKind::ConstBool(false), true).unwrap();
+        let tmp = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("Tuple"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("Tuple".into())),
+                },
+                true,
+            )
+            .unwrap();
+        for (i, v) in [b0, b1].into_iter().enumerate() {
+            graph.push_op_var(
+                entry,
+                OpKind::FieldWrite {
+                    base: tmp.clone(),
+                    field: FieldDescriptor {
+                        name: format!("__pos_{i}"),
+                        owner_root: Some("Tuple".into()),
+                        owner_id: None,
+                    },
+                    value: LinkArg::Value(v),
+                    ty: ValueType::Ref(None),
+                },
+                false,
+            );
+        }
+        graph.set_return(entry, None);
+
+        let removed = remove_dead_aggregates(&mut graph);
+
+        assert_eq!(removed, 3, "ctor + two field stores must be removed");
+        let has_ctor_or_store = graph.block(entry).operations.iter().any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                } | OpKind::FieldWrite { .. }
+            )
+        });
+        assert!(!has_ctor_or_store, "dead aggregate ctor + stores must be gone");
+    }
+
+    #[test]
+    fn remove_dead_aggregates_keeps_returned_ctor() {
+        // The same construction, but `tmp` is the return value — it is
+        // read, so neither the ctor nor its stores may be removed.
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let b0 = graph.push_op_var(entry, OpKind::ConstBool(true), true).unwrap();
+        let tmp = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("Tuple"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("Tuple".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(
+            entry,
+            OpKind::FieldWrite {
+                base: tmp.clone(),
+                field: FieldDescriptor {
+                    name: "__pos_0".into(),
+                    owner_root: Some("Tuple".into()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(b0),
+                ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        graph.set_return(entry, Some(tmp.clone()));
+
+        let removed = remove_dead_aggregates(&mut graph);
+
+        assert_eq!(removed, 0, "a returned aggregate must be kept");
+        assert!(
+            graph
+                .block(entry)
+                .operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&tmp)),
+            "the live ctor op must survive"
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2137,6 +2137,80 @@ fn run_phase_b_rtype_isolated(
         return;
     };
     let mut phase_b_reasons: Vec<String> = Vec::new();
+
+    // Upstream `RPythonTyper.specialize()` step 1 (rtyper.py:180-181):
+    // `if not dont_simplify_again: self.annotator.simplify()`. pyre's
+    // per-subject annotate-half (`drive_subject`) skips the annotator-wide
+    // simplify, so a graph's constant-folded dead arms stay structurally
+    // linked into Phase B. The annotator never followed those links — a
+    // constant exitswitch makes the mismatched-exitcase arm carry
+    // `s_ImpossibleValue` through `follow_link`, which returns before
+    // `links_followed[link] = True` (annrpython.rs:1762-1768), leaving the
+    // arm's target unannotated — but the surviving structural link reaches
+    // `specialize_block` → `insert_link_conversions` → `bindingrepr`, which
+    // then KeyErrors on the dead target's unbound inputargs.
+    //
+    // Run `transform_dead_code` (transform.py:145-165) once over the whole
+    // fully-annotated block set here: it is the simplify pass that prunes
+    // links absent from `links_followed`, folding a const switch back to a
+    // plain goto. It is a no-op on graphs whose every exit was followed, so
+    // healthy graphs are untouched. Per-block panic isolation:
+    // `cutoff_alwaysraising_block`'s consistency asserts can fire on an
+    // unrelated malformed always-raising block; isolating each block keeps
+    // one such graph from aborting dead-code removal for the rest (that
+    // graph then fails its own rtype below and Skips, unchanged).
+    {
+        use crate::flowspace::model::BlockKey;
+        use crate::translator::transform::{
+            fully_annotated_blocks, transform_dead_code, transform_dead_op_vars,
+        };
+        let annotated_blocks = fully_annotated_blocks(&annotator);
+
+        // Pass 1 — `transform_dead_code` (transform.py:145): prune the
+        // unfollowed const-switch dead arms. Per-block panic isolation
+        // (`cutoff_alwaysraising_block`'s consistency asserts can fire on an
+        // unrelated malformed always-raising block).
+        for block in &annotated_blocks {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                transform_dead_code(&annotator, std::slice::from_ref(block));
+            }));
+        }
+
+        // Pass 2 — `transform_dead_op_vars` (simplify.py:422, transform.py:137):
+        // drop dead ops and, crucially, dead inputargs together with their
+        // matching link args. This is the remaining half of upstream
+        // `specialize()` step-1 `simplify()` that the per-subject flow also
+        // skipped: removing a never-read merge inputarg clears the unbound
+        // operand the rtyper would otherwise `binding`-KeyError on. Grouped
+        // per owning graph and panic-isolated — the pass is whole-subgraph
+        // dataflow (its link-arity assert can fire on a malformed graph), so a
+        // single bad graph must not abort the drain for the rest; that graph
+        // then fails its own rtype below and Skips, unchanged.
+        let mut order: Vec<GraphKey> = Vec::new();
+        let mut by_graph: HashMap<GraphKey, Vec<BlockRef>> = HashMap::new();
+        {
+            let annotated = annotator.annotated.borrow();
+            for block in &annotated_blocks {
+                if let Some(Some(g)) = annotated.get(&BlockKey::of(block)) {
+                    let gk = GraphKey::of(g);
+                    by_graph
+                        .entry(gk.clone())
+                        .or_insert_with(|| {
+                            order.push(gk.clone());
+                            Vec::new()
+                        })
+                        .push(block.clone());
+                }
+            }
+        }
+        for gk in &order {
+            let group = &by_graph[gk];
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                transform_dead_op_vars(&annotator, group);
+            }));
+        }
+    }
+
     loop {
         // Skip-tolerant repr setup: a single unported repr (e.g. DictRepr)
         // must not abort rtyping of every other annotated graph. The graph
@@ -2195,8 +2269,12 @@ fn run_phase_b_rtype_isolated(
                             }
                             Ok(Ok(())) => unreachable!(),
                         };
+                        let gname = gopt
+                            .as_ref()
+                            .map(|g| g.borrow().name.clone())
+                            .unwrap_or_else(|| "<none>".to_string());
                         eprintln!(
-                            "[PREPASS phaseB fail] {:?}: {reason}",
+                            "[PREPASS phaseB fail] {:?} {gname}: {reason}",
                             gopt.as_ref().map(GraphKey::of)
                         );
                         phase_b_reasons.push(reason);

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -30,8 +30,7 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 use crate::translator::rtyper::lltypesystem::rstr::sub_helper_funcptr_constant;
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype,
-    exception_args,
+    ConvertedTo, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype, exception_args,
     helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
 
@@ -1785,28 +1784,12 @@ fn build_ll_list_getitem_checked_helper_graph(
     );
 
     let l_fix = variable_with_lltype("l", ptr_lltype.clone());
-    let length_fix = variable_with_lltype("length", LowLevelType::Signed);
-    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
-    let block_neg_fix = Block::shared(vec![
+    let i_fix_u = variable_with_lltype("index", LowLevelType::Unsigned);
+    let len_fix_u = variable_with_lltype("length", LowLevelType::Unsigned);
+    let block_fixup = Block::shared(vec![
         Hlvalue::Variable(l_fix.clone()),
-        Hlvalue::Variable(length_fix.clone()),
-        Hlvalue::Variable(i_fix.clone()),
-    ]);
-
-    let l_high = variable_with_lltype("l", ptr_lltype.clone());
-    let length_high = variable_with_lltype("length", LowLevelType::Signed);
-    let i_high = variable_with_lltype("index", LowLevelType::Signed);
-    let block_check_high = Block::shared(vec![
-        Hlvalue::Variable(l_high.clone()),
-        Hlvalue::Variable(length_high.clone()),
-        Hlvalue::Variable(i_high.clone()),
-    ]);
-
-    let l_low = variable_with_lltype("l", ptr_lltype.clone());
-    let i_low = variable_with_lltype("index", LowLevelType::Signed);
-    let block_check_low = Block::shared(vec![
-        Hlvalue::Variable(l_low.clone()),
-        Hlvalue::Variable(i_low.clone()),
+        Hlvalue::Variable(i_fix_u.clone()),
+        Hlvalue::Variable(len_fix_u.clone()),
     ]);
 
     let l_disp = variable_with_lltype("l", ptr_lltype);
@@ -1816,105 +1799,90 @@ fn build_ll_list_getitem_checked_helper_graph(
         Hlvalue::Variable(i_disp.clone()),
     ]);
 
-    // ---- start: length = <len read>; is_neg = int_lt(index, 0); branch.
+    // ---- start: length = <len read>; index_u = cast_int_to_uint(index);
+    //      length_u = cast_int_to_uint(length); oob = uint_ge(index_u, length_u);
+    //      branch.  The common 0 <= index < length case falls straight through
+    //      with no add (`ll_getitem`, rlist.py:699).
     let length = emit_list_length_read(&startblock, layout, &l);
-    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    let i_u = variable_with_lltype("index", LowLevelType::Unsigned);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "int_lt",
-        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
-        Hlvalue::Variable(is_neg.clone()),
+        "cast_int_to_uint",
+        vec![Hlvalue::Variable(i.clone())],
+        Hlvalue::Variable(i_u.clone()),
     ));
-    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    let len_u = variable_with_lltype("length", LowLevelType::Unsigned);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "cast_int_to_uint",
+        vec![Hlvalue::Variable(length)],
+        Hlvalue::Variable(len_u.clone()),
+    ));
+    let oob = variable_with_lltype("oob", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_ge",
+        vec![
+            Hlvalue::Variable(i_u.clone()),
+            Hlvalue::Variable(len_u.clone()),
+        ],
+        Hlvalue::Variable(oob.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob));
     startblock.closeblock(vec![
         Link::new(
             vec![
                 Hlvalue::Variable(l.clone()),
-                Hlvalue::Variable(length.clone()),
-                Hlvalue::Variable(i.clone()),
+                Hlvalue::Variable(i_u),
+                Hlvalue::Variable(len_u),
             ],
-            Some(block_neg_fix.clone()),
+            Some(block_fixup.clone()),
             Some(bool_const(true)),
         )
         .into_ref(),
         Link::new(
-            vec![
-                Hlvalue::Variable(l),
-                Hlvalue::Variable(length),
-                Hlvalue::Variable(i),
-            ],
-            Some(block_check_high.clone()),
+            vec![Hlvalue::Variable(l), Hlvalue::Variable(i)],
+            Some(block_dispatch.clone()),
             Some(bool_const(false)),
         )
         .into_ref(),
     ]);
 
-    // ---- block_neg_fix: i_fixed = int_add(index, length); -> check_high.
-    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
-    block_neg_fix
+    // ---- block_fixup: index_u = uint_add(index_u, length_u);
+    //      if uint_ge(index_u, length_u): raise IndexError;
+    //      index = intmask(index_u); -> dispatch.
+    let i_fixed_u = variable_with_lltype("index", LowLevelType::Unsigned);
+    block_fixup
         .borrow_mut()
         .operations
         .push(SpaceOperation::new(
-            "int_add",
+            "uint_add",
             vec![
-                Hlvalue::Variable(i_fix),
-                Hlvalue::Variable(length_fix.clone()),
+                Hlvalue::Variable(i_fix_u),
+                Hlvalue::Variable(len_fix_u.clone()),
             ],
+            Hlvalue::Variable(i_fixed_u.clone()),
+        ));
+    let oob2 = variable_with_lltype("oob", LowLevelType::Bool);
+    block_fixup
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_ge",
+            vec![
+                Hlvalue::Variable(i_fixed_u.clone()),
+                Hlvalue::Variable(len_fix_u),
+            ],
+            Hlvalue::Variable(oob2.clone()),
+        ));
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_fixup
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "cast_uint_to_int",
+            vec![Hlvalue::Variable(i_fixed_u)],
             Hlvalue::Variable(i_fixed.clone()),
         ));
-    block_neg_fix.closeblock(vec![
-        Link::new(
-            vec![
-                Hlvalue::Variable(l_fix),
-                Hlvalue::Variable(length_fix),
-                Hlvalue::Variable(i_fixed),
-            ],
-            Some(block_check_high.clone()),
-            None,
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_check_high: too_high = int_ge(index, length); branch.
-    let too_high = variable_with_lltype("too_high", LowLevelType::Bool);
-    block_check_high
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_ge",
-            vec![
-                Hlvalue::Variable(i_high.clone()),
-                Hlvalue::Variable(length_high),
-            ],
-            Hlvalue::Variable(too_high.clone()),
-        ));
-    block_check_high.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_high));
-    block_check_high.closeblock(vec![
-        Link::new(
-            exc_args.clone(),
-            Some(graph.exceptblock.clone()),
-            Some(bool_const(true)),
-        )
-        .into_ref(),
-        Link::new(
-            vec![Hlvalue::Variable(l_high), Hlvalue::Variable(i_high)],
-            Some(block_check_low.clone()),
-            Some(bool_const(false)),
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_check_low: too_low = int_lt(index, 0); branch.
-    let too_low = variable_with_lltype("too_low", LowLevelType::Bool);
-    block_check_low
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_lt",
-            vec![Hlvalue::Variable(i_low.clone()), signed_const(0)],
-            Hlvalue::Variable(too_low.clone()),
-        ));
-    block_check_low.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_low));
-    block_check_low.closeblock(vec![
+    block_fixup.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob2));
+    block_fixup.closeblock(vec![
         Link::new(
             exc_args,
             Some(graph.exceptblock.clone()),
@@ -1922,7 +1890,7 @@ fn build_ll_list_getitem_checked_helper_graph(
         )
         .into_ref(),
         Link::new(
-            vec![Hlvalue::Variable(l_low), Hlvalue::Variable(i_low)],
+            vec![Hlvalue::Variable(l_fix), Hlvalue::Variable(i_fixed)],
             Some(block_dispatch.clone()),
             Some(bool_const(false)),
         )
@@ -2383,34 +2351,14 @@ fn build_ll_list_setitem_checked_helper_graph(
     );
 
     let l_fix = variable_with_lltype("l", ptr_lltype.clone());
-    let length_fix = variable_with_lltype("length", LowLevelType::Signed);
-    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
+    let i_fix_u = variable_with_lltype("index", LowLevelType::Unsigned);
+    let len_fix_u = variable_with_lltype("length", LowLevelType::Unsigned);
     let item_fix = variable_with_lltype("item", item_lltype.clone());
-    let block_neg_fix = Block::shared(vec![
+    let block_fixup = Block::shared(vec![
         Hlvalue::Variable(l_fix.clone()),
-        Hlvalue::Variable(length_fix.clone()),
-        Hlvalue::Variable(i_fix.clone()),
+        Hlvalue::Variable(i_fix_u.clone()),
+        Hlvalue::Variable(len_fix_u.clone()),
         Hlvalue::Variable(item_fix.clone()),
-    ]);
-
-    let l_high = variable_with_lltype("l", ptr_lltype.clone());
-    let length_high = variable_with_lltype("length", LowLevelType::Signed);
-    let i_high = variable_with_lltype("index", LowLevelType::Signed);
-    let item_high = variable_with_lltype("item", item_lltype.clone());
-    let block_check_high = Block::shared(vec![
-        Hlvalue::Variable(l_high.clone()),
-        Hlvalue::Variable(length_high.clone()),
-        Hlvalue::Variable(i_high.clone()),
-        Hlvalue::Variable(item_high.clone()),
-    ]);
-
-    let l_low = variable_with_lltype("l", ptr_lltype.clone());
-    let i_low = variable_with_lltype("index", LowLevelType::Signed);
-    let item_low = variable_with_lltype("item", item_lltype.clone());
-    let block_check_low = Block::shared(vec![
-        Hlvalue::Variable(l_low.clone()),
-        Hlvalue::Variable(i_low.clone()),
-        Hlvalue::Variable(item_low.clone()),
     ]);
 
     let l_disp = variable_with_lltype("l", ptr_lltype);
@@ -2422,112 +2370,95 @@ fn build_ll_list_setitem_checked_helper_graph(
         Hlvalue::Variable(item_disp.clone()),
     ]);
 
-    // ---- start: length = <len read>; is_neg = int_lt(index, 0); branch.
+    // ---- start: length = <len read>; index_u = cast_int_to_uint(index);
+    //      length_u = cast_int_to_uint(length); oob = uint_ge(index_u, length_u);
+    //      branch.  The common 0 <= index < length case falls straight through
+    //      with no add (`ll_setitem`, rlist.py:737).
     let length = emit_list_length_read(&startblock, layout, &l);
-    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    let i_u = variable_with_lltype("index", LowLevelType::Unsigned);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "int_lt",
-        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
-        Hlvalue::Variable(is_neg.clone()),
+        "cast_int_to_uint",
+        vec![Hlvalue::Variable(i.clone())],
+        Hlvalue::Variable(i_u.clone()),
     ));
-    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    let len_u = variable_with_lltype("length", LowLevelType::Unsigned);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "cast_int_to_uint",
+        vec![Hlvalue::Variable(length)],
+        Hlvalue::Variable(len_u.clone()),
+    ));
+    let oob = variable_with_lltype("oob", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "uint_ge",
+        vec![
+            Hlvalue::Variable(i_u.clone()),
+            Hlvalue::Variable(len_u.clone()),
+        ],
+        Hlvalue::Variable(oob.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob));
     startblock.closeblock(vec![
         Link::new(
             vec![
                 Hlvalue::Variable(l.clone()),
-                Hlvalue::Variable(length.clone()),
-                Hlvalue::Variable(i.clone()),
+                Hlvalue::Variable(i_u),
+                Hlvalue::Variable(len_u),
                 Hlvalue::Variable(item.clone()),
             ],
-            Some(block_neg_fix.clone()),
+            Some(block_fixup.clone()),
             Some(bool_const(true)),
         )
         .into_ref(),
         Link::new(
             vec![
                 Hlvalue::Variable(l),
-                Hlvalue::Variable(length),
                 Hlvalue::Variable(i),
                 Hlvalue::Variable(item),
             ],
-            Some(block_check_high.clone()),
+            Some(block_dispatch.clone()),
             Some(bool_const(false)),
         )
         .into_ref(),
     ]);
 
-    // ---- block_neg_fix: i_fixed = int_add(index, length); -> check_high.
-    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
-    block_neg_fix
+    // ---- block_fixup: index_u = uint_add(index_u, length_u);
+    //      if uint_ge(index_u, length_u): raise IndexError;
+    //      index = intmask(index_u); -> dispatch.
+    let i_fixed_u = variable_with_lltype("index", LowLevelType::Unsigned);
+    block_fixup
         .borrow_mut()
         .operations
         .push(SpaceOperation::new(
-            "int_add",
+            "uint_add",
             vec![
-                Hlvalue::Variable(i_fix),
-                Hlvalue::Variable(length_fix.clone()),
+                Hlvalue::Variable(i_fix_u),
+                Hlvalue::Variable(len_fix_u.clone()),
             ],
+            Hlvalue::Variable(i_fixed_u.clone()),
+        ));
+    let oob2 = variable_with_lltype("oob", LowLevelType::Bool);
+    block_fixup
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "uint_ge",
+            vec![
+                Hlvalue::Variable(i_fixed_u.clone()),
+                Hlvalue::Variable(len_fix_u),
+            ],
+            Hlvalue::Variable(oob2.clone()),
+        ));
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_fixup
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "cast_uint_to_int",
+            vec![Hlvalue::Variable(i_fixed_u)],
             Hlvalue::Variable(i_fixed.clone()),
         ));
-    block_neg_fix.closeblock(vec![
-        Link::new(
-            vec![
-                Hlvalue::Variable(l_fix),
-                Hlvalue::Variable(length_fix),
-                Hlvalue::Variable(i_fixed),
-                Hlvalue::Variable(item_fix),
-            ],
-            Some(block_check_high.clone()),
-            None,
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_check_high: too_high = int_ge(index, length); branch.
-    let too_high = variable_with_lltype("too_high", LowLevelType::Bool);
-    block_check_high
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_ge",
-            vec![
-                Hlvalue::Variable(i_high.clone()),
-                Hlvalue::Variable(length_high),
-            ],
-            Hlvalue::Variable(too_high.clone()),
-        ));
-    block_check_high.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_high));
-    block_check_high.closeblock(vec![
-        Link::new(
-            exc_args.clone(),
-            Some(graph.exceptblock.clone()),
-            Some(bool_const(true)),
-        )
-        .into_ref(),
-        Link::new(
-            vec![
-                Hlvalue::Variable(l_high),
-                Hlvalue::Variable(i_high),
-                Hlvalue::Variable(item_high),
-            ],
-            Some(block_check_low.clone()),
-            Some(bool_const(false)),
-        )
-        .into_ref(),
-    ]);
-
-    // ---- block_check_low: too_low = int_lt(index, 0); branch.
-    let too_low = variable_with_lltype("too_low", LowLevelType::Bool);
-    block_check_low
-        .borrow_mut()
-        .operations
-        .push(SpaceOperation::new(
-            "int_lt",
-            vec![Hlvalue::Variable(i_low.clone()), signed_const(0)],
-            Hlvalue::Variable(too_low.clone()),
-        ));
-    block_check_low.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_low));
-    block_check_low.closeblock(vec![
+    block_fixup.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob2));
+    block_fixup.closeblock(vec![
         Link::new(
             exc_args,
             Some(graph.exceptblock.clone()),
@@ -2536,9 +2467,9 @@ fn build_ll_list_setitem_checked_helper_graph(
         .into_ref(),
         Link::new(
             vec![
-                Hlvalue::Variable(l_low),
-                Hlvalue::Variable(i_low),
-                Hlvalue::Variable(item_low),
+                Hlvalue::Variable(l_fix),
+                Hlvalue::Variable(i_fixed),
+                Hlvalue::Variable(item_fix),
             ],
             Some(block_dispatch.clone()),
             Some(bool_const(false)),
@@ -4204,12 +4135,14 @@ mod tests {
             .collect()
     }
 
-    /// rlist.py:697-714 checked `ll_getitem` (`dum_checkidx`, negative index
-    /// folded in) lowers to the signed-explicit `0 <= index < length` window:
-    /// a `getarraysize`+`int_lt` start (length read + neg test on the
-    /// `FixedSizeListRepr` receiver), an `int_add` neg-fix, an `int_ge`
-    /// high-check, an `int_lt` low-check, and a `direct_call` dispatch — with
-    /// both out-of-window arms raising IndexError (two links to exceptblock).
+    /// rlist.py:699-714 checked `ll_getitem` (`dum_checkidx`, negative index
+    /// folded in) lowers to the unsigned-window test `r_uint(index) >=
+    /// r_uint(length)`: the start reads length (`getarraysize` on the
+    /// `FixedSizeListRepr` receiver), casts index/length to unsigned and
+    /// `uint_ge`-branches; the fixup block does `uint_add`, a second `uint_ge`
+    /// raising IndexError, and `intmask` (`cast_uint_to_int`) feeding the
+    /// `direct_call` dispatch.  Only the post-add bound check raises (one link
+    /// to exceptblock); the common `0 <= index < length` case falls through.
     #[test]
     fn build_ll_list_getitem_checked_helper_fixed_has_window_checks() {
         // Keep `ann` alive for the duration: building the inner
@@ -4232,16 +4165,21 @@ mod tests {
         .expect("build_ll_list_getitem_checked_helper_graph");
         let seqs = block_op_sequences(&pygraph);
         assert!(
-            seqs.contains(&vec!["getarraysize".to_string(), "int_lt".to_string()]),
-            "start must read length (getarraysize) then int_lt, got {seqs:?}"
+            seqs.contains(&vec![
+                "getarraysize".to_string(),
+                "cast_int_to_uint".to_string(),
+                "cast_int_to_uint".to_string(),
+                "uint_ge".to_string(),
+            ]),
+            "start must read length (getarraysize), cast to unsigned, then uint_ge, got {seqs:?}"
         );
         assert!(
-            seqs.contains(&vec!["int_add".to_string()]),
-            "expected an int_add neg-fix block, got {seqs:?}"
-        );
-        assert!(
-            seqs.contains(&vec!["int_ge".to_string()]),
-            "expected an int_ge high-check block, got {seqs:?}"
+            seqs.contains(&vec![
+                "uint_add".to_string(),
+                "uint_ge".to_string(),
+                "cast_uint_to_int".to_string(),
+            ]),
+            "expected a uint_add/uint_ge/cast_uint_to_int fixup block, got {seqs:?}"
         );
         assert!(
             seqs.contains(&vec!["direct_call".to_string()]),
@@ -4249,16 +4187,17 @@ mod tests {
         );
         assert_eq!(
             count_links_to_exceptblock(&pygraph),
-            2,
-            "both out-of-window arms must raise IndexError"
+            1,
+            "only the post-add bound check raises IndexError"
         );
     }
 
-    /// rlist.py:716-734 checked `ll_setitem` for the resized [`ListRepr`]: the
+    /// rlist.py:737-742 checked `ll_setitem` for the resized [`ListRepr`]: the
     /// length read is `getfield(l, "length")` (struct header) not
-    /// `getarraysize`, and the body threads the `item` operand through to a
-    /// `direct_call` of `ll_setitem_fast`; both out-of-window arms raise
-    /// IndexError.
+    /// `getarraysize`, the unsigned-window test then casts/`uint_ge`-branches
+    /// and the fixup block (`uint_add`/`uint_ge`/`cast_uint_to_int`) threads the
+    /// `item` operand through to a `direct_call` of `ll_setitem_fast`; only the
+    /// post-add bound check raises IndexError.
     #[test]
     fn build_ll_list_setitem_checked_helper_resized_reads_length_via_getfield() {
         // Keep `ann` alive (see the getitem-checked test above).
@@ -4278,12 +4217,21 @@ mod tests {
         .expect("build_ll_list_setitem_checked_helper_graph");
         let seqs = block_op_sequences(&pygraph);
         assert!(
-            seqs.contains(&vec!["getfield".to_string(), "int_lt".to_string()]),
-            "resized start must read length (getfield) then int_lt, got {seqs:?}"
+            seqs.contains(&vec![
+                "getfield".to_string(),
+                "cast_int_to_uint".to_string(),
+                "cast_int_to_uint".to_string(),
+                "uint_ge".to_string(),
+            ]),
+            "resized start must read length (getfield), cast to unsigned, then uint_ge, got {seqs:?}"
         );
         assert!(
-            seqs.contains(&vec!["int_ge".to_string()]),
-            "expected an int_ge high-check block, got {seqs:?}"
+            seqs.contains(&vec![
+                "uint_add".to_string(),
+                "uint_ge".to_string(),
+                "cast_uint_to_int".to_string(),
+            ]),
+            "expected a uint_add/uint_ge/cast_uint_to_int fixup block, got {seqs:?}"
         );
         assert!(
             seqs.contains(&vec!["direct_call".to_string()]),
@@ -4291,8 +4239,8 @@ mod tests {
         );
         assert_eq!(
             count_links_to_exceptblock(&pygraph),
-            2,
-            "both out-of-window arms must raise IndexError"
+            1,
+            "only the post-add bound check raises IndexError"
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -19,17 +19,19 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::flowspace::model::{
-    Block, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
-    SpaceOperation,
+    Block, BlockRef, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
+    SpaceOperation, Variable,
 };
 use crate::flowspace::pygraph::PyGraph;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{
     ArrayType, LowLevelType, Ptr, PtrTarget, StructType,
 };
+use crate::translator::rtyper::lltypesystem::rstr::sub_helper_funcptr_constant;
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, RPythonTyper, constant_with_lltype, exception_args,
+    ConvertedTo, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype,
+    exception_args,
     helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
 
@@ -57,10 +59,12 @@ pub struct FixedSizeListRepr {
     /// (gcref-wrapped) element repr; its lowleveltype is the array
     /// element type and the `getitem` result type.
     item_repr: Arc<dyn Repr>,
-    /// `self.external_item_repr` (`rlist.py` `_setup_repr`) — the
-    /// surface element repr `recast` converts the internal `getitem`
-    /// result back to. For a primitive item `externalvsinternal` returns
-    /// the same repr, so `recast` is an identity (see [`list_recast`]).
+    /// `self.external_item_repr` (`lltypesystem/rlist.py:177`) — the
+    /// external element repr `recast` ([`list_recast`]) converts a getitem
+    /// result back to. For primitive items this is a clone of the same
+    /// cached `Arc` as `item_repr`, so the recast short-circuits to
+    /// identity; for a gc `InstanceRepr` it is the concrete repr while
+    /// `item_repr` is the generic `OBJECTPTR` root.
     external_item_repr: Arc<dyn Repr>,
 }
 
@@ -71,7 +75,7 @@ impl FixedSizeListRepr {
         // gcref so the array element type is never a gc container
         // (which `ArrayType::gc` rejects); non-instance reprs pass
         // through unchanged.
-        let (external, internal) =
+        let (external_item_repr, internal) =
             crate::translator::rtyper::rclass::externalvsinternal(rtyper, item_repr)?;
         let item_lltype = internal.lowleveltype().clone();
         let arr = ArrayType::gc(item_lltype);
@@ -82,29 +86,31 @@ impl FixedSizeListRepr {
             state: ReprState::new(),
             lltype,
             item_repr: internal,
-            external_item_repr: external,
+            external_item_repr,
         })
     }
 }
 
-/// RPython `AbstractBaseListRepr.recast(self, llops, v)` (`rlist.py:67`):
+/// RPython `AbstractBaseListRepr.recast(self, llops, v)` (`rlist.py:67-68`):
 ///
 /// ```python
 /// def recast(self, llops, v):
 ///     return llops.convertvar(v, self.item_repr, self.external_item_repr)
 /// ```
 ///
-/// Converts an element value produced at the internal `item_repr` back to
-/// the surface `external_item_repr` (`getitem` / `next` results). For a
-/// primitive item `externalvsinternal` returns the same repr instance, so
-/// `convertvar` short-circuits on its `ptr::eq` identity check and emits no
-/// op; a GC-instance element list (`external != internal`) routes through
-/// the pairtype dispatch.
+/// Converts a `getitem` result from the internal element repr (the array
+/// element type) back to the external repr the caller annotated. For the
+/// primitive items a live subject builds, `item_repr` and
+/// `external_item_repr` are clones of the same cached `Arc`, so `convertvar`
+/// short-circuits to identity (its `ptr::eq` guard) and emits no op. A
+/// gc-instance element list (`external != internal`) downcasts the generic
+/// `OBJECTPTR` internal repr to the concrete external `InstanceRepr` via the
+/// `cast_pointer` `pair(InstanceRepr, InstanceRepr)` arm.
 fn list_recast(
     hop: &HighLevelOp,
-    v: Hlvalue,
     item_repr: &Arc<dyn Repr>,
     external_item_repr: &Arc<dyn Repr>,
+    v: Hlvalue,
 ) -> Result<Hlvalue, TyperError> {
     hop.llops
         .borrow_mut()
@@ -180,78 +186,33 @@ impl Repr for FixedSizeListRepr {
     /// ```
     ///
     /// `FixedSizeListRepr` is the non-resized list — a Rust slice
-    /// (`&[T]`) or fixed array, indexed by `usize` values that annotate
-    /// as a non-negative `SomeInteger`. Only the `ll_getitem_nonneg` +
-    /// `dum_nocheck` branch arises, and that chain collapses through
+    /// (`&[T]`) or fixed array. The `(checkidx, nonneg)` selection is
+    /// shared with the resized list through [`list_rtype_getitem`]: the
+    /// nonneg + `dum_nocheck` fast path collapses through
     /// `ll_getitem_foldable_nonneg` → `ll_fixed_getitem_fast(l, index)` →
     /// `l[index]` (`lltypesystem/rlist.py:402-405`) to the bare
-    /// `getarrayitem` on the `Ptr(GcArray)` receiver. The negative-index
-    /// (`ll_getitem`) and `checkidx` (IndexError-raising) branches surface
-    /// a `TyperError` until those helpers land — Rust slice indexing never
-    /// produces them.
+    /// `getarrayitem` on the `Ptr(GcArray)` receiver, while the
+    /// negative-index (`ll_fixed_getitem`) and `checkidx`
+    /// (IndexError-raising `ll_fixed_getitem_*_checked`) helpers fold / window
+    /// the index before dispatching to that fast helper. Rust slice indexing
+    /// only ever exercises the nonneg + `dum_nocheck` path.
     ///
-    /// The upstream result `recast` (`rlist.py:267`
-    /// `return r_lst.recast(hop.llops, v_res)`) converts the internal
-    /// `getitem` result back to `external_item_repr` via [`list_recast`].
-    /// For a primitive item `externalvsinternal` returns the same repr, so
-    /// `convertvar` short-circuits to identity and emits no op; a GC-instance
-    /// list (`external != internal`) routes through the pairtype dispatch.
+    /// The upstream result `recast` (`rlist.py:266`
+    /// `return r_lst.recast(hop.llops, v_res)`) is applied via
+    /// [`list_recast`]: `convertvar(v_res, item_repr, external_item_repr)`.
+    /// For the primitive items a live subject builds `external == internal`
+    /// (clones of the same cached `Arc`), so the recast short-circuits to
+    /// identity and emits no op; a GC-instance list downcasts the internal
+    /// root repr to the concrete external repr.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
-        use crate::annotator::model::SomeValue;
-        if hop.has_implicit_exception("IndexError") {
-            return Err(TyperError::message(
-                "list rtype_getitem: checkidx IndexError branch not yet ported",
-            ));
-        }
-        let s1 = hop
-            .args_s
-            .borrow()
-            .get(1)
-            .cloned()
-            .ok_or_else(|| TyperError::message("list rtype_getitem: args_s[1] missing"))?;
-        let nonneg = match &s1 {
-            SomeValue::Integer(i) => i.nonneg,
-            other => {
-                return Err(TyperError::message(format!(
-                    "list rtype_getitem: args_s[1] must be SomeInteger, got {other:?}"
-                )));
-            }
-        };
-        if !nonneg {
-            return Err(TyperError::message(
-                "list rtype_getitem: negative-index ll_getitem branch not yet ported",
-            ));
-        }
-        let args = hop.inputargs(vec![
-            ConvertedTo::Repr(self),
-            ConvertedTo::LowLevelType(&LowLevelType::Signed),
-        ])?;
-        hop.exception_cannot_occur()?;
-        let item_lltype = self.item_repr.lowleveltype().clone();
-        let ptr_lltype = self.lltype.clone();
-        let ptr_for_builder = ptr_lltype.clone();
-        let item_for_builder = item_lltype.clone();
-        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_fixed_getitem_fast".to_string(),
-            vec![ptr_lltype, LowLevelType::Signed],
-            item_lltype,
-            move |_rtyper, _args, _result| {
-                build_ll_fixed_getitem_fast_helper_graph(
-                    "ll_fixed_getitem_fast",
-                    ptr_for_builder.clone(),
-                    item_for_builder.clone(),
-                )
-            },
-        )?;
-        let v_res = hop.gendirectcall(&helper, args)?.ok_or_else(|| {
-            TyperError::message("list rtype_getitem: ll_fixed_getitem_fast returned Void")
-        })?;
-        Ok(Some(list_recast(
+        let v_res = list_rtype_getitem(
             hop,
-            v_res,
-            &self.item_repr,
-            &self.external_item_repr,
-        )?))
+            self,
+            ListLayout::Fixed,
+            &self.lltype,
+            self.item_repr.lowleveltype(),
+        )?;
+        list_recast(hop, &self.item_repr, &self.external_item_repr, v_res).map(Some)
     }
 
     /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
@@ -273,65 +234,26 @@ impl Repr for FixedSizeListRepr {
     ///     return hop.gendirectcall(llfn, v_func, v_lst, v_index, v_item)
     /// ```
     ///
-    /// `FixedSizeListRepr` handles the `dum_nocheck` + nonneg fast path:
-    /// `ll_setitem_nonneg(dum_nocheck, l, index, item)` collapses (no
-    /// IndexError branch, `index >= 0` is a debug `ll_assert`) through
+    /// Shares the `(checkidx, nonneg)` selection with the resized list via
+    /// [`list_rtype_setitem`]. The `dum_nocheck` + nonneg fast path
+    /// (`ll_setitem_nonneg(dum_nocheck, l, index, item)`, no IndexError
+    /// branch — `index >= 0` is a debug `ll_assert`) collapses through
     /// `l.ll_setitem_fast` → `ll_fixed_setitem_fast(l, index, item)` →
     /// `l[index] = item` (`lltypesystem/rlist.py:407-410`) to the bare
-    /// `setarrayitem` on the `Ptr(GcArray)` receiver. The third inputarg
-    /// converts to `item_repr` (the gcref-wrapped element repr). The
-    /// `checkidx` (implicit-IndexError) and negative-index (`ll_setitem`)
-    /// branches surface a `TyperError` until those helpers land — Rust
-    /// slice indexing never produces them.
+    /// `setarrayitem` on the `Ptr(GcArray)` receiver; the negative-index
+    /// (`ll_fixed_setitem`) and `checkidx` (IndexError-raising
+    /// `ll_fixed_setitem_*_checked`) helpers fold / window the index first.
+    /// The third inputarg converts to the internal `item_repr` (the
+    /// gcref-wrapped element repr), so `rtype_setitem` does not `recast`.
     fn rtype_setitem(&self, hop: &HighLevelOp) -> RTypeResult {
-        use crate::annotator::model::SomeValue;
-        if hop.has_implicit_exception("IndexError") {
-            return Err(TyperError::message(
-                "list rtype_setitem: checkidx IndexError branch not yet ported",
-            ));
-        }
-        let s1 = hop
-            .args_s
-            .borrow()
-            .get(1)
-            .cloned()
-            .ok_or_else(|| TyperError::message("list rtype_setitem: args_s[1] missing"))?;
-        let nonneg = match &s1 {
-            SomeValue::Integer(i) => i.nonneg,
-            other => {
-                return Err(TyperError::message(format!(
-                    "list rtype_setitem: args_s[1] must be SomeInteger, got {other:?}"
-                )));
-            }
-        };
-        if !nonneg {
-            return Err(TyperError::message(
-                "list rtype_setitem: negative-index ll_setitem branch not yet ported",
-            ));
-        }
-        let args = hop.inputargs(vec![
-            ConvertedTo::Repr(self),
-            ConvertedTo::LowLevelType(&LowLevelType::Signed),
-            ConvertedTo::Repr(self.item_repr.as_ref()),
-        ])?;
-        hop.exception_is_here()?;
-        let item_lltype = self.item_repr.lowleveltype().clone();
-        let ptr_lltype = self.lltype.clone();
-        let ptr_for_builder = ptr_lltype.clone();
-        let item_for_builder = item_lltype.clone();
-        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_fixed_setitem_fast".to_string(),
-            vec![ptr_lltype, LowLevelType::Signed, item_lltype],
-            LowLevelType::Void,
-            move |_rtyper, _args, _result| {
-                build_ll_fixed_setitem_fast_helper_graph(
-                    "ll_fixed_setitem_fast",
-                    ptr_for_builder.clone(),
-                    item_for_builder.clone(),
-                )
-            },
-        )?;
-        hop.gendirectcall(&helper, args)
+        list_rtype_setitem(
+            hop,
+            self,
+            ListLayout::Fixed,
+            &self.lltype,
+            self.item_repr.lowleveltype(),
+            self.item_repr.as_ref(),
+        )
     }
 
     /// RPython `AbstractBaseListRepr.rtype_method_reverse(self, hop)`
@@ -483,9 +405,10 @@ pub struct ListRepr {
     /// `self.item_repr` (`rlist.py:111`) — the internal (gcref-wrapped)
     /// element repr.
     item_repr: Arc<dyn Repr>,
-    /// `self.external_item_repr` (`rlist.py` `_setup_repr`) — the surface
-    /// element repr `recast` converts the internal result back to (identity
-    /// for primitive items; see [`list_recast`]).
+    /// `self.external_item_repr` (`lltypesystem/rlist.py:110`) — the
+    /// external element repr `recast` ([`list_recast`]) converts a getitem
+    /// result back to (a clone of `item_repr` for primitives, the concrete
+    /// `InstanceRepr` for a gc-instance element list).
     external_item_repr: Arc<dyn Repr>,
 }
 
@@ -495,7 +418,7 @@ impl ListRepr {
         // gcref normalisation as `FixedSizeListRepr`: gc `InstanceRepr`
         // items become the generic `Ptr(OBJECT)` gcref so the array
         // element type is never a gc container.
-        let (external, internal) =
+        let (external_item_repr, internal) =
             crate::translator::rtyper::rclass::externalvsinternal(rtyper, item_repr)?;
         let item_lltype = internal.lowleveltype().clone();
         // upstream `get_itemarray_lowleveltype()` — `GcArray(ITEM)` (the
@@ -522,7 +445,7 @@ impl ListRepr {
             state: ReprState::new(),
             lltype,
             item_repr: internal,
-            external_item_repr: external,
+            external_item_repr,
         })
     }
 }
@@ -572,68 +495,23 @@ impl Repr for ListRepr {
     /// the `items` array out of the struct first
     /// (`l.ll_items()[index]` = `getfield(l, "items")` then
     /// `getarrayitem`). The negative-index (`ll_getitem`) and `checkidx`
-    /// (IndexError-raising) branches surface a `TyperError` until those
-    /// helpers land.
+    /// (IndexError-raising `ll_getitem_*_checked`) helpers fold / window the
+    /// index before dispatching to that fast helper — all selected by the
+    /// shared [`list_rtype_getitem`].
     ///
-    /// The upstream result `recast` (`rlist.py:267`) converts the internal
-    /// result back to `external_item_repr` via [`list_recast`] — identity
-    /// for primitive items, pairtype dispatch for a GC-instance list.
+    /// The upstream result `recast` (`rlist.py:266`) is applied via
+    /// [`list_recast`] — identical to `FixedSizeListRepr`: an identity
+    /// short-circuit for the primitive items a live subject builds, a
+    /// `cast_pointer` downcast for a gc-instance element list.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
-        use crate::annotator::model::SomeValue;
-        if hop.has_implicit_exception("IndexError") {
-            return Err(TyperError::message(
-                "list rtype_getitem: checkidx IndexError branch not yet ported",
-            ));
-        }
-        let s1 = hop
-            .args_s
-            .borrow()
-            .get(1)
-            .cloned()
-            .ok_or_else(|| TyperError::message("list rtype_getitem: args_s[1] missing"))?;
-        let nonneg = match &s1 {
-            SomeValue::Integer(i) => i.nonneg,
-            other => {
-                return Err(TyperError::message(format!(
-                    "list rtype_getitem: args_s[1] must be SomeInteger, got {other:?}"
-                )));
-            }
-        };
-        if !nonneg {
-            return Err(TyperError::message(
-                "list rtype_getitem: negative-index ll_getitem branch not yet ported",
-            ));
-        }
-        let args = hop.inputargs(vec![
-            ConvertedTo::Repr(self),
-            ConvertedTo::LowLevelType(&LowLevelType::Signed),
-        ])?;
-        hop.exception_cannot_occur()?;
-        let item_lltype = self.item_repr.lowleveltype().clone();
-        let ptr_lltype = self.lltype.clone();
-        let ptr_for_builder = ptr_lltype.clone();
-        let item_for_builder = item_lltype.clone();
-        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_getitem_fast".to_string(),
-            vec![ptr_lltype, LowLevelType::Signed],
-            item_lltype,
-            move |_rtyper, _args, _result| {
-                build_ll_getitem_fast_helper_graph(
-                    "ll_getitem_fast",
-                    ptr_for_builder.clone(),
-                    item_for_builder.clone(),
-                )
-            },
-        )?;
-        let v_res = hop.gendirectcall(&helper, args)?.ok_or_else(|| {
-            TyperError::message("list rtype_getitem: ll_getitem_fast returned Void")
-        })?;
-        Ok(Some(list_recast(
+        let v_res = list_rtype_getitem(
             hop,
-            v_res,
-            &self.item_repr,
-            &self.external_item_repr,
-        )?))
+            self,
+            ListLayout::Resized,
+            &self.lltype,
+            self.item_repr.lowleveltype(),
+        )?;
+        list_recast(hop, &self.item_repr, &self.external_item_repr, v_res).map(Some)
     }
 
     /// RPython `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
@@ -643,58 +521,58 @@ impl Repr for ListRepr {
     /// resized receiver reads the `items` array out of the
     /// `Ptr(GcStruct("list", length, items))` header first
     /// (`lltypesystem/rlist.py:264-267` `l.ll_items()[index] = item` =
-    /// `getfield(l, "items")` then `setarrayitem`). The `checkidx`
-    /// (implicit-IndexError) and negative-index (`ll_setitem`) branches
-    /// surface a `TyperError` until those helpers land.
+    /// `getfield(l, "items")` then `setarrayitem`). The negative-index
+    /// (`ll_setitem`) and `checkidx` (IndexError-raising
+    /// `ll_setitem_*_checked`) helpers fold / window the index before
+    /// dispatching to that fast helper — all selected by the shared
+    /// [`list_rtype_setitem`].
     fn rtype_setitem(&self, hop: &HighLevelOp) -> RTypeResult {
-        use crate::annotator::model::SomeValue;
-        if hop.has_implicit_exception("IndexError") {
-            return Err(TyperError::message(
-                "list rtype_setitem: checkidx IndexError branch not yet ported",
-            ));
-        }
-        let s1 = hop
-            .args_s
-            .borrow()
-            .get(1)
-            .cloned()
-            .ok_or_else(|| TyperError::message("list rtype_setitem: args_s[1] missing"))?;
-        let nonneg = match &s1 {
-            SomeValue::Integer(i) => i.nonneg,
-            other => {
-                return Err(TyperError::message(format!(
-                    "list rtype_setitem: args_s[1] must be SomeInteger, got {other:?}"
-                )));
+        list_rtype_setitem(
+            hop,
+            self,
+            ListLayout::Resized,
+            &self.lltype,
+            self.item_repr.lowleveltype(),
+            self.item_repr.as_ref(),
+        )
+    }
+
+    /// RPython `AbstractBaseListRepr.rtype_method_reverse(self, hop)`
+    /// (`rlist.py:138-143`) — defined on the common base, so it applies to
+    /// the resized [`ListRepr`] as well as [`FixedSizeListRepr`]. The body
+    /// shape is identical (`inputargs(self)`, `exception_cannot_occur()`,
+    /// `direct_call(ll_reverse, v_lst)`); only the lowered `ll_reverse`
+    /// differs — the resized receiver reads `length`/`items` out of the
+    /// `Ptr(GcStruct("list", length, items))` header
+    /// ([`build_ll_reverse_resized_helper_graph`]) rather than `getarraysize`
+    /// / bare `getarrayitem` on a `Ptr(GcArray)`.
+    fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
+        match method_name {
+            "reverse" => {
+                let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+                hop.exception_cannot_occur()?;
+                let item_lltype = self.item_repr.lowleveltype().clone();
+                let ptr_lltype = self.lltype.clone();
+                let ptr_for_builder = ptr_lltype.clone();
+                let item_for_builder = item_lltype.clone();
+                let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+                    "ll_reverse".to_string(),
+                    vec![ptr_lltype],
+                    LowLevelType::Void,
+                    move |_rtyper, _args, _result| {
+                        build_ll_reverse_resized_helper_graph(
+                            "ll_reverse",
+                            ptr_for_builder.clone(),
+                            item_for_builder.clone(),
+                        )
+                    },
+                )?;
+                hop.gendirectcall(&helper, vlist)
             }
-        };
-        if !nonneg {
-            return Err(TyperError::message(
-                "list rtype_setitem: negative-index ll_setitem branch not yet ported",
-            ));
+            _ => Err(TyperError::message(format!(
+                "missing ListRepr.rtype_method_{method_name}"
+            ))),
         }
-        let args = hop.inputargs(vec![
-            ConvertedTo::Repr(self),
-            ConvertedTo::LowLevelType(&LowLevelType::Signed),
-            ConvertedTo::Repr(self.item_repr.as_ref()),
-        ])?;
-        hop.exception_is_here()?;
-        let item_lltype = self.item_repr.lowleveltype().clone();
-        let ptr_lltype = self.lltype.clone();
-        let ptr_for_builder = ptr_lltype.clone();
-        let item_for_builder = item_lltype.clone();
-        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_setitem_fast".to_string(),
-            vec![ptr_lltype, LowLevelType::Signed, item_lltype],
-            LowLevelType::Void,
-            move |_rtyper, _args, _result| {
-                build_ll_setitem_fast_helper_graph(
-                    "ll_setitem_fast",
-                    ptr_for_builder.clone(),
-                    item_for_builder.clone(),
-                )
-            },
-        )?;
-        hop.gendirectcall(&helper, args)
     }
 
     /// RPython `lltypesystem/rlist.py` `make_iterator_repr` on the
@@ -1265,6 +1143,1547 @@ pub(crate) fn build_ll_reverse_helper_graph(
     ))
 }
 
+/// Synthesise the resized-list `ll_reverse` (`rlist.py:677-686`):
+///
+/// ```python
+/// def ll_reverse(l):
+///     length = l.ll_length()
+///     i = 0
+///     length_1_i = length-1-i
+///     while i < length_1_i:
+///         tmp = l.ll_getitem_fast(i)
+///         l.ll_setitem_fast(i, l.ll_getitem_fast(length_1_i))
+///         l.ll_setitem_fast(length_1_i, tmp)
+///         i += 1
+///         length_1_i -= 1
+/// ```
+///
+/// Same four-block swap loop as [`build_ll_reverse_helper_graph`], but the
+/// resized receiver is the `Ptr(GcStruct("list", length, items))` header, so
+/// the `ll_length` / `ll_getitem_fast` / `ll_setitem_fast` adtmeths read the
+/// header rather than a bare array: `length` is `getfield(l, "length")` (vs
+/// `getarraysize`), and each element access reads the `items` array out of
+/// the struct first — `getfield(l, "items")` then `getarrayitem` /
+/// `setarrayitem` (matching [`build_ll_getitem_fast_helper_graph`] /
+/// [`build_ll_setitem_fast_helper_graph`]). The repeated `items` reads fold
+/// in the malloc/CSE passes, mirroring upstream's per-adtmeth `l.ll_items()`.
+pub(crate) fn build_ll_reverse_resized_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let signed_const = |n: i64| {
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::Int(n),
+            LowLevelType::Signed,
+        ))
+    };
+    let bool_const = |b: bool| {
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::Bool(b),
+            LowLevelType::Bool,
+        ))
+    };
+    let items_ptr_lltype = LowLevelType::Ptr(Box::new(Ptr {
+        TO: PtrTarget::Array(ArrayType::gc(item_lltype.clone())),
+    }));
+
+    let l_arg = variable_with_lltype("l", ptr_lltype.clone());
+    let startblock = Block::shared(vec![Hlvalue::Variable(l_arg.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // The loop blocks carry (l, i, length_1_i) as their own fresh inputargs.
+    let l_cond = variable_with_lltype("l", ptr_lltype.clone());
+    let i_cond = variable_with_lltype("i", LowLevelType::Signed);
+    let j_cond = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    let block_loop_cond = Block::shared(vec![
+        Hlvalue::Variable(l_cond.clone()),
+        Hlvalue::Variable(i_cond.clone()),
+        Hlvalue::Variable(j_cond.clone()),
+    ]);
+
+    let l_body = variable_with_lltype("l", ptr_lltype);
+    let i_body = variable_with_lltype("i", LowLevelType::Signed);
+    let j_body = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    let block_loop_body = Block::shared(vec![
+        Hlvalue::Variable(l_body.clone()),
+        Hlvalue::Variable(i_body.clone()),
+        Hlvalue::Variable(j_body.clone()),
+    ]);
+
+    // ---- startblock: length = getfield(l, "length"); length_1_i = length - 1.
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l_arg.clone()), void_field_const("length")],
+        Hlvalue::Variable(length.clone()),
+    ));
+    let length_1_i = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(length), signed_const(1)],
+        Hlvalue::Variable(length_1_i.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_arg),
+                signed_const(0),
+                Hlvalue::Variable(length_1_i),
+            ],
+            Some(block_loop_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_loop_cond: int_lt(i, length_1_i). True -> body; False -> return None.
+    let cond = variable_with_lltype("cond", LowLevelType::Bool);
+    block_loop_cond
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_lt",
+            vec![
+                Hlvalue::Variable(i_cond.clone()),
+                Hlvalue::Variable(j_cond.clone()),
+            ],
+            Hlvalue::Variable(cond.clone()),
+        ));
+    block_loop_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+    let none_const = Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::None,
+        LowLevelType::Void,
+    ));
+    block_loop_cond.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_cond),
+                Hlvalue::Variable(i_cond),
+                Hlvalue::Variable(j_cond),
+            ],
+            Some(block_loop_body.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![none_const],
+            Some(graph.returnblock.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_loop_body: read BOTH endpoints (each via getfield "items" +
+    // getarrayitem) before writing either, then step the indices.
+    let items_tmp = variable_with_lltype("items", items_ptr_lltype.clone());
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(l_body.clone()), void_field_const("items")],
+            Hlvalue::Variable(items_tmp.clone()),
+        ));
+    let tmp = variable_with_lltype("tmp", item_lltype.clone());
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getarrayitem",
+            vec![
+                Hlvalue::Variable(items_tmp),
+                Hlvalue::Variable(i_body.clone()),
+            ],
+            Hlvalue::Variable(tmp.clone()),
+        ));
+    let items_v = variable_with_lltype("items", items_ptr_lltype.clone());
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(l_body.clone()), void_field_const("items")],
+            Hlvalue::Variable(items_v.clone()),
+        ));
+    let v = variable_with_lltype("v", item_lltype);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getarrayitem",
+            vec![
+                Hlvalue::Variable(items_v),
+                Hlvalue::Variable(j_body.clone()),
+            ],
+            Hlvalue::Variable(v.clone()),
+        ));
+    let items_wi = variable_with_lltype("items", items_ptr_lltype.clone());
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(l_body.clone()), void_field_const("items")],
+            Hlvalue::Variable(items_wi.clone()),
+        ));
+    let w_i = variable_with_lltype("v", LowLevelType::Void);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(items_wi),
+                Hlvalue::Variable(i_body.clone()),
+                Hlvalue::Variable(v),
+            ],
+            Hlvalue::Variable(w_i),
+        ));
+    let items_wj = variable_with_lltype("items", items_ptr_lltype);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(l_body.clone()), void_field_const("items")],
+            Hlvalue::Variable(items_wj.clone()),
+        ));
+    let w_j = variable_with_lltype("v", LowLevelType::Void);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "setarrayitem",
+            vec![
+                Hlvalue::Variable(items_wj),
+                Hlvalue::Variable(j_body.clone()),
+                Hlvalue::Variable(tmp),
+            ],
+            Hlvalue::Variable(w_j),
+        ));
+    let i_next = variable_with_lltype("i", LowLevelType::Signed);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(i_body.clone()), signed_const(1)],
+            Hlvalue::Variable(i_next.clone()),
+        ));
+    let j_next = variable_with_lltype("length_1_i", LowLevelType::Signed);
+    block_loop_body
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_sub",
+            vec![Hlvalue::Variable(j_body.clone()), signed_const(1)],
+            Hlvalue::Variable(j_next.clone()),
+        ));
+    block_loop_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_body),
+                Hlvalue::Variable(i_next),
+                Hlvalue::Variable(j_next),
+            ],
+            Some(block_loop_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string()],
+        func,
+    ))
+}
+
+/// `FixedSizeListRepr` (bare `Ptr(GcArray)`) vs the resized `ListRepr`
+/// (`Ptr(GcStruct("list", length, items))`) differ only in how `ll_length` /
+/// `ll_getitem_fast` / `ll_setitem_fast` reach the element array, so the
+/// checked / negative-index `ll_getitem` / `ll_setitem` CFGs
+/// (`rlist.py:688-748`) are written once and parameterised by this layout.
+#[derive(Clone, Copy)]
+enum ListLayout {
+    Fixed,
+    Resized,
+}
+
+impl ListLayout {
+    fn getitem_fast_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_getitem_fast",
+            ListLayout::Resized => "ll_getitem_fast",
+        }
+    }
+    fn setitem_fast_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_setitem_fast",
+            ListLayout::Resized => "ll_setitem_fast",
+        }
+    }
+    fn getitem_neg_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_getitem",
+            ListLayout::Resized => "ll_getitem",
+        }
+    }
+    fn getitem_nonneg_checked_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_getitem_nonneg_checked",
+            ListLayout::Resized => "ll_getitem_nonneg_checked",
+        }
+    }
+    fn getitem_checked_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_getitem_checked",
+            ListLayout::Resized => "ll_getitem_checked",
+        }
+    }
+    fn setitem_neg_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_setitem",
+            ListLayout::Resized => "ll_setitem",
+        }
+    }
+    fn setitem_nonneg_checked_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_setitem_nonneg_checked",
+            ListLayout::Resized => "ll_setitem_nonneg_checked",
+        }
+    }
+    fn setitem_checked_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_setitem_checked",
+            ListLayout::Resized => "ll_setitem_checked",
+        }
+    }
+}
+
+fn signed_const(n: i64) -> Hlvalue {
+    Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::Int(n),
+        LowLevelType::Signed,
+    ))
+}
+
+fn bool_const(b: bool) -> Hlvalue {
+    Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::Bool(b),
+        LowLevelType::Bool,
+    ))
+}
+
+/// Push the `ll_length` read for `layout` onto `block` and return the Signed
+/// length var: `getarraysize(l)` (Fixed, bare `Ptr(GcArray)`) or
+/// `getfield(l, "length")` (Resized, struct header).
+fn emit_list_length_read(block: &BlockRef, layout: ListLayout, l: &Variable) -> Variable {
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    let op = match layout {
+        ListLayout::Fixed => SpaceOperation::new(
+            "getarraysize",
+            vec![Hlvalue::Variable(l.clone())],
+            Hlvalue::Variable(length.clone()),
+        ),
+        ListLayout::Resized => SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(l.clone()), void_field_const("length")],
+            Hlvalue::Variable(length.clone()),
+        ),
+    };
+    block.borrow_mut().operations.push(op);
+    length
+}
+
+/// Build (or retrieve cached) the layout's `ll_*_getitem_fast` sub-helper and
+/// return a funcptr `Constant` to `direct_call` it (the `basegetitem` of
+/// `rlist.py:266`).
+fn list_getitem_fast_funcptr(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<Constant, TyperError> {
+    let name = layout.getitem_fast_name().to_string();
+    let name_owned = name.clone();
+    let ptr_for_builder = ptr_lltype.clone();
+    let item_for_builder = item_lltype.clone();
+    let inner = rtyper.lowlevel_helper_function_with_builder(
+        name,
+        vec![ptr_lltype, LowLevelType::Signed],
+        item_lltype,
+        move |_rtyper, _args, _result| match layout {
+            ListLayout::Fixed => build_ll_fixed_getitem_fast_helper_graph(
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+            ListLayout::Resized => build_ll_getitem_fast_helper_graph(
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+        },
+    )?;
+    sub_helper_funcptr_constant(rtyper, &inner)
+}
+
+/// rlist.py:697-714 `ll_getitem` with `func is dum_nocheck` — negative index,
+/// no bound check: `if index < 0: index += l.ll_length(); return
+/// basegetitem(l, index)`. 3-block CFG (start → block_neg_fix → block_dispatch)
+/// forwarding the possibly-fixed index to a `direct_call` of the layout's
+/// `ll_*_getitem_fast`.
+fn build_ll_list_getitem_neg_helper_graph(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let c_fast =
+        list_getitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_fix = variable_with_lltype("l", ptr_lltype.clone());
+    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
+    let block_neg_fix = Block::shared(vec![
+        Hlvalue::Variable(l_fix.clone()),
+        Hlvalue::Variable(i_fix.clone()),
+    ]);
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+    ]);
+
+    // ---- start: is_neg = int_lt(index, 0); branch.
+    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
+        Hlvalue::Variable(is_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(l.clone()), Hlvalue::Variable(i.clone())],
+            Some(block_neg_fix.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(l), Hlvalue::Variable(i)],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_neg_fix: length = <len read>; i_fixed = int_add(index, length).
+    let length = emit_list_length_read(&block_neg_fix, layout, &l_fix);
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_neg_fix
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(i_fix), Hlvalue::Variable(length)],
+            Hlvalue::Variable(i_fixed.clone()),
+        ));
+    block_neg_fix.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(l_fix), Hlvalue::Variable(i_fixed)],
+            Some(block_dispatch.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: c = direct_call(fast, l, index); return c.
+    let c = variable_with_lltype("c", item_lltype);
+    block_dispatch
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(c_fast),
+                Hlvalue::Variable(l_disp),
+                Hlvalue::Variable(i_disp),
+            ],
+            Hlvalue::Variable(c.clone()),
+        ));
+    block_dispatch.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(c)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string()],
+        func,
+    ))
+}
+
+/// rlist.py:688-692 `ll_getitem_nonneg` with `func is dum_checkidx` —
+/// nonneg index, bound check: `if index >= l.ll_length(): raise IndexError;
+/// return basegetitem(l, index)`. 2-block CFG plus graph.exceptblock.
+fn build_ll_list_getitem_nonneg_checked_helper_graph(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let c_fast =
+        list_getitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let exc_args = exception_args("IndexError")?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+    ]);
+
+    // ---- start: length = <len read>; oob = int_ge(index, length); branch.
+    let length = emit_list_length_read(&startblock, layout, &l);
+    let oob = variable_with_lltype("oob", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_ge",
+        vec![Hlvalue::Variable(i.clone()), Hlvalue::Variable(length)],
+        Hlvalue::Variable(oob.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob));
+    startblock.closeblock(vec![
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(l), Hlvalue::Variable(i)],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: c = direct_call(fast, l, index); return c.
+    let c = variable_with_lltype("c", item_lltype);
+    block_dispatch
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(c_fast),
+                Hlvalue::Variable(l_disp),
+                Hlvalue::Variable(i_disp),
+            ],
+            Hlvalue::Variable(c.clone()),
+        ));
+    block_dispatch.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(c)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string()],
+        func,
+    ))
+}
+
+/// rlist.py:697-714 `ll_getitem` with `func is dum_checkidx` — the negative
+/// index is folded in (`index += length`) then the `0 <= index < length`
+/// window is enforced, raising IndexError otherwise. The r_uint window test
+/// is lowered to the signed-explicit `index >= length or index < 0` form
+/// (matching the `ll_stritem_checked` lowering): 5-block CFG (start →
+/// block_neg_fix → block_check_high → block_check_low → block_dispatch) plus
+/// graph.exceptblock.
+fn build_ll_list_getitem_checked_helper_graph(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let c_fast =
+        list_getitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let exc_args = exception_args("IndexError")?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_fix = variable_with_lltype("l", ptr_lltype.clone());
+    let length_fix = variable_with_lltype("length", LowLevelType::Signed);
+    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
+    let block_neg_fix = Block::shared(vec![
+        Hlvalue::Variable(l_fix.clone()),
+        Hlvalue::Variable(length_fix.clone()),
+        Hlvalue::Variable(i_fix.clone()),
+    ]);
+
+    let l_high = variable_with_lltype("l", ptr_lltype.clone());
+    let length_high = variable_with_lltype("length", LowLevelType::Signed);
+    let i_high = variable_with_lltype("index", LowLevelType::Signed);
+    let block_check_high = Block::shared(vec![
+        Hlvalue::Variable(l_high.clone()),
+        Hlvalue::Variable(length_high.clone()),
+        Hlvalue::Variable(i_high.clone()),
+    ]);
+
+    let l_low = variable_with_lltype("l", ptr_lltype.clone());
+    let i_low = variable_with_lltype("index", LowLevelType::Signed);
+    let block_check_low = Block::shared(vec![
+        Hlvalue::Variable(l_low.clone()),
+        Hlvalue::Variable(i_low.clone()),
+    ]);
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+    ]);
+
+    // ---- start: length = <len read>; is_neg = int_lt(index, 0); branch.
+    let length = emit_list_length_read(&startblock, layout, &l);
+    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
+        Hlvalue::Variable(is_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l.clone()),
+                Hlvalue::Variable(length.clone()),
+                Hlvalue::Variable(i.clone()),
+            ],
+            Some(block_neg_fix.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(length),
+                Hlvalue::Variable(i),
+            ],
+            Some(block_check_high.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_neg_fix: i_fixed = int_add(index, length); -> check_high.
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_neg_fix
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![
+                Hlvalue::Variable(i_fix),
+                Hlvalue::Variable(length_fix.clone()),
+            ],
+            Hlvalue::Variable(i_fixed.clone()),
+        ));
+    block_neg_fix.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_fix),
+                Hlvalue::Variable(length_fix),
+                Hlvalue::Variable(i_fixed),
+            ],
+            Some(block_check_high.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_check_high: too_high = int_ge(index, length); branch.
+    let too_high = variable_with_lltype("too_high", LowLevelType::Bool);
+    block_check_high
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_ge",
+            vec![
+                Hlvalue::Variable(i_high.clone()),
+                Hlvalue::Variable(length_high),
+            ],
+            Hlvalue::Variable(too_high.clone()),
+        ));
+    block_check_high.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_high));
+    block_check_high.closeblock(vec![
+        Link::new(
+            exc_args.clone(),
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(l_high), Hlvalue::Variable(i_high)],
+            Some(block_check_low.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_check_low: too_low = int_lt(index, 0); branch.
+    let too_low = variable_with_lltype("too_low", LowLevelType::Bool);
+    block_check_low
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_lt",
+            vec![Hlvalue::Variable(i_low.clone()), signed_const(0)],
+            Hlvalue::Variable(too_low.clone()),
+        ));
+    block_check_low.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_low));
+    block_check_low.closeblock(vec![
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(l_low), Hlvalue::Variable(i_low)],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: c = direct_call(fast, l, index); return c.
+    let c = variable_with_lltype("c", item_lltype);
+    block_dispatch
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(c_fast),
+                Hlvalue::Variable(l_disp),
+                Hlvalue::Variable(i_disp),
+            ],
+            Hlvalue::Variable(c.clone()),
+        ));
+    block_dispatch.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(c)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string()],
+        func,
+    ))
+}
+
+/// Build (or retrieve cached) the list-getitem helper for the
+/// `(checkidx, nonneg)` combination (`rlist.py:247-267`), selecting the
+/// `dum_nocheck` fast path, the negative-index `ll_getitem`, the nonneg
+/// `dum_checkidx` `ll_getitem_nonneg`, or the full checked `ll_getitem`.
+fn list_getitem_helper(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    checkidx: bool,
+    nonneg: bool,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<LowLevelFunction, TyperError> {
+    let name = match (checkidx, nonneg) {
+        (false, true) => layout.getitem_fast_name(),
+        (false, false) => layout.getitem_neg_name(),
+        (true, true) => layout.getitem_nonneg_checked_name(),
+        (true, false) => layout.getitem_checked_name(),
+    }
+    .to_string();
+    let name_owned = name.clone();
+    let ptr_for_builder = ptr_lltype.clone();
+    let item_for_builder = item_lltype.clone();
+    rtyper.lowlevel_helper_function_with_builder(
+        name,
+        vec![ptr_lltype, LowLevelType::Signed],
+        item_lltype,
+        move |rtyper_inner, _args, _result| match (checkidx, nonneg) {
+            (false, true) => match layout {
+                ListLayout::Fixed => build_ll_fixed_getitem_fast_helper_graph(
+                    &name_owned,
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                ),
+                ListLayout::Resized => build_ll_getitem_fast_helper_graph(
+                    &name_owned,
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                ),
+            },
+            (false, false) => build_ll_list_getitem_neg_helper_graph(
+                rtyper_inner,
+                layout,
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+            (true, true) => build_ll_list_getitem_nonneg_checked_helper_graph(
+                rtyper_inner,
+                layout,
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+            (true, false) => build_ll_list_getitem_checked_helper_graph(
+                rtyper_inner,
+                layout,
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+        },
+    )
+}
+
+/// Shared `pair(AbstractBaseListRepr, IntegerRepr).rtype_getitem`
+/// (`rlist.py:247-267`) for both list layouts. The `getitem_idx` op collapses
+/// onto `getitem` in the rtyper dispatch, so `hop.has_implicit_exception` is
+/// the `dum_checkidx` selector — the same caught-IndexError signal
+/// `rtype_setitem` uses (`rlist.py:273`). Returns the (internal-repr) element
+/// value; the caller applies `recast`.
+fn list_rtype_getitem(
+    hop: &HighLevelOp,
+    self_repr: &dyn Repr,
+    layout: ListLayout,
+    ptr_lltype: &LowLevelType,
+    item_lltype: &LowLevelType,
+) -> Result<Hlvalue, TyperError> {
+    use crate::annotator::model::SomeValue;
+    let checkidx = hop.has_implicit_exception("IndexError");
+    let s1 = hop
+        .args_s
+        .borrow()
+        .get(1)
+        .cloned()
+        .ok_or_else(|| TyperError::message("list rtype_getitem: args_s[1] missing"))?;
+    let nonneg = match &s1 {
+        SomeValue::Integer(i) => i.nonneg,
+        other => {
+            return Err(TyperError::message(format!(
+                "list rtype_getitem: args_s[1] must be SomeInteger, got {other:?}"
+            )));
+        }
+    };
+    let args = hop.inputargs(vec![
+        ConvertedTo::Repr(self_repr),
+        ConvertedTo::LowLevelType(&LowLevelType::Signed),
+    ])?;
+    if checkidx {
+        hop.exception_is_here()?;
+    } else {
+        hop.exception_cannot_occur()?;
+    }
+    let helper = list_getitem_helper(
+        &hop.rtyper,
+        layout,
+        checkidx,
+        nonneg,
+        ptr_lltype.clone(),
+        item_lltype.clone(),
+    )?;
+    hop.gendirectcall(&helper, args)?
+        .ok_or_else(|| TyperError::message("list getitem helper unexpectedly returned Void"))
+}
+
+/// The `None` (Void) constant a void-returning helper's returnblock link
+/// carries (`rlist.py` setitem helpers return nothing).
+fn none_void() -> Hlvalue {
+    Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::None,
+        LowLevelType::Void,
+    ))
+}
+
+/// Build (or retrieve cached) the layout's `ll_*_setitem_fast` sub-helper and
+/// return a funcptr `Constant` to `direct_call` it (the `basesetitem` of
+/// `rlist.py:283`).
+fn list_setitem_fast_funcptr(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<Constant, TyperError> {
+    let name = layout.setitem_fast_name().to_string();
+    let name_owned = name.clone();
+    let ptr_for_builder = ptr_lltype.clone();
+    let item_for_builder = item_lltype.clone();
+    let inner = rtyper.lowlevel_helper_function_with_builder(
+        name,
+        vec![ptr_lltype, LowLevelType::Signed, item_lltype],
+        LowLevelType::Void,
+        move |_rtyper, _args, _result| match layout {
+            ListLayout::Fixed => build_ll_fixed_setitem_fast_helper_graph(
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+            ListLayout::Resized => build_ll_setitem_fast_helper_graph(
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+        },
+    )?;
+    sub_helper_funcptr_constant(rtyper, &inner)
+}
+
+/// rlist.py:716-734 `ll_setitem` with `func is dum_nocheck` — negative index,
+/// no bound check: `if index < 0: index += l.ll_length(); l.ll_setitem_fast(
+/// index, item)`. 3-block CFG forwarding the possibly-fixed index + item to a
+/// `direct_call` of the layout's `ll_*_setitem_fast` (Void).
+fn build_ll_list_setitem_neg_helper_graph(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let c_fast =
+        list_setitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let item = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+        Hlvalue::Variable(item.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_fix = variable_with_lltype("l", ptr_lltype.clone());
+    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
+    let item_fix = variable_with_lltype("item", item_lltype.clone());
+    let block_neg_fix = Block::shared(vec![
+        Hlvalue::Variable(l_fix.clone()),
+        Hlvalue::Variable(i_fix.clone()),
+        Hlvalue::Variable(item_fix.clone()),
+    ]);
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let item_disp = variable_with_lltype("item", item_lltype);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+        Hlvalue::Variable(item_disp.clone()),
+    ]);
+
+    // ---- start: is_neg = int_lt(index, 0); branch.
+    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
+        Hlvalue::Variable(is_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l.clone()),
+                Hlvalue::Variable(i.clone()),
+                Hlvalue::Variable(item.clone()),
+            ],
+            Some(block_neg_fix.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(i),
+                Hlvalue::Variable(item),
+            ],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_neg_fix: length = <len read>; i_fixed = int_add(index, length).
+    let length = emit_list_length_read(&block_neg_fix, layout, &l_fix);
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_neg_fix
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(i_fix), Hlvalue::Variable(length)],
+            Hlvalue::Variable(i_fixed.clone()),
+        ));
+    block_neg_fix.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_fix),
+                Hlvalue::Variable(i_fixed),
+                Hlvalue::Variable(item_fix),
+            ],
+            Some(block_dispatch.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: direct_call(fast, l, index, item); return None.
+    let v_void = variable_with_lltype("v", LowLevelType::Void);
+    block_dispatch
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(c_fast),
+                Hlvalue::Variable(l_disp),
+                Hlvalue::Variable(i_disp),
+                Hlvalue::Variable(item_disp),
+            ],
+            Hlvalue::Variable(v_void),
+        ));
+    block_dispatch.closeblock(vec![
+        Link::new(vec![none_void()], Some(graph.returnblock.clone()), None).into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// rlist.py:716-720 `ll_setitem_nonneg` with `func is dum_checkidx` — nonneg
+/// index, bound check: `if index >= l.ll_length(): raise IndexError;
+/// l.ll_setitem_fast(index, item)`. 2-block CFG plus graph.exceptblock.
+fn build_ll_list_setitem_nonneg_checked_helper_graph(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let c_fast =
+        list_setitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let exc_args = exception_args("IndexError")?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let item = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+        Hlvalue::Variable(item.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let item_disp = variable_with_lltype("item", item_lltype);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+        Hlvalue::Variable(item_disp.clone()),
+    ]);
+
+    // ---- start: length = <len read>; oob = int_ge(index, length); branch.
+    let length = emit_list_length_read(&startblock, layout, &l);
+    let oob = variable_with_lltype("oob", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_ge",
+        vec![Hlvalue::Variable(i.clone()), Hlvalue::Variable(length)],
+        Hlvalue::Variable(oob.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob));
+    startblock.closeblock(vec![
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(i),
+                Hlvalue::Variable(item),
+            ],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: direct_call(fast, l, index, item); return None.
+    let v_void = variable_with_lltype("v", LowLevelType::Void);
+    block_dispatch
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(c_fast),
+                Hlvalue::Variable(l_disp),
+                Hlvalue::Variable(i_disp),
+                Hlvalue::Variable(item_disp),
+            ],
+            Hlvalue::Variable(v_void),
+        ));
+    block_dispatch.closeblock(vec![
+        Link::new(vec![none_void()], Some(graph.returnblock.clone()), None).into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// rlist.py:716-734 `ll_setitem` with `func is dum_checkidx` — fold the
+/// negative index in (`index += length`) then enforce the `0 <= index <
+/// length` window, raising IndexError otherwise (the r_uint window test
+/// lowered to the signed-explicit `index >= length or index < 0` form, as in
+/// [`build_ll_list_getitem_checked_helper_graph`]): 5-block CFG plus
+/// graph.exceptblock.
+fn build_ll_list_setitem_checked_helper_graph(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let c_fast =
+        list_setitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let exc_args = exception_args("IndexError")?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let item = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+        Hlvalue::Variable(item.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_fix = variable_with_lltype("l", ptr_lltype.clone());
+    let length_fix = variable_with_lltype("length", LowLevelType::Signed);
+    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
+    let item_fix = variable_with_lltype("item", item_lltype.clone());
+    let block_neg_fix = Block::shared(vec![
+        Hlvalue::Variable(l_fix.clone()),
+        Hlvalue::Variable(length_fix.clone()),
+        Hlvalue::Variable(i_fix.clone()),
+        Hlvalue::Variable(item_fix.clone()),
+    ]);
+
+    let l_high = variable_with_lltype("l", ptr_lltype.clone());
+    let length_high = variable_with_lltype("length", LowLevelType::Signed);
+    let i_high = variable_with_lltype("index", LowLevelType::Signed);
+    let item_high = variable_with_lltype("item", item_lltype.clone());
+    let block_check_high = Block::shared(vec![
+        Hlvalue::Variable(l_high.clone()),
+        Hlvalue::Variable(length_high.clone()),
+        Hlvalue::Variable(i_high.clone()),
+        Hlvalue::Variable(item_high.clone()),
+    ]);
+
+    let l_low = variable_with_lltype("l", ptr_lltype.clone());
+    let i_low = variable_with_lltype("index", LowLevelType::Signed);
+    let item_low = variable_with_lltype("item", item_lltype.clone());
+    let block_check_low = Block::shared(vec![
+        Hlvalue::Variable(l_low.clone()),
+        Hlvalue::Variable(i_low.clone()),
+        Hlvalue::Variable(item_low.clone()),
+    ]);
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let item_disp = variable_with_lltype("item", item_lltype);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+        Hlvalue::Variable(item_disp.clone()),
+    ]);
+
+    // ---- start: length = <len read>; is_neg = int_lt(index, 0); branch.
+    let length = emit_list_length_read(&startblock, layout, &l);
+    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
+        Hlvalue::Variable(is_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l.clone()),
+                Hlvalue::Variable(length.clone()),
+                Hlvalue::Variable(i.clone()),
+                Hlvalue::Variable(item.clone()),
+            ],
+            Some(block_neg_fix.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(length),
+                Hlvalue::Variable(i),
+                Hlvalue::Variable(item),
+            ],
+            Some(block_check_high.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_neg_fix: i_fixed = int_add(index, length); -> check_high.
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_neg_fix
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![
+                Hlvalue::Variable(i_fix),
+                Hlvalue::Variable(length_fix.clone()),
+            ],
+            Hlvalue::Variable(i_fixed.clone()),
+        ));
+    block_neg_fix.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_fix),
+                Hlvalue::Variable(length_fix),
+                Hlvalue::Variable(i_fixed),
+                Hlvalue::Variable(item_fix),
+            ],
+            Some(block_check_high.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_check_high: too_high = int_ge(index, length); branch.
+    let too_high = variable_with_lltype("too_high", LowLevelType::Bool);
+    block_check_high
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_ge",
+            vec![
+                Hlvalue::Variable(i_high.clone()),
+                Hlvalue::Variable(length_high),
+            ],
+            Hlvalue::Variable(too_high.clone()),
+        ));
+    block_check_high.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_high));
+    block_check_high.closeblock(vec![
+        Link::new(
+            exc_args.clone(),
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_high),
+                Hlvalue::Variable(i_high),
+                Hlvalue::Variable(item_high),
+            ],
+            Some(block_check_low.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_check_low: too_low = int_lt(index, 0); branch.
+    let too_low = variable_with_lltype("too_low", LowLevelType::Bool);
+    block_check_low
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_lt",
+            vec![Hlvalue::Variable(i_low.clone()), signed_const(0)],
+            Hlvalue::Variable(too_low.clone()),
+        ));
+    block_check_low.borrow_mut().exitswitch = Some(Hlvalue::Variable(too_low));
+    block_check_low.closeblock(vec![
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_low),
+                Hlvalue::Variable(i_low),
+                Hlvalue::Variable(item_low),
+            ],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: direct_call(fast, l, index, item); return None.
+    let v_void = variable_with_lltype("v", LowLevelType::Void);
+    block_dispatch
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(c_fast),
+                Hlvalue::Variable(l_disp),
+                Hlvalue::Variable(i_disp),
+                Hlvalue::Variable(item_disp),
+            ],
+            Hlvalue::Variable(v_void),
+        ));
+    block_dispatch.closeblock(vec![
+        Link::new(vec![none_void()], Some(graph.returnblock.clone()), None).into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// Build (or retrieve cached) the list-setitem helper for the
+/// `(checkidx, nonneg)` combination (`rlist.py:272-284`).
+fn list_setitem_helper(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    checkidx: bool,
+    nonneg: bool,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<LowLevelFunction, TyperError> {
+    let name = match (checkidx, nonneg) {
+        (false, true) => layout.setitem_fast_name(),
+        (false, false) => layout.setitem_neg_name(),
+        (true, true) => layout.setitem_nonneg_checked_name(),
+        (true, false) => layout.setitem_checked_name(),
+    }
+    .to_string();
+    let name_owned = name.clone();
+    let ptr_for_builder = ptr_lltype.clone();
+    let item_for_builder = item_lltype.clone();
+    rtyper.lowlevel_helper_function_with_builder(
+        name,
+        vec![ptr_lltype, LowLevelType::Signed, item_lltype],
+        LowLevelType::Void,
+        move |rtyper_inner, _args, _result| match (checkidx, nonneg) {
+            (false, true) => match layout {
+                ListLayout::Fixed => build_ll_fixed_setitem_fast_helper_graph(
+                    &name_owned,
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                ),
+                ListLayout::Resized => build_ll_setitem_fast_helper_graph(
+                    &name_owned,
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                ),
+            },
+            (false, false) => build_ll_list_setitem_neg_helper_graph(
+                rtyper_inner,
+                layout,
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+            (true, true) => build_ll_list_setitem_nonneg_checked_helper_graph(
+                rtyper_inner,
+                layout,
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+            (true, false) => build_ll_list_setitem_checked_helper_graph(
+                rtyper_inner,
+                layout,
+                &name_owned,
+                ptr_for_builder.clone(),
+                item_for_builder.clone(),
+            ),
+        },
+    )
+}
+
+/// Shared `pair(AbstractBaseListRepr, IntegerRepr).rtype_setitem`
+/// (`rlist.py:272-284`) for both list layouts. `hop.has_implicit_exception`
+/// is the `dum_checkidx` selector; the item is the third inputarg, converted
+/// to the internal `item_repr` (so `rtype_setitem` does not `recast`).
+fn list_rtype_setitem(
+    hop: &HighLevelOp,
+    self_repr: &dyn Repr,
+    layout: ListLayout,
+    ptr_lltype: &LowLevelType,
+    item_lltype: &LowLevelType,
+    item_repr: &dyn Repr,
+) -> RTypeResult {
+    use crate::annotator::model::SomeValue;
+    let checkidx = hop.has_implicit_exception("IndexError");
+    let s1 = hop
+        .args_s
+        .borrow()
+        .get(1)
+        .cloned()
+        .ok_or_else(|| TyperError::message("list rtype_setitem: args_s[1] missing"))?;
+    let nonneg = match &s1 {
+        SomeValue::Integer(i) => i.nonneg,
+        other => {
+            return Err(TyperError::message(format!(
+                "list rtype_setitem: args_s[1] must be SomeInteger, got {other:?}"
+            )));
+        }
+    };
+    let args = hop.inputargs(vec![
+        ConvertedTo::Repr(self_repr),
+        ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ConvertedTo::Repr(item_repr),
+    ])?;
+    hop.exception_is_here()?;
+    let helper = list_setitem_helper(
+        &hop.rtyper,
+        layout,
+        checkidx,
+        nonneg,
+        ptr_lltype.clone(),
+        item_lltype.clone(),
+    )?;
+    hop.gendirectcall(&helper, args)
+}
+
 /// RPython `class ListIteratorRepr(AbstractListIteratorRepr)`
 /// (`lltypesystem/rlist.py:453-461`):
 ///
@@ -1474,9 +2893,9 @@ impl Repr for ListIteratorRepr {
             .ok_or_else(|| TyperError::message("list rtype_next: ll_listnext returned Void"))?;
         Ok(Some(list_recast(
             hop,
-            v_res,
             &self.item_repr,
             &self.external_item_repr,
+            v_res,
         )?))
     }
 }
@@ -1956,12 +3375,12 @@ mod tests {
         );
     }
 
-    /// Negative-index annotation (`args_s[1].nonneg == false`) is not yet
-    /// ported (the `ll_getitem` neg-fix branch) — it surfaces a
-    /// `TyperError` so the subject stays on the legacy walker rather than
-    /// miscompiling. Rust slice indexing never produces it.
+    /// rlist.py:247-267 negative-index branch (`args_s[1].nonneg == false`,
+    /// no caught IndexError → `dum_nocheck` `ll_getitem`) — `getitem` lowers
+    /// to a `direct_call` of the neg-fix helper `ll_fixed_getitem` (not the
+    /// `_fast` helper), preceded by `hop.exception_cannot_occur()`.
     #[test]
-    fn fixed_size_list_getitem_negative_index_is_deferred() {
+    fn fixed_size_list_getitem_negative_index_emits_direct_call_to_ll_fixed_getitem() {
         let ann = RPythonAnnotator::new(None, None, None, false);
         let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
         rtyper
@@ -2006,16 +3425,35 @@ mod tests {
             Some(list_repr.clone() as Arc<dyn Repr>),
             Some(signed_repr() as Arc<dyn Repr>),
         ]);
-        assert!(list_repr.rtype_getitem(&hop).is_err());
+
+        let result = list_repr
+            .rtype_getitem(&hop)
+            .unwrap_or_else(|err| panic!("list getitem neg: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "checkidx=False path must call hop.exception_cannot_occur()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_fixed_getitem") && !dbg.contains("ll_fixed_getitem_fast"),
+            "expected the neg helper 'll_fixed_getitem' (not '_fast') in {dbg}"
+        );
     }
 
-    /// A caught `IndexError` (`hop.has_implicit_exception("IndexError")`)
-    /// requires the `checkidx` path (`ll_getitem`), which is not yet
-    /// ported — `rtype_getitem` must surface a `TyperError` rather than
-    /// silently dropping the bounds check via the `dum_nocheck` fast path.
-    /// Mirrors the `rtype_setitem` checkidx guard.
+    /// rlist.py:247-267 checkidx branch (`hop.has_implicit_exception(
+    /// "IndexError")`, nonneg index → `ll_getitem_nonneg` with
+    /// `dum_checkidx`) — `getitem` lowers to a `direct_call` of the
+    /// bound-checking helper `ll_fixed_getitem_nonneg_checked`, preceded by
+    /// `hop.exception_is_here()`.
     #[test]
-    fn fixed_size_list_getitem_checkidx_indexerror_is_deferred() {
+    fn fixed_size_list_getitem_checkidx_emits_direct_call_to_nonneg_checked() {
         let ann = RPythonAnnotator::new(None, None, None, false);
         let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
         rtyper
@@ -2072,12 +3510,24 @@ mod tests {
             Some(list_repr.clone() as Arc<dyn Repr>),
             Some(signed_repr() as Arc<dyn Repr>),
         ]);
-        let err = list_repr
+        let result = list_repr
             .rtype_getitem(&hop)
-            .expect_err("checkidx IndexError must defer to a TyperError");
+            .unwrap_or_else(|err| panic!("list getitem checkidx: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
         assert!(
-            format!("{err}").contains("checkidx IndexError"),
-            "expected checkidx IndexError deferral message, got {err}"
+            ops._called_exception_is_here_or_cannot_occur,
+            "checkidx=True path must call hop.exception_is_here()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_fixed_getitem_nonneg_checked"),
+            "expected 'll_fixed_getitem_nonneg_checked' in {dbg}"
         );
     }
 
@@ -2167,13 +3617,12 @@ mod tests {
         );
     }
 
-    /// Negative-index annotation (`args_s[1].nonneg == false`) is not yet
-    /// ported (the `ll_setitem` neg-fix branch); like the `checkidx`
-    /// (implicit-IndexError) branch it surfaces a `TyperError` so the
-    /// subject stays on the legacy walker. Rust slice indexing never
-    /// produces a negative index.
+    /// rlist.py:272-284 negative-index branch (`args_s[1].nonneg == false`,
+    /// no caught IndexError → `dum_nocheck` `ll_setitem`) — `setitem` lowers
+    /// to a `direct_call` of the neg-fix helper `ll_fixed_setitem` (not the
+    /// `_fast` helper), preceded by `hop.exception_is_here()`.
     #[test]
-    fn fixed_size_list_setitem_negative_index_is_deferred() {
+    fn fixed_size_list_setitem_negative_index_emits_direct_call_to_ll_fixed_setitem() {
         let ann = RPythonAnnotator::new(None, None, None, false);
         let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
         rtyper
@@ -2227,7 +3676,26 @@ mod tests {
             Some(signed_repr() as Arc<dyn Repr>),
             Some(item_repr),
         ]);
-        assert!(list_repr.rtype_setitem(&hop).is_err());
+
+        let result = list_repr
+            .rtype_setitem(&hop)
+            .unwrap_or_else(|err| panic!("list setitem neg: {err:?}"));
+        assert!(result.is_some());
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "rtype_setitem must call hop.exception_is_here()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_fixed_setitem") && !dbg.contains("ll_fixed_setitem_fast"),
+            "expected the neg helper 'll_fixed_setitem' (not '_fast') in {dbg}"
+        );
     }
 
     /// rlist.py:247-267 nonneg + checkidx=False branch — `getitem` on a
@@ -2581,6 +4049,250 @@ mod tests {
                 "int_sub".to_string(),
             ]),
             "expected the read-both-before-write swap body, got {block_op_seqs:?}"
+        );
+    }
+
+    /// The resized [`ListRepr`] inherits `reverse` from the common base
+    /// (`rlist.py:138-143`); it rtypes through `rtype_method("reverse")` to a
+    /// `direct_call(ll_reverse, v_lst)` just like `FixedSizeListRepr`, and the
+    /// path calls `hop.exception_cannot_occur()`.
+    #[test]
+    fn resized_list_reverse_emits_direct_call_to_ll_reverse() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let list_repr: Arc<ListRepr> = Arc::new(
+            ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Void));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "simple_call".to_string(),
+                vec![Hlvalue::Variable(v_list)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .extend([SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ true,
+                /* resized */ true,
+            )))]);
+        hop.args_r
+            .borrow_mut()
+            .extend([Some(list_repr.clone() as Arc<dyn Repr>)]);
+
+        let result = list_repr
+            .rtype_method("reverse", &hop)
+            .unwrap_or_else(|err| panic!("resized list reverse: {err:?}"));
+        assert!(result.is_some());
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(
+            ops._called_exception_is_here_or_cannot_occur,
+            "rtype_method_reverse must call hop.exception_cannot_occur()"
+        );
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(dbg.contains("ll_reverse"), "expected 'll_reverse' in {dbg}");
+    }
+
+    /// The resized `ll_reverse` is the same four-block swap loop as the
+    /// fixed-size one, but the startblock reads `length` via `getfield`
+    /// (vs `getarraysize`) and every element access reads the `items` array
+    /// out of the struct header first (`getfield` before each
+    /// `getarrayitem` / `setarrayitem`).
+    #[test]
+    fn build_ll_reverse_resized_helper_has_swap_loop_blocks() {
+        let rtyper = fresh_rtyper();
+        let repr = ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new");
+        let pygraph = build_ll_reverse_resized_helper_graph(
+            "ll_reverse",
+            repr.lowleveltype().clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build_ll_reverse_resized_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let block_op_seqs: Vec<Vec<String>> = graph
+            .iterblocks()
+            .iter()
+            .map(|b| {
+                b.borrow()
+                    .operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .collect()
+            })
+            .collect();
+        // The resized startblock reads `length` from the struct header.
+        assert!(
+            block_op_seqs.contains(&vec!["getfield".to_string(), "int_sub".to_string()]),
+            "startblock must be getfield + int_sub, got {block_op_seqs:?}"
+        );
+        assert!(
+            block_op_seqs.contains(&vec!["int_lt".to_string()]),
+            "expected an int_lt condition block, got {block_op_seqs:?}"
+        );
+        // The swap body reads `items` (getfield) before each array op; both
+        // reads precede both writes, then the two index steps.
+        assert!(
+            block_op_seqs.contains(&vec![
+                "getfield".to_string(),
+                "getarrayitem".to_string(),
+                "getfield".to_string(),
+                "getarrayitem".to_string(),
+                "getfield".to_string(),
+                "setarrayitem".to_string(),
+                "getfield".to_string(),
+                "setarrayitem".to_string(),
+                "int_add".to_string(),
+                "int_sub".to_string(),
+            ]),
+            "expected the items-indirected swap body, got {block_op_seqs:?}"
+        );
+    }
+
+    /// Count the outgoing links across all reachable blocks of `pygraph`
+    /// whose target is `graph.exceptblock` (the IndexError-raising arms).
+    fn count_links_to_exceptblock(pygraph: &PyGraph) -> usize {
+        let graph = pygraph.graph.borrow();
+        graph
+            .iterblocks()
+            .iter()
+            .flat_map(|b| b.borrow().exits.clone())
+            .filter(|link| {
+                link.borrow()
+                    .target
+                    .as_ref()
+                    .is_some_and(|t| std::rc::Rc::ptr_eq(t, &graph.exceptblock))
+            })
+            .count()
+    }
+
+    fn block_op_sequences(pygraph: &PyGraph) -> Vec<Vec<String>> {
+        pygraph
+            .graph
+            .borrow()
+            .iterblocks()
+            .iter()
+            .map(|b| {
+                b.borrow()
+                    .operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// rlist.py:697-714 checked `ll_getitem` (`dum_checkidx`, negative index
+    /// folded in) lowers to the signed-explicit `0 <= index < length` window:
+    /// a `getarraysize`+`int_lt` start (length read + neg test on the
+    /// `FixedSizeListRepr` receiver), an `int_add` neg-fix, an `int_ge`
+    /// high-check, an `int_lt` low-check, and a `direct_call` dispatch — with
+    /// both out-of-window arms raising IndexError (two links to exceptblock).
+    #[test]
+    fn build_ll_list_getitem_checked_helper_fixed_has_window_checks() {
+        // Keep `ann` alive for the duration: building the inner
+        // `ll_*_getitem_fast` sub-helper annotates it through the typer's
+        // weak annotator reference.
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let repr = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let pygraph = build_ll_list_getitem_checked_helper_graph(
+            &rtyper,
+            ListLayout::Fixed,
+            "ll_fixed_getitem_checked",
+            repr.lowleveltype().clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build_ll_list_getitem_checked_helper_graph");
+        let seqs = block_op_sequences(&pygraph);
+        assert!(
+            seqs.contains(&vec!["getarraysize".to_string(), "int_lt".to_string()]),
+            "start must read length (getarraysize) then int_lt, got {seqs:?}"
+        );
+        assert!(
+            seqs.contains(&vec!["int_add".to_string()]),
+            "expected an int_add neg-fix block, got {seqs:?}"
+        );
+        assert!(
+            seqs.contains(&vec!["int_ge".to_string()]),
+            "expected an int_ge high-check block, got {seqs:?}"
+        );
+        assert!(
+            seqs.contains(&vec!["direct_call".to_string()]),
+            "expected a direct_call dispatch block, got {seqs:?}"
+        );
+        assert_eq!(
+            count_links_to_exceptblock(&pygraph),
+            2,
+            "both out-of-window arms must raise IndexError"
+        );
+    }
+
+    /// rlist.py:716-734 checked `ll_setitem` for the resized [`ListRepr`]: the
+    /// length read is `getfield(l, "length")` (struct header) not
+    /// `getarraysize`, and the body threads the `item` operand through to a
+    /// `direct_call` of `ll_setitem_fast`; both out-of-window arms raise
+    /// IndexError.
+    #[test]
+    fn build_ll_list_setitem_checked_helper_resized_reads_length_via_getfield() {
+        // Keep `ann` alive (see the getitem-checked test above).
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let repr = ListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>).expect("ListRepr::new");
+        let pygraph = build_ll_list_setitem_checked_helper_graph(
+            &rtyper,
+            ListLayout::Resized,
+            "ll_setitem_checked",
+            repr.lowleveltype().clone(),
+            LowLevelType::Signed,
+        )
+        .expect("build_ll_list_setitem_checked_helper_graph");
+        let seqs = block_op_sequences(&pygraph);
+        assert!(
+            seqs.contains(&vec!["getfield".to_string(), "int_lt".to_string()]),
+            "resized start must read length (getfield) then int_lt, got {seqs:?}"
+        );
+        assert!(
+            seqs.contains(&vec!["int_ge".to_string()]),
+            "expected an int_ge high-check block, got {seqs:?}"
+        );
+        assert!(
+            seqs.contains(&vec!["direct_call".to_string()]),
+            "expected a direct_call dispatch block, got {seqs:?}"
+        );
+        assert_eq!(
+            count_links_to_exceptblock(&pygraph),
+            2,
+            "both out-of-window arms must raise IndexError"
         );
     }
 


### PR DESCRIPTION
#37
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Front-end (`majit-translate`) prepass/rtyper changes plus an `AGENTS.md` note.

- `front/result_exc.rs`: add `close_loop_args` and `null_value` to `RESULT_EXC_LOWERING_SCOPE`.
- `front/mir.rs`: lower a Rust `!bool` (`invert` on a bool operand) to `eq(b, false)` instead of the bitwise `invert` op — capture whether the unary operand is a `Bool` before it is resolved, and when so emit a `ConstBool(false)` plus a `BinOp { op: "eq" }` rather than the `invert` op kind; a non-bool operand keeps `invert`.
- `front/mir.rs`: seed `&str` / `str` parameters with the `"str"` builtin `class_root`. `tyref_class_root` returns `None` for a string param (it strips to the `str` builtin, not an ADT), so add an `or_else` that, via `tyref_strips_to_str`, names the root `"str"`.
- `front/mir.rs` + `model.rs`: add a `remove_dead_aggregates` pass and call it in `simplify_lowered_graph` before `remove_assertion_errors`. The pass drops a `SyntheticTransparentCtor` call whose result flows only into its own result-less `FieldWrite` stores (never read/returned/passed), along with those stores; it runs to a fixpoint. `model.rs` adds the function plus two unit tests (`remove_dead_aggregates_drops_discarded_ctor_and_its_field_stores`, `remove_dead_aggregates_keeps_returned_ctor`).
- `front/mir.rs`: make `collapse_fmt_chains` and `collapse_fmt_chains_multi` return `bool` (whether any site collapsed); when either collapsed, run `clear_unreachable_blocks` then `prune_dead_phis` over the graph to sweep the dangling dead phis/link args left by the framestate-threaded argument-tuple ctor deletion.
- `translator/rtyper/rstr.rs`: implement `StringRepr::rtype_str`, dispatching the default `Repr.rtype_str` via `gendirectcall` to a new `ll_str` low-level helper.
- `translator/rtyper/lltypesystem/rstr.rs`: add `build_ll_str_string_helper_graph`, building the `ll_str` body — `ptr_nonzero(s)` guard returning `s` unchanged when non-null and the prebuilt `"None"` string constant otherwise.
- `AGENTS.md`: add a "Charon LLBC extraction" section documenting that the prepass/census reads frozen `build/llbc/*.ullbc` artefacts (interpreter-source changes are invisible until re-extraction, translator changes take effect live), the shared pre-installed Charon cache location, the `scripts/install-charon.py` / `scripts/extract-llbc.py` workflow and fingerprint-skip behavior, and the prepass rebuild step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on Charon LLBC extraction, prepass/census workflow, and build caching instructions.

* **Bug Fixes**
  * Fixed boolean invert operations to use correct logical semantics.
  * Improved string representation handling for nullable string pointers.
  * Extended exception type support in static address mapping.

* **Improvements**
  * Enhanced MIR graph correctness with improved format-chain lowering and unreachable block cleanup.
  * Expanded dead-code elimination pass to remove unused aggregate constructor chains.
  * Added dead-code cleanup in rtyping phase to prevent unbound variable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->