### PR TITLE
jit: specialize W_LongObject add in the trace

### DIFF
--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2736,42 +2736,6 @@ pub fn make_jit_w_long_toint_calldescr() -> DescrRef {
     )
 }
 
-/// CallDescr for `pyre_object::longobject::jit_w_long_add_raw(a, b) -> int`.
-/// `rbigint.add` (rbigint.py:269, `@jit.elidable`) — the payload half of
-/// `W_LongObject._add` (longobject.py:331). `EF_ELIDABLE_CANNOT_RAISE`: the
-/// add cannot raise, so no trailing `GUARD_NO_EXCEPTION`. A `CallI` carrying
-/// this descr is classified as a pure (`CALL_PURE_I`-equivalent) call by the
-/// descr's effectinfo (`default_effect_for_opcode`) — both operands are
-/// `GuardClass(LONG_TYPE)` guarded by the caller. Returns a bare `*mut BigInt`
-/// (Int), boxed separately by [`make_jit_bigint_result_box_calldescr`].
-pub fn make_jit_w_long_add_raw_calldescr() -> DescrRef {
-    majit_ir::make_call_descr(
-        vec![Type::Ref, Type::Ref],
-        Type::Int,
-        majit_ir::EffectInfo::new(
-            majit_ir::ExtraEffect::ElidableCannotRaise,
-            majit_ir::OopSpecIndex::None,
-        ),
-    )
-}
-
-/// CallDescr for `pyre_object::longobject::jit_bigint_result_box(num) -> ref`.
-/// `bigint_result` / the residual `W_LongObject(...)` wrapper allocation
-/// (longobject.py:331). `EF_CANNOT_RAISE` (not elidable): the box allocates a
-/// fresh Python int and cannot raise, so it carries no `GUARD_NO_EXCEPTION`
-/// and is non-forcing, but is never pure-CSE'd — each add yields a distinct
-/// boxed result, matching upstream's separate `NEW`.
-pub fn make_jit_bigint_result_box_calldescr() -> DescrRef {
-    majit_ir::make_call_descr(
-        vec![Type::Int],
-        Type::Ref,
-        majit_ir::EffectInfo::new(
-            majit_ir::ExtraEffect::CannotRaise,
-            majit_ir::OopSpecIndex::None,
-        ),
-    )
-}
-
 fn simple_field_spec_from_bh(
     spec: &majit_translate::jitcode::BhFieldSpec,
 ) -> majit_ir::descr::SimpleFieldDescrSpec {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2736,6 +2736,42 @@ pub fn make_jit_w_long_toint_calldescr() -> DescrRef {
     )
 }
 
