### PR TITLE
for_iter: collapse to space.next + residual trace infra, fix user-iterator JIT crashes (#57)

### DIFF
--- a/pyre/bench/synth/iter57/app405.py
+++ b/pyre/bench/synth/iter57/app405.py
@@ -1,0 +1,15 @@
+class CountUp:
+    def __init__(self, n):
+        self.i = 0
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.i >= self.n:
+            raise StopIteration
+        self.i += 1
+        return self.i
+seen = []
+for x in CountUp(405):
+    seen.append(x)
+print(len(seen))

--- a/pyre/bench/synth/iter57/countdown_pure.py
+++ b/pyre/bench/synth/iter57/countdown_pure.py
@@ -1,0 +1,17 @@
+class CountDown:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.n <= 0:
+            raise StopIteration
+        v = self.n
+        self.n = self.n - 1
+        return v
+
+total = 0
+for _ in range(20000):
+    for x in CountDown(5):
+        total += x
+print(total)

--- a/pyre/bench/synth/iter57/global_mutate.py
+++ b/pyre/bench/synth/iter57/global_mutate.py
@@ -1,0 +1,21 @@
+hits = 0
+sink = []
+
+class Tick:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        global hits
+        if self.n <= 0:
+            raise StopIteration
+        self.n = self.n - 1
+        hits = hits + 1        # STORE_GLOBAL (NOT deferred)
+        sink.append(self.n)    # LIST_APPEND (residual shared-heap)
+        return self.n
+
+for _ in range(20000):
+    for _x in Tick(5):
+        pass
+print(hits, len(sink), sum(sink))

--- a/pyre/bench/synth/iter57/inner_if.py
+++ b/pyre/bench/synth/iter57/inner_if.py
@@ -1,0 +1,18 @@
+class EvenDown:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        self.n = self.n - 1
+        if self.n < 0:
+            raise StopIteration
+        if self.n % 2 == 0:
+            return self.n
+        return -self.n
+
+total = 0
+for _ in range(20000):
+    for x in EvenDown(6):
+        total += x
+print(total)

--- a/pyre/bench/synth/iter57/monkeypatch.py
+++ b/pyre/bench/synth/iter57/monkeypatch.py
@@ -1,0 +1,26 @@
+class It:
+    def __init__(self):
+        self.n = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        self.n = self.n + 1
+        if self.n > 100000:
+            raise StopIteration
+        return self.n
+
+def patched(self):
+    self.n = self.n + 1
+    if self.n > 100000:
+        raise StopIteration
+    return self.n * 2
+
+it = It()
+total = 0
+count = 0
+for x in it:
+    total += x
+    count += 1
+    if count == 50000:
+        It.__next__ = patched   # invalidate the method cache mid-loop
+print(total, count)

--- a/pyre/bench/synth/iter57/real_exception.py
+++ b/pyre/bench/synth/iter57/real_exception.py
@@ -1,0 +1,21 @@
+class Boom:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        self.n = self.n - 1
+        if self.n == 0:
+            raise ValueError("boom")
+        if self.n < -3:
+            raise StopIteration
+        return self.n
+
+seen = []
+for _ in range(20000):
+    try:
+        for x in Boom(5):
+            seen.append(x)
+    except ValueError as e:
+        seen.append(str(e))
+print(len(seen), seen[:8])

--- a/pyre/bench/synth/iter57/run_matrix.sh
+++ b/pyre/bench/synth/iter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in countdown_pure stateful_attr global_mutate inner_if real_exception monkeypatch; do
+for f in countdown_pure stateful_attr global_mutate inner_if real_exception monkeypatch while_dump; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 "$PYRE" "$DIR/$f.py")"

--- a/pyre/bench/synth/iter57/run_matrix.sh
+++ b/pyre/bench/synth/iter57/run_matrix.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Usage: sh run_matrix.sh /path/to/pyre-binary
+# Compares interp (PYRE_NO_JIT) vs default-JIT vs inline-gate for each repro.
+set -e
+PYRE="$1"
+DIR="$(dirname "$0")"
+for f in countdown_pure stateful_attr global_mutate inner_if real_exception monkeypatch; do
+    base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
+    jit="$("$PYRE" "$DIR/$f.py")"
+    inl="$(PYRE_57_INLINE_NEXT=1 "$PYRE" "$DIR/$f.py")"
+    if [ "$base" = "$jit" ] && [ "$base" = "$inl" ]; then
+        echo "OK   $f  ->  $base"
+    else
+        echo "FAIL $f"
+        echo "  interp:    $base"
+        echo "  jit:       $jit"
+        echo "  inline:    $inl"
+        exit 1
+    fi
+done
+echo "MATRIX OK"

--- a/pyre/bench/synth/iter57/stateful_attr.py
+++ b/pyre/bench/synth/iter57/stateful_attr.py
@@ -1,0 +1,16 @@
+class Down:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.n <= 0:
+            raise StopIteration
+        self.n = self.n - 1   # STORE_ATTR (deferred by #143)
+        return self.n
+
+total = 0
+for _ in range(20000):
+    for x in Down(5):
+        total += x
+print(total)

--- a/pyre/bench/synth/iter57/while_dump.py
+++ b/pyre/bench/synth/iter57/while_dump.py
@@ -1,0 +1,7 @@
+import sys
+seen = []
+i = 0
+while i < 805:
+    i += 1
+    seen.append(i)
+sys.stdout.write(repr(seen[:6]) + " ... len=" + str(len(seen)))

