### PR TITLE
#171: orthodox descent walls 5a–5e — codewriter descr bridges, host-static const relocation, symbolic-fnaddr handling

### DIFF
--- a/majit/majit-translate/src/jit_codewriter/assembler.rs
+++ b/majit/majit-translate/src/jit_codewriter/assembler.rs
@@ -3578,7 +3578,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
             // `rint.py:rtype_int__Bool` emits `int_is_true` directly,
             // and `ptr_nonzero` / `same_as` / cast_* are similarly
             // already-canonical.
-            "int_is_true" | "ptr_nonzero" | "same_as" => op.clone(),
+            "int_is_true" | "ptr_nonzero" | "ptr_iszero" | "same_as" => op.clone(),
             s if s.starts_with("int_") || s.starts_with("uint_") => op.clone(),
             s if s.starts_with("float_") || s.starts_with("cast_") => op.clone(),
             _ => format!("int_{op}"),

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2639,6 +2639,36 @@ impl<'a> Transformer<'a> {
         {
             return RewriteResult::Identity(args[0].clone());
         }
+        // `<*mut T>::is_null` / `<*const T>::is_null` — the raw-pointer null
+        // test.  `front::mir`'s `impl_method_owner` routes it to
+        // `CallTarget::Method { name: "is_null", receiver_root }` through the
+        // `NON_ADT_OWNER_METHOD_ALLOWLIST` (Charon leaves the primitive `Self`
+        // unresolved, so the path stays method-shaped rather than surfacing a
+        // panicking `SomeInstance.getattr`).  `ptr_method_is_null`
+        // (`unaryop.rs`, shared by `const_ptr`/`mut_ptr` since mutability does
+        // not affect the null test) lowers the bound-method to `ptr_iszero`;
+        // the charon front-end skips the rtyper, so finish that lowering here
+        // the same way the `cast_pointer` family folds above — emit one
+        // `ptr_iszero/r>i` over the pointer operand instead of residualising
+        // the call to a symbolic helper fnaddr the executor cannot run.
+        if let CallTarget::Method {
+            name,
+            receiver_root: Some(receiver_root),
+            ..
+        } = target
+            && name == "is_null"
+            && matches!(receiver_root.as_str(), "mut_ptr" | "const_ptr")
+            && args.len() == 1
+        {
+            return RewriteResult::Replace(vec![SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::UnaryOp {
+                    op: "ptr_iszero".into(),
+                    operand: args[0].clone(),
+                    result_ty: ValueType::Int,
+                },
+            }]);
+        }
         // RPython: guess_call_kind(op) → dispatch to handle_*_call
         if let Some(cc) = self.callcontrol.as_mut() {
             let kind = cc.guess_call_kind(op);

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2669,6 +2669,31 @@ impl<'a> Transformer<'a> {
                 },
             }]);
         }
+        // `core::ptr::eq(a, b)` — raw-pointer identity comparison.  Like
+        // `is_null` above, `front::mir` leaves it as a `FunctionPath` residual
+        // because the charon front-end skips the rtyper lowering that turns a
+        // pointer `eq` into `ptr_eq` (`jtransform.py:1243-1255` routes `eq`
+        // over two Ref operands to `ptr_eq`).  Finish that lowering here: emit
+        // a `BinOp("eq")` over the two pointer operands — the assembler maps
+        // the `rr` operand shape to `ptr_eq` — instead of residualising the
+        // call to a symbolic helper fnaddr the executor cannot run.
+        if let CallTarget::FunctionPath { segments } = target
+            && segments.len() == 3
+            && segments[0] == "core"
+            && segments[1] == "ptr"
+            && segments[2] == "eq"
+            && args.len() == 2
+        {
+            return RewriteResult::Replace(vec![SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::BinOp {
+                    op: "eq".into(),
+                    lhs: args[0].clone(),
+                    rhs: args[1].clone(),
+                    result_ty: ValueType::Int,
+                },
+            }]);
+        }
         // RPython: guess_call_kind(op) → dispatch to handle_*_call
         if let Some(cc) = self.callcontrol.as_mut() {
             let kind = cc.guess_call_kind(op);

--- a/majit/majit-translate/src/jit_codewriter/jtransform.rs
+++ b/majit/majit-translate/src/jit_codewriter/jtransform.rs
@@ -2611,6 +2611,26 @@ impl<'a> Transformer<'a> {
         if self.is_synthetic_result_option_ctor(target, args, result_ty) {
             return RewriteResult::Identity(args[0].clone());
         }
+        // A zero-arg transparent `Tuple` constructor is the unit value `()` —
+        // the MIR return-place aggregate of a `-> ()` function (e.g.
+        // `w_list_append`).  It carries no payload and no runtime
+        // representation, so the residual `Call` to the synthetic ctor would
+        // mint a `symbolic_fnaddr` placeholder (absent from
+        // `jit_trace_fnaddrs()`) that the codewriter cannot lower — recording
+        // it bakes a 64-bit hash as a code address.  Emit a null-ref result
+        // placeholder instead; a unit has no fields for anything to read.
+        // (A non-empty `Tuple` is a real aggregate and a named unit *enum*
+        // variant carries a discriminant — both skip this arm.)
+        if let CallTarget::SyntheticTransparentCtor { name, .. } = target
+            && name == "Tuple"
+            && args.is_empty()
+            && matches!(result_ty, ValueType::Ref(_))
+        {
+            return RewriteResult::Replace(vec![SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::ConstRefNull,
+            }]);
+        }
         // `rewrite_op_cast_pointer` → `rewrite_op_same_as`
         // (jtransform.py:254-257): the JIT does not distinguish a
         // down-cast pointer from its source, so the

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -407,6 +407,32 @@ fn real_main() {
     )
     .unwrap();
 
+    // Same ASLR hazard for the static-data addresses the codewriter baked
+    // into `constants_i` (host `PyType` singletons and prebuilt refs supplied
+    // via `HostStaticAddrs`): the build-script process's `&pyre_object::X`
+    // address does not survive into the runtime executable.  Persist the
+    // `(name, build_addr)` tables so `runtime_fnaddr_patch::
+    // patch_constants_i_static_addrs` can re-pair them with the runtime
+    // addresses from `jit_static_pytype_addrs` / `jit_static_ref_addrs`.
+    let pytype_bindings_owned: Vec<(String, i64)> = static_pytype_addrs
+        .iter()
+        .map(|(n, a)| ((*n).to_string(), *a))
+        .collect();
+    std::fs::write(
+        format!("{out_dir}/static_pytype_bindings.bin"),
+        bincode::serialize(&pytype_bindings_owned).unwrap(),
+    )
+    .unwrap();
+    let ref_bindings_owned: Vec<(String, i64)> = static_ref_addrs
+        .iter()
+        .map(|(n, a)| ((*n).to_string(), *a))
+        .collect();
+    std::fs::write(
+        format!("{out_dir}/static_ref_bindings.bin"),
+        bincode::serialize(&ref_bindings_owned).unwrap(),
+    )
+    .unwrap();
+
     // Report
     let arms_with_jitcode = pipeline
         .opcode_dispatch

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2565,6 +2565,53 @@ mod tests {
     }
 
     #[test]
+    fn make_descr_from_bh_bridges_codewriter_box_payload_fields_to_group() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_translate::jitcode::BhDescr;
+
+        // A codewriter-lowered body reads a box payload through the producer's
+        // struct-layout descr: `W_IntObject` is modeled with a header, so its
+        // `intval` lands at `index_in_parent` = 2.  The walker materializes the
+        // same box through the single-field `W_*_DESCR_GROUP` (`index` = 0).
+        // The bridge must return the group entry so the optimizer's
+        // identity-keyed virtual-field cache matches the box-creation descr.
+        for (owner, name, expected, ty) in [
+            ("W_IntObject", "intval", int_intval_descr(), Type::Int),
+            (
+                "pyre_object::intobject::W_IntObject",
+                "intval",
+                int_intval_descr(),
+                Type::Int,
+            ),
+            ("W_BoolObject", "intval", bool_intval_descr(), Type::Int),
+            (
+                "W_FloatObject",
+                "floatval",
+                float_floatval_descr(),
+                Type::Float,
+            ),
+        ] {
+            let descr = make_descr_from_bh(&BhDescr::Field {
+                offset: 16,
+                field_size: 8,
+                field_type: ty,
+                field_flag: ArrayFlag::Signed,
+                is_field_signed: true,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                index_in_parent: 2,
+                parent: None,
+                name: name.into(),
+                owner: owner.into(),
+            });
+            assert!(
+                std::sync::Arc::ptr_eq(&descr, &expected),
+                "{owner}.{name} must bridge to the canonical group entry Arc",
+            );
+        }
+    }
+
+    #[test]
     fn make_descr_from_bh_struct_array_preserves_type_and_interior_fields() {
         use majit_ir::descr::ArrayFlag;
         use majit_translate::jitcode::{BhDescr, BhFieldSpec, BhInteriorFieldSpec, BhSizeSpec};
@@ -3312,6 +3359,31 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     "items" => return list_items_descr(),
                     _ => {}
                 }
