### PR TITLE
CPython suite: -m module mode, match/PEP-649 opcodes, stdlib/JIT fixes, gate baseline refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,11 +919,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -933,10 +931,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2080,7 +2080,7 @@ dependencies = [
 name = "pyre-wasm"
 version = "0.0.2"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "majit-backend",
  "pyre-interpreter",
  "pyre-jit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1177,12 +1177,12 @@ dependencies = [
 
 [[package]]
 name = "junction"
-version = "1.4.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1310,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memfd"
@@ -2347,13 +2347,13 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -2390,7 +2390,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "bitflags 2.11.1",
  "bitflagset",
@@ -2398,6 +2398,7 @@ dependencies = [
  "lz4_flex",
  "malachite-bigint",
  "num-complex",
+ "num-traits",
  "rustpython-ruff_source_file",
  "rustpython-wtf8",
 ]
@@ -2405,10 +2406,10 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "bitflags 2.11.1",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "junction",
  "libc",
  "libffi",
@@ -2430,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "hexf-parse",
  "icu_properties",
@@ -2442,9 +2443,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ruff_python_ast"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f021ff72cabf5e2cd6d8ec8813d376a8445a228dc610ab56c27bd9054cda70d4"
+version = "0.15.9"
+source = "git+https://github.com/RustPython/ruff.git?tag=0.15.19-rustpython#3c1ab2dd9987f190f3df94d28452ed5e65e106af"
 dependencies = [
  "aho-corasick",
  "bitflags 2.11.1",
@@ -2461,9 +2461,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ruff_python_parser"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e6ee78bd9671fb5766664b2695fe1f2a92a961f4d9101646c570d8acdb1e0b"
+version = "0.15.9"
+source = "git+https://github.com/RustPython/ruff.git?tag=0.15.19-rustpython#3c1ab2dd9987f190f3df94d28452ed5e65e106af"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2482,9 +2481,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ruff_python_trivia"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e7cfd1056f3a02ff0d2d0e4474286ca963260782f878b7b81c1dd87432e682"
+version = "0.15.9"
+source = "git+https://github.com/RustPython/ruff.git?tag=0.15.19-rustpython#3c1ab2dd9987f190f3df94d28452ed5e65e106af"
 dependencies = [
  "itertools",
  "rustpython-ruff_source_file",
@@ -2494,9 +2492,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ruff_source_file"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948107aad62ddb12a11fc7bf68a49e52a0b0a3737d415a2505e54f5a9edac737"
+version = "0.15.9"
+source = "git+https://github.com/RustPython/ruff.git?tag=0.15.19-rustpython#3c1ab2dd9987f190f3df94d28452ed5e65e106af"
 dependencies = [
  "memchr",
  "rustpython-ruff_text_size",
@@ -2504,9 +2501,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ruff_text_size"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8291ee0f5a779e54ccd4e0151a0c426f8b49a123f99b5b6545db17ccdd4277aa"
+version = "0.15.9"
+source = "git+https://github.com/RustPython/ruff.git?tag=0.15.19-rustpython#3c1ab2dd9987f190f3df94d28452ed5e65e106af"
 dependencies = [
  "get-size2",
 ]
@@ -2514,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "bitflags 2.11.1",
  "icu_properties",
@@ -2526,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=1385c4e472f8187f5087011a8c4e3619875cff89#1385c4e472f8187f5087011a8c4e3619875cff89"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
 dependencies = [
  "ascii",
  "bstr",
@@ -2750,7 +2746,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2813,7 +2809,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3706,7 +3702,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,11 @@ pyre-jit-trace = { version = "0.0.2", path = "pyre/pyre-jit-trace" }
 pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "1385c4e472f8187f5087011a8c4e3619875cff89" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "1385c4e472f8187f5087011a8c4e3619875cff89" }
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "1385c4e472f8187f5087011a8c4e3619875cff89" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "1385c4e472f8187f5087011a8c4e3619875cff89" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "1385c4e472f8187f5087011a8c4e3619875cff89" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,9 @@ wasmparser = "0.225"
 # `wasm_js` is enabled only by `pyre-wasm`'s `web` feature (browser crypto via
 # wasm-bindgen). The native-host `wasm-host` build instead selects getrandom's
 # `custom` backend (`--cfg getrandom_backend="custom"`) so it carries no
-# wasm-bindgen imports.
-getrandom = "0.3.4"
+# wasm-bindgen imports. Kept on the same 0.4 line as `rustpython-host_env` so
+# the `web` build's `getrandom/wasm_js` feature reaches that shared instance.
+getrandom = "0.4.2"
 # Native host runtime for the wasm runner. Pinned to the wasmtime release whose
 # `wasmtime-internal-*` support crates already ride along with cranelift 0.132
 # (the version the dynasm/cranelift backends use), so it reuses the existing

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -4,7 +4,7 @@
       "dynasm": "FAIL"
     },
     "test.test__colorize": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test__interpchannels": {
       "dynasm": "IMPORTERROR"
@@ -13,7 +13,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test__locale": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test__opcode": {
       "dynasm": "FAIL"
@@ -31,10 +31,10 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_annotationlib": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_apple": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_argparse": {
       "dynasm": "IMPORTERROR"
@@ -109,7 +109,7 @@
       "dynasm": "CRASH"
     },
     "test.test_c_locale_coercion": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_calendar": {
       "dynasm": "IMPORTERROR"
@@ -241,7 +241,7 @@
       "dynasm": "CRASH"
     },
     "test.test_copyreg": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_coroutines": {
       "dynasm": "IMPORTERROR"
@@ -421,7 +421,7 @@
       "dynasm": "FAIL"
     },
     "test.test_fnmatch": {
-      "dynasm": "FAIL"
+      "dynasm": "PASS"
     },
     "test.test_fork1": {
       "dynasm": "FAIL"
@@ -572,7 +572,7 @@
       "dynasm": "PASS"
     },
     "test.test_interpreters": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_io": {
       "dynasm": "IMPORTERROR"
@@ -624,7 +624,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_lltrace": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_locale": {
       "dynasm": "IMPORTERROR"
@@ -755,7 +755,7 @@
       "reason": "implementation detail"
     },
     "test.test_peg_generator": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_pep646_syntax": {
       "dynasm": "IMPORTERROR"
@@ -791,7 +791,7 @@
       "dynasm": "FAIL"
     },
     "test.test_popen": {
-      "dynasm": "FAIL"
+      "dynasm": "PASS"
     },
     "test.test_poplib": {
       "dynasm": "IMPORTERROR"
@@ -926,7 +926,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_shlex": {
-      "dynasm": "FAIL"
+      "dynasm": "PASS"
     },
     "test.test_shutil": {
       "dynasm": "IMPORTERROR"
@@ -996,7 +996,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_strtod": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_struct": {
       "dynasm": "IMPORTERROR"
@@ -1043,7 +1043,7 @@
       "dynasm": "CRASH"
     },
     "test.test_tabnanny": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_tarfile": {
       "dynasm": "IMPORTERROR"
@@ -1129,7 +1129,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_type_aliases": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_type_annotations": {
       "dynasm": "PASS"
@@ -1141,7 +1141,7 @@
       "dynasm": "FAIL"
     },
     "test.test_type_params": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_typechecks": {
       "dynasm": "PASS"
@@ -1274,7 +1274,7 @@
       "dynasm": "PASS"
     },
     "test.test_xml_dom_xmlbuilder": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_xml_etree": {
       "dynasm": "IMPORTERROR"
@@ -1286,7 +1286,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_xpickle": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_xxlimited": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -4,6 +4,7 @@
       "dynasm": "FAIL"
     },
     "test.test__colorize": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test__interpchannels": {