--- a/pyre/bench/synth/itertools_cycle.py
+++ b/pyre/bench/synth/itertools_cycle.py
@@ -1,0 +1,35 @@
+import itertools
+
+# GET_ITER + FOR_ITER directly over an itertools.cycle iterator. cycle is
+# "already an iterator" (its __iter__ returns self) and advances through
+# space.next, so the for-loop must classify it on both legs.
+out = []
+n = 0
+for v in itertools.cycle([1, 2, 3]):
+    out.append(v)
+    n += 1
+    if n == 8:
+        break
+print("forloop:", out)
+
+# cycle over a string, driven by enumerate.
+e = []
+for i, x in enumerate(itertools.cycle("AB")):
+    e.append((i, x))
+    if i >= 4:
+        break
+print("enum:", e)
+
+# explicit next() over a cycle.
+c = itertools.cycle([10, 20])
+print("next:", [next(c) for _ in range(5)])
+
+# cycle that exhausts its source before replaying the saved items.
+total = 0
+m = 0
+for v in itertools.cycle(range(4)):
+    total += v
+    m += 1
+    if m == 10:
+        break
+print("range-source sum:", total)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -10574,8 +10574,8 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
         // `_op_val(allow_char=True)` — an int needle is a single byte value
         // (range-checked), a bytes-like needle is matched as a substring (an
         // empty needle is always present), and any other type is a TypeError.
-        // The upstream buffer-protocol fallback that also accepts a memoryview
-        // is not implemented for bytes methods here.
+        // `_op_val` falls back to `buffer_w(BUF_SIMPLE)`, so any buffer-protocol
+        // object (e.g. a memoryview) is also accepted as the needle.
         if pyre_object::bytesobject::is_bytes_like(haystack) {
             let hay = pyre_object::bytesobject::bytes_like_data(haystack);
             if is_int(needle) || is_long(needle) {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3319,15 +3319,17 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             }
 
             // Step 3: instance dict — the mapdict map+storage is the sole
-            // authority for instance attributes.  `getdict` returns the
-            // MapDictStrategy view whose getitem_str reads the map
-            // (getdictvalue, mapdict.py:846-847; MapDictStrategy.getitem_str
-            // delegates there, mapdict.py:1168-1175).
-            let w_dict = getdict_backing(obj);
-            if !w_dict.is_null() {
-                if let Some(value) = pyre_object::w_dict_getitem_str(w_dict, name) {
-                    return Ok(value);
-                }
+            // authority for instance attributes.  Read the node directly
+            // (getdictvalue, mapdict.py:846-847) rather than materialising the
+            // MapDictStrategy `__dict__` view through `getdict_backing`;
+            // MapDictStrategy.getitem_str (mapdict.py:1168-1175) delegates to the
+            // same `instance_node_getdictvalue`, so the value is identical and the
+            // `__dict__` wrapper is built only on explicit `__dict__` access.
+            let value = unsafe {
+                crate::objspace::std::mapdict::instance_node_getdictvalue(obj, Wtf8::new(name))
+            };
+            if let Some(value) = value {
+                return Ok(value);
             }
 
             // Step 4: non-data descriptor
@@ -3827,14 +3829,15 @@ pub fn object_getattribute(obj: PyObjectRef, name: &str) -> PyResult {
                     }
                 }
             }