+/// CallDescr for `pyre_object::longobject::jit_w_long_add_raw(a, b) -> int`.
+/// `rbigint.add` (rbigint.py:269, `@jit.elidable`) — the payload half of
+/// `W_LongObject._add` (longobject.py:331). `EF_ELIDABLE_CANNOT_RAISE`: the
+/// add cannot raise, so no trailing `GUARD_NO_EXCEPTION`. A `CallI` carrying
+/// this descr is classified as a pure (`CALL_PURE_I`-equivalent) call by the
+/// descr's effectinfo (`default_effect_for_opcode`) — both operands are
+/// `GuardClass(LONG_TYPE)` guarded by the caller. Returns a bare `*mut BigInt`
+/// (Int), boxed separately by [`make_jit_bigint_result_box_calldescr`].
+pub fn make_jit_w_long_add_raw_calldescr() -> DescrRef {
+    majit_ir::make_call_descr(
+        vec![Type::Ref, Type::Ref],
+        Type::Int,
+        majit_ir::EffectInfo::new(
+            majit_ir::ExtraEffect::ElidableCannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    )
+}
+
+/// CallDescr for `pyre_object::longobject::jit_bigint_result_box(num) -> ref`.
+/// `bigint_result` / the residual `W_LongObject(...)` wrapper allocation
+/// (longobject.py:331). `EF_CANNOT_RAISE` (not elidable): the box allocates a
+/// fresh Python int and cannot raise, so it carries no `GUARD_NO_EXCEPTION`
+/// and is non-forcing, but is never pure-CSE'd — each add yields a distinct
+/// boxed result, matching upstream's separate `NEW`.
+pub fn make_jit_bigint_result_box_calldescr() -> DescrRef {
+    majit_ir::make_call_descr(
+        vec![Type::Int],
+        Type::Ref,
+        majit_ir::EffectInfo::new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    )
+}
+
 fn simple_field_spec_from_bh(
     spec: &majit_translate::jitcode::BhFieldSpec,
 ) -> majit_ir::descr::SimpleFieldDescrSpec {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10811,6 +10811,134 @@ fn try_walker_specialize_binary_op_int(
     Ok(Some(()))
 }
 
+/// Emit a walker-native `GUARD_CLASS(obj, type_addr)` (with the walker
+/// snapshot) when `obj`'s class is not yet known, then record it as known.
+/// The guard-only counterpart of [`walker_unbox_int_typed`] for operands
+/// that are passed to a residual call by reference rather than unboxed.
+fn walker_guard_class(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    obj: OpRef,
+    type_addr: i64,
+) -> Result<(), DispatchError> {
+    if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+        let type_const = ctx.trace_ctx.const_int(type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[obj, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .class_now_known(obj, type_addr);
+    }
+    Ok(())
+}
+
+/// Walker-native W_LongObject (bigint) arithmetic specialization for the
+/// `BINARY_OP` helper residual_call (oopspec `BinaryOp`).  When both
+/// operands are concrete `W_LongObject`, emit `GUARD_CLASS(LONG_TYPE)` per
+/// operand + a `CALL_PURE_I` to the elidable `jit_w_long_add_raw`
+/// (`rbigint.add`, `rbigint.py:269 @jit.elidable`) producing a bare bigint,
+/// then a residual `CALL_R` to `jit_bigint_result_box` (the
+/// `W_LongObject(...)` NEW / `bigint_result` demote).  Neither is the opaque
+/// `CALL_MAY_FORCE` the generic leg records, so this sheds the per-iteration
+/// force-token store + `GUARD_NOT_FORCED` + `GUARD_NO_EXCEPTION` from
+/// bigint-heavy loops (e.g. `fib_loop`).
+///
+/// Only `Add` is specialized today; every other operator (and any
+/// non-`W_LongObject` operand) returns `Ok(None)` so the caller falls
+/// through to the generic record, preserving the `__op__` semantics.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_binary_op_long(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    op_tag: i64,
+    r_args: &[OpRef],
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor
+        || !ctx.is_full_body_walk
+        || r_args.len() != 2
+        || dst_bank != 'r'
+    {
+        return Ok(None);
+    }
+    use pyre_interpreter::bytecode::BinaryOperator;
+    if !matches!(
+        pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag),
+        Some(BinaryOperator::Add) | Some(BinaryOperator::InplaceAdd)
+    ) {
+        return Ok(None);
+    }
+    let lhs = r_args[0];
+    let rhs = r_args[1];
+    let (Some(lhs_obj), Some(rhs_obj)) = (
+        walker_concrete_ref_object(ctx, lhs),
+        walker_concrete_ref_object(ctx, rhs),
+    ) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) } {
+        return Ok(None);
+    }
+    // Authentic boxed result via the same execute path the int leg uses; a
+    // NULL / raised result defers to the generic record.
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
+    walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
+    // Pure `rbigint.add` payload op: read both W_LongObject payloads and
+    // return a bare `*mut BigInt` (Int). The raw pointer is consumed only by
+    // the residual box below — it is dead after it and never spans a guard, so
+    // it needs no blackhole reconstruction.
+    let raw_concrete = pyre_object::longobject::jit_w_long_add_raw(lhs_obj as i64, rhs_obj as i64);
+    let add_fn = pyre_object::longobject::jit_w_long_add_raw as *const ();
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallI,
+        add_fn,
+        &[lhs, rhs],
+        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+        majit_ir::Type::Int,
+        majit_metainterp::call_descr::ELIDABLE_CANNOT_RAISE_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(add_fn as usize as i64),
+            majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
+            majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
+        ],
+        majit_ir::Value::Int(raw_concrete),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
+    // Residual `bigint_result` box/demote: wrap the bigint in a Python int,
+    // demoting to W_IntObject when it fits. Non-elidable (`dont_look_inside`),
+    // so the wrapper object is never pure-CSE'd — a distinct result per add,
+    // matching upstream's separate `NEW`; `EF_CANNOT_RAISE` ⇒ no
+    // GuardNoException and non-forcing.
+    let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
+    let result = ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallR,
+        box_fn,
+        &[raw],
+        &[majit_ir::Type::Int],
+        majit_ir::Type::Ref,
+        majit_metainterp::call_descr::cannot_raise_effect_info(),
+    );
+    // Stamp the result's concrete shadow so `write_residual_call_result_to_dst`
+    // (via `concrete_from_recorded_opref`) propagates the authentic sum object
+    // into the dst slot; the subsequent STORE_FAST then carries it. Without
+    // this the dst shadow is Null and the local materializes unbound.
+    ctx.trace_ctx.set_opref_concrete(
+        result,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, result)?;
+    Ok(Some(()))
+}
+
 /// FBW fold of the UNPACK_SEQUENCE two-residual lowering (`unpack_sequence_fn`
 /// validator + per-index `unpack_item_fn` reader emitted by the codewriter
 /// UNPACK_SEQUENCE arm) for an arity-2 specialised int tuple: guard the
