### PR TITLE
wasm JIT: GC-collecting nursery + growable shared-table foundation

### DIFF
--- a/majit/majit-backend-wasm/js/jit_glue.js
+++ b/majit/majit-backend-wasm/js/jit_glue.js
@@ -65,8 +65,11 @@ export function jit_compile_wasm(bytesPtr, bytesLen) {
   // Check if the module needs jit_call import
   // (wasm-encoder adds it when trace has CALL ops)
   try {
+    // `__indirect_function_table` is reserved for inter-trace call_indirect
+    // chaining; the module imports it only when it has CALL ops. Extra
+    // entries in the import object are ignored when not declared.
     const instance = new WebAssembly.Instance(module, {
-      env: { memory: mainMemory, jit_call: jitCallTrampoline }
+      env: { memory: mainMemory, jit_call: jitCallTrampoline, __indirect_function_table: mainTable }
     });
     const id = nextFuncId++;
     funcTable[id] = instance.exports.trace;

--- a/majit/majit-backend-wasm/js/jit_glue.js
+++ b/majit/majit-backend-wasm/js/jit_glue.js
@@ -71,33 +71,30 @@ export function jit_compile_wasm(bytesPtr, bytesLen) {
     const instance = new WebAssembly.Instance(module, {
       env: { memory: mainMemory, jit_call: jitCallTrampoline, __indirect_function_table: mainTable }
     });
-    const id = nextFuncId++;
-    funcTable[id] = instance.exports.trace;
-    registerTraceInTable(instance.exports.trace);
-    return id;
+    return registerTrace(instance.exports.trace);
   } catch (e) {
     // Retry without jit_call (for traces without CALL ops)
     const instance = new WebAssembly.Instance(module, {
       env: { memory: mainMemory }
     });
-    const id = nextFuncId++;
-    funcTable[id] = instance.exports.trace;
-    return id;
+    return registerTrace(instance.exports.trace);
   }
 }
 
-// Append a compiled trace to the shared indirect function table so it is
-// reachable by table index, mirroring the wasmtime host. Reserved for
-// inter-trace call_indirect chaining; execute still dispatches directly via
-// funcTable.
-function registerTraceInTable(traceFn) {
-  if (!mainTable) return;
-  try {
-    const slot = mainTable.grow(1);
-    mainTable.set(slot, traceFn);
-  } catch (e) {
-    console.error('[jit_compile] table registration failed:', e);
+// Append a compiled trace to the shared indirect function table and use its
+// table slot as the id, mirroring the wasmtime host. The slot is both the
+// jit_execute_wasm handle and the index an in-module call_indirect targets.
+// Falls back to a private counter when no table is available.
+function registerTrace(traceFn) {
+  let id;
+  if (mainTable) {
+    id = mainTable.grow(1);
+    mainTable.set(id, traceFn);
+  } else {
+    id = nextFuncId++;
   }
+  funcTable[id] = traceFn;
+  return id;
 }
 
 export function jit_execute_wasm(funcId, framePtr) {

--- a/majit/majit-backend-wasm/js/jit_glue.js
+++ b/majit/majit-backend-wasm/js/jit_glue.js
@@ -73,6 +73,7 @@ export function jit_compile_wasm(bytesPtr, bytesLen) {
     });
     const id = nextFuncId++;
     funcTable[id] = instance.exports.trace;
+    registerTraceInTable(instance.exports.trace);
     return id;
   } catch (e) {
     // Retry without jit_call (for traces without CALL ops)
@@ -82,6 +83,20 @@ export function jit_compile_wasm(bytesPtr, bytesLen) {
     const id = nextFuncId++;
     funcTable[id] = instance.exports.trace;
     return id;
+  }
+}
+
+// Append a compiled trace to the shared indirect function table so it is
+// reachable by table index, mirroring the wasmtime host. Reserved for
+// inter-trace call_indirect chaining; execute still dispatches directly via
+// funcTable.
+function registerTraceInTable(traceFn) {
+  if (!mainTable) return;
+  try {
+    const slot = mainTable.grow(1);
+    mainTable.set(slot, traceFn);
+  } catch (e) {
+    console.error('[jit_compile] table registration failed:', e);
   }
 }
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -42,6 +42,20 @@ const CALL_ARGS_OFS: u64 = 2024;
 /// Minimum frame allocation size in bytes to accommodate the call area.
 pub const MIN_FRAME_BYTES: usize = 2024 + 16 * 8; // 16 max call args
 
+/// Byte offset of the Ref-home region within the frame. Each Ref-typed value
+/// (input arg or op result) is given a dedicated home slot here: it is
+/// null-initialized at trace entry and written on every definition
+/// (store-on-def), so a home slot only ever holds null or a valid GcRef.
+/// A (future) collecting allocation registers these slots as GC roots and
+/// forwards them, then the trace reloads the live Ref locals from their homes
+/// — making object movement transparent without precise liveness.
+///
+/// Placed past the call area so it never overlaps the fail-index / input /
+/// output slots (which sit below the call area at offset 2000) or the call
+/// trampoline area. Inert while `wasm_jit_alloc` is no-collect (epic B): the
+/// extra stores write a region nothing reads until the allocator collects.
+pub const HOME_SLOT_BASE: u64 = MIN_FRAME_BYTES as u64;
+
 fn mem64(offset: u64) -> MemArg {
     MemArg {
         offset,
@@ -289,6 +303,36 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
     (guards, max_var)
 }
 
+/// Assign each Ref-typed value (input arg or op result) a dense home-slot
+/// index, keyed by its value id (`raw()`), the same id its wasm local uses
+/// (`1 + raw`). Input args and op results share one value-id space (see
+/// `collect_guards_and_vars`), so a single map covers both. Int / Float /
+/// Void values are skipped — only GC references need a forwarding home.
+fn collect_ref_homes(inputargs: &[InputArg], ops: &[Op]) -> HashMap<u32, u32> {
+    let mut homes = HashMap::new();
+    let mut next: u32 = 0;
+    for ia in inputargs {
+        if ia.tp == Type::Ref {
+            homes.entry(ia.index).or_insert_with(|| {
+                let h = next;
+                next += 1;
+                h
+            });
+        }
+    }
+    for op in ops {
+        let r = op.pos.get();
+        if r != OpRef::NONE && !r.is_constant() && op.result_type() == Type::Ref {
+            homes.entry(r.raw()).or_insert_with(|| {
+                let h = next;
+                next += 1;
+                h
+            });
+        }
+    }
+    homes
+}
+
 /// Build a wasm module from majit IR.
 pub fn build_wasm_module(
     inputargs: &[InputArg],
@@ -299,8 +343,10 @@ pub fn build_wasm_module(
     guard_gc_type_info: &GuardGcTypeInfo,
     alloc_fn_ptr: i64,
     alloc_array_fn_ptr: i64,
-) -> Result<(Vec<u8>, Vec<GuardExit>), BackendError> {
+) -> Result<(Vec<u8>, Vec<GuardExit>, usize), BackendError> {
     let (guards, num_vars) = collect_guards_and_vars(inputargs, ops);
+    let ref_homes = collect_ref_homes(inputargs, ops);
+    let num_ref_homes = ref_homes.len();
     let needs_call = has_call_ops(ops);
 
     let mut module = Module::new();
@@ -374,11 +420,12 @@ pub fn build_wasm_module(
         guard_gc_type_info,
         alloc_fn_ptr,
         alloc_array_fn_ptr,
+        &ref_homes,
     )?;
     codes.function(&func);
     module.section(&codes);
 
-    Ok((module.finish(), guards))
+    Ok((module.finish(), guards, num_ref_homes))
 }
 
 fn build_function(
@@ -392,6 +439,7 @@ fn build_function(
     guard_gc_type_info: &GuardGcTypeInfo,
     alloc_fn_ptr: i64,
     alloc_array_fn_ptr: i64,
+    ref_homes: &HashMap<u32, u32>,
 ) -> Result<Function, BackendError> {
     // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
     // locals past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) as scratch for
@@ -399,13 +447,26 @@ fn build_function(
     let mut func = Function::new(vec![(num_vars + UMULHI_SCRATCH, ValType::I64)]);
     let mut sink = func.instructions();
 
-    // Load inputs from frame into locals
+    // Null-init every Ref-home slot so a slot read before its value is defined
+    // is null (forwarding-safe), not a stale word from the reused host frame.
+    for h in 0..ref_homes.len() as u64 {
+        sink.local_get(0);
+        sink.i64_const(0);
+        sink.i64_store(mem64(HOME_SLOT_BASE + h * SLOT_SIZE));
+    }
+
+    // Load inputs from frame into locals, and store Ref inputs to their homes.
     for ia in inputargs {
         let local_idx = 1 + ia.index;
         let offset = FRAME_SLOT_BASE + ia.index as u64 * SLOT_SIZE;
         sink.local_get(0)
             .i64_load(mem64(offset))
             .local_set(local_idx);
+        if let Some(&h) = ref_homes.get(&ia.index) {
+            sink.local_get(0);
+            sink.local_get(local_idx);
+            sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
+        }
     }
 
     // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
@@ -1629,6 +1690,19 @@ fn build_function(
                     )));
                 }
             }
+        }
+
+        // store-on-def: mirror a freshly-defined Ref result into its home slot
+        // so a (future) collecting allocation can forward it. The local
+        // `1 + raw` holds the value the matched arm just set; `ref_homes` only
+        // keys Ref-typed value ids, so non-Ref / void / constant ops are
+        // skipped. Each value-producing arm is operand-stack-neutral, so this
+        // appended store is balanced.
+        let result = op.pos.get();
+        if let Some(&h) = ref_homes.get(&result.raw()) {
+            sink.local_get(0);
+            sink.local_get(1 + result.raw());
+            sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
         }
     }
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -21,7 +21,8 @@ use majit_gc::header::{GcHeader, TYPE_ID_MASK};
 use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
 use wasm_encoder::{
     BlockType, CodeSection, EntityType, ExportKind, ExportSection, Function, FunctionSection,
-    ImportSection, InstructionSink, MemArg, MemoryType, Module, TypeSection, ValType,
+    ImportSection, InstructionSink, MemArg, MemoryType, Module, RefType, TableType, TypeSection,
+    ValType,
 };
 
 /// Frame slot byte offset: slot[i] is at frame_ptr + 8 + i * 8.
@@ -330,6 +331,21 @@ pub fn build_wasm_module(
     if needs_call {
         // Import jit_call trampoline as function index 0
         imports.import("env", "jit_call", EntityType::Function(1));
+        // Import the host's shared indirect function table as table index 0.
+        // Inert for now: reserved for inter-trace `call_indirect` chaining;
+        // nothing in the trace body references it yet, so behavior is
+        // unchanged. The host registers each compiled trace into this table.
+        imports.import(
+            "env",
+            "__indirect_function_table",
+            EntityType::Table(TableType {
+                element_type: RefType::FUNCREF,
+                table64: false,
+                minimum: 0,
+                maximum: None,
+                shared: false,
+            }),
+        );
     }
     module.section(&imports);
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -179,6 +179,90 @@ fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
         .unwrap_or((8, true))
 }
 
+/// Maps each Ref-typed value (input arg / op result) to a compact home-slot
+/// index `0..len`, where its current `GcRef` is mirrored into the frame's
+/// GC-root region (`HOME_SLOT_BASE + home * 8`) so a collecting allocation
+/// inside the trace can forward it.
+///
+/// Keyed by value id (`OpRef::raw()` / input `index`), which is the dense
+/// `[0, num_vars)` space the wasm value locals already use (`1 + raw`); a flat
+/// vector indexed by that id is the natural fit — no hashing, and iteration is
+/// in id order, so the emitted module stays deterministic without sorting. The
+/// `is_constant` guard lives in one place (`home`): a constant `raw()` is a
+/// distinct namespace that must never alias a value's home.
+struct RefHomes {
+    /// `by_id[raw] = home index`, or `NONE` where the value is not a Ref home.
+    /// Sized to the last Ref id; queries for higher ids miss via `get`.
+    by_id: Vec<u32>,
+    len: usize,
+}
+
+impl RefHomes {
+    const NONE: u32 = u32::MAX;
+
+    fn assign(by_id: &mut Vec<u32>, next: &mut u32, id: u32) {
+        let i = id as usize;
+        if i >= by_id.len() {
+            by_id.resize(i + 1, Self::NONE);
+        }
+        if by_id[i] == Self::NONE {
+            by_id[i] = *next;
+            *next += 1;
+        }
+    }
+
+    fn collect(inputargs: &[InputArg], ops: &[Op]) -> Self {
+        let mut by_id = Vec::new();
+        let mut next = 0u32;
+        for ia in inputargs {
+            if ia.tp == Type::Ref {
+                Self::assign(&mut by_id, &mut next, ia.index);
+            }
+        }
+        for op in ops {
+            let r = op.pos.get();
+            if r != OpRef::NONE && !r.is_constant() && op.result_type() == Type::Ref {
+                Self::assign(&mut by_id, &mut next, r.raw());
+            }
+        }
+        RefHomes {
+            by_id,
+            len: next as usize,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Home index of value id `id` (caller guarantees it is a value, not a
+    /// constant — e.g. an input-arg index).
+    fn home_id(&self, id: u32) -> Option<u32> {
+        match self.by_id.get(id as usize) {
+            Some(&h) if h != Self::NONE => Some(h),
+            _ => None,
+        }
+    }
+
+    /// Home index of `v`, or `None` if it is a constant or not a Ref home.
+    fn home(&self, v: OpRef) -> Option<u32> {
+        if v.is_constant() {
+            return None;
+        }
+        self.home_id(v.raw())
+    }
+
+    /// `(value id, home index)` pairs in id order (deterministic).
+    fn iter(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.by_id
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|&(_, h)| h != Self::NONE)
+            .map(|(id, h)| (id as u32, h))
+    }
+}
+
 /// Argument index of the stored value for a GC ref-storing op. `SetfieldRaw` /
 /// `SetarrayitemRaw` store into non-GC memory and never need a write barrier,
 /// so only the `*Gc` variants are listed (rewrite.py only routes `SETFIELD_GC`
@@ -198,18 +282,16 @@ fn ref_store_value_arg(op: &Op) -> Option<usize> {
 /// `handle_write_barrier_setfield` gate `v.type == 'r' and not ConstPtr`: a
 /// constant reference is an immortal/old object whose store never makes the base
 /// point to young, so it needs no barrier (rewrite.py:930-931).
-fn write_barrier_base(op: &Op, ref_homes: &HashMap<u32, u32>) -> Option<OpRef> {
+fn write_barrier_base(op: &Op, ref_homes: &RefHomes) -> Option<OpRef> {
     let val = op.arg(ref_store_value_arg(op)?).to_opref();
-    if !val.is_constant() && ref_homes.contains_key(&val.raw()) {
-        Some(op.arg(0).to_opref())
-    } else {
-        None
-    }
+    // `home` returns `None` for a constant value, matching the gate's
+    // `not ConstPtr`.
+    ref_homes.home(val).map(|_| op.arg(0).to_opref())
 }
 
 /// Whether any op in the trace needs a write-barrier trampoline call, which
 /// requires the `jit_call` import to be present.
-fn has_ref_store_op(ops: &[Op], ref_homes: &HashMap<u32, u32>) -> bool {
+fn has_ref_store_op(ops: &[Op], ref_homes: &RefHomes) -> bool {
     ops.iter()
         .any(|op| write_barrier_base(op, ref_homes).is_some())
 }
@@ -252,19 +334,15 @@ fn emit_write_barrier(
 /// liveness. Over-reloading a dead Ref is harmless (it is never read again).
 fn emit_reload_refs_from_homes(
     sink: &mut InstructionSink<'_>,
-    ref_homes: &HashMap<u32, u32>,
+    ref_homes: &RefHomes,
     skip_raw: Option<u32>,
 ) {
-    let mut entries: Vec<(u32, u32)> = Vec::with_capacity(ref_homes.len());
-    for (&raw, &h) in ref_homes {
-        if Some(raw) != skip_raw {
-            entries.push((raw, h));
+    // `iter` yields id order, so the emitted module is reproducible without a
+    // sort; each reload is independent (home and local storage are disjoint).
+    for (raw, h) in ref_homes.iter() {
+        if Some(raw) == skip_raw {
+            continue;
         }
-    }
-    // Deterministic order (each reload is independent — home and local storage
-    // are disjoint — but sorted output keeps the emitted module reproducible).
-    entries.sort_unstable();
-    for (raw, h) in entries {
         sink.local_get(0);
         sink.i64_load(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
         sink.local_set(1 + raw);
@@ -406,31 +484,6 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
 /// (`1 + raw`). Input args and op results share one value-id space (see
 /// `collect_guards_and_vars`), so a single map covers both. Int / Float /
 /// Void values are skipped — only GC references need a forwarding home.
-fn collect_ref_homes(inputargs: &[InputArg], ops: &[Op]) -> HashMap<u32, u32> {
-    let mut homes = HashMap::new();
-    let mut next: u32 = 0;
-    for ia in inputargs {
-        if ia.tp == Type::Ref {
-            homes.entry(ia.index).or_insert_with(|| {
-                let h = next;
-                next += 1;
-                h
-            });
-        }
-    }
-    for op in ops {
-        let r = op.pos.get();
-        if r != OpRef::NONE && !r.is_constant() && op.result_type() == Type::Ref {
-            homes.entry(r.raw()).or_insert_with(|| {
-                let h = next;
-                next += 1;
-                h
-            });
-        }
-    }
-    homes
-}
-
 /// Build a wasm module from majit IR.
 pub fn build_wasm_module(
     inputargs: &[InputArg],
@@ -451,7 +504,11 @@ pub fn build_wasm_module(
     // value slots would reach the call area must be declined, or those stores
     // silently clobber the call trampoline / home roots. (Pre-existing for the
     // call area; the home region inherits the same bound.)
-    let max_fail_args = guards.iter().map(|g| g.fail_arg_refs.len()).max().unwrap_or(0);
+    let max_fail_args = guards
+        .iter()
+        .map(|g| g.fail_arg_refs.len())
+        .max()
+        .unwrap_or(0);
     let max_value_slots = 1 + max_fail_args.max(inputargs.len());
     if max_value_slots as u64 > CALL_AREA_FIRST_SLOT {
         return Err(BackendError::Unsupported(format!(
@@ -460,7 +517,7 @@ pub fn build_wasm_module(
         )));
     }
 
-    let ref_homes = collect_ref_homes(inputargs, ops);
+    let ref_homes = RefHomes::collect(inputargs, ops);
     let num_ref_homes = ref_homes.len();
     // A ref-storing store needs the `jit_call` import for its write barrier,
     // even when the trace has no `New*`/CALL of its own.
@@ -558,7 +615,7 @@ fn build_function(
     alloc_fn_ptr: i64,
     alloc_array_fn_ptr: i64,
     wb_fn_ptr: i64,
-    ref_homes: &HashMap<u32, u32>,
+    ref_homes: &RefHomes,
 ) -> Result<Function, BackendError> {
     // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
     // locals past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) as scratch for
@@ -581,7 +638,7 @@ fn build_function(
         sink.local_get(0)
             .i64_load(mem64(offset))
             .local_set(local_idx);
-        if let Some(&h) = ref_homes.get(&ia.index) {
+        if let Some(h) = ref_homes.home_id(ia.index) {
             sink.local_get(0);
             sink.local_get(local_idx);
             sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
@@ -643,7 +700,7 @@ fn build_function(
                 // iteration's reload-after-allocation sees the current value
                 // (not the previous iteration's).
                 for la in label_args.iter().take(n) {
-                    if let Some(&h) = ref_homes.get(&la.raw()) {
+                    if let Some(h) = ref_homes.home(*la) {
                         sink.local_get(0);
                         sink.local_get(1 + la.raw());
                         sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
@@ -1859,7 +1916,7 @@ fn build_function(
         // skipped. Each value-producing arm is operand-stack-neutral, so this
         // appended store is balanced.
         let result = op.pos.get();
-        if let Some(&h) = ref_homes.get(&result.raw()) {
+        if let Some(h) = ref_homes.home(result) {
             sink.local_get(0);
             sink.local_get(1 + result.raw());
             sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -173,6 +173,98 @@ fn array_item_size_sign_from_descr(op: &Op) -> (usize, bool) {
         .unwrap_or((8, true))
 }
 
+/// Argument index of the stored value for a GC ref-storing op. `SetfieldRaw` /
+/// `SetarrayitemRaw` store into non-GC memory and never need a write barrier,
+/// so only the `*Gc` variants are listed (rewrite.py only routes `SETFIELD_GC`
+/// / `SETARRAYITEM_GC` / `SETINTERIORFIELD_GC` through the barrier).
+fn ref_store_value_arg(op: &Op) -> Option<usize> {
+    match op.opcode {
+        OpCode::SetfieldGc => Some(1),
+        OpCode::SetarrayitemGc | OpCode::SetinteriorfieldGc => Some(2),
+        _ => None,
+    }
+}
+
+/// If `op` stores a (non-constant) reference into a GC object, return the base
+/// object operand that must be passed through the write barrier; otherwise
+/// `None`. A value is a reference exactly when it has a Ref home slot
+/// (`ref_homes` keys every Ref-typed input/result). This mirrors the native
+/// `handle_write_barrier_setfield` gate `v.type == 'r' and not ConstPtr`: a
+/// constant reference is an immortal/old object whose store never makes the base
+/// point to young, so it needs no barrier (rewrite.py:930-931).
+fn write_barrier_base(op: &Op, ref_homes: &HashMap<u32, u32>) -> Option<OpRef> {
+    let val = op.arg(ref_store_value_arg(op)?).to_opref();
+    if !val.is_constant() && ref_homes.contains_key(&val.raw()) {
+        Some(op.arg(0).to_opref())
+    } else {
+        None
+    }
+}
+
+/// Whether any op in the trace needs a write-barrier trampoline call, which
+/// requires the `jit_call` import to be present.
+fn has_ref_store_op(ops: &[Op], ref_homes: &HashMap<u32, u32>) -> bool {
+    ops.iter()
+        .any(|op| write_barrier_base(op, ref_homes).is_some())
+}
+
+/// Emit a write-barrier trampoline call on `base_ref` before a ref-storing
+/// field/array store. The host helper `wasm_jit_write_barrier` checks
+/// TRACK_YOUNG_PTRS and remembers an old→young store, standing in for the
+/// `COND_CALL_GC_WB` the native GC rewrite pass inserts. Operand-stack-neutral:
+/// every push is consumed by a store or the call.
+fn emit_write_barrier(
+    sink: &mut InstructionSink<'_>,
+    constants: &majit_ir::VecAssoc<u32, i64>,
+    jit_call: u32,
+    wb_fn_ptr: i64,
+    base_ref: OpRef,
+) {
+    // func_ptr = wasm_jit_write_barrier
+    sink.local_get(0);
+    sink.i64_const(wb_fn_ptr);
+    sink.i64_store(mem64(CALL_FUNC_OFS));
+    // num_args = 1 (the trampoline reflects arity from the wasm signature;
+    // written for protocol symmetry with the alloc/call paths)
+    sink.local_get(0);
+    sink.i64_const(1);
+    sink.i64_store(mem64(CALL_NARGS_OFS));
+    // arg0 = base object pointer
+    sink.local_get(0);
+    emit_resolve(sink, constants, base_ref);
+    sink.i64_store(mem64(CALL_ARGS_OFS));
+    // call trampoline; void result ignored
+    sink.local_get(0);
+    sink.call(jit_call);
+}
+
+/// Reload every live Ref local from its home slot, optionally skipping one
+/// value id (`skip_raw` — the freshly-allocated result, whose home is not yet
+/// written). Emitted after a collecting allocation: the collection forwarded
+/// the home slots (registered as GC roots), so reloading the locals makes
+/// object movement transparent to the trace without precise per-safepoint
+/// liveness. Over-reloading a dead Ref is harmless (it is never read again).
+fn emit_reload_refs_from_homes(
+    sink: &mut InstructionSink<'_>,
+    ref_homes: &HashMap<u32, u32>,
+    skip_raw: Option<u32>,
+) {
+    let mut entries: Vec<(u32, u32)> = Vec::with_capacity(ref_homes.len());
+    for (&raw, &h) in ref_homes {
+        if Some(raw) != skip_raw {
+            entries.push((raw, h));
+        }
+    }
+    // Deterministic order (each reload is independent — home and local storage
+    // are disjoint — but sorted output keeps the emitted module reproducible).
+    entries.sort_unstable();
+    for (raw, h) in entries {
+        sink.local_get(0);
+        sink.i64_load(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
+        sink.local_set(1 + raw);
+    }
+}
+
 /// llsupport/gc.py:563 GcLLDescr_framework
 ///   .get_typeid_from_classptr_if_gcremovetypeptr(classptr)
 /// Looks up the materialized table populated by the runner from the
@@ -343,11 +435,14 @@ pub fn build_wasm_module(
     guard_gc_type_info: &GuardGcTypeInfo,
     alloc_fn_ptr: i64,
     alloc_array_fn_ptr: i64,
+    wb_fn_ptr: i64,
 ) -> Result<(Vec<u8>, Vec<GuardExit>, usize), BackendError> {
     let (guards, num_vars) = collect_guards_and_vars(inputargs, ops);
     let ref_homes = collect_ref_homes(inputargs, ops);
     let num_ref_homes = ref_homes.len();
-    let needs_call = has_call_ops(ops);
+    // A ref-storing store needs the `jit_call` import for its write barrier,
+    // even when the trace has no `New*`/CALL of its own.
+    let needs_call = has_call_ops(ops) || has_ref_store_op(ops, &ref_homes);
 
     let mut module = Module::new();
 
@@ -420,6 +515,7 @@ pub fn build_wasm_module(
         guard_gc_type_info,
         alloc_fn_ptr,
         alloc_array_fn_ptr,
+        wb_fn_ptr,
         &ref_homes,
     )?;
     codes.function(&func);
@@ -439,6 +535,7 @@ fn build_function(
     guard_gc_type_info: &GuardGcTypeInfo,
     alloc_fn_ptr: i64,
     alloc_array_fn_ptr: i64,
+    wb_fn_ptr: i64,
     ref_homes: &HashMap<u32, u32>,
 ) -> Result<Function, BackendError> {
     // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
@@ -517,6 +614,18 @@ fn build_function(
                 }
                 for i in (0..n).rev() {
                     sink.local_set(1 + label_args[i].raw());
+                }
+                // The parallel move rebinds loop-carried locals without going
+                // through store-on-def, so any Ref label arg's home slot is now
+                // stale. Refresh it before branching back, so the next
+                // iteration's reload-after-allocation sees the current value
+                // (not the previous iteration's).
+                for la in label_args.iter().take(n) {
+                    if let Some(&h) = ref_homes.get(&la.raw()) {
+                        sink.local_get(0);
+                        sink.local_get(1 + la.raw());
+                        sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
+                    }
                 }
                 sink.br(0);
             }
@@ -910,6 +1019,11 @@ fn build_function(
                 }
             }
             OpCode::SetfieldGc | OpCode::SetfieldRaw => {
+                if let (Some(jit_call), Some(base)) =
+                    (jit_call_idx, write_barrier_base(op, ref_homes))
+                {
+                    emit_write_barrier(&mut sink, constants, jit_call, wb_fn_ptr, base);
+                }
                 emit_resolve(&mut sink, constants, op.arg(0).to_opref()); // struct ptr
                 sink.i32_wrap_i64();
                 let field_offset = field_offset_from_descr(op);
@@ -989,6 +1103,11 @@ fn build_function(
                 }
             }
             OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
+                if let (Some(jit_call), Some(base)) =
+                    (jit_call_idx, write_barrier_base(op, ref_homes))
+                {
+                    emit_write_barrier(&mut sink, constants, jit_call, wb_fn_ptr, base);
+                }
                 emit_array_addr(&mut sink, constants, op);
                 emit_resolve(&mut sink, constants, op.arg(2).to_opref()); // value
                 // A Ref item is pointer-width (4 bytes on wasm32). Storing a
@@ -1029,6 +1148,11 @@ fn build_function(
                 }
             }
             OpCode::SetinteriorfieldGc => {
+                if let (Some(jit_call), Some(base)) =
+                    (jit_call_idx, write_barrier_base(op, ref_homes))
+                {
+                    emit_write_barrier(&mut sink, constants, jit_call, wb_fn_ptr, base);
+                }
                 emit_resolve(&mut sink, constants, op.arg(0).to_opref());
                 sink.i32_wrap_i64();
                 let field_offset = field_offset_from_descr(op);
@@ -1491,6 +1615,11 @@ fn build_function(
                     sink.i64_load(mem64(CALL_RESULT_OFS));
                     sink.local_set(1 + vi);
                 }
+                // No reload after a residual call: the interpreter's host-side
+                // allocations use the *no-collect* nursery hook (their callers
+                // hold unrooted raw pointers), so a residual callee never moves
+                // objects. Only `New*` (which uses the collecting allocator)
+                // needs a reload.
             }
 
             // ── Allocation (via trampoline — treated as CALL) ──
@@ -1555,6 +1684,12 @@ fn build_function(
                         });
                     }
                 }
+                // The collecting allocation may have moved every other live
+                // Ref; reload them from their (forwarded) homes. Skip the fresh
+                // result — it was allocated after the collection and its home is
+                // written by store-on-def below.
+                let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
+                emit_reload_refs_from_homes(&mut sink, ref_homes, skip);
             }
             OpCode::NewArray | OpCode::NewArrayClear => {
                 let jit_call = jit_call_idx.expect("NewArray op present but jit_call not imported");
@@ -1606,6 +1741,9 @@ fn build_function(
                     sink.i64_load(mem64(CALL_RESULT_OFS));
                     sink.local_set(1 + vi);
                 }
+                // `wasm_jit_alloc_array` collects; reload other live Refs.
+                let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
+                emit_reload_refs_from_homes(&mut sink, ref_homes, skip);
             }
 
             // ── Misc ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -35,6 +35,12 @@ const UMULHI_SCRATCH: u32 = 5;
 
 /// Call area layout (fixed offsets from frame_ptr).
 const CALL_RESULT_OFS: u64 = 2000;
+/// First frame *slot* index occupied by the fixed call area. Frame value slots
+/// (inputs at entry, fail-arg spills at guard exit) occupy `[1, 1 + max(num
+/// inputs, max fail args))`; they must stay below this index, or they clobber
+/// the call area and — past `HOME_SLOT_BASE` — the Ref-home region. A trace that
+/// would exceed it is declined in `build_wasm_module`.
+pub const CALL_AREA_FIRST_SLOT: u64 = CALL_RESULT_OFS / SLOT_SIZE;
 const CALL_FUNC_OFS: u64 = 2008;
 const CALL_NARGS_OFS: u64 = 2016;
 const CALL_ARGS_OFS: u64 = 2024;
@@ -438,6 +444,22 @@ pub fn build_wasm_module(
     wb_fn_ptr: i64,
 ) -> Result<(Vec<u8>, Vec<GuardExit>, usize), BackendError> {
     let (guards, num_vars) = collect_guards_and_vars(inputargs, ops);
+
+    // Frame value slots (inputs at entry, fail-arg spills at guard exit) occupy
+    // `[1, 1 + max(num inputs, max fail args))`. They sit below the fixed call
+    // area and the Ref-home region, which are at constant offsets; a trace whose
+    // value slots would reach the call area must be declined, or those stores
+    // silently clobber the call trampoline / home roots. (Pre-existing for the
+    // call area; the home region inherits the same bound.)
+    let max_fail_args = guards.iter().map(|g| g.fail_arg_refs.len()).max().unwrap_or(0);
+    let max_value_slots = 1 + max_fail_args.max(inputargs.len());
+    if max_value_slots as u64 > CALL_AREA_FIRST_SLOT {
+        return Err(BackendError::Unsupported(format!(
+            "wasm backend: {max_value_slots} frame value slots reach the call area \
+             (limit {CALL_AREA_FIRST_SLOT})"
+        )));
+    }
+
     let ref_homes = collect_ref_homes(inputargs, ops);
     let num_ref_homes = ref_homes.len();
     // A ref-storing store needs the `jit_call` import for its write barrier,

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -71,4 +71,8 @@ pub struct CompiledWasmLoop {
     pub fail_descrs: Vec<Arc<WasmFailDescr>>,
     pub num_inputs: usize,
     pub max_output_slots: usize,
+    /// Number of Ref-typed values given a home slot in the frame's Ref-home
+    /// region (`codegen::HOME_SLOT_BASE`). `execute_token` sizes the host
+    /// frame to include this region and registers each home slot as a GC root.
+    pub num_ref_homes: usize,
 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -154,8 +154,18 @@ fn wasm_alloc_oldgen_typed(type_id: u32, size: usize) -> GcRef {
 /// lands in the table) and invokes it with `(type_id, size)`. Returns the new
 /// object pointer, or 0 when no GC is installed. The `ob_type` field for
 /// `NewWithVtable` is written inline by codegen at `vtable_offset`.
+///
+/// Unlike the general [`wasm_alloc_nursery_typed`] host hook (which must not
+/// collect — its callers hold unrooted raw pointers), this JIT-trace path is
+/// safe to collect: the trace registers every live Ref's frame home slot as a
+/// GC root and reloads its locals from the (forwarded) homes after each
+/// allocation. So it uses the *collecting* `alloc_nursery_typed`, which
+/// triggers a minor collection on nursery-full instead of leaking to old-gen.
 pub extern "C" fn wasm_jit_alloc(type_id: i64, size: i64) -> i64 {
-    wasm_alloc_nursery_typed(type_id as u32, size as usize).0 as i64
+    WASM_ACTIVE_GC.with(|cell| match cell.borrow_mut().as_deref_mut() {
+        Some(gc) => gc.alloc_nursery_typed(type_id as u32, size as usize).0 as i64,
+        None => 0,
+    })
 }
 
 /// JIT-trace variable-size allocation trampoline target for `NewArray` /
@@ -192,6 +202,22 @@ pub extern "C" fn wasm_jit_alloc_array(
     })
 }
 
+/// JIT-trace write-barrier trampoline target for ref-storing `SetfieldGc` /
+/// `SetarrayitemGc` / `SetinteriorfieldGc`. Routes through the host `jit_call`
+/// trampoline; invokes the active GC's `write_barrier`, which adds an old
+/// object that may now hold a young reference to the remembered set (and clears
+/// TRACK_YOUNG_PTRS). A young base (no flag) or a null base is a no-op. wasm
+/// skips the native GC rewrite pass, so the trace emits this barrier directly
+/// instead of `COND_CALL_GC_WB`. Returns 0 — the store codegen ignores it.
+pub extern "C" fn wasm_jit_write_barrier(obj: i64) -> i64 {
+    WASM_ACTIVE_GC.with(|cell| {
+        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
+            gc.write_barrier(GcRef(obj as usize));
+        }
+    });
+    0
+}
+
 /// Host-side root-register trampoline.
 ///
 /// # Safety
@@ -212,6 +238,19 @@ fn wasm_gc_remove_root(slot: *mut GcRef) {
         let mut guard = cell.borrow_mut();
         if let Some(gc) = guard.as_deref_mut() {
             gc.remove_root(slot);
+        }
+    });
+}
+
+/// Host-side write-barrier trampoline for the interpreter (mapdict / list /
+/// set / dict stores route through `majit_gc::gc_write_barrier`). Mirrors
+/// `dynasm_gc_write_barrier`; without it every interpreter ref-store is a
+/// silent no-op, so a collecting nursery loses old→young pointers.
+fn wasm_active_gc_write_barrier(obj: GcRef) {
+    WASM_ACTIVE_GC.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        if let Some(gc) = guard.as_deref_mut() {
+            gc.write_barrier(obj);
         }
     });
 }
@@ -301,6 +340,7 @@ impl WasmBackend {
         majit_gc::set_active_alloc_oldgen_typed(Some(wasm_alloc_oldgen_typed));
         majit_gc::set_active_root_hooks(Some(wasm_gc_add_root), Some(wasm_gc_remove_root));
         majit_gc::set_active_gc_owns_object(Some(wasm_gc_owns_object));
+        majit_gc::set_active_write_barrier(Some(wasm_active_gc_write_barrier));
     }
 
     /// llmodel.py:64-69 self.vtable_offset configuration.
@@ -447,8 +487,6 @@ unsafe impl Send for WasmBackend {}
 fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
     let mut has_label = false;
     let mut has_jump = false;
-    let mut has_new = false;
-    let mut has_call = false;
     for op in ops {
         if op.opcode.is_call_assembler() {
             // CALL_ASSEMBLER enters another trace's compiled token; the wasm
@@ -461,11 +499,6 @@ fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
         match op.opcode {
             majit_ir::OpCode::Label => has_label = true,
             majit_ir::OpCode::Jump => has_jump = true,
-            majit_ir::OpCode::New
-            | majit_ir::OpCode::NewWithVtable
-            | majit_ir::OpCode::NewArray
-            | majit_ir::OpCode::NewArrayClear => has_new = true,
-            opcode if opcode.is_call() => has_call = true,
             _ => {}
         }
     }
@@ -473,17 +506,6 @@ fn wasm_unsupported_trace_reason(ops: &[Op]) -> Option<String> {
     // no enclosing loop block, yielding invalid wasm.
     if has_jump && !has_label {
         return Some("wasm backend: JUMP to external loop (no local LABEL)".into());
-    }
-    // A loop that BOTH allocates and makes residual calls every iteration grows
-    // the heap without bound (the wasm backend has no GC malloc-nursery rewrite,
-    // so wasm_jit_alloc never collects) while the host-trampoline calls keep it
-    // running long enough to exhaust memory. Decline so the interpreter (with
-    // its GC) runs the loop. An all-inline allocating loop (no residual call)
-    // stays compiled: it is fast and its bounded run does not exhaust memory.
-    if has_label && has_new && has_call {
-        return Some(
-            "wasm backend: allocation + residual call in loop trace (no GC nursery)".into(),
-        );
     }
     None
 }
@@ -612,6 +634,7 @@ impl majit_backend::Backend for WasmBackend {
         // index on wasm32; taking it here keeps the function in the table.
         let alloc_fn_ptr = wasm_jit_alloc as *const () as usize as i64;
         let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
+        let wb_fn_ptr = wasm_jit_write_barrier as *const () as usize as i64;
         let (wasm_bytes, guard_exits, num_ref_homes) = codegen::build_wasm_module(
             inputargs,
             ops,
@@ -621,6 +644,7 @@ impl majit_backend::Backend for WasmBackend {
             &guard_gc_type_info,
             alloc_fn_ptr,
             alloc_array_fn_ptr,
+            wb_fn_ptr,
         )?;
 
         // Build fail descriptors

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -733,6 +733,19 @@ impl majit_backend::Backend for WasmBackend {
         }
         #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
         {
+            // Register each Ref-home slot (codegen::HOME_SLOT_BASE region) as a
+            // GC root so a collecting allocation inside the trace (epic B)
+            // forwards the live refs. A home slot only ever holds null (its
+            // entry init) or a valid GcRef (store-on-def), so forwarding is
+            // always safe without precise liveness. Inert while wasm_jit_alloc
+            // is no-collect: no collection runs during the trace, so the roots
+            // are registered and removed without ever being consulted.
+            let home_base = codegen::HOME_SLOT_BASE as usize / 8;
+            for h in 0..compiled.num_ref_homes {
+                let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
+                unsafe { wasm_gc_add_root(slot) };
+            }
+
             // The pending-exception cell is global, unlike the native
             // per-jitframe `jf_guard_exc`. A residual raise on a blackhole
             // resume path (publish_residual_call_exception) writes it outside
@@ -741,6 +754,13 @@ impl majit_backend::Backend for WasmBackend {
             // exception from a previous frame's resume as this trace's.
             jit_exc_clear();
             glue::execute(compiled.func_handle, _frame_ptr);
+
+            // Companion to the add_root loop above: drop the home-slot roots
+            // now the trace has returned (the host frame is freed on return).
+            for h in 0..compiled.num_ref_homes {
+                let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
+                wasm_gc_remove_root(slot);
+            }
 
             // A GuardNoException / GuardException exit leaves the pending
             // exception in the global slot; capture and clear it here so

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -761,9 +761,13 @@ impl majit_backend::Backend for WasmBackend {
             // GC root so a collecting allocation inside the trace (epic B)
             // forwards the live refs. A home slot only ever holds null (its
             // entry init) or a valid GcRef (store-on-def), so forwarding is
-            // always safe without precise liveness. Inert while wasm_jit_alloc
-            // is no-collect: no collection runs during the trace, so the roots
-            // are registered and removed without ever being consulted.
+            // always safe without precise liveness.
+            //
+            // No RAII guard is needed for the removal below: the path from here
+            // to `wasm_gc_remove_root` is straight-line (no `?`/early return),
+            // and the wasm32 build is `panic=abort`, so `glue::execute` cannot
+            // unwind past this frame — a trap aborts the process rather than
+            // leaking the roots.
             let home_base = codegen::HOME_SLOT_BASE as usize / 8;
             for h in 0..compiled.num_ref_homes {
                 let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -612,7 +612,7 @@ impl majit_backend::Backend for WasmBackend {
         // index on wasm32; taking it here keeps the function in the table.
         let alloc_fn_ptr = wasm_jit_alloc as *const () as usize as i64;
         let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
-        let (wasm_bytes, guard_exits) = codegen::build_wasm_module(
+        let (wasm_bytes, guard_exits, num_ref_homes) = codegen::build_wasm_module(
             inputargs,
             ops,
             &self.constants,
@@ -658,6 +658,7 @@ impl majit_backend::Backend for WasmBackend {
             fail_descrs,
             num_inputs: inputargs.len(),
             max_output_slots,
+            num_ref_homes,
         };
 
         token.compiled = Some(Box::new(compiled));
@@ -704,10 +705,13 @@ impl majit_backend::Backend for WasmBackend {
             .downcast_ref::<CompiledWasmLoop>()
             .expect("not CompiledWasmLoop");
 
-        // Allocate frame area large enough for slots + call trampoline area.
-        // MIN_FRAME_BYTES accommodates the call area at offset 2000+.
+        // Allocate frame area large enough for slots + call trampoline area +
+        // the Ref-home region. MIN_FRAME_BYTES accommodates the call area at
+        // offset 2000+; the Ref-home region (`codegen::HOME_SLOT_BASE`) follows
+        // it, one slot per Ref-typed value (`num_ref_homes`).
         let min_slots = codegen::MIN_FRAME_BYTES / 8;
-        let frame_size = min_slots.max(1 + compiled.max_output_slots.max(compiled.num_inputs));
+        let base_slots = min_slots.max(1 + compiled.max_output_slots.max(compiled.num_inputs));
+        let frame_size = base_slots + compiled.num_ref_homes;
         let mut frame = vec![0i64; frame_size];
 
         // Write inputs to frame[1..]

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -52,6 +52,7 @@ fn test_empty_trace() {
         &codegen::GuardGcTypeInfo::default(),
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -107,6 +108,7 @@ fn test_int_add_loop() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
         0,
         0,
     )
@@ -168,6 +170,7 @@ fn test_float_ops() {
         &codegen::GuardGcTypeInfo::default(),
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -201,6 +204,7 @@ fn test_call_generates_import() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
         0,
         0,
     )
@@ -295,6 +299,7 @@ fn test_guard_types() {
         &codegen::GuardGcTypeInfo::default(),
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -337,6 +342,7 @@ fn test_exception_guards() {
         &codegen::GuardGcTypeInfo::default(),
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -373,6 +379,7 @@ fn test_guard_gc_type_uses_immediate_typeid() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
         0,
         0,
     )
@@ -435,6 +442,7 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
         &enabled_guard_gc_type_info(),
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
@@ -483,6 +491,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         &info,
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
@@ -496,6 +505,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         Some(8),
         &HashMap::new(),
         &info,
+        0,
         0,
         0,
     )
@@ -562,6 +572,7 @@ fn test_sameas_and_conversions() {
         &codegen::GuardGcTypeInfo::default(),
         0,
         0,
+        0,
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -610,6 +621,7 @@ fn test_overflow_ops() {
         Some(0),
         &HashMap::new(),
         &codegen::GuardGcTypeInfo::default(),
+        0,
         0,
         0,
     )

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -43,7 +43,7 @@ fn test_empty_trace() {
         op
     }];
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -100,7 +100,7 @@ fn test_int_add_loop() {
         Op::new(OpCode::Jump, &[rb(OpRef::int_op(3)), rb(OpRef::int_op(2))]),
     ];
 
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -159,7 +159,7 @@ fn test_float_ops() {
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -194,7 +194,7 @@ fn test_call_generates_import() {
         },
     ];
 
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -286,7 +286,7 @@ fn test_guard_types() {
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -328,7 +328,7 @@ fn test_exception_guards() {
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -366,7 +366,7 @@ fn test_guard_gc_type_uses_immediate_typeid() {
         Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
     ];
 
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -426,7 +426,7 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -474,7 +474,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
     info.subclass_ranges.insert(0xCAFE, (10, 20));
 
     // gcremovetypeptr branch: vtable_offset = None.
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -489,7 +489,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
     assert_eq!(guards.len(), 1);
 
     // vtable-load branch: vtable_offset = Some(...).
-    let (bytes2, _) = codegen::build_wasm_module(
+    let (bytes2, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -553,7 +553,7 @@ fn test_sameas_and_conversions() {
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, _) = codegen::build_wasm_module(
+    let (bytes, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -603,7 +603,7 @@ fn test_overflow_ops() {
     ];
 
     let constants: majit_ir::VecAssoc<u32, i64> = majit_ir::VecAssoc::new();
-    let (bytes, guards) = codegen::build_wasm_module(
+    let (bytes, guards, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1120,15 +1120,17 @@ def main():
 
         B = BENCH_DIR
 
-        # These heavy benchmarks are structurally slow on wasm and cannot meet
-        # the native-tuned timeouts, so skip them for wasm (they still produce
-        # correct output). Two distinct causes:
+        # These heavy benchmarks produce correct output on wasm but cannot meet
+        # the native-tuned timeouts, so skip them for wasm. Two distinct causes:
         #   * fib_recursive: recursion compiles once but pays an interpreter
         #     round-trip per call (no inter-trace call_indirect chaining yet),
         #     ~265s for ~30M calls.
         #   * raise_catch / nbody / fannkuch: per-iteration allocation (exception
-        #     / float / list objects); with no wasm GC nursery these loops are
-        #     correctly declined to the interpreter.
+        #     / float / list objects). These now JIT-compile and collect through
+        #     the wasm GC nursery (epic B) — verified correct via the synthetic
+        #     suite's allocation tests and scaled runs — but at full bench scale
+        #     they are far slower than native (raise_catch ~100M iters) and
+        #     fannkuch at DEFAULT_ARG=9 exceeds the wasm linear-memory budget.
         # wasm correctness is covered by the lighter real benchmarks below and
         # the synthetic suite.
         WASM_TOO_SLOW = ("wasm",)

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -115,8 +115,13 @@ WASM_MODULE_PATH = "target/wasm32-unknown-unknown/release/pyre_wasm.wasm-host.wa
 # panic, so the build needs neither unwinding nor `-Z build-std`: it runs on the
 # precompiled wasm32 std with the default `panic=abort`, on the stable toolchain.
 # `--export-table` exposes the indirect-call table the runner patches for JIT
-# re-entry; `getrandom_backend="custom"` selects the no-import getrandom backend.
-WASM_RUSTFLAGS = '-C link-arg=--export-table --cfg getrandom_backend="custom"'
+# re-entry; `--growable-table` drops its fixed maximum so the host can append
+# compiled trace functions for inter-trace call_indirect chaining;
+# `getrandom_backend="custom"` selects the no-import getrandom backend.
+WASM_RUSTFLAGS = (
+    '-C link-arg=--export-table -C link-arg=--growable-table '
+    '--cfg getrandom_backend="custom"'
+)
 # Stable toolchain, no build-std. Kept as a (possibly empty) arg list so the
 # build invocation can splat it uniformly.
 WASM_CARGO_TOOLCHAIN = []

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1120,11 +1120,17 @@ def main():
 
         B = BENCH_DIR
 
-        # The wasm backend recompiles every trace through cranelift at runtime
-        # inside the sandbox, so these heavy benchmarks run ~100x slower than
-        # native (e.g. fib_recursive ~265s) and cannot meet the native timeouts;
-        # skip them for wasm. wasm correctness is covered by the lighter real
-        # benchmarks below and the synthetic suite.
+        # These heavy benchmarks are structurally slow on wasm and cannot meet
+        # the native-tuned timeouts, so skip them for wasm (they still produce
+        # correct output). Two distinct causes:
+        #   * fib_recursive: recursion compiles once but pays an interpreter
+        #     round-trip per call (no inter-trace call_indirect chaining yet),
+        #     ~265s for ~30M calls.
+        #   * raise_catch / nbody / fannkuch: per-iteration allocation (exception
+        #     / float / list objects); with no wasm GC nursery these loops are
+        #     correctly declined to the interpreter.
+        # wasm correctness is covered by the lighter real benchmarks below and
+        # the synthetic suite.
         WASM_TOO_SLOW = ("wasm",)
 
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1115,17 +1115,28 @@ def main():
 
         B = BENCH_DIR
 
-        #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py  skip
+        # The wasm backend recompiles every trace through cranelift at runtime
+        # inside the sandbox, so these heavy benchmarks run ~100x slower than
+        # native (e.g. fib_recursive ~265s) and cannot meet the native timeouts;
+        # skip them for wasm. wasm correctness is covered by the lighter real
+        # benchmarks below and the synthetic suite.
+        WASM_TOO_SLOW = ("wasm",)
+
+        #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    2)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
         chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       4,       2,       4)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
-        chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       13,      2,       13)
+        chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       13,      2,       13,
+                      skip_backends=WASM_TOO_SLOW)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
-        chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,       None,    2)
+        chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,       None,    2,
+                      skip_backends=WASM_TOO_SLOW)
         chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",        5,       2,       7,       2,       7)
-        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       3,       None,    3,       None)
-        chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None)
+        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       3,       None,    3,       None,
+                      skip_backends=WASM_TOO_SLOW)
+        chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       None,
+                      skip_backends=WASM_TOO_SLOW)
 
     if not args.no_synthetic:
         print()

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -228,6 +228,14 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             return Err(e);
         }
     };
+    if std::env::var_os("PYRE_WASM_JIT_STATS").is_some() {
+        use std::sync::atomic::Ordering::Relaxed;
+        eprintln!(
+            "[jit-stats] compiles={} executes={}",
+            JIT_COMPILE_COUNT.load(Relaxed),
+            JIT_EXECUTE_COUNT.load(Relaxed),
+        );
+    }
     let out_ptr = (packed >> 32) as u32;
     let out_len = (packed & 0xffff_ffff) as u32;
 
@@ -489,7 +497,11 @@ fn host_read(
 
 /// Compile and instantiate a JIT-emitted trace module, sharing the main
 /// module's linear memory and wiring the `jit_call` trampoline.
+static JIT_COMPILE_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static JIT_EXECUTE_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) -> Result<u32> {
+    JIT_COMPILE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let memory = caller
         .data()
         .memory
@@ -562,6 +574,7 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
 
 /// Run a previously compiled trace, returning its guard-exit index.
 fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
+    JIT_EXECUTE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let trace = *caller
         .data()
         .traces

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -81,6 +81,12 @@ struct Host {
     /// from (`$PYRE_STDLIB`, forwarded by `pyre/check.py`). The wasm side
     /// seeds it on `sys.path`, so the host serves genuine absolute paths.
     stdlib_root: Option<String>,
+    /// `PYRE_WASM_JIT_STATS` diagnostic counters: trace modules compiled /
+    /// executed this run. Per-store (not a global static) because they are
+    /// per-run state like `traces` — the increment sites already hold the
+    /// `Caller<Host>`, and the runner is single-threaded.
+    jit_compile_count: u64,
+    jit_execute_count: u64,
 }
 
 fn main() {
@@ -231,11 +237,10 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
         }
     };
     if std::env::var_os("PYRE_WASM_JIT_STATS").is_some() {
-        use std::sync::atomic::Ordering::Relaxed;
+        let host = store.data();
         eprintln!(
             "[jit-stats] compiles={} executes={}",
-            JIT_COMPILE_COUNT.load(Relaxed),
-            JIT_EXECUTE_COUNT.load(Relaxed),
+            host.jit_compile_count, host.jit_execute_count,
         );
     }
     let out_ptr = (packed >> 32) as u32;
@@ -505,11 +510,9 @@ fn host_read(
 
 /// Compile and instantiate a JIT-emitted trace module, sharing the main
 /// module's linear memory and wiring the `jit_call` trampoline.
-static JIT_COMPILE_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static JIT_EXECUTE_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) -> Result<u32> {
-    JIT_COMPILE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    caller.data_mut().jit_compile_count += 1;
     let memory = caller
         .data()
         .memory
@@ -588,7 +591,7 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
 
 /// Run a previously compiled trace, returning its guard-exit index.
 fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
-    JIT_EXECUTE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    caller.data_mut().jit_execute_count += 1;
     if !caller.data().traces.contains_key(&func_id) {
         return Err(Error::msg(format!(
             "jit_execute_wasm: unknown func id {func_id}"

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -71,8 +71,10 @@ struct Host {
     memory: Option<Memory>,
     /// The main module's `__indirect_function_table`, used by the trampoline.
     table: Option<Table>,
-    /// Compiled trace `trace` functions, keyed by the id handed back to wasm.
-    traces: HashMap<u32, Func>,
+    /// Compiled traces, keyed by the id handed back to wasm. The value is the
+    /// `trace` function and its index in the shared `__indirect_function_table`
+    /// (where the host registers it for inter-trace `call_indirect` dispatch).
+    traces: HashMap<u32, (Func, u32)>,
     next_id: u32,
     /// Real stdlib root the wasm module's `pyre_host.*` imports read source
     /// from (`$PYRE_STDLIB`, forwarded by `pyre/check.py`). The wasm side
@@ -369,7 +371,13 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
         "pyre_jit",
         "jit_free_wasm",
         |mut caller: Caller<'_, Host>, func_id: u32| {
-            caller.data_mut().traces.remove(&func_id);
+            if let Some((_, slot)) = caller.data_mut().traces.remove(&func_id) {
+                // Release the table's hold on the trace function; the slot
+                // itself stays (wasm tables cannot shrink).
+                if let Some(table) = caller.data().table {
+                    let _ = table.set(&mut caller, slot as u64, Ref::Func(None));
+                }
+            }
         },
     )?;
 
@@ -570,21 +578,35 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
         .get_func(&mut *caller, "trace")
         .context("trace module is missing its `trace` export")?;
 
+    // Register the trace into the shared indirect function table so it is
+    // reachable by table index. `grow` returns the previous size, i.e. the
+    // index of the newly appended entry.
+    let slot = table
+        .grow(&mut *caller, 1, Ref::Func(Some(trace)))
+        .context("register trace into shared table")?;
+
     let host = caller.data_mut();
     let id = host.next_id;
     host.next_id += 1;
-    host.traces.insert(id, trace);
+    host.traces.insert(id, (trace, slot as u32));
     Ok(id)
 }
 
 /// Run a previously compiled trace, returning its guard-exit index.
 fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
     JIT_EXECUTE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let trace = *caller
+    let (_, slot) = *caller
         .data()
         .traces
         .get(&func_id)
         .with_context(|| format!("jit_execute_wasm: unknown func id {func_id}"))?;
+    let table = caller.data().table.context("main table not initialized")?;
+    // Dispatch through the shared table by index — the same lookup an
+    // in-module `call_indirect` would perform.
+    let trace = match table.get(&mut *caller, slot as u64) {
+        Some(Ref::Func(Some(f))) => f,
+        _ => return Err(Error::msg(format!("trace slot {slot} is not a function"))),
+    };
     let mut results = [Val::I32(0)];
     trace.call(&mut *caller, &[Val::I32(frame_ptr as i32)], &mut results)?;
     Ok(match results[0] {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -514,10 +514,7 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
         .data()
         .memory
         .context("main memory not initialized")?;
-    let table = caller
-        .data()
-        .table
-        .context("main table not initialized")?;
+    let table = caller.data().table.context("main table not initialized")?;
 
     let mut bytes = vec![0u8; bytes_len as usize];
     memory
@@ -593,14 +590,20 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
 fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
     JIT_EXECUTE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     if !caller.data().traces.contains_key(&func_id) {
-        return Err(Error::msg(format!("jit_execute_wasm: unknown func id {func_id}")));
+        return Err(Error::msg(format!(
+            "jit_execute_wasm: unknown func id {func_id}"
+        )));
     }
     let table = caller.data().table.context("main table not initialized")?;
     // The id IS the table slot; dispatch through the shared table by index —
     // the same lookup an in-module `call_indirect` would perform.
     let trace = match table.get(&mut *caller, func_id as u64) {
         Some(Ref::Func(Some(f))) => f,
-        _ => return Err(Error::msg(format!("trace slot {func_id} is not a function"))),
+        _ => {
+            return Err(Error::msg(format!(
+                "trace slot {func_id} is not a function"
+            )));
+        }
     };
     let mut results = [Val::I32(0)];
     trace.call(&mut *caller, &[Val::I32(frame_ptr as i32)], &mut results)?;

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -71,11 +71,12 @@ struct Host {
     memory: Option<Memory>,
     /// The main module's `__indirect_function_table`, used by the trampoline.
     table: Option<Table>,
-    /// Compiled traces, keyed by the id handed back to wasm. The value is the
-    /// `trace` function and its index in the shared `__indirect_function_table`
-    /// (where the host registers it for inter-trace `call_indirect` dispatch).
-    traces: HashMap<u32, (Func, u32)>,
-    next_id: u32,
+    /// Compiled traces, keyed by their index in the shared
+    /// `__indirect_function_table`. That table slot IS the id handed back to
+    /// wasm, so a trace can be both dispatched (`jit_execute_wasm`) and reached
+    /// by an in-module `call_indirect` through the same number. The `Func` is
+    /// retained to root its instance.
+    traces: HashMap<u32, Func>,
     /// Real stdlib root the wasm module's `pyre_host.*` imports read source
     /// from (`$PYRE_STDLIB`, forwarded by `pyre/check.py`). The wasm side
     /// seeds it on `sys.path`, so the host serves genuine absolute paths.
@@ -186,7 +187,6 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     let module = load_main_module(&engine, module_path)?;
 
     let mut store = Store::new(&engine, Host::default());
-    store.data_mut().next_id = 1;
     store.data_mut().stdlib_root = std::env::var("PYRE_STDLIB").ok();
 
     let linker = build_linker(&engine)?;
@@ -371,11 +371,11 @@ fn build_linker(engine: &Engine) -> Result<Linker<Host>> {
         "pyre_jit",
         "jit_free_wasm",
         |mut caller: Caller<'_, Host>, func_id: u32| {
-            if let Some((_, slot)) = caller.data_mut().traces.remove(&func_id) {
+            if caller.data_mut().traces.remove(&func_id).is_some() {
                 // Release the table's hold on the trace function; the slot
                 // itself stays (wasm tables cannot shrink).
                 if let Some(table) = caller.data().table {
-                    let _ = table.set(&mut caller, slot as u64, Ref::Func(None));
+                    let _ = table.set(&mut caller, func_id as u64, Ref::Func(None));
                 }
             }
         },
@@ -580,32 +580,27 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
 
     // Register the trace into the shared indirect function table so it is
     // reachable by table index. `grow` returns the previous size, i.e. the
-    // index of the newly appended entry.
+    // index of the newly appended entry, which becomes this trace's id.
     let slot = table
         .grow(&mut *caller, 1, Ref::Func(Some(trace)))
-        .context("register trace into shared table")?;
+        .context("register trace into shared table")? as u32;
 
-    let host = caller.data_mut();
-    let id = host.next_id;
-    host.next_id += 1;
-    host.traces.insert(id, (trace, slot as u32));
-    Ok(id)
+    caller.data_mut().traces.insert(slot, trace);
+    Ok(slot)
 }
 
 /// Run a previously compiled trace, returning its guard-exit index.
 fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> Result<u32> {
     JIT_EXECUTE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let (_, slot) = *caller
-        .data()
-        .traces
-        .get(&func_id)
-        .with_context(|| format!("jit_execute_wasm: unknown func id {func_id}"))?;
+    if !caller.data().traces.contains_key(&func_id) {
+        return Err(Error::msg(format!("jit_execute_wasm: unknown func id {func_id}")));
+    }
     let table = caller.data().table.context("main table not initialized")?;
-    // Dispatch through the shared table by index — the same lookup an
-    // in-module `call_indirect` would perform.
-    let trace = match table.get(&mut *caller, slot as u64) {
+    // The id IS the table slot; dispatch through the shared table by index —
+    // the same lookup an in-module `call_indirect` would perform.
+    let trace = match table.get(&mut *caller, func_id as u64) {
         Some(Ref::Func(Some(f))) => f,
-        _ => return Err(Error::msg(format!("trace slot {slot} is not a function"))),
+        _ => return Err(Error::msg(format!("trace slot {func_id} is not a function"))),
     };
     let mut results = [Val::I32(0)];
     trace.call(&mut *caller, &[Val::I32(frame_ptr as i32)], &mut results)?;

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -506,6 +506,10 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
         .data()
         .memory
         .context("main memory not initialized")?;
+    let table = caller
+        .data()
+        .table
+        .context("main table not initialized")?;
 
     let mut bytes = vec![0u8; bytes_len as usize];
     memory
@@ -551,6 +555,7 @@ fn jit_compile(caller: &mut Caller<'_, Host>, bytes_ptr: u32, bytes_len: u32) ->
         match (import.module(), import.name()) {
             ("env", "memory") => externs.push(Extern::Memory(memory)),
             ("env", "jit_call") => externs.push(Extern::Func(jit_call)),
+            ("env", "__indirect_function_table") => externs.push(Extern::Table(table)),
             (m, n) => {
                 return Err(Error::msg(format!(
                     "trace module has unexpected import {m}.{n}"

--- a/pyre/pyre-wasm/build-web.sh
+++ b/pyre/pyre-wasm/build-web.sh
@@ -31,9 +31,11 @@ fi
 
 # `web` selects the wasm-bindgen entry point, getrandom's wasm_js backend, and
 # the embedded stdlib VFS (no host filesystem in the browser). `--export-table`
-# exposes __indirect_function_table for the JIT glue (jit_set_table); unlike the
-# wasm-host build, web does not use getrandom's `custom` backend.
-RUSTFLAGS='-C link-arg=--export-table' \
+# exposes __indirect_function_table for the JIT glue (jit_set_table) and
+# `--growable-table` drops its fixed maximum so the glue can append compiled
+# trace functions; unlike the wasm-host build, web does not use getrandom's
+# `custom` backend.
+RUSTFLAGS='-C link-arg=--export-table -C link-arg=--growable-table' \
     cargo build --release -p pyre-wasm \
     --target wasm32-unknown-unknown \
     --no-default-features --features web


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Two related threads of wasm-backend JIT work, landing as inert foundation slices plus one activating change.

### GC nursery (epic B) — JIT traces now allocate-and-collect safely

Previously the wasm JIT declined any loop that both allocates and makes a residual call (no GC malloc-nursery rewrite → unbounded heap growth → OOM), and `wasm_jit_alloc` used the *no-collect* nursery hook. Now:

- Each Ref-typed trace value gets a dedicated frame **home slot** (null-init at entry, store-on-def), and `execute_token` registers the home slots as GC roots for the trace's duration — so a moving collection can forward them without precise per-safepoint liveness.
- `wasm_jit_alloc` uses the collecting `alloc_nursery_typed`; after each collecting `New`/`NewArray` the trace reloads live Ref locals from their forwarded homes, and the loop back-edge refreshes Ref label-arg homes.
- The interpreter write-barrier hook (`set_active_write_barrier`) is now installed for wasm. It was silently absent (dynasm/cranelift install it), which made every interpreter `mapdict`/`list`/`set`/`dict` ref-store a no-op — harmless under no-collect, but it loses old→young pointers once the nursery collects. This was the decisive correctness fix.
- Ref-storing `SetfieldGc`/`SetarrayitemGc`/`SetinteriorfieldGc` in compiled traces emit a write-barrier trampoline call, standing in for the `COND_CALL_GC_WB` that wasm's skipped GC-rewrite pass would otherwise insert.
- The "allocation + residual call in loop" decline is removed.

Result: the alloc-heavy synthetic tests (attr/list/set/dict mutation of long-lived objects) JIT-compile and stay correct under collection; `raise_catch` and `nbody` run correctly on wasm; `fannkuch` is correct through n=8 (n=9 exceeds the wasm linear-memory budget — a separate scale limit).

### Inter-trace chaining foundation (epic A) — inert

Trace modules now import the host's shared `__indirect_function_table`, the table is linked growable, the host registers each compiled trace into it and dispatches by slot, and the trace id *is* its table slot. Nothing chains yet; this is the groundwork for `call_indirect` trace-to-trace chaining.

### Housekeeping

`PYRE_WASM_JIT_STATS` compile/execute counters; corrected and updated the heavy-bench skip rationale (the benches stay skipped on wasm for timing/memory-scale, not capability).

### Testing

- wasm synthetic suite **129/129** (with the collecting nursery active)
- `majit-backend-wasm` unit tests 12/12
- `raise_catch`, `nbody` verified correct vs CPython on wasm; `fannkuch` correct n=6–8

## Self-review

This patch is AI-assisted; every commit carries an `Assisted-by: Claude` trailer.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT/runtime handling for WebAssembly traces, including safer trace registration and better support for dynamically growing tables.

* **Bug Fixes**
  * Fixed reference handling during allocations and loops so live values are preserved correctly across collecting operations.
  * Improved wasm execution stability by updating build settings and skipping a few oversized benchmarks on wasm targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->