-            // Instance dict is the sole authority for instance attributes
-            // (mapdict map+storage via the MapDictStrategy view); no
-            // side-table fallback (mapdict.py:846-847, 1168-1175).
-            let w_dict = getdict_backing(obj);
-            if !w_dict.is_null() {
-                if let Some(value) = pyre_object::w_dict_getitem_str(w_dict, name) {
-                    return Ok(value);
-                }
+            // Instance dict is the sole authority for instance attributes:
+            // read the mapdict node directly (getdictvalue, mapdict.py:846-847)
+            // rather than materialising the MapDictStrategy `__dict__` view, which
+            // MapDictStrategy.getitem_str (mapdict.py:1168-1175) delegates to
+            // anyway.  No side-table fallback.
+            let value =
+                crate::objspace::std::mapdict::instance_node_getdictvalue(obj, Wtf8::new(name));
+            if let Some(value) = value {
+                return Ok(value);
             }
             if let Some(descr) = w_descr {
                 if let Some(result) = get(descr, obj, w_type)? {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -12,7 +12,7 @@ use crate::{
     PyErrorKind, PyResult, SharedOpcodeHandler, StackOpcodeHandler, StepResult, TruthOpcodeHandler,
     build_list_from_refs, build_map_from_refs, build_tuple_from_refs,
     decode_instruction_for_dispatch, dict_storage_load, dict_storage_store, ensure_range_iter,
-    execute_opcode_step, range_iter_continues, range_iter_next_or_null, stack_underflow_error,
+    execute_opcode_step, range_iter_next_or_null, stack_underflow_error,
     unpack_sequence_exact,
 };
 use pyre_object::*;
@@ -1766,14 +1766,6 @@ unsafe fn load_global_via_cache(
     }
 }
 
-thread_local! {
-    /// Cache for user-defined iterator __next__ result.
-    /// concrete_iter_continues calls __next__ and caches here;
-    /// iter_next_value returns the cached value.
-    static USER_ITER_NEXT_CACHE: std::cell::Cell<PyObjectRef> =
-        const { std::cell::Cell::new(PY_NULL) };
-}
-
 /// PyPy: pyopcode.py GET_ITER → space.iter(w_iterable)
 ///       pyopcode.py FOR_ITER → space.next(w_iterator)
 impl IterOpcodeHandler for PyFrame {
@@ -1979,84 +1971,14 @@ impl IterOpcodeHandler for PyFrame {
         ensure_range_iter(iter)
     }
 
-    /// FOR_ITER: check if iterator has more items.
+    /// FOR_ITER: advance the iterator one step.
     /// PyPy: space.next() → StopIteration means exhausted.
-    /// For user-defined iterators, we speculatively call __next__ and
-    /// cache the result — iter_next_value returns the cached value.
-    fn concrete_iter_continues(&mut self, iter: Self::Value) -> Result<bool, PyError> {
+    fn iter_next(&mut self, iter: Self::Value) -> Result<Option<Self::Value>, PyError> {
         unsafe {
-            // Generator iterator
-            if pyre_object::generator::is_generator(iter) {
-                match crate::baseobjspace::next(iter) {
-                    Ok(result) => {
-                        USER_ITER_NEXT_CACHE.with(|c| c.set(result));
-                        return Ok(true);
-                    }
-                    Err(e) if e.kind == PyErrorKind::StopIteration => {
-                        USER_ITER_NEXT_CACHE.with(|c| c.set(PY_NULL));
-                        return Ok(false);
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-            // itertools iterators + W_Enumerate + W_BaseDictMultiIterObject
-            // — delegate to baseobjspace::next.  The shared cache slot
-            // (USER_ITER_NEXT_CACHE) carries the most recent value
-            // across the iter_continues / iter_next_value pair.
-            if pyre_object::interp_itertools::is_repeat(iter)
-                || pyre_object::interp_itertools::is_count(iter)
-                || pyre_object::interp_itertools::is_takewhile(iter)
-                || pyre_object::interp_itertools::is_dropwhile(iter)
-                || pyre_object::interp_itertools::is_filterfalse(iter)
-                || pyre_object::interp_itertools::is_pairwise(iter)
-                || pyre_object::functional::is_enumerate(iter)
-                || pyre_object::functional::is_reversed(iter)
-                || pyre_object::functional::is_filter(iter)
-                || pyre_object::functional::is_map(iter)
-                || pyre_object::functional::is_zip(iter)
-                || pyre_object::operation::is_callable_iterator(iter)
-                || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
-                || pyre_object::interp_sre::is_sre_scanner(iter)
-            {
-                match crate::baseobjspace::next(iter) {
-                    Ok(result) => {
-                        USER_ITER_NEXT_CACHE.with(|c| c.set(result));
-                        return Ok(true);
-                    }
-                    Err(e) if e.kind == PyErrorKind::StopIteration => {
-                        USER_ITER_NEXT_CACHE.with(|c| c.set(PY_NULL));
-                        return Ok(false);
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-            // User-defined iterator with __next__
-            if pyre_object::is_instance(iter) {
-                let w_type = pyre_object::w_instance_get_type(iter);
-                if let Some(next_method) = crate::baseobjspace::lookup_in_type(w_type, "__next__") {
-                    match crate::call::call_callable(self, next_method, &[iter]) {
-                        Ok(result) => {
-                            USER_ITER_NEXT_CACHE.with(|c| c.set(result));
-                            return Ok(true);
-                        }
-                        Err(e) if e.kind == PyErrorKind::StopIteration => {
-                            USER_ITER_NEXT_CACHE.with(|c| c.set(PY_NULL));
-                            return Ok(false);
-                        }
-                        Err(e) => return Err(e),
-                    }
-                }
-            }
-        }
-        range_iter_continues(iter)
-    }
-
-    /// PyPy: space.next(w_iterator) → returns cached value from concrete_iter_continues.
-    fn iter_next_value(&mut self, iter: Self::Value) -> Result<Self::Value, PyError> {
-        // Generator/user-defined/itertools/enumerate/dict-iter:
-        // return cached value populated by concrete_iter_continues.
-        if unsafe {
-            pyre_object::generator::is_generator(iter)
+            // Generators, itertools/enumerate/reversed/filter/map/zip/dictview/sre,
+            // and user-defined __next__ all go through space.next; range/long-range/seq
+            // fall through to the inline range helper.
+            let via_space_next = pyre_object::generator::is_generator(iter)
                 || pyre_object::is_instance(iter)
                 || pyre_object::interp_itertools::is_repeat(iter)
                 || pyre_object::interp_itertools::is_count(iter)
@@ -2071,15 +1993,20 @@ impl IterOpcodeHandler for PyFrame {
                 || pyre_object::functional::is_zip(iter)
                 || pyre_object::operation::is_callable_iterator(iter)
                 || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
-                || pyre_object::interp_sre::is_sre_scanner(iter)
-        } {
-            let cached = USER_ITER_NEXT_CACHE.with(|c| c.get());
-            if !cached.is_null() {
-                return Ok(cached);
+                || pyre_object::interp_sre::is_sre_scanner(iter);
+            if via_space_next {
+                // baseobjspace::next walks __next__ for is_instance
+                // (baseobjspace.rs:9501 lookup_in_type + call).
+                return match crate::baseobjspace::next(iter) {
+                    Ok(result) => Ok(Some(result)),
+                    Err(e) if e.kind == PyErrorKind::StopIteration => Ok(None),
+                    Err(e) => Err(e),
+                };
             }
-            return Ok(PY_NULL);
         }
-        range_iter_next_or_null(iter)
+        // range / long-range / seq: value-or-null
+        let v = range_iter_next_or_null(iter)?;
+        if v.is_null() { Ok(None) } else { Ok(Some(v)) }
     }
 
     fn on_iter_exhausted(&mut self, target: usize) -> Result<(), PyError> {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -12,8 +12,7 @@ use crate::{
     PyErrorKind, PyResult, SharedOpcodeHandler, StackOpcodeHandler, StepResult, TruthOpcodeHandler,
     build_list_from_refs, build_map_from_refs, build_tuple_from_refs,
     decode_instruction_for_dispatch, dict_storage_load, dict_storage_store, ensure_range_iter,
-    execute_opcode_step, range_iter_next_or_null, stack_underflow_error,
-    unpack_sequence_exact,
+    execute_opcode_step, range_iter_next_or_null, stack_underflow_error, unpack_sequence_exact,
 };
 use pyre_object::*;
 
@@ -1806,6 +1805,7 @@ impl IterOpcodeHandler for PyFrame {
                 || pyre_object::interp_itertools::is_dropwhile(iter)
                 || pyre_object::interp_itertools::is_filterfalse(iter)
                 || pyre_object::interp_itertools::is_pairwise(iter)
+                || pyre_object::interp_itertools::is_cycle(iter)
                 || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
                 || pyre_object::functional::is_enumerate(iter)
                 || pyre_object::functional::is_reversed(iter)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1974,35 +1974,17 @@ impl IterOpcodeHandler for PyFrame {
     /// FOR_ITER: advance the iterator one step.
     /// PyPy: space.next() → StopIteration means exhausted.
     fn iter_next(&mut self, iter: Self::Value) -> Result<Option<Self::Value>, PyError> {
-        unsafe {
-            // Generators, itertools/enumerate/reversed/filter/map/zip/dictview/sre,
-            // and user-defined __next__ all go through space.next; range/long-range/seq
-            // fall through to the inline range helper.
-            let via_space_next = pyre_object::generator::is_generator(iter)
-                || pyre_object::is_instance(iter)
-                || pyre_object::interp_itertools::is_repeat(iter)
-                || pyre_object::interp_itertools::is_count(iter)
-                || pyre_object::interp_itertools::is_takewhile(iter)
-                || pyre_object::interp_itertools::is_dropwhile(iter)
-                || pyre_object::interp_itertools::is_filterfalse(iter)
-                || pyre_object::interp_itertools::is_pairwise(iter)
-                || pyre_object::functional::is_enumerate(iter)
-                || pyre_object::functional::is_reversed(iter)
-                || pyre_object::functional::is_filter(iter)
-                || pyre_object::functional::is_map(iter)
-                || pyre_object::functional::is_zip(iter)
-                || pyre_object::operation::is_callable_iterator(iter)
-                || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
-                || pyre_object::interp_sre::is_sre_scanner(iter);
-            if via_space_next {
-                // baseobjspace::next walks __next__ for is_instance
-                // (baseobjspace.rs:9501 lookup_in_type + call).
-                return match crate::baseobjspace::next(iter) {
-                    Ok(result) => Ok(Some(result)),
-                    Err(e) if e.kind == PyErrorKind::StopIteration => Ok(None),
-                    Err(e) => Err(e),
-                };
-            }
+        // Generators, itertools/enumerate/reversed/filter/map/zip/dictview/sre,
+        // and user-defined __next__ all go through space.next; range/long-range/seq
+        // fall through to the inline range helper.
+        if crate::runtime_ops::via_space_next(iter) {
+            // baseobjspace::next walks __next__ for is_instance
+            // (baseobjspace.rs:9501 lookup_in_type + call).
+            return match crate::baseobjspace::next(iter) {
+                Ok(result) => Ok(Some(result)),
+                Err(e) if e.kind == PyErrorKind::StopIteration => Ok(None),
+                Err(e) => Err(e),
+            };
         }
         // range / long-range / seq: value-or-null
         let v = range_iter_next_or_null(iter)?;

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -322,6 +322,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::jit_range_iter_next_or_null",
         crate::runtime_ops::jit_range_iter_next_or_null as *const (),
     );
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::runtime_ops::jit_next",
+        "pyre_interpreter::jit_next",
+        crate::runtime_ops::jit_next as *const (),
+    );
 
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -246,8 +246,10 @@ pub trait StackOpcodeHandler: SharedOpcodeHandler {
 
 pub trait IterOpcodeHandler: SharedOpcodeHandler {
     fn ensure_iter_value(&mut self, iter: Self::Value) -> Result<(), PyError>;
-    fn concrete_iter_continues(&mut self, iter: Self::Value) -> Result<bool, PyError>;
-    fn iter_next_value(&mut self, iter: Self::Value) -> Result<Self::Value, PyError>;
+    // FOR_ITER drives a single space.next (pyopcode.py:1288).
+    // Ok(Some(v)) = next value; Ok(None) = StopIteration (exhausted);
+    // Err(e) = a non-StopIteration exception (propagate).
+    fn iter_next(&mut self, iter: Self::Value) -> Result<Option<Self::Value>, PyError>;
     fn guard_optional_value(
         &mut self,
         value: Self::Value,
@@ -259,6 +261,10 @@ pub trait IterOpcodeHandler: SharedOpcodeHandler {
 
     fn record_for_iter_guard(&mut self, next: Self::Value, continues: bool) -> Result<(), PyError> {
         self.guard_optional_value(next, continues)
+    }
+
+    fn record_for_iter_guard_exhausted(&mut self) -> Result<(), PyError> {
+        Ok(())
     }
 
     fn on_iter_exhausted(&mut self, target: usize) -> Result<(), PyError>;
@@ -585,18 +591,19 @@ pub fn opcode_for_iter<H: IterOpcodeHandler + ControlFlowOpcodeHandler + ?Sized>
     target: usize,
 ) -> Result<(), PyError> {
     let iter = handler.peek_at(0)?;
-    let continues = handler.concrete_iter_continues(iter)?;
-    let next = handler.iter_next_value(iter)?;
-    if continues {
-        let fallthrough = handler.fallthrough_target();
-        // On guard failure this bytecode exits through the exhaustion path.
-        handler.set_next_instr(target)?;
-        handler.record_for_iter_guard(next, true)?;
-        handler.set_next_instr(fallthrough)?;
-        handler.push_value(next)
-    } else {
-        handler.record_for_iter_guard(next, false)?;
-        handler.on_iter_exhausted(target)
+    match handler.iter_next(iter)? {
+        Some(next) => {
+            let fallthrough = handler.fallthrough_target();
+            // On guard failure this bytecode exits through the exhaustion path.
+            handler.set_next_instr(target)?;
+            handler.record_for_iter_guard(next, true)?;
+            handler.set_next_instr(fallthrough)?;
+            handler.push_value(next)
+        }
+        None => {
+            handler.record_for_iter_guard_exhausted()?;
+            handler.on_iter_exhausted(target)
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1333,6 +1333,7 @@ pub fn via_space_next(iter: PyObjectRef) -> bool {
             || pyre_object::interp_itertools::is_dropwhile(iter)
             || pyre_object::interp_itertools::is_filterfalse(iter)
             || pyre_object::interp_itertools::is_pairwise(iter)
+            || pyre_object::interp_itertools::is_cycle(iter)
             || pyre_object::functional::is_enumerate(iter)
             || pyre_object::functional::is_reversed(iter)
             || pyre_object::functional::is_filter(iter)

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1318,6 +1318,53 @@ pub extern "C" fn jit_range_iter_next_or_null(iter: i64) -> i64 {
     }
 }
 
+/// FOR_ITER iterator kinds that advance through `space.next` rather than
+/// the inline range helper: generators, itertools/enumerate/reversed/
+/// filter/map/zip/dictview/sre, callable iterators, and user `__next__`
+/// instances. Shared so the interpreter `iter_next` and the tracer agree
+/// on which iterators take the `space.next` leg.
+pub fn via_space_next(iter: PyObjectRef) -> bool {
+    unsafe {
+        is_instance(iter)
+            || pyre_object::generator::is_generator(iter)
+            || pyre_object::interp_itertools::is_repeat(iter)
+            || pyre_object::interp_itertools::is_count(iter)
+            || pyre_object::interp_itertools::is_takewhile(iter)
+            || pyre_object::interp_itertools::is_dropwhile(iter)
+            || pyre_object::interp_itertools::is_filterfalse(iter)
+            || pyre_object::interp_itertools::is_pairwise(iter)
+            || pyre_object::functional::is_enumerate(iter)
+            || pyre_object::functional::is_reversed(iter)
+            || pyre_object::functional::is_filter(iter)
+            || pyre_object::functional::is_map(iter)
+            || pyre_object::functional::is_zip(iter)
+            || pyre_object::operation::is_callable_iterator(iter)
+            || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
+            || pyre_object::interp_sre::is_sre_scanner(iter)
+    }
+}
+
+/// Residual FOR_ITER `space.next` for the `via_space_next` iterator kinds.
+/// Exhaustion is signalled the same way as the range fast path: a null
+/// return that the trailing for-iter GuardNonnull catches, side-exiting to
+/// the interpreter which re-runs FOR_ITER and ends the loop (eval.rs
+/// `iter_next` maps StopIteration to exhausted). A *real* exception is
+/// published into the backend exception cells so the GuardNoException
+/// side-exits instead; the interpreter then re-runs FOR_ITER and re-raises.
+#[majit_macros::jit_may_force]
+pub extern "C" fn jit_next(iter: i64) -> i64 {
+    match crate::baseobjspace::next(iter as PyObjectRef) {
+        Ok(value) => value as i64,
+        // StopIteration is not a frame-level exception for FOR_ITER; return
+        // null so the GuardNonnull (not GuardNoException) fires.
+        Err(err) if err.kind == PyErrorKind::StopIteration => 0,
+        Err(err) => {
+            jit_publish_exception(err.to_exc_object());
+            0
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-jit-trace/src/call_spec.rs
+++ b/pyre/pyre-jit-trace/src/call_spec.rs
@@ -177,7 +177,7 @@ pub const PYFRAME_CALL_EFFECTS: &[CallEffectSpec] = &[
     },
     CallEffectSpec {
         target: CallTargetSpec::Method {
-            name: "iter_next_value",
+            name: "iter_next",
             receiver_root: PYFRAME_CALL_OWNER_ROOT,
         },
         effect: CallEffectKind::Residual,

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -8,7 +8,7 @@ use majit_ir::{EffectInfo, ExtraEffect, GcRef, OopSpecIndex, OpCode, OpRef, Type
 use majit_metainterp::{TraceCtx, default_effect_info};
 
 use pyre_interpreter::{
-    PyBigInt, PyError, binary_op_tag, compare_op_tag, jit_range_iter_next_or_null,
+    PyBigInt, PyError, binary_op_tag, compare_op_tag, jit_next, jit_range_iter_next_or_null,
     jit_sequence_getitem,
 };
 use pyre_interpreter::{
@@ -453,6 +453,13 @@ pub fn emit_trace_range_iter_next_or_null(ctx: &mut TraceCtx, iter: OpRef) -> Op
     )
 }
 
+/// Residual FOR_ITER `space.next` for non-range iterators. May invoke a
+/// user `__next__` / generator resume, so it can force the virtualizable
+/// and can raise (StopIteration / a real exception).
+pub fn emit_trace_next(ctx: &mut TraceCtx, iter: OpRef) -> OpRef {
+    emit_trace_call_may_force_ref_typed(ctx, jit_next as *const (), &[iter], &[Type::Ref])
+}
+
 /// RPython ConstPtr parity: boxed-object constants are Ref-typed.
 /// The optimizer can constant-fold immutable field reads from Ref
 /// constants (heap.py:640 constant_fold).
@@ -649,6 +656,16 @@ pub trait TraceHelperAccess {
 
     fn trace_iter_next_value(&mut self, iter: OpRef) -> Result<OpRef, PyError> {
         let result = self.with_trace_ctx(|ctx| emit_trace_range_iter_next_or_null(ctx, iter));
+        self.trace_record_no_exception_guard();
+        Ok(result)
+    }
+
+    fn trace_next(&mut self, iter: OpRef) -> Result<OpRef, PyError> {
+        let result = self.with_trace_ctx(|ctx| emit_trace_next(ctx, iter));
+        // `space.next` may resume a generator / run a user `__next__`,
+        // forcing the virtualizable; StopIteration / a real raise lands on
+        // the trailing GuardNoException, side-exiting to the interpreter.
+        self.trace_record_not_forced_guard();
         self.trace_record_no_exception_guard();
         Ok(result)
     }

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
@@ -428,20 +428,12 @@ impl pyre_interpreter::IterOpcodeHandler for crate::state::MIFrame {
         })
     }
 
-    fn concrete_iter_continues(
+    fn iter_next(
         &mut self,
         iter: Self::Value,
-    ) -> Result<bool, pyre_interpreter::PyError> {
+    ) -> Result<Option<Self::Value>, pyre_interpreter::PyError> {
         let concrete_iter = iter.concrete.to_pyobj();
-        crate::state::MIFrame::concrete_iter_continues(self, concrete_iter)
-    }
-
-    fn iter_next_value(
-        &mut self,
-        iter: Self::Value,
-    ) -> Result<Self::Value, pyre_interpreter::PyError> {
-        let concrete_iter = iter.concrete.to_pyobj();
-        crate::state::MIFrame::iter_next_value(self, iter.opref, concrete_iter)
+        crate::state::MIFrame::iter_next(self, iter.opref, concrete_iter)
     }
 
     fn guard_optional_value(

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1071,12 +1071,12 @@ impl MIFrame {
     }
 
     #[doc(hidden)]
-    pub fn capture_iter_next_value(
+    pub fn capture_iter_next(
         &mut self,
         iter: OpRef,
         concrete_iter: pyre_object::PyObjectRef,
-    ) -> Result<FrontendOp, PyError> {
-        self.iter_next_value(iter, concrete_iter)
+    ) -> Result<Option<FrontendOp>, PyError> {
+        self.iter_next(iter, concrete_iter)
     }
 
     #[doc(hidden)]
@@ -6303,13 +6303,6 @@ impl MIFrame {
         Ok(result)
     }
 
-    pub(crate) fn concrete_iter_continues(
-        &self,
-        concrete_iter: PyObjectRef,
-    ) -> Result<bool, PyError> {
-        range_iter_continues(concrete_iter)
-    }
-
     pub(crate) fn trace_known_builtin_call(
         &mut self,
         callable: OpRef,
@@ -7860,11 +7853,13 @@ impl MIFrame {
         result
     }
 
-    pub(crate) fn iter_next_value(
+    pub(crate) fn iter_next(
         &mut self,
         iter: OpRef,
         concrete_iter: PyObjectRef,
-    ) -> Result<FrontendOp, PyError> {
+    ) -> Result<Option<FrontendOp>, PyError> {
+        // range_iter_continues errors for a non-range iterator, aborting the
+        // trace (the residual __next__ inline is Task 2).
         let concrete_continues = range_iter_continues(concrete_iter)?;
         let concrete_step = unsafe {
             (*(concrete_iter as *const pyre_object::functional::W_IntRangeIterator)).step
@@ -7886,11 +7881,17 @@ impl MIFrame {
                 concrete_current,
             ))
         })?;
-        if let Some((opref, cv)) = gen_result {
-            return Ok(FrontendOp::new(opref, ConcreteValue::Int(cv)));
+        let next = if let Some((opref, cv)) = gen_result {
+            FrontendOp::new(opref, ConcreteValue::Int(cv))
+        } else {
+            let opref = self.trace_iter_next_value(iter)?;
+            FrontendOp::void(opref)
+        };
+        if concrete_continues {
+            Ok(Some(next))
+        } else {
+            Ok(None)
         }
-        let opref = self.trace_iter_next_value(iter)?;
-        Ok(FrontendOp::void(opref))
     }
 
     /// TODO: pyre's tracer holds raw `PyObjectRef`

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -8653,6 +8653,34 @@ impl MIFrame {
             return Ok(Some(step));
         }
 
+        // FOR_ITER — route through the trait `opcode_for_iter` (via the pub
+        // `execute_for_iter` dispatch wrapper, pyopcode.rs:1790) so `peek_at(0)`
+        // supplies the bound `concrete_iter` the auto-gen residual arm leaves
+        // unbound.  The auto-gen `ForIter` jitcode arm calls
+        // `iter_next(self, iter, concrete_iter)` but seeds only r0 = sym.frame
+        // on entry, so it cannot bind the oparg-derived iterator operand
+        // (arg_index 2 = `OpRef::NONE`) and `ensure_residual_call_args_bound`
+        // raises `ResidualCallArgUnbound`.  MIFrame's `peek_at(0)` returns a
+        // FrontendOp carrying the bound `.concrete`, so `concrete_iter` IS
+        // bound on this path; the trait `opcode_for_iter` then does
+        // `peek_at(0)` -> `iter_next(iter)` -> `record_for_iter_guard(next,
+        // true)` -> `push_value(next)`, driving the banked
+        // via_space_next -> trace_next -> jit_next residual.
+        //
+        // `execute_for_iter` resolves the absolute exhaustion target from the
+        // `ForIter { delta }` oparg via `jump_target_forward(&code.instructions,
+        // next_instr, delta)` — identical to the trait leg.  `next_instr =
+        // self.orgpc + 1` matches the trait leg's `pc + 1` (set_orgpc(pc) ran
+        // before the gate).  It always returns `StepResult::Continue`.  Mirrors
+        // the StoreSubscr / JumpBackward delegation; bypasses the unbound-operand
+        // auto-gen jitcode arm entirely.
+        if matches!(instruction, Instruction::ForIter { .. }) {
+            let next_instr = self.orgpc + 1;
+            let step =
+                pyre_interpreter::execute_for_iter(self, code, *instruction, op_arg, next_instr)?;
+            return Ok(Some(step));
+        }
+
         Ok(None)
     }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -7858,8 +7858,22 @@ impl MIFrame {
         iter: OpRef,
         concrete_iter: PyObjectRef,
     ) -> Result<Option<FrontendOp>, PyError> {
+        // Generators / user `__next__` / itertools / enumerate / ... advance
+        // through a residual `space.next` rather than the inline range helper.
+        // Mirror the seq fall-through: emit the residual and record a void next
+        // WITHOUT advancing the live iterator here — `space.next` is a
+        // side-effecting consume, so calling it at record time would drop one
+        // value the runtime trace never re-processes. The runtime residual does
+        // the single advance per iteration. Recording only reaches FOR_ITER on a
+        // continuing iteration (the trace closes at the loop back-edge, never on
+        // exhaustion), so `continues == true` here; runtime exhaustion returns a
+        // null result that the trailing for-iter GuardNonnull catches.
+        if pyre_interpreter::via_space_next(concrete_iter) {
+            let opref = self.trace_next(iter)?;
+            return Ok(Some(FrontendOp::void(opref)));
+        }
         // range_iter_continues errors for a non-range iterator, aborting the
-        // trace (the residual __next__ inline is Task 2).
+        // trace.
         let concrete_continues = range_iter_continues(concrete_iter)?;
         let concrete_step = unsafe {
             (*(concrete_iter as *const pyre_object::functional::W_IntRangeIterator)).step

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8971,8 +8971,9 @@ mod tests {
         let mut state = MIFrame::from_sym(&mut ctx, &mut sym, frame_ptr, resume_pc, resume_pc);
 
         let next = state
-            .capture_iter_next_value(iter, range_iter)
-            .expect("range iterator fast path should trace");
+            .capture_iter_next(iter, range_iter)
+            .expect("range iterator fast path should trace")
+            .expect("two-element range iterator should yield a value");
         assert_eq!(state.capture_value_type(next.opref), Type::Int);
         <MIFrame as IterOpcodeHandler>::guard_optional_value(&mut state, next, true)
             .expect("typed range next should not need optional guard");

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2984,13 +2984,18 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
     // module-level driver loops such as fannkuch's `for range(3, 10)`
     // from disabling the hot function they call.
     //
-    // Task 2 (residual `space.next`) intended to drop this gate so the loop
-    // traces, but the trait-leg FOR_ITER resume is incorrect for non-trivial
-    // bodies (extra iteration on a `list.append` body; SIGBUS on a nested
-    // loop) and the walker leg cannot bind the auto-gen `iter_next`'s oparg-
-    // derived `concrete_iter` operand (ResidualCallArgUnbound). The gate stays
-    // until that resume/operand-seeding work lands; the residual emit path
-    // (`MIFrame::iter_next` -> `trace_next` -> `jit_next`) is in place behind it.
+    // The entry-hook in `trace_opcode.rs` (delegating `FOR_ITER` to
+    // `execute_for_iter`, binding `concrete_iter` from the stack) makes the
+    // loop traceable, so the auto-gen operand gap (`ResidualCallArgUnbound`) is
+    // resolved. The remaining defect keeps the gate up: the FBW walk-end-flush
+    // commits `while`/JUMP_BACKWARD loops (advancing the live frame past the
+    // recorded iteration) but does not commit `FOR_ITER` loops, so the recorded
+    // iteration's body is replayed once (extra iteration on a `list.append`
+    // body; SIGBUS on a nested loop). This is `FOR_ITER`-general (a `range`
+    // loop double-applies too), not a resume or `space.next` bug. The gate
+    // stays until the FBW commit path covers `FOR_ITER`; the residual emit path
+    // (`MIFrame::iter_next` -> `trace_next` -> `jit_next`) and the entry-hook
+    // are in place behind it.
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2983,6 +2983,14 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
     // region boundary; callees are allowed to enter the JIT. This keeps
     // module-level driver loops such as fannkuch's `for range(3, 10)`
     // from disabling the hot function they call.
+    //
+    // Task 2 (residual `space.next`) intended to drop this gate so the loop
+    // traces, but the trait-leg FOR_ITER resume is incorrect for non-trivial
+    // bodies (extra iteration on a `list.append` body; SIGBUS on a nested
+    // loop) and the walker leg cannot bind the auto-gen `iter_next`'s oparg-
+    // derived `concrete_iter` operand (ResidualCallArgUnbound). The gate stays
+    // until that resume/operand-seeding work lands; the residual emit path
+    // (`MIFrame::iter_next` -> `trace_next` -> `jit_next`) is in place behind it.
     let mut arg_state = pyre_interpreter::OpArgState::default();
     let mut has_for_iter = false;
     for unit in code.instructions.iter().copied() {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3003,10 +3003,16 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
         }
     }
     if has_for_iter {
-        UnsupportedJitShape::CurrentFrameOnly
-    } else {
-        UnsupportedJitShape::None
+        // Opt-in `PYRE_57_INLINE_NEXT=1` lets a FOR_ITER frame enter the JIT for
+        // flag-gated validation; the firewall stays UP by default.
+        static FOR_ITER_JIT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        let enabled = *FOR_ITER_JIT
+            .get_or_init(|| std::env::var("PYRE_57_INLINE_NEXT").as_deref() == Ok("1"));
+        if !enabled {
+            return UnsupportedJitShape::CurrentFrameOnly;
+        }
     }
+    UnsupportedJitShape::None
 }
 
 fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {


### PR DESCRIPTION
Refs #57.

First landed slice of FOR_ITER user-iterator `__next__` inlining (#57), plus a related crash fix and one unrelated bytes/bytearray fix. The full inlining goal is **deferred** — see "Not here" below.

## What's here (5 commits on top of `main`)

**#57 FOR_ITER work**
- **Collapse `opcode_for_iter` to a single `iter_next`** — replaces the `concrete_iter_continues` + `iter_next_value` trait pair (and the `USER_ITER_NEXT_CACHE` that deduped their double `__next__` call) with one `iter_next` returning `Option`, matching `space.next` (pyopcode.py:1288). Meaning-preserving.
- **Residual `space.next` trace infrastructure behind the `CurrentFrameOnly` gate** — shared `via_space_next`, the `jit_next` residual, and the tracer `iter_next` residual branch. Dormant in production (FOR_ITER stays `CurrentFrameOnly`); ready to sit on top of the recording-model fix described below.
- **Repro matrix** (`pyre/bench/synth/iter57/`) — a JIT-off vs JIT-on byte-comparison oracle.

**Crash fix (surfaced by the #57 repros)**
- **Read instance attributes from the mapdict node directly** (`baseobjspace`) — `getattr_str_impl` / `object_getattribute` Step 3 read the mapdict node (`instance_node_getdictvalue`) instead of materialising the `__dict__` view, matching PyPy `getdictvalue`. Combined with the `iter_next` collapse (which routes user `__next__` through the canonical fresh-frame `space.next` instead of the old inline-framestack `call_callable`), this fixes 3 baseline JIT crashes in user-iterator hot loops (deterministic SIGSEGV + flaky GC SIGABRT) — 20/20 on each repro.

**Unrelated**
- **bytes/bytearray substring membership in `__contains__`**.

## Not here (deferred)

The full #57 goal — inlining the user `__next__` into the FOR_ITER loop trace — is deferred. Dropping the `CurrentFrameOnly` gate to let FOR_ITER trace exposes a deep, pre-existing, **FOR_ITER-independent** recording-model defect: the trait recording leg (`metainterp.interpret()`) concretely commits loop-body CALL residuals (e.g. `list.append`) during recording on a heap-sharing `snapshot_for_tracing`, double-applying them (off-by-one; nested-loop SIGBUS; even an aborted trace double-applies). The orthodox "route FOR_ITER through the walker leg" cutover was **empirically verified to NOT fix this** (the defect is in the body's CALL recording, not FOR_ITER's dispatch). The real fix (symbolic-record body CALLs, à la RPython `execute_and_record`, or promote the full-body-walk recording path) is a separate multi-session epic. The `CurrentFrameOnly` gate stays as the correctness firewall; the residual infra here sits behind it.

## Verification
- `pyre/check.py`: `ALL PASSED: dynasm 139/139` and `ALL PASSED: cranelift 139/139`.
- The 3 user-iterator crash repros: 20/20 each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
