### PR TITLE
#171: orthodox w_list_append descent foundation + discriminant/cast lowering fixes

### DIFF
--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -2253,7 +2253,12 @@ pub fn generated_list_append_by_strategy(
     let len = crate::state::opimpl_getfield_gc_i(ctx, list, len_descr.clone());
     guard_append_without_resize(frame, ctx, list, value, strategy_id, len, is_inline);
 
-    // Write value: object strategy stores directly, int/float unbox first.
+    // Write value: object strategy stores a GC ref into the items block (a
+    // write-barriered array store); int/float strategies unbox to a scalar and
+    // store it through the native `int_items`/`float_items` typed-array data
+    // pointer. Those backing arrays hold plain i64/f64, not GC pointers, so the
+    // store carries no write barrier — the `setlistitem_gc` shape applies only
+    // to a GC-items array, not to these strategies' unboxed storage.
     match strategy_id {
         0 => {
             let items_block = load_items_block(ctx, list, crate::descr::list_items_descr());

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -92,6 +92,13 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                          initializer; this signals a marker encoding/decoder drift"
                     )
                 });
+                // Only the spec string is harvested, not a companion
+                // `oopspec_argnames`.  The support layer's `parse_oopspec`
+                // splits the spec's argument list positionally, which is exact
+                // for the current specs (every arg is a bare parameter name in
+                // declaration order).  A spec that referenced its parameters
+                // out of order or by expression would need the argnames map to
+                // resolve names→positions; emit it here when such a spec lands.
                 push_hint(
                     &mut out,
                     marker_path_to_fn_path(&path, "oopspec_"),

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3194,10 +3194,8 @@ impl<'a> Lowering<'a> {
                 // the field offset — matching the runtime `strategy` field
                 // descr (offset 32, size 1, Int) the production fold uses.
                 // A non-zero tag offset falls through to the generic read.
-                let inline_enum_field = if let PlaceKind::Projection(
-                    _,
-                    ProjectionElem::Tagged(v),
-                ) = &place.kind
+                let inline_enum_field = if let PlaceKind::Projection(_, ProjectionElem::Tagged(v)) =
+                    &place.kind
                     && let Some(field_payload) = v.as_object().and_then(|m| m.get("Field"))
                     && let Some((f_owner_root, f_name, f_ty, f_owner_id)) =
                         self.resolve_adt_field(field_payload)

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -751,8 +751,28 @@ fn derive_program_metadata(
                 // receiver (`enum_variant_narrowing_knowntypedata`) and
                 // reads at the variant-qualified runtime offset
                 // (`resolve_adt_field` owner_root = `{enum_leaf}::{variant}`).
+                // `__discriminant` width.  For a FIELDLESS enum the tag IS
+                // the whole value, so model it at the enum's true byte size
+                // — the heuristic layout then sizes an inline field of this
+                // enum exactly (`W_ListObject.strategy` = 1 byte for a
+                // `repr(u8)` `ListStrategy`), so a discriminant read of the
+                // field reads only the tag, not 7 trailing padding bytes.  A
+                // data-carrying enum's `layout.size` includes the variant
+                // payload, which is not the tag width, so keep the wide
+                // `i64` model there (the tag still sits in the low bytes; a
+                // switch key compares equal under the wide read).
+                let disc_ty = if variants.iter().all(|v| v.fields.is_empty()) {
+                    match td.layout_for_target(&target).and_then(|l| l.size) {
+                        Some(1) => "u8",
+                        Some(2) => "u16",
+                        Some(4) => "u32",
+                        _ => "i64",
+                    }
+                } else {
+                    "i64"
+                };
                 let rows: Vec<(String, String)> =
-                    vec![("__discriminant".to_string(), "i64".to_string())];
+                    vec![("__discriminant".to_string(), disc_ty.to_string())];
                 struct_fields.fields.insert(name.clone(), rows.clone());
                 struct_fields.fields.insert(leaf.clone(), rows.clone());
                 struct_fields.fields.insert(canon_base.clone(), rows);
@@ -3161,6 +3181,47 @@ impl<'a> Lowering<'a> {
                     && let Some(&tag) = self.const_discriminant_locals.get(&(*i as usize))
                 {
                     return Ok((Some(OpKind::ConstInt(tag)), res));
+                }
+                // `Discriminant` of an INLINE enum field (`self.strategy`):
+                // the field is stored by value, so the container holds the
+                // enum's bytes directly — there is no pointer to follow.
+                // Reading `&self.strategy` as a `getfield_gc_r` would load
+                // the field's first word as a bogus pointer (the deref then
+                // faults on the tag read).  When the tag sits at the field's
+                // base (the C-like repr, `inline_enum_field_disc_offset ==
+                // Some(0)`), the field's own offset already addresses the
+                // tag, so read the tag in ONE getfield from the container at
+                // the field offset — matching the runtime `strategy` field
+                // descr (offset 32, size 1, Int) the production fold uses.
+                // A non-zero tag offset falls through to the generic read.
+                let inline_enum_field = if let PlaceKind::Projection(
+                    _,
+                    ProjectionElem::Tagged(v),
+                ) = &place.kind
+                    && let Some(field_payload) = v.as_object().and_then(|m| m.get("Field"))
+                    && let Some((f_owner_root, f_name, f_ty, f_owner_id)) =
+                        self.resolve_adt_field(field_payload)
+                    && self.inline_fieldless_enum_field_tag0(&f_ty)
+                {
+                    Some((f_owner_root, f_name, f_owner_id))
+                } else {
+                    None
+                };
+                if let Some((f_owner_root, f_name, f_owner_id)) = inline_enum_field {
+                    let PlaceKind::Projection(inner, _) = place.kind else {
+                        unreachable!("inline_enum_field implies a Projection place")
+                    };
+                    let base = self.resolve_place(mir_bb, *inner)?;
+                    return Ok((
+                        Some(OpKind::FieldRead {
+                            base,
+                            field: FieldDescriptor::new(f_name, Some(f_owner_root))
+                                .with_owner_id(f_owner_id),
+                            ty: ValueType::Int,
+                            pure: true,
+                        }),
+                        res,
+                    ));
                 }
                 let base = self.resolve_place(mir_bb, place)?;
                 Ok((
@@ -6681,6 +6742,58 @@ impl<'a> Lowering<'a> {
         let def_id = inline_adt_def_id(v)?;
         let td = self.llbc.type_by_id(def_id)?;
         Some(td.item_meta.name_path())
+    }
+
+    /// `true` when `ty` resolves to a FIELDLESS enum whose discriminant
+    /// tag sits at the value's base (byte 0).  Mirrors the
+    /// [`Lowering::tyref_adt_name_path`] resolution (dedup / hash-consed
+    /// bodies), then checks the enum layout's tag position.  The
+    /// `Discriminant` lowering folds the tag read of such an inline enum
+    /// field directly into the container at the field offset: a
+    /// fieldless enum's whole value IS the tag, so reading the field's
+    /// bytes (sized to the enum at `disc_ty` above) yields the
+    /// discriminant.  A data-carrying enum or a non-zero tag offset is
+    /// rejected so the read never picks up variant payload bytes.
+    fn inline_fieldless_enum_field_tag0(&self, ty: &TyRef) -> bool {
+        let Some(mut v) = self.tyref_body(ty) else {
+            return false;
+        };
+        loop {
+            let Some(obj) = v.as_object() else {
+                return false;
+            };
+            if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+                let Some(next) = self.llbc.dedup_body(id) else {
+                    return false;
+                };
+                v = next;
+                continue;
+            }
+            if let Some(arr) = obj
+                .get("HashConsedValue")
+                .and_then(serde_json::Value::as_array)
+                && arr.len() == 2
+            {
+                v = &arr[1];
+                continue;
+            }
+            break;
+        }
+        let Some(def_id) = inline_adt_def_id(v) else {
+            return false;
+        };
+        let Some(td) = self.llbc.type_by_id(def_id) else {
+            return false;
+        };
+        let TypeDeclKind::Enum(variants) = &td.kind else {
+            return false;
+        };
+        variants.iter().all(|variant| variant.fields.is_empty())
+            && td
+                .layout_for_target("")
+                .and_then(|l| l.discriminant_offset())
+                .unwrap_or(0)
+                == 0
     }
 
     /// The resolved JSON body of a [`TyRef`], following the dedup

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2625,6 +2625,21 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
+        // `__pyre_cast_instance/<Root>` — front::mir's pointer-downcast
+        // narrow (#298, `mir.rs` emits `Call(["__pyre_cast_instance",
+        // root], [v])` for a `Ref → *Struct` reinterpret).  The rtyper
+        // lowers it to `cast_pointer` (`rbuiltin.rs rtype_pyre_cast_instance`,
+        // `exception_cannot_occur`), which jtransform folds to `same_as`;
+        // the charon front-end skips the rtyper, so fold the marker to the
+        // operand alias here too.  The JIT does not distinguish a downcast
+        // pointer from its source, so this emits no jitcode op.
+        if let CallTarget::FunctionPath { segments } = target
+            && segments.len() == 2
+            && segments[0] == "__pyre_cast_instance"
+            && args.len() == 1
+        {
+            return RewriteResult::Identity(args[0].clone());
+        }
         // RPython: guess_call_kind(op) → dispatch to handle_*_call
         if let Some(cc) = self.callcontrol.as_mut() {
             let kind = cc.guess_call_kind(op);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9026,6 +9026,21 @@ fn dispatch_residual_call_iRd_kind(
     // local across the fold's mid-statement guards.  Loop traces resume
     // through the loop-header pc_map coordinate and reconstruct it correctly
     // (a no-loop helper's append falls back to the generic residual).
+    // #171 ORTHODOX descent (WIP, default OFF — `PYRE_171_ORTHODOX=1`).  When
+    // enabled, try descending the real `w_list_append` body first; a decline
+    // (`None`) falls through to the hand-rolled fold below.  Same gating
+    // preconditions as the fold (loop full-body frame, not inside a sub-walk).
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
+        && ctx.trace_ctx.header_pc != 0
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && pyre_171_orthodox_enabled()
+        && try_walker_orthodox_list_append(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
@@ -10667,6 +10682,269 @@ fn try_walker_specialize_subscr(
 /// live path is the validated loop-trace append.
 fn pyre_171_inline_list_enabled() -> bool {
     std::env::var("PYRE_171_INLINE_LIST").as_deref() != Ok("0")
+}
+
+/// #171 orthodox descent gate (WIP, default OFF — `PYRE_171_ORTHODOX=1`
+/// opts in).  When the resume-coordinate publication for sub-walk guards
+/// is verified correct this replaces the hand-rolled
+/// [`try_walker_specialize_list_append`] below.
+fn pyre_171_orthodox_enabled() -> bool {
+    std::env::var("PYRE_171_ORTHODOX").as_deref() == Ok("1")
+}
+
+/// Global descr-pool sub-jitcode lookup (resolves a global jitcode index
+/// through `ALL_JITCODES`, mirroring the shadow walker's lookup).  A
+/// build-time canonical sub-body (`w_list_append`) carries no per-fn descr
+/// pool (`JitCodeBody` has no `descrs` field), so it resolves its `d`/`j`
+/// descr operands through the global pool (`all_descr_refs()` /
+/// `RawDescrPool::Global`), and its inline-call descrs through this lookup.
+static GLOBAL_SUB_JITCODE_LOOKUP_FN: fn(usize) -> Option<SubJitCodeBody> =
+    sub_jitcode_body_by_index;
+
+/// #171 ORTHODOX descent of the real `w_list_append` charon body (WIP).
+///
+/// Instead of hand-rolling the int-storage append IR (the fold below), walk
+/// the compiled `w_list_append` jitcode (`list_append_jitcode()`): its
+/// strategy `switch` folds to `guard_value(strategy==Integer)` over the
+/// concrete receiver, the `is_plain_int1` / `plain_int_w` leaves recurse via
+/// `inline_call`, the `ll_list_int_*` leaves are oopspec-lowered to
+/// getfield/setfield/setarrayitem, and the capacity `goto_if_not` guards the
+/// spare-capacity fast path.
+///
+/// The sub-walk's guards must resume at the `lst.append` CALL site (re-execute
+/// the append generically on deopt — any of strategy / plain-int / capacity
+/// failing).  The inline-subwalk capture (`walker_capture_snapshot_for_last_
+/// guard_impl` single-frame fallthrough) reads `ctx.{outer_active_boxes,
+/// outer_jitcode_index,entry_py_pc}` + the vable shadow directly, so this
+/// pre-publishes that ONE call-site coordinate (mapped from `op.pc`) before
+/// the sub-walk under [`InlineSubwalkCaptureGuard`].
+///
+/// Like the fold, the walker only RECORDS the array-op IR; this applies the
+/// append to the concrete list + journals the rewind.  Declines (`Ok(None)`)
+/// BEFORE emitting any IR for a non-matching shape (SAFE fallback to the fold
+/// / residual).
+///
+/// WIP STATUS (default OFF — inert in production): the descr-pool wiring is
+/// correct (the global pool resolves the body's residual_call descr), but
+/// walking the body flag-ON currently SEGVs at the strategy read
+/// (`getfield_gc_r self.strategy` → `getfield_gc_i_pure strategy.tag`,
+/// jitcode pc 12→17): the loaded strategy Ref comes back garbage.  This
+/// canonical *helper* body has never been walked before (unlike opcode-arm
+/// jitcodes), so either its field descrs do not resolve through the global
+/// pool the way arm bodies do, or the shared parent heapcache returns a
+/// stale box across mismatched descr-index spaces.  Resolving that is the
+/// `register in-body helpers` infra epic (#171), tracked separately; until
+/// then the gate stays default OFF and the hand-rolled fold below remains
+/// the production path.
+fn try_walker_orthodox_list_append(
+    ctx: &mut WalkContext<'_, '_>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (ConcreteValue::Ref(callable), ConcreteValue::Ref(null_or_self), ConcreteValue::Ref(value)) =
+        (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    else {
+        return Ok(None);
+    };
+    if callable.is_null() || !null_or_self.is_null() || value.is_null() {
+        return Ok(None);
+    }
+
+    // Recognition: bound builtin `list.append` + Integer-storage list +
+    // plain-int value + spare capacity (mirror the fold's gate).
+    let (inner_func, inner_self, len_before) = unsafe {
+        if !pyre_object::methodobject::is_method(callable) {
+            return Ok(None);
+        }
+        let inner_func = pyre_object::methodobject::w_method_get_func(callable);
+        let inner_self = pyre_object::methodobject::w_method_get_self(callable);
+        if inner_func.is_null() || inner_self.is_null() {
+            return Ok(None);
+        }
+        let list_type = pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE);
+        if pyre_interpreter::lookup_in_type(list_type, "append") != Some(inner_func) {
+            return Ok(None);
+        }
+        if !pyre_object::pyobject::is_list(inner_self)
+            || !pyre_object::w_list_uses_int_storage(inner_self)
+            || !pyre_object::is_plain_int1(value)
+            || pyre_object::pyobject::is_long(value)
+            || !pyre_object::w_list_can_append_without_realloc(inner_self)
+        {
+            return Ok(None);
+        }
+        (inner_func, inner_self, pyre_object::w_list_len(inner_self))
+    };
+
+    // Resolve the compiled `w_list_append` body + the full-body sym (the
+    // resume-coordinate source).  Both absent ⇒ decline (no IR emitted yet).
+    let Some(jc_arc) = crate::jitcode_runtime::list_append_jitcode() else {
+        return Ok(None);
+    };
+    let Some(sub_body) = sub_jitcode_body_by_index(jc_arc.index()) else {
+        return Ok(None);
+    };
+    let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if sym_ptr.is_null() {
+        return Ok(None);
+    }
+    // SAFETY: set for the lifetime of the enclosing full-body walk.
+    let sym = unsafe { &*sym_ptr };
+    if sym.jitcode.is_null() {
+        return Ok(None);
+    }
+
+    // ── commit (record IR; no further declines) ──
+    let callable_op = r_args[0];
+    let value_op = r_args[2];
+
+    // Pin the callable to `list.append`: guard_class METHOD + guard_value on
+    // the stable function slot (these guards resume via the full-body path at
+    // `op.pc`, ignoring the call-site fields set below).
+    let method_type_addr = &pyre_object::methodobject::METHOD_TYPE as *const _ as i64;
+    if !callable_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(callable_op) {
+        let type_const = ctx.trace_ctx.const_int(method_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[callable_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(callable_op, method_type_addr);
+    let func_ref = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        callable_op,
+        crate::descr::method_w_function_descr(),
+    );
+    let func_const = ctx.trace_ctx.const_ref(inner_func as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[func_ref, func_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(func_ref, func_const);
+
+    // Recover the receiver list OpRef + stamp it concrete (the sub-walk reads
+    // it as ref-arg 0; its strategy switch needs the concrete receiver).
+    let self_ref = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        callable_op,
+        crate::descr::method_w_self_descr(),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        self_ref,
+        majit_ir::Value::Ref(majit_ir::GcRef(inner_self as usize)),
+    );
+
+    // Pre-publish the ONE call-site resume coordinate the sub-walk's guards
+    // collapse to (mirror the full-body path's last_instr / valuestackdepth
+    // publication, keyed to the CALL op's py_pc).
+    let (call_site_py_pc, vsd_value, outer_jitcode_index) = unsafe {
+        let jc = &*sym.jitcode;
+        let jc_index = jc.index as u32;
+        let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+        if jc.payload.code_ptr.is_null() {
+            (py, sym.valuestackdepth as i64, jc_index)
+        } else {
+            let codeobj = &*jc.payload.code_ptr;
+            py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+            let lv = crate::liveness::liveness_for(jc.payload.code_ptr);
+            let vsd = match lv.depth_at_py_pc().get(py as usize).copied() {
+                Some(d) => (sym.nlocals + d as usize) as i64,
+                None => sym.valuestackdepth as i64,
+            };
+            (py, vsd, jc_index)
+        }
+    };
+    if sym.owns_virtualizable_shadow() {
+        let li = call_site_py_pc as i64 - 1;
+        let li_op = ctx.trace_ctx.const_int(li);
+        crate::trace_opcode::mirror_vable_static_to_boxes(
+            ctx.trace_ctx,
+            "last_instr",
+            li_op,
+            Value::Int(li),
+        );
+        let vsd_op = ctx.trace_ctx.const_int(vsd_value);
+        crate::trace_opcode::mirror_vable_static_to_boxes(
+            ctx.trace_ctx,
+            "valuestackdepth",
+            vsd_op,
+            Value::Int(vsd_value),
+        );
+    }
+    let active = collect_outer_active_boxes(
+        sym,
+        ctx.trace_ctx,
+        ctx.registers_i,
+        ctx.registers_r,
+        ctx.registers_f,
+        outer_jitcode_index,
+        call_site_py_pc,
+        None,
+        majit_ir::resumedata::NO_JITCODE_PC,
+    );
+
+    // Swap in the call-site resume context + the callee's GLOBAL descr pool
+    // for the sub-walk, restore after.  `w_list_append` is a build-time
+    // canonical body with no per-fn descr pool, so its `d`/`j` operands
+    // resolve through `all_descr_refs()` / `RawDescrPool::Global` — NOT the
+    // parent loop's per-fn pool (which mis-resolves the first residual_call
+    // descr → `ResidualCallDescrNotCallDescr`).
+    let saved_entry = ctx.entry_py_pc;
+    let saved_oji = ctx.outer_jitcode_index;
+    let saved_active = std::mem::take(&mut ctx.outer_active_boxes);
+    let saved_descr_refs = ctx.descr_refs;
+    let saved_raw_descrs = ctx.raw_descrs;
+    let saved_lookup = ctx.sub_jitcode_lookup;
+    ctx.entry_py_pc = call_site_py_pc;
+    ctx.outer_jitcode_index = outer_jitcode_index;
+    ctx.outer_active_boxes = active;
+    ctx.descr_refs = crate::jitcode_runtime::all_descr_refs();
+    ctx.raw_descrs = RawDescrPool::Global;
+    ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
+
+    let self_concrete = ConcreteValue::Ref(inner_self);
+    let value_concrete = ConcreteValue::Ref(value);
+    let walk_result = {
+        let _boundary = InlineSubwalkCaptureGuard::enter();
+        run_sub_jitcode_walk(
+            ctx,
+            op.pc,
+            &sub_body,
+            &[],
+            &[self_ref, value_op],
+            &[self_concrete, value_concrete],
+            &[],
+        )
+    };
+
+    ctx.entry_py_pc = saved_entry;
+    ctx.outer_jitcode_index = saved_oji;
+    ctx.outer_active_boxes = saved_active;
+    ctx.descr_refs = saved_descr_refs;
+    ctx.raw_descrs = saved_raw_descrs;
+    ctx.sub_jitcode_lookup = saved_lookup;
+
+    match walk_result? {
+        DispatchOutcome::SubReturn { result: None } => {}
+        _ => return Err(DispatchError::UnexpectedNonVoidSubReturn { pc: op.pc }),
+    }
+
+    // Tracing is execution: apply the append + journal the rewind (the walker
+    // recorded the IR but did not mutate the concrete list).
+    fbw_append_journal_push(inner_self, len_before);
+    unsafe { pyre_object::w_list_append(inner_self, value) };
+
+    let none_ref = ctx.trace_ctx.const_ref(pyre_object::w_none() as i64);
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', none_ref)?;
+    Ok(Some(()))
 }
 
 /// #171 P3: specialize `lst.append(x)` so its array ops (getfield length /


### PR DESCRIPTION
Continues #171 (trace the real `w_list_append` builtin callee via the codewriter-lowered jitcode body, replacing the hand-rolled `try_walker_specialize_list_append` fold). This lands the descent scaffolding behind a default-OFF flag plus two production-visible lowering fixes that clear the first walls of the descent.

Three commits over `main`:

1. **`jit: fold the charon __pyre_cast_instance marker to an operand alias`** (production-visible) — the `w_list_append` jitcode prologue (pc3/pc15, every path) carried a symbolic `__pyre_cast_instance(W_ListObject)` residual: front::mir emits a `Call(["__pyre_cast_instance", root],[v])` marker for a `Ref→*Struct` reinterpret, the rtyper lowers it to `cast_pointer`→`same_as`, but the charon→jtransform pipeline left it a symbolic `residual_call`. Lower it to `RewriteResult::Identity(args[0])` (mirrors the adjacent `__cast_pointer` arm). General parity fix — every pointer-downcast body shrinks. `jitcode[472]` `constants_i` 6→5 (cast hash gone).

2. **`jit: add default-OFF #171 orthodox w_list_append descent scaffolding`** (flag-gated, inert in default build) — `try_walker_orthodox_list_append` (jitcode_dispatch.rs) behind `PYRE_171_ORTHODOX=1` (default OFF), dispatch gate placed before the fold so flag-on routes to the descent first and `None` declines fall through. Resolves `w_list_append` by fnaddr, swaps to the global descr pool, walks the canonical body via `run_sub_jitcode_walk`, manually applies `fbw_append_journal_push + w_list_append`. Flag-OFF is fully inert.

3. **`jit: lower inline fieldless-enum discriminant to a direct tag-width field read`** (production-visible) — clears two descent walls:
   - **Inline-struct deref SIGSEGV**: `Rvalue::Discriminant` of an inline **fieldless** enum field (tag at offset 0) now lowers to a single `FieldRead` at the field offset, instead of resolving the place and dereferencing the by-value field (`bh_getfield_gc_r` unconditionally derefs, so a `FLAG_STRUCT` field read returned garbage-as-pointer). A fieldless enum's whole value is the tag, so the field-sized read yields the discriminant directly.
   - **Discriminant read size**: front::mir registered every enum's synthetic `__discriminant` as `i64`, so the heuristic layout sized a `repr(u8)` enum (e.g. `ListStrategy`) at 8 bytes — an inline `W_ListObject.strategy` read pulled 7 trailing padding bytes and produced a garbage switch value. A **fieldless** enum's `__discriminant` is now modeled at the enum's true `layout.size` (`1→u8, 2→u16, 4→u32, else i64`); data-carrying enums keep `i64` (their `layout.size` includes payload, which is not the tag width).

### State

With the flag on, the descent now clears wall-1 (descr pool), wall-2 (no SIGSEGV), and wall-3 (the strategy `switch` folds to the Integer arm, `search_value=1`), then aborts gracefully at the spare-capacity branch (`GotoIfNotValueNotConcrete` on `len<cap`) and falls through to the existing fold — correct results, no corruption. Resolving that branch (concrete Int-shadow propagation, then the call-site guard resume) is the next increment.

Production behavior change is limited to the two ungated lowering fixes (commits 1 and 3); the descent (commit 2) is inert unless `PYRE_171_ORTHODOX=1`.

### Verification

- `python3 pyre/check.py`: **139/139 dynasm + 139/139 cranelift** (2/2 backend runs).
- Flag-on smoke: `/tmp/orthodox_small.py` → `20000 199990000`, `/tmp/orthodox_smoke.py` → `100000 4999950000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized list append operations with integer values through new fast-path dispatch
  * Eliminated unnecessary code generation for specific pointer reinterpret operations

* **Improvements**
  * Enhanced enum discriminant handling precision for inline fieldless enums
  * Clarified internal documentation on list write strategies and specification processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->