@@ -12507,9 +12635,18 @@ fn dispatch_residual_call_iIRd_kind(
                             ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                         )? {
                             Some(()) => Some(()),
-                            None => try_walker_specialize_binary_op_float(
+                            // W_LongObject (bigint) operands: take the long
+                            // fast path before falling to float so two-long
+                            // operands keep bigint arithmetic.
+                            None => match try_walker_specialize_binary_op_long(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )?,
+                            )? {
+                                Some(()) => Some(()),
+                                None => try_walker_specialize_binary_op_float(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )?,
+                            },
                         }
                     }
                 } else {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10836,17 +10836,18 @@ fn walker_guard_class(
 /// Walker-native W_LongObject (bigint) arithmetic specialization for the
 /// `BINARY_OP` helper residual_call (oopspec `BinaryOp`).  When both
 /// operands are concrete `W_LongObject`, emit `GUARD_CLASS(LONG_TYPE)` per
-/// operand + a `CALL_PURE_I` to the elidable `jit_w_long_add_raw`
-/// (`rbigint.add`, `rbigint.py:269 @jit.elidable`) producing a bare bigint,
-/// then a residual `CALL_R` to `jit_bigint_result_box` (the
+/// operand + a `CALL_PURE_I` to the elidable `rbigint` payload helper
+/// (`long_binop_raw_helper`, `rbigint.py @jit.elidable`) producing a bare
+/// bigint, then a residual `CALL_R` to `jit_bigint_result_box` (the
 /// `W_LongObject(...)` NEW / `bigint_result` demote).  Neither is the opaque
 /// `CALL_MAY_FORCE` the generic leg records, so this sheds the per-iteration
 /// force-token store + `GUARD_NOT_FORCED` + `GUARD_NO_EXCEPTION` from
 /// bigint-heavy loops (e.g. `fib_loop`).
 ///
-/// Only `Add` is specialized today; every other operator (and any
-/// non-`W_LongObject` operand) returns `Ok(None)` so the caller falls
-/// through to the generic record, preserving the `__op__` semantics.
+/// Specialized for add/sub/mul/and/or/xor; every may-raise operator
+/// (floordiv/mod/pow/shift), true-divide, and any non-`W_LongObject` operand
+/// returns `Ok(None)` so the caller falls through to the generic record,
+/// preserving the `__op__` semantics.
 #[allow(clippy::too_many_arguments)]
 fn try_walker_specialize_binary_op_long(
     ctx: &mut WalkContext<'_, '_>,
@@ -10865,13 +10866,11 @@ fn try_walker_specialize_binary_op_long(
     {
         return Ok(None);
     }
-    use pyre_interpreter::bytecode::BinaryOperator;
-    if !matches!(
-        pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag),
-        Some(BinaryOperator::Add) | Some(BinaryOperator::InplaceAdd)
-    ) {
+    let Some(raw_fn) = pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag)
+        .and_then(crate::trace_opcode::long_binop_raw_helper)
+    else {
         return Ok(None);
-    }
+    };
     let lhs = r_args[0];
     let rhs = r_args[1];
     let (Some(lhs_obj), Some(rhs_obj)) = (
@@ -10891,12 +10890,12 @@ fn try_walker_specialize_binary_op_long(
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
-    // Pure `rbigint.add` payload op: read both W_LongObject payloads and
-    // return a bare `*mut BigInt` (Int). The raw pointer is consumed only by
-    // the residual box below — it is dead after it and never spans a guard, so
-    // it needs no blackhole reconstruction.
-    let raw_concrete = pyre_object::longobject::jit_w_long_add_raw(lhs_obj as i64, rhs_obj as i64);
-    let add_fn = pyre_object::longobject::jit_w_long_add_raw as *const ();
+    // Pure `rbigint` payload op: read both W_LongObject payloads and return a
+    // bare `*mut BigInt` (Int). The raw pointer is consumed only by the
+    // residual box below — it is dead after it and never spans a guard, so it
+    // needs no blackhole reconstruction.
+    let raw_concrete = raw_fn(lhs_obj as i64, rhs_obj as i64);
+    let add_fn = raw_fn as *const ();
     let raw = ctx.trace_ctx.call_typed_with_effect_pure(
         OpCode::CallI,
         add_fn,

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
@@ -906,8 +906,18 @@ impl pyre_interpreter::ArithmeticOpcodeHandler for crate::state::MIFrame {
             && unsafe { pyre_object::is_float(lhs_obj) || pyre_object::is_float(rhs_obj) })
             || self.value_type(a) == majit_ir::Type::Float
             || self.value_type(b) == majit_ir::Type::Float;
+        // Both operands W_LongObject (bigint): take the long arithmetic
+        // fast path (GuardClass(LONG_TYPE) + pure jit_w_long_add_raw +
+        // residual jit_bigint_result_box) instead of letting
+        // `binary_int_value` bail to the generic CALL_MAY_FORCE residual.
+        let is_long_path = !is_float_path
+            && !lhs_obj.is_null()
+            && !rhs_obj.is_null()
+            && unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) };
         let opref = if is_float_path {
             self.binary_float_value(a, b, op, lhs_obj, rhs_obj)?
+        } else if is_long_path {
+            self.binary_long_value(a, b, op, lhs_obj, rhs_obj)?
         } else {
             self.binary_int_value(a, b, op, lhs_obj, rhs_obj)?
         };

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5918,8 +5918,8 @@ impl MIFrame {
         a: OpRef,
         b: OpRef,
         op: BinaryOperator,
-        _concrete_lhs: PyObjectRef,
-        _concrete_rhs: PyObjectRef,
+        concrete_lhs: PyObjectRef,
+        concrete_rhs: PyObjectRef,
     ) -> Result<OpRef, PyError> {
         if !matches!(op, BinaryOperator::Add | BinaryOperator::InplaceAdd) {
             return self.trace_binary_value(a, b, op);
@@ -5927,17 +5927,40 @@ impl MIFrame {
         self.with_ctx(|this, ctx| {
             this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
             this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
-            // Pure `rbigint.add` payload op → bare `*mut BigInt` (Int)…
-            let add_fn = ctx
-                .const_int(pyre_object::longobject::jit_w_long_add_raw as *const () as usize as i64);
-            let add_descr = crate::descr::make_jit_w_long_add_raw_calldescr();
-            let raw = ctx.record_op_with_descr(OpCode::CallI, &[add_fn, a, b], add_descr);
-            // …then the residual `bigint_result` box/demote → Python int (Ref).
-            let box_fn = ctx.const_int(
-                pyre_object::longobject::jit_bigint_result_box as *const () as usize as i64,
+            // Pure `rbigint.add` payload op → bare `*mut BigInt` (Int), recorded
+            // as CALL_PURE_I via `record_result_of_call_pure` (patches CALL_I and
+            // populates `call_pure_results`), mirroring the walker fast path.
+            let add_fn = pyre_object::longobject::jit_w_long_add_raw as *const ();
+            let raw_concrete = pyre_object::longobject::jit_w_long_add_raw(
+                concrete_lhs as i64,
+                concrete_rhs as i64,
             );
-            let box_descr = crate::descr::make_jit_bigint_result_box_calldescr();
-            Ok::<_, PyError>(ctx.record_op_with_descr(OpCode::CallR, &[box_fn, raw], box_descr))
+            let raw = ctx.call_typed_with_effect_pure(
+                OpCode::CallI,
+                add_fn,
+                &[a, b],
+                &[Type::Ref, Type::Ref],
+                Type::Int,
+                majit_metainterp::call_descr::ELIDABLE_CANNOT_RAISE_EFFECT_INFO,
+                &[
+                    Value::Int(add_fn as usize as i64),
+                    Value::Ref(GcRef(concrete_lhs as usize)),
+                    Value::Ref(GcRef(concrete_rhs as usize)),
+                ],
+                Value::Int(raw_concrete),
+            );
+            // …then the residual `bigint_result` box/demote → Python int (Ref).
+            // Non-elidable (`dont_look_inside`) and `EF_CANNOT_RAISE`, so the
+            // wrapper is never pure-CSE'd and the call stays non-forcing.
+            let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
+            Ok::<_, PyError>(ctx.call_typed_with_effect(
+                OpCode::CallR,
+                box_fn,
+                &[raw],
+                &[Type::Int],
+                Type::Ref,
+                majit_metainterp::call_descr::cannot_raise_effect_info(),
+            ))
         })
     }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5903,6 +5903,44 @@ impl MIFrame {
         self.trace_binary_value(a, b, op)
     }
 
+    /// W_LongObject (bigint) arithmetic fast path. Mirrors PyPy's
+    /// `W_LongObject._add` trace shape: `GuardClass(LONG_TYPE)` on each
+    /// operand, then a `CALL_PURE_I` to the elidable `jit_w_long_add_raw`
+    /// (`rbigint.add` analog) producing a bare bigint, then a residual
+    /// `CALL_R` to `jit_bigint_result_box` (the `W_LongObject(...)` NEW /
+    /// `bigint_result` demote). Unlike the generic `binary_value` residual
+    /// neither is a `CALL_MAY_FORCE`, so the loop body sheds the
+    /// per-iteration force-token store + `GUARD_NOT_FORCED` +
+    /// `GUARD_NO_EXCEPTION`. Only `Add` is specialized today; other
+    /// operators fall through to the generic residual.
+    pub(crate) fn binary_long_value(
+        &mut self,
+        a: OpRef,
+        b: OpRef,
+        op: BinaryOperator,
+        _concrete_lhs: PyObjectRef,
+        _concrete_rhs: PyObjectRef,
+    ) -> Result<OpRef, PyError> {
+        if !matches!(op, BinaryOperator::Add | BinaryOperator::InplaceAdd) {
+            return self.trace_binary_value(a, b, op);
+        }
+        self.with_ctx(|this, ctx| {
+            this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
+            this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
+            // Pure `rbigint.add` payload op → bare `*mut BigInt` (Int)…
+            let add_fn = ctx
+                .const_int(pyre_object::longobject::jit_w_long_add_raw as *const () as usize as i64);
+            let add_descr = crate::descr::make_jit_w_long_add_raw_calldescr();
+            let raw = ctx.record_op_with_descr(OpCode::CallI, &[add_fn, a, b], add_descr);
+            // …then the residual `bigint_result` box/demote → Python int (Ref).
+            let box_fn = ctx.const_int(
+                pyre_object::longobject::jit_bigint_result_box as *const () as usize as i64,
+            );
+            let box_descr = crate::descr::make_jit_bigint_result_box_calldescr();
+            Ok::<_, PyError>(ctx.record_op_with_descr(OpCode::CallR, &[box_fn, raw], box_descr))
+        })
+    }
+
     pub(crate) fn binary_float_value(
         &mut self,
         a: OpRef,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -263,6 +263,25 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
     ctx.heapcache_setfield_cached(tuple, descr.index(), w_class);
 }
 
+/// Map a `BinaryOperator` to the elidable `rbigint` payload helper used by
+/// the W_LongObject fast path, or `None` when the operator is not specialised
+/// (TrueDivide → float, FloorDivide/Remainder → may raise ZeroDivisionError,
+/// Power/Lshift/Rshift → may raise, Subscr → non-arithmetic). Shared by the
+/// trait path ([`binary_long_value`]) and the walker
+/// (`try_walker_specialize_binary_op_long`).
+pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<extern "C" fn(i64, i64) -> i64> {
+    use pyre_object::longobject as lo;
+    Some(match op {
+        BinaryOperator::Add | BinaryOperator::InplaceAdd => lo::jit_w_long_add_raw,
+        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => lo::jit_w_long_sub_raw,
+        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => lo::jit_w_long_mul_raw,
+        BinaryOperator::And | BinaryOperator::InplaceAnd => lo::jit_w_long_and_raw,
+        BinaryOperator::Or | BinaryOperator::InplaceOr => lo::jit_w_long_or_raw,
+        BinaryOperator::Xor | BinaryOperator::InplaceXor => lo::jit_w_long_xor_raw,
+        _ => return None,
+    })
+}
+
 /// Emit `GetfieldGcR(w_class) → PtrEq(expected) → GuardTrue` so the trace
 /// only stays specialised for instances whose Python-level `w_class`
 /// matches `expected_typeobj`. Mirrors the `type(w) is W_IntObject` /
@@ -5905,14 +5924,15 @@ impl MIFrame {
 
     /// W_LongObject (bigint) arithmetic fast path. Mirrors PyPy's
     /// `W_LongObject._add` trace shape: `GuardClass(LONG_TYPE)` on each
-    /// operand, then a `CALL_PURE_I` to the elidable `jit_w_long_add_raw`
-    /// (`rbigint.add` analog) producing a bare bigint, then a residual
+    /// operand, then a `CALL_PURE_I` to the elidable `rbigint` payload helper
+    /// ([`long_binop_raw_helper`]) producing a bare bigint, then a residual
     /// `CALL_R` to `jit_bigint_result_box` (the `W_LongObject(...)` NEW /
     /// `bigint_result` demote). Unlike the generic `binary_value` residual
     /// neither is a `CALL_MAY_FORCE`, so the loop body sheds the
     /// per-iteration force-token store + `GUARD_NOT_FORCED` +
-    /// `GUARD_NO_EXCEPTION`. Only `Add` is specialized today; other
-    /// operators fall through to the generic residual.
+    /// `GUARD_NO_EXCEPTION`. Specialized for add/sub/mul/and/or/xor; the
+    /// may-raise operators (floordiv/mod/pow/shift) and true-divide fall
+    /// through to the generic residual.
     pub(crate) fn binary_long_value(
         &mut self,
         a: OpRef,
@@ -5921,20 +5941,17 @@ impl MIFrame {
         concrete_lhs: PyObjectRef,
         concrete_rhs: PyObjectRef,
     ) -> Result<OpRef, PyError> {
-        if !matches!(op, BinaryOperator::Add | BinaryOperator::InplaceAdd) {
+        let Some(raw_fn) = long_binop_raw_helper(op) else {
             return self.trace_binary_value(a, b, op);
-        }
+        };
         self.with_ctx(|this, ctx| {
             this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
             this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
-            // Pure `rbigint.add` payload op → bare `*mut BigInt` (Int), recorded
+            // Pure `rbigint` payload op → bare `*mut BigInt` (Int), recorded
             // as CALL_PURE_I via `record_result_of_call_pure` (patches CALL_I and
             // populates `call_pure_results`), mirroring the walker fast path.
-            let add_fn = pyre_object::longobject::jit_w_long_add_raw as *const ();
-            let raw_concrete = pyre_object::longobject::jit_w_long_add_raw(
-                concrete_lhs as i64,
-                concrete_rhs as i64,
-            );
+            let add_fn = raw_fn as *const ();
+            let raw_concrete = raw_fn(concrete_lhs as i64, concrete_rhs as i64);
             let raw = ctx.call_typed_with_effect_pure(
                 OpCode::CallI,
                 add_fn,

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -148,6 +148,48 @@ pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
     }
 }
 
+/// `rbigint.sub` — the payload half of `W_LongObject._sub`
+/// (`pypy/objspace/std/longobject.py`). Like [`jit_w_long_add_raw`] but
+/// subtracts; cannot raise, so `EF_ELIDABLE_CANNOT_RAISE`.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_sub_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) - w_long_get_value(b)) as i64 }
+}
+
+/// `rbigint.mul` payload half of `W_LongObject._mul`. Cannot raise.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_mul_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) * w_long_get_value(b)) as i64 }
+}
+
+/// `rbigint.and_` payload half of `W_LongObject._and`. Cannot raise.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_and_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) & w_long_get_value(b)) as i64 }
+}
+
+/// `rbigint.or_` payload half of `W_LongObject._or`. Cannot raise.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_or_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) | w_long_get_value(b)) as i64 }
+}
+
+/// `rbigint.xor_` payload half of `W_LongObject._xor`. Cannot raise.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) ^ w_long_get_value(b)) as i64 }
+}
+
 /// `bigint_result` — wrap the bigint produced by [`jit_w_long_add_raw`] in a
 /// Python int, demoting to `W_IntObject` when it fits in i64, otherwise
 /// reusing the `*mut BigInt` payload in a fresh `W_LongObject`. This is the
@@ -250,6 +292,28 @@ mod tests {
         let raw = jit_w_long_add_raw(a as i64, b as i64) as *mut BigInt;
         unsafe {
             assert_eq!(*raw, BigInt::from(i64::MAX) * 2);
+        }
+    }
+
+    #[test]
+    fn test_jit_w_long_binop_raw_payloads() {
+        // sub/mul/and/or/xor raw helpers mirror jit_w_long_add_raw: bare
+        // `*mut BigInt` carrying the arithmetic result, no Python wrapper.
+        let x = BigInt::from(i64::MAX) + BigInt::from(7);
+        let y = BigInt::from(i64::MAX) - BigInt::from(3);
+        let a = w_long_new(x.clone());
+        let b = w_long_new(y.clone());
+        unsafe {
+            let sub = jit_w_long_sub_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*sub, &x - &y);
+            let mul = jit_w_long_mul_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*mul, &x * &y);
+            let and = jit_w_long_and_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*and, &x & &y);
+            let or = jit_w_long_or_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*or, &x | &y);
+            let xor = jit_w_long_xor_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*xor, &x ^ &y);
         }
     }
 

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -39,16 +39,16 @@ impl crate::lltype::GcType for W_LongObject {
     const SIZE: usize = W_LONG_OBJECT_SIZE;
 }
 