@@ -13,6 +14,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test__locale": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test__opcode": {
@@ -31,9 +33,11 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_annotationlib": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_apple": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_argparse": {
@@ -73,6 +77,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_bigaddrspace": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_bigmem": {
@@ -109,6 +114,7 @@
       "dynasm": "CRASH"
     },
     "test.test_c_locale_coercion": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_calendar": {
@@ -199,6 +205,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_colorsys": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_compare": {
@@ -211,9 +218,11 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_compiler_assemble": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_compiler_codegen": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_complex": {
@@ -241,6 +250,7 @@
       "dynasm": "CRASH"
     },
     "test.test_copyreg": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_coroutines": {
@@ -330,6 +340,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_dtrace": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_dynamic": {
@@ -364,6 +375,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_errno": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_except_star": {
@@ -421,6 +433,7 @@
       "dynasm": "FAIL"
     },
     "test.test_fnmatch": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_fork1": {
@@ -529,6 +542,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_html": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_htmlparser": {
@@ -569,9 +583,11 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_int_literal": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_interpreters": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_io": {
@@ -599,9 +615,11 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_keyword": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_keywordonlyarg": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_kqueue": {
@@ -624,6 +642,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_lltrace": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_locale": {
@@ -636,6 +655,7 @@
       "dynasm": "FAIL"
     },
     "test.test_longexp": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_lzma": {
@@ -651,6 +671,7 @@
       "dynasm": "FAIL"
     },
     "test.test_math_property": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_memoryio": {
@@ -721,6 +742,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_openpty": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_operator": {
@@ -739,6 +761,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_osx_env": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_pathlib": {
@@ -755,6 +778,7 @@
       "reason": "implementation detail"
     },
     "test.test_peg_generator": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_pep646_syntax": {
@@ -791,6 +815,7 @@
       "dynasm": "FAIL"
     },
     "test.test_popen": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_poplib": {
@@ -926,6 +951,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_shlex": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_shutil": {
@@ -981,6 +1007,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_strftime": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_string": {
@@ -996,6 +1023,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_strtod": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_struct": {
@@ -1011,6 +1039,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_sundry": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_super": {
@@ -1043,6 +1072,7 @@
       "dynasm": "CRASH"
     },
     "test.test_tabnanny": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_tarfile": {
@@ -1058,6 +1088,7 @@
       "dynasm": "FAIL"
     },
     "test.test_textwrap": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_thread": {
@@ -1067,6 +1098,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_threadedtempfile": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_threading": {
@@ -1129,9 +1161,11 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_type_aliases": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_type_annotations": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_type_cache": {
@@ -1141,9 +1175,11 @@
       "dynasm": "FAIL"
     },
     "test.test_type_params": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_typechecks": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_types": {
@@ -1156,6 +1192,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_unary": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_unicode_file": {
@@ -1271,9 +1308,11 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_xml_dom_minicompat": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_xml_dom_xmlbuilder": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_xml_etree": {
@@ -1286,6 +1325,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_xpickle": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_xxlimited": {

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -321,20 +321,35 @@ def main() -> int:
         env["PYRE_NO_JIT"] = "1"
 
     # Decide which modules to actually run.
+    #
+    # The gate only protects modules the baseline records as PASS: a PASS that
+    # regresses fails CI. In the plain gate run it therefore runs *only* those
+    # PASS modules — running the whole suite at the per-module timeout overruns
+    # the CI job budget, and the non-PASS modules carry no gate signal. The
+    # exploratory lanes still see everything: `--full` reports the full suite,
+    # `--update-baseline` re-records it, and `--strict-baseline` must observe
+    # non-PASS modules to flag newly-passing ones.
+    gate_pass_only = not (args.full or args.update_baseline or args.strict_baseline)
     to_run: list[str] = []
     skipped: list[str] = []
+    deselected = 0
     for m in modules:
         exp = expected_status(baseline, m, args.backend)
         is_skip = (exp == "SKIP") or (m in KNOWN_SKIPS)
         if is_skip and not args.full and not args.update_baseline:
             skipped.append(m)
             continue
+        if gate_pass_only and exp != "PASS":
+            deselected += 1
+            continue
         to_run.append(m)
 
     print(f"pyre CPython suite — backend={args.backend} mode={args.mode} "
           f"jit={'off' if args.no_jit else 'on'} jobs={args.jobs}")
     print(f"binary: {binary}")
-    print(f"{len(to_run)} to run, {len(skipped)} skipped, timeout={args.timeout}s\n")
+    extra = f", {deselected} not gated (non-PASS)" if deselected else ""
+    print(f"{len(to_run)} to run, {len(skipped)} skipped{extra}, "
+          f"timeout={args.timeout}s\n")
 
     results: dict[str, tuple[str, str]] = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:

--- a/pyre/extra_tests/snippets/syntax_annotations.py
+++ b/pyre/extra_tests/snippets/syntax_annotations.py
@@ -8,3 +8,21 @@ hints = get_type_hints(func)
 # The order of type hints matters for certain functions
 # e.g. functools.singledispatch
 assert list(hints.items()) == [('s', str), ('return', int)]
+
+
+# A module-level annotation makes the compiler emit an implicit
+# `__conditional_annotations__` cell (MAKE_CELL) whose binding is written into
+# the namespace dict by STORE_NAME. Materializing the namespace mapping with
+# `locals()` runs the fast2locals sync, which must leave that binding intact,
+# or a later annotation's load of the cell raises NameError.
+count: int = 1
+assert count == 1
+
+_ = locals()  # fast2locals sync must not erase the implicit cell's binding
+
+maybe: "int | None" = None
+assert maybe is None
+
+first: int = 10
+second: str = "s"
+assert (first, second) == (10, "s")

--- a/pyre/extra_tests/snippets/syntax_match.py
+++ b/pyre/extra_tests/snippets/syntax_match.py
@@ -147,5 +147,41 @@ def test_mapping_comprehensive():
     assert cap_x == 1, f"Expected x=1, got {cap_x}"
     assert cap_y == 2, f"Expected y=2, got {cap_y}"
 
+    # A dict subclass with __missing__ must not satisfy a key it does not hold.
+    # MATCH_KEYS looks keys up with get(key, sentinel), so __missing__ never runs
+    # and no entry is fabricated.
+    class DefaultMap(dict):
+        def __missing__(self, key):
+            return f"default-{key}"
+
+    dm = DefaultMap(present=1)
+    match dm:
+        case {"absent": _}:
+            missed = "matched"
+        case _:
+            missed = "fell-through"
+    assert missed == "fell-through", f"Expected fell-through, got {missed}"
+
+    match dm:
+        case {"present": v}:
+            got = v
+        case _:
+            got = None
+    assert got == 1, f"Expected 1, got {got}"
+
+    # A value-pattern key equal to a literal key is a runtime duplicate. The
+    # subject holds enough keys to clear the length guard ahead of MATCH_KEYS.
+    class Key:
+        name = "a"
+
+    raised = False
+    try:
+        match {"a": 1, "b": 2}:
+            case {Key.name: _, "a": _}:
+                pass
+    except ValueError as exc:
+        raised = "duplicate key" in str(exc)
+    assert raised, "Expected ValueError for duplicate mapping key"
+
 
 test_mapping_comprehensive()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -989,9 +989,10 @@ fn is_coroutine(w_obj: PyObjectRef) -> bool {
         if frame_ptr.is_null() {
             return false;
         }
-        (*frame_ptr).code().flags.intersects(
-            crate::CodeFlags::COROUTINE | crate::CodeFlags::ITERABLE_COROUTINE,
-        )
+        (*frame_ptr)
+            .code()
+            .flags
+            .intersects(crate::CodeFlags::COROUTINE | crate::CodeFlags::ITERABLE_COROUTINE)
     }
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -971,6 +971,86 @@ pub(crate) unsafe fn get_and_call_function(
     crate::call::call_function_impl_result(w_impl, args_w)
 }
 
+/// `isinstance(w_obj, Coroutine) or gen_is_coroutine(w_obj)` from
+/// `generator.py:569`, collapsed onto pyre's single generator object: an
+/// `async def` coroutine and a `@types.coroutine`-marked generator both carry
+/// their marker on the suspended frame's code (`CO_COROUTINE` /
+/// `CO_ITERABLE_COROUTINE`), so the distinct PyPy `Coroutine` class becomes a
+/// code-flag test here.
+fn is_coroutine(w_obj: PyObjectRef) -> bool {
+    unsafe {
+        if !pyre_object::generator::is_generator(w_obj) {
+            return false;
+        }
+        let frame_ptr =
+            pyre_object::generator::w_generator_get_frame(w_obj) as *const crate::pyframe::PyFrame;
+        // An exhausted generator has a null frame and so no readable flags; an
+        // awaited coroutine is never exhausted at this point.
+        if frame_ptr.is_null() {
+            return false;
+        }
+        (*frame_ptr).code().flags.intersects(
+            crate::CodeFlags::COROUTINE | crate::CodeFlags::ITERABLE_COROUTINE,
+        )
+    }
+}
+
+/// `generator.py:563 get_awaitable_iter` — return the iterator implementing the
+/// awaitable protocol for `w_obj`:
+///   - `w_obj` itself when it is a coroutine (or `@types.coroutine` generator);
+///   - otherwise `w_obj.__await__()`, which must be an iterator.
+///
+/// `context`: 0 = plain `await`, 1 = `__aenter__`, 2 = `__aexit__` — only the
+/// missing-`__await__` error message differs.
+pub fn get_awaitable_iter(w_obj: PyObjectRef, context: u32) -> PyResult {
+    if is_coroutine(w_obj) {
+        return Ok(w_obj);
+    }
+    let w_await = crate::typedef::r#type(w_obj)
+        .and_then(|w_type| unsafe { lookup_in_type(w_type, "__await__") });
+    let Some(w_await) = w_await else {
+        let msg = match context {
+            1 => format!(
+                "'async with' received an object from __aenter__ that does not \
+                 implement __await__: {}",
+                object_functionstr_type_name(w_obj),
+            ),
+            2 => format!(
+                "'async with' received an object from __aexit__ that does not \
+                 implement __await__: {}",
+                object_functionstr_type_name(w_obj),
+            ),
+            _ => format!(
+                "object {} can't be used in 'await' expression",
+                object_functionstr_type_name(w_obj),
+            ),
+        };
+        return Err(PyError::type_error(msg));
+    };
+    let w_type = crate::typedef::r#type(w_obj).unwrap_or(w_obj);
+    let w_res = unsafe { get_and_call_function(w_await, w_obj, w_type, &[]) }?;
+    if is_coroutine(w_res) {
+        return Err(PyError::type_error(
+            "__await__() returned a coroutine (it must return an iterator \
+             instead, see PEP 492)",
+        ));
+    }
+    // `space.lookup(w_res, "__next__")` — w_res must be an iterator.  pyre's
+    // generator object (the usual `__await__` return) carries `__next__` at the
+    // instance level rather than on its type, so it is accepted directly; other
+    // iterators expose `__next__` on their type.
+    let has_next = unsafe { pyre_object::generator::is_generator(w_res) }
+        || crate::typedef::r#type(w_res)
+            .is_some_and(|w_type| unsafe { lookup_in_type(w_type, "__next__") }.is_some());
+    if !has_next {
+        return Err(PyError::type_error(format!(
+            "__await__() returned non-iterator of type '{}'",
+            object_functionstr_type_name(w_res),
+        )));
+    }
+    Ok(w_res)
+}
+
 /// _set_names (typeobject.py:1006) — invoke `__set_name__(owner, name)` for one
 /// class-body entry.  `__set_name__` is found by a type-only lookup on
 /// `type(w_value)` (`space.lookup`, NOT the full attribute protocol, so a

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4659,12 +4659,16 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             // arguments, with class default `None` (`:360`).  Each is a
             // plain slot read: an instance allocated via `__new__` (which
             // never touches the slot) reads `None`.  Gated on the
-            // ImportError kind (which also tags ModuleNotFoundError).
+            // ImportError-family kind (ImportError / ModuleNotFoundError).
             // `name` is handled by the shared arm below since NameError /
             // AttributeError expose it too.
             "msg" | "path" | "name_from" => {
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
-                if kind == pyre_object::interp_exceptions::ExcKind::ImportError {
+                if matches!(
+                    kind,
+                    pyre_object::interp_exceptions::ExcKind::ImportError
+                        | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
+                ) {
                     let stored = unsafe {
                         match name {
                             "msg" => {
@@ -4689,15 +4693,16 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                 }
             }
             // Shared `name` attribute for the kinds that expose it —
-            // `W_ImportError`, `W_NameError`, and `W_AttributeError`
-            // (Python 3.10+).  Read from the shared `w_exc_name` slot
-            // (default `None`); falls through to normal attribute lookup
-            // on every other exception kind.
+            // `W_ImportError` (and `W_ModuleNotFoundError`), `W_NameError`,
+            // and `W_AttributeError` (Python 3.10+).  Read from the shared
+            // `w_exc_name` slot (default `None`); falls through to normal
+            // attribute lookup on every other exception kind.
             "name" => {
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
                 if matches!(
                     kind,
                     pyre_object::interp_exceptions::ExcKind::ImportError
+                        | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
                         | pyre_object::interp_exceptions::ExcKind::NameError
                         | pyre_object::interp_exceptions::ExcKind::AttributeError
                 ) {
@@ -6951,11 +6956,15 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
             // `interp_exceptions.py:679-681 W_ImportError` writable
             // `msg` / `name` / `path` (plus `name_from`) slots; the
             // matching getattr arm reads them back.  Gated on the
-            // ImportError kind (covers ModuleNotFoundError).  `name` is
-            // handled by the shared arm below.
+            // ImportError-family kind (ImportError / ModuleNotFoundError).
+            // `name` is handled by the shared arm below.
             "msg" | "path" | "name_from" => {
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
-                if kind == pyre_object::interp_exceptions::ExcKind::ImportError {
+                if matches!(
+                    kind,
+                    pyre_object::interp_exceptions::ExcKind::ImportError
+                        | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
+                ) {
                     unsafe {
                         match name {
                             "msg" => pyre_object::interp_exceptions::w_exception_set_import_msg(
@@ -6972,13 +6981,15 @@ pub fn object_setattr(obj: PyObjectRef, name: &str, value: PyObjectRef) -> PyRes
                     return Ok(w_none());
                 }
             }
-            // Shared writable `name` slot for ImportError / NameError /
-            // AttributeError; the matching getattr arm reads it back.
+            // Shared writable `name` slot for ImportError / ModuleNotFoundError
+            // / NameError / AttributeError; the matching getattr arm reads it
+            // back.
             "name" => {
                 let kind = unsafe { pyre_object::w_exception_get_kind(obj) };
                 if matches!(
                     kind,
                     pyre_object::interp_exceptions::ExcKind::ImportError
+                        | pyre_object::interp_exceptions::ExcKind::ModuleNotFoundError
                         | pyre_object::interp_exceptions::ExcKind::NameError
                         | pyre_object::interp_exceptions::ExcKind::AttributeError
                 ) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -286,7 +286,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
         make_module_builtin_function("print", builtin_print)
     });
     namespace.get_or_insert_with("range", || {
-        make_module_builtin_function("range", builtin_range)
+        crate::typedef::gettypeobject(&pyre_object::functional::RANGE_TYPE)
     });
     namespace.get_or_insert_with("len", || {
         make_module_builtin_function_with_arity("len", builtin_len, 1)
@@ -349,13 +349,17 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
     namespace.get_or_insert_with("chr", || {
         make_module_builtin_function_with_arity("chr", builtin_chr, 1)
     });
-    namespace.get_or_insert_with("map", || make_module_builtin_function("map", builtin_map));
-    namespace.get_or_insert_with("zip", || make_module_builtin_function("zip", builtin_zip));
+    namespace.get_or_insert_with("map", || {
+        crate::typedef::gettypeobject(&pyre_object::functional::MAP_TYPE)
+    });
+    namespace.get_or_insert_with("zip", || {
+        crate::typedef::gettypeobject(&pyre_object::functional::ZIP_TYPE)
+    });
     namespace.get_or_insert_with("enumerate", || {
-        make_module_builtin_function("enumerate", builtin_enumerate)
+        crate::typedef::gettypeobject(&pyre_object::functional::ENUMERATE_TYPE)
     });
     namespace.get_or_insert_with("reversed", || {
-        make_module_builtin_function_with_arity("reversed", builtin_reversed, 1)
+        crate::typedef::gettypeobject(&pyre_object::functional::REVERSED_TYPE)
     });
     namespace.get_or_insert_with("sorted", || {
         make_module_builtin_function("sorted", builtin_sorted)
@@ -665,7 +669,7 @@ pub fn install_default_builtins(namespace: &mut DictStorage) {
         crate::typedef::gettypeobject(&pyre_object::COMPLEX_TYPE)
     });
     namespace.get_or_insert_with("filter", || {
-        make_module_builtin_function("filter", builtin_filter)
+        crate::typedef::gettypeobject(&pyre_object::functional::FILTER_TYPE)
     });
     namespace.get_or_insert_with("input", || {
         make_module_builtin_function("input", |_| Ok(pyre_object::w_str_new("")))
@@ -1168,7 +1172,7 @@ unsafe fn range_index_bound(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyEr
 /// (`__index__`) and is stored wrapped, so a range may span past a
 /// machine word; `iter()` then produces a `rangeiterator` (machine-int,
 /// JIT-specializable) or a `longrange_iterator` accordingly.
-fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let n = args.len();
     if n == 0 {
         return Err(crate::PyError::type_error(
@@ -5502,7 +5506,7 @@ fn builtin_chr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `filter(function or None, iterable)` — `functional.py:980-995
 /// W_Filter___new__`.  A lazy iterator: `function == None` keeps truthy
 /// items, otherwise `function(item)` is the predicate.
-fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 2 {
         return Err(crate::PyError::type_error(format!(
             "filter expected 2 arguments, got {}",
@@ -5527,7 +5531,7 @@ fn builtin_filter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `map(func, *iterables, strict=False)` — `functional.py:888-902
 /// W_Map___new__` plus the CPython 3.14 `strict` keyword.  A lazy iterator:
 /// each `next()` pulls one item per iterable and calls `func(*items)`.
-fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (args, kwargs) = split_builtin_kwargs(args);
     kwarg_reject_unknown(kwargs, &["strict"], "map")?;
     let strict = kwarg_get(kwargs, "strict")
@@ -5557,7 +5561,7 @@ fn builtin_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// A lazy iterator: each `next()` pulls one item per iterable into a tuple,
 /// stopping at the shortest (an empty `zip()` stops immediately); `strict`
 /// raises `ValueError` on a length mismatch.
-fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // Pyre's flat builtin ABI surfaces kwargs as a trailing dict; strip it
     // before the positional walk and look up `strict` from it.
     let (args, kwargs) = split_builtin_kwargs(args);
@@ -5597,7 +5601,7 @@ fn builtin_zip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 // resolving `start` via `space.index_w` (with overflow promotion to a
 // bigint slot) and capturing either the source iterator or the
 // source list directly when `start == 0 + isinstance(it, list)`.
-fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (positional, kwargs) = split_builtin_kwargs(args);
     if positional.is_empty() {
         return Err(crate::PyError::type_error(
@@ -5643,7 +5647,7 @@ fn builtin_enumerate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 }
 
 /// `reversed()` — PyPy: functional.py W_ReversedIterator
-fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn builtin_reversed(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.is_empty() {
         return Err(crate::PyError::type_error(
             "reversed() requires one argument",

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -503,6 +503,17 @@ impl PyError {
         err
     }
 
+    /// A ModuleNotFoundError carrying the unresolved module `name` so
+    /// `e.name` reads back once the instance is materialised — the import
+    /// machinery raises `ModuleNotFoundError(msg, name=fullname)`.  The
+    /// `name` rides the shared `w_n` slot (ImportError / NameError /
+    /// AttributeError), stamped by `to_exc_object`.
+    pub fn module_not_found_with_name(msg: impl Into<String>, name: &str) -> Self {
+        let mut err = Self::new(PyErrorKind::ModuleNotFoundError, msg);
+        err.w_name_context = pyre_object::w_str_new(name);
+        err
+    }
+
     pub fn internal_trace_abort(reason: impl Into<String>) -> Self {
         let mut err = Self::new(PyErrorKind::TraceAbort, reason);
         err.attach_tb = false;

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2689,6 +2689,39 @@ impl OpcodeStepExecutor for PyFrame {
         )
     }
 
+    fn build_template_op(&mut self) -> Result<(), PyError> {
+        // Stack: [strings, interpolations] (two tuples the compiler split).
+        let interpolations = self.pop();
+        let strings = self.pop();
+        let module = self.import_module("_template")?;
+        let func = getattr_str(module, "_build_template")?;
+        let result = call_callable(self, func, &[strings, interpolations])?;
+        self.push(result);
+        Ok(())
+    }
+
+    fn build_interpolation_op(
+        &mut self,
+        conversion: u32,
+        has_format_spec: bool,
+    ) -> Result<(), PyError> {
+        // Stack: [value, expression, format_spec?] — format_spec present only
+        // when the oparg low bit is set, else it defaults to the empty string.
+        let format_spec = if has_format_spec {
+            self.pop()
+        } else {
+            pyre_object::w_str_new("")
+        };
+        let expression = self.pop();
+        let value = self.pop();
+        let conversion_obj = pyre_object::w_int_new(conversion as i64);
+        let module = self.import_module("_template")?;
+        let func = getattr_str(module, "_build_interpolation")?;
+        let result = call_callable(self, func, &[value, expression, conversion_obj, format_spec])?;
+        self.push(result);
+        Ok(())
+    }
+
     fn import_name(&mut self, name: &str) -> Result<(), PyError> {
         let w_fromlist = self.pop();
         let w_level = self.pop();

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3269,6 +3269,19 @@ impl OpcodeStepExecutor for PyFrame {
         Ok(())
     }
 
+    fn get_awaitable(&mut self, context: u32) -> Result<(), PyError> {
+        // pyopcode.py:1599 GET_AWAITABLE.
+        let w_iterable = self.pop();
+        let w_iter = crate::baseobjspace::get_awaitable_iter(w_iterable, context)?;
+        // pyopcode.py:1604 guards a coroutine that is already being awaited
+        // (`w_iter.get_delegate() is not None`) with RuntimeError.  pyre's
+        // generator object has no delegate / `w_yielded_from` field, so the
+        // reentrant-await case is instead caught at SEND by the generator
+        // `running` flag.
+        self.push(w_iter);
+        Ok(())
+    }
+
     // ── load_method ──
     // PyPy: LOOKUP_METHOD — interpreter-only override.
     // For instances, pushes [attr, self] so CALL prepends self.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3085,10 +3085,15 @@ impl OpcodeStepExecutor for PyFrame {
         }
         let key_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(keys) };
         let mut values = Vec::with_capacity(key_items.len());
-        // pyopcode.py:1797-1806 — a key repeated in the pattern is rejected
+        // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
         // before it binds anything; track keys already looked up and raise on
-        // a duplicate.
+        // a duplicate. Each key is looked up with `map.get(key, sentinel)`
+        // rather than subscription so a mapping subclass that defines
+        // `__missing__` (defaultdict) neither creates entries nor raises; a
+        // sentinel result means the key is absent.
         let w_seen = pyre_object::w_set_new();
+        let w_sentinel =
+            pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INSTANCE_TYPE);
         let mut all_match = true;
         for key in key_items {
             if crate::baseobjspace::contains(w_seen, key)? {
@@ -3098,14 +3103,17 @@ impl OpcodeStepExecutor for PyFrame {
                 )));
             }
             unsafe { pyre_object::w_set_add(w_seen, key) };
-            match crate::baseobjspace::getitem(subject, key) {
-                Ok(v) => values.push(v),
-                Err(e) if e.kind == crate::PyErrorKind::KeyError => {
-                    all_match = false;
-                    break;
-                }
-                Err(e) => return Err(e),
+            let w_value = crate::baseobjspace::call_method(subject, "get", &[key, w_sentinel]);
+            if w_value.is_null() {
+                return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                    crate::PyError::type_error("mapping pattern lookup failed")
+                }));
             }
+            if crate::baseobjspace::is_w(w_value, w_sentinel) {
+                all_match = false;
+                break;
+            }
+            values.push(w_value);
         }
         if all_match {
             self.push(pyre_object::w_tuple_new(values));

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2717,7 +2717,11 @@ impl OpcodeStepExecutor for PyFrame {
         let conversion_obj = pyre_object::w_int_new(conversion as i64);
         let module = self.import_module("_template")?;
         let func = getattr_str(module, "_build_interpolation")?;
-        let result = call_callable(self, func, &[value, expression, conversion_obj, format_spec])?;
+        let result = call_callable(
+            self,
+            func,
+            &[value, expression, conversion_obj, format_spec],
+        )?;
         self.push(result);
         Ok(())
     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3042,6 +3042,223 @@ impl OpcodeStepExecutor for PyFrame {
         Ok(len)
     }
 
+    // ── Pattern matching (PEP 634) ──
+    // MATCH_MAPPING / MATCH_SEQUENCE peek the subject and push a bool from the
+    // type's PATMA flag (the raw mapping/sequence marker — no `__getitem__`
+    // fallback, which is the pattern-matching contract, unlike `ismapping_w`).
+    fn match_mapping(&mut self) -> Result<(), PyError> {
+        let subject = PyFrame::peek_at(self, 0);
+        let is_mapping = unsafe {
+            let ty = crate::typedef::r#type(subject).unwrap_or(std::ptr::null_mut());
+            pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'M'
+        };
+        self.push(pyre_object::boolobject::w_bool_from(is_mapping));
+        Ok(())
+    }
+
+    fn match_sequence(&mut self) -> Result<(), PyError> {
+        let subject = PyFrame::peek_at(self, 0);
+        let is_sequence = unsafe {
+            let ty = crate::typedef::r#type(subject).unwrap_or(std::ptr::null_mut());
+            pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'S'
+        };
+        self.push(pyre_object::boolobject::w_bool_from(is_sequence));
+        Ok(())
+    }
+
+    // MATCH_KEYS: STACK[-1] = keys tuple, STACK[-2] = subject (neither popped).
+    // Push a tuple of the looked-up values when every key is present, else None.
+    fn match_keys(&mut self) -> Result<(), PyError> {
+        let keys = PyFrame::peek_at(self, 0);
+        let subject = PyFrame::peek_at(self, 1);
+        let is_mapping = unsafe {
+            let ty = crate::typedef::r#type(subject).unwrap_or(std::ptr::null_mut());
+            pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'M'
+        };
+        if !is_mapping {
+            self.push(pyre_object::w_none());
+            return Ok(());
+        }
+        let key_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(keys) };
+        let mut values = Vec::with_capacity(key_items.len());
+        // pyopcode.py:1797-1806 — a key repeated in the pattern is rejected
+        // before it binds anything; track keys already looked up and raise on
+        // a duplicate.
+        let w_seen = pyre_object::w_set_new();
+        let mut all_match = true;
+        for key in key_items {
+            if crate::baseobjspace::contains(w_seen, key)? {
+                let key_repr = unsafe { crate::py_repr(key)? };
+                return Err(crate::PyError::value_error(format!(
+                    "mapping pattern checks duplicate key ({key_repr})"
+                )));
+            }
+            unsafe { pyre_object::w_set_add(w_seen, key) };
+            match crate::baseobjspace::getitem(subject, key) {
+                Ok(v) => values.push(v),
+                Err(e) if e.kind == crate::PyErrorKind::KeyError => {
+                    all_match = false;
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        if all_match {
+            self.push(pyre_object::w_tuple_new(values));
+        } else {
+            self.push(pyre_object::w_none());
+        }
+        Ok(())
+    }
+
+    // MATCH_CLASS count: STACK[-1] = keyword attr-name tuple, STACK[-2] = class,
+    // STACK[-3] = subject (all popped). Push the extracted-attrs tuple on a
+    // match, else None. `count` is the number of positional sub-patterns.
+    fn match_class(&mut self, count: usize) -> Result<(), PyError> {
+        let kwd_attrs = self.pop();
+        let cls = self.pop();
+        let subject = self.pop();
+
+        if unsafe { !pyre_object::typeobject::is_type(cls) } {
+            return Err(crate::PyError::type_error(
+                "called match pattern must be a class",
+            ));
+        }
+        let type_name = unsafe { pyre_object::w_type_get_name(cls) };
+
+        if !crate::baseobjspace::isinstance(subject, cls)? {
+            self.push(pyre_object::w_none());
+            return Ok(());
+        }
+
+        let mut extracted: Vec<PyObjectRef> = Vec::new();
+        let mut seen: Vec<String> = Vec::new();
+
+        if count > 0 {
+            let match_args = match crate::baseobjspace::getattr_str(cls, "__match_args__") {
+                Ok(v) => Some(v),
+                Err(e) if e.kind == crate::PyErrorKind::AttributeError => None,
+                Err(e) => return Err(e),
+            };
+            if let Some(match_args) = match_args {
+                if unsafe { !pyre_object::is_tuple(match_args) } {
+                    let got = unsafe {
+                        pyre_object::w_type_get_name(
+                            crate::typedef::r#type(match_args).unwrap_or(std::ptr::null_mut()),
+                        )
+                    };
+                    return Err(crate::PyError::type_error(format!(
+                        "{type_name}.__match_args__ must be a tuple (got {got})"
+                    )));
+                }
+                let ma = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(match_args) };
+                if ma.len() < count {
+                    let plural = if ma.len() == 1 { "" } else { "s" };
+                    return Err(crate::PyError::type_error(format!(
+                        "{type_name}() accepts {} positional sub-pattern{plural} ({count} given)",
+                        ma.len()
+                    )));
+                }
+                for attr_obj in ma.into_iter().take(count) {
+                    let attr_name = match unsafe { pyre_object::w_str_get_value_opt(attr_obj) } {
+                        Some(s) => s,
+                        None => {
+                            let got = unsafe {
+                                pyre_object::w_type_get_name(
+                                    crate::typedef::r#type(attr_obj)
+                                        .unwrap_or(std::ptr::null_mut()),
+                                )
+                            };
+                            return Err(crate::PyError::type_error(format!(
+                                "__match_args__ elements must be strings (got {got})"
+                            )));
+                        }
+                    };
+                    if seen.iter().any(|s| s == attr_name) {
+                        return Err(crate::PyError::type_error(format!(
+                            "{type_name}() got multiple sub-patterns for attribute '{attr_name}'"
+                        )));
+                    }
+                    seen.push(attr_name.to_string());
+                    match crate::baseobjspace::getattr_str(subject, attr_name) {
+                        Ok(v) => extracted.push(v),
+                        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                            self.push(pyre_object::w_none());
+                            return Ok(());
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            } else {
+                // No `__match_args__`: the builtin "atomic" types (int, str,
+                // bytes, ...) match the subject itself as their single
+                // positional sub-pattern (Py_TPFLAGS_MATCH_SELF).
+                let is_self = {
+                    use pyre_object::pyobject::get_instantiate;
+                    let atomics: [PyObjectRef; 11] = [
+                        get_instantiate(&pyre_object::pyobject::INT_TYPE),
+                        get_instantiate(&pyre_object::pyobject::BOOL_TYPE),
+                        get_instantiate(&pyre_object::pyobject::FLOAT_TYPE),
+                        get_instantiate(&pyre_object::pyobject::STR_TYPE),
+                        get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+                        get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
+                        get_instantiate(&pyre_object::pyobject::DICT_TYPE),
+                        get_instantiate(&pyre_object::bytesobject::BYTES_TYPE),
+                        get_instantiate(&pyre_object::bytearrayobject::BYTEARRAY_TYPE),
+                        get_instantiate(&pyre_object::setobject::SET_TYPE),
+                        get_instantiate(&pyre_object::setobject::FROZENSET_TYPE),
+                    ];
+                    let mut found = false;
+                    for ty_obj in atomics {
+                        if crate::baseobjspace::issubclass(cls, ty_obj)? {
+                            found = true;
+                            break;
+                        }
+                    }
+                    found
+                };
+                if is_self {
+                    if count == 1 {
+                        extracted.push(subject);
+                    } else {
+                        return Err(crate::PyError::type_error(format!(
+                            "{type_name}() accepts 1 positional sub-pattern ({count} given)"
+                        )));
+                    }
+                } else {
+                    return Err(crate::PyError::type_error(format!(
+                        "{type_name}() accepts 0 positional sub-patterns ({count} given)"
+                    )));
+                }
+            }
+        }
+
+        let kwd_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(kwd_attrs) };
+        for name_obj in kwd_items {
+            let name = match unsafe { pyre_object::w_str_get_value_opt(name_obj) } {
+                Some(s) => s,
+                None => return Err(crate::PyError::type_error("Attribute name must be string")),
+            };
+            if seen.iter().any(|s| s == name) {
+                return Err(crate::PyError::type_error(format!(
+                    "{type_name}() got multiple sub-patterns for attribute '{name}'"
+                )));
+            }
+            seen.push(name.to_string());
+            match crate::baseobjspace::getattr_str(subject, name) {
+                Ok(v) => extracted.push(v),
+                Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                    self.push(pyre_object::w_none());
+                    return Ok(());
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        self.push(pyre_object::w_tuple_new(extracted));
+        Ok(())
+    }
+
     // ── LoadFastAndClear (comprehension scope) ──
     fn load_fast_and_clear(&mut self, idx: usize) -> Result<(), PyError> {
         let val = self.locals_w()[idx];

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3075,14 +3075,9 @@ impl OpcodeStepExecutor for PyFrame {
     fn match_keys(&mut self) -> Result<(), PyError> {
         let keys = PyFrame::peek_at(self, 0);
         let subject = PyFrame::peek_at(self, 1);
-        let is_mapping = unsafe {
-            let ty = crate::typedef::r#type(subject).unwrap_or(std::ptr::null_mut());
-            pyre_object::typeobject::w_type_get_flag_map_or_seq(ty) == b'M'
-        };
-        if !is_mapping {
-            self.push(pyre_object::w_none());
-            return Ok(());
-        }
+        // MATCH_MAPPING already proved the subject is a mapping, so match_keys
+        // looks the keys up directly without re-gating (Python/ceval.c
+        // match_keys).
         let key_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(keys) };
         let mut values = Vec::with_capacity(key_items.len());
         // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
@@ -3090,10 +3085,13 @@ impl OpcodeStepExecutor for PyFrame {
         // a duplicate. Each key is looked up with `map.get(key, sentinel)`
         // rather than subscription so a mapping subclass that defines
         // `__missing__` (defaultdict) neither creates entries nor raises; a
-        // sentinel result means the key is absent.
+        // sentinel result means the key is absent.  The sentinel is a fresh
+        // `object()` (match_keys `dummy = object()`), so a value present in the
+        // subject can never be mistaken for the absent marker.
         let w_seen = pyre_object::w_set_new();
-        let w_sentinel =
-            pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INSTANCE_TYPE);
+        let w_sentinel = pyre_object::w_instance_new(crate::typedef::gettypeobject(
+            &pyre_object::pyobject::INSTANCE_TYPE,
+        ));
         let mut all_match = true;
         for key in key_items {
             if crate::baseobjspace::contains(w_seen, key)? {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1442,9 +1442,9 @@ fn absolute_import(
         let parent_dirs = parent.and_then(parent_package_path);
         let w_mod = load_part(&full_name, part, parent_dirs.as_deref(), execution_context)?;
         let Some(module) = w_mod else {
-            return Err(crate::PyError::new(
-                crate::PyErrorKind::ModuleNotFoundError,
+            return Err(crate::PyError::module_not_found_with_name(
                 format!("No module named '{modulename}'"),
+                modulename,
             ));
         };
         // _bootstrap._find_and_load (_bootstrap.py:1346-1352): bind the
@@ -1482,9 +1482,9 @@ fn absolute_import(
 
     // `import X.Y` → return the top-level module (X)
     first.ok_or_else(|| {
-        crate::PyError::new(
-            crate::PyErrorKind::ModuleNotFoundError,
+        crate::PyError::module_not_found_with_name(
             format!("No module named '{modulename}'"),
+            modulename,
         )
     })
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -801,6 +801,21 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
             }
         }
     });
+    // importlib/__init__.py:16,34 aliases the frozen bootstrap modules as
+    // `_bootstrap` / `_bootstrap_external`. The native importer loads the `.py`
+    // submodules instead, so register the same objects under the frozen names
+    // when they enter sys.modules — modules that import `_frozen_importlib`
+    // / `_frozen_importlib_external` directly (zipimport, the runpy
+    // diagnostics) then resolve them. The recursive call terminates: the
+    // frozen names do not match the bootstrap names.
+    let frozen_alias = match name {
+        "importlib._bootstrap" => Some("_frozen_importlib"),
+        "importlib._bootstrap_external" => Some("_frozen_importlib_external"),
+        _ => None,
+    };
+    if let Some(alias) = frozen_alias {
+        set_sys_module(alias, module);
+    }
 }
 
 /// Remove a (partially initialised) module from `sys.modules`.
@@ -1492,6 +1507,27 @@ fn absolute_import(
     w_fromlist: PyObjectRef,
     execution_context: *const PyExecutionContext,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // The frozen importlib bootstrap modules live on disk as the
+    // `importlib._bootstrap{,_external}` submodules. A direct
+    // `import _frozen_importlib` / `_frozen_importlib_external` (zipimport,
+    // the runpy diagnostics) loads the corresponding submodule, whose
+    // registration aliases it under the frozen name (set_sys_module); return
+    // that. The recursive call terminates: the submodule name does not match.
+    let frozen_target = match modulename {
+        "_frozen_importlib" => Some("importlib._bootstrap"),
+        "_frozen_importlib_external" => Some("importlib._bootstrap_external"),
+        _ => None,
+    };
+    if let Some(target) = frozen_target {
+        if let Some(cached) = check_sys_modules(modulename) {
+            return Ok(cached);
+        }
+        absolute_import(target, pyre_object::PY_NULL, execution_context)?;
+        if let Some(cached) = check_sys_modules(modulename) {
+            return Ok(cached);
+        }
+    }
+
     let parts: Vec<&str> = modulename.split('.').collect();
     let mut first: Option<PyObjectRef> = None;
     let mut parent: Option<PyObjectRef> = None;

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -433,6 +433,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(binascii);
     pyre_install_module!(zlib);
     pyre_install_module!(_typing);
+    pyre_install_module!(_template);
     pyre_install_module!(_hashlib);
     pyre_install_module!(_blake2);
     pyre_install_module!(gc);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -781,6 +781,32 @@ pub fn get_sys_module(name: &str) -> Option<PyObjectRef> {
     check_sys_modules(name)
 }
 
+/// Mirror the native search path (`SYS_PATH`) into Python `sys.path` so
+/// `PathFinder` — reached by `importlib.util.find_spec` for top-level module
+/// names — can resolve modules. `runpy._get_module_details` (the `-m` entry)
+/// drives that path, which is otherwise left empty.
+#[cfg(feature = "host_env")]
+pub fn sync_python_sys_path() {
+    // wasm seeds `sys.path` from its bootstrap and has no current_exe/python3
+    // lazy stdlib detection, so `ensure_stdlib_path` exists only off-wasm.
+    #[cfg(not(target_arch = "wasm32"))]
+    ensure_stdlib_path();
+    let items: Vec<PyObjectRef> = SYS_PATH.with(|p| {
+        p.borrow()
+            .iter()
+            .map(|d| pyre_object::w_str_new(&d.to_string_lossy()))
+            .collect()
+    });
+    if let Some(sys_mod) = get_sys_module("sys") {
+        let _ = crate::setattr_str(sys_mod, "path", pyre_object::w_list_new(items));
+    }
+}
+
+/// Off-`host_env` builds keep no native `SYS_PATH`, so there is nothing to
+/// mirror into Python `sys.path`.
+#[cfg(not(feature = "host_env"))]
+pub fn sync_python_sys_path() {}
+
 /// The Python-visible `sys.modules` dict, or `PY_NULL` before it is
 /// installed. Used by callers that need to iterate every loaded module
 /// (e.g. pickle's `whichmodule` scan).

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -930,6 +930,10 @@ enum FindInfo {
     /// A package directory with __init__.py was found.
     #[cfg(feature = "host_env")]
     Package { dirpath: PathBuf },
+    /// PEP 420 namespace package: one or more matching directories that carry
+    /// no `__init__.py`. The portions become the package's `__path__`.
+    #[cfg(feature = "host_env")]
+    Namespace { dirs: Vec<PathBuf> },
     /// A builtin (Rust-implemented) module was found.
     /// PyPy equivalent: C_BUILTIN modtype in find_module()
     Builtin,
@@ -1008,6 +1012,7 @@ fn ensure_stdlib_path() {
 
 #[cfg(feature = "host_env")]
 fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
+    let mut namespace_dirs: Vec<PathBuf> = Vec::new();
     for dir in dirs {
         // Check for package: <dir>/<partname>/__init__.py
         let pkg_dir = dir.join(partname);
@@ -1023,6 +1028,19 @@ fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
                 pathname: source_file,
             });
         }
+
+        // PEP 420: a matching directory without `__init__.py` is a namespace
+        // portion. Record it and keep scanning — a regular module or package
+        // in a later directory still wins; only if no concrete match is found
+        // do the recorded portions form a namespace package.
+        if with_source_provider(|p| p.is_dir(&pkg_dir)) {
+            namespace_dirs.push(pkg_dir);
+        }
+    }
+    if !namespace_dirs.is_empty() {
+        return Some(FindInfo::Namespace {
+            dirs: namespace_dirs,
+        });
     }
     None
 }
@@ -1340,6 +1358,46 @@ fn load_package(
     load_source_module(modulename, &init_path, Some(dirpath), execution_context)
 }
 
+// ── load_namespace_package ───────────────────────────────────────────
+// PEP 420: a package directory (or set of directories) with no `__init__.py`.
+
+#[cfg(feature = "host_env")]
+fn load_namespace_package(
+    modulename: &str,
+    dirs: &[PathBuf],
+    execution_context: *const PyExecutionContext,
+) -> Result<PyObjectRef, crate::PyError> {
+    // A namespace package has no source to read or execute: it is a module
+    // carrying `__path__` (the portions) and `__package__`, but no `__file__`.
+    // Submodule imports resolve against `__path__` exactly as for a regular
+    // package.
+    let ctx = unsafe { &*execution_context };
+    let mut namespace = Box::new(ctx.fresh_dict_storage());
+    namespace.fix_ptr();
+
+    crate::dict_storage_store(
+        &mut namespace,
+        "__package__",
+        pyre_object::w_str_new(modulename),
+    );
+
+    let path_items: Vec<PyObjectRef> = dirs
+        .iter()
+        .map(|d| pyre_object::w_str_new(&d.to_string_lossy()))
+        .collect();
+    crate::dict_storage_store(
+        &mut namespace,
+        "__path__",
+        pyre_object::w_list_new(path_items),
+    );
+
+    let ns_ptr = Box::into_raw(namespace);
+    let canonical = crate::baseobjspace::dict_storage_to_dict(ns_ptr);
+    let module = pyre_object::w_module_new_aliasing_dict(modulename, ns_ptr as *mut u8, canonical);
+    set_sys_module(modulename, module);
+    Ok(module)
+}
+
 // ── load_part ────────────────────────────────────────────────────────
 // PyPy equivalent: importing.py `load_part()`
 
@@ -1398,6 +1456,10 @@ fn load_part(
         }
         #[cfg(feature = "host_env")]
         FindInfo::Package { dirpath } => load_package(modulename, &dirpath, execution_context)?,
+        #[cfg(feature = "host_env")]
+        FindInfo::Namespace { dirs } => {
+            load_namespace_package(modulename, &dirs, execution_context)?
+        }
         FindInfo::Builtin => {
             // Same builtins-identity path as the full_is_builtin branch
             // above: route `import builtins` through `EC.get_builtin()`

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -801,21 +801,6 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
             }
         }
     });
-    // importlib/__init__.py:16,34 aliases the frozen bootstrap modules as
-    // `_bootstrap` / `_bootstrap_external`. The native importer loads the `.py`
-    // submodules instead, so register the same objects under the frozen names
-    // when they enter sys.modules — modules that import `_frozen_importlib`
-    // / `_frozen_importlib_external` directly (zipimport, the runpy
-    // diagnostics) then resolve them. The recursive call terminates: the
-    // frozen names do not match the bootstrap names.
-    let frozen_alias = match name {
-        "importlib._bootstrap" => Some("_frozen_importlib"),
-        "importlib._bootstrap_external" => Some("_frozen_importlib_external"),
-        _ => None,
-    };
-    if let Some(alias) = frozen_alias {
-        set_sys_module(alias, module);
-    }
 }
 
 /// Remove a (partially initialised) module from `sys.modules`.
@@ -1510,9 +1495,12 @@ fn absolute_import(
     // The frozen importlib bootstrap modules live on disk as the
     // `importlib._bootstrap{,_external}` submodules. A direct
     // `import _frozen_importlib` / `_frozen_importlib_external` (zipimport,
-    // the runpy diagnostics) loads the corresponding submodule, whose
-    // registration aliases it under the frozen name (set_sys_module); return
-    // that. The recursive call terminates: the submodule name does not match.
+    // the runpy diagnostics) loads the corresponding submodule and, only once
+    // it has been fully imported, aliases it under the frozen name. Registering
+    // the alias after a successful import (rather than when the module is
+    // pre-registered) means a body that raises during execution does not leave
+    // a stale alias behind. The recursive call terminates: the submodule name
+    // does not match.
     let frozen_target = match modulename {
         "_frozen_importlib" => Some("importlib._bootstrap"),
         "_frozen_importlib_external" => Some("importlib._bootstrap_external"),
@@ -1523,8 +1511,9 @@ fn absolute_import(
             return Ok(cached);
         }
         absolute_import(target, pyre_object::PY_NULL, execution_context)?;
-        if let Some(cached) = check_sys_modules(modulename) {
-            return Ok(cached);
+        if let Some(leaf) = check_sys_modules(target) {
+            set_sys_module(modulename, leaf);
+            return Ok(leaf);
         }
     }
 
@@ -1541,9 +1530,11 @@ fn absolute_import(
         let parent_dirs = parent.and_then(parent_package_path);
         let w_mod = load_part(&full_name, part, parent_dirs.as_deref(), execution_context)?;
         let Some(module) = w_mod else {
+            // _bootstrap.py:1335 raises for the prefix that actually failed
+            // (`name=name`): `import a.b.c` with `a.b` missing reports `a.b`.
             return Err(crate::PyError::module_not_found_with_name(
-                format!("No module named '{modulename}'"),
-                modulename,
+                format!("No module named '{full_name}'"),
+                &full_name,
             ));
         };
         // _bootstrap._find_and_load (_bootstrap.py:1346-1352): bind the

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -20,7 +20,12 @@ crate::py_module! {
     functions: {
         "IncrementalNewlineDecoder" / * = |_| Ok(w_none()),
         "open"            / * = crate::builtins::builtin_open,
-        "open_code"       / * = |_| Ok(w_none()),
+        // `io.open_code(path)` — `_PyIO_open_code` opens the path in binary
+        // read mode ("rb"); pyre has no audit hooks so it is just `open`.
+        "open_code"       / * = |args| {
+            let path = args.first().copied().unwrap_or_else(w_none);
+            crate::builtins::builtin_open(&[path, w_str_new("rb")])
+        },
         "text_encoding"   / * = |args| Ok(args.first().copied().unwrap_or_else(|| w_str_new("utf-8"))),
     },
     extra_init: |ns| {

--- a/pyre/pyre-interpreter/src/module/_template/_template_app.py
+++ b/pyre/pyre-interpreter/src/module/_template/_template_app.py
@@ -1,0 +1,147 @@
+"""Runtime objects for t-string template literals (PEP 750).
+
+CPython implements Template and Interpolation in C and exposes them through
+`string.templatelib`, whose `Template = type(t"{0}")` recovers the type from a
+template literal.  Here they are app-level Python that the BUILD_TEMPLATE and
+BUILD_INTERPOLATION opcodes construct through `_build_template` /
+`_build_interpolation`.
+"""
+
+import itertools
+
+# The BUILD_INTERPOLATION conversion oparg field: 0 means no conversion.
+_CONVERSIONS = (None, 's', 'r', 'a')
+
+
+class Interpolation:
+    __match_args__ = ('value', 'expression', 'conversion', 'format_spec')
+
+    def __init__(self, value, expression='', conversion=None, format_spec=''):
+        self._value = value
+        self._expression = expression
+        self._conversion = conversion
+        self._format_spec = format_spec
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def expression(self):
+        return self._expression
+
+    @property
+    def conversion(self):
+        return self._conversion
+
+    @property
+    def format_spec(self):
+        return self._format_spec
+
+    def __repr__(self):
+        return (f'Interpolation({self._value!r}, {self._expression!r}, '
+                f'{self._conversion!r}, {self._format_spec!r})')
+
+
+class Template:
+    def __new__(cls, *args):
+        # Public constructor: interleaved strings and Interpolations.  Adjacent
+        # strings are merged and the result always begins and ends with a
+        # string, so `len(strings) == len(interpolations) + 1`.
+        strings = []
+        interpolations = []
+        current = ''
+        for arg in args:
+            if isinstance(arg, str):
+                current += arg
+            elif isinstance(arg, Interpolation):
+                strings.append(current)
+                current = ''
+                interpolations.append(arg)
+            else:
+                raise TypeError('Template.__new__ *args need to be of type '
+                                "'str' or 'Interpolation'")
+        strings.append(current)
+        return cls._make(tuple(strings), tuple(interpolations))
+
+    @classmethod
+    def _make(cls, strings, interpolations):
+        self = object.__new__(cls)
+        self._strings = strings
+        self._interpolations = interpolations
+        return self
+
+    @property
+    def strings(self):
+        return self._strings
+
+    @property
+    def interpolations(self):
+        return self._interpolations
+
+    @property
+    def values(self):
+        return tuple(i.value for i in self._interpolations)
+
+    def __iter__(self):
+        for string, interpolation in itertools.zip_longest(
+                self._strings, self._interpolations):
+            if string:
+                yield string
+            if interpolation is not None:
+                yield interpolation
+
+    def __add__(self, other):
+        if isinstance(other, Template):
+            return Template._make(
+                _concat_boundary(self._strings, other._strings),
+                self._interpolations + other._interpolations)
+        if isinstance(other, str):
+            return Template._make(
+                _concat_boundary(self._strings, (other,)),
+                self._interpolations)
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, str):
+            return Template._make(
+                _concat_boundary((other,), self._strings),
+                self._interpolations)
+        return NotImplemented
+
+    def __repr__(self):
+        return (f'Template(strings={self._strings!r}, '
+                f'interpolations={self._interpolations!r})')
+
+    def __reduce__(self):
+        return (_reconstruct, (self._strings, self._interpolations))
+
+
+def _concat_boundary(left, right):
+    # Merge the touching boundary strings of two templates: the last static
+    # string of `left` joins the first of `right`.
+    return left[:-1] + (left[-1] + right[0],) + right[1:]
+
+
+def _reconstruct(strings, interpolations):
+    return Template._make(strings, interpolations)
+
+
+def _build_template(strings, interpolations):
+    # BUILD_TEMPLATE: the compiler already split the literal into the static
+    # string parts and the interpolations, with one more string than
+    # interpolation.
+    return Template._make(tuple(strings), tuple(interpolations))
+
+
+def _build_interpolation(value, expression, conversion, format_spec):
+    # BUILD_INTERPOLATION: `conversion` is the opcode's conversion oparg field.
+    return Interpolation(value, expression, _CONVERSIONS[conversion],
+                         format_spec)
+
+
+# Present the types as living in their public home, `string.templatelib`, where
+# `Template = type(t"{0}")` rebinds them.
+for _cls in (Template, Interpolation):
+    _cls.__module__ = 'string.templatelib'
+del _cls

--- a/pyre/pyre-interpreter/src/module/_template/_template_app.py
+++ b/pyre/pyre-interpreter/src/module/_template/_template_app.py
@@ -92,22 +92,25 @@ class Template:
                 yield interpolation
 
     def __add__(self, other):
+        # Only two Templates concatenate; a str operand is rejected so callers
+        # must say whether it is static text (Template(...)) or dynamic data
+        # (Interpolation(...)) rather than have it inferred.
         if isinstance(other, Template):
             return Template._make(
                 _concat_boundary(self._strings, other._strings),
                 self._interpolations + other._interpolations)
-        if isinstance(other, str):
-            return Template._make(
-                _concat_boundary(self._strings, (other,)),
-                self._interpolations)
-        return NotImplemented
+        raise TypeError(
+            'can only concatenate string.templatelib.Template '
+            f'(not "{type(other).__name__}") to string.templatelib.Template')
 
     def __radd__(self, other):
-        if isinstance(other, str):
+        if isinstance(other, Template):
             return Template._make(
-                _concat_boundary((other,), self._strings),
-                self._interpolations)
-        return NotImplemented
+                _concat_boundary(other._strings, self._strings),
+                other._interpolations + self._interpolations)
+        raise TypeError(
+            'can only concatenate string.templatelib.Template '
+            f'(not "{type(other).__name__}") to string.templatelib.Template')
 
     def __repr__(self):
         return (f'Template(strings={self._strings!r}, '

--- a/pyre/pyre-interpreter/src/module/_template/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_template/mod.rs
@@ -1,0 +1,15 @@
+//! _template module — the t-string runtime objects (Template, Interpolation)
+//! that `string.templatelib` exposes.  CPython implements these in C
+//! (Objects/templateobject.c, Objects/interpolationobject.c); here they are
+//! app-level Python the BUILD_TEMPLATE / BUILD_INTERPOLATION opcodes construct
+//! through `_build_template` / `_build_interpolation`.
+
+crate::py_module! {
+    "_template",
+    appleveldefs: {
+        "_template_app.py" => [
+            "Template", "Interpolation",
+            "_build_template", "_build_interpolation", "_reconstruct",
+        ],
+    },
+}

--- a/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
+++ b/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
@@ -25,6 +25,16 @@ def _caller_module():
         return None
 
 
+def _evaluate_typeparam(thunk):
+    # Call a PEP 695 bound / constraints thunk emitted by the compiler. A 3.14
+    # thunk takes an annotation `format` argument (annotationlib.Format.VALUE
+    # == 1); accept a zero-argument thunk as well.
+    code = getattr(thunk, '__code__', None)
+    if code is not None and code.co_argcount >= 1:
+        return thunk(1)
+    return thunk()
+
+
 class _NoDefaultType:
     """Type of the typing.NoDefault sentinel."""
 
@@ -73,9 +83,45 @@ class TypeVar:
             raise TypeError("Constraints cannot be combined with bound=...")
         if len(constraints) == 1:
             raise TypeError("A single constraint is not allowed")
-        self.__constraints__ = tuple(constraints)
-        self.__bound__ = bound
+        self._constraints = tuple(constraints)
+        self._evaluate_constraints = None
+        self._bound = bound
+        self._evaluate_bound = None
         self.__module__ = _caller_module()
+
+    @classmethod
+    def _make(cls, name, *, evaluate_bound=None, evaluate_constraints=None):
+        # Lazy construction for the TYPEVAR_WITH_BOUND and
+        # TYPEVAR_WITH_CONSTRAINTS intrinsics. The bound / constraints arrive as
+        # thunks the compiler defers so they may reference names bound later in
+        # the enclosing scope; they are evaluated on first `__bound__` /
+        # `__constraints__` access and cached (Objects/typevarobject.c).
+        self = cls.__new__(cls)
+        self.__name__ = name
+        self.__covariant__ = False
+        self.__contravariant__ = False
+        self.__infer_variance__ = False
+        self.__default__ = NoDefault
+        self._constraints = ()
+        self._evaluate_constraints = evaluate_constraints
+        self._bound = None
+        self._evaluate_bound = evaluate_bound
+        self.__module__ = _caller_module()
+        return self
+
+    @property
+    def __bound__(self):
+        if self._evaluate_bound is not None:
+            self._bound = _evaluate_typeparam(self._evaluate_bound)
+            self._evaluate_bound = None
+        return self._bound
+
+    @property
+    def __constraints__(self):
+        if self._evaluate_constraints is not None:
+            self._constraints = tuple(_evaluate_typeparam(self._evaluate_constraints))
+            self._evaluate_constraints = None
+        return self._constraints
 
     def __typing_subst__(self, arg):
         import typing
@@ -303,12 +349,12 @@ def _intrinsic_typevartuple(name):
     return TypeVarTuple(name)
 
 
-def _intrinsic_typevar_with_bound(name, bound):
-    return TypeVar(name, bound=bound)
+def _intrinsic_typevar_with_bound(name, evaluate_bound):
+    return TypeVar._make(name, evaluate_bound=evaluate_bound)
 
 
-def _intrinsic_typevar_with_constraints(name, constraints):
-    return TypeVar(name, *constraints)
+def _intrinsic_typevar_with_constraints(name, evaluate_constraints):
+    return TypeVar._make(name, evaluate_constraints=evaluate_constraints)
 
 
 def _intrinsic_set_typeparam_default(typeparam, default):

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -59,7 +59,9 @@ pub fn register_module(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "enable",
-        crate::make_builtin_function("enable", |args| {
+        crate::make_builtin_function_with_signature(
+            "enable",
+            |args| {
             // `handler.py:141-145 enable` — file=None, all_threads=True.
             let _fd =
                 faulthandler_extract_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
@@ -81,7 +83,9 @@ pub fn register_module(ns: &mut DictStorage) {
             Err(crate::PyError::not_implemented(
                 "faulthandler.enable requires host_env feature",
             ))
-        }),
+            },
+            crate::Signature::new(vec!["file", "all_threads"], None, None, 0, 0),
+        ),
     );
     crate::dict_storage_store(
         ns,
@@ -156,25 +160,34 @@ pub fn register_module(ns: &mut DictStorage) {
     crate::dict_storage_store(
         ns,
         "register",
-        crate::make_builtin_function("register", |args| {
-            if args.is_empty() {
+        crate::make_builtin_function_with_signature(
+            "register",
+            |args| {
+            let w_signum = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+            if w_signum.is_null() {
                 return Err(crate::PyError::type_error("register() missing signal"));
             }
-            let signum = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
+            let signum = (unsafe { pyre_object::w_int_get_value(w_signum) }) as libc::c_int;
             let fd = faulthandler_extract_fd(args.get(1).copied().unwrap_or(pyre_object::PY_NULL))?;
             // handler.py:174 `@unwrap_spec(all_threads=int, chain=int)`
             // with defaults `all_threads=1, chain=0`: the arguments are
             // coerced as integers (`gateway_int_w`, raising on a non-int),
-            // not by truthiness; `register` then tests `if all_threads:`.
+            // not by truthiness; `register` then tests `if all_threads:`.  An
+            // omitted keyword leaves a null slot from the signature binding, so
+            // treat null as the default.
             let all_threads = args
                 .get(2)
-                .map(|&a| crate::baseobjspace::gateway_int_w(a))
+                .copied()
+                .filter(|a| !a.is_null())
+                .map(crate::baseobjspace::gateway_int_w)
                 .transpose()?
                 .unwrap_or(1)
                 != 0;
             let chain = args
                 .get(3)
-                .map(|&a| crate::baseobjspace::gateway_int_w(a))
+                .copied()
+                .filter(|a| !a.is_null())
+                .map(crate::baseobjspace::gateway_int_w)
                 .transpose()?
                 .unwrap_or(0)
                 != 0;
@@ -202,7 +215,15 @@ pub fn register_module(ns: &mut DictStorage) {
                     "faulthandler.register requires host_env feature",
                 ))
             }
-        }),
+            },
+            crate::Signature::new(
+                vec!["signum", "file", "all_threads", "chain"],
+                None,
+                None,
+                0,
+                0,
+            ),
+        ),
     );
     crate::dict_storage_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -51,6 +51,19 @@ pub fn register_module(ns: &mut DictStorage) {
             1,
         ),
     );
+    // `_imp.find_frozen(name)` — `FrozenImporter.find_spec` calls this and
+    // treats None as "not a frozen module". Pyre has no frozen modules, so
+    // every name resolves to None and the import falls through to the next
+    // finder on `sys.meta_path`.
+    crate::dict_storage_store(
+        ns,
+        "find_frozen",
+        crate::make_builtin_function_with_arity(
+            "find_frozen",
+            |_| Ok(pyre_object::w_none()),
+            1,
+        ),
+    );
     // `_imp._override_frozen_modules_for_tests(value)` — the CPython test
     // harness (`test.support.import_helper`) toggles frozen-module
     // overriding.  Pyre has no frozen modules, so accept and ignore.

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -46,6 +46,8 @@ pub mod _random;
 pub mod _socket;
 pub mod _sre;
 #[allow(non_snake_case)]
+pub mod _template;
+#[allow(non_snake_case)]
 pub mod _typing;
 pub mod _weakref;
 pub mod array;

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -661,7 +661,7 @@ pub fn register_module(ns: &mut DictStorage) {
                 }
                 let src = extract_path(args[0])?;
                 let dst = extract_path(args[1])?;
-                host_os::rename(&src, &dst).map_err(|e| io_err(e, &src))?;
+                host_os::rename(&src, None, &dst, None).map_err(|e| io_err(e, &src))?;
                 Ok(pyre_object::w_none())
             },
             2,

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -868,7 +868,7 @@ pub fn register_module(ns: &mut DictStorage) {
                         // interp_signal.py:502-513 _sigset_to_signals
                         let items: Vec<pyre_object::PyObjectRef> = (1..signalstate::NSIG)
                             .filter(|s| {
-                                rustpython_host_env::signal::sigset_contains(&mask, *s)
+                                rustpython_host_env::signal::sigset_contains(mask, *s as i32)
                             })
                             .map(|s| pyre_object::w_int_new(s as i64))
                             .collect();
@@ -988,7 +988,7 @@ pub fn register_module(ns: &mut DictStorage) {
                         checksignals_now()?;
                         let out: Vec<pyre_object::PyObjectRef> = (1..=64)
                             .filter(|s| {
-                                rustpython_host_env::signal::sigset_contains(&prev, *s as i32)
+                                rustpython_host_env::signal::sigset_contains(prev, *s as i32)
                             })
                             .map(|s| pyre_object::w_int_new(s as i64))
                             .collect();

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -979,6 +979,10 @@ pub fn register_module(ns: &mut DictStorage) {
     dict_storage_store(ns, "meta_path", w_list_new(vec![]));
     // sys.dont_write_bytecode
     dict_storage_store(ns, "dont_write_bytecode", w_bool_from(true));
+    // sys.pycache_prefix — None unless -X pycache_prefix / PYTHONPYCACHEPREFIX.
+    // `importlib._bootstrap_external.cache_from_source` reads it to compute the
+    // bytecode path before `dont_write_bytecode` is consulted.
+    dict_storage_store(ns, "pycache_prefix", w_none());
     // sys.addaudithook
     dict_storage_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -305,16 +305,20 @@ pub fn register_module(ns: &mut DictStorage) {
     dict_storage_store(ns, "modules", modules_dict);
     // sys.path — empty list placeholder
     dict_storage_store(ns, "path", w_list_new(vec![]));
-    // sys.stdout/stderr/stdin — stub file-like objects.  Real CPython
-    // wires these through io.TextIOWrapper around sys.__stdout__; pyre
-    // exposes a tiny object with the bare minimum surface so anything
-    // that writes status (unittest, traceback, warnings) keeps working.
-    dict_storage_store(ns, "stdout", make_std_stream("<stdout>", false));
-    dict_storage_store(ns, "stderr", make_std_stream("<stderr>", true));
-    dict_storage_store(ns, "stdin", make_std_stream("<stdin>", false));
-    dict_storage_store(ns, "__stdout__", make_std_stream("<stdout>", false));
-    dict_storage_store(ns, "__stderr__", make_std_stream("<stderr>", true));
-    dict_storage_store(ns, "__stdin__", make_std_stream("<stdin>", false));
+    // sys.stdout/stderr/stdin — `_io.TextIOWrapper`-typed file-like objects.
+    // Real CPython wires these through io.TextIOWrapper around the std fds;
+    // pyre exposes objects of the same type with the minimum surface so
+    // anything that writes status (unittest, traceback, warnings) keeps
+    // working.  `sys.__stdout__ is sys.stdout` (a single object each).
+    let stdout = make_std_stream("<stdout>", 1);
+    let stderr = make_std_stream("<stderr>", 2);
+    let stdin = make_std_stream("<stdin>", 0);
+    dict_storage_store(ns, "stdout", stdout);
+    dict_storage_store(ns, "stderr", stderr);
+    dict_storage_store(ns, "stdin", stdin);
+    dict_storage_store(ns, "__stdout__", stdout);
+    dict_storage_store(ns, "__stderr__", stderr);
+    dict_storage_store(ns, "__stdin__", stdin);
     // `pypy/module/sys/vm.py:30 _getframe` walks the
     // `space.getexecutioncontext().gettopframe_nohidden()` chain,
     // following `f_back` `depth` times.  PyPy returns the frame
@@ -972,6 +976,19 @@ pub fn register_module(ns: &mut DictStorage) {
         "excepthook",
         make_builtin_function_with_arity("excepthook", |_| Ok(w_none()), 3),
     );
+    // sys.unraisablehook(unraisable) — handles exceptions raised where they
+    // cannot propagate (e.g. __del__).  Stored alongside the read-only
+    // `__unraisablehook__` original so code can save and restore it.
+    dict_storage_store(
+        ns,
+        "unraisablehook",
+        make_builtin_function_with_arity("unraisablehook", |_| Ok(w_none()), 1),
+    );
+    dict_storage_store(
+        ns,
+        "__unraisablehook__",
+        make_builtin_function_with_arity("unraisablehook", |_| Ok(w_none()), 1),
+    );
     // sys.path_hooks / path_importer_cache
     dict_storage_store(ns, "path_hooks", w_list_new(vec![]));
     dict_storage_store(ns, "path_importer_cache", w_dict_new());
@@ -991,15 +1008,25 @@ pub fn register_module(ns: &mut DictStorage) {
     );
 }
 
-/// Construct a stub stdio object exposing `write`, `flush`, `isatty`,
-/// `fileno`, and `name`.  PyPy uses real W_File-backed objects via the io
-/// module; pyre routes writes through Rust's stdout/stderr directly.
-fn make_std_stream(name: &'static str, is_stderr: bool) -> PyObjectRef {
-    let stream = make_sys_namespace_instance();
+/// Construct a stdio object whose type is `_io.TextIOWrapper` (so
+/// `isinstance(sys.stdout, io.TextIOWrapper)` holds), exposing `write`,
+/// `flush`, `isatty`, `fileno`, `reconfigure`, and `name`.  `fd` is the
+/// descriptor it reports: 0 (stdin) / 1 (stdout) / 2 (stderr).  PyPy wires a
+/// real W_File-backed `TextIOWrapper`; pyre routes writes through Rust's
+/// stdout/stderr (the same sink as `print`) so output ordering is preserved,
+/// storing the read/write surface as instance attributes.
+fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
+    let writable = fd != 0;
+    let to_stderr = fd == 2;
+    let stream = pyre_object::w_instance_new(crate::builtins::text_io_wrapper_type());
     let _ = crate::baseobjspace::setattr_str(stream, "name", w_str_new(name));
     let _ = crate::baseobjspace::setattr_str(stream, "encoding", w_str_new("utf-8"));
-    let _ =
-        crate::baseobjspace::setattr_str(stream, "mode", w_str_new(if is_stderr { "w" } else { "r" }));
+    let _ = crate::baseobjspace::setattr_str(stream, "errors", w_str_new("strict"));
+    let _ = crate::baseobjspace::setattr_str(
+        stream,
+        "mode",
+        w_str_new(if writable { "w" } else { "r" }),
+    );
     let _ = crate::baseobjspace::setattr_str(stream, "closed", w_bool_from(false));
     let _ = crate::baseobjspace::setattr_str(stream, "buffer", w_none());
     // Instance-stored builtin methods do not get `self` prepended (see
@@ -1013,7 +1040,7 @@ fn make_std_stream(name: &'static str, is_stderr: bool) -> PyObjectRef {
         }
         None
     }
-    let write_fn = if is_stderr {
+    let write_fn = if to_stderr {
         crate::make_builtin_function("write", |args| {
             use std::io::Write;
             if let Some(text) = pick_str(args) {
@@ -1048,21 +1075,34 @@ fn make_std_stream(name: &'static str, is_stderr: bool) -> PyObjectRef {
         "isatty",
         crate::make_builtin_function("isatty", |_| Ok(w_bool_from(false))),
     );
-    let fileno_fn = if is_stderr {
-        crate::make_builtin_function("fileno", |_| Ok(w_int_new(2)))
-    } else {
-        crate::make_builtin_function("fileno", |_| Ok(w_int_new(1)))
+    // `TextIOWrapper.reconfigure(*, encoding=None, errors=None, ...)` only
+    // adjusts codec/newline policy; pyre's streams are fixed UTF-8, so accept
+    // and ignore the request.
+    let _ = crate::baseobjspace::setattr_str(
+        stream,
+        "reconfigure",
+        crate::make_builtin_function("reconfigure", |_| Ok(w_none())),
+    );
+    // `BuiltinCodeFn` is a bare `fn` pointer (no captures), so select a
+    // constant-returning function per descriptor rather than closing over `fd`.
+    let fileno_fn = match fd {
+        0 => crate::make_builtin_function("fileno", |_| Ok(w_int_new(0))),
+        2 => crate::make_builtin_function("fileno", |_| Ok(w_int_new(2))),
+        _ => crate::make_builtin_function("fileno", |_| Ok(w_int_new(1))),
     };
     let _ = crate::baseobjspace::setattr_str(stream, "fileno", fileno_fn);
-    let _ = crate::baseobjspace::setattr_str(
-        stream,
-        "writable",
-        crate::make_builtin_function("writable", |_| Ok(w_bool_from(true))),
-    );
-    let _ = crate::baseobjspace::setattr_str(
-        stream,
-        "readable",
-        crate::make_builtin_function("readable", |_| Ok(w_bool_from(false))),
-    );
+    let (writable_fn, readable_fn) = if writable {
+        (
+            crate::make_builtin_function("writable", |_| Ok(w_bool_from(true))),
+            crate::make_builtin_function("readable", |_| Ok(w_bool_from(false))),
+        )
+    } else {
+        (
+            crate::make_builtin_function("writable", |_| Ok(w_bool_from(false))),
+            crate::make_builtin_function("readable", |_| Ok(w_bool_from(true))),
+        )
+    };
+    let _ = crate::baseobjspace::setattr_str(stream, "writable", writable_fn);
+    let _ = crate::baseobjspace::setattr_str(stream, "readable", readable_fn);
     stream
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2070,7 +2070,14 @@ impl PyFrame {
                 };
                 if !w_value.is_null() {
                     setitem_str_object(w_locals, name, w_value)?;
-                } else {
+                } else if code.flags.contains(CodeFlags::OPTIMIZED) {
+                    // Optimized (function) frames own their cellvars in the
+                    // cell, so an empty cell means the local is unbound and its
+                    // locals entry must be removed.  Module/class frames are
+                    // namespace-authoritative: a cellvar can hold its binding in
+                    // `w_locals` via STORE_NAME while its cell stays empty
+                    // (`__conditional_annotations__`), so an empty cell there
+                    // must not erase the STORE_NAME binding.
                     delitem_str_object(w_locals, name)?;
                 }
             }

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1257,6 +1257,12 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn end_send(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("end_send not implemented").into())
     }
+    /// GET_AWAITABLE — replace TOS with its awaitable iterator (`__await__`).
+    /// Overridden by the interpreter; the trace path declines (await suspends
+    /// the frame and is never JIT-traced).
+    fn get_awaitable(&mut self, _context: u32) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("get_awaitable not implemented").into())
+    }
 
     // Class
     fn load_build_class(&mut self) -> Result<(), PyError> {
@@ -2091,6 +2097,18 @@ pub fn execute_get_yield_from_iter<E: OpcodeStepExecutor>(
     executor: &mut E,
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
     executor.get_yield_from_iter()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_get_awaitable<E: OpcodeStepExecutor>(
+    executor: &mut E,
+    instruction: Instruction,
+    op_arg: OpArg,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    let Instruction::GetAwaitable { r#where } = instruction else {
+        unreachable!()
+    };
+    executor.get_awaitable(r#where.get(op_arg))?;
     Ok(StepResult::Continue)
 }
 
@@ -3264,9 +3282,13 @@ where
             execute_call_intrinsic_2(executor, instruction, op_arg)
         }
 
+        // ── Await ──
+        Instruction::GetAwaitable { .. } => {
+            execute_get_awaitable(executor, instruction, op_arg)
+        }
+
         // ── Async stubs ──
-        Instruction::GetAwaitable { .. }
-        | Instruction::GetAiter
+        Instruction::GetAiter
         | Instruction::GetAnext
         | Instruction::EndAsyncFor
         | Instruction::CleanupThrow => {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1315,6 +1315,21 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn match_stub(&mut self) -> Result<(), PyError> {
         Err(crate::PyError::type_error("pattern matching not implemented").into())
     }
+    // MATCH_MAPPING / MATCH_SEQUENCE / MATCH_KEYS / MATCH_CLASS (PEP 634).
+    // The JIT tracer inherits these erroring defaults and declines a trace
+    // that reaches a match statement; the interpreter overrides them.
+    fn match_mapping(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("pattern matching not implemented").into())
+    }
+    fn match_sequence(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("pattern matching not implemented").into())
+    }
+    fn match_keys(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("pattern matching not implemented").into())
+    }
+    fn match_class(&mut self, _count: usize) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("pattern matching not implemented").into())
+    }
     fn unpack_ex(&mut self, _args: crate::bytecode::UnpackExArgs) -> Result<(), PyError> {
         Err(crate::PyError::type_error("unpack_ex not implemented").into())
     }
@@ -1917,6 +1932,39 @@ pub fn execute_match_stub<E: OpcodeStepExecutor>(
     executor: &mut E,
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
     executor.match_stub()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_match_mapping<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    executor.match_mapping()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_match_sequence<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    executor.match_sequence()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_match_keys<E: OpcodeStepExecutor>(
+    executor: &mut E,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    executor.match_keys()?;
+    Ok(StepResult::Continue)
+}
+
+pub fn execute_match_class<E: OpcodeStepExecutor>(
+    executor: &mut E,
+    instruction: Instruction,
+    op_arg: OpArg,
+) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
+    let Instruction::MatchClass { count } = instruction else {
+        unreachable!()
+    };
+    executor.match_class(count.get(op_arg) as usize)?;
     Ok(StepResult::Continue)
 }
 
@@ -3269,7 +3317,10 @@ where
         }
 
         // ── Pattern matching (Python 3.10+) ──
-        Instruction::MatchMapping | Instruction::MatchSequence => execute_match_stub(executor),
+        Instruction::MatchMapping => execute_match_mapping(executor),
+        Instruction::MatchSequence => execute_match_sequence(executor),
+        Instruction::MatchKeys => execute_match_keys(executor),
+        Instruction::MatchClass { .. } => execute_match_class(executor, instruction, op_arg),
 
         // ── Unpack extended ──
         Instruction::UnpackEx { .. } => execute_unpack_ex(executor, instruction, op_arg),

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1344,6 +1344,25 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
         Ok(())
     }
 
+    /// BUILD_TEMPLATE: pop the interpolations and strings tuples and build a
+    /// `string.templatelib.Template`.  Overridden by the interpreter; the trace
+    /// path declines (t-strings run at import time, never inside a JIT-traced
+    /// loop).
+    fn build_template_op(&mut self) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("BUILD_TEMPLATE not implemented").into())
+    }
+
+    /// BUILD_INTERPOLATION: build a `string.templatelib.Interpolation` from the
+    /// value/expression (and optional format spec) on the stack, with the
+    /// conversion taken from the opcode oparg.  Overridden by the interpreter.
+    fn build_interpolation_op(
+        &mut self,
+        _conversion: u32,
+        _has_format_spec: bool,
+    ) -> Result<(), PyError> {
+        Err(crate::PyError::type_error("BUILD_INTERPOLATION not implemented").into())
+    }
+
     fn call_intrinsic_1(&mut self, func: IntrinsicFunction1) -> Result<(), PyError> {
         match func {
             IntrinsicFunction1::UnaryPositive => {
@@ -1918,7 +1937,7 @@ pub fn execute_get_len<E: OpcodeStepExecutor>(
 pub fn execute_build_template<E: OpcodeStepExecutor>(
     executor: &mut E,
 ) -> Result<StepResult<<E as SharedOpcodeHandler>::Value>, PyError> {
-    OpcodeStepExecutor::build_tuple(executor, 2)?;
+    OpcodeStepExecutor::build_template_op(executor)?;
     Ok(StepResult::Continue)
 }
 
@@ -1932,16 +1951,9 @@ pub fn execute_build_interpolation<E: OpcodeStepExecutor>(
     };
     let oparg_val = u32::from(format.get(op_arg));
     let has_format_spec = (oparg_val & 1) != 0;
-    if has_format_spec {
-        // `let _ = expr?` rewritten as a plain expression-statement to
-        // stay inside the Rust-AST adapter's RPython-orthodox subset
-        // (Position-2 adaptation; the adapter's `lower_let` accepts
-        // `Pat::Ident` / `Pat::Type(Pat::Ident)` only — there is no
-        // upstream analogue for binding `_`).
-        executor.pop_value()?;
-    }
-    // Stack: [value, expression_str] — wrap as a 2-tuple interpolation.
-    OpcodeStepExecutor::build_tuple(executor, 2)?;
+    // The conversion (`!s` / `!r` / `!a`) is encoded in the upper oparg bits.
+    let conversion = oparg_val >> 2;
+    OpcodeStepExecutor::build_interpolation_op(executor, conversion, has_format_spec)?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -3334,9 +3334,7 @@ where
         }
 
         // ── Await ──
-        Instruction::GetAwaitable { .. } => {
-            execute_get_awaitable(executor, instruction, op_arg)
-        }
+        Instruction::GetAwaitable { .. } => execute_get_awaitable(executor, instruction, op_arg),
 
         // ── Async stubs ──
         Instruction::GetAiter

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -700,7 +700,13 @@ pub fn init_typeobjects() {
         );
         reg.insert(
             &pyre_object::functional::RANGE_TYPE as *const PyType as usize,
-            new_typeobject_with_base("range", |_| {}, object_type) as usize,
+            new_typeobject_with_base(
+                "range",
+                |ns| {
+                    dict_storage_store(ns, "__new__", make_new_descr(range_descr_new));
+                },
+                object_type,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::iterobject::SEQ_ITER_TYPE as *const PyType as usize,
@@ -715,23 +721,53 @@ pub fn init_typeobjects() {
         );
         reg.insert(
             &pyre_object::functional::ENUMERATE_TYPE as *const PyType as usize,
-            new_typeobject_with_base("enumerate", |_| {}, object_type) as usize,
+            new_typeobject_with_base(
+                "enumerate",
+                |ns| {
+                    dict_storage_store(ns, "__new__", make_new_descr(enumerate_descr_new));
+                },
+                object_type,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::REVERSED_TYPE as *const PyType as usize,
-            new_typeobject_with_base("reversed", |_| {}, object_type) as usize,
+            new_typeobject_with_base(
+                "reversed",
+                |ns| {
+                    dict_storage_store(ns, "__new__", make_new_descr(reversed_descr_new));
+                },
+                object_type,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::FILTER_TYPE as *const PyType as usize,
-            new_typeobject_with_base("filter", |_| {}, object_type) as usize,
+            new_typeobject_with_base(
+                "filter",
+                |ns| {
+                    dict_storage_store(ns, "__new__", make_new_descr(filter_descr_new));
+                },
+                object_type,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::MAP_TYPE as *const PyType as usize,
-            new_typeobject_with_base("map", |_| {}, object_type) as usize,
+            new_typeobject_with_base(
+                "map",
+                |ns| {
+                    dict_storage_store(ns, "__new__", make_new_descr(map_descr_new));
+                },
+                object_type,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::functional::ZIP_TYPE as *const PyType as usize,
-            new_typeobject_with_base("zip", |_| {}, object_type) as usize,
+            new_typeobject_with_base(
+                "zip",
+                |ns| {
+                    dict_storage_store(ns, "__new__", make_new_descr(zip_descr_new));
+                },
+                object_type,
+            ) as usize,
         );
         reg.insert(
             &pyre_object::dictmultiobject::DICT_KEYITERATOR_TYPE as *const PyType as usize,
@@ -1604,6 +1640,94 @@ fn tuple_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     }
     Ok(value)
 }
+/// `enumerate.__new__(cls, iterable, start=0)` — `functional.py:253-275
+/// W_Enumerate.descr___new__`.  `builtin_enumerate` builds a fresh
+/// `W_Enumerate`; a subclass instance is the same object with `w_class`
+/// retagged (the instance keeps the `enumerate` GC tag so iteration still
+/// dispatches through the builtin `__next__`).
+fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let value = crate::builtins::builtin_enumerate(&args[1..])?;
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ENUMERATE_TYPE) {
+        unsafe {
+            (*value).w_class = sub;
+        }
+    }
+    Ok(value)
+}
+
+/// `map.__new__(cls, func, *iterables, strict=False)` — `functional.py:888-902
+/// W_Map.descr___new__`.
+fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let value = crate::builtins::builtin_map(&args[1..])?;
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::MAP_TYPE) {
+        unsafe {
+            (*value).w_class = sub;
+        }
+    }
+    Ok(value)
+}
+
+/// `filter.__new__(cls, predicate, iterable)` — `functional.py:917-925
+/// W_Filter.descr___new__`.
+fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let value = crate::builtins::builtin_filter(&args[1..])?;
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::FILTER_TYPE) {
+        unsafe {
+            (*value).w_class = sub;
+        }
+    }
+    Ok(value)
+}
+
+/// `zip.__new__(cls, *iterables, strict=False)` — `functional.py:1101-1105
+/// W_Zip.descr___new__`.
+fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let value = crate::builtins::builtin_zip(&args[1..])?;
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ZIP_TYPE) {
+        unsafe {
+            (*value).w_class = sub;
+        }
+    }
+    Ok(value)
+}
+
+/// `reversed.__new__(cls, sequence)` — `functional.py:330-359
+/// W_ReversedIterator`.  `builtin_reversed` returns a `W_ReversedIterator`
+/// only for the exact builtin-sequence fast path; for a range or a
+/// `__reversed__`-defining object it returns a foreign iterator, which must
+/// NOT be retagged to the subclass.  Retag only the canonical reversed
+/// object.
+fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let value = crate::builtins::builtin_reversed(&args[1..])?;
+    if unsafe { pyre_object::functional::is_reversed(value) } {
+        if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::REVERSED_TYPE) {
+            unsafe {
+                (*value).w_class = sub;
+            }
+        }
+    }
+    Ok(value)
+}
+
+/// `range.__new__(cls, stop)` / `range.__new__(cls, start, stop[, step])` —
+/// `rangeobject.py descr_new`.  `builtin_range` builds a fresh `W_Range`; a
+/// subclass instance is the same object with `w_class` retagged.
+fn range_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let value = crate::builtins::builtin_range(&args[1..])?;
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::RANGE_TYPE) {
+        unsafe {
+            (*value).w_class = sub;
+        }
+    }
+    Ok(value)
+}
+
 // dict_new handled by dict_descr_new above (supports dict subclasses)
 
 /// typeobject.py:511-524 W_TypeObject.check_user_subclass.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -698,15 +698,19 @@ pub fn init_typeobjects() {
             &pyre_object::functional::RANGE_ITER_TYPE as *const PyType as usize,
             new_typeobject_with_base("range_iterator", |_| {}, object_type) as usize,
         );
+        // rangeobject.c PyRange_Type carries no Py_TPFLAGS_BASETYPE, so
+        // `range` is not an acceptable base class.
+        let range_type = new_typeobject_with_base(
+            "range",
+            |ns| {
+                dict_storage_store(ns, "__new__", make_new_descr(range_descr_new));
+            },
+            object_type,
+        );
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(range_type, false) };
         reg.insert(
             &pyre_object::functional::RANGE_TYPE as *const PyType as usize,
-            new_typeobject_with_base(
-                "range",
-                |ns| {
-                    dict_storage_store(ns, "__new__", make_new_descr(range_descr_new));
-                },
-                object_type,
-            ) as usize,
+            range_type as usize,
         );
         reg.insert(
             &pyre_object::iterobject::SEQ_ITER_TYPE as *const PyType as usize,
@@ -1598,8 +1602,15 @@ fn subclass_to_tag(cls: PyObjectRef, base: &'static pyre_object::PyType) -> Opti
         return None;
     }
     match gettypefor(base) {
+        // `cls` is the builtin base itself → keep the canonical layout, no retag.
         Some(t) if std::ptr::eq(cls, t) => None,
-        _ => Some(cls),
+        // Retag only for a genuine subclass.  A foreign type
+        // (`range.__new__(dict, 3)`) must never be stamped onto the builtin
+        // object, or `type(obj)`/dispatch would read it through an
+        // incompatible layout.
+        Some(t) if unsafe { crate::baseobjspace::issubtype_w(cls, t) } => Some(cls),
+        Some(_) => None,
+        None => Some(cls),
     }
 }
 
@@ -1647,7 +1658,7 @@ fn tuple_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 /// dispatches through the builtin `__next__`).
 fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_enumerate(&args[1..])?;
+    let value = crate::builtins::builtin_enumerate(args.get(1..).unwrap_or(&[]))?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ENUMERATE_TYPE) {
         unsafe {
             (*value).w_class = sub;
@@ -1660,7 +1671,7 @@ fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// W_Map.descr___new__`.
 fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_map(&args[1..])?;
+    let value = crate::builtins::builtin_map(args.get(1..).unwrap_or(&[]))?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::MAP_TYPE) {
         unsafe {
             (*value).w_class = sub;
@@ -1673,7 +1684,7 @@ fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// W_Filter.descr___new__`.
 fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_filter(&args[1..])?;
+    let value = crate::builtins::builtin_filter(args.get(1..).unwrap_or(&[]))?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::FILTER_TYPE) {
         unsafe {
             (*value).w_class = sub;
@@ -1686,7 +1697,7 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// W_Zip.descr___new__`.
 fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_zip(&args[1..])?;
+    let value = crate::builtins::builtin_zip(args.get(1..).unwrap_or(&[]))?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ZIP_TYPE) {
         unsafe {
             (*value).w_class = sub;
@@ -1703,7 +1714,7 @@ fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// object.
 fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_reversed(&args[1..])?;
+    let value = crate::builtins::builtin_reversed(args.get(1..).unwrap_or(&[]))?;
     if unsafe { pyre_object::functional::is_reversed(value) } {
         if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::REVERSED_TYPE) {
             unsafe {
@@ -1719,7 +1730,7 @@ fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 /// subclass instance is the same object with `w_class` retagged.
 fn range_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-    let value = crate::builtins::builtin_range(&args[1..])?;
+    let value = crate::builtins::builtin_range(args.get(1..).unwrap_or(&[]))?;
     if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::RANGE_TYPE) {
         unsafe {
             (*value).w_class = sub;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -858,6 +858,8 @@ pub fn init_typeobjects() {
             (&pyre_object::pyobject::DICT_TYPE, b'M'),
             (&pyre_object::pyobject::LIST_TYPE, b'S'),
             (&pyre_object::pyobject::TUPLE_TYPE, b'S'),
+            // rangeobject.c PyRange_Type carries Py_TPFLAGS_SEQUENCE.
+            (&pyre_object::functional::RANGE_TYPE, b'S'),
         ] {
             let w_typeobject = *reg
                 .get(&(pytype as *const PyType as usize))
@@ -1597,21 +1599,38 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// subclass-tagging path `str`/`int`/`float` `__new__` already use so
 /// `type(obj)` / `isinstance` / overridden-dunder dispatch see the
 /// subclass while the object keeps its builtin layout.
-fn subclass_to_tag(cls: PyObjectRef, base: &'static pyre_object::PyType) -> Option<PyObjectRef> {
-    if cls.is_null() || !unsafe { pyre_object::is_type(cls) } {
-        return None;
+fn subclass_to_tag(
+    cls: PyObjectRef,
+    base: &'static pyre_object::PyType,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    if cls.is_null() {
+        return Ok(None);
     }
-    match gettypefor(base) {
-        // `cls` is the builtin base itself → keep the canonical layout, no retag.
-        Some(t) if std::ptr::eq(cls, t) => None,
-        // Retag only for a genuine subclass.  A foreign type
-        // (`range.__new__(dict, 3)`) must never be stamped onto the builtin
-        // object, or `type(obj)`/dispatch would read it through an
-        // incompatible layout.
-        Some(t) if unsafe { crate::baseobjspace::issubtype_w(cls, t) } => Some(cls),
-        Some(_) => None,
-        None => Some(cls),
+    let base_obj = match gettypefor(base) {
+        Some(t) => t,
+        None => return Ok(Some(cls)),
+    };
+    // `cls` is the builtin base itself → keep the canonical layout, no retag.
+    if std::ptr::eq(cls, base_obj) {
+        return Ok(None);
     }
+    // tp_new_wrapper rejects a non-type, or a type that is not a subtype of the
+    // builtin: `range.__new__(int, 1)` must raise, not stamp a W_Range as int
+    // (which later dispatch would read through an incompatible layout).
+    if !unsafe { pyre_object::is_type(cls) } {
+        let base_name = unsafe { pyre_object::w_type_get_name(base_obj) };
+        return Err(crate::PyError::type_error(format!(
+            "{base_name}.__new__(X): X is not a type object"
+        )));
+    }
+    if !unsafe { crate::baseobjspace::issubtype_w(cls, base_obj) } {
+        let base_name = unsafe { pyre_object::w_type_get_name(base_obj) };
+        let cls_name = unsafe { pyre_object::w_type_get_name(cls) };
+        return Err(crate::PyError::type_error(format!(
+            "{base_name}.__new__({cls_name}): {cls_name} is not a subtype of {base_name}"
+        )));
+    }
+    Ok(Some(cls))
 }
 
 /// `list.__new__(cls, *args)` — `listobject.py:descr__new__` allocates a
@@ -1621,7 +1640,7 @@ fn subclass_to_tag(cls: PyObjectRef, base: &'static pyre_object::PyType) -> Opti
 fn list_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_list_ctor(&args[1..])?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::LIST_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::LIST_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
@@ -1636,7 +1655,7 @@ fn list_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn tuple_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_tuple(&args[1..])?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::TUPLE_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::TUPLE_TYPE)? {
         let n = unsafe { pyre_object::w_tuple_len(value) };
         let items: Vec<PyObjectRef> = (0..n)
             .filter_map(|i| unsafe { pyre_object::w_tuple_getitem(value, i as i64) })
@@ -1659,7 +1678,7 @@ fn tuple_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_enumerate(args.get(1..).unwrap_or(&[]))?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ENUMERATE_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ENUMERATE_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
@@ -1672,7 +1691,7 @@ fn enumerate_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_map(args.get(1..).unwrap_or(&[]))?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::MAP_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::MAP_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
@@ -1685,7 +1704,7 @@ fn map_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_filter(args.get(1..).unwrap_or(&[]))?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::FILTER_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::FILTER_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
@@ -1698,7 +1717,7 @@ fn filter_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 fn zip_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_zip(args.get(1..).unwrap_or(&[]))?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ZIP_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::ZIP_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
@@ -1716,7 +1735,7 @@ fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_reversed(args.get(1..).unwrap_or(&[]))?;
     if unsafe { pyre_object::functional::is_reversed(value) } {
-        if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::REVERSED_TYPE) {
+        if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::REVERSED_TYPE)? {
             unsafe {
                 (*value).w_class = sub;
             }
@@ -1731,7 +1750,7 @@ fn reversed_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 fn range_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = crate::builtins::builtin_range(args.get(1..).unwrap_or(&[]))?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::RANGE_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::functional::RANGE_TYPE)? {
         unsafe {
             (*value).w_class = sub;
         }
@@ -8628,8 +8647,19 @@ fn bool_dunder_xor(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     )
 }
 
+/// `bool.__repr__` / `bool.__str__` — boolobject.c `bool_repr` returns
+/// "True"/"False" instead of inheriting int's decimal formatter (`tp_str`
+/// falls back to `tp_repr`, so both dunders share this).
+fn bool_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let w_self = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+    let truthy = !w_self.is_null() && crate::baseobjspace::is_true(w_self)?;
+    Ok(w_str_new(if truthy { "True" } else { "False" }))
+}
+
 fn init_bool_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(bool_descr_new));
+    dict_storage_store(ns, "__repr__", make_builtin_function("__repr__", bool_repr));
+    dict_storage_store(ns, "__str__", make_builtin_function("__str__", bool_repr));
     // boolobject.py:97-106 — bool defines its own bitwise dunders so that
     // `True & True` is `True`; int.__and__ etc. return int.
     for (and_name, rand_name, f) in [
@@ -8955,7 +8985,7 @@ fn init_object_type(ns: &mut DictStorage) {
 fn bytearray_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = bytearray_descr_new_impl(args)?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::bytearrayobject::BYTEARRAY_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::bytearrayobject::BYTEARRAY_TYPE)? {
         let data = unsafe { pyre_object::bytesobject::bytes_like_data(value).to_vec() };
         let fresh = pyre_object::bytearrayobject::w_bytearray_from_bytes(&data);
         unsafe {
@@ -11401,7 +11431,7 @@ fn bytes_method_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 fn bytes_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let cls = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     let value = bytes_descr_new_impl(args)?;
-    if let Some(sub) = subclass_to_tag(cls, &pyre_object::bytesobject::BYTES_TYPE) {
+    if let Some(sub) = subclass_to_tag(cls, &pyre_object::bytesobject::BYTES_TYPE)? {
         // `bytes(b)` may return the argument unchanged, so rebuild a
         // fresh object before retagging to avoid aliasing the input.
         let data = unsafe { pyre_object::bytesobject::bytes_like_data(value).to_vec() };

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1107,18 +1107,18 @@ mod tests {
 
     #[test]
     fn pop_top_lookup() {
-        // Instruction::PopTop is arm_id=21 at build time. The opcode
+        // Instruction::PopTop is arm_id=23 at build time. The opcode
         // dispatch is sourced from the lowered MIR switch, which orders the
         // arms by first-encounter target-block order of that switch.
         // Confirm arm → jitcode resolution works end-to-end and the jitcode
         // carries bytecode bytes (not an empty shell).
-        let jc = jitcode_for_arm(21).expect("PopTop arm should resolve to a jitcode");
+        let jc = jitcode_for_arm(23).expect("PopTop arm should resolve to a jitcode");
         assert!(
             !jc.code.is_empty(),
             "PopTop jitcode should have non-empty bytecode"
         );
         assert_eq!(
-            jc.name, "Instruction::PopTop#21",
+            jc.name, "Instruction::PopTop#23",
             "jitcode name should match the arm selector"
         );
     }
@@ -1137,20 +1137,20 @@ mod tests {
     }
 
     #[test]
-    fn arm_id_for_pop_top_matches_arm_21() {
+    fn arm_id_for_pop_top_matches_arm_23() {
         // PopTop is a single-variant arm; `Instruction::PopTop` must
-        // resolve to the same arm_id as the direct `jitcode_for_arm(21)`
+        // resolve to the same arm_id as the direct `jitcode_for_arm(23)`
         // lookup above.
         let arm_id =
             arm_id_for_instruction(&Instruction::PopTop).expect("PopTop must resolve to an arm_id");
-        assert_eq!(arm_id, 21);
+        assert_eq!(arm_id, 23);
     }
 
     #[test]
     fn jitcode_for_instruction_matches_arm_lookup() {
         let jc = jitcode_for_instruction(&Instruction::PopTop)
             .expect("PopTop must resolve to a jitcode");
-        assert_eq!(jc.name, "Instruction::PopTop#21");
+        assert_eq!(jc.name, "Instruction::PopTop#23");
         assert!(!jc.code.is_empty());
     }
 
@@ -1563,7 +1563,7 @@ mod tests {
         let bt_jc = jitcode_for_instruction(&Instruction::PopTop)
             .expect("PopTop must resolve to a jitcode");
         assert!(!bt_jc.code.is_empty());
-        assert_eq!(bt_jc.name, "Instruction::PopTop#21");
+        assert_eq!(bt_jc.name, "Instruction::PopTop#23");
         assert_eq!(arm.entry_jitcode_index, Some(bt_jc.index()));
         assert_eq!(
             bt_jc.num_regs_and_consts_i(),

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -873,6 +873,7 @@ fn stack_effects(
         Instruction::GetLen
         | Instruction::MatchMapping
         | Instruction::MatchSequence
+        | Instruction::MatchKeys
         | Instruction::ImportFrom { .. } => (d + 1, d + 1),
         // ImportName: pop 2 (fromlist + level), push 1 (module). Net -1.
         Instruction::ImportName { .. } => (d - 1, d - 1),
@@ -951,9 +952,9 @@ fn stack_effects(
             let s = count.get(op_arg) as usize as i32;
             (d - 1 + s, d - 1 + s)
         }
-        // MATCH_CLASS (pyopcode.py:1730): pops w_names, w_type, w_subject (−3)
-        // and pushes either (None, False) or (tuple, True) (+2). Net −1.
-        Instruction::MatchClass { .. } => (d - 1, d - 1),
+        // MATCH_CLASS: pops subject, type, names (−3) and pushes the attrs
+        // tuple or None (+1). Net −2.
+        Instruction::MatchClass { .. } => (d - 2, d - 2),
         // Reraise pops TOS (exception). Net -1.
         Instruction::Reraise { .. } => (d - 1, d - 1),
         // RaiseVarargs: pops argc values from stack.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -10114,8 +10114,6 @@ pub fn production_walker_handles(instruction: &Instruction) -> bool {
             // above, which arm-walk.
             | Instruction::ToBool
             | Instruction::GetIter
-            | Instruction::MatchMapping
-            | Instruction::MatchSequence
             | Instruction::SetupAnnotations
             | Instruction::FormatSimple
             | Instruction::FormatWithSpec
@@ -10429,8 +10427,6 @@ fn apply_walker_stack_effect(state: &mut MIFrame, instruction: &Instruction) {
         | Instruction::UnaryInvert
         | Instruction::UnaryNegative
         | Instruction::GetIter
-        | Instruction::MatchMapping
-        | Instruction::MatchSequence
         | Instruction::SetupAnnotations
         | Instruction::FormatSimple
         | Instruction::FormatWithSpec

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -281,6 +281,81 @@ pub(crate) fn import_site(
         eprintln!("'import site' failed");
     }
 }
+
+/// Run the `init_importlib` / `init_importlib_external` sequence
+/// (pylifecycle.c) so `sys.meta_path` / `sys.path_hooks` are populated and
+/// `importlib.util.find_spec` works — which `runpy._get_module_details`
+/// (the `-m` entry) requires. pyre's native importer does not consult
+/// `sys.meta_path`, so before this `importlib._bootstrap` has neither `sys`
+/// nor `_imp` injected and `meta_path` is empty.
+///
+/// `_bootstrap._setup` (importlib/_bootstrap.py) reads the bootstrap builtins
+/// `_thread`/`_warnings`/`_weakref` from `sys.modules`, so import them first to
+/// seed `sys.modules` (otherwise `_setup` falls into `_builtin_from_name` →
+/// `_imp.create_builtin`, which the native importer does not implement).
+fn init_importlib_bootstrap(
+    canonical: pyre_object::PyObjectRef,
+    ec_ptr: *const pyre_interpreter::PyExecutionContext,
+) -> Result<(), pyre_interpreter::PyError> {
+    let import =
+        |name: &str| importing::importhook(name, canonical, pyre_object::PY_NULL, 0, ec_ptr);
+    let call_checked = |func: pyre_object::PyObjectRef,
+                        args: &[pyre_object::PyObjectRef]|
+     -> Result<pyre_object::PyObjectRef, pyre_interpreter::PyError> {
+        let res = pyre_interpreter::call_function(func, args);
+        if res.is_null() {
+            return Err(
+                pyre_interpreter::call::take_call_error().unwrap_or_else(|| {
+                    pyre_interpreter::PyError::new(
+                        pyre_interpreter::PyErrorKind::RuntimeError,
+                        "importlib bootstrap _install returned NULL without an exception",
+                    )
+                }),
+            );
+        }
+        Ok(res)
+    };
+
+    for name in ["_thread", "_warnings", "_weakref"] {
+        import(name)?;
+    }
+    let sys_mod = import("sys")?;
+    let imp_mod = import("_imp")?;
+    import("importlib._bootstrap")?;
+    import("importlib._bootstrap_external")?;
+    let bootstrap = importing::get_sys_module("importlib._bootstrap").ok_or_else(|| {
+        pyre_interpreter::PyError::new(
+            pyre_interpreter::PyErrorKind::RuntimeError,
+            "importlib._bootstrap missing from sys.modules after import",
+        )
+    })?;
+    let bootstrap_ext =
+        importing::get_sys_module("importlib._bootstrap_external").ok_or_else(|| {
+            pyre_interpreter::PyError::new(
+                pyre_interpreter::PyErrorKind::RuntimeError,
+                "importlib._bootstrap_external missing from sys.modules after import",
+            )
+        })?;
+
+    // init_importlib: importlib._bootstrap._install(sys, _imp)
+    let install = pyre_interpreter::getattr(bootstrap, pyre_object::w_str_new("_install"))?;
+    call_checked(install, &[sys_mod, imp_mod])?;
+    // init_importlib_external: importlib._bootstrap_external._install(_bootstrap)
+    let install_ext = pyre_interpreter::getattr(bootstrap_ext, pyre_object::w_str_new("_install"))?;
+    call_checked(install_ext, &[bootstrap])?;
+    // importlib/__init__.py: _bootstrap._bootstrap_external = _bootstrap_external
+    // (`_install` only calls `_set_bootstrap_module`; the reverse link that
+    // `ModuleSpec.cached` / `_get_cached` reads is wired by importlib's package
+    // init, which the native importer does not run for `_bootstrap`).
+    pyre_interpreter::baseobjspace::setattr_str(bootstrap, "_bootstrap_external", bootstrap_ext)?;
+    // The bootstrap modules are exposed under their frozen names; modules such
+    // as `zipimport` import `_frozen_importlib{,_external}` directly. Register
+    // the same objects under the frozen names once `_install` has wired them.
+    importing::set_sys_module("_frozen_importlib", bootstrap);
+    importing::set_sys_module("_frozen_importlib_external", bootstrap_ext);
+    Ok(())
+}
+
 /// Run a library module as `__main__` via `runpy._run_module_as_main`,
 /// the `-m` entry point. `vm.run_module` analog.
 fn run_module(module: &str, no_site: bool) {
@@ -309,6 +384,10 @@ fn run_module(module: &str, no_site: bool) {
     importing::set_sys_module("__main__", main_module);
 
     let result = (|| -> Result<(), pyre_interpreter::PyError> {
+        init_importlib_bootstrap(canonical, ec_ptr)?;
+        // Mirror the native search path into Python `sys.path` so `PathFinder`
+        // (used by `find_spec` for top-level module names) can resolve modules.
+        importing::sync_python_sys_path();
         import_site(no_site, canonical, ec_ptr);
         let runpy = importing::importhook("runpy", canonical, pyre_object::PY_NULL, 0, ec_ptr)?;
         let func = pyre_interpreter::getattr(runpy, pyre_object::w_str_new("_run_module_as_main"))?;

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -35,6 +35,7 @@ Options:
 -i     : inspect interactively after running script
 -O     : optimize (no-op, reserved for compatibility)
 -q     : don't print version on interactive startup
+-S     : don't imply 'import site' on initialization
 -V     : print the Python version number and exit (also --version)
 file   : program read from script file
 -      : program read from stdin (default; interactive mode if a tty)
@@ -54,22 +55,25 @@ fn drain_args(parser: &mut lexopt::Parser) -> Result<Vec<String>, lexopt::Error>
     Ok(rest)
 }
 
-fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool, Vec<String>), lexopt::Error> {
+fn parse_args(
+    binary_name: &str,
+) -> Result<(RunMode, bool, bool, bool, Vec<String>), lexopt::Error> {
     let mut parser = lexopt::Parser::from_env();
     let mut inspect = false;
     let mut quiet = false;
+    let mut no_site = false;
 
     while let Some(arg) = parser.next()? {
         match arg {
             Short('c') => {
                 let cmd = parser.value()?.string()?;
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Command(cmd), inspect, quiet, rest));
+                return Ok((RunMode::Command(cmd), inspect, quiet, no_site, rest));
             }
             Short('m') => {
                 let module = parser.value()?.string()?;
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Module(module), inspect, quiet, rest));
+                return Ok((RunMode::Module(module), inspect, quiet, no_site, rest));
             }
             Short('h') | Long("help") => {
                 print!("{}", usage(binary_name));
@@ -78,6 +82,7 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool, Vec<String>), l
             Short('i') => inspect = true,
             Short('O') => {} // no-op
             Short('q') => quiet = true,
+            Short('S') => no_site = true,
             Short('V') | Long("version") => {
                 println!("{binary_name} 0.0.1");
                 std::process::exit(0);
@@ -85,15 +90,15 @@ fn parse_args(binary_name: &str) -> Result<(RunMode, bool, bool, Vec<String>), l
             Value(script) => {
                 let script = script.string()?;
                 if script == "-" {
-                    return Ok((RunMode::Repl, inspect, quiet, vec![]));
+                    return Ok((RunMode::Repl, inspect, quiet, no_site, vec![]));
                 }
                 let rest = drain_args(&mut parser)?;
-                return Ok((RunMode::Script(script), inspect, quiet, rest));
+                return Ok((RunMode::Script(script), inspect, quiet, no_site, rest));
             }
             _ => return Err(arg.unexpected()),
         }
     }
-    Ok((RunMode::Repl, inspect, quiet, vec![]))
+    Ok((RunMode::Repl, inspect, quiet, no_site, vec![]))
 }
 
 pub fn main_entry(binary_name: &'static str) {
@@ -140,7 +145,7 @@ fn real_main(binary_name: &str) {
             default_hook(info);
         }
     }));
-    let (mode, inspect, quiet, args) = match parse_args(binary_name) {
+    let (mode, inspect, quiet, no_site, args) = match parse_args(binary_name) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{binary_name}: {e}");
@@ -169,9 +174,9 @@ fn real_main(binary_name: &str) {
             let mut argv = vec!["-c".to_string()];
             argv.extend(args);
             importing::set_sys_argv(&argv);
-            run_source(&cmd, Mode::Exec, "<string>");
+            run_source(&cmd, Mode::Exec, "<string>", no_site);
             if inspect {
-                repl::run_repl(true);
+                repl::run_repl(true, no_site);
             }
         }
         RunMode::Module(module) => {
@@ -182,9 +187,9 @@ fn real_main(binary_name: &str) {
             let mut argv = vec![module.clone()];
             argv.extend(args);
             importing::set_sys_argv(&argv);
-            run_module(&module);
+            run_module(&module, no_site);
             if inspect {
-                repl::run_repl(true);
+                repl::run_repl(true, no_site);
             }
         }
         RunMode::Script(path) => {
@@ -206,16 +211,16 @@ fn real_main(binary_name: &str) {
             let mut argv = vec![path.clone()];
             argv.extend(args);
             importing::set_sys_argv(&argv);
-            run_source(&source, Mode::Exec, &path);
+            run_source(&source, Mode::Exec, &path, no_site);
             if inspect {
-                repl::run_repl(true);
+                repl::run_repl(true, no_site);
             }
         }
         RunMode::Repl => {
             // Initialize sys.path with CWD for REPL mode.
             let cwd = std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
             importing::init_sys_path(&cwd);
-            repl::run_repl(quiet);
+            repl::run_repl(quiet, no_site);
         }
     }
 }
@@ -259,9 +264,26 @@ fn setup_exec_context() -> Rc<PyExecutionContext> {
     execution_context
 }
 
+/// app_main.py:875-882 — unless `-S` (`no_site`) was given, `import site`
+/// once `__main__` is registered so the standard `site` initialization runs
+/// before user code (sys.path finalization, the `quit`/`exit`/`help`
+/// builtins). The import failing is non-fatal (the bare `except`): print
+/// "'import site' failed" to stderr and continue.
+pub(crate) fn import_site(
+    no_site: bool,
+    w_main_globals: pyre_object::PyObjectRef,
+    ec_ptr: *const pyre_interpreter::PyExecutionContext,
+) {
+    if no_site {
+        return;
+    }
+    if importing::importhook("site", w_main_globals, pyre_object::PY_NULL, 0, ec_ptr).is_err() {
+        eprintln!("'import site' failed");
+    }
+}
 /// Run a library module as `__main__` via `runpy._run_module_as_main`,
 /// the `-m` entry point. `vm.run_module` analog.
-fn run_module(module: &str) {
+fn run_module(module: &str, no_site: bool) {
     let execution_context = setup_exec_context();
     let ec_ptr = Rc::as_ptr(&execution_context);
 
@@ -287,6 +309,7 @@ fn run_module(module: &str) {
     importing::set_sys_module("__main__", main_module);
 
     let result = (|| -> Result<(), pyre_interpreter::PyError> {
+        import_site(no_site, canonical, ec_ptr);
         let runpy = importing::importhook("runpy", canonical, pyre_object::PY_NULL, 0, ec_ptr)?;
         let func = pyre_interpreter::getattr(runpy, pyre_object::w_str_new("_run_module_as_main"))?;
         let res = pyre_interpreter::call_function(func, &[pyre_object::w_str_new(module)]);
@@ -315,7 +338,7 @@ fn run_module(module: &str) {
     maybe_print_jit_stats();
 }
 
-fn run_source(source: &str, mode: Mode, filename: &str) {
+fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
     let code = match compile_source_with_filename(source, mode, filename) {
         Ok(code) => code,
         Err(e) => {
@@ -325,6 +348,7 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
     };
 
     let execution_context = setup_exec_context();
+    let ec_ptr = Rc::as_ptr(&execution_context);
     let mut frame = match PyFrame::new_with_context(code, execution_context) {
         Ok(frame) => frame,
         Err(e) => {
@@ -367,6 +391,8 @@ fn run_source(source: &str, mode: Mode, filename: &str) {
             pyre_object::w_none(),
         );
     }
+
+    import_site(no_site, canonical, ec_ptr);
 
     match eval_with_jit(&mut frame) {
         Ok(result) => {

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -318,7 +318,11 @@ fn compile_repl_input(
                 CompileError::Parse(parse_err) => match &parse_err.error {
                     ParseErrorType::Lexical(LexicalErrorType::IndentationError) => continuing_block,
                     ParseErrorType::OtherError(msg) => {
-                        !msg.starts_with("Expected an indented block")
+                        // The compiler reports the missing suite as the CPython
+                        // form "expected an indented block after <clause> on
+                        // line N"; an incomplete block at the REPL continues
+                        // rather than erroring.
+                        !msg.to_ascii_lowercase().starts_with("expected an indented block")
                     }
                     _ => true,
                 },

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -38,7 +38,7 @@ struct ReplRuntime {
     sys_module: pyre_object::PyObjectRef,
 }
 
-pub fn run_repl(quiet: bool) {
+pub fn run_repl(quiet: bool, no_site: bool) {
     let mut repl = Readline::new();
     let history_path = repl_history_path();
 
@@ -92,6 +92,8 @@ pub fn run_repl(quiet: bool) {
         }
     };
     configure_sys_for_repl(sys_module);
+
+    crate::import_site(no_site, canonical, Rc::as_ptr(&execution_context));
 
     let runtime = ReplRuntime {
         ctx_ptr: Rc::into_raw(Rc::clone(&execution_context)),

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -324,7 +324,8 @@ fn compile_repl_input(
                         // form "expected an indented block after <clause> on
                         // line N"; an incomplete block at the REPL continues
                         // rather than erroring.
-                        !msg.to_ascii_lowercase().starts_with("expected an indented block")
+                        !msg.to_ascii_lowercase()
+                            .starts_with("expected an indented block")
                     }
                     _ => true,
                 },


### PR DESCRIPTION
Advances the CPython regression-suite infrastructure (#188): enables the `-m`
entry the runner relies on, clears the interpreter gaps that blocked importing
the suite, refreshes the gate baseline against the current interpreter, and
adjusts the CI gate budget. Rebased onto current `main`.

## Interpreter / compiler

- **Pin the rustpython compiler crates** to the bytecode-parity revision
  (#8138); fixes PEP 614 class decorators.
- **`-m module` mode**: wire CPython's importlib bootstrap for the `-m` path
  (`_bootstrap._install` + `_bootstrap_external` link, seed
  `_thread`/`_warnings`/`_weakref` into `sys.modules`, mirror native `SYS_PATH`
  into Python `sys.path` for `PathFinder`, `_imp.find_frozen`,
  `sys.pycache_prefix`, `_io.open_code`). Adds PEP 634 match opcodes
  (`MATCH_MAPPING`/`MATCH_SEQUENCE`/`MATCH_KEYS`/`MATCH_CLASS` + `MATCH_SELF`)
  and a PEP 649 `fast2locals` fix (don't erase the empty
  `__conditional_annotations__` cell binding at module/class scope).
- **Stdlib and JIT compatibility fixes** (incl. `int.__repr__`/`__str__` so the
  pure-Python `json` encoder formats ints).
- **list-append fold: decline after a may-force residual call** — a JIT loop
  doing `out.append(<may-force call>())` (e.g. `lst.pop()`, `len(buf)`,
  `popitem()` into a local) underflowed the value stack at the fold's
  spare-capacity guard resume. The encode side is correct; the blackhole decode
  rebuilds the operand stack empty for a forced-call result. A scoped per-walk
  decline (`FBW_MAYFORCE_RECORDED`) falls back to the generic residual append,
  whose `GUARD_NOT_FORCED` resume is correct. The deep decode fix is tracked as
  a follow-up.

## Test infrastructure (#188)

- **Refresh `pyre/cpython_tests/baseline.json`** against the current
  darwin-aarch64 interpreter, from two confirming full runs (PASS set identical
  across both, no flakiness; `KNOWN_SKIPS` stay `SKIP`):

  | status | before | after |
  |---|---|---|
  | PASS | 22 | 38 |
  | IMPORTERROR | 271 | 30 |
  | FAIL | 80 | 191 |
  | CRASH | 36 | 88 |
  | TIMEOUT | 5 | 22 |
  | SKIP | 20 | 65 |

  Import-gateway/stdlib fixes moved 241 modules out of fast-failing
  `IMPORTERROR` into real test execution; the new `SKIP`s are module-load
  `SkipTest`s for absent C test extensions (`_testlimitedcapi`,
  `_testinternalcapi`, `_testmultiphase`) and platform-only modules. No
  previously-PASS module regressed.
- **Raise the CI gate budget**: the gate now runs every non-SKIP module (since
  most no longer fast-fail), so `timeout-minutes` 30→45 and `--jobs` 4→6. The
  per-module `--timeout` stays 120s (an infinite-loop guard, not a perf
  measurement).

## Verification

Verified locally on the immediately-prior rebase base; the branch has since
been rebased onto the current `main`, where CI re-runs the gate and `check.py`
on the pushed commit:

- `pyre/check.py` **dynasm 139/139** + **cranelift 139/139**.
- Full CPython suite: **0 PASS regression** vs the refreshed baseline.
- `out.append(lst.pop())` ×5000 JIT loop returns `[5, 4, 3, 2, 1]` (was a
  value-stack underflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime support for structural pattern matching, awaitables, and PEP 750 template-string objects (including an importable `_template` runtime module).
  * Enhanced import behavior for namespace packages.
  * Added `-S` / `no_site` to skip site initialization for REPL, `-m`, and script execution.
* **Bug Fixes**
  * Improved error reporting for missing modules/names.
  * Fixed `_io.open_code` to perform real binary reads.
  * Corrected pattern-matching and locals synchronization edge cases.
* **Tests**
  * Added regression snippets and updated JIT/CPython baseline expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->