### PR TITLE
SSA-repr codewriter: RPython-faithful flatten + jtransform parity (#37)

### DIFF
--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -3767,20 +3767,32 @@ fn init_someinstance_overrides(
                 // `match disc { k => ... }` switch refines this base-classed
                 // receiver to SomeInstance(variant_k) per arm via follow_link's
                 // improve.  No RPython analogue (RPython has no Rust enums).
+                //
+                // The tag is a non-negative integer.  An interpreter-defined
+                // enum projects a `__discriminant` row that `s_getattr` returns
+                // as `SomeInteger`; a per-instantiation `Option`/`Result`
+                // classdef (#100) carries no row (the std enum was never
+                // registered as a struct, so the bare template has nothing to
+                // project) yet — unlike before the split — is classdef-bearing,
+                // so it skips the classdef-less short-circuit above and reaches
+                // here with `s_attr == Impossible`.  Synthesize the tag in that
+                // case, the same value the classdef-less arm returns, so the
+                // read does not block the inference.
                 if attr == "__discriminant" {
-                    if let (SomeValue::Integer(si), Hlvalue::Variable(recv)) =
-                        (&s_attr, &hl.args[0])
-                    {
+                    let mut si = match &s_attr {
+                        SomeValue::Integer(si) => si.clone(),
+                        _ => super::model::SomeInteger::new(true, false),
+                    };
+                    if let Hlvalue::Variable(recv) = &hl.args[0] {
                         let enum_root = classdef.borrow().name.clone();
                         if let Some(ktd) = ann.bookkeeper.enum_variant_narrowing_knowntypedata(
                             &enum_root,
                             &Rc::new(recv.clone()),
                         ) {
-                            let mut si = si.clone();
                             si.set_knowntypedata(ktd);
-                            return SomeValue::Integer(si);
                         }
                     }
+                    return SomeValue::Integer(si);
                 }
                 s_attr
             }),

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -607,6 +607,39 @@ impl Assembler {
                 state.code.push(0);
             }
 
+            // RPython `flatten.py:247` fused guard: the jitcode key is
+            // `goto_if_not_<op>/<argcodes>`, where the argcodes are the
+            // per-operand register kinds (`i`/`r`/`f`) followed by the
+            // `L` label code (e.g. `goto_if_not_int_lt/iiL`,
+            // `goto_if_not_int_is_zero/iL`).  A Bool-producing compare's
+            // operands carry the matching concretetype, so the kinds
+            // resolve to the keys registered in `insns.rs:780-796`.
+            FlatOp::GotoIfNotOp {
+                opname,
+                args,
+                target,
+            } => {
+                let mut argcodes = String::with_capacity(args.len() + 1);
+                for arg in args {
+                    argcodes.push(match arg.kind {
+                        RegKind::Int => 'i',
+                        RegKind::Ref => 'r',
+                        RegKind::Float => 'f',
+                    });
+                }
+                argcodes.push('L');
+                let opnum = self.get_opnum(&format!("goto_if_not_{opname}/{argcodes}"));
+                state.startpoints.insert(state.code.len());
+                state.code.push(opnum);
+                for arg in args {
+                    state.code.push(arg.index as u8);
+                }
+                state.alllabels.insert(state.code.len());
+                state.tlabel_fixups.push((*target, state.code.len()));
+                state.code.push(0);
+                state.code.push(0);
+            }
+
             FlatOp::Switch { value, targets } => {
                 // `flatten.py:275-276` — `kind = getkind(block.exitswitch.
                 // concretetype); assert kind == 'int'`.  The production
@@ -2361,6 +2394,7 @@ impl Assembler {
                     }
                 }
                 FlatOp::GotoIfNot { .. }
+                | FlatOp::GotoIfNotOp { .. }
                 | FlatOp::Switch { .. }
                 | FlatOp::IntBinOpJumpIfOvf { .. } => {
                     // Guard ops carry [`Register`] operands
@@ -4399,6 +4433,65 @@ mod tests {
         assert_eq!(body.c_num_regs_r as usize, 0);
         assert_eq!(body.c_num_regs_f as usize, 0);
         assert_eq!(asm.count_jitcodes(), 1);
+    }
+
+    #[test]
+    fn assemble_fused_goto_if_not_routes_to_reserved_opcode() {
+        // gh #37: a `FlatOp::GotoIfNotOp` assembles through the
+        // registered `goto_if_not_<op>/<argcodes>` jitcode key — the
+        // per-arg register kinds form the argcodes, and the key must
+        // resolve to the reserved opcode the metainterp blackhole
+        // dispatches, NOT a freshly-minted dynamic byte (which would
+        // have no consumer).
+        use crate::flatten::Register;
+        let regallocs = empty_regallocs();
+
+        // Binary compare: `int_lt` with two int operands → `iiL`.
+        let mut flat = SSARepr {
+            name: "fused".into(),
+            insns: vec![
+                FlatOp::GotoIfNotOp {
+                    opname: "int_lt".into(),
+                    args: vec![
+                        Register::new(RegKind::Int, 0),
+                        Register::new(RegKind::Int, 1),
+                    ],
+                    target: Label(0),
+                },
+                FlatOp::Label(Label(0)),
+            ],
+            num_blocks: 1,
+            insns_pos: None,
+        };
+        let mut asm = Assembler::new();
+        let _ = asm.assemble(&mut flat, &regallocs);
+        assert_eq!(
+            asm.insns.get("goto_if_not_int_lt/iiL").copied(),
+            Some(crate::insns::BC_GOTO_IF_NOT_INT_LT),
+            "binary int compare must route to the reserved fused opcode",
+        );
+
+        // Unary test: `int_is_zero` with one int operand → `iL`.
+        let mut flat = SSARepr {
+            name: "fused_unary".into(),
+            insns: vec![
+                FlatOp::GotoIfNotOp {
+                    opname: "int_is_zero".into(),
+                    args: vec![Register::new(RegKind::Int, 0)],
+                    target: Label(0),
+                },
+                FlatOp::Label(Label(0)),
+            ],
+            num_blocks: 1,
+            insns_pos: None,
+        };
+        let mut asm = Assembler::new();
+        let _ = asm.assemble(&mut flat, &regallocs);
+        assert_eq!(
+            asm.insns.get("goto_if_not_int_is_zero/iL").copied(),
+            Some(crate::insns::BC_GOTO_IF_NOT_INT_IS_ZERO),
+            "unary int test must route to the reserved fused opcode",
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/flatten.rs
+++ b/majit/majit-translate/src/codewriter/flatten.rs
@@ -119,6 +119,21 @@ pub enum FlatOp {
     /// goto_if_true — RPython only uses goto_if_not; the true path is
     /// the fall-through.
     GotoIfNot { cond: Register, target: Label },
+    /// `flatten.py:247` fused producer-side guard:
+    /// `('goto_if_not_<op>', arg0[, arg1], TLabel(false_path))`.
+    /// Emitted when `jtransform::optimize_goto_if_not` folds a
+    /// Bool-producing comparison/test op into the exitswitch
+    /// (`ExitSwitch::Fused`), eliding the separate compare op.
+    /// `opname` is the RPython base opname (`int_lt`, `int_is_zero`,
+    /// …); `args` are the comparison operands (1 for the unary
+    /// `*_is_zero`/`*_is_true`/`ptr_*` tests, 2 for the binary
+    /// compares).  The assembler appends the per-arg argcodes + `L`
+    /// to form the registered jitcode key `goto_if_not_<op>/<codes>`.
+    GotoIfNotOp {
+        opname: String,
+        args: Vec<Register>,
+        target: Label,
+    },
     /// RPython `flatten.py:278-308` integer switch:
     /// `('switch', value, SwitchDictDescr)` after a preceding
     /// `-live-`.  `value` is always Int-kinded (asserted in
@@ -280,7 +295,11 @@ pub struct SSARepr {
 }
 
 fn is_bool_branch(block: &crate::model::Block) -> bool {
-    if !matches!(block.exitswitch, Some(ExitSwitch::Value(_))) || block.exits.len() != 2 {
+    if !matches!(
+        block.exitswitch,
+        Some(ExitSwitch::Value(_)) | Some(ExitSwitch::Fused { .. })
+    ) || block.exits.len() != 2
+    {
         return false;
     }
     // RPython `flatten.py:244-246` accepts both orderings: `linkfalse,
@@ -1102,10 +1121,6 @@ impl<'a> GraphFlattener<'a> {
 
         // `elif len(block.exits) == 2 and (... bool ...): ...`.
         if is_bool_branch(block) {
-            let cond = match exitswitch {
-                Some(ExitSwitch::Value(cond)) => cond,
-                _ => unreachable!(),
-            };
             // `linkfalse, linktrue = block.exits;
             //  if linkfalse.llexitcase == True: linkfalse, linktrue = linktrue, linkfalse`.
             let (linkfalse, linktrue) = if bool_llexitcase(&exits[0]) == Some(true) {
@@ -1121,11 +1136,29 @@ impl<'a> GraphFlattener<'a> {
             });
             let false_landing = Label(self.next_label);
             self.next_label += 1;
-            let cond_reg = self.getcolor(&cond);
-            self.emitline(FlatOp::GotoIfNot {
-                cond: cond_reg,
-                target: false_landing,
-            });
+            // A plain `Value` exitswitch emits `goto_if_not(cond, …)`;
+            // a `Fused` exitswitch (`jtransform::optimize_goto_if_not`,
+            // `flatten.py:247`) emits the comparison-specialised
+            // `goto_if_not_<op>(args, …)` with the compare elided.
+            match &exitswitch {
+                Some(ExitSwitch::Value(cond)) => {
+                    let cond_reg = self.getcolor(cond);
+                    self.emitline(FlatOp::GotoIfNot {
+                        cond: cond_reg,
+                        target: false_landing,
+                    });
+                }
+                Some(ExitSwitch::Fused { opname, args }) => {
+                    let arg_regs: Vec<Register> =
+                        args.iter().map(|arg| self.getcolor(arg)).collect();
+                    self.emitline(FlatOp::GotoIfNotOp {
+                        opname: opname.clone(),
+                        args: arg_regs,
+                        target: false_landing,
+                    });
+                }
+                _ => unreachable!(),
+            }
             // `flatten.py:264-267`:
             //   # true path:
             //   self.make_link(linktrue, handling_ovf)
@@ -1657,6 +1690,79 @@ mod tests {
             true_first, 70,
             "true fallthrough path must follow link.llexitcase, not flow-level exitcase: {:?}",
             flat.insns
+        );
+    }
+
+    /// gh #37 Stage 2: a `Fused { opname: "int_lt", args: [a, b] }`
+    /// exitswitch (produced by `jtransform::optimize_goto_if_not`) lowers
+    /// to a single `FlatOp::GotoIfNotOp` carrying both operand registers,
+    /// with the standalone `int_lt` compare elided (`flatten.py:247`).
+    #[test]
+    fn flatten_fused_bool_branch_emits_goto_if_not_op() {
+        use crate::model::ExitSwitch;
+
+        let mut graph = FunctionGraph::new("fused_branch");
+        let entry = graph.startblock;
+        // `a`/`b` stand in for compare operands defined earlier; the
+        // `int_lt` that produced the bool was removed by the fusion.
+        let a = graph.push_op_var(entry, OpKind::ConstInt(3), true).unwrap();
+        let b = graph.push_op_var(entry, OpKind::ConstInt(5), true).unwrap();
+
+        let true_block = graph.create_block();
+        let false_block = graph.create_block();
+        let t_marker = graph
+            .push_op_var(true_block, OpKind::ConstInt(70), true)
+            .unwrap();
+        let f_marker = graph
+            .push_op_var(false_block, OpKind::ConstInt(80), true)
+            .unwrap();
+        graph.set_return(true_block, Some(t_marker));
+        graph.set_return(false_block, Some(f_marker));
+
+        // The exits keep their bool exitcase/llexitcase — fusion only
+        // substitutes link args, never the exitcases.
+        let false_link =
+            Link::from_variables(&graph, Vec::new(), false_block, Some(ExitCase::Bool(false)))
+                .with_llexitcase(ConstValue::Bool(false));
+        let true_link =
+            Link::from_variables(&graph, Vec::new(), true_block, Some(ExitCase::Bool(true)))
+                .with_llexitcase(ConstValue::Bool(true));
+        graph.set_control_flow_metadata(
+            entry,
+            Some(ExitSwitch::Fused {
+                opname: "int_lt".to_string(),
+                args: vec![a.clone(), b.clone()],
+            }),
+            vec![false_link, true_link],
+        );
+
+        let mut regallocs = identity_regallocs(&graph, 8);
+        let flat = flatten_graph(&graph, &mut regallocs);
+
+        // No standalone int_lt op (none was ever emitted) and — the key
+        // assertion — exactly one fused guard carrying both operands.
+        let fused = flat
+            .insns
+            .iter()
+            .find_map(|op| match op {
+                FlatOp::GotoIfNotOp { opname, args, .. } => Some((opname.clone(), args.clone())),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("fused bool branch must emit GotoIfNotOp: {:?}", flat.insns));
+        assert_eq!(fused.0, "int_lt");
+        assert_eq!(
+            fused.1,
+            vec![var_reg(&regallocs, &a), var_reg(&regallocs, &b)],
+            "fused guard must carry the compare operand registers in order",
+        );
+        // A fused branch must NOT also emit a plain goto_if_not.
+        assert!(
+            !flat
+                .insns
+                .iter()
+                .any(|op| matches!(op, FlatOp::GotoIfNot { .. })),
+            "fused branch must not also emit a plain goto_if_not: {:?}",
+            flat.insns,
         );
     }
 

--- a/majit/majit-translate/src/codewriter/format.rs
+++ b/majit/majit-translate/src/codewriter/format.rs
@@ -87,7 +87,8 @@ pub fn format_assembler(ssarepr: &SSARepr) -> String {
             | FlatOp::CatchException { target: label }
             | FlatOp::GotoIfExceptionMismatch { target: label, .. }
             | FlatOp::IntBinOpJumpIfOvf { target: label, .. }
-            | FlatOp::GotoIfNot { target: label, .. } => {
+            | FlatOp::GotoIfNot { target: label, .. }
+            | FlatOp::GotoIfNotOp { target: label, .. } => {
                 name_label(*label, &mut seenlabels, &mut next_label);
             }
             FlatOp::Switch { targets, .. } => {
@@ -150,6 +151,19 @@ pub fn format_assembler(ssarepr: &SSARepr) -> String {
             FlatOp::GotoIfNot { cond, target } => {
                 let num = name_label(*target, &mut seenlabels, &mut next_label);
                 let _ = writeln!(out, "{prefix}goto_if_not {}, L{num}", cond.repr());
+            }
+            FlatOp::GotoIfNotOp {
+                opname,
+                args,
+                target,
+            } => {
+                let num = name_label(*target, &mut seenlabels, &mut next_label);
+                let arglist = args
+                    .iter()
+                    .map(|reg| reg.repr())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let _ = writeln!(out, "{prefix}goto_if_not_{opname} {arglist}, L{num}");
             }
             FlatOp::Switch { value, targets } => {
                 let cases: Vec<String> = targets

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4317,6 +4317,198 @@ impl<'a> Transformer<'a> {
     }
 }
 
+/// `jtransform.py:196-234 Transformer.optimize_goto_if_not` — fuse a
+/// comparison op into the block's `exitswitch`.
+///
+/// Replaces `v = int_gt(x, y); exitswitch = v` with the fused
+/// `exitswitch = ('int_gt', x, y, '-live-before')`.  The `-live-before`
+/// marker is implicit in pyre's [`ExitSwitch::Fused`] (re-applied at
+/// emit time, `flatten.py:248-253`) so it is not stored in `args`.
+///
+/// Faithful port, line-for-line:
+/// ```python
+/// def optimize_goto_if_not(self, block):
+///     if len(block.exits) != 2:
+///         return False
+///     v = block.exitswitch
+///     if (block.canraise or isinstance(v, tuple)
+///             or v.concretetype != lltype.Bool):
+///         return False
+///     for op in block.operations[::-1]:
+///         for arg in op.args:
+///             if arg == v:
+///                 return False
+///             if isinstance(arg, ListOfKind) and v in arg.content:
+///                 return False
+///         if v is op.result:
+///             if op.opname not in (...comparison opnames...):
+///                 return False
+///             block.operations.remove(op)
+///             block.exitswitch = (op.opname,) + tuple(op.args)
+///             block.exitswitch += ('-live-before',)
+///             for link in block.exits:
+///                 while v in link.args:
+///                     index = link.args.index(v)
+///                     link.args[index] = Constant(link.llexitcase, lltype.Bool)
+///             return True
+///     return False
+/// ```
+///
+/// Notes on faithful adaptations to pyre's IR:
+/// - `isinstance(v, tuple)` (an already-fused switch) maps to "the
+///   `exitswitch` is not a plain [`ExitSwitch::Value`]" — i.e.
+///   `Fused` / `LastException` / `None` all return `false`, exactly as
+///   upstream skips a tuple / can-raise / unset switch.
+/// - `v.concretetype != lltype.Bool` reads the backing Variable's raw
+///   `LowLevelType` (`Variable::concretetype()`), checking
+///   [`LowLevelType::Bool`] directly.  Going through
+///   [`FunctionGraph::concretetype_of`] / [`ConcreteType`] would be
+///   wrong here because that projection collapses `Bool` into
+///   `ConcreteType::Signed` (`getkind`, `history.py:45-71`); the Bool
+///   distinction only survives on the raw lltype cell.
+/// - `for arg in op.args` (incl. the `ListOfKind` content scan) maps to
+///   [`crate::inline::op_variable_refs`], which already flattens every
+///   operand Variable of any op — including aggregate operands
+///   (`NewTuple`, `JitMergePoint`, ...) that are pyre's `ListOfKind`
+///   analogue — so the explicit `ListOfKind`/`v in arg.content` arm is
+///   subsumed.
+/// - `Constant(link.llexitcase, lltype.Bool)`: pyre's `link.llexitcase`
+///   may be `None` pre-rtyper, but the bool branch value is reliably in
+///   `link.exitcase` as [`ExitCase::Bool`] (the same source
+///   `with_llexitcase_from_exitcase` reads, `model.rs:1244-1252`); the
+///   substituted constant is
+///   `Constant::with_concretetype(ConstValue::Bool(b), lltype.Bool)`,
+///   carrying the `lltype.Bool` concretetype upstream stamps.
+//
+// gh #37 Stage 1: defined inert; the call site in optimize_block +
+// flatten emission land in Stage 2.
+#[allow(dead_code)]
+fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
+    use crate::flowspace::model::{ConstValue, Constant};
+    use crate::model::{ExitCase, ExitSwitch};
+    use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+    // `if len(block.exits) != 2: return False`
+    if graph.blocks[block_idx].exits.len() != 2 {
+        return false;
+    }
+    // `v = block.exitswitch`
+    //
+    // `isinstance(v, tuple)` / can-raise (`LastException`) / unset
+    // switch all collapse to "not a plain `Value(v)`".
+    let v = match &graph.blocks[block_idx].exitswitch {
+        Some(ExitSwitch::Value(var)) => var.clone(),
+        _ => return false,
+    };
+    // `if block.canraise or ...: return False`
+    if graph.blocks[block_idx].canraise() {
+        return false;
+    }
+    // `or v.concretetype != lltype.Bool: return False`
+    if v.concretetype() != Some(LowLevelType::Bool) {
+        return false;
+    }
+
+    // `for op in block.operations[::-1]:`
+    let ops_len = graph.blocks[block_idx].operations.len();
+    for op_idx in (0..ops_len).rev() {
+        // `for arg in op.args: if arg == v (or v in ListOfKind): return False`
+        let reads =
+            crate::inline::op_variable_refs(&graph.blocks[block_idx].operations[op_idx].kind);
+        if reads.iter().any(|arg| *arg == v) {
+            return false;
+        }
+        // `if v is op.result:`
+        if graph.blocks[block_idx].operations[op_idx].result.as_ref() == Some(&v) {
+            // `if op.opname not in (...): return False` else fuse.
+            let Some((opname, args)) =
+                goto_if_not_fusable(&graph.blocks[block_idx].operations[op_idx].kind)
+            else {
+                return false;
+            };
+            // `block.operations.remove(op)`
+            graph.blocks[block_idx].operations.remove(op_idx);
+            // `block.exitswitch = (op.opname,) + tuple(op.args) + ('-live-before',)`
+            // (the `-live-before` marker is implicit in `Fused`).
+            graph.blocks[block_idx].exitswitch = Some(ExitSwitch::Fused { opname, args });
+            // `for link in block.exits:
+            //      while v in link.args:
+            //          link.args[index] = Constant(link.llexitcase, lltype.Bool)`
+            for link in graph.blocks[block_idx].exits.iter_mut() {
+                let bool_const = match &link.exitcase {
+                    Some(ExitCase::Bool(b)) => *b,
+                    // A 2-exit Bool branch always carries `ExitCase::Bool`
+                    // on each arm (`set_branch`); any other shape would
+                    // not have passed the `lltype.Bool` switch above.
+                    other => panic!(
+                        "optimize_goto_if_not: bool branch link missing ExitCase::Bool \
+                         (jtransform.py:230 link.llexitcase), got {other:?}"
+                    ),
+                };
+                for arg in link.args.iter_mut() {
+                    if arg.as_variable() == Some(&v) {
+                        // `Constant(link.llexitcase, lltype.Bool)` —
+                        // bool value carries the `lltype.Bool` concretetype.
+                        *arg = LinkArg::Const(Constant::with_concretetype(
+                            ConstValue::Bool(bool_const),
+                            LowLevelType::Bool,
+                        ));
+                    }
+                }
+            }
+            // `return True`
+            return true;
+        }
+    }
+    // `return False`
+    false
+}
+
+/// `jtransform.py:206-209` supported-opname gate for
+/// [`optimize_goto_if_not`].  Returns the RPython opname and the op's
+/// operand Variables (`tuple(op.args)`) when the op is one of the
+/// comparison / boolean-test opcodes that may be fused into a guard;
+/// `None` for any other op (upstream's `return False`).
+///
+/// The Bool-producing compares are pyre [`OpKind::BinOp`]s; the unary
+/// `int_is_zero` / `int_is_true` / `ptr_iszero` / `ptr_nonzero` tests
+/// are [`OpKind::UnaryOp`]s.
+#[allow(dead_code)]
+fn goto_if_not_fusable(kind: &OpKind) -> Option<(String, Vec<crate::flowspace::model::Variable>)> {
+    match kind {
+        OpKind::BinOp { op, lhs, rhs, .. }
+            if matches!(
+                op.as_str(),
+                "int_lt"
+                    | "int_le"
+                    | "int_eq"
+                    | "int_ne"
+                    | "int_gt"
+                    | "int_ge"
+                    | "float_lt"
+                    | "float_le"
+                    | "float_eq"
+                    | "float_ne"
+                    | "float_gt"
+                    | "float_ge"
+                    | "ptr_eq"
+                    | "ptr_ne"
+            ) =>
+        {
+            Some((op.clone(), vec![lhs.clone(), rhs.clone()]))
+        }
+        OpKind::UnaryOp { op, operand, .. }
+            if matches!(
+                op.as_str(),
+                "int_is_zero" | "int_is_true" | "ptr_iszero" | "ptr_nonzero"
+            ) =>
+        {
+            Some((op.clone(), vec![operand.clone()]))
+        }
+        _ => None,
+    }
+}
+
 /// RPython: `getkind(concretetype)[0]` → 'i', 'r', 'f', or 'v'.
 ///
 /// RPython's rtyper resolves all types before jtransform runs, so
@@ -5095,6 +5287,133 @@ mod tests {
     use super::*;
     use crate::codewriter::type_state::ConcreteType;
     use crate::model::{CallFuncPtr, CallTarget, FunctionGraph, LinkArg, OpKind, ValueType};
+
+    /// gh #37 Stage 1: `int_lt(a, b); exitswitch = t` fuses into a
+    /// `Fused { opname: "int_lt", args: [a, b] }` switch, the `int_lt`
+    /// op is removed, and the `t` riding a link's args is replaced by
+    /// that link's bool constant (`jtransform.py:196-234`).
+    #[test]
+    fn optimize_goto_if_not_fuses_int_lt_compare() {
+        use crate::flowspace::model::ConstValue;
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+        let mut graph = FunctionGraph::new("goto_if_not_fuse");
+        let a = graph.alloc_value_var();
+        let b = graph.alloc_value_var();
+        // `t = int_lt(a, b)` — a Bool-producing comparison.
+        let t = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::BinOp {
+                    op: "int_lt".to_string(),
+                    lhs: a.clone(),
+                    rhs: b.clone(),
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        // `v.concretetype == lltype.Bool` — stamp the raw Bool lltype
+        // (`getkind`/`ConcreteType` would otherwise collapse it to int).
+        t.set_concretetype(Some(LowLevelType::Bool));
+
+        // Two destination blocks; the true arm carries `t` in its args.
+        let if_false = graph.create_block();
+        let if_true = graph.create_block();
+        let true_iarg = graph.alloc_value_var();
+        graph.push_inputarg_var(if_true, true_iarg);
+        let false_link = Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false)));
+        let true_link = Link::new_mixed(
+            vec![LinkArg::Value(t.clone())],
+            if_true,
+            Some(ExitCase::Bool(true)),
+        );
+        let start = graph.startblock.0;
+        graph.set_control_flow_metadata(
+            graph.startblock,
+            Some(ExitSwitch::Value(t.clone())),
+            vec![false_link, true_link],
+        );
+
+        let fused = super::optimize_goto_if_not(&mut graph, start);
+        assert!(fused, "supported compare must fuse");
+
+        let block = &graph.blocks[start];
+        // The `int_lt` op was removed.
+        assert!(
+            !block
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::BinOp { op, .. } if op == "int_lt")),
+            "fused int_lt op must be removed"
+        );
+        // exitswitch == Fused { opname: "int_lt", args: [a, b] }.
+        match &block.exitswitch {
+            Some(ExitSwitch::Fused { opname, args }) => {
+                assert_eq!(opname, "int_lt");
+                assert_eq!(args.len(), 2);
+                assert_eq!(args[0], a);
+                assert_eq!(args[1], b);
+            }
+            other => panic!("expected Fused exitswitch, got {other:?}"),
+        }
+        // The `t` riding the true arm became a Bool const(true).
+        let true_arm = &block.exits[1];
+        assert!(
+            matches!(
+                &true_arm.args[0],
+                LinkArg::Const(c) if c.value == ConstValue::Bool(true)
+            ),
+            "escaping v must be replaced with the link's bool constant, got {:?}",
+            true_arm.args[0],
+        );
+    }
+
+    /// gh #37 Stage 1: a non-supported result op (`int_add`) is NOT
+    /// fusable — `optimize_goto_if_not` returns false and leaves the
+    /// block untouched (`jtransform.py:206-209` opname gate).
+    #[test]
+    fn optimize_goto_if_not_rejects_unsupported_result_op() {
+        use crate::model::{ExitCase, ExitSwitch, Link};
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+
+        let mut graph = FunctionGraph::new("goto_if_not_reject");
+        let a = graph.alloc_value_var();
+        let b = graph.alloc_value_var();
+        let t = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::BinOp {
+                    op: "int_add".to_string(),
+                    lhs: a,
+                    rhs: b,
+                    result_ty: ValueType::Bool,
+                },
+                true,
+            )
+            .unwrap();
+        t.set_concretetype(Some(LowLevelType::Bool));
+
+        let if_false = graph.create_block();
+        let if_true = graph.create_block();
+        let false_link = Link::new_mixed(vec![], if_false, Some(ExitCase::Bool(false)));
+        let true_link = Link::new_mixed(vec![], if_true, Some(ExitCase::Bool(true)));
+        graph.set_control_flow_metadata(
+            graph.startblock,
+            Some(ExitSwitch::Value(t.clone())),
+            vec![false_link, true_link],
+        );
+
+        let start = graph.startblock.0;
+        let before = graph.blocks[start].clone();
+        let fused = super::optimize_goto_if_not(&mut graph, start);
+        assert!(!fused, "unsupported int_add result op must not fuse");
+        // Block unchanged: op kept, exitswitch still Value(t).
+        let after = &graph.blocks[start];
+        assert_eq!(after.operations.len(), before.operations.len());
+        assert!(matches!(&after.exitswitch, Some(ExitSwitch::Value(_))));
+    }
 
     #[test]
     fn rewrite_graph_canonicalizes_frontend_bitops() {

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -519,10 +519,19 @@ impl<'a> Transformer<'a> {
                 |b| b,
             )
         };
-        let block = &mut graph.blocks[block_idx];
-        block.operations = new_ops;
-        block.exitswitch = exitswitch;
-        block.exits = exits;
+        {
+            let block = &mut graph.blocks[block_idx];
+            block.operations = new_ops;
+            block.exitswitch = exitswitch;
+            block.exits = exits;
+        }
+
+        // `jtransform.py:123 self.optimize_goto_if_not(block)` — fuse a
+        // Bool-producing comparison into the exitswitch
+        // (`ExitSwitch::Fused`), eliding the standalone compare op.  Runs
+        // after the exitswitch/exits remap is committed; it never alters
+        // link targets, so the exceptblock note below is unaffected.
+        optimize_goto_if_not(graph, block_idx);
 
         // Upstream `rpython/translator/backendopt/canraise.py:25-47
         // analyze_exceptblock_in_graph` identifies raising blocks by the
@@ -531,6 +540,7 @@ impl<'a> Transformer<'a> {
         // such blocks so later phases (e.g. reporting) can surface
         // unconditional raise sites — the note mirrors the upstream signal
         // without the pyre-specific Terminator::Abort variant.
+        let block = &graph.blocks[block_idx];
         if block.exits.iter().any(|link| link.target == exceptblock) {
             self.notes.push(GraphTransformNote {
                 function: graph_name.to_string(),
@@ -4380,9 +4390,8 @@ impl<'a> Transformer<'a> {
 ///   `Constant::with_concretetype(ConstValue::Bool(b), lltype.Bool)`,
 ///   carrying the `lltype.Bool` concretetype upstream stamps.
 //
-// gh #37 Stage 1: defined inert; the call site in optimize_block +
-// flatten emission land in Stage 2.
-#[allow(dead_code)]
+// gh #37: called from `optimize_block` (jtransform.py:123); the fused
+// `ExitSwitch::Fused` is lowered to `FlatOp::GotoIfNotOp` in flatten.
 fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
     use crate::flowspace::model::{ConstValue, Constant};
     use crate::model::{ExitCase, ExitSwitch};
@@ -4434,16 +4443,29 @@ fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
             // `for link in block.exits:
             //      while v in link.args:
             //          link.args[index] = Constant(link.llexitcase, lltype.Bool)`
+            //
+            // The substitution only matters when the fused result `v`
+            // flows into a successor block (rare); links that do not
+            // carry `v` are left untouched.  The replacement bool is
+            // read `llexitcase`-first then `exitcase` — the same source
+            // order as `flatten.rs::bool_llexitcase` — so post-rtyper
+            // graphs (bool in `llexitcase`) and pre-rtyper semantic
+            // graphs (bool in `exitcase`) both resolve.
             for link in graph.blocks[block_idx].exits.iter_mut() {
-                let bool_const = match &link.exitcase {
-                    Some(ExitCase::Bool(b)) => *b,
-                    // A 2-exit Bool branch always carries `ExitCase::Bool`
-                    // on each arm (`set_branch`); any other shape would
-                    // not have passed the `lltype.Bool` switch above.
-                    other => panic!(
-                        "optimize_goto_if_not: bool branch link missing ExitCase::Bool \
-                         (jtransform.py:230 link.llexitcase), got {other:?}"
-                    ),
+                if !link.args.iter().any(|arg| arg.as_variable() == Some(&v)) {
+                    continue;
+                }
+                let bool_const = match &link.llexitcase {
+                    Some(ConstValue::Bool(b)) => *b,
+                    _ => match &link.exitcase {
+                        Some(ExitCase::Bool(b)) => *b,
+                        Some(ExitCase::Const(ConstValue::Bool(b))) => *b,
+                        other => panic!(
+                            "optimize_goto_if_not: fused bool branch link carrying the \
+                             result variable lacks a bool ll/exitcase \
+                             (jtransform.py:230 link.llexitcase), got {other:?}"
+                        ),
+                    },
                 };
                 for arg in link.args.iter_mut() {
                     if arg.as_variable() == Some(&v) {
@@ -4473,7 +4495,6 @@ fn optimize_goto_if_not(graph: &mut FunctionGraph, block_idx: usize) -> bool {
 /// The Bool-producing compares are pyre [`OpKind::BinOp`]s; the unary
 /// `int_is_zero` / `int_is_true` / `ptr_iszero` / `ptr_nonzero` tests
 /// are [`OpKind::UnaryOp`]s.
-#[allow(dead_code)]
 fn goto_if_not_fusable(kind: &OpKind) -> Option<(String, Vec<crate::flowspace::model::Variable>)> {
     match kind {
         OpKind::BinOp { op, lhs, rhs, .. }

--- a/majit/majit-translate/src/codewriter/liveness.rs
+++ b/majit/majit-translate/src/codewriter/liveness.rs
@@ -267,6 +267,18 @@ fn compute_liveness_pass(
                     alive.extend(alive_at_target.iter());
                 }
             }
+            FlatOp::GotoIfNotOp { args, target, .. } => {
+                // Fused guard (`goto_if_not_<op>`): a pure use of each
+                // comparison operand, plus the false-path target merge —
+                // same backward semantics as `GotoIfNot`.
+                let target = *target;
+                for arg in args {
+                    alive.insert(*arg);
+                }
+                if let Some(alive_at_target) = label2alive.get(&target) {
+                    alive.extend(alive_at_target.iter());
+                }
+            }
             FlatOp::Switch { value, targets } => {
                 alive.insert(*value);
                 for (_, target) in targets {

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1145,6 +1145,16 @@ pub struct SpaceOperation {
 pub enum ExitSwitch {
     Value(crate::flowspace::model::Variable),
     LastException,
+    /// `jtransform.py:196-234 optimize_goto_if_not` fuses a comparison
+    /// op into the exitswitch: `block.exitswitch = (opname,) +
+    /// tuple(op.args) + ('-live-before',)`.  Carries the RPython
+    /// comparison opname (e.g. `int_lt`) and the operands; the trailing
+    /// `-live-before` marker is implicit (always present for a fused
+    /// guard) and re-applied at emit time (`flatten.py:248-253`).
+    Fused {
+        opname: String,
+        args: Vec<crate::flowspace::model::Variable>,
+    },
 }
 
 /// RPython `Link.exitcase`.
@@ -2961,6 +2971,10 @@ where
     let exitswitch = exitswitch.as_ref().map(|switch| match switch {
         ExitSwitch::Value(var) => ExitSwitch::Value(remap_value(var)),
         ExitSwitch::LastException => ExitSwitch::LastException,
+        ExitSwitch::Fused { opname, args } => ExitSwitch::Fused {
+            opname: opname.clone(),
+            args: args.iter().map(&remap_value).collect(),
+        },
     });
     let exits = exits
         .iter()

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2853,6 +2853,13 @@ pub fn function_graph_to_flowspace(
                 })?)
             }
             Some(ExitSwitch::LastException) => Some(Hlvalue::Constant(c_last_exception())),
+            // `ExitSwitch::Fused` is produced only by the JIT codewriter's
+            // `jtransform::optimize_goto_if_not` (post-rtyper); the
+            // pre-rtyper legacy graph this adapter translates never carries
+            // a fused exitswitch.
+            Some(ExitSwitch::Fused { .. }) => {
+                unreachable!("fused exitswitch cannot reach the pre-rtyper flowspace adapter")
+            }
         };
 
         // Commit to the flowspace::Block. Borrow scope is tight to

--- a/majit/majit-translate/tests/test_mir_stress.rs
+++ b/majit/majit-translate/tests/test_mir_stress.rs
@@ -693,6 +693,17 @@ fn dump_lowering_signatures() {
             match &blk.exitswitch {
                 Some(ExitSwitch::Value(v)) => s.push_str(&format!("sw:{};", label(v.id()))),
                 Some(ExitSwitch::LastException) => s.push_str("swLE;"),
+                // `optimize_goto_if_not` fuses a compare into a `Fused`
+                // switch; the flat MIR driver never produces one (it is a
+                // jtransform-stage rewrite), so this arm only keeps the
+                // match exhaustive.
+                Some(ExitSwitch::Fused { opname, args }) => {
+                    s.push_str(&format!("swF:{opname}("));
+                    for a in args {
+                        s.push_str(&format!("{},", label(a.id())));
+                    }
+                    s.push_str(");");
+                }
                 None => {}
             }
             for link in &blk.exits {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -687,16 +687,22 @@ pub fn offset2lineno(code: &CodeObject, stopat: isize) -> usize {
 #[inline]
 #[majit_macros::elidable_cannot_raise]
 pub fn npure_cellvars(code: &CodeObject) -> usize {
-    code.cellvars
-        .iter()
-        .filter(|c| {
-            let cs: &str = c.as_ref();
-            !code.varnames.iter().any(|v| {
-                let vs: &str = v.as_ref();
-                vs == cs
-            })
-        })
-        .count()
+    let mut count = 0;
+    for c in code.cellvars.iter() {
+        let cs: &str = c.as_ref();
+        let mut overlaps = false;
+        for v in code.varnames.iter() {
+            let vs: &str = v.as_ref();
+            if vs == cs {
+                overlaps = true;
+                break;
+            }
+        }
+        if !overlaps {
+            count += 1;
+        }
+    }
+    count
 }
 
 #[inline]


### PR DESCRIPTION
Tracks #37 (SSA-repr codewriter parity).

## Summary

Brings the `majit-translate` JIT codewriter closer to a structural 1:1 port of
`rpython/jit/codewriter` (`flatten.py` + `jtransform.py`) and lands the
supporting trace / runtime / backend work. Net delta vs `main` (#247): 65 files.

### Codewriter parity (#37)
- `flatten_graph` aligned to RPython: retire the eager local-register coloring
  deviations; per-PC color↔slot resume map (#27 / #233).
- `optimize_goto_if_not` producer-side comparison/branch fusion ported from
  `jtransform.py:196-234` — `ExitSwitch::Fused` → `FlatOp::GotoIfNotOp`,
  assembled to the `goto_if_not_<op>/<argcodes>` jitcodes. Encoding-only;
  structurally complete. Currently **dormant** because the production corpus
  still routes through the legacy walker (rtyper dual-gate Skips); firing is
  gated on the rtyper cutover.
- Orthodox descent walls 5a–5e: codewriter descr bridges, host-static const
  relocation, symbolic-fnaddr handling (#171 / #255).

### Trace / runtime
- JIT trace coverage: pre-opcode guard snapshots, portal entry routing,
  kept-stack branch guards (#236).
- `for_iter` collapsed to `space.next` + residual trace infra; fixes
  user-iterator JIT crashes (#57 / #253).

### wasm backend
- GC-collecting nursery + growable shared-table foundation (#257).

### codegen
- `push_str` trait-impl codegen replaced with a hand-maintained module (#260).

## Verification
- `python pyre/check.py --backend dynasm` and `--backend cranelift`: 141/141.
- `cargo test -p majit-translate`: green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of certain boolean branches so optimized comparisons can be carried through code generation more directly.
  * Added support for representing and formatting a new optimized branch form in generated output.

* **Bug Fixes**
  * Fixed cases where some optimized branches were not being preserved correctly during lowering and liveness analysis.
  * Improved consistency in label and branch output, including for fused comparison branches.
  * Added coverage for supported and unsupported optimization paths to prevent incorrect transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->