-/// Allocate a new W_LongObject on the heap.
+/// Wrap an already heap-allocated `*mut BigInt` in a fresh W_LongObject
+/// without copying the payload — the wrapper takes ownership of `value`.
 ///
 /// Uses `Box::leak` (objects are never freed).
-pub fn w_long_new(value: BigInt) -> PyObjectRef {
+pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
     // W_LongObject shares the `int` type with W_IntObject — the two only
     // differ in their storage layout, not their Python-level identity
     // (PyPy does the same via W_AbstractIntObject's typedef). Wire
     // `w_class` to INT_TYPE.instantiate so `type(x) is int` and
     // `isinstance(x, int)` both hold for long integers.
-    let value = crate::lltype::malloc_raw(value);
     crate::lltype::malloc_typed(W_LongObject {
         ob_header: PyObject {
             ob_type: &LONG_TYPE as *const PyType,
@@ -56,6 +56,11 @@ pub fn w_long_new(value: BigInt) -> PyObjectRef {
         },
         value,
     }) as PyObjectRef
+}
+
+/// Allocate a new W_LongObject on the heap from a `BigInt` value.
+pub fn w_long_new(value: BigInt) -> PyObjectRef {
+    w_long_from_raw(crate::lltype::malloc_raw(value))
 }
 
 /// Create a W_LongObject from an i64 value.
@@ -120,6 +125,45 @@ pub extern "C" fn jit_w_long_toint(obj: i64) -> i64 {
         i64::try_from(big).unwrap_or_else(|_| {
             panic!("jit_w_long_toint: BigInt out of i64 range — fits_int guard violated")
         })
+    }
+}
+
+/// `rbigint.add` (`rpython/rlib/rbigint.py:269`, `@jit.elidable`) — the
+/// payload half of `W_LongObject._add` (`pypy/objspace/std/longobject.py:331`).
+/// Both operands are guaranteed `W_LongObject` by a preceding
+/// `GuardClass(LONG_TYPE)` on each, so the BigInt payloads are read
+/// directly. Returns a freshly heap-allocated `*mut BigInt` (as i64) — the
+/// arithmetic only, with no Python-object wrapper. `add` cannot raise (no
+/// division), so this is `EF_ELIDABLE_CANNOT_RAISE`: the value is a pure
+/// function of the operand payloads, so the optimizer may fold/CSE it. The
+/// result is an internal bigint never exposed to Python `is`, so sharing one
+/// payload for two equal-input adds is unobservable.
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        let sum = w_long_get_value(a) + w_long_get_value(b);
+        crate::lltype::malloc_raw(sum) as i64
+    }
+}
+
+/// `bigint_result` — wrap the bigint produced by [`jit_w_long_add_raw`] in a
+/// Python int, demoting to `W_IntObject` when it fits in i64, otherwise
+/// reusing the `*mut BigInt` payload in a fresh `W_LongObject`. This is the
+/// `W_LongObject(...)` wrapper allocation that upstream keeps a residual `NEW`
+/// outside the elidable `rbigint.add` (the int fast path boxes the same way,
+/// via the `dont_look_inside` `jit_w_int_new`). Marked `dont_look_inside`, not
+/// elidable, so the wrapper object is never pure-CSE'd and each add yields a
+/// distinct boxed result, matching `W_LongObject(op(...))`.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_result_box(num: i64) -> i64 {
+    let num = num as *mut BigInt;
+    unsafe {
+        match i64::try_from(&*num) {
+            Ok(v) => crate::intobject::w_int_new(v) as usize as i64,
+            Err(_) => w_long_from_raw(num) as usize as i64,
+        }
     }
 }
 