+            }
+            // #171 codewriter descr-bridge: a codewriter-lowered body reads a
+            // box payload (`W_IntObject.intval` / `W_BoolObject.intval` /
+            // `W_FloatObject.floatval`) through the producer's struct-layout
+            // `SimpleFieldDescr` (header modeled, `index_in_parent` = 2).  The
+            // walker materializes those same boxes through the single-field
+            // `W_*_DESCR_GROUP` (`index_in_parent` = 0).  Both address the same
+            // offset, but the optimizer's virtual-field cache matches on descr
+            // identity, so a sub-walk read with the producer descr misses the
+            // virtual built with the group descr — the box is forced and the
+            // field read folds to uninitialized storage.  Return the canonical
+            // group entry so the read matches the box-creation descr and folds
+            // to the carried unboxed value (the payload is genuinely immutable
+            // post-construction, matching the group entry's flag).
+            match (owner.as_str(), name.as_str()) {
+                ("W_IntObject" | "pyre_object::intobject::W_IntObject", "intval") => {
+                    return int_intval_descr();
+                }
+                ("W_BoolObject" | "pyre_object::boolobject::W_BoolObject", "intval") => {
+                    return bool_intval_descr();
+                }
+                ("W_FloatObject" | "pyre_object::floatobject::W_FloatObject", "floatval") => {
+                    return float_floatval_descr();
+                }
+                _ => {}
             }
             let full_name = if owner.is_empty() || name.contains('.') {
                 name.clone()

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2524,6 +2524,47 @@ mod tests {
     }
 
     #[test]
+    fn make_descr_from_bh_bridges_codewriter_list_header_fields_to_group() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_translate::jitcode::BhDescr;
+
+        // The `w_list_append` body reads `list.{strategy,length,items}`
+        // directly. The codewriter mints these as a `SimpleFieldDescr` with no
+        // parent_descr backreference, which `ensure_ptr_info_arg0` rejects.
+        // The bridge must route them to the canonical group entries so
+        // `get_parent_descr()` is populated (and the offset matches).
+        for (name, expected, ty) in [
+            ("strategy", list_strategy_descr(), Type::Int),
+            ("length", list_length_descr(), Type::Int),
+            ("items", list_items_descr(), Type::Ref),
+        ] {
+            let descr = make_descr_from_bh(&BhDescr::Field {
+                offset: 0,
+                field_size: 8,
+                field_type: ty,
+                field_flag: ArrayFlag::Signed,
+                is_field_signed: false,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                index_in_parent: 0,
+                parent: None,
+                name: name.into(),
+                owner: "W_ListObject".into(),
+            });
+            let field = descr.as_field_descr().expect("Field BhDescr -> FieldDescr");
+            assert!(
+                field.get_parent_descr().is_some(),
+                "{name} must carry a parent_descr after the bridge",
+            );
+            assert_eq!(
+                field.offset(),
+                expected.as_field_descr().unwrap().offset(),
+                "{name} offset must match the W_LIST_DESCR_GROUP entry",
+            );
+        }
+    }
+
+    #[test]
     fn make_descr_from_bh_struct_array_preserves_type_and_interior_fields() {
         use majit_ir::descr::ArrayFlag;
         use majit_translate::jitcode::{BhDescr, BhFieldSpec, BhInteriorFieldSpec, BhSizeSpec};
@@ -3259,6 +3300,16 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     "int_items.len" => return list_int_items_len_descr(),
                     "int_items.heap_cap" => return list_int_items_heap_cap_descr(),
                     "int_items.block" => return list_int_items_block_descr(),
+                    // The `w_list_append` body's `match list.strategy` reads the
+                    // header `strategy` field directly.  The codewriter resolves
+                    // its offset but produces a `SimpleFieldDescr` with no
+                    // `parent_descr` backreference, which the optimizer's
+                    // `ensure_ptr_info_arg0` rejects.  Bridge it to the canonical
+                    // group entry (correct offset + parent_descr) like the
+                    // `int_items.*` leaves above.
+                    "strategy" => return list_strategy_descr(),
+                    "length" => return list_length_descr(),
+                    "items" => return list_items_descr(),
                     _ => {}
                 }
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3577,7 +3577,11 @@ fn ptr_nullity_record(
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let box_ = read_ref_reg(code, op, 0, ctx)?;
     let null_const = ctx.trace_ctx.const_null();
-    let opcode = if nonzero { OpCode::PtrNe } else { OpCode::PtrEq };
+    let opcode = if nonzero {
+        OpCode::PtrNe
+    } else {
+        OpCode::PtrEq
+    };
     let result = ctx.trace_ctx.record_op(opcode, &[box_, null_const]);
     // Concrete stamp: prefer the box's own value carrier.  Inside an inline
     // sub-walk the operand is often a callee argument whose concrete pointer
@@ -6091,8 +6095,8 @@ pub(crate) fn fbw_store_journal_push(
 /// length rewind when the walk does not commit its end state.  `list` must
 /// be an Integer-strategy list whose backing array had spare capacity (the
 /// append's gate), so the rewind is allocation-free.
-// Consumed by the #171 P3 `list.append` specialization arm
-// (`try_walker_specialize_list_append`).
+// Consumed by the #171 `list.append` orthodox descent
+// (`try_walker_orthodox_list_append`).
 pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_before: usize) {
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
 }
@@ -9111,12 +9115,12 @@ fn dispatch_residual_call_iRd_kind(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
-    // #171 P3: specialize `lst.append(x)` so its array ops reach the trace,
-    // replacing the opaque `bh_call_fn` residual (walker-native fold; see
-    // `try_walker_specialize_list_append`).  The call arrives as `CallFn` with
-    // `dst_bank == 'r'` (the None result is a Ref, not void) and
-    // `r_args = [bound-method, PY_NULL, value]`.  Default ON
-    // (`PYRE_171_INLINE_LIST=0` opts out); falls through to the
+    // #171: specialize `lst.append(x)` so its array ops reach the trace,
+    // replacing the opaque `bh_call_fn` residual (orthodox descent of the
+    // real `w_list_append` body; see `try_walker_orthodox_list_append`).  The
+    // call arrives as `CallFn` with `dst_bank == 'r'` (the None result is a
+    // Ref, not void) and `r_args = [bound-method, PY_NULL, value]`.  Default
+    // ON (`PYRE_171_ORTHODOX=0` opts out); falls through to the
     // residual for any non-matching shape (SAFE).  The eager append rides
     // `FBW_APPEND_JOURNAL`, whose commit/rollback epilogues run on FBW walk
     // ends (same lifecycle as the STORE_SUBSCR store journal).
@@ -9139,10 +9143,11 @@ fn dispatch_residual_call_iRd_kind(
     // local across the fold's mid-statement guards.  Loop traces resume
     // through the loop-header pc_map coordinate and reconstruct it correctly
     // (a no-loop helper's append falls back to the generic residual).
-    // #171 ORTHODOX descent (WIP, default OFF — `PYRE_171_ORTHODOX=1`).  When
-    // enabled, try descending the real `w_list_append` body first; a decline
-    // (`None`) falls through to the hand-rolled fold below.  Same gating
-    // preconditions as the fold (loop full-body frame, not inside a sub-walk).
+    // #171 ORTHODOX descent (default ON — `PYRE_171_ORTHODOX=0` opts out):
+    // descend the real `w_list_append` body, recording its array ops native.
+    // A decline (`None`) falls through to the generic residual below; an
+    // un-lowered in-body helper aborts the trace (graceful interpreter
+    // fallback).  Gated to loop full-body frames, not inside a sub-walk.
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
@@ -9151,17 +9156,6 @@ fn dispatch_residual_call_iRd_kind(
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && pyre_171_orthodox_enabled()
         && try_walker_orthodox_list_append(ctx, code, op, &r_args, dst)?.is_some()
-    {
-        return Ok((DispatchOutcome::Continue, op.next_pc));
-    }
-    if ctx.is_authoritative_executor
-        && ctx.is_full_body_walk
-        && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
-        && ctx.trace_ctx.header_pc != 0
-        && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && pyre_171_inline_list_enabled()
-        && try_walker_specialize_list_append(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -10788,21 +10782,11 @@ fn try_walker_specialize_subscr(
     Ok(Some(()))
 }
 
-/// Env gate for the #171 P3 `list.append` int-storage fold.  Default ON;
-/// `PYRE_171_INLINE_LIST=0` opts out.  The fold is restricted to loop traces
-/// at the top full-body frame (see the dispatch-site gate): inline sub-walks
-/// and function-entry traces decline to the generic residual, so the only
-/// live path is the validated loop-trace append.
-fn pyre_171_inline_list_enabled() -> bool {
-    std::env::var("PYRE_171_INLINE_LIST").as_deref() != Ok("0")
-}
-
 /// #171 orthodox descent gate (default ON — `PYRE_171_ORTHODOX=0` opts
-/// out).  The descent of the real `w_list_append` charon body replaces the
-/// hand-rolled [`try_walker_specialize_list_append`] below; an unresolved
-/// in-body helper still declines via `OrthodoxSubWalkTraceUnsupported`
-/// (graceful interpreter fallback), so a stale build-time jitcode never
-/// commits a wrong trace.
+/// out).  The descent of the real `w_list_append` charon body is the
+/// `list.append` int-storage specialization; an unresolved in-body helper
+/// declines via `OrthodoxSubWalkTraceUnsupported` (graceful interpreter
+/// fallback), so a stale build-time jitcode never commits a wrong trace.
 fn pyre_171_orthodox_enabled() -> bool {
     std::env::var("PYRE_171_ORTHODOX").as_deref() != Ok("0")
 }
@@ -11095,261 +11079,6 @@ fn try_walker_orthodox_list_append(
         write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', none_ref)?;
         Ok(Some(()))
     }
-}
-
-/// #171 P3: specialize `lst.append(x)` so its array ops (getfield length /
-/// capacity guard / setarrayitem / setfield length+1) reach the trace,
-/// replacing the opaque `bh_call_fn` residual that hides them.  Emits the IR
-/// walker-native — the `generated_list_append_by_strategy` int-storage fold
-/// (codegen.rs), hand-rolled against the walker register banks.
-///
-/// (Descending the canonical `w_list_append` body — the single-source
-/// alternative — is blocked: that body's prologue residuals call low-level
-/// strategy/storage helpers whose addresses are absent from
-/// `jit_trace_fnaddrs()`, so they stay symbolic `stable_symbolic_fnaddr`
-/// hashes and the executor declines them at the `>>47` guard, leaving the
-/// strategy switch non-concrete.  Registering + GC-safety-proving those
-/// helpers is a separate infra epic.)
-///
-/// Shape (confirmed empirically + cross-verified): the walker sees the call
-/// as `pyre_helper == CallFn`, `dst_bank == 'r'`, `r_args = [bound-method,
-/// PY_NULL, value]` (arity 3 — `bh_call_fn(callable, null_or_self, arg0)`).
-/// The Python result is `None` (a Ref, not void), so a None const is written
-/// to `dst` for the trailing `POP_TOP` to discard.
-///
-/// Gates to the Integer-storage / plain-`W_IntObject` / spare-capacity path
-/// (the no-realloc fast path).  Like [`try_walker_specialize_store_subscr`],
-/// the fold records the append IR but does NOT mutate the concrete list; this
-/// applies the append itself and journals the length rewind
-/// (`fbw_append_journal_push`) so a non-commit walk's legacy replay re-appends
-/// against the pre-walk heap.  Any non-matching shape declines (`Ok(None)`)
-/// BEFORE emitting IR, leaving the generic residual fallback intact (SAFE).
-fn try_walker_specialize_list_append(
-    ctx: &mut WalkContext<'_, '_>,
-    code: &[u8],
-    op: &DecodedOp,
-    r_args: &[OpRef],
-    dst: usize,
-) -> Result<Option<()>, DispatchError> {
-    if r_args.len() != 3 {
-        return Ok(None);
-    }
-    // r_args = [callable(bound method), null_or_self(PY_NULL), value].
-    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
-    let (ConcreteValue::Ref(callable), ConcreteValue::Ref(null_or_self), ConcreteValue::Ref(value)) =
-        (arg_concretes[0], arg_concretes[1], arg_concretes[2])
-    else {
-        return Ok(None);
-    };
-    // Plain bound-call shape only: callable + value present, null_or_self the
-    // PY_NULL sentinel.  A non-null `null_or_self` is a receiver
-    // `bh_call_fn_impl` prepends as arg0 — not the `lst.append(x)` shape.
-    if callable.is_null() || !null_or_self.is_null() || value.is_null() {
-        return Ok(None);
-    }
-
-    // Recognize the bound builtin `list.append` + Integer-storage list +
-    // plain-int value + spare capacity.  Mirrors the trait recognition
-    // (`trace_opcode.rs` is_method / canonical_list_method("append")).
-    let (inner_func, inner_self, len_before, is_inline, elem) = unsafe {
-        if !pyre_object::function::is_method(callable) {
-            return Ok(None);
-        }
-        let inner_func = pyre_object::function::w_method_get_func(callable);
-        let inner_self = pyre_object::function::w_method_get_self(callable);
-        if inner_func.is_null() || inner_self.is_null() {
-            return Ok(None);
-        }
-        // Canonical-identity check: a list subclass overriding `append`, or a
-        // same-named method on another type, declines (its func differs).
-        let list_type = pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE);
-        if pyre_interpreter::lookup_in_type(list_type, "append") != Some(inner_func) {
-            return Ok(None);
-        }
-        // Int storage + plain `W_IntObject` value + spare capacity.  `is_plain_int1`
-        // also admits a fits-int `W_LongObject`, but the fold unboxes through a
-        // plain `INT_TYPE` guard, so exclude `long` here (the `unbox_long` arm is
-        // a follow-up); a long value falls to the generic residual.
-        if !pyre_object::pyobject::is_list(inner_self)
-            || !pyre_object::w_list_uses_int_storage(inner_self)
-            || !pyre_object::is_plain_int1(value)
-            || pyre_object::pyobject::is_long(value)
-            || !pyre_object::w_list_can_append_without_realloc(inner_self)
-        {
-            return Ok(None);
-        }
-        (
-            inner_func,
-            inner_self,
-            pyre_object::w_list_len(inner_self),
-            pyre_object::w_list_is_inline_storage(inner_self),
-            pyre_object::w_int_get_value(value),
-        )
-    };
-
-    // --- commit to the specialization: emit IR (no further declines) ---
-    let callable_op = r_args[0];
-    let value_op = r_args[2];
-
-    // Pin the callable: guard_class METHOD, then guard_value on the stable
-    // `w_function` slot.  The bound method is freshly allocated each
-    // iteration but its function pointer is stable, so the receiver alone
-    // cannot tie the trace to `list.append` — guard the function.
-    let method_type_addr = &pyre_object::function::METHOD_TYPE as *const _ as i64;
-    if !callable_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(callable_op) {
-        let type_const = ctx.trace_ctx.const_int(method_type_addr);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardClass, &[callable_op, type_const], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    }
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .class_now_known(callable_op, method_type_addr);
-
-    let func_ref = crate::state::opimpl_getfield_gc_r(
-        ctx.trace_ctx,
-        callable_op,
-        crate::descr::method_w_function_descr(),
-    );
-    let func_const = ctx.trace_ctx.const_ref(inner_func as i64);
-    ctx.trace_ctx
-        .record_guard(OpCode::GuardValue, &[func_ref, func_const], 0);
-    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(func_ref, func_const);
-
-    // Recover the receiver list OpRef from the method object for the fold.
-    let self_ref = crate::state::opimpl_getfield_gc_r(
-        ctx.trace_ctx,
-        callable_op,
-        crate::descr::method_w_self_descr(),
-    );
-    ctx.trace_ctx.set_opref_concrete(
-        self_ref,
-        majit_ir::Value::Ref(majit_ir::GcRef(inner_self as usize)),
-    );
-
-    // --- emit the int-storage append fold (walker-native) ---
-    // Mirrors `generated_list_append_by_strategy` (strategy_id=1), hand-rolled
-    // against the walker register banks with the real `op.pc` resume
-    // coordinate.  (The `WalkerFrameOps` trait impl captures snapshots at pc
-    // 0 — valid only for the per-opcode arm path, not this full-body walk —
-    // and `generated_list_append_by_strategy` is `MIFrame`-bound, so neither
-    // is reusable here.)  No charon-body descent: that body's prologue
-    // residuals call low-level strategy/storage helpers whose addresses are
-    // absent from `jit_trace_fnaddrs()`, so they stay symbolic and the
-    // executor declines them — the trace leg uses this fold; the
-    // runtime/blackhole leg still runs the canonical `w_list_append` body.
-
-    // guard_class LIST (skip when the class is already known / operand const).
-    let list_type_addr = &pyre_object::pyobject::LIST_TYPE as *const _ as i64;
-    if !self_ref.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(self_ref) {
-        let type_const = ctx.trace_ctx.const_int(list_type_addr);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardClass, &[self_ref, type_const], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    }
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .class_now_known(self_ref, list_type_addr);
-
-    // guard_value(strategy == Integer): getfield strategy + GuardValue.
-    let strategy = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        self_ref,
-        crate::descr::list_strategy_descr(),
-    );
-    let sid_const = ctx.trace_ctx.const_int(1);
-    ctx.trace_ctx
-        .record_guard(OpCode::GuardValue, &[strategy, sid_const], 0);
-    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(strategy, sid_const);
-
-    // length read (int_items.len), stamped to the concrete pre-append length
-    // so the `IntLt` capacity guard and `IntAdd` length update fold.
-    let len = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        self_ref,
-        crate::descr::list_int_items_len_descr(),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(len, majit_ir::Value::Int(len_before as i64));
-
-    // Spare-capacity guard (`_ll_list_resize_ge` fast case, rlist.py:285):
-    // append inlines only while `len < capacity`.  On guard failure the
-    // resume at `op.pc` re-executes the method CALL — the real, resizing
-    // append performed generically.
-    let heap_cap = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        self_ref,
-        crate::descr::list_int_items_heap_cap_descr(),
-    );
-    let capacity = if is_inline {
-        // Inline arrays encode capacity as `heap_cap == 0`; guard that shape,
-        // then use the compile-time inline-capacity constant.
-        let zero_const = ctx.trace_ctx.const_int(0);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[heap_cap, zero_const], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(heap_cap, zero_const);
-        ctx.trace_ctx
-            .const_int(pyre_object::INT_ARRAY_INLINE_CAP as i64)
-    } else {
-        // Heap storage: `heap_cap > 0` is the backing-array capacity.
-        let zero = ctx.trace_ctx.const_int(0);
-        let heap_storage = ctx.trace_ctx.record_op(OpCode::IntGt, &[heap_cap, zero]);
-        ctx.trace_ctx
-            .set_opref_concrete(heap_storage, majit_ir::Value::Int(1));
-        walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardTrue, &[heap_storage])?;
-        heap_cap
-    };
-    let has_room = ctx.trace_ctx.record_op(OpCode::IntLt, &[len, capacity]);
-    ctx.trace_ctx
-        .set_opref_concrete(has_room, majit_ir::Value::Int(1));
-    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardTrue, &[has_room])?;
-
-    // Write the value: `items_ptr[len] = unbox(value)`, then `len += 1`.
-    let items_ptr = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        self_ref,
-        crate::descr::list_int_items_ptr_descr(),
-    );
-    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-    let raw = walker_unbox_int(ctx, op.pc, value_op, int_type_addr)?;
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Int(elem));
-    crate::state::trace_raw_int_array_setitem_value(ctx.trace_ctx, items_ptr, len, raw);
-
-    let one = ctx.trace_ctx.const_int(1);
-    let new_len = ctx.trace_ctx.record_op(OpCode::IntAdd, &[len, one]);
-    ctx.trace_ctx
-        .set_opref_concrete(new_len, majit_ir::Value::Int(len_before as i64 + 1));
-    let len_descr = crate::descr::list_int_items_len_descr();
-    let len_descr_idx = len_descr.index();
-    ctx.trace_ctx
-        .record_op_with_descr(OpCode::SetfieldGc, &[self_ref, new_len], len_descr);
-    ctx.trace_ctx
-        .heapcache_setfield_cached(self_ref, len_descr_idx, new_len);
-
-    // Tracing is execution (pyjitpl.py:2095): apply the append to the
-    // concrete list now (the fold recorded the IR but did not mutate) and
-    // journal the length rewind for a non-commit walk.  The int-spare append
-    // allocates nothing (no realloc by the gate, raw int store), so no GC can
-    // move the operands between recognition and here — `inner_self` / `value`
-    // stay valid, no shadow re-read needed.
-    fbw_append_journal_push(inner_self, len_before);
-    unsafe { pyre_object::w_list_append(inner_self, value) };
-
-    // The Python result is None (a Ref); write it to the 'r' dst so the
-    // trailing POP_TOP has a slot to discard.
-    let none_ref = ctx.trace_ctx.const_ref(pyre_object::w_none() as i64);
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', none_ref)?;
-    Ok(Some(()))
 }
 
 /// #62: walker-native speculative specialization for the `STORE_SUBSCR`
