### PR TITLE
majit: trace-compile pipeline fixes — O(1) compile, is_gc_managed guard gating, pool-array reads, macro bridges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ version = "0.0.2"
 dependencies = [
  "dynasm",
  "dynasmrt",
+ "indexmap",
  "libc",
  "majit-backend",
  "majit-gc",
@@ -1441,6 +1442,7 @@ dependencies = [
 name = "majit-metainterp"
 version = "0.0.2"
 dependencies = [
+ "indexmap",
  "majit-backend",
  "majit-backend-cranelift",
  "majit-backend-dynasm",

--- a/majit/majit-backend-dynasm/Cargo.toml
+++ b/majit/majit-backend-dynasm/Cargo.toml
@@ -14,6 +14,7 @@ majit-gc = { workspace = true }
 dynasm = { workspace = true }
 dynasmrt = { workspace = true }
 libc = { workspace = true }
+indexmap = { workspace = true }
 
 [dev-dependencies]
 majit-ir = { workspace = true, features = ["test-support"] }

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -223,8 +223,14 @@ pub struct AssemblerARM64<'a> {
     bridge_input_locs: Option<Vec<Loc>>,
 
     // ── State tracking for code generation ──
-    /// Maps OpRef → jitframe slot index.
-    opref_to_slot: VecMap<OpRef, usize>,
+    /// Maps OpRef → jitframe slot index. `IndexMap` (O(1) get/insert), not the
+    /// Vec-backed `VecMap`: `resolve_opref` reads this per emitted op during
+    /// codegen and the sync loop inserts one entry per live var, so a Vec-`get`
+    /// is O(n) and makes `_assemble` O(n^2) on large traces — `get_index_of`
+    /// inlines into `_assemble` and dominated aheui's logo compile. The box→
+    /// location map is a dict in the reference assembler; insertion order is
+    /// preserved (no semantic change, only the lookup cost).
+    opref_to_slot: indexmap::IndexMap<OpRef, usize>,
     /// Trace inputargs — borrowed for `opref_type` lookups.
     inputargs: &'a [InputArg],
     /// Trace operations — borrowed for `opref_type` lookups (reads
@@ -427,7 +433,7 @@ impl<'a> AssemblerARM64<'a> {
             header_pc,
             input_types: Vec::new(),
             bridge_input_locs: None,
-            opref_to_slot: VecMap::new(),
+            opref_to_slot: indexmap::IndexMap::new(),
             inputargs,
             operations,
             inputarg_pos,

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -251,7 +251,16 @@ impl FixedRegisterPositions {
 
 /// regalloc.py:1054 LifetimeManager — manages Lifetime info for all variables.
 pub struct LifetimeManager {
-    lifetimes: VecMap<OpRef, Lifetime>,
+    // Insertion-ordered map (`IndexMap`) rather than the Vec-backed
+    // `VecMap`: every register-allocation location query
+    // (`RegisterManager::loc`/`_sync_var_to_stack`/`spill_*`,
+    // `FrameManager::get`/`bind`/`get_new_loc`) resolves a variable through
+    // `lifetimes.get(v)`, and a Vec-backed `get` is O(n) — making regalloc
+    // O(n^2) on very large traces (aheui's logo whole-program loop spends
+    // ~all its backend time in `VecMap::get_index_of` here). regalloc.py:1054
+    // keys longevity by a dict (O(1)); `IndexMap` restores that O(1) lookup
+    // while keeping the insertion-ordered iteration `VecMap` provided.
+    lifetimes: indexmap::IndexMap<OpRef, Lifetime>,
     /// regalloc.py:1064 maps register → FixedRegisterPositions
     pub fixed_register_use: VecMap<RegLoc, FixedRegisterPositions>,
 }
@@ -259,7 +268,7 @@ pub struct LifetimeManager {
 impl LifetimeManager {
     pub fn new() -> Self {
         LifetimeManager {
-            lifetimes: VecMap::new(),
+            lifetimes: indexmap::IndexMap::new(),
             fixed_register_use: VecMap::new(),
         }
     }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1154,12 +1154,15 @@ impl DynasmBackend {
             // variant carries its own type (`Const::get_type`).
             let (result, new_constants, gcrefs) =
                 rewriter.rewrite_for_gc_with_constants(&normalized, &self.constants);
-            // rewrite.py creates fresh ConstInt boxes for sizes, offsets
-            // and helper addresses; `new_constants` is the full typed pool.
-            // Pre-existing keys `or_insert`-no-op.
-            for (k, c) in new_constants {
-                self.constants.entry(k).or_insert(c);
-            }
+            // `new_constants` is the full typed pool: the rewriter clones the
+            // current pool and only appends fresh ConstInts (size/offset/
+            // helper-address keys minted above the existing max index — see
+            // `next_const_idx` seeding in `with_constants`), never overwriting
+            // a pre-existing key, so a move-replace is equivalent to re-merging
+            // every key. The old `entry`/`or_insert` merge rescanned the whole
+            // Vec-backed pool per fresh key (O(n^2), quadratic on large traces
+            // like aheui's logo).
+            self.constants = new_constants;
             (result, gcrefs)
         } else {
             (normalized, Vec::new())

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -2662,6 +2662,20 @@ pub trait SizeDescr: Descr {
         false
     }
 
+    /// Whether the described struct carries a GC header (a `ref - 8`
+    /// type-id word).  True for JIT-GC-allocated structs (`new_struct` /
+    /// `new_with_vtable`), false for a natively-allocated raw struct
+    /// (`register_struct_layout`).  `StructPtrInfo.make_guards` gates
+    /// `GUARD_GC_TYPE` on this: a header-less raw struct cannot be
+    /// runtime-type-pinned (RPython emits `GUARD_GC_TYPE` only for a real
+    /// `GcStruct`).  Default `true` so existing descrs keep their guard;
+    /// only the raw-struct path overrides to `false`.  Independent of
+    /// `is_object()` because a `new_struct` GC struct also has
+    /// `vtable == 0`.
+    fn is_gc_managed(&self) -> bool {
+        true
+    }
+
     /// Vtable address, if is_object().
     fn vtable(&self) -> usize {
         0
@@ -3783,6 +3797,17 @@ pub struct SimpleSizeDescr {
     /// descr.py:64,112: SizeDescr.immutable_flag
     pub is_immutable: bool,
     vtable: usize,
+    /// True when the described struct carries a GC header (allocated by
+    /// the JIT GC via `new_struct` / `new_with_vtable`), so a `ref - 8`
+    /// type-id word exists for `GuardGcType` to read.  False for a
+    /// natively-allocated raw struct registered via
+    /// `register_struct_layout` (no header).  Mirrors RPython's
+    /// `lltype.GcStruct` vs raw `Struct` distinction: a header-less raw
+    /// struct must not be runtime-type-pinned (`StructPtrInfo.make_guards`
+    /// emits `GUARD_GC_TYPE` only for a real GC type).  Independent of
+    /// `is_object()` (`vtable != 0`) because a `new_struct` GC struct
+    /// also has `vtable == 0`.
+    is_gc_managed: bool,
     /// descr.py:72 `self.all_fielddescrs = all_fielddescrs`.
     all_fielddescrs: Vec<Arc<dyn FieldDescr>>,
     /// descr.py:71 `self.gc_fielddescrs = gc_fielddescrs`.
@@ -3802,6 +3827,7 @@ impl Clone for SimpleSizeDescr {
             cache_key: self.cache_key,
             is_immutable: self.is_immutable,
             vtable: self.vtable,
+            is_gc_managed: self.is_gc_managed,
             all_fielddescrs: self.all_fielddescrs.clone(),
             gc_fielddescrs: self.gc_fielddescrs.clone(),
         }
@@ -3818,6 +3844,7 @@ impl SimpleSizeDescr {
             cache_key: 0,
             is_immutable: false,
             vtable: 0,
+            is_gc_managed: true,
             all_fielddescrs: Vec::new(),
             gc_fielddescrs: Vec::new(),
         }
@@ -3832,6 +3859,7 @@ impl SimpleSizeDescr {
             cache_key: 0,
             is_immutable: false,
             vtable,
+            is_gc_managed: true,
             all_fielddescrs: Vec::new(),
             gc_fielddescrs: Vec::new(),
         }
@@ -3842,6 +3870,14 @@ impl SimpleSizeDescr {
     /// path after `init_size_descr` allocates the dense GC `type_id`.
     pub fn set_cache_key(&mut self, key: u64) {
         self.cache_key = key;
+    }
+
+    /// Override the GC-header flag (default `true` from the constructors).
+    /// Set `false` for a natively-allocated raw struct registered via
+    /// `register_struct_layout` (no `ref - 8` type-id word, so
+    /// `GuardGcType` must not be emitted for it).
+    pub fn set_gc_managed(&mut self, is_gc_managed: bool) {
+        self.is_gc_managed = is_gc_managed;
     }
 
     /// descr.py:123-126 — `get_size_descr` calls
@@ -3907,6 +3943,9 @@ impl SizeDescr for SimpleSizeDescr {
     fn is_object(&self) -> bool {
         self.vtable != 0
     }
+    fn is_gc_managed(&self) -> bool {
+        self.is_gc_managed
+    }
     fn vtable(&self) -> usize {
         self.vtable
     }
@@ -3955,9 +3994,18 @@ pub fn make_simple_descr_group_keyed(
     type_id: u32,
     cache_key: u64,
     vtable: usize,
+    is_gc_managed: bool,
     field_specs: &[SimpleFieldDescrSpec],
 ) -> SimpleDescrGroup {
-    let group = make_simple_descr_group_inner(index, size, type_id, cache_key, vtable, field_specs);
+    let group = make_simple_descr_group_inner(
+        index,
+        size,
+        type_id,
+        cache_key,
+        vtable,
+        is_gc_managed,
+        field_specs,
+    );
     let struct_key = LLType::struct_key(cache_key);
     // `descr.py:108-118 get_size_descr` cache-miss `cache[STRUCT] =
     // sizedescr` — for mint sites that bypass `get_size_descr` proper
@@ -4001,6 +4049,7 @@ fn make_simple_descr_group_inner(
     type_id: u32,
     cache_key: u64,
     vtable: usize,
+    is_gc_managed: bool,
     field_specs: &[SimpleFieldDescrSpec],
 ) -> SimpleDescrGroup {
     let field_descrs_cell = std::cell::RefCell::new(Vec::<Arc<SimpleFieldDescr>>::new());
@@ -4043,6 +4092,7 @@ fn make_simple_descr_group_inner(
         // through `_cache_size[LLType::Struct(cache_key)]` instead of
         // landing on a stale slot via `type_id` widening.
         sd.set_cache_key(cache_key);
+        sd.set_gc_managed(is_gc_managed);
         sd.with_all_fielddescrs(all_fielddescrs)
     });
     let field_descrs = field_descrs_cell.into_inner();
@@ -4066,7 +4116,10 @@ pub fn make_simple_descr_group(
     vtable: usize,
     field_specs: &[SimpleFieldDescrSpec],
 ) -> SimpleDescrGroup {
-    let group = make_simple_descr_group_inner(index, size, type_id, 0, vtable, field_specs);
+    // No-cache legacy mint sites are JIT-allocated structs; default
+    // `is_gc_managed = true` (the raw-struct path goes through the keyed
+    // factory with an explicit flag).
+    let group = make_simple_descr_group_inner(index, size, type_id, 0, vtable, true, field_specs);
     // descr.py:236-247 `get_size_descr` cache-miss branch — snapshot
     // order only.
     crate::descr_registry::register_size(group.size_descr.clone() as DescrRef);

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -778,6 +778,25 @@ impl EffectInfo {
         )
     }
 
+    /// Raw-set fallback for the macro / `JitDriver` path, where
+    /// `compute_bitstrings` never runs: the bitstring `write_descrs_fields`
+    /// stays empty and a field descr's `ei_index` stays at the `u32::MAX`
+    /// sentinel, so every `check_write_descr_field` lookup misses.  Returns
+    /// true iff this EI's concrete `_write_descrs_fields` names `descr` by
+    /// pointer identity — the same identity `compute_bitstrings` keys on.
+    /// `OptHeap::force_from_effectinfo` consults this only when
+    /// `compute_bitstrings_has_run()` is false, leaving the translated
+    /// (rustpython) bitstring path untouched.
+    pub fn writes_field_descr_by_identity(&self, descr: &DescrRef) -> bool {
+        match self._write_descrs_fields.as_deref() {
+            Some(fields) => {
+                let target = descr_ptr_id(descr);
+                fields.iter().any(|d| descr_ptr_id(d) == target)
+            }
+            None => false,
+        }
+    }
+
     /// effectinfo.py:217-219: check_readonly_descr_array(arraydescr)
     pub fn check_readonly_descr_array(&self, descr_idx: u32) -> bool {
         crate::bitstring::bitcheck(

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1641,6 +1641,216 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 #(#initialize_sym_ref_scalar_parts)*
             }
 
+            // ── Part A (bridge resume-decode). ──
+            //
+            // resume.py:1042-1057 rebuild_from_resumedata parity for the
+            // JitDriver state.  Without this the trait default returns None and
+            // `start_bridge_tracing` aborts (jitdriver.rs:3789) so no guard-exit
+            // bridge ever forms — a failing loop guard re-enters via
+            // ContinueRunningNormally instead of forming a bridge.  Adding it
+            // flips `start_bridge_tracing` ok=false→ok=true and bridges form;
+            // aheui hello/99bottles/fib stay byte-identical.
+            //
+            // NOTE: this is general guard-exit bridge-formation infrastructure.
+            // It does NOT address the logo `--jit` hang: that was root-caused
+            // to a separate optimizer issue (a sel=4 peeled loop constant-folds
+            // the stacksize red and drops the stack-size exit guard, looping on
+            // a stack-mutating residual) — not a missing or unseeded bridge.
+            // See `aheui-logo-spin-observer-replay-rootcause.md`.
+            fn rebuild_from_resumedata(
+                _meta: &mut __JitMeta,
+                fail_arg_types: &[majit_ir::Type],
+                storage: Option<&std::sync::Arc<majit_metainterp::resume::ResumeStorage>>,
+            ) -> Option<majit_metainterp::ResumeDataResult> {
+                // The macro mainloop trace is single-frame (storage/helper calls
+                // are residuals, not inlined traced sub-frames), so the generic
+                // single-frame fallback (None frame_value_count) recovers the one
+                // frame's full register slice from rd_numb.
+                //
+                // PART B TODO: the single-frame fallback returns the frame in
+                // OPENCODER order (greens+reds interleaved); `setup_bridge_sym`
+                // must map that to the sym's red slots.  A `frame_value_count`
+                // callback (pyre `frame_value_count_at` parity) may be needed
+                // here once part B lands.
+                let storage = storage?;
+                let rd_numb = storage.rd_numb.as_slice();
+                let rd_consts = storage.rd_consts();
+                let (num_failargs, vable_values, vref_values, frames) =
+                    majit_ir::resumedata::rebuild_from_numbering(
+                        rd_numb,
+                        rd_consts,
+                        fail_arg_types,
+                        None,
+                        storage.rd_virtuals.len(),
+                    );
+                if frames.is_empty() {
+                    return None;
+                }
+                Some(majit_metainterp::ResumeDataResult {
+                    frames,
+                    virtualizable_values: vable_values,
+                    virtualref_values: vref_values,
+                    storage: Some(storage.clone()),
+                    num_failargs,
+                    fail_arg_types: fail_arg_types.to_vec(),
+                })
+            }
+
+            // ── Part B (bridge sym seeding) — resume.py:1042/1054 setup_bridge_sym
+            //    + consume_boxes parity for the JitDriver state.  Seeds each red
+            //    slot's symbolic OpRef + concrete shadow from the guard's decoded
+            //    resume frame so the bridge specializes its guards on the real
+            //    loop state (without this a guard-exit bridge re-traces
+            //    un-seeded). ──
+            //
+            // STATUS: this seeds int/ref SCALAR slots only.  No available aheui
+            // workload has been observed to reach this path (setup_bridge_sym
+            // emits no MAJIT_BRIDGE_DEBUG lines for 99bottles/fibonacci/
+            // factorial), so part B is present-but-unexercised; treat the
+            // seeding as unverified on real traces.  Latent gaps once it IS
+            // exercised by a consumer:
+            //   * flattened `[int]` arrays + virt-array ptr/len slots are NOT
+            //     seeded — they keep `create_sym`'s positional InputArg indices,
+            //     which need not equal the decoded failarg index; seed them from
+            //     `reg_indices` like the scalars below (consume_boxes fills all
+            //     live int/ref/float registers, not just selected scalars);
+            //   * a multi-frame resume (inlined sub-frames) is decoded as a
+            //     single frame by `rebuild_from_resumedata` (None
+            //     frame_value_count) — later frame headers would be read as
+            //     values.  Both bite only for non-aheui macro states.
+            //
+            // `frame.values` is laid out by liveness bank: [int-bank, then
+            // ref-bank, then float], greens/loop-invariants decoded as `Const`,
+            // live reds as `Box(n)`.  The optimizer renumbers the int bank, so
+            // the i-th int Box is NOT necessarily int scalar i — routing by a
+            // naive kind-counter mis-binds (e.g. pool_ptr → stacksize slot,
+            // deref-crashing on the swapped pointer).  Instead we read the
+            // per-bank live REGISTER index of each value from the guard jitcode's
+            // liveness (`ctx.bridge_reg_indices()`, stashed by
+            // `start_bridge_tracing`) and map register → decl slot via
+            // IDENTITY-SLOT MATCHING: each state field is read during tracing
+            // by `load_state_field(fi)` (lower_vable.rs) from its FIXED identity
+            // register `int_identity_base + fi` (refs: `ref_identity_base + fi`),
+            // and that slot is kept live across guards, so the resume frame
+            // carries the field's current value at exactly that register.  We
+            // therefore locate, for each decl slot k, the frame value whose live
+            // register == identity_base + k (NOT a positional/kind-counter zip —
+            // the optimizer puts recomputed temps like stacksize's `.size`
+            // reload at high working registers, and promotes loop-invariant
+            // fields like `selected` to `Const`, so only the identity register
+            // reliably names the field).  Box → `input_arg(n)` + `fail_values[n]`;
+            // Const → a folded pool constant.  MAJIT_BRIDGE_DEBUG dumps it.
+            fn setup_bridge_sym(
+                sym: &mut __JitSym,
+                ctx: &mut majit_metainterp::TraceCtx,
+                resume_data: &majit_metainterp::ResumeDataResult,
+                _rd_virtuals: Option<&[std::rc::Rc<majit_ir::RdVirtualInfo>]>,
+                fail_values: &[i64],
+                fail_types: &[majit_ir::Type],
+            ) {
+                use majit_ir::resumedata::RebuiltValue;
+                use majit_metainterp::JitCodeSym as _;
+                let frame = match resume_data.frames.first() {
+                    Some(f) => f,
+                    None => return,
+                };
+                let __dbg = std::env::var("MAJIT_BRIDGE_DEBUG").is_ok();
+                // Clone so `ctx` is free for `const_int`/`const_ref` below.
+                let reg_indices = match ctx.bridge_reg_indices() {
+                    Some(r) => r.clone(),
+                    None => {
+                        if __dbg {
+                            eprintln!("[bridgeB] no reg_indices stashed — declining to seed");
+                        }
+                        return;
+                    }
+                };
+                if __dbg {
+                    eprintln!(
+                        "[bridgeB] frame jc={} pc={} fail_values={:?} fail_types={:?}",
+                        frame.jitcode_index, frame.pc, fail_values, fail_types
+                    );
+                    eprintln!(
+                        "[bridgeB] reg_indices int={:?} ref={:?} float={:?} values.len={} int_base={} ref_base={}",
+                        reg_indices.int,
+                        reg_indices.ref_,
+                        reg_indices.float,
+                        frame.values.len(),
+                        #int_identity_base,
+                        #ref_identity_base
+                    );
+                }
+                if reg_indices.total_len() != frame.values.len() {
+                    if __dbg {
+                        eprintln!("[bridgeB] reg_indices/frame length mismatch — declining");
+                    }
+                    return;
+                }
+                let __ref_off = reg_indices.int.len();
+                // int scalars: identity register = int_identity_base + k.
+                for __k in 0..#num_scalars {
+                    let __target = #int_identity_base + __k;
+                    let __pos = reg_indices.int.iter().position(|&r| r as usize == __target);
+                    let __pos = match __pos {
+                        Some(p) => p,
+                        None => continue,
+                    };
+                    match &frame.values[__pos] {
+                        RebuiltValue::Box(n, kind) if matches!(kind, majit_ir::Type::Int) => {
+                            let (__op, __shadow) = majit_metainterp::bridge_decode_red(
+                                *n, *kind, fail_values, fail_types,
+                            );
+                            sym.set_state_field_ref(__k, __op);
+                            sym.set_state_field_value(__k, __shadow);
+                            if __dbg {
+                                eprintln!("  int scalar {} <- reg {} Box {} = {}", __k, __target, n, __shadow);
+                            }
+                        }
+                        RebuiltValue::Const(c) => {
+                            let __bits = c.as_raw_i64();
+                            let __op = ctx.const_int(__bits);
+                            sym.set_state_field_ref(__k, __op);
+                            sym.set_state_field_value(__k, __bits);
+                            if __dbg {
+                                eprintln!("  int scalar {} <- reg {} Const {}", __k, __target, __bits);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                // ref scalars: identity register = ref_identity_base + j.
+                for __j in 0..#num_ref_scalars {
+                    let __target = #ref_identity_base + __j;
+                    let __pos = reg_indices.ref_.iter().position(|&r| r as usize == __target);
+                    let __pos = match __pos {
+                        Some(p) => p,
+                        None => continue,
+                    };
+                    match &frame.values[__ref_off + __pos] {
+                        RebuiltValue::Box(n, kind) if matches!(kind, majit_ir::Type::Ref) => {
+                            let (__op, __shadow) = majit_metainterp::bridge_decode_red(
+                                *n, *kind, fail_values, fail_types,
+                            );
+                            sym.set_state_ref_field_ref(__j, __op);
+                            sym.set_state_ref_field_value(__j, __shadow);
+                            if __dbg {
+                                eprintln!("  ref scalar {} <- reg {} Box {} = {:#x}", __j, __target, n, __shadow);
+                            }
+                        }
+                        RebuiltValue::Const(c) => {
+                            let __bits = c.as_raw_i64();
+                            let __op = ctx.const_ref(__bits);
+                            sym.set_state_ref_field_ref(__j, __op);
+                            sym.set_state_ref_field_value(__j, __bits);
+                            if __dbg {
+                                eprintln!("  ref scalar {} <- reg {} Const {:#x}", __j, __target, __bits);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
             fn is_compatible(&self, meta: &__JitMeta) -> bool {
                 true #(#compat_checks)*
             }

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -32,6 +32,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.reds,
         &config.state_type,
         &config.env_type,
+        &config.residual_writes,
     );
 
     let classified = classify_arms(&match_expr.arms);

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -33,6 +33,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.state_type,
         &config.env_type,
         &config.residual_writes,
+        &config.pool_arrays,
     );
 
     let classified = classify_arms(&match_expr.arms);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1,6 +1,34 @@
 use super::*;
+use super::lower_value::struct_type_id;
 
 impl<'c> Lowerer<'c> {
+    /// If `func` is a registered `residual_writes` mutator, return the
+    /// `struct_field_write_effect_info(...)` expression naming the written
+    /// field, so the residual call records a write-set `EffectInfo` that
+    /// invalidates the cached `getfield_gc_i` on that field.  `None` for a
+    /// plain residual call (empty write-set).
+    fn residual_write_effect_info_tokens(&self, func: &Expr) -> Option<TokenStream> {
+        let config = self.config?;
+        let func_segments = canonical_expr_segments(func)?;
+        let (_, struct_path, field) = config
+            .residual_writes
+            .iter()
+            .find(|(segments, _, _)| *segments == func_segments)?;
+        let tid = struct_type_id(struct_path);
+        Some(quote! {
+            majit_metainterp::struct_field_write_effect_info(
+                ::core::mem::size_of::<#struct_path>(),
+                #tid,
+                &[(
+                    ::core::mem::offset_of!(#struct_path, #field),
+                    false,
+                    stringify!(#field),
+                )],
+                stringify!(#field),
+            )
+        })
+    }
+
     pub(super) fn lower_stmt(&mut self, stmt: &Stmt) -> Option<()> {
         match stmt {
             Stmt::Local(local) => {
@@ -846,6 +874,13 @@ impl<'c> Lowerer<'c> {
         if let Some(()) = self.lower_state_field_write(expr) {
             return Some(());
         }
+        // Field write-through a `ref(T)` state scalar:
+        // `state.<ref>.<member> = <int expr>` → setfield_gc_i (invalidates the
+        // matching cached getfield). After lower_state_field_write (which only
+        // matches `state.<scalar> = ...` whose LHS base is `state`).
+        if let Some(()) = self.lower_state_ref_field_setfield(expr) {
+            return Some(());
+        }
         if let Some(()) = self.lower_state_array_write(expr) {
             return Some(());
         }
@@ -946,7 +981,19 @@ impl<'c> Lowerer<'c> {
                         kind,
                         crate::jit_interp::CallPolicyKind::ResidualVoidCannotRaise,
                     );
-                    let call_stmt = if cannot_raise {
+                    let write_ei = self.residual_write_effect_info_tokens(func);
+                    let call_stmt = if let Some(write_ei) = write_ei {
+                        // Declared field mutator: residual + can-raise, but with
+                        // a write-set naming the mutated field so the optimizer
+                        // invalidates its cached `getfield_gc_i`.
+                        quote! {
+                            __builder.residual_call_void_canonical_via_target_with_effect_info(
+                                __fn_idx,
+                                __typed_args,
+                                #write_ei,
+                            );
+                        }
+                    } else if cannot_raise {
                         quote! {
                             __builder.residual_call_void_canonical_via_target_with_effect_info(
                                 __fn_idx,
@@ -1095,7 +1142,35 @@ impl<'c> Lowerer<'c> {
                         }
                         _ => unreachable!(),
                     };
+                    // A declared `residual_writes` mutator routes through the
+                    // `_with_effect_info` int variant carrying the field
+                    // write-set; only the residual policy qualifies (may-force /
+                    // release-gil / loop-invariant carry their own effects).
+                    let write_ei = match kind {
+                        crate::jit_interp::CallPolicyKind::ResidualInt => {
+                            self.residual_write_effect_info_tokens(func)
+                        }
+                        _ => None,
+                    };
                     if let Some(arg_regs) = int_arg_regs(&arg_bindings) {
+                        let call_invocation = if let Some(write_ei) = &write_ei {
+                            quote! {
+                                __builder.residual_call_int_canonical_via_target_with_effect_info(
+                                    __fn_idx,
+                                    &[#(majit_metainterp::JitCallArg::int(#arg_regs)),*],
+                                    #throwaway_reg,
+                                    #write_ei,
+                                );
+                            }
+                        } else {
+                            quote! {
+                                __builder.#canonical_call(
+                                    __fn_idx,
+                                    &[#(majit_metainterp::JitCallArg::int(#arg_regs)),*],
+                                    #throwaway_reg,
+                                );
+                            }
+                        };
                         self.emit_op(
                             OpMeta::linear(
                                 OpKind::Call,
@@ -1104,17 +1179,27 @@ impl<'c> Lowerer<'c> {
                             ),
                             quote! {
                                 let __fn_idx = __builder.add_fn_ptr(#func as *const ());
-                                __builder.#canonical_call(
-                                    __fn_idx,
-                                    &[#(majit_metainterp::JitCallArg::int(#arg_regs)),*],
-                                    #throwaway_reg,
-                                );
+                                #call_invocation
                             },
                         );
                     } else {
                         let typed_args = typed_call_arg_tokens(&arg_bindings);
                         let __arg_regs: Vec<Register> =
                             arg_bindings.iter().map(Register::from_binding).collect();
+                        let call_invocation = if let Some(write_ei) = &write_ei {
+                            quote! {
+                                __builder.residual_call_int_canonical_via_target_with_effect_info(
+                                    __fn_idx,
+                                    #typed_args,
+                                    #throwaway_reg,
+                                    #write_ei,
+                                );
+                            }
+                        } else {
+                            quote! {
+                                __builder.#canonical_call(__fn_idx, #typed_args, #throwaway_reg);
+                            }
+                        };
                         self.emit_op(
                             OpMeta::linear(
                                 OpKind::Call,
@@ -1123,7 +1208,7 @@ impl<'c> Lowerer<'c> {
                             ),
                             quote! {
                                 let __fn_idx = __builder.add_fn_ptr(#func as *const ());
-                                __builder.#canonical_call(__fn_idx, #typed_args, #throwaway_reg);
+                                #call_invocation
                             },
                         );
                     }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -16,9 +16,14 @@ impl<'c> Lowerer<'c> {
             .find(|(segments, _, _)| *segments == func_segments)?;
         let tid = struct_type_id(struct_path);
         Some(quote! {
+            // The residual mutates a host-owned native struct field (no
+            // GC header) → `is_gc_managed = false`, matching the
+            // getfield/setfield lowering so the write-EI rebuilds the
+            // SAME parent SizeDescr identity the getfield reads back.
             majit_metainterp::struct_field_write_effect_info(
                 ::core::mem::size_of::<#struct_path>(),
                 #tid,
+                false,
                 &[(
                     ::core::mem::offset_of!(#struct_path, #field),
                     false,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::lower_value::struct_type_id;
+use super::*;
 
 impl<'c> Lowerer<'c> {
     /// If `func` is a registered `residual_writes` mutator, return the

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -708,6 +708,19 @@ impl<'c> Lowerer<'c> {
                 // field read must not be runtime-type-pinned with a
                 // `GUARD_GC_TYPE` that would read a non-existent `ref - 8`
                 // type-id word.
+                //
+                // LATENT (no current consumer): `#tid = struct_type_id(T)` is
+                // shared with the GC `new_struct` path, and the size-descr
+                // cache is first-write-wins by `LLType::Struct(type_id)`.  If
+                // some `T` were used BOTH as a JIT-allocated struct literal
+                // (is_gc_managed=true) and as a `ref(T)` state scalar
+                // (is_gc_managed=false), whichever registered first would pin
+                // the flag for both — a raw getfield could then emit
+                // GUARD_GC_TYPE against a headerless pointer, or a GC alloc
+                // could lose its type guard.  No aheui type is used both ways
+                // (ref scalars are Stack/Storage, never New-allocated).  Fix
+                // when a dual-use type appears: fold raw-vs-GC into the
+                // descriptor identity (separate type IDs per kind).
                 __builder.register_struct_layout(
                     ::core::mem::size_of::<#struct_path>(),
                     #tid,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -703,9 +703,15 @@ impl<'c> Lowerer<'c> {
                 vec![Register::int(result_reg)],
             ),
             quote! {
+                // A `ref(T)` state scalar points at a host-owned native
+                // struct (no GC header), so `is_gc_managed = false`: the
+                // field read must not be runtime-type-pinned with a
+                // `GUARD_GC_TYPE` that would read a non-existent `ref - 8`
+                // type-id word.
                 __builder.register_struct_layout(
                     ::core::mem::size_of::<#struct_path>(),
                     #tid,
+                    false,
                     &[(
                         ::core::mem::offset_of!(#struct_path, #member),
                         false,
@@ -836,9 +842,13 @@ impl<'c> Lowerer<'c> {
                 vec![],
             ),
             quote! {
+                // `ref(T)` state scalar = host-owned native struct (no GC
+                // header) → `is_gc_managed = false`; see the getfield
+                // lowering for the `GUARD_GC_TYPE` rationale.
                 __builder.register_struct_layout(
                     ::core::mem::size_of::<#struct_path>(),
                     #tid,
+                    false,
                     &[(
                         ::core::mem::offset_of!(#struct_path, #member),
                         false,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::lower_value::struct_type_id;
 
 impl<'c> Lowerer<'c> {
     /// Read an immediate operand byte from the green bytecode array:
@@ -208,8 +209,8 @@ impl<'c> Lowerer<'c> {
         }
         // ref(T) scalar: the RHS must lower to a ref binding (another ref
         // state read or a residual ref-returning call).
-        if let Some(&field_index) = config.state_ref_scalars.get(&member_name) {
-            let fi = field_index as u16;
+        if let Some((field_index, _)) = config.state_ref_scalars.get(&member_name) {
+            let fi = *field_index as u16;
             let binding = self.lower_value_expr(&assign.right)?;
             if !matches!(binding.kind, BindingKind::Ref) {
                 return None;
@@ -630,8 +631,8 @@ impl<'c> Lowerer<'c> {
         }
         // ref(T) scalar: read into the ref register bank so a subsequent
         // getfield_gc reads its struct base from a real ref value.
-        if let Some(&field_index) = config.state_ref_scalars.get(&member_name) {
-            let fi = field_index as u16;
+        if let Some((field_index, _)) = config.state_ref_scalars.get(&member_name) {
+            let fi = *field_index as u16;
             let reg = self.alloc_reg();
             // Declare the ref identity slot as a read so the backward
             // liveness walk keeps it live across guards (mirrors the int
@@ -656,6 +657,136 @@ impl<'c> Lowerer<'c> {
             });
         }
         None
+    }
+
+    /// Recognizes a field READ through a `ref(T)` state scalar:
+    /// `state.<ref_scalar>.<member>` → `getfield_gc_i` on the heap object the
+    /// ref points at.  Unlike the residual-call form (an opaque CALL_I whose
+    /// result the optimizer can neither re-produce in the short preamble nor
+    /// invalidate on a write), a `getfield_gc` on a non-immutable field is
+    /// re-readable each loop entry and is invalidated by a matching
+    /// `setfield_gc` on the same `(struct_type_id, field)` — mirroring an
+    /// RPython `len(obj)`/`obj.field` getfield_gc_i on a mutable field.
+    ///
+    /// Only int fields are lowered here (the aheui length read); a ref field
+    /// read would route through `getfield_gc_r` and is left unimplemented
+    /// until a caller needs it.
+    pub(super) fn lower_state_ref_field_getfield(&mut self, expr: &Expr) -> Option<Binding> {
+        let config = self.config?;
+        let Expr::Field(field) = expr else {
+            return None;
+        };
+        // The base must be `state.<ref_scalar>` (a ref(T) state field).
+        let Expr::Field(base_field) = &*field.base else {
+            return None;
+        };
+        if !expr_matches_local_name(&base_field.base, "state") {
+            return None;
+        }
+        let base_name = named_member(&base_field.member)?;
+        let (_, struct_path) = config.state_ref_scalars.get(&base_name).cloned()?;
+        let member = field.member.clone();
+        let tid = struct_type_id(&struct_path);
+        // Lower the `state.<ref_scalar>` base to a ref binding (its
+        // load_state_field_ref already declares the ref identity slot live for
+        // resume), then read the field off that concrete ref.
+        let base = self.lower_state_field_read(&field.base)?;
+        if !matches!(base.kind, BindingKind::Ref) {
+            return None;
+        }
+        let base_reg = base.reg;
+        let result_reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::Vable,
+                vec![Register::ref_(base_reg)],
+                vec![Register::int(result_reg)],
+            ),
+            quote! {
+                __builder.register_struct_layout(
+                    ::core::mem::size_of::<#struct_path>(),
+                    #tid,
+                    &[(
+                        ::core::mem::offset_of!(#struct_path, #member),
+                        false,
+                        stringify!(#member),
+                    )],
+                );
+                __builder.getfield_gc_i(
+                    #result_reg,
+                    #base_reg,
+                    ::core::mem::offset_of!(#struct_path, #member),
+                    #tid,
+                );
+            },
+        );
+        Some(Binding {
+            reg: result_reg,
+            kind: BindingKind::Int,
+            depends_on_stack: false,
+        })
+    }
+
+    /// Recognizes a field WRITE through a `ref(T)` state scalar:
+    /// `state.<ref_scalar>.<member> = <int expr>` → `setfield_gc_i`.  The
+    /// store shares the same `(struct_type_id, field)` interned `Field` descr
+    /// as [`Self::lower_state_ref_field_getfield`], so the heapcache
+    /// invalidates the cached getfield on every write — the in-trace
+    /// counterpart of an RPython inlined `self.field = ...` store that keeps a
+    /// length getfield from freezing to a loop-invariant constant.
+    pub(super) fn lower_state_ref_field_setfield(&mut self, expr: &Expr) -> Option<()> {
+        let config = self.config?;
+        let Expr::Assign(assign) = expr else {
+            return None;
+        };
+        let Expr::Field(field) = &*assign.left else {
+            return None;
+        };
+        let Expr::Field(base_field) = &*field.base else {
+            return None;
+        };
+        if !expr_matches_local_name(&base_field.base, "state") {
+            return None;
+        }
+        let base_name = named_member(&base_field.member)?;
+        let (_, struct_path) = config.state_ref_scalars.get(&base_name).cloned()?;
+        let member = field.member.clone();
+        let tid = struct_type_id(&struct_path);
+        let base = self.lower_state_field_read(&field.base)?;
+        if !matches!(base.kind, BindingKind::Ref) {
+            return None;
+        }
+        let base_reg = base.reg;
+        let rhs = self.lower_value_expr(&assign.right)?;
+        if !matches!(rhs.kind, BindingKind::Int) {
+            return None;
+        }
+        let src = rhs.reg;
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::SetfieldGc,
+                vec![Register::ref_(base_reg), Register::int(src)],
+                vec![],
+            ),
+            quote! {
+                __builder.register_struct_layout(
+                    ::core::mem::size_of::<#struct_path>(),
+                    #tid,
+                    &[(
+                        ::core::mem::offset_of!(#struct_path, #member),
+                        false,
+                        stringify!(#member),
+                    )],
+                );
+                __builder.setfield_gc_i(
+                    #base_reg,
+                    #src,
+                    ::core::mem::offset_of!(#struct_path, #member),
+                    #tid,
+                );
+            },
+        );
+        Some(())
     }
 
     /// Recognizes `state.array[index]` for array state fields.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::lower_value::struct_type_id;
+use super::*;
 
 impl<'c> Lowerer<'c> {
     /// Read an immediate operand byte from the green bytecode array:
@@ -724,6 +724,73 @@ impl<'c> Lowerer<'c> {
             reg: result_reg,
             kind: BindingKind::Int,
             depends_on_stack: false,
+        })
+    }
+
+    /// Recognizes a pool-array element read through a marker call
+    /// `<fn>(state.<pool_base_ref>, <int index>)` → `getarrayitem_gc_r` on the
+    /// raw-pointer array (`[*mut U; N]` at offset 0) the ref-scalar points at —
+    /// the aheui `pools[selected]` read.  Unlike the residual-call form (an
+    /// opaque CALL_R the optimizer can neither re-produce in the short preamble
+    /// nor invalidate), the getarrayitem on the immutable `pools` array
+    /// re-derives the element each loop entry from the consistent `selected`
+    /// index, so the loaded ref can no longer be carried as an independent
+    /// loop-red that diverges from the promoted index.
+    ///
+    /// `state.<base>` must be declared in `pool_arrays`; pointer elements are 8
+    /// bytes at array offset 0 (`add_ptr_array_descr`).  The call's function
+    /// name is irrelevant — what selects the lowering is that arg0 is a
+    /// declared pool-base ref-scalar (the marker function's body remains the
+    /// concrete-path fallback when no `pool_arrays` is configured).
+    pub(super) fn lower_pool_array_get_call(&mut self, call: &syn::ExprCall) -> Option<Binding> {
+        let config = self.config?;
+        if call.args.len() != 2 {
+            return None;
+        }
+        // arg0 must be `state.<base>` where <base> is a declared pool-array base.
+        let Expr::Field(base_field) = &call.args[0] else {
+            return None;
+        };
+        if !expr_matches_local_name(&base_field.base, "state") {
+            return None;
+        }
+        let base_name = named_member(&base_field.member)?;
+        if !config.pool_arrays.iter().any(|n| n == &base_name) {
+            return None;
+        }
+        // Lower the `state.<base>` ref-scalar (declares its ref identity slot
+        // live for resume) and the index, then read the pointer element.
+        let base = self.lower_state_field_read(&call.args[0])?;
+        if !matches!(base.kind, BindingKind::Ref) {
+            return None;
+        }
+        let base_reg = base.reg;
+        let index = self.lower_value_expr(&call.args[1])?;
+        if !matches!(index.kind, BindingKind::Int) {
+            return None;
+        }
+        let index_reg = index.reg;
+        let result_reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::Vable,
+                vec![Register::ref_(base_reg), Register::int(index_reg)],
+                vec![Register::ref_(result_reg)],
+            ),
+            quote! {
+                let __descr_idx = __builder.add_ptr_array_descr();
+                __builder.getarrayitem_gc_r(
+                    #result_reg as u16,
+                    #base_reg as u16,
+                    #index_reg as u16,
+                    __descr_idx,
+                );
+            },
+        );
+        Some(Binding {
+            reg: result_reg,
+            kind: BindingKind::Ref,
+            depends_on_stack: base.depends_on_stack || index.depends_on_stack,
         })
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -127,6 +127,12 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_assert_not_none_call(call) {
                     return Some(binding);
                 }
+                // A `<fn>(state.<pool_base_ref>, <idx>)` marker call reading a
+                // raw-pointer pool array lowers to getarrayitem_gc_r instead of
+                // a residual CALL_R (re-producible heap read, no diverging red).
+                if let Some(binding) = self.lower_pool_array_get_call(call) {
+                    return Some(binding);
+                }
                 self.lower_call_value(call)
             }
             Expr::MethodCall(call) => self.lower_method_call_value(call),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -6,7 +6,7 @@ use super::*;
 /// `index_in_parent` (`descr.py:238`).  Distinct struct paths collide only
 /// at `DefaultHasher`'s 64-bit range, matching the runtime
 /// `LLType::Struct(type_id)` cache-key identity.
-fn struct_type_id(path: &syn::Path) -> u64 {
+pub(super) fn struct_type_id(path: &syn::Path) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     quote!(#path).to_string().hash(&mut hasher);
@@ -17,6 +17,13 @@ impl<'c> Lowerer<'c> {
     pub(super) fn lower_value_expr(&mut self, expr: &Expr) -> Option<Binding> {
         // State field read (register/tape machines).
         if let Some(binding) = self.lower_state_field_read(expr) {
+            return Some(binding);
+        }
+        // Field read through a `ref(T)` state scalar: `state.<ref>.<member>`
+        // → getfield_gc_i. Placed after lower_state_field_read (which only
+        // matches `state.<scalar>` whose base is `state`) so the plain scalar
+        // read wins and this handles the `Field`-of-`Field` shape.
+        if let Some(binding) = self.lower_state_ref_field_getfield(expr) {
             return Some(binding);
         }
         if let Some(binding) = self.lower_state_array_read(expr) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -137,10 +137,14 @@ pub struct LowererConfig {
     /// State field virtualizable arrays: field_name → virt_array_index.
     /// These emit GETARRAYITEM_RAW_I/SETARRAYITEM_RAW instead of element-level tracking.
     pub(super) state_virt_arrays: HashMap<String, usize>,
-    /// State field ref scalars: field_name → ref_scalar_index (0-based, its own
-    /// space separate from `state_scalars`). These lower to
-    /// load_state_field_ref/store_state_field_ref in the ref register bank.
-    pub(super) state_ref_scalars: HashMap<String, usize>,
+    /// State field ref scalars: field_name → (ref_scalar_index, struct Path).
+    /// The index is 0-based in its own space (separate from `state_scalars`);
+    /// these lower to load_state_field_ref/store_state_field_ref in the ref
+    /// register bank.  The `ref(T)` struct Path `T` is retained so a field
+    /// read/write through the ref (`state.<ref_scalar>.<member>`) can emit
+    /// `getfield_gc_*`/`setfield_gc_*` with `offset_of!(T, member)` + the
+    /// matching `struct_type_id(T)`.
+    pub(super) state_ref_scalars: HashMap<String, (usize, syn::Path)>,
     /// Green-variable expressions for `jit_merge_point` / `promote_greens`.
     ///
     /// Source: `JitInterpConfig.greens` (mod.rs:65) — the `greens = [...]` list
@@ -167,6 +171,14 @@ pub struct LowererConfig {
     /// (the env parameter — convention fixed at the dispatch portal-input
     /// installer below). Source: `JitInterpConfig.env_type` Ident.
     pub(super) env_type_name: String,
+    /// Residual helpers that mutate a ref-scalar field, resolved per helper to
+    /// `(helper path segments, struct Path, field Ident)`.  When
+    /// `lower_config_call_stmt` emits a residual call whose path segments match,
+    /// it attaches a write-set `EffectInfo` (`struct_field_write_effect_info`)
+    /// naming the field so the optimizer invalidates the cached
+    /// `getfield_gc_i`.  Source: `JitInterpConfig.residual_writes`, the struct
+    /// `Path` recovered from `state_ref_scalars[ref_scalar]`.
+    pub(super) residual_writes: Vec<(Vec<String>, syn::Path, Ident)>,
 }
 
 impl LowererConfig {
@@ -745,6 +757,7 @@ impl LowererConfig {
         reds: &[Expr],
         state_type: &Ident,
         env_type: &Ident,
+        residual_writes: &[crate::jit_interp::ResidualWriteEntry],
     ) -> Self {
         let io_shims = io_shims
             .iter()
@@ -813,9 +826,11 @@ impl LowererConfig {
                         // the lowering layer must not see them as state slots.
                         StateFieldKind::Opaque(_) => {}
                         // ref(T) scalars get a separate 0-based index space;
-                        // they lower to the ref register bank.
-                        StateFieldKind::Ref(_) => {
-                            ref_scalars.insert(f.name.to_string(), ref_scalar_idx);
+                        // they lower to the ref register bank. Retain the
+                        // struct Path `T` so a field access through the ref
+                        // can resolve `offset_of!(T, member)` + struct type_id.
+                        StateFieldKind::Ref(p) => {
+                            ref_scalars.insert(f.name.to_string(), (ref_scalar_idx, p.clone()));
                             ref_scalar_idx += 1;
                         }
                     }
@@ -844,6 +859,23 @@ impl LowererConfig {
                 vable_arrays.insert(name.clone(), (idx, ValueKind::Int));
             }
         }
+        // Resolve each `residual_writes` entry into per-helper
+        // `(helper segments, struct Path, field Ident)`, recovering the struct
+        // `Path` from `state_ref_scalars[ref_scalar]` (same source the matching
+        // getfield uses for `offset_of!` + `struct_type_id`).
+        let residual_writes = residual_writes
+            .iter()
+            .flat_map(|entry| {
+                let struct_path = state_ref_scalars
+                    .get(&entry.ref_scalar.to_string())
+                    .map(|(_, p)| p.clone());
+                entry.helpers.iter().filter_map(move |helper| {
+                    struct_path
+                        .clone()
+                        .map(|p| (canonical_path_segments(helper), p, entry.field.clone()))
+                })
+            })
+            .collect();
         Self {
             io_shims,
             calls,
@@ -861,6 +893,7 @@ impl LowererConfig {
             reds: reds.to_vec(),
             state_type_name: state_type.to_string(),
             env_type_name: env_type.to_string(),
+            residual_writes,
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -179,6 +179,11 @@ pub struct LowererConfig {
     /// `getfield_gc_i`.  Source: `JitInterpConfig.residual_writes`, the struct
     /// `Path` recovered from `state_ref_scalars[ref_scalar]`.
     pub(super) residual_writes: Vec<(Vec<String>, syn::Path, Ident)>,
+    /// Names of `ref(T)` state scalars that are raw-pointer-array bases.  When a
+    /// marker call `<fn>(state.<ref>, <int>)` indexes one of these, the call
+    /// lowers to `getarrayitem_gc_r` instead of a residual CALL_R.  Source:
+    /// `JitInterpConfig.pool_arrays`.
+    pub(super) pool_arrays: Vec<String>,
 }
 
 impl LowererConfig {
@@ -758,6 +763,7 @@ impl LowererConfig {
         state_type: &Ident,
         env_type: &Ident,
         residual_writes: &[crate::jit_interp::ResidualWriteEntry],
+        pool_arrays: &[Ident],
     ) -> Self {
         let io_shims = io_shims
             .iter()
@@ -894,6 +900,7 @@ impl LowererConfig {
             state_type_name: state_type.to_string(),
             env_type_name: env_type.to_string(),
             residual_writes,
+            pool_arrays: pool_arrays.iter().map(|i| i.to_string()).collect(),
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -116,6 +116,14 @@ pub struct JitInterpConfig {
     /// so the optimizer invalidates the matching cached `getfield_gc_i` after
     /// the call.  Empty for interpreters with no residual field mutators.
     pub residual_writes: Vec<ResidualWriteEntry>,
+    /// `ref(T)` state scalars that are bases of a contiguous raw-pointer array
+    /// (`[*mut U; N]` at offset 0 of `T`), declared as `pool_arrays = [<ref>]`.
+    /// An indexing marker call `<fn>(state.<ref>, <int>)` on such a base lowers
+    /// to `getarrayitem_gc_r` (a re-producible heap read) instead of an opaque
+    /// residual CALL_R, so the loaded element re-derives from the index each
+    /// loop entry and the short preamble can re-emit it.  Empty for
+    /// interpreters with no pool-array indexing.
+    pub pool_arrays: Vec<Ident>,
 }
 
 /// Virtualizable frame field declaration for `#[jit_interp]`.
@@ -443,6 +451,7 @@ impl Parse for JitInterpConfig {
         let mut recover: Option<Path> = None;
         let mut recursive_entry: Option<Path> = None;
         let mut residual_writes: Vec<ResidualWriteEntry> = Vec::new();
+        let mut pool_arrays: Vec<Ident> = Vec::new();
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -492,6 +501,13 @@ impl Parse for JitInterpConfig {
                 "residual_writes" => {
                     residual_writes = parse_residual_writes_map(input)?;
                 }
+                "pool_arrays" => {
+                    let content;
+                    bracketed!(content in input);
+                    let idents: Punctuated<Ident, Token![,]> =
+                        content.parse_terminated(Ident::parse, Token![,])?;
+                    pool_arrays = idents.into_iter().collect();
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -536,6 +552,7 @@ impl Parse for JitInterpConfig {
             recover,
             recursive_entry,
             residual_writes,
+            pool_arrays,
         })
     }
 }

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -110,6 +110,12 @@ pub struct JitInterpConfig {
     /// emits `BC_RECURSIVE_CALL_*`.  Required iff the body uses
     /// `recursive_portal_call!`.
     pub recursive_entry: Option<Path>,
+    /// Residual helpers that mutate a `state.<ref_scalar>.<field>` through
+    /// opaque host code, declared as `residual_writes = { <ref_scalar>.<field>
+    /// => [helpers] }`.  Drives the write-set `EffectInfo` the lowering attaches
+    /// so the optimizer invalidates the matching cached `getfield_gc_i` after
+    /// the call.  Empty for interpreters with no residual field mutators.
+    pub residual_writes: Vec<ResidualWriteEntry>,
 }
 
 /// Virtualizable frame field declaration for `#[jit_interp]`.
@@ -261,6 +267,21 @@ pub enum StateFieldKind {
 pub struct CallEntry {
     pub path: Path,
     pub policy: Option<CallPolicyKind>,
+}
+
+/// One entry in the `residual_writes = { <ref_scalar>.<field> => [helpers] }`
+/// map.  Each listed residual helper mutates `<ref_scalar>.<field>` through
+/// opaque host code; the lowering attaches a write-set `EffectInfo` naming that
+/// field so `OptHeap::force_from_effectinfo` invalidates the cached
+/// `getfield_gc_i` after the call (the residual analogue of a traced mutator's
+/// in-trace `setfield_gc` write barrier).  `ref_scalar` is resolved against
+/// `state_ref_scalars` to recover the struct `Path` for `offset_of!` +
+/// `struct_type_id`.
+#[derive(Clone)]
+pub struct ResidualWriteEntry {
+    pub ref_scalar: Ident,
+    pub field: Ident,
+    pub helpers: Vec<Path>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -421,6 +442,7 @@ impl Parse for JitInterpConfig {
         let mut state_fields = None;
         let mut recover: Option<Path> = None;
         let mut recursive_entry: Option<Path> = None;
+        let mut residual_writes: Vec<ResidualWriteEntry> = Vec::new();
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -467,6 +489,9 @@ impl Parse for JitInterpConfig {
                 "recursive_entry" => {
                     recursive_entry = Some(input.parse::<Path>()?);
                 }
+                "residual_writes" => {
+                    residual_writes = parse_residual_writes_map(input)?;
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -510,8 +535,36 @@ impl Parse for JitInterpConfig {
             state_fields,
             recover,
             recursive_entry,
+            residual_writes,
         })
     }
+}
+
+/// Parse `residual_writes = { <ref_scalar>.<field> => [helper, ...], ... }`.
+/// Each map key is a `state` ref-scalar field path (`selected_ref.size`) and
+/// the value is a bracketed list of residual helper function paths that mutate
+/// it.  See [`ResidualWriteEntry`].
+fn parse_residual_writes_map(input: ParseStream) -> syn::Result<Vec<ResidualWriteEntry>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        let ref_scalar: Ident = content.parse()?;
+        content.parse::<Token![.]>()?;
+        let field: Ident = content.parse()?;
+        content.parse::<Token![=>]>()?;
+        let helpers_content;
+        bracketed!(helpers_content in content);
+        let helpers: Punctuated<Path, Token![,]> =
+            helpers_content.parse_terminated(Path::parse, Token![,])?;
+        entries.push(ResidualWriteEntry {
+            ref_scalar,
+            field,
+            helpers: helpers.into_iter().collect(),
+        });
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
 }
 
 fn parse_expr_list(input: ParseStream) -> syn::Result<Vec<Expr>> {
@@ -921,15 +974,112 @@ fn generate_merge_wrapper(config: &JitInterpConfig, func: &ItemFn) -> TokenStrea
 
 /// Transform the original function: replace jit_merge_point!() and can_enter_jit!() markers.
 fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
+    use syn::visit_mut::VisitMut;
+
     let vis = &func.vis;
     let sig = &func.sig;
     let attrs = &func.attrs;
     let fn_name = &func.sig.ident;
     let merge_fn_name = quote::format_ident!("__merge_{}", fn_name);
 
+    // A field access through a `ref(T)` state scalar — `state.<ref>.<member>` —
+    // lowers to a `getfield_gc_*` / `setfield_gc_*` on the JIT side, but the
+    // concrete (non-JIT) function carries the ref as raw pointer bits (`usize`),
+    // so the same source has no `.<member>` to resolve.  Rewrite each such
+    // access in the concrete body to an unsafe deref of the raw pointer through
+    // the declared `ref(T)` struct type, matching the heap object the JIT
+    // getfield/setfield touches.
+    struct RefFieldRewriter {
+        // ref-scalar field name -> the `ref(T)` struct path `T`.
+        ref_fields: std::collections::HashMap<String, syn::Path>,
+    }
+    impl RefFieldRewriter {
+        // For `e == state.<ref_scalar>`, return the `ref(T)` struct path.
+        fn ref_struct_of_base(&self, e: &Expr) -> Option<syn::Path> {
+            let Expr::Field(f) = e else { return None };
+            if !matches!(&*f.base, Expr::Path(p) if p.path.is_ident("state")) {
+                return None;
+            }
+            let syn::Member::Named(ref_name) = &f.member else {
+                return None;
+            };
+            self.ref_fields.get(&ref_name.to_string()).cloned()
+        }
+    }
+    impl VisitMut for RefFieldRewriter {
+        fn visit_expr_mut(&mut self, expr: &mut Expr) {
+            // Write-through: `state.<ref>.<member> = <rhs>` ->
+            // `unsafe { (*(state.<ref> as *mut T)).<member> = <rhs> }`.
+            if let Expr::Assign(assign) = expr {
+                if let Expr::Field(lhs) = &*assign.left {
+                    if let Some(struct_path) = self.ref_struct_of_base(&lhs.base) {
+                        let base = (*lhs.base).clone();
+                        let member = lhs.member.clone();
+                        let mut rhs = (*assign.right).clone();
+                        self.visit_expr_mut(&mut rhs);
+                        *expr = syn::parse_quote! {
+                            unsafe { (*(#base as *mut #struct_path)).#member = #rhs }
+                        };
+                        return;
+                    }
+                }
+            }
+            // Read: `state.<ref>.<member>` reads a mutable heap field. In the
+            // observer-replay tracing model the recording walk advances this
+            // field over the whole loop circuit before the concrete body
+            // re-runs, so a raw re-read would see a stale value. Replay the
+            // walk-position value when one is queued (keyed by the live object
+            // pointer + field offset), else read the field live:
+            //   match consume_observed_getfield(obj as usize, offset_of!(T, m)) {
+            //       Some(v) => observer_i64_to_value(v),
+            //       None    => unsafe { (*(obj as *const T)).m },
+            //   }
+            // The JIT side records the matching value in BC_GETFIELD_GC_I.
+            if let Expr::Field(field) = expr {
+                if let Some(struct_path) = self.ref_struct_of_base(&field.base) {
+                    let base = (*field.base).clone();
+                    let member = field.member.clone();
+                    *expr = syn::parse_quote! {
+                        {
+                            let __majit_getfield_obj = #base;
+                            match majit_metainterp::consume_observed_getfield(
+                                __majit_getfield_obj as usize,
+                                ::core::mem::offset_of!(#struct_path, #member),
+                            ) {
+                                ::core::option::Option::Some(__majit_getfield_v) => unsafe {
+                                    majit_metainterp::observer_i64_to_value(__majit_getfield_v)
+                                },
+                                ::core::option::Option::None => unsafe {
+                                    (*(__majit_getfield_obj as *const #struct_path)).#member
+                                },
+                            }
+                        }
+                    };
+                    return;
+                }
+            }
+            syn::visit_mut::visit_expr_mut(self, expr);
+        }
+    }
+
+    let mut block = func.block.clone();
+    if let Some(sf) = &config.state_fields {
+        let ref_fields: std::collections::HashMap<String, syn::Path> = sf
+            .fields
+            .iter()
+            .filter_map(|f| match &f.kind {
+                StateFieldKind::Ref(p) => Some((f.name.to_string(), p.clone())),
+                _ => None,
+            })
+            .collect();
+        if !ref_fields.is_empty() {
+            RefFieldRewriter { ref_fields }.visit_block_mut(&mut block);
+        }
+    }
+
     // Rewrite the function body, replacing marker macros
     let body = rewrite_body(
-        &func.block,
+        &block,
         &merge_fn_name,
         &config.greens,
         &config.green_type_tags,

--- a/majit/majit-metainterp/Cargo.toml
+++ b/majit/majit-metainterp/Cargo.toml
@@ -24,6 +24,7 @@ majit-gc = { workspace = true }
 majit-translate = { workspace = true }
 smallvec = { workspace = true }
 vecset = { workspace = true }
+indexmap = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Native backends never build for wasm32; on wasm32 the backend is

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2471,6 +2471,13 @@ impl TraceCtx {
         self.recorder.num_ops() > self.trace_limit
     }
 
+    /// Current count of recorded (non-inputarg) ops.  The trace-recording
+    /// loop reads this to detect a non-productive spin — steps advancing
+    /// without the op list growing (which `is_too_long` cannot catch).
+    pub fn num_recorded_ops(&self) -> usize {
+        self.recorder.num_ops()
+    }
+
     /// Current cached trace limit snapshot (for diagnostics + force_finish
     /// segmenting heuristic).
     pub fn trace_limit(&self) -> usize {

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -142,6 +142,27 @@ pub struct ResumeDataResult {
     pub fail_arg_types: Vec<Type>,
 }
 
+/// resume.py:1245 `decode_box(num, kind)` parity for a generic
+/// (non-virtualizable) JitDriver sym. Returns the bridge `InputArg` OpRef
+/// for failarg `n` paired with its concrete deadframe shadow
+/// `fail_values[n]`. Both the OpRef and the shadow key off the Box's own
+/// failarg index `n` (authoritative), so they stay correct regardless of
+/// how `n` maps to a sym slot. Greens / `Const` / `Virtual` reds are
+/// caller-skipped.
+pub fn bridge_decode_red(
+    n: usize,
+    kind: Type,
+    fail_values: &[i64],
+    fail_types: &[Type],
+) -> (OpRef, i64) {
+    debug_assert_eq!(
+        fail_types.get(n).copied().unwrap_or(kind),
+        kind,
+        "bridge_decode_red: Box({n}) failarg type != decoded kind"
+    );
+    (OpRef::input_arg_typed(n as u32, kind), fail_values[n])
+}
+
 /// Interpreter-specific JIT state contract.
 pub trait JitState: Sized {
     type Meta: Clone;

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -460,19 +460,16 @@ impl JitCodeBuilder {
         fields: &[(usize, bool, &str)],
     ) {
         self.touch_ref_reg(dest);
-        let all_fielddescrs = Self::field_specs_from_layout(fields);
         // descr.py:108-120 get_size_descr + init_size_descr: cache the
         // full per-struct layout so the matching setfield_gc_* resolves
         // the parent SizeDescr and field index (descr.py:238).
-        self.struct_size_specs.insert(
-            type_id,
-            BhSizeSpec {
-                size,
-                type_id,
-                vtable: 0,
-                all_fielddescrs: all_fielddescrs.clone(),
-            },
-        );
+        self.register_struct_layout(size, type_id, fields);
+        let all_fielddescrs = self
+            .struct_size_specs
+            .get(&type_id)
+            .expect("register_struct_layout just inserted this type_id")
+            .all_fielddescrs
+            .clone();
         let descr = self.add_bh_descr(CanonicalBhDescr::Size {
             size,
             type_id,
@@ -483,6 +480,33 @@ impl JitCodeBuilder {
         self.write_insn("new/d>r");
         self.push_u16(descr);
         self.push_reg_u8(dest, "new result");
+    }
+
+    /// Register a struct's `(offset, is_ref, name)` layout under `type_id`
+    /// WITHOUT emitting a `new/d>r` allocation op.  Used for a struct that
+    /// is allocated natively (outside the JIT) but whose fields are still
+    /// read/written through `getfield_gc_*` / `setfield_gc_*`: the layout
+    /// must be cached so `add_struct_field_descr` can resolve the parent
+    /// SizeDescr + `index_in_parent`, giving read and write the same interned
+    /// `Field` descr (the heapcache aliases get against set by that identity).
+    /// Idempotent: re-registering the same `type_id` overwrites with an
+    /// identical layout.
+    pub fn register_struct_layout(
+        &mut self,
+        size: usize,
+        type_id: u64,
+        fields: &[(usize, bool, &str)],
+    ) {
+        let all_fielddescrs = Self::field_specs_from_layout(fields);
+        self.struct_size_specs.insert(
+            type_id,
+            BhSizeSpec {
+                size,
+                type_id,
+                vtable: 0,
+                all_fielddescrs,
+            },
+        );
     }
 
     /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name)` layout,
@@ -660,10 +684,18 @@ impl JitCodeBuilder {
 
     /// Emit `getfield_gc_i/rd>i` (`blackhole.py:1432 bhimpl_getfield_gc_i`):
     /// load `struct_reg`'s int field at `offset` into `dest`.
-    pub fn getfield_gc_i(&mut self, dest: u16, struct_reg: u16, offset: usize) {
+    ///
+    /// `type_id` resolves the parent-carrying struct field descr (the same
+    /// `add_struct_field_descr` the matching `setfield_gc_i` uses), so a
+    /// getfield and a setfield on the same `(type_id, offset)` intern the
+    /// same `Field` descr and the heapcache can alias read against write.
+    /// A `type_id` whose layout was never registered degrades to a parentless
+    /// scalar descr (`add_struct_field_descr` returns the scalar form), which
+    /// keeps existing callers correct.
+    pub fn getfield_gc_i(&mut self, dest: u16, struct_reg: u16, offset: usize, type_id: u64) {
         self.touch_ref_reg(struct_reg);
         self.touch_reg(dest);
-        let descr = self.add_scalar_field_descr(offset, majit_ir::value::Type::Int);
+        let descr = self.add_struct_field_descr(offset, majit_ir::value::Type::Int, type_id);
         self.write_insn("getfield_gc_i/rd>i");
         self.push_reg_u8(struct_reg, "getfield_gc_i struct");
         self.push_u16(descr);
@@ -672,10 +704,12 @@ impl JitCodeBuilder {
 
     /// Emit `getfield_gc_r/rd>r` (`blackhole.py:1437 bhimpl_getfield_gc_r`):
     /// load `struct_reg`'s ref field at `offset` into `dest`.
-    pub fn getfield_gc_r(&mut self, dest: u16, struct_reg: u16, offset: usize) {
+    ///
+    /// See [`Self::getfield_gc_i`] for the `type_id` parent-descr contract.
+    pub fn getfield_gc_r(&mut self, dest: u16, struct_reg: u16, offset: usize, type_id: u64) {
         self.touch_ref_reg(struct_reg);
         self.touch_ref_reg(dest);
-        let descr = self.add_scalar_field_descr(offset, majit_ir::value::Type::Ref);
+        let descr = self.add_struct_field_descr(offset, majit_ir::value::Type::Ref, type_id);
         self.write_insn("getfield_gc_r/rd>r");
         self.push_reg_u8(struct_reg, "getfield_gc_r struct");
         self.push_u16(descr);

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -435,6 +435,7 @@ impl JitCodeBuilder {
             vtable,
             owner: String::new(),
             all_fielddescrs: Vec::new(),
+            is_gc_managed: true,
         });
         self.write_insn("new_with_vtable/d>r");
         self.push_u16(descr);
@@ -462,8 +463,9 @@ impl JitCodeBuilder {
         self.touch_ref_reg(dest);
         // descr.py:108-120 get_size_descr + init_size_descr: cache the
         // full per-struct layout so the matching setfield_gc_* resolves
-        // the parent SizeDescr and field index (descr.py:238).
-        self.register_struct_layout(size, type_id, fields);
+        // the parent SizeDescr and field index (descr.py:238).  A JIT
+        // `new` allocates a GC-headered struct, so `is_gc_managed = true`.
+        self.register_struct_layout(size, type_id, true, fields);
         let all_fielddescrs = self
             .struct_size_specs
             .get(&type_id)
@@ -476,6 +478,7 @@ impl JitCodeBuilder {
             vtable: 0,
             owner: String::new(),
             all_fielddescrs,
+            is_gc_managed: true,
         });
         self.write_insn("new/d>r");
         self.push_u16(descr);
@@ -491,10 +494,19 @@ impl JitCodeBuilder {
     /// `Field` descr (the heapcache aliases get against set by that identity).
     /// Idempotent: re-registering the same `type_id` overwrites with an
     /// identical layout.
+    ///
+    /// `is_gc_managed` records whether the struct carries a GC header
+    /// (`ref - 8` type-id word): `false` for a raw native struct (the
+    /// caller above the JIT owns the memory, no header), `true` when a
+    /// JIT-GC `new_struct` reuses this for layout caching.  Threaded to
+    /// `SimpleSizeDescr.is_gc_managed` so `StructPtrInfo.make_guards`
+    /// gates `GUARD_GC_TYPE`: a header-less raw struct must not be
+    /// runtime-type-pinned.
     pub fn register_struct_layout(
         &mut self,
         size: usize,
         type_id: u64,
+        is_gc_managed: bool,
         fields: &[(usize, bool, &str)],
     ) {
         let all_fielddescrs = Self::field_specs_from_layout(fields);
@@ -504,6 +516,7 @@ impl JitCodeBuilder {
                 size,
                 type_id,
                 vtable: 0,
+                is_gc_managed,
                 all_fielddescrs,
             },
         );

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1327,6 +1327,22 @@ impl JitCodeBuilder {
         self.push_reg_u8(dst, "getarrayitem_gc_i dst");
     }
 
+    /// Ref-result array read: `dst = array[index]` where the element is a
+    /// GC pointer (8 bytes). Mirrors [`Self::getarrayitem_gc_i`] but routes
+    /// `dst` through the ref register bank and uses the `/rid>r` mnemonic.
+    /// Used to re-derive a pointer-array element (aheui `pools[selected]`)
+    /// as a re-producible heap read instead of an opaque residual call.
+    pub fn getarrayitem_gc_r(&mut self, dst: u16, array_reg: u16, index_reg: u16, descr_idx: u16) {
+        self.touch_ref_reg(array_reg);
+        self.touch_reg(index_reg);
+        self.touch_ref_reg(dst);
+        self.write_insn("getarrayitem_gc_r/rid>r");
+        self.push_reg_u8(array_reg, "getarrayitem_gc_r array");
+        self.push_reg_u8(index_reg, "getarrayitem_gc_r index");
+        self.push_u16(descr_idx);
+        self.push_reg_u8(dst, "getarrayitem_gc_r dst");
+    }
+
     /// Add a GC-array descriptor for a byte-element array to the descrs pool.
     ///
     /// Returns the descr index to pass as `descr_idx` to `getarrayitem_gc_i`.
@@ -1361,6 +1377,34 @@ impl JitCodeBuilder {
             // `&[u8]` byte-array descrs are minted at assembler bootstrap
             // with no source-level array_type_id; the structural tuple
             // (base_size=0, itemsize=1, …) uniquely identifies them.
+            array_type_id: None,
+            interior_fields: Vec::new(),
+        })
+    }
+
+    /// Add a GC-array descriptor for a raw-pointer-element array (8-byte
+    /// `*mut T` items) to the descrs pool; returns the descr index for
+    /// `getarrayitem_gc_r`.  Models a length-prefixed `{ len: usize,
+    /// items: [*mut T; N] }` whose base pointer points at the `len` word:
+    /// `base_size = 8` (items start one word in), `len_offset = Some(0)`
+    /// (length at the base).  The lendescr is required: the optimizer
+    /// narrows the array's lenbound on a constant-index read (`heap.py:676
+    /// getlenbound().make_gt_const(index)`) and the short preamble re-emits
+    /// `ARRAYLEN_GC` to re-establish the `len > index` guard each loop entry
+    /// — without a lendescr the GC rewrite of that `ARRAYLEN_GC` panics.
+    /// The aheui `Storage` carries this header as `pools_len` (offset 0,
+    /// `pools` at offset 8).  Deduped structurally by `add_bh_descr`.
+    pub fn add_ptr_array_descr(&mut self) -> u16 {
+        self.add_array_descr(CanonicalBhDescr::Array {
+            base_size: std::mem::size_of::<usize>(),
+            itemsize: 8,
+            len_offset: Some(0),
+            type_id: 0,
+            item_type: majit_ir::value::Type::Ref,
+            is_array_of_pointers: true,
+            is_array_of_structs: false,
+            is_item_signed: false,
+            ei_index: u32::MAX,
             array_type_id: None,
             interior_fields: Vec::new(),
         })

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2176,7 +2176,22 @@ impl<S: JitState> JitDriver<S> {
                 .map(|pc| pc as usize)
                 .unwrap_or(target_pc);
 
+            // compile.py:701-716 handle_fail. PyPy: `must_compile() and not
+            // stack_almost_full()` → `_trace_and_compile_from_bridge`, else
+            // `resume_in_blackhole`; the two are mutually exclusive and
+            // neither returns. majit adapts by returning the interpreter
+            // resume pc.
             if should_bridge {
+                // Reconstruct the concrete interpreter state from storage
+                // BEFORE tracing the bridge: a guard failure leaves `state`'s
+                // delta-tracked / carried reds (e.g. a `stacksize` recomputed
+                // from `selected_ref.size`) at their stale pre-run values, so
+                // recording the bridge body from the raw `state` bakes the
+                // wrong loop-control branch. `recover_after_compiled_run`
+                // (the macro's `recover` fn) re-derives them from the live
+                // storage so `build_meta(resume_pc)` and the recorded bridge
+                // see the post-guard-failure values.
+                state.recover_after_compiled_run();
                 // compile.py:704-709: _trace_and_compile_from_bridge
                 let bridge_ok =
                     self.start_bridge_tracing(&descr_arc, state, env, &raw_values, guard_resume_pc);
@@ -2186,23 +2201,35 @@ impl<S: JitState> JitDriver<S> {
                         green_key, trace_id, fail_index, guard_resume_pc, bridge_ok
                     );
                 }
-            }
-
-            // compile.py:701-716 handle_fail. PyPy: `must_compile() and not
-            // stack_almost_full()` → `_trace_and_compile_from_bridge`, else
-            // `resume_in_blackhole`; the two are mutually exclusive and
-            // neither returns. majit adapts by returning the interpreter
-            // resume pc. The bridge path (started above) keeps the crude loop
-            // teardown (status quo); only the blackhole path below is the
-            // forward-resume this epic introduces.
-            if should_bridge {
+                if bridge_ok {
+                    // The bridge tracing session is now active
+                    // (`begin_trace_session`). Resume the interpreter at the
+                    // guard's resume pc and let the mainloop record the bridge
+                    // body; it closes into a bridge attached to the failing
+                    // guard (`compile_bridge`), so the guard-failure case stops
+                    // re-tracing the loop. Do NOT tear the loop down — the
+                    // bridge attaches to it. (`back_edge_internal` is the macro
+                    // `#[jit_interp]`-only back edge; pyre-jit-trace forms
+                    // bridges through its own eval.rs path, so this does not
+                    // touch the rustpython JIT.)
+                    if crate::majit_log_enabled() {
+                        eprintln!(
+                            "[jit-run] guard failure (bridge-record) fail_index={}, resume_pc={}, target_pc={}, key={}",
+                            fail_index, guard_resume_pc, target_pc, green_key
+                        );
+                    }
+                    return Some(guard_resume_pc);
+                }
+                // start_bridge_tracing declined (dead jct / non-traceable /
+                // resume-decode gap): crude loop teardown + interpreter resume
+                // (status-quo fallback).
                 state.recover_after_compiled_run();
                 self.meta.invalidate_loop(green_key);
                 self.meta.remove_compiled_loop(green_key);
                 self.meta.warm_state_mut().abort_tracing(green_key, true);
                 if crate::majit_log_enabled() {
                     eprintln!(
-                        "[jit-run] guard failure (bridge) fail_index={}, resume_pc={}, target_pc={}, key={}",
+                        "[jit-run] guard failure (bridge-decline) fail_index={}, resume_pc={}, target_pc={}, key={}",
                         fail_index, guard_resume_pc, target_pc, green_key
                     );
                 }
@@ -2422,6 +2449,17 @@ impl<S: JitState> JitDriver<S> {
                                 &bh.registers_i[int_base..],
                                 &bh.registers_r[ref_base..],
                             );
+                            // The carried/delta-tracked reds in the deadframe
+                            // can lag the authoritative live storage (e.g. a
+                            // `stacksize` whose backing stack was popped by the
+                            // compiled body but whose red was captured stale).
+                            // Re-derive them from storage so the green recomputed
+                            // at the resumed `jit_merge_point` (here: `stackok =
+                            // req_size <= stacksize`) reflects reality instead of
+                            // the stale red, otherwise the interpreter re-enters
+                            // the same compiled loop and re-fails the same green
+                            // guard with zero forward progress.
+                            state.recover_after_compiled_run();
                             Some(green_pc.unwrap_or(target_pc))
                         }
                         // The interpreted frame ran to completion inside the
@@ -3865,6 +3903,30 @@ impl<S: JitState> JitDriver<S> {
                 .pending_frontend_boxes_ref()
                 .map(|s| s.to_vec())
                 .unwrap_or_default();
+            // resume.py:1054 consume_boxes parity: decode the guard frame's
+            // per-bank live register indices here, where the dispatch JitCode
+            // + `liveness_info` are reachable, and stash them on the trace ctx.
+            // A JitDriver `setup_bridge_sym` (static, metainterp-blind) reads
+            // them back to map each decoded frame value to its sym slot. The
+            // macro mainloop bridge is single-frame, so the root frame's
+            // dispatch JitCode is the only coordinate needed.
+            //
+            // We pass `frame.pc`, not `frame.jitcode_pc`: the single-frame macro
+            // capture records the dispatch-JitCode position in `pc` and leaves
+            // `jitcode_pc = NO_JITCODE_PC` (sentinel, resume.rs single_frame_boxes),
+            // so `pc` is the valid liveness coordinate here.  A multi-frame
+            // consumer whose inlined callees carry real `jitcode_pc` words would
+            // index liveness per-frame by `jitcode_pc` instead.
+            let bridge_reg_indices = self.dispatch_jitcode().and_then(|jc| {
+                bfm.frames.first().map(|frame| {
+                    crate::resume::read_frame_liveness_reg_indices(
+                        jc,
+                        frame.pc as usize,
+                        self.meta.staticdata.op_live as u8,
+                        &self.meta.staticdata.liveness_info,
+                    )
+                })
+            });
             // Both `self.sym` (set above via `self.sym = Some(sym)`) and
             // `self.meta.tracing` (set by `start_retrace_from_guard`) must be
             // live by construction at this point. Skipping `setup_bridge_sym`
@@ -3878,6 +3940,9 @@ impl<S: JitState> JitDriver<S> {
                 .tracing
                 .as_mut()
                 .expect("bridge: tracing context must be live");
+            if let Some(idx) = bridge_reg_indices {
+                ctx.set_bridge_reg_indices(idx);
+            }
             S::setup_bridge_sym(
                 sym,
                 ctx,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -118,9 +118,8 @@ pub use pyjitpl::{
     MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, build_state_field_snapshot,
     call_int_function, call_ref_function, call_void_function, consume_observed_float_call,
     consume_observed_getfield, consume_observed_int_call, consume_observed_ref_call,
-    consume_observed_void_call, counters,
-    observer_arg_to_i64, observer_i64_to_value, struct_field_write_effect_info, trace_jitcode,
-    trace_jitcode_observer,
+    consume_observed_void_call, counters, observer_arg_to_i64, observer_i64_to_value,
+    struct_field_write_effect_info, trace_jitcode, trace_jitcode_observer,
     trace_jitcode_observer_with_args, trace_jitcode_observer_with_args_and_runtime,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -91,7 +91,7 @@ pub use io_buffer::{
 };
 pub use jit_state::{
     DeoptMaterializationCache, JitState, PendingFieldWriteLayout, ResidualVirtualizableSync,
-    ResumeDataResult,
+    ResumeDataResult, bridge_decode_red,
 };
 pub use jitcode::{
     BC_GOTO, JitArgKind, JitCallArg, JitCode, JitCodeBuilder, LivenessInfo, insns,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -117,8 +117,10 @@ pub use pyjitpl::{
     JitCodeSym, JitHooks, JitStats, MIFrame, MIFrameStack, MetaInterp, MetaInterpGlobalData,
     MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, build_state_field_snapshot,
     call_int_function, call_ref_function, call_void_function, consume_observed_float_call,
-    consume_observed_int_call, consume_observed_ref_call, consume_observed_void_call, counters,
-    observer_arg_to_i64, observer_i64_to_value, trace_jitcode, trace_jitcode_observer,
+    consume_observed_getfield, consume_observed_int_call, consume_observed_ref_call,
+    consume_observed_void_call, counters,
+    observer_arg_to_i64, observer_i64_to_value, struct_field_write_effect_info, trace_jitcode,
+    trace_jitcode_observer,
     trace_jitcode_observer_with_args, trace_jitcode_observer_with_args_and_runtime,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1965,7 +1965,17 @@ impl OptHeap {
                 // [can_cache=True].
                 self.force_lazy_set_field(&descr, true, ctx);
             }
-            if ei.check_write_descr_field(effect_idx) {
+            // Raw-set fallback for the macro / `JitDriver` path where
+            // `compute_bitstrings` never runs (so `effect_idx` is the unset
+            // u32::MAX sentinel and the bitstring lookup always misses):
+            // invalidate when the call's concrete `_write_descrs_fields` names
+            // this exact field descr by pointer identity.  Gated on
+            // `!compute_bitstrings_has_run()` so the translated interpreter's
+            // bitstring path is unchanged.
+            let writes_field = ei.check_write_descr_field(effect_idx)
+                || (!majit_ir::effectinfo::compute_bitstrings_has_run()
+                    && ei.writes_field_descr_by_identity(&descr));
+            if writes_field {
                 // heap.py:545-546 cf.force_lazy_set(self, fielddescr,
                 //                                   can_cache=False).
                 self.force_lazy_set_field(&descr, false, ctx);

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -536,17 +536,34 @@ impl PtrInfoExt for PtrInfo {
                 //       c_typeid = ConstInt(self.descr.get_type_id())
                 //       short.extend([GUARD_NONNULL[op],
                 //                     GUARD_GC_TYPE[op, c_typeid]])
-                let type_id = info
+                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
+                // GUARD_GC_TYPE only for a real `GcStruct`: it reads a
+                // type-id word at `ref - 8` (the GC header).  A header-less
+                // raw native struct (registered via `register_struct_layout`
+                // — e.g. a `ref(T)` state scalar's target, or a `pools[i]`
+                // element loaded by `getarrayitem_gc_r`) has no such word,
+                // so the guard would read content-dependent garbage that
+                // mutates on every push/pop and fail on every loop
+                // re-entry.  RPython emits GUARD_GC_TYPE only for
+                // `lltype.GcStruct`; a raw `Struct` gets GUARD_NONNULL only.
+                // No descr → preserve the guard (default true).
+                let is_gc_managed = info
                     .descr
                     .as_size_descr()
-                    .map(|sd| sd.type_id() as i64)
-                    .unwrap_or(0);
-                let type_id_const = alloc_const(ctx, Value::Int(type_id));
-                short.push(Op::new(OpCode::GuardNonnull, &[op_b.clone()]));
-                short.push(Op::new(
-                    OpCode::GuardGcType,
-                    &[op_b.clone(), type_id_const.clone()],
-                ));
+                    .map(|sd| sd.is_gc_managed())
+                    .unwrap_or(true);
+                if is_gc_managed {
+                    let type_id = info
+                        .descr
+                        .as_size_descr()
+                        .map(|sd| sd.type_id() as i64)
+                        .unwrap_or(0);
+                    let type_id_const = alloc_const(ctx, Value::Int(type_id));
+                    short.push(Op::new(
+                        OpCode::GuardGcType,
+                        &[op_b.clone(), type_id_const.clone()],
+                    ));
+                }
             }
             PtrInfo::Constant(gcref) => {
                 // info.py:715-716: ConstPtrInfo.make_guards

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -779,7 +779,16 @@ pub struct OptContext {
     /// Keyed by the full type-tagged `OpRef`, so a typed and an untyped
     /// (or differently-typed) position sharing a raw `u32` are distinct
     /// entries instead of evicting each other in a raw-indexed slot.
-    pub(crate) resop_refs: majit_ir::VecMap<OpRef, majit_ir::resoperation::OpRc>,
+    // Insertion-ordered map (`IndexMap`) rather than the Vec-backed
+    // `VecMap`: `find_producer_op` does `resop_refs.get(&opref)` once per
+    // live box of every guard inside `store_final_boxes_in_guard`, and a
+    // Vec-backed `get` is O(n), making the box-numbering O(n^2) on very
+    // large traces (aheui's logo loop spends ~all its compile time there).
+    // `IndexMap` keeps the same insertion-ordered `values()` semantics the
+    // earlier container guaranteed but resolves `get` in O(1).  Same O(1)
+    // acceleration rationale as `input_ops_index`; no PyPy counterpart
+    // (upstream keys producers on `box._forwarded`, not a positional map).
+    pub(crate) resop_refs: indexmap::IndexMap<OpRef, majit_ir::resoperation::OpRc>,
     /// Live synthetic stand-ins (mint_synthetic_resop / bind_input_resops
     /// products) that have NOT been superseded by an `emit` at their
     /// position. The end-of-Phase-1 orphan-binding pass drains this into
@@ -802,6 +811,17 @@ pub struct OptContext {
     /// `op_at` falls back to this slice so `op.type_` stays the single source
     /// of truth for Phase 1 emit OpRef types.
     pub phase1_emit_ops: Vec<majit_ir::OpRc>,
+    /// `pos -> producer` index over `phase1_emit_ops`, mirroring the `rfind`
+    /// (last-occurrence-wins) lookup in `find_producer_op`. This OptContext
+    /// field is written exactly once — the Phase 1→2 handoff
+    /// (`ctx.phase1_emit_ops = mem::take(...)` in `optimizer.rs`) — and never
+    /// mutated afterwards, so the index is rebuilt in lockstep there via
+    /// `rebuild_phase1_emit_ops_index`. Without it, `find_producer_op` scans
+    /// the full cross-phase carry (~60k ops on aheui's logo loop) per live
+    /// box of every Phase 2 guard, the dominant O(n^2) compile cost. Same
+    /// derived-index rationale as `input_ops_index` (no PyPy counterpart:
+    /// upstream keys producers on `box._forwarded`, not a positional map).
+    pub(crate) phase1_emit_ops_index: std::collections::HashMap<OpRef, majit_ir::OpRc>,
     /// Recorder trace ops that carry the input operands' producer `Op`
     /// (e.g. the `IntLt`/`GetfieldGcPureI` operands of a recorded loop),
     /// shared by `Rc` with the canonical stores but absent from
@@ -1652,9 +1672,10 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
-            resop_refs: majit_ir::VecMap::new(),
+            resop_refs: indexmap::IndexMap::new(),
             live_synthetics: Vec::new(),
             phase1_emit_ops: Vec::new(),
+            phase1_emit_ops_index: std::collections::HashMap::new(),
             input_ops: Vec::new(),
             input_ops_index: std::collections::HashMap::new(),
             last_guard_idx: None,
@@ -1808,12 +1829,8 @@ impl OptContext {
         if let Some(op) = self.new_operations.iter().rfind(|op| op.pos.get() == opref) {
             return Some(op.clone());
         }
-        if let Some(op) = self
-            .phase1_emit_ops
-            .iter()
-            .rfind(|op| op.pos.get() == opref)
-        {
-            return Some(op.clone());
+        if let Some(op) = self.phase1_emit_ops_index.get(&opref).cloned() {
+            return Some(op);
         }
         if let Some(op) = self.resop_refs.get(&opref).cloned() {
             return Some(op);
@@ -1838,6 +1855,20 @@ impl OptContext {
         self.input_ops_index.reserve(self.input_ops.len());
         for op in &self.input_ops {
             self.input_ops_index.insert(op.pos.get(), op.clone());
+        }
+    }
+
+    /// Rebuild `phase1_emit_ops_index` from `phase1_emit_ops`. Called once
+    /// at the Phase 1→2 handoff right after `phase1_emit_ops` is assigned;
+    /// the field is never mutated afterwards. Forward iteration with
+    /// `insert` makes the last occurrence at each position win, matching the
+    /// `rfind` the index replaces.
+    pub(crate) fn rebuild_phase1_emit_ops_index(&mut self) {
+        self.phase1_emit_ops_index.clear();
+        self.phase1_emit_ops_index
+            .reserve(self.phase1_emit_ops.len());
+        for op in &self.phase1_emit_ops {
+            self.phase1_emit_ops_index.insert(op.pos.get(), op.clone());
         }
     }
 
@@ -2232,9 +2263,10 @@ impl OptContext {
 
             inputargs: Vec::new(),
             inputarg_refs: Vec::new(),
-            resop_refs: majit_ir::VecMap::new(),
+            resop_refs: indexmap::IndexMap::new(),
             live_synthetics: Vec::new(),
             phase1_emit_ops: Vec::new(),
+            phase1_emit_ops_index: std::collections::HashMap::new(),
             input_ops: Vec::new(),
             input_ops_index: std::collections::HashMap::new(),
             last_guard_idx: None,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2468,6 +2468,9 @@ impl Optimizer {
         // Phase 1 emit ops: single source of truth for cross-phase OpRef →
         // `op.type_` lookup (history.py:220 parity).
         ctx.phase1_emit_ops = std::mem::take(&mut self.phase1_emit_ops);
+        // Single write site for the OptContext field: rebuild its O(1)
+        // producer index in lockstep (never mutated afterwards).
+        ctx.rebuild_phase1_emit_ops_index();
         // 3. (removed) 5: transformed trace ops carry `op.type_`
         //    intrinsically (resoperation.py:1693 parity); the pipeline
         //    emits each op into `new_operations` before moving to the

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4,9 +4,11 @@ mod frame;
 pub use dispatch::build_state_field_snapshot;
 pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
-    StandaloneFrameStack, consume_observed_float_call, consume_observed_int_call,
-    consume_observed_ref_call, consume_observed_void_call, observer_arg_to_i64,
-    observer_i64_to_value, trace_jitcode, trace_jitcode_observer, trace_jitcode_observer_with_args,
+    StandaloneFrameStack, consume_observed_float_call, consume_observed_getfield,
+    consume_observed_int_call, consume_observed_ref_call, consume_observed_void_call,
+    observer_arg_to_i64,
+    observer_i64_to_value, struct_field_write_effect_info, trace_jitcode, trace_jitcode_observer,
+    trace_jitcode_observer_with_args,
     trace_jitcode_observer_with_args_and_runtime, trace_jitcode_with_args,
     trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6,9 +6,8 @@ pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
     StandaloneFrameStack, consume_observed_float_call, consume_observed_getfield,
     consume_observed_int_call, consume_observed_ref_call, consume_observed_void_call,
-    observer_arg_to_i64,
-    observer_i64_to_value, struct_field_write_effect_info, trace_jitcode, trace_jitcode_observer,
-    trace_jitcode_observer_with_args,
+    observer_arg_to_i64, observer_i64_to_value, struct_field_write_effect_info, trace_jitcode,
+    trace_jitcode_observer, trace_jitcode_observer_with_args,
     trace_jitcode_observer_with_args_and_runtime, trace_jitcode_with_args,
     trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -57,6 +57,18 @@ enum ObservedCall {
         args: Vec<i64>,
         result: i64,
     },
+    /// A `getfield_gc` read of a mutable heap field recorded during the
+    /// observer walk. Unlike an immutable field, a residual-mutated field
+    /// (e.g. aheui's `Stack.size`) is advanced by the full-circuit observer
+    /// walk before the outer replay re-reads it, so a raw re-read sees a
+    /// stale value. Recording the loaded word lets the replay consume the
+    /// value the walk observed at the matching position, keyed by the live
+    /// object pointer and field offset.
+    Getfield {
+        obj: usize,
+        offset: usize,
+        result: i64,
+    },
 }
 
 /// Returns whether the current thread is running `JitCodeMachine::run_to_end`
@@ -225,6 +237,19 @@ pub fn record_observed_float_call(func: *const (), args: &[i64], result: i64) {
     });
 }
 
+/// Record a mutable-field `getfield_gc` load observed during the walk so the
+/// outer replay can reproduce the walk-position value instead of re-reading a
+/// field the rest of the walk has already advanced. See [`ObservedCall::Getfield`].
+pub fn record_observed_getfield(obj: usize, offset: usize, result: i64) {
+    if observer_debug() {
+        eprintln!("[observer] record getfield obj={obj:#x} offset={offset} result={result}");
+    }
+    OBSERVED_CALLS.with(|q| {
+        q.borrow_mut()
+            .push_back(ObservedCall::Getfield { obj, offset, result });
+    });
+}
+
 #[inline(always)]
 pub fn consume_observed_void_call(func: *const (), args: &[i64]) -> bool {
     if !in_observer_replay() {
@@ -355,6 +380,45 @@ pub fn consume_observed_float_call(func: *const (), args: &[i64]) -> Option<i64>
                 Some(result)
             }
             other => observed_call_mismatch("float", func, args, other),
+        }
+    })
+}
+
+/// Replay a mutable-field `getfield_gc` load recorded by the observer walk.
+/// Returns `Some(result)` when the queue front is the matching `Getfield`
+/// (same object pointer + offset), so the outer interpreter reproduces the
+/// walk-position value rather than a stale re-read; `None` when not replaying
+/// (the caller then reads the field live).
+#[inline(always)]
+pub fn consume_observed_getfield(obj: usize, offset: usize) -> Option<i64> {
+    if !in_observer_replay() {
+        return None;
+    }
+    OBSERVED_CALLS.with(|q| {
+        let mut q = q.borrow_mut();
+        let Some(front) = q.front() else {
+            OBSERVER_REPLAY.with(|m| m.set(false));
+            return None;
+        };
+        if observer_debug() {
+            eprintln!("[observer] consume getfield obj={obj:#x} offset={offset}");
+        }
+        match front {
+            ObservedCall::Getfield {
+                obj: observed_obj,
+                offset: observed_offset,
+                result,
+            } if *observed_obj == obj && *observed_offset == offset => {
+                let result = *result;
+                q.pop_front();
+                if q.is_empty() {
+                    OBSERVER_REPLAY.with(|m| m.set(false));
+                }
+                Some(result)
+            }
+            other => {
+                observed_call_mismatch("getfield", obj as *const (), &[obj as i64, offset as i64], other)
+            }
         }
     })
 }
@@ -572,6 +636,94 @@ fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, majit_i
         }
         other => panic!("getfield_gc/setfield_gc: descr is not a Field: {other:?}"),
     }
+}
+
+/// Build a `CanRaise` [`EffectInfo`] whose field write-set names `write_field`
+/// of struct `type_id`, sharing the exact keyed `Arc<SimpleFieldDescr>` that a
+/// `getfield_gc_i` on the same `(type_id, write_field)` resolves to.  A
+/// residual helper that mutates a struct field through opaque host code — e.g.
+/// aheui's `jit_storage_*` advancing the selected `Stack.size` — declares this
+/// so `OptHeap::force_from_effectinfo` invalidates the cached `getfield_gc_i`
+/// on that field after the call.  Without it the residual call carries an empty
+/// write-set, the optimizer CSE-folds the field load to a single loop-invariant
+/// read, and a loop whose exit condition derives from that field never
+/// re-observes the mutation.  This is the residual analogue of the in-trace
+/// `setfield_gc` write barrier a traced mutator would emit.
+///
+/// `fields` is the same `(offset, is_ref, name)` layout the matching getfield
+/// passes to `register_struct_layout`; the parented size+field group is rebuilt
+/// here identically (`make_simple_descr_group_keyed`, idempotent / first-write-
+/// wins) so the field descr published into `gc_cache()._cache_field[Struct
+/// (type_id)][name]` is the one `field_descr_ref_from_bh` reads back for the
+/// getfield — pointer identity, which `compute_bitstrings` keys on.  Must run
+/// before `finish_setup_descrs` (jitcode assembly does), matching the
+/// non-trivial-raw-set construction-timing `call_descr` asserts.
+pub fn struct_field_write_effect_info(
+    struct_size: usize,
+    type_id: u64,
+    fields: &[(usize, bool, &str)],
+    write_field: &str,
+) -> majit_ir::EffectInfo {
+    // Mirror `JitCodeBuilder::field_specs_from_layout`: sort by offset so
+    // `index_in_parent` is the stable by-offset rank, scalar = one machine word.
+    let mut ordered: Vec<(usize, bool, &str)> = fields.to_vec();
+    ordered.sort_by_key(|&(offset, _, _)| offset);
+    let specs: Vec<majit_ir::descr::SimpleFieldDescrSpec> = ordered
+        .iter()
+        .enumerate()
+        .map(|(idx, &(offset, is_ref, name))| {
+            let (field_type, flag) = if is_ref {
+                (
+                    majit_ir::value::Type::Ref,
+                    majit_ir::descr::ArrayFlag::Pointer,
+                )
+            } else {
+                (
+                    majit_ir::value::Type::Int,
+                    majit_ir::descr::ArrayFlag::Signed,
+                )
+            };
+            majit_ir::descr::SimpleFieldDescrSpec {
+                index: u32::MAX,
+                name: name.to_string(),
+                offset,
+                field_size: 8,
+                field_type,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                flag,
+                virtualizable: false,
+                index_in_parent: idx,
+            }
+        })
+        .collect();
+    majit_ir::descr::make_simple_descr_group_keyed(
+        u32::MAX,
+        struct_size,
+        type_id as u32,
+        type_id,
+        0,
+        &specs,
+    );
+    let struct_key = majit_ir::descr::LLType::Struct(type_id);
+    let fd = majit_ir::descr::gc_cache()
+        .lock()
+        .unwrap()
+        ._cache_field
+        .get(&struct_key)
+        .and_then(|m| m.get(write_field))
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!(
+                "struct_field_write_effect_info: field `{write_field}` not registered for type {type_id}"
+            )
+        });
+    let mut ei = majit_ir::EffectInfo::const_new(
+        majit_ir::ExtraEffect::CanRaise,
+        majit_ir::OopSpecIndex::None,
+    );
+    ei._write_descrs_fields = Some(vec![fd as majit_ir::DescrRef]);
+    ei
 }
 
 pub trait JitCodeSym {
@@ -2752,6 +2904,20 @@ where
                 } else {
                     0
                 };
+                // A non-pure (mutable) field is advanced by the residual storage
+                // ops of this full-circuit observer walk, so a raw re-read on the
+                // outer replay would see the already-advanced value. Record the
+                // loaded word keyed by (object ptr, offset) so the replay
+                // reproduces the walk-position value (`consume_observed_getfield`).
+                // Pure/immutable getfields never move, so they stay a live read.
+                let is_pure = matches!(
+                    bytecode,
+                    jitcode::insns::BC_GETFIELD_GC_I_PURE
+                        | jitcode::insns::BC_GETFIELD_GC_R_PURE
+                );
+                if !is_pure && in_observer_mode() {
+                    record_observed_getfield(struct_ptr as usize, offset, loaded);
+                }
                 let kind = if is_ref {
                     OpCode::GetfieldGcR
                 } else {
@@ -7646,8 +7812,8 @@ mod tests {
         builder.load_const_i_value(0, 99); // int reg 0 = 99
         builder.setfield_gc_i(0, 0, 0, 0xCD); // Node.value = 99
         builder.setfield_gc_r(0, 0, 8, 0xCD); // Node.next  = Node (self-ref)
-        builder.getfield_gc_i(1, 0, 0); // int reg 1 = Node.value
-        builder.getfield_gc_r(1, 0, 8); // ref reg 1 = Node.next
+        builder.getfield_gc_i(1, 0, 0, 0xCD); // int reg 1 = Node.value
+        builder.getfield_gc_r(1, 0, 8, 0xCD); // ref reg 1 = Node.next
         let jitcode = builder.finish();
 
         let mut ctx = TraceCtx::for_test(0);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -245,8 +245,11 @@ pub fn record_observed_getfield(obj: usize, offset: usize, result: i64) {
         eprintln!("[observer] record getfield obj={obj:#x} offset={offset} result={result}");
     }
     OBSERVED_CALLS.with(|q| {
-        q.borrow_mut()
-            .push_back(ObservedCall::Getfield { obj, offset, result });
+        q.borrow_mut().push_back(ObservedCall::Getfield {
+            obj,
+            offset,
+            result,
+        });
     });
 }
 
@@ -416,9 +419,12 @@ pub fn consume_observed_getfield(obj: usize, offset: usize) -> Option<i64> {
                 }
                 Some(result)
             }
-            other => {
-                observed_call_mismatch("getfield", obj as *const (), &[obj as i64, offset as i64], other)
-            }
+            other => observed_call_mismatch(
+                "getfield",
+                obj as *const (),
+                &[obj as i64, offset as i64],
+                other,
+            ),
         }
     })
 }
@@ -1650,6 +1656,28 @@ where
              relying on the new shape.",
             cache_key.interior_fields,
         );
+        // A length-prefixed array (`len_offset = Some`) needs a real
+        // lendescr: the optimizer narrows the array's lenbound on a
+        // constant-index read (`heap.py:676 getlenbound().make_gt_const`)
+        // and the short preamble re-emits `ARRAYLEN_GC`, whose GC rewrite
+        // reads `lendescr.offset()` (`rewrite.rs` ARRAYLEN_GC arm) to load
+        // the length word.  Mirrors `descr.py:256-267
+        // get_field_arraylen_descr` — a `("len", ofs, WORD, FLAG_SIGNED)`
+        // FieldDescr with no parent.  `program: &[u8]` keeps
+        // `len_offset = None` (a fixed-size buffer with no length word) and
+        // stays `lendescr = None`.
+        let lendescr: Option<majit_ir::DescrRef> = len_offset.map(|ofs| {
+            let d: majit_ir::DescrRef = Arc::new(majit_ir::descr::SimpleFieldDescr::new_with_name(
+                u32::MAX,
+                ofs,
+                std::mem::size_of::<usize>(),
+                majit_ir::value::Type::Int,
+                false,
+                majit_ir::descr::ArrayFlag::Signed,
+                "len".to_string(),
+            ));
+            d
+        });
         let descr_arc = majit_ir::descr::make_array_descr_from_lltype_shape(
             // TODO: `make_array_descr_from_lltype_shape`
             // takes the u32 gc tid; this caller has the u64 cache key.
@@ -1663,7 +1691,7 @@ where
             is_array_of_pointers,
             is_array_of_structs,
             is_item_signed,
-            None,  // lendescr — `program: &[u8]` is fixed-size
+            lendescr,
             false, // is_pure — bytecode array is mutable from the JIT's POV
             ei_index,
             Vec::new(),
@@ -2912,8 +2940,7 @@ where
                 // Pure/immutable getfields never move, so they stay a live read.
                 let is_pure = matches!(
                     bytecode,
-                    jitcode::insns::BC_GETFIELD_GC_I_PURE
-                        | jitcode::insns::BC_GETFIELD_GC_R_PURE
+                    jitcode::insns::BC_GETFIELD_GC_I_PURE | jitcode::insns::BC_GETFIELD_GC_R_PURE
                 );
                 if !is_pure && in_observer_mode() {
                     record_observed_getfield(struct_ptr as usize, offset, loaded);
@@ -3223,6 +3250,70 @@ where
                         (opref, concrete)
                     };
                 self.set_int_reg(dst, Some(opref), Some(reg_concrete));
+            }
+            // ── BC_GETARRAYITEM_GC_R ──
+            //
+            // Ref-result element read for a raw-pointer array (aheui
+            // `pools[selected]` → `*mut Stack`).  Mirrors BC_GETARRAYITEM_GC_I
+            // but loads an 8-byte GC pointer and writes the ref bank.  Unlike
+            // the int arm there is NO all-constant fold: the array base is a
+            // live state pointer and the result must stay a `GetarrayitemGcR`
+            // op so the short preamble re-produces it each loop entry (the
+            // whole point of replacing the residual `jit_sel_get_ref` call).
+            // The `pools` array is immutable (`_immutable_fields_`), so a
+            // re-read during the observer concrete replay returns the same
+            // pointer — no `record_observed_*` queue is needed (none exists
+            // for getarrayitem).
+            jitcode::insns::BC_GETARRAYITEM_GC_R_RID => {
+                let (array_reg, index_reg, descr_idx, dst) = {
+                    let frame = self.frames.current_mut();
+                    let array_reg = frame.next_u8() as usize;
+                    let index_reg = frame.next_u8() as usize;
+                    let descr_idx = frame.next_u16() as usize;
+                    let dst = frame.next_u8() as usize;
+                    (array_reg, index_reg, descr_idx, dst)
+                };
+                let Some(descr) = self.dispatch_array_descr_ref(ctx, descr_idx) else {
+                    return TraceAction::Abort;
+                };
+                let Some((base_size, itemsize, _is_signed)) =
+                    self.dispatch_array_geometry(descr_idx)
+                else {
+                    return TraceAction::Abort;
+                };
+                let (array_opref, array_addr) = self.read_ref_reg(array_reg);
+                let (index_opref, index_value) = self.read_int_reg(index_reg);
+                let descr_index = descr.index();
+                let cached = ctx.heapcache_getarrayitem(array_opref, index_opref, descr_index);
+                // SAFETY: `array_addr` is the live pools-array base ref;
+                // `index_value` is the `selected` slot, bounded by
+                // STORAGE_COUNT. Pointer elements are 8 bytes (base_size=0).
+                let item_addr = (array_addr as usize)
+                    .wrapping_add(base_size)
+                    .wrapping_add((index_value as usize).wrapping_mul(itemsize));
+                let concrete = unsafe { *(item_addr as *const i64) };
+                let opref = if let Some(cached) = cached {
+                    ctx.profiler().count_ops(
+                        OpCode::GetarrayitemGcR,
+                        crate::pyjitpl::counters::HEAPCACHED_OPS,
+                    );
+                    cached
+                } else {
+                    let opref = ctx.record_op_with_descr(
+                        OpCode::GetarrayitemGcR,
+                        &[array_opref, index_opref],
+                        descr,
+                    );
+                    ctx.set_opref_concrete(opref, Value::Ref(majit_ir::GcRef(concrete as usize)));
+                    ctx.heapcache_getarrayitem_now_known(
+                        array_opref,
+                        index_opref,
+                        descr_index,
+                        opref,
+                    );
+                    opref
+                };
+                self.set_ref_reg(dst, Some(opref), Some(concrete));
             }
             jitcode::insns::BC_GETARRAYITEM_VABLE_I => {
                 let (opcode_pc, vable_reg, array_idx, index_reg, dest) = {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1966,7 +1966,50 @@ where
             .outer_program_pc
             .unwrap_or_else(|| self.frames.current_mut().pc);
         sym.begin_portal_op(portal_pc);
+        // Safety backstop against a runaway trace-recording loop.  A
+        // jitcode-level cycle that re-steps without growing the recorded op
+        // list never trips `is_too_long` (which counts ops), so the
+        // metainterp can spin unbounded and exhaust CPU/memory.  Two bounds:
+        //   * `stall_window` — abort once this many consecutive steps pass
+        //     with no new op recorded (a real trace grows ops continuously;
+        //     a non-productive spin never does).  Catches the cycle early.
+        //   * `step_limit` — absolute cap for any other runaway.
+        // `MAJIT_STALL_WINDOW` / `MAJIT_STEP_LIMIT` override for diagnosis.
+        let stall_window: u64 = std::env::var("MAJIT_STALL_WINDOW")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1_000_000);
+        let step_limit: u64 = std::env::var("MAJIT_STEP_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8_000_000);
+        let mut step_count: u64 = 0;
+        let mut last_num_ops = ctx.num_recorded_ops();
+        let mut steps_since_growth: u64 = 0;
         while !self.frames.is_empty() {
+            step_count += 1;
+            let n = ctx.num_recorded_ops();
+            if n > last_num_ops {
+                last_num_ops = n;
+                steps_since_growth = 0;
+            } else {
+                steps_since_growth += 1;
+            }
+            if steps_since_growth > stall_window || step_count > step_limit {
+                if crate::majit_log_enabled() {
+                    let why = if step_count > step_limit {
+                        "step limit"
+                    } else {
+                        "op-growth stall"
+                    };
+                    eprintln!(
+                        "[jit] trace_jitcode aborting ({why}): portal pc={portal_pc} jit pc={} steps={step_count} ops={n} (runaway trace)",
+                        self.frames.current_mut().pc
+                    );
+                }
+                sym.abort_portal_op();
+                return TraceAction::Abort;
+            }
             // Catch panics from BigInt overflow in runtime stack operations.
             // RPython doesn't have this issue (no BigInt); we abort the trace.
             let action = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -542,6 +542,7 @@ fn size_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> majit_ir::DescrR
         type_id,
         vtable,
         all_fielddescrs,
+        is_gc_managed,
         ..
     } = descr
     {
@@ -553,6 +554,7 @@ fn size_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> majit_ir::DescrR
                 *type_id as u32,
                 *type_id,
                 *vtable,
+                *is_gc_managed,
                 &specs,
             );
             let sd: majit_ir::DescrRef = group.size_descr;
@@ -618,6 +620,7 @@ fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, majit_i
                         p.type_id as u32,
                         p.type_id,
                         p.vtable,
+                        p.is_gc_managed,
                         &specs,
                     );
                     let struct_key = majit_ir::descr::LLType::Struct(p.type_id);
@@ -667,6 +670,7 @@ fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, majit_i
 pub fn struct_field_write_effect_info(
     struct_size: usize,
     type_id: u64,
+    is_gc_managed: bool,
     fields: &[(usize, bool, &str)],
     write_field: &str,
 ) -> majit_ir::EffectInfo {
@@ -709,6 +713,7 @@ pub fn struct_field_write_effect_info(
         type_id as u32,
         type_id,
         0,
+        is_gc_managed,
         &specs,
     );
     let struct_key = majit_ir::descr::LLType::Struct(type_id);

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -7124,6 +7124,74 @@ impl ResolvedJitCode {
     }
 }
 
+/// resume.py:1054 `consume_boxes` liveness split for a generic JitDriver
+/// `setup_bridge_sym`: the live register indices of a guard's resume frame,
+/// split by the three liveness banks (int / ref / float).  A frame decoded
+/// by `rebuild_from_numbering` lays its `values` out in this same bank order
+/// (all int-bank values, then all ref-bank, then float), so the i-th `int`
+/// index here pairs with the i-th int-bank `RebuiltValue`.
+#[derive(Default, Clone, Debug)]
+pub struct FrameLivenessRegIndices {
+    pub int: Vec<u32>,
+    pub ref_: Vec<u32>,
+    pub float: Vec<u32>,
+}
+
+impl FrameLivenessRegIndices {
+    pub fn total_len(&self) -> usize {
+        self.int.len() + self.ref_.len() + self.float.len()
+    }
+}
+
+/// jitcode.py:149-166 `enumerate_vars` parity: read the per-bank live
+/// register indices at a resolved JitCode `pc`. `all_liveness` is
+/// `metainterp_sd.liveness_info`; `op_live` is `metainterp_sd.op_live`.
+/// Returns empty banks when `pc` is not a valid liveness startpoint, so the
+/// caller can decline to seed rather than panic in `get_live_vars_info`.
+///
+/// jitcode.py:82-100 `get_live_vars_info` asserts on a missing startpoint
+/// (MissingLiveness); we deliberately soft-decline instead, because a frame
+/// resuming through the Python `pc` legitimately has no JitCode liveness at
+/// this coordinate.  An empty return can however mask a genuinely bad resume
+/// coordinate (the caller then seeds nothing), so each decline is logged
+/// under `MAJIT_BRIDGE_DEBUG` rather than being fully silent.
+pub fn read_frame_liveness_reg_indices(
+    jitcode: &crate::jitcode::JitCode,
+    pc: usize,
+    op_live: u8,
+    all_liveness: &[u8],
+) -> FrameLivenessRegIndices {
+    use majit_translate::liveness::LivenessIterator;
+    if !jitcode.can_decode_live_vars(pc, op_live) {
+        return FrameLivenessRegIndices::default();
+    }
+    let info = jitcode.get_live_vars_info(pc, op_live);
+    if info + 2 >= all_liveness.len() {
+        return FrameLivenessRegIndices::default();
+    }
+    // jitcode.py:149-151 — three length bytes; jitcode.py:152 — body offset.
+    let length_i = all_liveness[info] as u32;
+    let length_r = all_liveness[info + 1] as u32;
+    let length_f = all_liveness[info + 2] as u32;
+    let mut offset = info + 3;
+    fn read_bank(offset: &mut usize, length: u32, all_liveness: &[u8]) -> Vec<u32> {
+        if length == 0 {
+            return Vec::new();
+        }
+        let mut it = LivenessIterator::new(*offset, length, all_liveness);
+        let mut out = Vec::with_capacity(length as usize);
+        while let Some(reg_idx) = it.next() {
+            out.push(reg_idx);
+        }
+        *offset = it.offset;
+        out
+    }
+    let int = read_bank(&mut offset, length_i, all_liveness);
+    let ref_ = read_bank(&mut offset, length_r, all_liveness);
+    let float = read_bank(&mut offset, length_f, all_liveness);
+    FrameLivenessRegIndices { int, ref_, float }
+}
+
 pub fn blackhole_from_resumedata<'a>(
     builder: &mut crate::blackhole::BlackholeInterpBuilder,
     resolve_jitcode: &dyn Fn(i32, i32, i32) -> Option<ResolvedJitCode>,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -454,6 +454,12 @@ pub struct TraceCtx {
     /// []` before `rebuild_from_resumedata` (pyjitpl.py:3427). This makes a
     /// stale carrier leaking across bridges structurally impossible.
     pub(crate) bridge_inline_carrier: Option<BridgeInlineCarrier>,
+    /// resume.py:1054 consume_boxes parity: per-bank live register indices
+    /// of the bridge's guard resume frame, stashed by `start_bridge_tracing`
+    /// (which has the dispatch JitCode) so a JitDriver `setup_bridge_sym`
+    /// (a static trait method with no metainterp access) can map each
+    /// decoded frame value to its sym slot via `reg_idx - identity_base`.
+    pub(crate) bridge_reg_indices: Option<crate::resume::FrameLivenessRegIndices>,
 }
 
 /// A decoded-but-not-yet-built description of one inlined
@@ -1121,6 +1127,7 @@ impl TraceCtx {
             pending_switch_to_blackhole: None,
             virtualref_boxes: Vec::new(),
             bridge_inline_carrier: None,
+            bridge_reg_indices: None,
         }
     }
 
@@ -1189,6 +1196,7 @@ impl TraceCtx {
             pending_switch_to_blackhole: None,
             virtualref_boxes: Vec::new(),
             bridge_inline_carrier: None,
+            bridge_reg_indices: None,
         }
     }
 
@@ -1205,6 +1213,19 @@ impl TraceCtx {
     /// and single-frame bridges.
     pub fn take_bridge_inline_carrier(&mut self) -> Option<BridgeInlineCarrier> {
         self.bridge_inline_carrier.take()
+    }
+
+    /// Stash the bridge guard frame's per-bank live register indices (set by
+    /// `start_bridge_tracing` before `setup_bridge_sym`).
+    pub fn set_bridge_reg_indices(&mut self, indices: crate::resume::FrameLivenessRegIndices) {
+        self.bridge_reg_indices = Some(indices);
+    }
+
+    /// The bridge guard frame's per-bank live register indices, if stashed.
+    /// A JitDriver `setup_bridge_sym` reads this to map each decoded frame
+    /// value (laid out int-bank then ref-bank then float) to its sym slot.
+    pub fn bridge_reg_indices(&self) -> Option<&crate::resume::FrameLivenessRegIndices> {
+        self.bridge_reg_indices.as_ref()
     }
 
     /// Get or create a constant OpRef for a given i64 value.

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2879,6 +2879,10 @@ fn bh_size_spec_from_callcontrol(
         .or_else(|| heuristic_struct_size_for_bh(cc, owner))?;
     Some(crate::jitcode::BhSizeSpec {
         size,
+        // Analyzer-side structs keep the guard (unchanged); the raw
+        // header-less gate is driven by the runtime
+        // `register_struct_layout` path.
+        is_gc_managed: true,
         // `descr.py:105-127 get_size_descr` keys `_cache_size[STRUCT]` on
         // the lltype STRUCT object identity.  Pyre's analogue is
         // `path_hash(owner)` per `majit_ir::descr::path_hash` doc
@@ -3215,6 +3219,10 @@ fn bh_size_spec_from_descr(sd: &dyn majit_ir::descr::SizeDescr) -> crate::jitcod
         // path_hash key, polluting cross-path identity.
         type_id: sd.cache_key(),
         vtable: sd.vtable(),
+        // Round-trip the GC-header flag off the descr so a raw native
+        // struct stays raw through the inverse path (it must not regain
+        // a spurious `GUARD_GC_TYPE`).
+        is_gc_managed: sd.is_gc_managed(),
         all_fielddescrs: sd
             .all_fielddescrs()
             .iter()
@@ -3241,6 +3249,7 @@ pub(crate) fn bh_interior_field_specs_from_array_descr(
                     size: array_descr.item_size(),
                     type_id: 0,
                     vtable: 0,
+                    is_gc_managed: true,
                     all_fielddescrs: vec![field.clone()],
                 });
             Some(crate::jitcode::BhInteriorFieldSpec {
@@ -4011,6 +4020,9 @@ impl AssemblerDescrKey {
                 vtable,
                 owner,
                 all_fielddescrs,
+                // Functionally determined by `type_id` (a struct is GC or
+                // raw, not both), so not part of the dedup-key identity.
+                is_gc_managed: _,
             } => Self::Size {
                 size: *size,
                 type_id: *type_id,

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1077,7 +1077,22 @@ pub struct BhSizeSpec {
     /// the same `LLType::Struct(u64)` cache key in `gc_cache._cache_size`.
     pub type_id: u64,
     pub vtable: usize,
+    /// True when the struct carries a GC header (`ref - 8` type-id word),
+    /// false for a natively-allocated raw struct registered via
+    /// `register_struct_layout`.  Threaded to `SimpleSizeDescr.is_gc_managed`
+    /// so `StructPtrInfo.make_guards` gates `GUARD_GC_TYPE` correctly: a
+    /// header-less raw struct must not be runtime-type-pinned.
+    /// `serde(default)` keeps any spec serialized before the flag existed
+    /// emitting its guard (default `true`).
+    #[serde(default = "bh_gc_managed_default")]
+    pub is_gc_managed: bool,
     pub all_fielddescrs: Vec<BhFieldSpec>,
+}
+
+/// serde default for `is_gc_managed` — preserve the guard for specs
+/// serialized before the flag existed.
+fn bh_gc_managed_default() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -1213,6 +1228,11 @@ pub enum BhDescr {
         /// `heaptracker.all_fielddescrs(STRUCT)` snapshot; empty when
         /// the size descr is purely transient (no struct context).
         all_fielddescrs: Vec<BhFieldSpec>,
+        /// True when the struct carries a GC header; false for a raw
+        /// native struct (`register_struct_layout`).  Threaded to
+        /// `SimpleSizeDescr.is_gc_managed` for the `GUARD_GC_TYPE` gate.
+        #[serde(default = "bh_gc_managed_default")]
+        is_gc_managed: bool,
     },
     /// Call descriptor: for residual_call. Carries calling convention.
     /// RPython: `CallDescr`.

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2422,6 +2422,7 @@ mod tests {
             size: 24,
             type_id: 7,
             vtable: 0,
+            is_gc_managed: true,
             all_fielddescrs: vec![
                 BhFieldSpec {
                     index: 0,
@@ -2646,6 +2647,7 @@ mod tests {
             size: 16,
             type_id: 11,
             vtable: 0,
+            is_gc_managed: true,
             all_fielddescrs: fields.clone(),
         };
         let interior_fields = vec![
@@ -2808,6 +2810,7 @@ fn simple_descr_group_from_bh_size(
             spec.type_id as u32,
             spec.type_id,
             spec.vtable,
+            spec.is_gc_managed,
             &field_specs,
         )
     };
@@ -3480,6 +3483,7 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             type_id,
             vtable,
             all_fielddescrs,
+            is_gc_managed,
             ..
         } => {
             // `descr.py:108-118 get_size_descr` cache-hit semantics:
@@ -3530,6 +3534,7 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     size: *size,
                     type_id: *type_id,
                     vtable: *vtable,
+                    is_gc_managed: *is_gc_managed,
                     all_fielddescrs: all_fielddescrs.clone(),
                 };
                 simple_descr_group_from_bh_size(&spec).size_descr.clone()

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5821,6 +5821,8 @@ fn bh_size_descr_from_size_descr(
         vtable,
         owner: String::new(),
         all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(size_descr),
+        // Round-trip the GC-header flag off the descr.
+        is_gc_managed: size_descr.is_gc_managed(),
     }
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4993,6 +4993,7 @@ fn allocate_struct(typedescr: &dyn majit_ir::SizeDescr) -> usize {
         vtable: 0,
         owner: String::new(),
         all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(typedescr),
+        is_gc_managed: typedescr.is_gc_managed(),
     };
     let (driver, _) = driver_pair();
     driver.meta_interp().backend().bh_new(&descr) as usize
@@ -5074,6 +5075,7 @@ fn allocate_with_vtable(descr: &dyn majit_ir::SizeDescr) -> usize {
         vtable,
         owner: String::new(),
         all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(descr),
+        is_gc_managed: descr.is_gc_managed(),
     };
     let (driver, _) = driver_pair();
     driver.meta_interp().backend().bh_new_with_vtable(&bh_descr) as usize
@@ -7163,6 +7165,7 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
             vtable: 0,
             owner: String::new(),
             all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(sd),
+            is_gc_managed: sd.is_gc_managed(),
         };
         let (driver, _) = driver_pair();
         driver.meta_interp().backend().bh_new(&bh_descr)
@@ -7211,6 +7214,7 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
                     vtable,
                     owner: String::new(),
                     all_fielddescrs: majit_translate::jitcode::bh_field_specs_from_size_descr(sd),
+                    is_gc_managed: sd.is_gc_managed(),
                 };
                 let (driver, _) = driver_pair();
                 driver.meta_interp().backend().bh_new_with_vtable(&bh_descr)


### PR DESCRIPTION
#231

## Summary

majit (RPython/PyPy meta-tracing JIT port) trace-compile pipeline fixes, surfaced by the `#[jit_interp]` macro JitDriver path (aheui) on large traces. Rebased onto current `main`.

**Compile-time (O(n²) → O(n) on large traces)**
- *O(1) maps in the hot loop-compile path*: replace Vec-backed `VecAssoc` (O(n) `get`) with `IndexMap` (O(1)) for `regalloc LifetimeManager.lifetimes`, `aarch64 Assembler.opref_to_slot`, and optimizer `resop_refs`; add a parallel O(1) index for `phase1_emit_ops` (`find_producer_op`); drop a redundant O(n²) per-constant pool merge in `prepare_ops_for_compile`.
- *bound the trace-recording loop with stall/step backstops*: abort a recording that makes no op-count progress for `stall_window` steps or exceeds `step_limit` (`MAJIT_STALL_WINDOW` / `MAJIT_STEP_LIMIT` override).

**Correctness**
- *gate GUARD_GC_TYPE on a per-descr is_gc_managed flag*: `StructPtrInfo::make_guards` emitted `GUARD_GC_TYPE` for every struct ref, reading a type-id word at `ref-8` (the GC header) — but a natively allocated struct (`register_struct_layout`) has no header, so the guard read unrelated, iteration-varying memory. Add `SizeDescr::is_gc_managed` (default `true`), threaded through `BhSizeSpec` / `BhDescr::Size` / `make_simple_descr_group_keyed`. Macro `ref(T)` field getfield/setfield + residual write-set EI pass `false`; `new_struct` / `new_with_vtable` pass `true`. `GUARD_GC_TYPE` is emitted only when `is_gc_managed`, `GUARD_NONNULL` always kept.
- *getarrayitem_gc_r for ref-element array reads + lendescr from len_offset*: lower a `<fn>(state.<ref>, <int>)` marker call on a declared pool-array base to a re-producible `getarrayitem_gc_r` (length-prefixed `[*mut T; N]` descr) instead of an opaque residual `CALL_R`, so the element re-derives from the index each loop entry; `dispatch_array_descr_ref` builds the lendescr from `len_offset` so the array re-establishes its `ARRAYLEN_GC` guard in the short preamble.
- *residual-call write-set EffectInfo + state ref-scalar field getfield/setfield*: read a state ref-scalar's field as a `getfield` and invalidate it across residual calls declared (`residual_writes = { ref_scalar.field => [helpers] }`) to write it. `struct_field_write_effect_info` builds an EffectInfo whose `_write_descrs_fields` shares the field's keyed gc_cache `FieldDescr` Arc (pointer-identical to the getfield's descr); optimizer `force_from_effectinfo` invalidates the cached getfield by descr pointer-identity when write bitstrings are uncomputed (the macro/JitDriver path).

**Macro JitDriver bridges**
- *macro JitDriver bridge resume-decode*: generate `rebuild_from_resumedata` + `setup_bridge_sym` for the `#[jit_interp]` macro `JitState` impl (previously the trait defaults `None` / no-op, so `start_bridge_tracing` aborted on every guard failure and no guard-exit bridge formed). Adds `bridge_decode_red` (resume.py `decode_box` parity), `FrameLivenessRegIndices` + `read_frame_liveness_reg_indices`, `TraceCtx.bridge_reg_indices`, and wires per-bank reg-index computation + `recover_after_compiled_run` into the bridge path.

### Verification
- `check.py`: dynasm 144/144 + cranelift 144/144.
- aheui `hello` / `hello-world` / `99bottles` / `fibonacci` / `factorial`: `jit` == `--no-jit` byte-identical.

## Self-review

This patch is AI-assisted; all commits carry an `Assisted-by: Claude` trailer.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for replaying bridge state more accurately, including restored register mappings and observed field reads.
  * Improved handling of reference-backed state fields and raw array access during tracing.
  * Added clearer tracking for whether structs are GC-managed or native.

* **Bug Fixes**
  * Reduced tracing slowdowns by avoiding repeated constant merging and speeding up lookup paths.
  * Fixed guard and field-access behavior for native structs without GC headers.
  * Improved bridge and loop resumption to avoid stale state causing repeat failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->