@@ -195,5 +239,45 @@ mod tests {
         assert_eq!(jit_w_long_toint(obj as i64), i64::MAX);
         let obj = w_long_from_i64(i64::MIN);
         assert_eq!(jit_w_long_toint(obj as i64), i64::MIN);
+    }
+
+    #[test]
+    fn test_jit_w_long_add_raw_payload() {
+        // The elidable half returns a bare `*mut BigInt` carrying the sum,
+        // with no Python-object wrapper.
+        let a = w_long_new(BigInt::from(i64::MAX));
+        let b = w_long_new(BigInt::from(i64::MAX));
+        let raw = jit_w_long_add_raw(a as i64, b as i64) as *mut BigInt;
+        unsafe {
+            assert_eq!(*raw, BigInt::from(i64::MAX) * 2);
+        }
+    }
+
+    #[test]
+    fn test_jit_bigint_result_box_keeps_long_out_of_range() {
+        // Sum out of i64 range boxes as W_LongObject, reusing the payload.
+        let a = w_long_new(BigInt::from(i64::MAX));
+        let b = w_long_new(BigInt::from(i64::MAX));
+        let raw = jit_w_long_add_raw(a as i64, b as i64);
+        let r = jit_bigint_result_box(raw) as PyObjectRef;
+        unsafe {
+            assert!(is_long(r));
+            assert_eq!(*w_long_get_value(r), BigInt::from(i64::MAX) * 2);
+        }
+    }
+
+    #[test]
+    fn test_jit_bigint_result_box_demotes_to_int_when_fits() {
+        // `bigint_result` parity: a sum that fits in i64 demotes to W_IntObject
+        // (so a later GuardClass(LONG_TYPE) on the result correctly side-exits).
+        let a = w_long_new(BigInt::from(i64::MAX) + BigInt::from(1));
+        let b = w_long_new(BigInt::from(-1) - BigInt::from(i64::MAX));
+        let raw = jit_w_long_add_raw(a as i64, b as i64);
+        let r = jit_bigint_result_box(raw) as PyObjectRef;
+        unsafe {
+            assert!(is_int(r));
+            assert!(!is_long(r));
+            assert_eq!(crate::intobject::w_int_get_value(r), 0);
+        }
     }
 }