@@ -15164,9 +14893,8 @@ mod tests {
         // The shared by-index `SubJitCodeBody` builder must resolve a
         // build-time charon body (`w_list_append`) to a well-formed body —
         // non-empty bytecode and >= 2 ref registers for the (list, value)
-        // params (calldescr arg_classes 'rr').  (Foundation for the deferred
-        // Route C single-source descent; the shipping `lst.append` arm folds
-        // walker-native instead — see `try_walker_specialize_list_append`.)
+        // params (calldescr arg_classes 'rr').  This body is descended by the
+        // shipping `lst.append` arm (`try_walker_orthodox_list_append`).
         let idx = crate::jitcode_runtime::list_append_jitcode()
             .expect("w_list_append must be present in ALL_JITCODES")
             .index();
@@ -15212,7 +14940,7 @@ mod tests {
         );
 
         // Rollback path: journal push + eager append (production order, see
-        // try_walker_specialize_list_append), then a non-commit exit rewinds
+        // try_walker_orthodox_list_append), then a non-commit exit rewinds
         // the length.
         super::fbw_append_journal_push(list, len_before);
         unsafe { w_list_append(list, w_int_new(50)) };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -876,6 +876,16 @@ pub enum DispatchError {
     /// orthodox `w_list_append` descent over a descr (e.g.
     /// `W_ListObject.strategy`) not yet resolved to its parent descr group.
     FieldDescrMissingParentDescr { pc: usize },
+    /// The orthodox `w_list_append` body sub-walk descended the full append
+    /// (past the strategy switch + `is_plain_int1`, descr-pool resolved) and
+    /// the trace compiles, but the guards it records resume through side-exit
+    /// bridges whose reconstruction is wrong — executing the compiled loop
+    /// jumps to garbage.  This is the sub-walk guard resume/faillocs epic
+    /// (#62/#73/#34) the hand-rolled fold sidesteps with explicit
+    /// `walker_capture_snapshot_for_last_guard` snapshots.  Surfaced here to
+    /// abort the trace gracefully (interpreter fallback) instead of committing
+    /// a trace that SIGSEGVs on its first side exit.  Default OFF.
+    OrthodoxSubWalkTraceUnsupported { pc: usize },
     /// `switch/id` decoded a descr that does not implement
     /// `SwitchDescr`. RPython parity: `pyjitpl.py:601` asserts
     /// `isinstance(switchdict, SwitchDictDescr)`.
@@ -10807,20 +10817,22 @@ static GLOBAL_SUB_JITCODE_LOOKUP_FN: fn(usize) -> Option<SubJitCodeBody> =
 /// BEFORE emitting any IR for a non-matching shape (SAFE fallback to the fold
 /// / residual).
 ///
-/// WIP STATUS (default OFF — inert in production): the descr-pool wiring and
-/// the host-static const relocation are in place — the strategy `switch` and
-/// the inlined `is_int`/`is_bool` type predicates now fold over the concrete
-/// receiver, so the walk descends past `is_plain_int1` into the Integer
-/// fast-path.  The next wall is the `W_ListObject.strategy` (and sibling list)
-/// field descrs carrying no `get_parent_descr()` backreference: recording a
-/// `getfield_gc_*` over them would crash the optimizer's
-/// `ensure_ptr_info_arg0`, so the walk aborts gracefully there
-/// (`FieldDescrMissingParentDescr`) and falls back to the hand-rolled fold.
-/// Resolving those descrs to their parent descr group (extending
-/// `make_descr_from_bh`'s `int_items.*` bridge to the strategy/header fields)
-/// is the `register in-body helpers` infra epic (#171), tracked separately;
-/// until then the gate stays default OFF and the hand-rolled fold below
-/// remains the production path.
+/// WIP STATUS (default OFF — inert in production): the descr-pool wiring, the
+/// host-static const relocation, and the list header field descr-group bridge
+/// (`make_descr_from_bh` strategy/length/items → `W_LIST_DESCR_GROUP`) are all
+/// in place — the strategy `switch` and the inlined `is_int`/`is_bool` type
+/// predicates fold over the concrete receiver, the `W_ListObject.strategy`
+/// read resolves a parent_descr, and the walk descends the full append into the
+/// Integer fast-path and COMPILES.  The remaining wall (wall-5d) is the deep
+/// sub-walk guard resume/faillocs epic (#62/#73/#34): the guards the body walk
+/// records resume through side-exit bridges whose reconstruction is wrong, so
+/// the compiled loop jumps to garbage on its first side exit.  The walk
+/// therefore aborts after descending (`OrthodoxSubWalkTraceUnsupported`,
+/// graceful interpreter fallback) rather than committing that trace;
+/// `PYRE_171_ORTHODOX_COMMIT` opts in to the committing path to reproduce the
+/// SIGSEGV while working on wall-5d.  The hand-rolled fold below — which emits
+/// its guards with explicit `walker_capture_snapshot_for_last_guard` snapshots
+/// — remains the production path until wall-5d is resolved.
 fn try_walker_orthodox_list_append(
     ctx: &mut WalkContext<'_, '_>,
     code: &[u8],
@@ -11040,14 +11052,33 @@ fn try_walker_orthodox_list_append(
         _ => return Err(DispatchError::UnexpectedNonVoidSubReturn { pc: op.pc }),
     }
 
+    // wall-5d (deep, not yet fixed): the body sub-walk now descends the full
+    // append (strategy switch + is_plain_int1 + the Integer-storage fast path)
+    // and the trace compiles, but the guards it records resume through
+    // side-exit bridges whose reconstruction is wrong — executing the compiled
+    // loop jumps to a garbage address.  This is the sub-walk guard
+    // resume/faillocs epic (#62/#73/#34) the hand-rolled fold sidesteps by
+    // emitting its guards with explicit `walker_capture_snapshot_for_last_
+    // guard` snapshots.  Until that is resolved, abort the trace (graceful
+    // interpreter fallback) instead of committing a trace that SIGSEGVs on its
+    // first side exit.  The descr-pool wiring above (strategy/header field
+    // descrs) is exercised on the way to this point, so wall-5c stays closed.
+    // `PYRE_171_ORTHODOX_COMMIT` opts in to the committing path for working on
+    // wall-5d (reproduces the SIGSEGV); default OFF aborts.
+    if std::env::var("PYRE_171_ORTHODOX_COMMIT").is_err() {
+        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op.pc });
+    }
+
     // Tracing is execution: apply the append + journal the rewind (the walker
     // recorded the IR but did not mutate the concrete list).
-    fbw_append_journal_push(inner_self, len_before);
-    unsafe { pyre_object::w_list_append(inner_self, value) };
+    {
+        fbw_append_journal_push(inner_self, len_before);
+        unsafe { pyre_object::w_list_append(inner_self, value) };
 
-    let none_ref = ctx.trace_ctx.const_ref(pyre_object::w_none() as i64);
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', none_ref)?;
-    Ok(Some(()))
+        let none_ref = ctx.trace_ctx.const_ref(pyre_object::w_none() as i64);
+        write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', none_ref)?;
+        Ok(Some(()))
+    }
 }
 
 /// #171 P3: specialize `lst.append(x)` so its array ops (getfield length /

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -3474,7 +3474,8 @@ fn binop_ref_to_int_record(
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 
-/// `ptr_nonzero/r>i` handler (operand layout `r>i`: 1B r-src + 1B i-dst).
+/// `ptr_nonzero/r>i` (`nonzero = true`) and `ptr_iszero/r>i`
+/// (`nonzero = false`) handler (operand layout `r>i`: 1B r-src + 1B i-dst).
 ///
 /// RPython parity:
 /// `pyjitpl.py:378-380 opimpl_ptr_nonzero(box)`:
@@ -3483,28 +3484,45 @@ fn binop_ref_to_int_record(
 /// def opimpl_ptr_nonzero(self, box):
 ///     return self.execute(rop.PTR_NE, box, CONST_NULL)
 /// ```
+/// `opimpl_ptr_iszero` is the `PTR_EQ` complement.
 ///
-/// Walker reads one `r` reg, records `OpCode::PtrNe` with
+/// Walker reads one `r` reg, records `OpCode::PtrNe`/`PtrEq` with
 /// `[box, CONST_NULL]` (via `trace_ctx.const_null()` —
 /// `history.py:361 CONST_NULL = ConstPtr(ConstPtr.value)`), and writes
 /// the recorder result into `registers_i[dst]`.  RPython does the
 /// same `b1 is b2` short-circuit at `pyjitpl.py:328-332` for
-/// `opimpl_ptr_eq` but `ptr_nonzero` against `CONST_NULL` cannot
+/// `opimpl_ptr_eq` but the nullity test against `CONST_NULL` cannot
 /// short-circuit because `box` is never the literal `CONST_NULL`
 /// constant (codewriter would have folded that).
-fn ptr_nonzero_record(
+fn ptr_nullity_record(
     code: &[u8],
     op: &DecodedOp,
     ctx: &mut WalkContext<'_, '_>,
+    nonzero: bool,
 ) -> Result<(DispatchOutcome, usize), DispatchError> {
     let box_ = read_ref_reg(code, op, 0, ctx)?;
     let null_const = ctx.trace_ctx.const_null();
-    let result = ctx.trace_ctx.record_op(OpCode::PtrNe, &[box_, null_const]);
-    // Box(value) parity: stamp the nullity result from the operand's
-    // Box.value carrier (matches dispatch.rs trace_ptr_nullity nonzero=true).
-    if let Some(majit_ir::Value::Ref(r)) = ctx.trace_ctx.box_value(box_) {
+    let opcode = if nonzero { OpCode::PtrNe } else { OpCode::PtrEq };
+    let result = ctx.trace_ctx.record_op(opcode, &[box_, null_const]);
+    // Concrete stamp: prefer the box's own value carrier.  Inside an inline
+    // sub-walk the operand is often a callee argument whose concrete pointer
+    // lives only in the walk's ref-register shadow (seeded by
+    // `run_sub_jitcode_walk` / the inline-call setup), not on the box, so fall
+    // back to that shadow there.  A non-`Ref` shadow (`Null`) means the
+    // pointer is untracked, not provably null — leave the result symbolic.
+    let nonnull = match ctx.trace_ctx.box_value(box_) {
+        Some(majit_ir::Value::Ref(r)) => Some(r.0 != 0),
+        _ if INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get()) => {
+            match read_ref_reg_concrete(code, op, 0, ctx) {
+                ConcreteValue::Ref(p) => Some(!p.is_null()),
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+    if let Some(nonnull) = nonnull {
         ctx.trace_ctx
-            .set_opref_concrete(result, majit_ir::Value::Int((r.0 != 0) as i64));
+            .set_opref_concrete(result, majit_ir::Value::Int((nonnull == nonzero) as i64));
     }
     let dst = code[op.pc + 2] as usize;
     let concrete_for_shadow = concrete_from_recorded_opref(ctx, result);
@@ -13184,7 +13202,8 @@ fn handle(
         }
         "ptr_eq/rr>i" => binop_ref_to_int_record(code, op, ctx, OpCode::PtrEq),
         "ptr_ne/rr>i" => binop_ref_to_int_record(code, op, ctx, OpCode::PtrNe),
-        "ptr_nonzero/r>i" => ptr_nonzero_record(code, op, ctx),
+        "ptr_nonzero/r>i" => ptr_nullity_record(code, op, ctx, true),
+        "ptr_iszero/r>i" => ptr_nullity_record(code, op, ctx, false),
         "ref_guard_value/r" => ref_guard_value_record(code, op, ctx),
         "abort/>r" => {
             // pyre-only result marker: `Assembler::encode_op`'s default

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -866,6 +866,16 @@ pub enum DispatchError {
     /// crash into a graceful trace abort, matching the pre-seam inline
     /// arm whose payload read aborted with `GotoIfNotValueNotConcrete`.
     ResidualCallArgUnbound { pc: usize, arg_index: usize },
+    /// A `getfield_gc_*` cache-miss would record an op whose `FieldDescr`
+    /// carries no `get_parent_descr()` backreference.  The optimizer's
+    /// `ensure_ptr_info_arg0` (`optimizer.py:478-484`) panics rather than
+    /// install a malformed PtrInfo for such a descr, so — like
+    /// `ResidualCallArgUnbound` — surface it here to turn the would-be
+    /// optimizer crash into a graceful trace abort.  Production sub-walks
+    /// never reach this (they would already panic); it fires only on the
+    /// orthodox `w_list_append` descent over a descr (e.g.
+    /// `W_ListObject.strategy`) not yet resolved to its parent descr group.
+    FieldDescrMissingParentDescr { pc: usize },
     /// `switch/id` decoded a descr that does not implement
     /// `SwitchDescr`. RPython parity: `pyjitpl.py:601` asserts
     /// `isinstance(switchdict, SwitchDictDescr)`.
@@ -2848,6 +2858,30 @@ fn getfield_gc_via_heapcache(
         );
         cached
     } else {
+        // Recording a `getfield_gc_*` whose FieldDescr lacks a parent_descr
+        // backreference would later crash the optimizer's
+        // `ensure_ptr_info_arg0` (`optimizer.py:478-484`).  Inside a sub-walk
+        // abort gracefully instead, so the trace falls back to the interpreter
+        // rather than carrying an op the optimizer cannot lower.  The fold
+        // paths above (typeptr / const-pure / cache-hit) record nothing, so
+        // they are unaffected; production sub-walks never reach this (they
+        // would already panic).
+        if INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
+            && matches!(
+                opcode,
+                OpCode::GetfieldGcI
+                    | OpCode::GetfieldGcR
+                    | OpCode::GetfieldGcF
+                    | OpCode::GetfieldGcPureI
+                    | OpCode::GetfieldGcPureR
+                    | OpCode::GetfieldGcPureF
+            )
+            && descr
+                .as_field_descr()
+                .is_some_and(|fd| fd.get_parent_descr().is_none())
+        {
+            return Err(DispatchError::FieldDescrMissingParentDescr { pc: op.pc });
+        }
         // Cache miss — record op + write through.  `box_value`
         // resolves the Box.value chain PyPy reads off
         // `box.getref_base()` in `executor.do_getfield_gc_*`
@@ -10773,18 +10807,20 @@ static GLOBAL_SUB_JITCODE_LOOKUP_FN: fn(usize) -> Option<SubJitCodeBody> =
 /// BEFORE emitting any IR for a non-matching shape (SAFE fallback to the fold
 /// / residual).
 ///
-/// WIP STATUS (default OFF — inert in production): the descr-pool wiring is
-/// correct (the global pool resolves the body's residual_call descr), but
-/// walking the body flag-ON currently SEGVs at the strategy read
-/// (`getfield_gc_r self.strategy` → `getfield_gc_i_pure strategy.tag`,
-/// jitcode pc 12→17): the loaded strategy Ref comes back garbage.  This
-/// canonical *helper* body has never been walked before (unlike opcode-arm
-/// jitcodes), so either its field descrs do not resolve through the global
-/// pool the way arm bodies do, or the shared parent heapcache returns a
-/// stale box across mismatched descr-index spaces.  Resolving that is the
-/// `register in-body helpers` infra epic (#171), tracked separately; until
-/// then the gate stays default OFF and the hand-rolled fold below remains
-/// the production path.
+/// WIP STATUS (default OFF — inert in production): the descr-pool wiring and
+/// the host-static const relocation are in place — the strategy `switch` and
+/// the inlined `is_int`/`is_bool` type predicates now fold over the concrete
+/// receiver, so the walk descends past `is_plain_int1` into the Integer
+/// fast-path.  The next wall is the `W_ListObject.strategy` (and sibling list)
+/// field descrs carrying no `get_parent_descr()` backreference: recording a
+/// `getfield_gc_*` over them would crash the optimizer's
+/// `ensure_ptr_info_arg0`, so the walk aborts gracefully there
+/// (`FieldDescrMissingParentDescr`) and falls back to the hand-rolled fold.
+/// Resolving those descrs to their parent descr group (extending
+/// `make_descr_from_bh`'s `int_items.*` bridge to the strategy/header fields)
+/// is the `register in-body helpers` infra epic (#171), tracked separately;
+/// until then the gate stays default OFF and the hand-rolled fold below
+/// remains the production path.
 fn try_walker_orthodox_list_append(
     ctx: &mut WalkContext<'_, '_>,
     code: &[u8],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13041,7 +13041,36 @@ fn handle(
                 // edge's `ref_copy` parallel-move trampoline (decoded below),
                 // exact for any kept-stack depth.  Plain `while` / `if`
                 // branches resume at depth 0 and carry no kept temp.
-                let resume_depth = branch_resume_target_stack_depth(other_target);
+                //
+                // #171 sub-walk single-frame collapse: inside an inlined-callee
+                // sub-walk that resumes at the caller's CALL boundary,
+                // `other_target` is a *callee* coordinate absent from the outer
+                // jitcode's `pc_map`, so `branch_resume_target_stack_depth`
+                // (which maps through `FULL_BODY_SNAPSHOT_SYM`) would read a
+                // meaningless outer depth at the coincidental offset.  The
+                // collapse guard does not resume at a callee coordinate at all:
+                // like every other single-frame sub-walk guard it collapses to
+                // the caller's CALL boundary (`entry_py_pc` / `outer_active_boxes`,
+                // `walker_capture_snapshot_for_last_guard_impl`), re-executing
+                // the whole call on deopt — so there is no callee kept-stack
+                // slot to recover.  Treat it as depth 0.
+                //
+                // Scope this to the collapse case ONLY: the #68 multiframe
+                // inline path (`PYRE_FBW_INLINE_MULTIFRAME`,
+                // `n_parents == n_callees`, both > 0) resumes the callee at its
+                // OWN pc through `BRANCH_GUARD_JITCODE_PC`
+                // (`walker_capture_multi_frame_inline_snapshot`), so its
+                // kept-stack branches still need the real depth/recovery.
+                let single_frame_collapse = INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get()) && {
+                    let n_parents = FBW_INLINE_PARENT_FRAMES.with(|s| s.borrow().len());
+                    let n_callees = FBW_INLINE_CODE_STACK.with(|s| s.borrow().len());
+                    !(n_parents > 0 && n_parents == n_callees)
+                };
+                let resume_depth = if single_frame_collapse {
+                    None
+                } else {
+                    branch_resume_target_stack_depth(other_target)
+                };
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
                 let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10797,12 +10797,14 @@ fn pyre_171_inline_list_enabled() -> bool {
     std::env::var("PYRE_171_INLINE_LIST").as_deref() != Ok("0")
 }
 
-/// #171 orthodox descent gate (WIP, default OFF — `PYRE_171_ORTHODOX=1`
-/// opts in).  When the resume-coordinate publication for sub-walk guards
-/// is verified correct this replaces the hand-rolled
-/// [`try_walker_specialize_list_append`] below.
+/// #171 orthodox descent gate (default ON — `PYRE_171_ORTHODOX=0` opts
+/// out).  The descent of the real `w_list_append` charon body replaces the
+/// hand-rolled [`try_walker_specialize_list_append`] below; an unresolved
+/// in-body helper still declines via `OrthodoxSubWalkTraceUnsupported`
+/// (graceful interpreter fallback), so a stale build-time jitcode never
+/// commits a wrong trace.
 fn pyre_171_orthodox_enabled() -> bool {
-    std::env::var("PYRE_171_ORTHODOX").as_deref() == Ok("1")
+    std::env::var("PYRE_171_ORTHODOX").as_deref() != Ok("0")
 }
 
 /// Global descr-pool sub-jitcode lookup (resolves a global jitcode index
@@ -10837,30 +10839,20 @@ static GLOBAL_SUB_JITCODE_LOOKUP_FN: fn(usize) -> Option<SubJitCodeBody> =
 /// BEFORE emitting any IR for a non-matching shape (SAFE fallback to the fold
 /// / residual).
 ///
-/// WIP STATUS (default OFF — inert in production): the descr-pool wiring, the
-/// host-static const relocation, and the list header field descr-group bridge
-/// (`make_descr_from_bh` strategy/length/items → `W_LIST_DESCR_GROUP`) are all
-/// in place — the strategy `switch` and the inlined `is_int`/`is_bool` type
-/// predicates fold over the concrete receiver, the `W_ListObject.strategy`
-/// read resolves a parent_descr, and the walk descends the full append into the
-/// Integer fast-path.  The remaining wall (wall-5d) is an un-lowered in-body
-/// helper: `w_list_append` constructs a zero-arg `SyntheticTransparentCtor
-/// "Tuple"` (unit `()`) that the front-end neither folds nor registers in
-/// `jit_trace_fnaddrs()`, so the codewriter mints a `symbolic_fnaddr` hash for
-/// it.  Recording that residual `CallR` into the committed trace makes the
-/// backend bake the hash as a code address and the compiled loop branches to it
-/// -> SIGSEGV (the crash PC equals the hash).  `try_execute_residual_call_via_
-/// executor` now declines (`OrthodoxSubWalkTraceUnsupported`) on any sub-walk
-/// residual whose funcbox is a symbolic (`>>47`) fnaddr, so the descent aborts
-/// gracefully at the first un-lowered helper instead of committing a trace that
-/// jumps to garbage.  Clearing wall-5d means folding/registering that helper
-/// (the #6 INC-4/5 lowering work — the transparent-tuple ctor wants the
-/// `is_synthetic_result_option_ctor` elision extended past single-arg
-/// `Ok`/`Err`/`Some`, or a `NewTuple` lowering).  `PYRE_171_ORTHODOX_COMMIT`
-/// opts past the post-walk blanket abort for a walk that completes with every
-/// helper lowered.  The hand-rolled fold below — which emits its guards with
-/// explicit `walker_capture_snapshot_for_last_guard` snapshots — remains the
-/// production path until the descent commits a working trace.
+/// STATUS (default ON — `PYRE_171_ORTHODOX=0` opts out): the descr-pool
+/// wiring, the host-static const relocation, and the list header field
+/// descr-group bridge (`make_descr_from_bh` strategy/length/items →
+/// `W_LIST_DESCR_GROUP`) are all in place — the strategy `switch` and the
+/// inlined `is_int`/`is_bool` type predicates fold over the concrete receiver,
+/// the `W_ListObject.strategy` read resolves a parent_descr, and the walk
+/// descends the full append into the Integer fast-path.  The unit-`()` return
+/// aggregate (`SyntheticTransparentCtor "Tuple"`) is elided to `ConstRefNull`
+/// at build time (`jtransform.rs`), so the descent completes and commits a
+/// working trace.  Safety net: if a stale build-time jitcode kept that ctor as
+/// a symbolic (`>>47`) fnaddr, `try_execute_residual_call_via_executor`
+/// declines it (`OrthodoxSubWalkTraceUnsupported`) and the descent aborts
+/// gracefully (interpreter fallback) instead of baking the hash as a code
+/// address and branching to garbage.
 fn try_walker_orthodox_list_append(
     ctx: &mut WalkContext<'_, '_>,
     code: &[u8],
@@ -11081,21 +11073,17 @@ fn try_walker_orthodox_list_append(
     }
 
     // Reaching here means the body sub-walk completed without hitting an
-    // un-lowered helper.  wall-5d (not yet cleared): in practice it does not —
-    // `w_list_append` constructs a zero-arg `SyntheticTransparentCtor "Tuple"`
-    // (unit `()`) that is neither folded nor registered in
-    // `jit_trace_fnaddrs()`, so `try_execute_residual_call_via_executor`
-    // declines it (`OrthodoxSubWalkTraceUnsupported`, symbolic `>>47` funcbox)
-    // and `walk_result?` above propagates that abort before this point.
-    // Clearing wall-5d is the #6 INC-4/5 lowering work (fold the transparent
-    // tuple ctor / register the in-body helpers).  The descr-pool wiring above
-    // (strategy/header field descrs) is exercised on the way in, so wall-5c
-    // stays closed.  `PYRE_171_ORTHODOX_COMMIT` opts past this blanket abort so
-    // a walk that DOES complete cleanly (every helper lowered) commits its
-    // trace; default OFF aborts (graceful interpreter fallback).
-    if std::env::var("PYRE_171_ORTHODOX_COMMIT").is_err() {
-        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op.pc });
-    }
+    // un-lowered helper: the strategy switch folded over the concrete
+    // receiver, the `is_plain_int1` leaves recursed, the `ll_list_int_*`
+    // leaves lowered to getfield/setfield/setarrayitem, and the unit-`()`
+    // return aggregate (`SyntheticTransparentCtor "Tuple"`) was elided to
+    // `ConstRefNull` at build time.  Any residual that does NOT lower —
+    // e.g. a stale build-time jitcode whose tuple ctor kept a symbolic
+    // `>>47` funcbox — is declined by `try_execute_residual_call_via_executor`
+    // (`OrthodoxSubWalkTraceUnsupported`) and `walk_result?` propagates that
+    // abort before this point (graceful interpreter fallback, never a wrong
+    // trace).  The descr-pool wiring above (strategy/header field descrs) is
+    // exercised on the way in.
 
     // Tracing is execution: apply the append + journal the rewind (the walker
     // recorded the IR but did not mutate the concrete list).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4569,6 +4569,26 @@ fn try_execute_residual_call_via_executor(
     recorded: OpRef,
     op_pc: usize,
 ) -> Result<Option<Result<i64, i64>>, DispatchError> {
+    // Orthodox sub-jitcode walk safety (#171 wall-5d): a residual call whose
+    // funcbox is a `symbolic_fnaddr` placeholder — a 64-bit `DefaultHasher`
+    // hash of an in-body helper's `CallPath`/`CallTarget`, minted when
+    // `jit_trace_fnaddrs()` has no entry for it (e.g. the zero-arg
+    // `SyntheticTransparentCtor "Tuple"` unit constructor inside
+    // `w_list_append`) — must not be recorded while inlining a sub-jitcode
+    // body.  The production fall-throughs below leave such a call symbolic when
+    // folding declines, on the contract that it runs at runtime against live
+    // state; but a sub-walk's recorded trace is committed and compiled, so the
+    // backend bakes the hash as a code address and the trace branches straight
+    // to it -> SIGSEGV.  Decline the whole descent so it aborts gracefully at
+    // the first un-lowered helper.  A user-space code address fits in 47 bits
+    // on 64-bit macOS/Linux; symbolic hashes set bits >= 47.
+    if INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
+        && allboxes.first().is_some_and(|b| b.is_constant())
+        && let Some(majit_ir::Value::Int(addr)) = ctx.trace_ctx.box_value(allboxes[0])
+        && (addr as u64) >> 47 != 0
+    {
+        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op_pc });
+    }
     // Authoritative-executor gate (#51b/#54): fire ONLY when the walk
     // is the sole concrete-execution leg (production full-body walk and
     // production per-opcode arm walk).  Shadow / diagnostic-probe runs
@@ -10823,16 +10843,24 @@ static GLOBAL_SUB_JITCODE_LOOKUP_FN: fn(usize) -> Option<SubJitCodeBody> =
 /// in place — the strategy `switch` and the inlined `is_int`/`is_bool` type
 /// predicates fold over the concrete receiver, the `W_ListObject.strategy`
 /// read resolves a parent_descr, and the walk descends the full append into the
-/// Integer fast-path and COMPILES.  The remaining wall (wall-5d) is the deep
-/// sub-walk guard resume/faillocs epic (#62/#73/#34): the guards the body walk
-/// records resume through side-exit bridges whose reconstruction is wrong, so
-/// the compiled loop jumps to garbage on its first side exit.  The walk
-/// therefore aborts after descending (`OrthodoxSubWalkTraceUnsupported`,
-/// graceful interpreter fallback) rather than committing that trace;
-/// `PYRE_171_ORTHODOX_COMMIT` opts in to the committing path to reproduce the
-/// SIGSEGV while working on wall-5d.  The hand-rolled fold below — which emits
-/// its guards with explicit `walker_capture_snapshot_for_last_guard` snapshots
-/// — remains the production path until wall-5d is resolved.
+/// Integer fast-path.  The remaining wall (wall-5d) is an un-lowered in-body
+/// helper: `w_list_append` constructs a zero-arg `SyntheticTransparentCtor
+/// "Tuple"` (unit `()`) that the front-end neither folds nor registers in
+/// `jit_trace_fnaddrs()`, so the codewriter mints a `symbolic_fnaddr` hash for
+/// it.  Recording that residual `CallR` into the committed trace makes the
+/// backend bake the hash as a code address and the compiled loop branches to it
+/// -> SIGSEGV (the crash PC equals the hash).  `try_execute_residual_call_via_
+/// executor` now declines (`OrthodoxSubWalkTraceUnsupported`) on any sub-walk
+/// residual whose funcbox is a symbolic (`>>47`) fnaddr, so the descent aborts
+/// gracefully at the first un-lowered helper instead of committing a trace that
+/// jumps to garbage.  Clearing wall-5d means folding/registering that helper
+/// (the #6 INC-4/5 lowering work — the transparent-tuple ctor wants the
+/// `is_synthetic_result_option_ctor` elision extended past single-arg
+/// `Ok`/`Err`/`Some`, or a `NewTuple` lowering).  `PYRE_171_ORTHODOX_COMMIT`
+/// opts past the post-walk blanket abort for a walk that completes with every
+/// helper lowered.  The hand-rolled fold below — which emits its guards with
+/// explicit `walker_capture_snapshot_for_last_guard` snapshots — remains the
+/// production path until the descent commits a working trace.
 fn try_walker_orthodox_list_append(
     ctx: &mut WalkContext<'_, '_>,
     code: &[u8],
@@ -11052,19 +11080,19 @@ fn try_walker_orthodox_list_append(
         _ => return Err(DispatchError::UnexpectedNonVoidSubReturn { pc: op.pc }),
     }
 
-    // wall-5d (deep, not yet fixed): the body sub-walk now descends the full
-    // append (strategy switch + is_plain_int1 + the Integer-storage fast path)
-    // and the trace compiles, but the guards it records resume through
-    // side-exit bridges whose reconstruction is wrong — executing the compiled
-    // loop jumps to a garbage address.  This is the sub-walk guard
-    // resume/faillocs epic (#62/#73/#34) the hand-rolled fold sidesteps by
-    // emitting its guards with explicit `walker_capture_snapshot_for_last_
-    // guard` snapshots.  Until that is resolved, abort the trace (graceful
-    // interpreter fallback) instead of committing a trace that SIGSEGVs on its
-    // first side exit.  The descr-pool wiring above (strategy/header field
-    // descrs) is exercised on the way to this point, so wall-5c stays closed.
-    // `PYRE_171_ORTHODOX_COMMIT` opts in to the committing path for working on
-    // wall-5d (reproduces the SIGSEGV); default OFF aborts.
+    // Reaching here means the body sub-walk completed without hitting an
+    // un-lowered helper.  wall-5d (not yet cleared): in practice it does not —
+    // `w_list_append` constructs a zero-arg `SyntheticTransparentCtor "Tuple"`
+    // (unit `()`) that is neither folded nor registered in
+    // `jit_trace_fnaddrs()`, so `try_execute_residual_call_via_executor`
+    // declines it (`OrthodoxSubWalkTraceUnsupported`, symbolic `>>47` funcbox)
+    // and `walk_result?` above propagates that abort before this point.
+    // Clearing wall-5d is the #6 INC-4/5 lowering work (fold the transparent
+    // tuple ctor / register the in-body helpers).  The descr-pool wiring above
+    // (strategy/header field descrs) is exercised on the way in, so wall-5c
+    // stays closed.  `PYRE_171_ORTHODOX_COMMIT` opts past this blanket abort so
+    // a walk that DOES complete cleanly (every helper lowered) commits its
+    // trace; default OFF aborts (graceful interpreter fallback).
     if std::env::var("PYRE_171_ORTHODOX_COMMIT").is_err() {
         return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op.pc });
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2801,7 +2801,38 @@ fn getfield_gc_via_heapcache(
         None
     };
 
-    let result = if let Some(constant) = const_pure_result {
+    // heaptracker.py:66 special-cases the `typeptr` field: once a GUARD_CLASS
+    // has pinned an object's class, reading its typeptr yields the known
+    // class constant.  Inside an inline sub-walk the receiver's concrete
+    // pointer often lives only in the register shadow (not the box value), so
+    // the const-pure path above misses; fold the typeptr read straight from
+    // the heapcache's known class instead.  This lets inlined type predicates
+    // (`is_int`/`is_bool`, which read the typeptr and compare it against a
+    // type address) fold during the walk.
+    let is_typeptr_field = descr
+        .as_field_descr()
+        .is_some_and(|fd| fd.offset() == pyre_object::pyobject::OB_TYPE_OFFSET);
+    let typeptr_const = if INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
+        && !obj.is_constant()
+        && is_typeptr_field
+    {
+        let known = ctx.trace_ctx.heap_cache().get_known_class(obj);
+        match (known, opcode) {
+            (Some(cls), OpCode::GetfieldGcI | OpCode::GetfieldGcPureI) => {
+                Some(ctx.trace_ctx.const_int(cls))
+            }
+            (Some(cls), OpCode::GetfieldGcR | OpCode::GetfieldGcPureR) => {
+                Some(ctx.trace_ctx.const_ref(cls))
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    let result = if let Some(folded) = typeptr_const {
+        folded
+    } else if let Some(constant) = const_pure_result {
         constant
     } else if let Some(cached) = ctx.trace_ctx.heapcache_getfield_cached(obj, descr_index) {
         // Cache hit (RPython pyjitpl.py:929-947 _opimpl_getfield_gc_any_pureornot):
@@ -10859,6 +10890,24 @@ fn try_walker_orthodox_list_append(
         self_ref,
         majit_ir::Value::Ref(majit_ir::GcRef(inner_self as usize)),
     );
+
+    // Pin the appended value's class so the inlined `is_plain_int1` type
+    // predicate folds during the sub-walk: guard_class(value, INT_TYPE) +
+    // class_now_known, so its `is_int`/`is_bool` typeptr reads fold to the
+    // INT_TYPE const (the typeptr fold in `getfield_gc_via_heapcache`).  The
+    // recognition gate already proved `is_plain_int1(value)`; this guard
+    // enforces ob_type==INT_TYPE at runtime.  The value's integer payload
+    // stays symbolic — only its class is pinned.
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    if !value_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(value_op) {
+        let type_const = ctx.trace_ctx.const_int(int_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[value_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(value_op, int_type_addr);
 
     // Pre-publish the ONE call-site resume coordinate the sub-walk's guards
     // collapse to (mirror the full-body path's last_instr / valuestackdepth

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -72,6 +72,11 @@ fn load_all_jitcodes() -> &'static [Arc<JitCode>] {
     // still 1 here, no consumer has cloned yet — using
     // `pyre_interpreter::jit_trace_fnaddrs()`'s runtime values.
     crate::runtime_fnaddr_patch::patch_constants_i_fnaddrs(&mut vec);
+    // The codewriter also baked stale build-time host-static *data* addresses
+    // (`PyType` singletons + prebuilt refs from `HostStaticAddrs`) into
+    // `constants_i` — e.g. `is_int`'s `&INT_TYPE` inlined into `w_list_append`.
+    // Re-pair them with the runtime addresses while refcount is still 1.
+    crate::runtime_fnaddr_patch::patch_static_addr_constants(&mut vec);
     // Deferred prebuilt-string constants the codewriter could not allocate
     // at build time (separate process) carry a non-canonical sentinel in
     // `constants_r`; materialize their immortal STR blocks and overwrite the

--- a/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
+++ b/pyre/pyre-jit-trace/src/runtime_fnaddr_patch.rs
@@ -110,6 +110,85 @@ pub fn patch_constants_i_fnaddrs(jitcodes: &mut Vec<Arc<JitCode>>) {
     }
 }
 
+/// Build-time `(name, build_addr)` snapshot for the host `PyType` singleton
+/// pointers the codewriter baked into `constants_i` (supplied through
+/// `HostStaticAddrs.pytypes`). Same ASLR hazard + bincode round-trip as
+/// [`build_time_fnaddr_bindings`].
+fn build_time_pytype_bindings() -> Vec<(String, i64)> {
+    const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/static_pytype_bindings.bin"));
+    bincode::deserialize(BYTES).unwrap_or_else(|e| {
+        panic!(
+            "pyre-jit-trace: failed to deserialize static_pytype_bindings.bin ({} bytes): {e}",
+            BYTES.len(),
+        )
+    })
+}
+
+/// Build-time `(name, build_addr)` snapshot for the prebuilt ref singletons
+/// (`HostStaticAddrs.refs`).
+fn build_time_ref_bindings() -> Vec<(String, i64)> {
+    const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/static_ref_bindings.bin"));
+    bincode::deserialize(BYTES).unwrap_or_else(|e| {
+        panic!(
+            "pyre-jit-trace: failed to deserialize static_ref_bindings.bin ({} bytes): {e}",
+            BYTES.len(),
+        )
+    })
+}
+
+/// Rewrite stale build-time host-static addresses (`PyType` singletons and
+/// prebuilt refs) the codewriter baked into the constant pools.  Mirrors
+/// [`patch_constants_i_fnaddrs`] for the `HostStaticAddrs` *data* the body
+/// references directly — e.g. `is_int`'s `ptr::eq((*obj).ob_type, &INT_TYPE)`
+/// inlined into the `w_list_append` body, whose `&INT_TYPE` const was captured
+/// in the build-script process and ASLR-invalidated at runtime.  Re-pairs each
+/// build address with the runtime address from `jit_static_pytype_addrs` /
+/// `jit_static_ref_addrs`, keyed by the shared name.  Both pools are scanned:
+/// a host static used as a pointer-`eq` operand materializes as a `GcRef`
+/// constant in `constants_r`, while one consumed as an integer lands in
+/// `constants_i`.  `JitCode.fnaddr` is left untouched (these are data, not
+/// call targets).
+pub fn patch_static_addr_constants(jitcodes: &mut Vec<Arc<JitCode>>) {
+    let mut runtime_map: HashMap<&'static str, i64> = HashMap::new();
+    runtime_map.extend(pyre_interpreter::jit_static_pytype_addrs());
+    runtime_map.extend(pyre_interpreter::jit_static_ref_addrs());
+
+    let mut correspondence: HashMap<i64, i64> = HashMap::new();
+    for (name, build_addr) in build_time_pytype_bindings()
+        .into_iter()
+        .chain(build_time_ref_bindings())
+    {
+        if let Some(&runtime_addr) = runtime_map.get(name.as_str()) {
+            if build_addr != runtime_addr {
+                correspondence.insert(build_addr, runtime_addr);
+            }
+        }
+    }
+
+    if correspondence.is_empty() {
+        return;
+    }
+
+    for arc in jitcodes.iter_mut() {
+        let jc = Arc::get_mut(arc).expect(
+            "patch_static_addr_constants: Arc<JitCode> already shared before patch — \
+             every caller must run this before publishing the table to consumers",
+        );
+        if jc.try_body().is_some() {
+            let body = jc.body_mut();
+            for c in body
+                .constants_i
+                .iter_mut()
+                .chain(body.constants_r.iter_mut())
+            {
+                if let Some(&runtime) = correspondence.get(c) {
+                    *c = runtime;
+                }
+            }
+        }
+    }
+}
+
 /// High 16 bits of a deferred prebuilt-string sentinel (see
 /// [`majit_translate::assembler::STR_CONST_SENTINEL_BASE`]).  x86-64 user
 /// addresses occupy `0..2^48`, so a real GCREF / host-static address always


### PR DESCRIPTION
Continues #171 (trace the real `w_list_append` builtin callee via the codewriter-lowered jitcode body, eventually retiring the hand-rolled `try_walker_specialize_list_append` fold). The whole descent stays behind a default-OFF flag (`PYRE_171_ORTHODOX=1`, with `PYRE_171_ORTHODOX_COMMIT=1` opting into the committing path) — **inert in the default build**. With both flags on, the int-list-append-in-loop case now compiles to the same optimal IR as the hand-rolled fold.

Seven commits over `main`, clearing walls 5a–5e of the descent:

**wall-5a — pointer predicate / type-check folding**
1. **`jit: lower raw-pointer is_null to ptr_iszero in codewriter + walker`** — the body's `*mut T` null checks lowered to an unwired op; route them to `ptr_iszero`.
2. **`jit: fold core::ptr::eq to ptr_eq + typeptr reads to known class in sub-walks`** — `is_int`/`is_bool`'s `ptr::eq((*obj).ob_type, &INT_TYPE)` now folds over the concrete receiver (typeptr read → known class), so `is_plain_int1` resolves and the descent reaches the Integer fast path.

**wall-5b — host-static const ASLR relocation**
3. **`jit: relocate host-static pytype/ref consts in jitcode constant pools at runtime`** — the codewriter bakes `&INT_TYPE`/`&BOOL_TYPE`/`&LONG_TYPE` (HostStaticAddrs.pytypes/refs) into `JitCodeBody.constants_{i,r}` as **build-script-process** addresses; ASLR invalidates them at runtime (the exact hazard `patch_constants_i_fnaddrs` already fixes for funcptrs, but no patch existed for pytype/ref data). Mirror the fnaddr patch: serialize the build-time addrs to `.bin` alongside the body, re-pair build→runtime by name, and rewrite **both** `constants_i` AND `constants_r` (pytype refs used as `ptr_eq` operands materialize as `GcRef` in `constants_r`, which the fnaddr patch never scanned).

**wall-5c — list header field descrs**
4. **`jit: bridge codewriter list header field descrs to W_LIST_DESCR_GROUP; abort orthodox sub-walk at wall-5d`** — `W_ListObject` is a runtime Rust type absent from the codewriter struct layouts, so `strategy`/`length`/`items` (and the `int_items.*` leaves) resolve to offset 0 with no `parent_descr` (optimizer `ensure_ptr_info_arg0` panic). `make_descr_from_bh` maps them to the canonical `W_LIST_DESCR_GROUP` entries the walker-native specializations already use.

**wall-5d — symbolic-fnaddr residual call (was misdiagnosed as a resume epic)**
5. **`jit: decline #171 orthodox sub-walk residual calls to symbolic fnaddrs`** — a residual `CallR` to an un-lowered in-body helper carries a `DefaultHasher` `symbolic_fnaddr` (bits ≥ 47); recording it into a committed trace makes the backend bake the hash as a code address → branch-to-garbage SIGSEGV. `try_execute_residual_call_via_executor` now declines (graceful `OrthodoxSubWalkTraceUnsupported`) when an `INLINE_SUBWALK_CAPTURE_BOUNDARY` residual call's funcbox is a `>>47` constant.
6. **`jit: fold zero-arg transparent Tuple ctor to a null-ref result`** — the specific helper above was `w_list_append`'s unit `()` return, lowered to a zero-arg `SyntheticTransparentCtor "Tuple"`. `jtransform` now folds it to `ConstRefNull` (a unit has no fields). Production-visible, but those bodies would otherwise be latent symbolic-fnaddr SIGSEGVs.

**wall-5e — box payload descr identity**
7. **`jit: resolve codewriter box payload field descrs to walker W_*_DESCR_GROUP entries`** — the codewriter reads the appended box's payload through its struct-layout `SimpleFieldDescr` (`W_IntObject.intval` `index_in_parent=2`, header modeled), but the walker materializes that box through the single-field `W_INT_DESCR_GROUP` (`index 0`). Same offset, different descr objects; the optimizer's virtual-field cache keys on descr identity, so the sub-walk read missed the virtual → the box was forced and the field read was scheduled before the `SetfieldGc` that initializes `intval` → stored uninitialized `0`. `make_descr_from_bh` now maps `W_IntObject.intval` / `W_BoolObject.intval` / `W_FloatObject.floatval` to the canonical group entries. The optimized loop then folds the box away entirely and stores the unboxed counter directly (`SetarrayitemGc(block, idx, v85)`), matching the hand-rolled fold.

## Verification
- `python3 pyre/check.py`: dynasm 139/139 + cranelift 139/139 (default mode).
- `cargo test -p pyre-jit-trace`: 273/0 (incl. new `make_descr_from_bh_bridges_codewriter_box_payload_fields_to_group`, Arc::ptr_eq).
- Orthodox repro (both backends): `PYRE_171_ORTHODOX=1 PYRE_171_ORTHODOX_COMMIT=1` output == default for the int-list-append loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)