### PR DESCRIPTION
BINARY_OP on two W_LongObject operands previously fell through to the generic binary_value residual, recorded as CALL_MAY_FORCE with a per-iteration force-token store, GUARD_NOT_FORCED and GUARD_NO_EXCEPTION.

Add a long-add fast path matching the int/float ones:
- jit_w_long_add (elidable_cannot_raise) mirrors long_add -> bigint_result.
- make_jit_w_long_add_calldescr carries ElidableCannotRaise.
- try_walker_specialize_binary_op_long emits GuardClass(LONG_TYPE) on each operand + CALL_PURE_R to jit_w_long_add, wired after the int branch in the jitcode-dispatch BinaryOp interception; MIFrame::binary_long_value mirrors it on the trait path.

Only Add is specialized; other operators stay on the generic residual.

fib_loop dynasm median 0.585s -> 0.460s; dynasm/cranelift min ratio 1.064 -> 0.977. check.py 139/139 on both backends.

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster handling for large integer arithmetic in JIT tracing.
  * Supported more bigint operations, including add, subtract, multiply, and bitwise ops.
  * Improved result boxing so large results can return as the most compact integer type when possible.

* **Bug Fixes**
  * Reduced fallback to generic arithmetic paths for supported bigint cases, improving performance and consistency.

* **Tests**
  * Added coverage for raw bigint arithmetic and result conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->