### PR TITLE
interp: collapse frame locals onto a single w_locals object; jit: module-loop folds + inline frame alloc

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -527,6 +527,13 @@ pub enum PyreHelperKind {
     BoxInt,
     StoreSubscr,
     LoadGlobal,
+    /// `bh_load_name_fn(frame, w_name, namei)` — the LOAD_NAME frame-receiver
+    /// helper (`pyopcode.py:945-955`, w_locals probe + LOAD_GLOBAL fallback).
+    /// The full-body walker recognises this tag to fold a module-scope name
+    /// read (frame's `w_locals_object` is null, so `w_locals` aliases
+    /// `w_globals`) through the same module-dict cell fast path as
+    /// [`PyreHelperKind::LoadGlobal`], eliding the per-iteration residual.
+    LoadName,
     /// `bh_call_fn_N(callable, null_or_self, args...)` — the CALL-family
     /// Python-call helper.  `null_or_self` (arg index 1) is a sentinel
     /// the helper checks before use (a non-null receiver is prepended as

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4481,7 +4481,7 @@ fn exec_or_eval(
     // pypy/interpreter/pyopcode.py:771-776 — `code.exec_code(space,
     // w_globals, w_locals, outer_func)` runs the frame on the
     // user-supplied dict directly.  Pyre routes locals through
-    // `frame.setdictscope_object(w_locals)` so STORE_NAME / LOAD_NAME /
+    // `frame.setdictscope(w_locals)` so STORE_NAME / LOAD_NAME /
     // DELETE_NAME dispatch via `space.setitem` / `space.getitem` /
     // `space.delitem` on the live mapping (dict subclass `__getitem__`
     // overrides win, alias mutations are visible immediately, and
@@ -4506,7 +4506,7 @@ fn exec_or_eval(
         // pyframe.py:540 getdictscope returns the caller's
         // w_locals (PyObjectRef) — same dict-or-mapping the
         // interpreter sees inside the calling function body.
-        implicit_caller_locals = unsafe { (*caller_frame).getdictscope_w()? };
+        implicit_caller_locals = unsafe { (*caller_frame).getdictscope()? };
     }
     let mut locals_object_arg: pyre_object::PyObjectRef = std::ptr::null_mut();
     if !is_none_or_null(locals_arg) {
@@ -4514,14 +4514,14 @@ fn exec_or_eval(
             !is_none_or_null(globals_arg) && std::ptr::eq(locals_arg, globals_arg);
         if !same_as_globals {
             // Dict and non-dict mapping arms share the
-            // setdictscope_object path — for exact dict locals this
+            // setdictscope path — for exact dict locals this
             // matches PyPy's `code.exec_code(space, w_globals,
             // w_locals)` chain (pyopcode.py:776) which feeds
             // `space.setitem(w_locals, name, value)` to STORE_NAME.
             // Pyre's earlier `is_dict_w` arm built a storage copy and
             // drained it back through a `Vec<String>` snapshot to
             // mirror DELETE_GLOBAL while preserving alias mutations;
-            // routing through `setdictscope_object` retires the copy +
+            // routing through `setdictscope` retires the copy +
             // snapshot entirely.
             locals_object_arg = locals_arg;
         }
@@ -4545,7 +4545,7 @@ fn exec_or_eval(
     // module-code arm has already bound w_locals = w_globals, matching
     // PyPy's `exec(src, g)` (and `exec(src, g, l)` where `l is g`).
     if !locals_object_arg.is_null() {
-        frame.setdictscope_object(locals_object_arg)?;
+        frame.setdictscope(locals_object_arg)?;
     } else if !implicit_caller_locals.is_null() {
         // pyopcode.py:2015 — `exec(src)` with no globals/locals uses
         // the caller's `getdictscope()` as locals.  Skip when the
@@ -4556,7 +4556,7 @@ fn exec_or_eval(
         let same_as_globals = !caller_globals_obj.is_null()
             && std::ptr::eq(implicit_caller_locals, caller_globals_obj);
         if !same_as_globals {
-            frame.setdictscope_object(implicit_caller_locals)?;
+            frame.setdictscope(implicit_caller_locals)?;
         }
     }
     // run_with_jit rather than execute_frame so that
@@ -4623,14 +4623,14 @@ fn builtin_locals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             ));
         }
         // pyframe.py:540 getdictscope: non-dict mapping locals are
-        // returned to caller as the live `w_locals_object` so
+        // returned to caller as the live `w_locals` so
         // `locals()['x'] = ...` goes through the mapping's
         // `__setitem__` and reads observe the same object the
         // exec/eval caller passed in.
         let frame_mut = unsafe { &mut *frame };
-        let w_locals_object = frame_mut.get_w_locals_object();
-        if !w_locals_object.is_null() {
-            return Ok(w_locals_object);
+        let w_locals = frame_mut.get_w_locals();
+        if !w_locals.is_null() {
+            return Ok(w_locals);
         }
         // `pypy/interpreter/pyframe.py:540 getdictscope` runs
         // `fast2locals()` then returns `self.debugdata.w_locals`.
@@ -4640,7 +4640,7 @@ fn builtin_locals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // object — `locals() is locals()` (function scope) and
         // `locals() is globals()` (module scope, where
         // `debugdata.w_locals is w_globals`) both hold.
-        frame_mut.getdictscope_w()
+        frame_mut.getdictscope()
     })
 }
 
@@ -4736,7 +4736,7 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 return Ok(w_list_new(vec![]));
             }
             let frame_mut = unsafe { &mut *frame };
-            let w_locals_dict = frame_mut.getdictscope_w()?;
+            let w_locals_dict = frame_mut.getdictscope()?;
             if w_locals_dict.is_null() {
                 return Ok(w_list_new(vec![]));
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4622,24 +4622,18 @@ fn builtin_locals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 "locals() requires an active frame",
             ));
         }
-        // pyframe.py:540 getdictscope: non-dict mapping locals are
-        // returned to caller as the live `w_locals` so
-        // `locals()['x'] = ...` goes through the mapping's
-        // `__setitem__` and reads observe the same object the
-        // exec/eval caller passed in.
+        // `interp_inspect.py:7-11 locals` returns
+        // `ec.gettopframe_nohidden().getdictscope()` unconditionally.
+        // `getdictscope` (`pyframe.py:525-530`) always runs `fast2locals()`
+        // before returning `debugdata.w_locals`, so a second `locals()`
+        // re-syncs the mapping with the current fast locals —
+        // `x = 1; locals(); x = 2; locals()["x"]` reads `2`.  `fast2locals`
+        // lazily allocates and caches the mapping on first call, so identity
+        // holds (`locals() is locals()`, and `locals() is globals()` at
+        // module scope where `debugdata.w_locals is w_globals`); for a
+        // non-dict exec/eval mapping it returns that live object and writes
+        // through its `__setitem__`.
         let frame_mut = unsafe { &mut *frame };
-        let w_locals = frame_mut.get_w_locals();
-        if !w_locals.is_null() {
-            return Ok(w_locals);
-        }
-        // `pypy/interpreter/pyframe.py:540 getdictscope` runs
-        // `fast2locals()` then returns `self.debugdata.w_locals`.
-        // `fast2locals` (`pyframe.py:557-562`) lazily allocates the
-        // locals mapping dict on first call and caches it in
-        // `debugdata.w_locals`, so subsequent calls reuse the same
-        // object — `locals() is locals()` (function scope) and
-        // `locals() is globals()` (module scope, where
-        // `debugdata.w_locals is w_globals`) both hold.
         frame_mut.getdictscope()
     })
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4635,27 +4635,12 @@ fn builtin_locals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // `pypy/interpreter/pyframe.py:540 getdictscope` runs
         // `fast2locals()` then returns `self.debugdata.w_locals`.
         // `fast2locals` (`pyframe.py:557-562`) lazily allocates the
-        // backing dict on first call and stamps it into
+        // locals mapping dict on first call and caches it in
         // `debugdata.w_locals`, so subsequent calls reuse the same
-        // storage — `locals() is locals()` (function scope) and
+        // object — `locals() is locals()` (function scope) and
         // `locals() is globals()` (module scope, where
-        // `debugdata.w_locals is w_globals`) both hold.  Pyre's
-        // `frame.fast2locals()` follows the same shape; the canonical
-        // W_DictObject for that storage is then resolved via
-        // `dict_storage_to_dict` (mirror_target invariant).
-        frame_mut.fast2locals()?;
-        let w_locals = frame_mut.get_w_locals();
-        if !w_locals.is_null() {
-            return Ok(crate::baseobjspace::dict_storage_to_dict(
-                w_locals as *const _,
-            ));
-        }
-        // Fallback only fires when `fast2locals` neither found a
-        // mapping nor materialised a storage (no fast locals, no
-        // module-level w_globals shadow).  Build a plain dict so
-        // `locals()` still returns *something* in that degenerate
-        // case rather than `None`.
-        Ok(pyre_object::w_dict_new())
+        // `debugdata.w_locals is w_globals`) both hold.
+        frame_mut.getdictscope_w()
     })
 }
 
@@ -4751,19 +4736,10 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
                 return Ok(w_list_new(vec![]));
             }
             let frame_mut = unsafe { &mut *frame };
-            let w_locals_dict = {
-                let w_locals_object = frame_mut.get_w_locals_object();
-                if !w_locals_object.is_null() {
-                    w_locals_object
-                } else {
-                    frame_mut.fast2locals()?;
-                    let w_locals = frame_mut.get_w_locals();
-                    if w_locals.is_null() {
-                        return Ok(w_list_new(vec![]));
-                    }
-                    crate::baseobjspace::dict_storage_to_dict(w_locals as *const _)
-                }
-            };
+            let w_locals_dict = frame_mut.getdictscope_w()?;
+            if w_locals_dict.is_null() {
+                return Ok(w_list_new(vec![]));
+            }
             let keys_iter = crate::baseobjspace::iter(w_locals_dict)?;
             let keys = collect_iterable(keys_iter)?;
             builtin_sorted(&[w_list_new(keys)])

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2738,26 +2738,51 @@ fn build_class_inner(
             exec_ctx,
             closure,
         )?);
-    if let Some(w_ns) = mapping_namespace {
-        frame.setdictscope_object(w_ns)?;
-    } else {
-        frame.setdictscope(class_ns_ptr)?;
-    }
+    // The class body executes against a namespace OBJECT (setdictscope_object)
+    // so STORE_NAME / LOAD_NAME route through the object form, not the raw
+    // `*mut DictStorage` w_locals.  A custom non-dict `__prepare__` mapping is
+    // used directly (already rooted by the caller); otherwise a fresh dict,
+    // seeded from class_ns's pre-body entries and pinned as a GC root for the
+    // run.  class_ns is rebuilt from the object after the body for the
+    // downstream type construction.
+    let _ns_root = pyre_object::gc_roots::push_roots();
+    let body_ns: PyObjectRef = match mapping_namespace {
+        Some(w_ns) => w_ns,
+        None => {
+            let w_ns = unsafe { pyre_object::w_dict_new() };
+            pyre_object::gc_roots::pin_root(w_ns);
+            for (key, &value) in unsafe { (*class_ns_ptr).entries_wtf8() } {
+                if value.is_null() {
+                    continue;
+                }
+                match key.as_str() {
+                    Ok(s) => unsafe {
+                        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(w_ns, s, value)
+                    },
+                    Err(_) => unsafe {
+                        pyre_object::dictmultiobject::w_dict_setitem_wtf8_no_proxy(w_ns, key, value)
+                    },
+                }
+            }
+            w_ns
+        }
+    };
+    frame.setdictscope_object(body_ns)?;
 
     // Route the class body through the JIT portal (like the exec / import
     // run-sites) so a hot class-level loop can warm and compile.  The body's
-    // NEWLOCALS bindings land in a distinct `w_locals` dict; that dict's
-    // values are rooted by the `debugdata.w_locals` walk in
-    // `walk_pyframe_roots`.
+    // NEWLOCALS bindings land in `body_ns`; that object's values are rooted by
+    // the `debugdata.w_locals_object` walk in `walk_pyframe_roots`.
     frame.run_with_jit()?;
 
-    // The body wrote through the custom mapping; mirror its final contents
-    // into class_ns for the downstream type construction (classcell capture,
+    // The body wrote through `body_ns`; mirror its final contents into
+    // class_ns for the downstream type construction (classcell capture,
     // create_all_slots, __set_name__), which read class_ns.
-    if let Some(w_ns) = mapping_namespace {
+    {
+        let w_ns = body_ns;
         let class_ns = unsafe { &mut *class_ns_ptr };
         // Rebuild from the final contents so names `del`eted from the
-        // mapping during body execution don't survive in class_ns.
+        // namespace during body execution don't survive in class_ns.
         class_ns.clear();
         let backing = crate::type_methods::resolve_dict_backing(w_ns);
         if !backing.is_null() && unsafe { pyre_object::is_dict(backing) } {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2724,7 +2724,7 @@ fn build_class_inner(
     // resolved on assignment, not the stale `auto()` sentinels.  Upstream
     // `compiling.py:207-209` runs `frame.setdictscope(w_namespace)`
     // unconditionally; route the frame's name binding through the mapping
-    // via setdictscope_object.  An absent or plain-dict namespace keeps the
+    // via setdictscope.  An absent or plain-dict namespace keeps the
     // DictStorage fast path (plain-dict stores have no observable side
     // effects, and the metaclass replay below restores its final contents).
     let mapping_namespace = w_namespace.filter(|&w| unsafe { !pyre_object::is_dict(w) });
@@ -2738,7 +2738,7 @@ fn build_class_inner(
             exec_ctx,
             closure,
         )?);
-    // The class body executes against a namespace OBJECT (setdictscope_object)
+    // The class body executes against a namespace OBJECT (setdictscope)
     // so STORE_NAME / LOAD_NAME route through the object form, not the raw
     // `*mut DictStorage` w_locals.  A custom non-dict `__prepare__` mapping is
     // used directly (already rooted by the caller); otherwise a fresh dict,
@@ -2767,12 +2767,12 @@ fn build_class_inner(
             w_ns
         }
     };
-    frame.setdictscope_object(body_ns)?;
+    frame.setdictscope(body_ns)?;
 
     // Route the class body through the JIT portal (like the exec / import
     // run-sites) so a hot class-level loop can warm and compile.  The body's
     // NEWLOCALS bindings land in `body_ns`; that object's values are rooted by
-    // the `debugdata.w_locals_object` walk in `walk_pyframe_roots`.
+    // the `debugdata.w_locals` walk in `walk_pyframe_roots`.
     frame.run_with_jit()?;
 
     // The body wrote through `body_ns`; mirror its final contents into
@@ -2930,7 +2930,7 @@ fn build_class_inner(
             // Replay class body stores into the prepared dict so __setitem__
             // side effects (EnumDict tracking) fire — but only on the legacy
             // path where the body wrote into class_ns.  When the body executed
-            // directly against the mapping (setdictscope_object above) it
+            // directly against the mapping (setdictscope above) it
             // already holds every store; replaying would re-run __setitem__
             // and, for _EnumDict, reject the duplicate member keys.
             if mapping_namespace.is_none() {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1553,9 +1553,6 @@ impl NamespaceOpcodeHandler for PyFrame {
             unsafe {
                 pyre_object::dictmultiobject::w_dict_setitem_str(w_globals, name, value);
             }
-        } else {
-            let ns = unsafe { &mut *self.get_w_globals_storage() };
-            dict_storage_store(ns, name, value);
         }
         Ok(())
     }
@@ -2947,13 +2944,6 @@ impl OpcodeStepExecutor for PyFrame {
                 self.push(val);
                 return Ok(());
             }
-        } else {
-            unsafe {
-                if let Some(&val) = (*self.get_w_globals_storage()).get(name) {
-                    self.push(val);
-                    return Ok(());
-                }
-            }
         }
         Err(PyError::name_error_with_name(
             format!("name '{name}' is not defined"),
@@ -3724,15 +3714,6 @@ impl OpcodeStepExecutor for PyFrame {
                     {
                         if !value.is_null() {
                             pyre_object::w_dict_store(dict, key, value);
-                        }
-                    }
-                } else {
-                    let w_globals = self.get_w_globals_storage();
-                    if self.nlocals() == 0 && !w_globals.is_null() {
-                        for (key, &value) in (*w_globals).entries() {
-                            if !value.is_null() {
-                                pyre_object::w_dict_store(dict, pyre_object::w_str_new(key), value);
-                            }
                         }
                     }
                 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -486,60 +486,18 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                 // globals and was walked earlier in this collection.
                 let w_globals_obj_slot = &mut (*frame).w_globals as *mut PyObjectRef;
                 visitor(&mut *(w_globals_obj_slot as *mut majit_ir::GcRef));
-                // pyframe.py:147 `debugdata.w_locals` (and the pyre-only
-                // `w_locals_object` companion for non-dict mapping
-                // locals) carry GCREFs that survive the frame.
+                // pyframe.py:147 `debugdata.w_locals` (the frame's locals
+                // mapping object) and `w_f_trace` carry GCREFs that survive
+                // the frame; forward both slots.  The locals mapping holds its
+                // own bindings (module globals, class namespace, function
+                // `locals()` dict, or an `exec` mapping), so forwarding the
+                // object pointer keeps the whole namespace reachable.
                 if !(*frame).debugdata.is_null() {
                     let d = &mut *(*frame).debugdata;
                     let w_locals_object_slot = &mut d.w_locals_object as *mut PyObjectRef;
                     visitor(&mut *(w_locals_object_slot as *mut majit_ir::GcRef));
                     let w_f_trace_slot = &mut d.w_f_trace as *mut PyObjectRef;
                     visitor(&mut *(w_f_trace_slot as *mut majit_ir::GcRef));
-                    // A NEWLOCALS class body (`setdictscope` with a plain dict,
-                    // call.rs build_class_inner) binds names into
-                    // `debugdata.w_locals` — a raw DictStorage distinct from the
-                    // globals storage and not exposed as `w_locals_object`.  The
-                    // values it stores live nowhere else this walker reaches (the
-                    // globals walk below covers only the globals storage; the
-                    // array walk covers fastlocals), so a minor collection would
-                    // relocate a young binding and leave a dangling ref that
-                    // faults on a later read or guard-failure resume.  Forward
-                    // those values in place, mirroring the globals walk.  Skip
-                    // the module alias (`w_locals` IS the globals storage,
-                    // walked below) and the mapping/object scope (`w_locals`
-                    // null — rooted via `w_locals_object`).
-                    let w_locals = d.w_locals;
-                    let globals_storage = if (*frame).w_globals.is_null() {
-                        std::ptr::null_mut()
-                    } else {
-                        pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(
-                            (*frame).w_globals,
-                        ) as *mut crate::DictStorage
-                    };
-                    if !w_locals.is_null() && w_locals != globals_storage {
-                        let value_slots: Vec<*mut PyObjectRef> = (&mut *w_locals)
-                            .values_mut()
-                            .iter_mut()
-                            .map(|value| value as *mut PyObjectRef)
-                            .collect();
-                        for value in value_slots {
-                            visitor(&mut *(value as *mut majit_ir::GcRef));
-                            walk_raw_function_roots(*value, visitor);
-                        }
-                        // The class-body namespace's lazily-cached canonical
-                        // `W_DictObject` (the storage's `mirror_target`,
-                        // materialized when the body's locals are accessed as a
-                        // dict) is GC-managed but reachable only through this
-                        // off-GC storage field; forward it so a relocating
-                        // collection updates the cache instead of leaving a
-                        // dangling pointer, mirroring the type-namespace walk
-                        // above and the globals back-mirror below.
-                        if let Some(mirror_slot) = (&mut *w_locals).mirror_target_slot_mut() {
-                            visitor(
-                                &mut *(mirror_slot as *mut PyObjectRef as *mut majit_ir::GcRef),
-                            );
-                        }
-                    }
                 }
                 // pyframe.py:49 `self.w_globals` is the dict OBJECT.  Its slot
                 // was forwarded above (before the debugdata walk), so this
@@ -1504,13 +1462,7 @@ impl NamespaceOpcodeHandler for PyFrame {
             }
             return self.load_global_value(name, nameindex);
         }
-        let w_locals = self.get_w_locals();
-        if !w_locals.is_null() {
-            let locals = unsafe { &*w_locals };
-            if let Ok(value) = dict_storage_load(locals, name) {
-                return Ok(value);
-            }
-        }
+        // No locals mapping bound (degenerate): fall through to globals.
         self.load_global_value(name, nameindex)
     }
 
@@ -1528,14 +1480,9 @@ impl NamespaceOpcodeHandler for PyFrame {
         _nameindex: usize,
         value: Self::Value,
     ) -> Result<(), PyError> {
-        let w_locals_object = self.get_w_locals_object();
-        if !w_locals_object.is_null() {
-            let key = unsafe { pyre_object::w_str_new(name) };
-            crate::baseobjspace::setitem(w_locals_object, key, value)?;
-            return Ok(());
-        }
-        let ns = unsafe { &mut *self.get_or_create_w_locals() };
-        dict_storage_store(ns, name, value);
+        let w_locals_object = self.get_or_create_w_locals_object();
+        let key = unsafe { pyre_object::w_str_new(name) };
+        crate::baseobjspace::setitem(w_locals_object, key, value)?;
         Ok(())
     }
 
@@ -2343,24 +2290,12 @@ impl OpcodeStepExecutor for PyFrame {
     /// pyre-equivalent flow runs the bytecode opcode and writes into
     /// the class_locals namespace just like CPython).
     fn setup_annotations(&mut self) -> Result<(), PyError> {
-        // Module scope (and any object-form locals): route the
-        // `__annotations__` ensure through `space.contains` / `space.setitem`
-        // on the namespace object, mirroring STORE_NAME's object arm.
-        let w_locals_object = self.get_w_locals_object();
-        if !w_locals_object.is_null() {
-            let key = unsafe { pyre_object::w_str_new("__annotations__") };
-            if !crate::baseobjspace::contains(w_locals_object, key)? {
-                crate::baseobjspace::setitem(w_locals_object, key, pyre_object::w_dict_new())?;
-            }
-            return Ok(());
-        }
-        let ns = self.getdictscope()?;
-        if ns.is_null() {
-            return Ok(());
-        }
-        let ns = unsafe { &mut *ns };
-        if dict_storage_load(ns, "__annotations__").is_err() {
-            dict_storage_store(ns, "__annotations__", pyre_object::w_dict_new());
+        // Route the `__annotations__` ensure through `space.contains` /
+        // `space.setitem` on the locals mapping object, mirroring STORE_NAME.
+        let w_locals_object = self.get_or_create_w_locals_object();
+        let key = unsafe { pyre_object::w_str_new("__annotations__") };
+        if !crate::baseobjspace::contains(w_locals_object, key)? {
+            crate::baseobjspace::setitem(w_locals_object, key, pyre_object::w_dict_new())?;
         }
         Ok(())
     }
@@ -3104,40 +3039,18 @@ impl OpcodeStepExecutor for PyFrame {
     // ── delete_name ──
     // pypy/interpreter/pyopcode.py:821 DELETE_NAME — delete from w_locals; KeyError → NameError.
     fn delete_name(&mut self, name: &str) -> Result<(), PyError> {
-        let w_locals_object = self.get_w_locals_object();
-        if !w_locals_object.is_null() {
-            let key = unsafe { pyre_object::w_str_new(name) };
-            crate::baseobjspace::delitem(w_locals_object, key).map_err(|err| {
-                if matches!(err.kind, PyErrorKind::KeyError) {
-                    PyError::name_error_with_name(format!("name '{name}' is not defined"), name)
-                } else {
-                    err
-                }
-            })?;
-            return Ok(());
-        }
-        let w_locals = self.get_w_locals();
-        let w_globals = self.get_w_globals();
-        let found: bool = if !w_locals.is_null() {
-            // No `get_w_locals_obj` accessor yet — locals DictStorage
-            // doesn't have a canonical W_DictObject sibling for routing.
-            unsafe { crate::dict_storage_delete(&mut *w_locals, name) }
-        } else if w_globals.is_null() {
-            let ns = self.get_w_globals_storage();
-            unsafe { crate::dict_storage_delete(&mut *ns, name) }
-        } else {
-            // Globals fallback: route through `w_dict_delitem_str` on
-            // the canonical W_DictObject so the W_ModuleDictObject
-            // strategy and mirror `DictStorage` stay coherent via
-            // `maybe_sync_dict_storage_delete`.
-            unsafe { pyre_object::w_dict_delitem_str(w_globals, name) }
-        };
-        if !found {
-            return Err(PyError::name_error_with_name(
-                format!("name '{name}' is not defined"),
-                name,
-            ));
-        }
+        // `space.delitem(w_locals, w_name)`; at module scope `w_locals` is the
+        // globals dict, so a module DELETE_NAME routes through the canonical
+        // W_DictObject too.  KeyError → NameError.
+        let w_locals_object = self.get_or_create_w_locals_object();
+        let key = unsafe { pyre_object::w_str_new(name) };
+        crate::baseobjspace::delitem(w_locals_object, key).map_err(|err| {
+            if matches!(err.kind, PyErrorKind::KeyError) {
+                PyError::name_error_with_name(format!("name '{name}' is not defined"), name)
+            } else {
+                err
+            }
+        })?;
         Ok(())
     }
 
@@ -3174,14 +3087,8 @@ impl OpcodeStepExecutor for PyFrame {
     // generic `w_obj`.
     fn import_star(&mut self) -> Result<(), PyError> {
         let module = self.pop();
-        let w_locals_object = self.get_w_locals_object();
-        if !w_locals_object.is_null() {
-            crate::importing::import_all_from_w(module, w_locals_object)?;
-            return Ok(());
-        }
-        let w_locals = self.getdictscope()?;
-        crate::importing::import_all_from(module, w_locals)?;
-        self.setdictscope(w_locals)?;
+        let w_locals_object = self.get_or_create_w_locals_object();
+        crate::importing::import_all_from_w(module, w_locals_object)?;
         Ok(())
     }
 
@@ -3703,11 +3610,11 @@ impl OpcodeStepExecutor for PyFrame {
     fn load_locals(&mut self) -> Result<(), PyError> {
         let dict = pyre_object::w_dict_new();
         unsafe {
-            let w_locals = self.get_w_locals();
-            if !w_locals.is_null() {
-                for (key, &value) in (*w_locals).entries() {
+            let w_locals_object = self.get_w_locals_object();
+            if !w_locals_object.is_null() && pyre_object::is_dict(w_locals_object) {
+                for (key, value) in pyre_object::dictmultiobject::w_dict_items(w_locals_object) {
                     if !value.is_null() {
-                        pyre_object::w_dict_store(dict, pyre_object::w_str_new(key), value);
+                        pyre_object::w_dict_store(dict, key, value);
                     }
                 }
             } else {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -170,6 +170,10 @@ unsafe fn walk_raw_function_roots(
         }
         let func = &mut *(value as *mut crate::function::Function);
         visitor(&mut *(&mut func.code as *mut *const () as *mut majit_ir::GcRef));
+        // The code object caches its own globals dict (`PyCode.w_globals`),
+        // a movable dict for custom-globals functions; the code is Box-immortal
+        // so the standard tracer never recurses into it.
+        walk_raw_code_roots(func.code as PyObjectRef, visitor);
         visitor(&mut *(&mut func.closure as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.defs_w as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_kw_defs as *mut PyObjectRef as *mut majit_ir::GcRef));
@@ -181,6 +185,24 @@ unsafe fn walk_raw_function_roots(
         visitor(&mut *(&mut func.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_objclass as *mut PyObjectRef as *mut majit_ir::GcRef));
         visitor(&mut *(&mut func.w_text_signature as *mut PyObjectRef as *mut majit_ir::GcRef));
+    }
+}
+
+/// Forward a Box-immortal `PyCode`'s cached globals dict object
+/// (`pycode.py:105 "w_globals?"`).  Module globals are `malloc_typed`-immortal,
+/// but `exec`/`eval` with a plain dict (or a function built with custom
+/// globals) caches a `try_gc_alloc` movable dict here, which a minor collection
+/// relocates.  The code object itself is Box-immortal, so the standard tracer
+/// never recurses into it; visit the slot as a root the same way
+/// `walk_raw_function_roots` forwards `w_func_globals_obj`.  No-op for non-code
+/// values and inert when the cached dict is non-moving.
+unsafe fn walk_raw_code_roots(value: PyObjectRef, visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    unsafe {
+        if value.is_null() || !crate::pycode::is_code(value) {
+            return;
+        }
+        let code = &mut *(value as *mut crate::pycode::PyCode);
+        visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
     }
 }
 
@@ -428,6 +450,10 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                 // inert today.
                 let pycode_slot = &mut (*(frame)).pycode as *mut *const ();
                 visitor(&mut *(pycode_slot as *mut majit_ir::GcRef));
+                // Forward the running code object's cached globals dict.  For
+                // `exec`'d code with a movable (non-module) globals dict and no
+                // owning Function, this frame is the only root that reaches it.
+                walk_raw_code_roots((*(frame)).pycode as PyObjectRef, visitor);
 
                 // PyFrame is normally a GC object in PyPy, so its GCREF
                 // fields are traced before consumers dereference them.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2343,6 +2343,17 @@ impl OpcodeStepExecutor for PyFrame {
     /// pyre-equivalent flow runs the bytecode opcode and writes into
     /// the class_locals namespace just like CPython).
     fn setup_annotations(&mut self) -> Result<(), PyError> {
+        // Module scope (and any object-form locals): route the
+        // `__annotations__` ensure through `space.contains` / `space.setitem`
+        // on the namespace object, mirroring STORE_NAME's object arm.
+        let w_locals_object = self.get_w_locals_object();
+        if !w_locals_object.is_null() {
+            let key = unsafe { pyre_object::w_str_new("__annotations__") };
+            if !crate::baseobjspace::contains(w_locals_object, key)? {
+                crate::baseobjspace::setitem(w_locals_object, key, pyre_object::w_dict_new())?;
+            }
+            return Ok(());
+        }
         let ns = self.getdictscope()?;
         if ns.is_null() {
             return Ok(());

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -494,8 +494,8 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                 // object pointer keeps the whole namespace reachable.
                 if !(*frame).debugdata.is_null() {
                     let d = &mut *(*frame).debugdata;
-                    let w_locals_object_slot = &mut d.w_locals_object as *mut PyObjectRef;
-                    visitor(&mut *(w_locals_object_slot as *mut majit_ir::GcRef));
+                    let w_locals_slot = &mut d.w_locals as *mut PyObjectRef;
+                    visitor(&mut *(w_locals_slot as *mut majit_ir::GcRef));
                     let w_f_trace_slot = &mut d.w_f_trace as *mut PyObjectRef;
                     visitor(&mut *(w_f_trace_slot as *mut majit_ir::GcRef));
                 }
@@ -682,8 +682,8 @@ pub fn walk_suspended_generator_frame(
 
         if !(*frame).debugdata.is_null() {
             let d = &mut *(*frame).debugdata;
-            let w_locals_object_slot = &mut d.w_locals_object as *mut PyObjectRef;
-            visitor(&mut *(w_locals_object_slot as *mut majit_ir::GcRef));
+            let w_locals_slot = &mut d.w_locals as *mut PyObjectRef;
+            visitor(&mut *(w_locals_slot as *mut majit_ir::GcRef));
             let w_f_trace_slot = &mut d.w_f_trace as *mut PyObjectRef;
             visitor(&mut *(w_f_trace_slot as *mut majit_ir::GcRef));
         }
@@ -1445,13 +1445,13 @@ impl NamespaceOpcodeHandler for PyFrame {
     /// Non-dict mapping locals (`exec(src, g, mapping)`,
     /// `pypy/interpreter/pyopcode.py:2003 ensure_ns`) bypass the
     /// `*mut DictStorage` fast path and route through
-    /// `space.getitem(w_locals_object, name)` directly per PyPy
+    /// `space.getitem(w_locals, name)` directly per PyPy
     /// `pyopcode.py:LOAD_NAME` `space.finditem_str(w_locals, name)`.
     fn load_name_value(&mut self, name: &str, nameindex: usize) -> Result<Self::Value, PyError> {
-        let w_locals_object = self.get_w_locals_object();
-        if !w_locals_object.is_null() {
+        let w_locals = self.get_w_locals();
+        if !w_locals.is_null() {
             let key = unsafe { pyre_object::w_str_new(name) };
-            match crate::baseobjspace::getitem(w_locals_object, key) {
+            match crate::baseobjspace::getitem(w_locals, key) {
                 Ok(value) => return Ok(value),
                 Err(err) if matches!(err.kind, PyErrorKind::KeyError) => {
                     // pyopcode.py:LOAD_NAME `if not w_value: w_value =
@@ -1480,9 +1480,9 @@ impl NamespaceOpcodeHandler for PyFrame {
         _nameindex: usize,
         value: Self::Value,
     ) -> Result<(), PyError> {
-        let w_locals_object = self.get_or_create_w_locals_object();
+        let w_locals = self.get_or_create_w_locals();
         let key = unsafe { pyre_object::w_str_new(name) };
-        crate::baseobjspace::setitem(w_locals_object, key, value)?;
+        crate::baseobjspace::setitem(w_locals, key, value)?;
         Ok(())
     }
 
@@ -2292,10 +2292,10 @@ impl OpcodeStepExecutor for PyFrame {
     fn setup_annotations(&mut self) -> Result<(), PyError> {
         // Route the `__annotations__` ensure through `space.contains` /
         // `space.setitem` on the locals mapping object, mirroring STORE_NAME.
-        let w_locals_object = self.get_or_create_w_locals_object();
+        let w_locals = self.get_or_create_w_locals();
         let key = unsafe { pyre_object::w_str_new("__annotations__") };
-        if !crate::baseobjspace::contains(w_locals_object, key)? {
-            crate::baseobjspace::setitem(w_locals_object, key, pyre_object::w_dict_new())?;
+        if !crate::baseobjspace::contains(w_locals, key)? {
+            crate::baseobjspace::setitem(w_locals, key, pyre_object::w_dict_new())?;
         }
         Ok(())
     }
@@ -3042,9 +3042,9 @@ impl OpcodeStepExecutor for PyFrame {
         // `space.delitem(w_locals, w_name)`; at module scope `w_locals` is the
         // globals dict, so a module DELETE_NAME routes through the canonical
         // W_DictObject too.  KeyError → NameError.
-        let w_locals_object = self.get_or_create_w_locals_object();
+        let w_locals = self.get_or_create_w_locals();
         let key = unsafe { pyre_object::w_str_new(name) };
-        crate::baseobjspace::delitem(w_locals_object, key).map_err(|err| {
+        crate::baseobjspace::delitem(w_locals, key).map_err(|err| {
             if matches!(err.kind, PyErrorKind::KeyError) {
                 PyError::name_error_with_name(format!("name '{name}' is not defined"), name)
             } else {
@@ -3087,8 +3087,8 @@ impl OpcodeStepExecutor for PyFrame {
     // generic `w_obj`.
     fn import_star(&mut self) -> Result<(), PyError> {
         let module = self.pop();
-        let w_locals_object = self.get_or_create_w_locals_object();
-        crate::importing::import_all_from_w(module, w_locals_object)?;
+        let w_locals = self.get_or_create_w_locals();
+        crate::importing::import_all_from_w(module, w_locals)?;
         Ok(())
     }
 
@@ -3610,9 +3610,9 @@ impl OpcodeStepExecutor for PyFrame {
     fn load_locals(&mut self) -> Result<(), PyError> {
         let dict = pyre_object::w_dict_new();
         unsafe {
-            let w_locals_object = self.get_w_locals_object();
-            if !w_locals_object.is_null() && pyre_object::is_dict(w_locals_object) {
-                for (key, value) in pyre_object::dictmultiobject::w_dict_items(w_locals_object) {
+            let w_locals = self.get_w_locals();
+            if !w_locals.is_null() && pyre_object::is_dict(w_locals) {
+                for (key, value) in pyre_object::dictmultiobject::w_dict_items(w_locals) {
                     if !value.is_null() {
                         pyre_object::w_dict_store(dict, key, value);
                     }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3792,6 +3792,11 @@ mod tests {
     }
 
     fn run_exec_frame(source: &str) -> (PyResult, crate::pyframe::FrameBox) {
+        // Module globals are now a celldict whose str keys hash through the
+        // `hash_w` trampoline (production installs it before the first frame
+        // via `init_jit_hooks`); mirror that here so frame construction can
+        // seed the builtins.
+        crate::test_hooks::install_hash_hook();
         let code = compile_exec(source).expect("compile failed");
         let mut frame = PyFrame::new(code);
         let result = frame.execute_frame(None, None);
@@ -3801,9 +3806,11 @@ mod tests {
     #[test]
     fn test_exception_is_valid_obj_as_class_w_matches_baseexception_subclass_rule() {
         let (_result, frame) = run_exec_frame("good = ValueError\nbad = int");
-        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
-        let good = *w_globals.get("good").expect("missing good");
-        let bad = *w_globals.get("bad").expect("missing bad");
+        let w_globals = frame.get_w_globals();
+        let good =
+            unsafe { pyre_object::w_dict_getitem_str(w_globals, "good") }.expect("missing good");
+        let bad =
+            unsafe { pyre_object::w_dict_getitem_str(w_globals, "bad") }.expect("missing bad");
 
         unsafe {
             assert!(crate::baseobjspace::exception_is_valid_obj_as_class_w(good));
@@ -3827,8 +3834,9 @@ mod tests {
         let (_result, frame) = run_exec_frame(
             "def make_adder(n):\n    def add(x):\n        return x + n\n    return add\nresult = make_adder(10)(5)",
         );
-        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
-        let result = *w_globals.get("result").expect("missing result");
+        let w_globals = frame.get_w_globals();
+        let result = unsafe { pyre_object::w_dict_getitem_str(w_globals, "result") }
+            .expect("missing result");
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 15);
     }
 
@@ -3842,8 +3850,9 @@ mod tests {
         let (_result, frame) = run_exec_frame(
             "class A:\n    def f(self):\n        return 1\nclass B(A):\n    def f(self):\n        return 10 + super().f()\nresult = B().f()",
         );
-        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
-        let result = *w_globals.get("result").expect("missing result");
+        let w_globals = frame.get_w_globals();
+        let result = unsafe { pyre_object::w_dict_getitem_str(w_globals, "result") }
+            .expect("missing result");
         assert_eq!(unsafe { pyre_object::w_int_get_value(result) }, 11);
     }
 
@@ -3861,15 +3870,25 @@ mod tests {
     #[test]
     fn test_raise_from_sets_cause_attribute() {
         let (_result, frame) = run_exec_frame("exc = ValueError()\ncause = KeyError()");
-        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
-        let exc = *w_globals.get("exc").expect("missing exc");
-        let cause = *w_globals.get("cause").expect("missing cause");
+        let w_globals = frame.get_w_globals();
+        let exc =
+            unsafe { pyre_object::w_dict_getitem_str(w_globals, "exc") }.expect("missing exc");
+        let cause =
+            unsafe { pyre_object::w_dict_getitem_str(w_globals, "cause") }.expect("missing cause");
 
         let code = compile_exec("raise exc from cause").expect("compile failed");
         let mut raise_frame = PyFrame::new(code);
         unsafe {
-            (*raise_frame.fget_w_globals_storage()).insert("exc".to_string(), exc);
-            (*raise_frame.fget_w_globals_storage()).insert("cause".to_string(), cause);
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                raise_frame.get_w_globals(),
+                "exc",
+                exc,
+            );
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                raise_frame.get_w_globals(),
+                "cause",
+                cause,
+            );
         }
 
         let err = raise_frame
@@ -5406,11 +5425,15 @@ except (ValueError, 42):
         let (_result, frame) = run_exec_frame(
             "exc = ValueError(\"boom\")\nplain = 5\nvalue_error = ValueError\ntype_error = TypeError",
         );
-        let w_globals = unsafe { &*frame.fget_w_globals_storage() };
-        let exc = *w_globals.get("exc").expect("missing exc");
-        let plain = *w_globals.get("plain").expect("missing plain");
-        let value_error = *w_globals.get("value_error").expect("missing value_error");
-        let type_error = *w_globals.get("type_error").expect("missing type_error");
+        let w_globals = frame.get_w_globals();
+        let exc =
+            unsafe { pyre_object::w_dict_getitem_str(w_globals, "exc") }.expect("missing exc");
+        let plain =
+            unsafe { pyre_object::w_dict_getitem_str(w_globals, "plain") }.expect("missing plain");
+        let value_error = unsafe { pyre_object::w_dict_getitem_str(w_globals, "value_error") }
+            .expect("missing value_error");
+        let type_error = unsafe { pyre_object::w_dict_getitem_str(w_globals, "type_error") }
+            .expect("missing type_error");
 
         assert!(check_exc_match_against(exc, value_error));
         assert!(!check_exc_match_against(exc, type_error));

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1634,6 +1634,40 @@ impl ExecutionContext {
         ns
     }
 
+    /// Proxy-less celldict globals for a fresh module (`__main__`, imported
+    /// source modules) — the `dict_storage_proxy`-free analog of
+    /// `fresh_dict_storage`.  Seeds the builtins + `__builtins__` directly into
+    /// the `W_ModuleDictObject`'s authoritative cell storage so the JIT sees a
+    /// stable globals shape up front (same seed-vs-fallback rationale as
+    /// `fresh_dict_storage`), and module `STORE_NAME` / `STORE_GLOBAL` skip the
+    /// legacy proxy fan-out — `maybe_sync_dict_storage_store` no-ops on a null
+    /// proxy, so the per-store `w_str_new` + `DictStorage::insert` +
+    /// back-mirror disappear (the `IntMutableCell` in-place write stands alone,
+    /// matching pypy's `ModuleDictStrategy`).
+    pub fn fresh_module_globals(&self) -> PyObjectRef {
+        let dict = pyre_object::dictmultiobject::w_module_dict_new();
+        // Root the fresh dict across the seeding loop: each
+        // `w_dict_setitem_str_no_proxy` allocates a cell and may trigger a
+        // minor collection that would otherwise reclaim the not-yet-referenced
+        // dict.
+        let _root = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(dict);
+        unsafe {
+            for (k, v) in pyre_object::w_dict_str_entries(self.builtins_module) {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(dict, &k, v);
+            }
+            let w_builtin = self.get_builtin();
+            if !w_builtin.is_null() {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    dict,
+                    "__builtins__",
+                    w_builtin,
+                );
+            }
+        }
+        dict
+    }
+
     /// `pypy/module/__builtin__/moduledef.py:Module.__init__` — `space.builtin`
     /// is a `Module` (not a dict).  Lazily build a `Module` whose
     /// backing dict IS `self.builtins_module`, so subsequent

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -127,7 +127,7 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
         // matches that identity; reading it here avoids a second
         // `dict_storage_to_dict` round-trip below.
         let w_globals = frame_ref.get_w_globals();
-        let w_locals_object = frame_ref.get_w_locals_object();
+        let w_locals = frame_ref.get_w_locals();
         let w_trace = frame_ref.get_w_f_trace();
         // pypy/interpreter/pyframe.py:154 fget_f_back walks the
         // f_backref vref to materialise the parent frame.  Pyre's
@@ -167,12 +167,12 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
             w_frame,
             "f_locals",
             // pyframe.py:546 fast2locals (run by the trace gate before this
-            // callback) caches the locals mapping in `w_locals_object`; expose
+            // callback) caches the locals mapping in `w_locals`; expose
             // it directly.  A frame with no locals bound surfaces as None.
-            if w_locals_object.is_null() {
+            if w_locals.is_null() {
                 pyre_object::w_none()
             } else {
-                w_locals_object
+                w_locals
             },
         );
         let _ = crate::baseobjspace::setattr_str(
@@ -1436,7 +1436,7 @@ impl ExecutionContext {
             };
             let had_locals = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
-                !d.w_locals_object.is_null()
+                !d.w_locals.is_null()
             };
             if had_locals {
                 unsafe { (*frame).fast2locals()? };
@@ -1500,7 +1500,7 @@ impl ExecutionContext {
             // `had_locals` from before the call.
             let post_had_locals = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
-                !d.w_locals_object.is_null()
+                !d.w_locals.is_null()
             };
             if post_had_locals {
                 unsafe { (*frame).locals2fast(false)? };

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -128,7 +128,6 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
         // `dict_storage_to_dict` round-trip below.
         let w_globals = frame_ref.get_w_globals();
         let w_locals_object = frame_ref.get_w_locals_object();
-        let w_locals = frame_ref.get_w_locals();
         let w_trace = frame_ref.get_w_f_trace();
         // pypy/interpreter/pyframe.py:154 fget_f_back walks the
         // f_backref vref to materialise the parent frame.  Pyre's
@@ -167,20 +166,13 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
         let _ = crate::baseobjspace::setattr_str(
             w_frame,
             "f_locals",
-            if !w_locals_object.is_null() {
-                // Module scope (`w_locals is w_globals`) and any object-form
-                // locals namespace expose the object directly.
-                w_locals_object
-            } else if w_locals.is_null() {
+            // pyframe.py:546 fast2locals (run by the trace gate before this
+            // callback) caches the locals mapping in `w_locals_object`; expose
+            // it directly.  A frame with no locals bound surfaces as None.
+            if w_locals_object.is_null() {
                 pyre_object::w_none()
             } else {
-                // `pypy/interpreter/pyframe.py:546 fast2locals` builds a
-                // regular dict, not a module-strategy dict; function
-                // locals don't need GlobalCache machinery.
-                crate::baseobjspace::dict_storage_to_dict_kind(
-                    w_locals as *const DictStorage,
-                    crate::baseobjspace::DictWrapKind::Instance,
-                )
+                w_locals_object
             },
         );
         let _ = crate::baseobjspace::setattr_str(
@@ -1444,7 +1436,7 @@ impl ExecutionContext {
             };
             let had_locals = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
-                !d.w_locals.is_null() || !d.w_locals_object.is_null()
+                !d.w_locals_object.is_null()
             };
             if had_locals {
                 unsafe { (*frame).fast2locals()? };
@@ -1508,7 +1500,7 @@ impl ExecutionContext {
             // `had_locals` from before the call.
             let post_had_locals = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
-                !d.w_locals.is_null() || !d.w_locals_object.is_null()
+                !d.w_locals_object.is_null()
             };
             if post_had_locals {
                 unsafe { (*frame).locals2fast(false)? };

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -127,6 +127,7 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
         // matches that identity; reading it here avoids a second
         // `dict_storage_to_dict` round-trip below.
         let w_globals = frame_ref.get_w_globals();
+        let w_locals_object = frame_ref.get_w_locals_object();
         let w_locals = frame_ref.get_w_locals();
         let w_trace = frame_ref.get_w_f_trace();
         // pypy/interpreter/pyframe.py:154 fget_f_back walks the
@@ -166,7 +167,11 @@ fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
         let _ = crate::baseobjspace::setattr_str(
             w_frame,
             "f_locals",
-            if w_locals.is_null() {
+            if !w_locals_object.is_null() {
+                // Module scope (`w_locals is w_globals`) and any object-form
+                // locals namespace expose the object directly.
+                w_locals_object
+            } else if w_locals.is_null() {
                 pyre_object::w_none()
             } else {
                 // `pypy/interpreter/pyframe.py:546 fast2locals` builds a
@@ -1439,7 +1444,7 @@ impl ExecutionContext {
             };
             let had_locals = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
-                !d.w_locals.is_null()
+                !d.w_locals.is_null() || !d.w_locals_object.is_null()
             };
             if had_locals {
                 unsafe { (*frame).fast2locals()? };
@@ -1503,7 +1508,7 @@ impl ExecutionContext {
             // `had_locals` from before the call.
             let post_had_locals = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
-                !d.w_locals.is_null()
+                !d.w_locals.is_null() || !d.w_locals_object.is_null()
             };
             if post_had_locals {
                 unsafe { (*frame).locals2fast(false)? };

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1809,23 +1809,10 @@ where
     Ok(())
 }
 
-/// pypy/interpreter/pyopcode.py:2221-2258 `import_all_from` —
-/// `*mut DictStorage` (dict locals fast path) target variant.
-pub fn import_all_from(
-    module: PyObjectRef,
-    into_namespace: *mut DictStorage,
-) -> Result<(), crate::PyError> {
-    let dst_ns = unsafe { &mut *into_namespace };
-    import_all_from_each(module, |name, value| {
-        dict_storage_store(dst_ns, name, value);
-        Ok(())
-    })
-}
-
-/// pypy/interpreter/pyopcode.py:2221-2258 `import_all_from` — generic
-/// mapping (`PyObjectRef`) target variant.  Errors from `__setitem__`
-/// propagate (CPython behaviour: a misbehaving mapping surfaces its
-/// TypeError / KeyError to the caller).
+/// pypy/interpreter/pyopcode.py:2221-2258 `import_all_from` — applies each
+/// public name to the locals mapping object via `space.setitem`.  Errors from
+/// `__setitem__` propagate (a misbehaving mapping surfaces its TypeError /
+/// KeyError to the caller).
 pub fn import_all_from_w(
     module: PyObjectRef,
     into_locals: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -72,7 +72,7 @@ fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
         // `pyframe.py:540-545 getdictscope`: PyPy materialises
         // `f_locals` by running `fast2locals()` and exposing the
         // resulting `debugdata.w_locals` dict.
-        let w_locals_obj = frame_ref.getdictscope_w().unwrap_or(pyre_object::PY_NULL);
+        let w_locals_obj = frame_ref.getdictscope().unwrap_or(pyre_object::PY_NULL);
         // pyframe.py:128 get_w_globals_storage returns the globals dict object.  The
         // canonical `w_globals` is seeded by every frame constructor and
         // is the source of truth for the frame's globals.

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -149,10 +149,14 @@ pub struct PyCode {
     /// Opaque pointer to a `CodeObject` (owned via Box::into_raw).
     pub code_ptr: *const (),
     /// PyPy: `PyCode.w_globals` — the globals dict OBJECT (`W_DictMultiObject`,
-    /// `pycode.py:105 "w_globals?"`).  A `malloc_typed`-immortal wrapper, so
-    /// the pointer never moves.  Null until first stamped by
-    /// `frame_stores_global`.  The off-GC `DictStorage` storage is recovered
-    /// on demand via `w_globals_storage`.
+    /// `pycode.py:105 "w_globals?"`).  Module globals are `malloc_typed`-
+    /// immortal, but `exec`/custom-globals dicts are `try_gc_alloc` movable.
+    /// The code object is Box-immortal, so the collector never reaches this
+    /// slot by tracing into it; `eval::walk_raw_code_roots` forwards it as a
+    /// root (via `walk_raw_function_roots` for `func.code` and the frame walk
+    /// for `frame.pycode`).  Null until first stamped by `frame_stores_global`.
+    /// The off-GC `DictStorage` storage is recovered on demand via
+    /// `w_globals_storage`.
     pub w_globals: PyObjectRef,
     /// PyPy: `PyCode.hidden_applevel` (`pycode.py:111, 147`). Set by
     /// `pycompiler.compile(hidden_applevel=True)` for PyPy gateway/

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1018,12 +1018,20 @@ impl PyFrame {
         let code = unsafe { &*pyframe_get_pycode(self) };
         let flags = code.flags;
         if !flags.contains(CodeFlags::OPTIMIZED) {
-            let w_locals = if flags.contains(CodeFlags::NEWLOCALS) {
-                pyre_object::lltype::malloc_raw(DictStorage::new())
+            if flags.contains(CodeFlags::NEWLOCALS) {
+                // Class body — a fresh locals namespace. Still bound in the
+                // raw `*mut DictStorage` form pending the class-scope half of
+                // the w_locals object-ification.
+                let w_locals = pyre_object::lltype::malloc_raw(DictStorage::new());
+                self.getorcreate_debug_data(-1).w_locals = w_locals;
             } else {
-                self.get_w_globals_storage()
-            };
-            self.getorcreate_debug_data(-1).w_locals = w_locals;
+                // pyframe.py:216-218 — module scope binds `w_locals = w_globals`.
+                // Bind the canonical W_DictObject so STORE_NAME / LOAD_NAME /
+                // DELETE_NAME and `locals()` route through the object instead of
+                // the raw DictStorage proxy.
+                let w_globals = self.get_w_globals();
+                self.getorcreate_debug_data(-1).w_locals_object = w_globals;
+            }
         }
 
         let npure = npure_cellvars(code);
@@ -1323,10 +1331,11 @@ impl PyFrame {
         // Module-level w_locals = w_globals binding flows naturally
         // through `createframe → initialize_frame_scopes` since RustPython
         // codegen emits empty flags for the module seed CodeInfo
-        // (pyframe.py:233-235).  This constructor bypasses
+        // (pyframe.py:216-218).  This constructor bypasses
         // initialize_frame_scopes, so still bind w_locals to w_globals
-        // explicitly to match what `createframe` would observe.
-        frame.getorcreate_debug_data(-1).w_locals = w_globals_storage;
+        // explicitly to match what `createframe` would observe — in the
+        // object form (the canonical W_DictObject), not the raw storage.
+        frame.getorcreate_debug_data(-1).w_locals_object = w_globals;
         frame
     }
 

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -490,8 +490,8 @@ pub struct FrameDebugData {
     /// the class namespace; for a function it is the dict lazily
     /// materialised by `fast2locals`; `exec(src, g, mapping)` binds an
     /// arbitrary `__getitem__` mapping here.  `STORE/LOAD/DELETE_NAME`
-    /// route through `space.setitem/getitem/delitem(w_locals_object, ...)`.
-    pub w_locals_object: PyObjectRef,
+    /// route through `space.setitem/getitem/delitem(w_locals, ...)`.
+    pub w_locals: PyObjectRef,
     /// pyframe.py:37
     pub w_f_trace: PyObjectRef,
     /// pyframe.py:40
@@ -517,7 +517,7 @@ impl FrameDebugData {
     // longer snapshots `pycode.w_globals`.
     pub fn new(_pycode: *const (), init_lineno: isize) -> Self {
         Self {
-            w_locals_object: pyre_object::PY_NULL,
+            w_locals: pyre_object::PY_NULL,
             w_f_trace: pyre_object::PY_NULL,
             is_being_profiled: false,
             is_in_line_tracing: false,
@@ -875,18 +875,18 @@ impl PyFrame {
     /// Unlike `getdictscope` it performs no `fast2locals` materialization, so
     /// it never disturbs `CO_FAST_HIDDEN` slots.
     #[inline]
-    pub fn get_or_create_w_locals_object(&mut self) -> PyObjectRef {
-        let existing = self.get_w_locals_object();
+    pub fn get_or_create_w_locals(&mut self) -> PyObjectRef {
+        let existing = self.get_w_locals();
         if !existing.is_null() {
             return existing;
         }
         // A frame that reaches STORE_NAME / SETUP_ANNOTATIONS without a
         // bound locals mapping is degenerate (module / class / exec all
-        // bind one in `initialize_frame_scopes` / `setdictscope_object`).
+        // bind one in `initialize_frame_scopes` / `setdictscope`).
         // Allocate a fresh dict so the write still lands somewhere
         // observable instead of faulting.
         let w_locals = unsafe { pyre_object::w_dict_new() };
-        self.getorcreate_debug_data(-1).w_locals_object = w_locals;
+        self.getorcreate_debug_data(-1).w_locals = w_locals;
         w_locals
     }
 
@@ -1003,17 +1003,17 @@ impl PyFrame {
                 // pyframe.py:213 — class body binds a fresh locals namespace
                 // dict object (`space.newdict(module=True)`).  `build_class`
                 // replaces it with the `__prepare__` namespace via
-                // `setdictscope_object`; an orphan NEWLOCALS frame still has a
+                // `setdictscope`; an orphan NEWLOCALS frame still has a
                 // usable mapping.
                 let w_locals = unsafe { pyre_object::w_dict_new() };
-                self.getorcreate_debug_data(-1).w_locals_object = w_locals;
+                self.getorcreate_debug_data(-1).w_locals = w_locals;
             } else {
                 // pyframe.py:216-218 — module scope binds `w_locals = w_globals`.
                 // Bind the canonical W_DictObject so STORE_NAME / LOAD_NAME /
                 // DELETE_NAME and `locals()` route through the object instead of
                 // the raw DictStorage proxy.
                 let w_globals = self.get_w_globals();
-                self.getorcreate_debug_data(-1).w_locals_object = w_globals;
+                self.getorcreate_debug_data(-1).w_locals = w_globals;
             }
         }
 
@@ -1061,7 +1061,7 @@ impl PyFrame {
     }
 
     /// pyframe.py:547-552 setdictscope(w_locals, skip_free_vars=False) —
-    /// install `w_locals_object` as the frame's locals mapping and reflect
+    /// install `w_locals` as the frame's locals mapping and reflect
     /// its entries into the fastlocals via `locals2fast`.
     ///
     /// `pypy/interpreter/pyopcode.py:2003-2013 ensure_ns` admits any object
@@ -1070,21 +1070,21 @@ impl PyFrame {
     /// share this path and `STORE_NAME` / `LOAD_NAME` / `DELETE_NAME` route
     /// through `space.setitem` / `space.getitem` / `space.delitem` on it.
     #[inline]
-    pub fn setdictscope_object(
+    pub fn setdictscope(
         &mut self,
-        w_locals_object: PyObjectRef,
+        w_locals: PyObjectRef,
     ) -> Result<(), crate::PyError> {
-        self.getorcreate_debug_data(-1).w_locals_object = w_locals_object;
+        self.getorcreate_debug_data(-1).w_locals = w_locals;
         self.locals2fast(false)
     }
 
-    /// Read the frame's locals mapping registered by `setdictscope_object`
+    /// Read the frame's locals mapping registered by `setdictscope`
     /// (or `initialize_frame_scopes`).  Returns `PY_NULL` when the frame has
     /// no locals bound yet (a function before its first `fast2locals`).
     #[inline]
-    pub fn get_w_locals_object(&self) -> PyObjectRef {
+    pub fn get_w_locals(&self) -> PyObjectRef {
         self.getdebug_data()
-            .map_or(pyre_object::PY_NULL, |data| data.w_locals_object)
+            .map_or(pyre_object::PY_NULL, |data| data.w_locals)
     }
 
     /// pyframe.py:540-545 getdictscope — runs `fast2locals` then returns
@@ -1092,12 +1092,12 @@ impl PyFrame {
     ///
     /// `fast2locals` lazily materialises a fresh dict for a function frame
     /// (pyframe.py:557 `space.newdict(instance=True)`) and caches it in
-    /// `w_locals_object`, so repeated calls return the same object —
+    /// `w_locals`, so repeated calls return the same object —
     /// `frame.f_locals is frame.f_locals` holds.
     #[inline]
-    pub fn getdictscope_w(&mut self) -> Result<PyObjectRef, crate::PyError> {
+    pub fn getdictscope(&mut self) -> Result<PyObjectRef, crate::PyError> {
         self.fast2locals()?;
-        Ok(self.get_w_locals_object())
+        Ok(self.get_w_locals())
     }
 
     /// Create a minimal frame stub for passing to call dispatch.
@@ -1271,7 +1271,7 @@ impl PyFrame {
         // initialize_frame_scopes, so still bind w_locals to w_globals
         // explicitly to match what `createframe` would observe — in the
         // object form (the canonical W_DictObject), not the raw storage.
-        frame.getorcreate_debug_data(-1).w_locals_object = w_globals;
+        frame.getorcreate_debug_data(-1).w_locals = w_globals;
         frame
     }
 
@@ -1928,27 +1928,14 @@ impl PyFrame {
     }
 
     /// pyframe.py:601-636 locals2fast(skip_free_vars=False) — reflect the
-    /// locals mapping back into the fastlocals.  A frame with no locals
-    /// bound (a function before its first `getdictscope`) has nothing to
-    /// copy.
+    /// locals mapping back into the fastlocals.  Reads each varname / cellvar
+    /// / freevar from the mapping via `space.finditem_str` (KeyError →
+    /// missing); a frame with no locals bound has nothing to copy.
     pub fn locals2fast(&mut self, skip_free_vars: bool) -> Result<(), crate::PyError> {
-        let w_locals_object = self.get_w_locals_object();
-        if w_locals_object.is_null() {
+        let w_locals = self.get_w_locals();
+        if w_locals.is_null() {
             return Ok(());
         }
-        self.locals2fast_object(w_locals_object, skip_free_vars)
-    }
-
-    /// pyframe.py:601-636 locals2fast — non-dict mapping branch.
-    ///
-    /// Reads each varname / cellvar / freevar from the mapping via
-    /// `space.finditem_str` (KeyError → missing) and populates the
-    /// corresponding fast slot.  Non-KeyError errors propagate.
-    fn locals2fast_object(
-        &mut self,
-        w_locals_object: PyObjectRef,
-        skip_free_vars: bool,
-    ) -> Result<(), crate::PyError> {
         let code_ptr = unsafe { pyframe_get_pycode(self) };
         let code = unsafe { &*code_ptr };
         let numlocals = code.varnames.len();
@@ -1962,7 +1949,7 @@ impl PyFrame {
                 continue;
             }
             let name = &code.varnames[i];
-            if let Some(w_value) = finditem_str_object(w_locals_object, name)? {
+            if let Some(w_value) = finditem_str_object(w_locals, name)? {
                 new_fastlocals_w[i] = w_value;
             }
         }
@@ -1994,7 +1981,7 @@ impl PyFrame {
             };
             let idx = numlocals + i;
             if idx < self.locals_w().len() {
-                let w_value = finditem_str_object(w_locals_object, name)?.unwrap_or(PY_NULL);
+                let w_value = finditem_str_object(w_locals, name)?.unwrap_or(PY_NULL);
                 let slot = self.locals_w()[idx];
                 if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
                     unsafe { pyre_object::w_cell_set(slot, w_value) };
@@ -2023,23 +2010,13 @@ impl PyFrame {
     pub fn init_cells(&mut self) {}
 
     /// pyframe.py:554-598 fast2locals — copy the fastlocals into the locals
-    /// mapping.  A function frame with no locals bound yet lazily allocates a
-    /// fresh dict (pyframe.py:557 `self.space.newdict(instance=True)`) and
-    /// caches it, so `locals() is locals()` holds.
+    /// mapping via `space.setitem_str` (`pyframe.py:568`), using `space.delitem`
+    /// for missing slots (`pyframe.py:571-574`; `delitem`'s `KeyError` is
+    /// silently dropped).  A function frame with no locals bound yet lazily
+    /// allocates a fresh dict (pyframe.py:557 `self.space.newdict(instance=True)`)
+    /// and caches it, so `locals() is locals()` holds.  Errors propagate.
     pub fn fast2locals(&mut self) -> Result<(), crate::PyError> {
-        let w_locals_object = self.get_or_create_w_locals_object();
-        self.fast2locals_object(w_locals_object)
-    }
-
-    /// pyframe.py:554-598 fast2locals — non-dict mapping branch.
-    ///
-    /// Writes each fastlocal / cellvar / freevar to the mapping via
-    /// `space.setitem_str` (`pyframe.py:568`) and uses `space.delitem`
-    /// for missing slots (`pyframe.py:571-574`).  Errors propagate to
-    /// the caller; `delitem`'s `KeyError` is silently dropped (matches
-    /// `pyframe.py:573-574 if not e.match(self.space, w_KeyError):
-    /// raise`).
-    fn fast2locals_object(&mut self, w_locals_object: PyObjectRef) -> Result<(), crate::PyError> {
+        let w_locals = self.get_or_create_w_locals();
         let code_ptr = unsafe { pyframe_get_pycode(self) };
         let code = unsafe { &*code_ptr };
         let varnames = &code.varnames;
@@ -2053,9 +2030,9 @@ impl PyFrame {
             let name = &varnames[i];
             let w_value = self.locals_w()[i];
             if !w_value.is_null() {
-                setitem_str_object(w_locals_object, name, w_value)?;
+                setitem_str_object(w_locals, name, w_value)?;
             } else {
-                delitem_str_object(w_locals_object, name)?;
+                delitem_str_object(w_locals, name)?;
             }
         }
 
@@ -2092,9 +2069,9 @@ impl PyFrame {
                     slot
                 };
                 if !w_value.is_null() {
-                    setitem_str_object(w_locals_object, name, w_value)?;
+                    setitem_str_object(w_locals, name, w_value)?;
                 } else {
-                    delitem_str_object(w_locals_object, name)?;
+                    delitem_str_object(w_locals, name)?;
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1070,10 +1070,7 @@ impl PyFrame {
     /// share this path and `STORE_NAME` / `LOAD_NAME` / `DELETE_NAME` route
     /// through `space.setitem` / `space.getitem` / `space.delitem` on it.
     #[inline]
-    pub fn setdictscope(
-        &mut self,
-        w_locals: PyObjectRef,
-    ) -> Result<(), crate::PyError> {
+    pub fn setdictscope(&mut self, w_locals: PyObjectRef) -> Result<(), crate::PyError> {
         self.getorcreate_debug_data(-1).w_locals = w_locals;
         self.locals2fast(false)
     }
@@ -1191,27 +1188,30 @@ impl PyFrame {
         code: CodeObject,
         execution_context: Rc<PyExecutionContext>,
     ) -> Result<FrameBox, crate::PyError> {
-        // `fresh_dict_storage` already seeds `__builtins__ = space
-        // .builtin` (PyPy `main.py:45 / Module.__init__` parity).  Just
-        // set `__name__` on top.
-        let mut w_globals = Box::new(execution_context.fresh_dict_storage());
-        w_globals.fix_ptr();
-        crate::dict_storage_store(
-            &mut w_globals,
-            "__name__",
-            pyre_object::w_str_new("__main__"),
-        );
-        let w_globals = Box::into_raw(w_globals);
+        // `fresh_module_globals` seeds `__builtins__ = space.builtin`
+        // (PyPy `main.py:45 / Module.__init__` parity) into a proxy-less
+        // celldict.  Just set `__name__` on top.
+        let w_globals = execution_context.fresh_module_globals();
+        // Root the fresh globals across the `__name__` store, code/object
+        // allocations, and frame construction; `createframe_obj` stores
+        // `w_globals` into the frame (and `w_code_set_w_globals` into the
+        // code), both of which root it once they return.
+        let _root = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_globals);
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                w_globals,
+                "__name__",
+                pyre_object::w_str_new("__main__"),
+            );
+        }
         let code_ptr = Box::into_raw(Box::new(code));
         let w_code = crate::w_code_new(code_ptr as *const ());
         unsafe {
-            crate::w_code_set_w_globals(
-                w_code,
-                crate::baseobjspace::dict_storage_to_dict(w_globals),
-            );
+            crate::w_code_set_w_globals(w_code, w_globals);
         }
         let ctx_ptr = Rc::into_raw(execution_context);
-        crate::createframe(w_code as *const (), w_globals, ctx_ptr, None)
+        crate::createframe_obj(w_code as *const (), w_globals, ctx_ptr, None)
     }
 
     /// PyFrame constructor body called from `createframe` (PyPy

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -485,15 +485,12 @@ pub unsafe fn pyframe_get_pycode(frame: &PyFrame) -> *const CodeObject {
 #[repr(C)]
 #[derive(Clone)]
 pub struct FrameDebugData {
-    /// pyframe.py:44
-    pub w_locals: *mut DictStorage,
-    /// pyframe.py:44 — non-dict mapping locals (`exec(src, g, mapping)`).
-    /// PyPy stores `w_locals` as a generic `w_obj`; pyre keeps the
-    /// `*mut DictStorage` fast path for the common dict case and falls
-    /// back to this `PyObjectRef` when the caller hands a non-dict
-    /// mapping with `__getitem__` per pyopcode.py:2003-2013 ensure_ns.
-    /// `STORE/LOAD/DELETE_NAME` route through `space.setitem/getitem
-    /// /delitem(w_locals_object, ...)` when this field is non-null.
+    /// pyframe.py:44 — the frame's locals mapping (`self.w_locals`).
+    /// At module scope it is the `w_globals` dict; in a class body it is
+    /// the class namespace; for a function it is the dict lazily
+    /// materialised by `fast2locals`; `exec(src, g, mapping)` binds an
+    /// arbitrary `__getitem__` mapping here.  `STORE/LOAD/DELETE_NAME`
+    /// route through `space.setitem/getitem/delitem(w_locals_object, ...)`.
     pub w_locals_object: PyObjectRef,
     /// pyframe.py:37
     pub w_f_trace: PyObjectRef,
@@ -520,7 +517,6 @@ impl FrameDebugData {
     // longer snapshots `pycode.w_globals`.
     pub fn new(_pycode: *const (), init_lineno: isize) -> Self {
         Self {
-            w_locals: std::ptr::null_mut(),
             w_locals_object: pyre_object::PY_NULL,
             w_f_trace: pyre_object::PY_NULL,
             is_being_profiled: false,
@@ -873,34 +869,25 @@ impl PyFrame {
             .map_or(false, |data| data.is_being_profiled)
     }
 
-    /// pyframe.py:147 get_w_locals
-    #[inline]
-    pub fn get_w_locals(&self) -> *mut DictStorage {
-        self.getdebug_data()
-            .map_or(std::ptr::null_mut(), |data| data.w_locals)
-    }
-
-    /// pyframe.py:540-545 getdictscope — runs `fast2locals` then returns
-    /// `self.debugdata.w_locals`.  PyPy exposes the failure of
-    /// `fast2locals` as an exception; pyre propagates the same way.
-    #[inline]
-    pub fn getdictscope(&mut self) -> Result<*mut DictStorage, crate::PyError> {
-        self.fast2locals()?;
-        Ok(self.get_w_locals())
-    }
-
     /// `getorcreatedebug().w_locals` — the STORE_NAME / DELETE_NAME target
     /// (`pyopcode.py:855-865`): the class namespace, or the globals dict at
     /// module scope. Lazily allocates an empty dict if the frame has none.
     /// Unlike `getdictscope` it performs no `fast2locals` materialization, so
     /// it never disturbs `CO_FAST_HIDDEN` slots.
     #[inline]
-    pub fn get_or_create_w_locals(&mut self) -> *mut DictStorage {
-        let data = self.getorcreate_debug_data(-1);
-        if data.w_locals.is_null() {
-            data.w_locals = pyre_object::lltype::malloc_raw(DictStorage::new());
+    pub fn get_or_create_w_locals_object(&mut self) -> PyObjectRef {
+        let existing = self.get_w_locals_object();
+        if !existing.is_null() {
+            return existing;
         }
-        data.w_locals
+        // A frame that reaches STORE_NAME / SETUP_ANNOTATIONS without a
+        // bound locals mapping is degenerate (module / class / exec all
+        // bind one in `initialize_frame_scopes` / `setdictscope_object`).
+        // Allocate a fresh dict so the write still lands somewhere
+        // observable instead of faulting.
+        let w_locals = unsafe { pyre_object::w_dict_new() };
+        self.getorcreate_debug_data(-1).w_locals_object = w_locals;
+        w_locals
     }
 
     /// PyPy-compatible `__init__` hook.
@@ -974,12 +961,6 @@ impl PyFrame {
         )
     }
 
-    /// PyPy-compatible `fget_getdictscope`.
-    #[inline]
-    pub fn fget_getdictscope(&mut self) -> Result<*mut DictStorage, crate::PyError> {
-        self.getdictscope()
-    }
-
     /// PyPy-compatible `fget_w_globals_storage`.
     #[inline]
     pub fn fget_w_globals_storage(&self) -> *mut DictStorage {
@@ -1019,11 +1000,13 @@ impl PyFrame {
         let flags = code.flags;
         if !flags.contains(CodeFlags::OPTIMIZED) {
             if flags.contains(CodeFlags::NEWLOCALS) {
-                // Class body — a fresh locals namespace. Still bound in the
-                // raw `*mut DictStorage` form pending the class-scope half of
-                // the w_locals object-ification.
-                let w_locals = pyre_object::lltype::malloc_raw(DictStorage::new());
-                self.getorcreate_debug_data(-1).w_locals = w_locals;
+                // pyframe.py:213 — class body binds a fresh locals namespace
+                // dict object (`space.newdict(module=True)`).  `build_class`
+                // replaces it with the `__prepare__` namespace via
+                // `setdictscope_object`; an orphan NEWLOCALS frame still has a
+                // usable mapping.
+                let w_locals = unsafe { pyre_object::w_dict_new() };
+                self.getorcreate_debug_data(-1).w_locals_object = w_locals;
             } else {
                 // pyframe.py:216-218 — module scope binds `w_locals = w_globals`.
                 // Bind the canonical W_DictObject so STORE_NAME / LOAD_NAME /
@@ -1077,91 +1060,44 @@ impl PyFrame {
         Ok(())
     }
 
-    /// pyframe.py:547-552 setdictscope(w_locals, skip_free_vars=False)
-    #[inline]
-    pub fn setdictscope(&mut self, w_locals: *mut DictStorage) -> Result<(), crate::PyError> {
-        self.setdictscope_with_options(w_locals, false)
-    }
-
-    /// pyframe.py:547-552 setdictscope(w_locals, skip_free_vars=False)
-    #[inline]
-    pub fn setdictscope_with_options(
-        &mut self,
-        w_locals: *mut DictStorage,
-        skip_free_vars: bool,
-    ) -> Result<(), crate::PyError> {
-        let data = self.getorcreate_debug_data(-1);
-        data.w_locals = w_locals;
-        data.w_locals_object = pyre_object::PY_NULL;
-        self.locals2fast(skip_free_vars)
-    }
-
-    /// pyframe.py:547-552 setdictscope path for non-dict mapping locals.
+    /// pyframe.py:547-552 setdictscope(w_locals, skip_free_vars=False) —
+    /// install `w_locals_object` as the frame's locals mapping and reflect
+    /// its entries into the fastlocals via `locals2fast`.
     ///
-    /// `pypy/interpreter/pyopcode.py:2003-2013 ensure_ns` admits any
-    /// object exposing `__getitem__` as locals.  Pyre's frame keeps the
-    /// `*mut DictStorage` fast path zeroed in this branch and stores
-    /// the mapping object so `STORE_NAME` / `LOAD_NAME` / `DELETE_NAME`
-    /// route through `space.setitem` / `space.getitem` /
-    /// `space.delitem` directly — matching PyPy's in-place mutation
-    /// visibility on the original mapping object.
-    ///
-    /// `locals2fast(skip_free_vars=false)` runs after the slot install
-    /// so any pre-populated entries on the mapping reflect into the
-    /// frame's fastlocals, mirroring `pyframe.py:551 self.locals2fast`.
+    /// `pypy/interpreter/pyopcode.py:2003-2013 ensure_ns` admits any object
+    /// exposing `__getitem__` as locals, so the mapping may be a plain dict
+    /// (module / class / `exec(src, g, l)`) or an arbitrary mapping; both
+    /// share this path and `STORE_NAME` / `LOAD_NAME` / `DELETE_NAME` route
+    /// through `space.setitem` / `space.getitem` / `space.delitem` on it.
     #[inline]
     pub fn setdictscope_object(
         &mut self,
         w_locals_object: PyObjectRef,
     ) -> Result<(), crate::PyError> {
-        let data = self.getorcreate_debug_data(-1);
-        data.w_locals = std::ptr::null_mut();
-        data.w_locals_object = w_locals_object;
+        self.getorcreate_debug_data(-1).w_locals_object = w_locals_object;
         self.locals2fast(false)
     }
 
-    /// Read the optional non-dict mapping locals registered by
-    /// `setdictscope_object`.  Returns `PY_NULL` when locals are
-    /// either absent or a plain `*mut DictStorage` dict.
+    /// Read the frame's locals mapping registered by `setdictscope_object`
+    /// (or `initialize_frame_scopes`).  Returns `PY_NULL` when the frame has
+    /// no locals bound yet (a function before its first `fast2locals`).
     #[inline]
     pub fn get_w_locals_object(&self) -> PyObjectRef {
         self.getdebug_data()
             .map_or(pyre_object::PY_NULL, |data| data.w_locals_object)
     }
 
-    /// pyframe.py:540-545 getdictscope returning the wrapped locals
-    /// namespace as a `PyObjectRef` (PyPy's generic w_obj contract).
+    /// pyframe.py:540-545 getdictscope — runs `fast2locals` then returns
+    /// `self.debugdata.w_locals` (the locals mapping object).
     ///
-    /// * Mapping case (`setdictscope_object`): returns `w_locals_object`
-    ///   directly so callers (`IMPORT_STAR`, `locals()`) operate on the
-    ///   live mapping with `space.setitem` / `space.getitem`.
-    /// * Dict case (`setdictscope`): routes through
-    ///   `dict_storage_to_dict` so the live `*mut DictStorage` is
-    ///   always wrapped by the same `W_DictObject` (identity
-    ///   preserved via `storage.mirror_target()`).  PyPy's
-    ///   `pyframe.py:540-545 getdictscope` returns
-    ///   `self.debugdata.w_locals` — a single cached dict per frame.
-    ///   pyre achieves the same identity by memoising the wrapper on
-    ///   the storage; allocating a fresh dict shell every call would
-    ///   let `frame.f_locals is frame.f_locals` evaluate to `False`.
-    /// * Empty case: forces `fast2locals` to materialise a fresh
-    ///   `DictStorage` (matching pyframe.py:557-562 `w_locals = self
-    ///   .space.newdict(instance=True)` followed by `d.w_locals =
-    ///   w_locals`) and wraps it as above.
+    /// `fast2locals` lazily materialises a fresh dict for a function frame
+    /// (pyframe.py:557 `space.newdict(instance=True)`) and caches it in
+    /// `w_locals_object`, so repeated calls return the same object —
+    /// `frame.f_locals is frame.f_locals` holds.
     #[inline]
     pub fn getdictscope_w(&mut self) -> Result<PyObjectRef, crate::PyError> {
-        let w_locals_object = self.get_w_locals_object();
-        if !w_locals_object.is_null() {
-            return Ok(w_locals_object);
-        }
         self.fast2locals()?;
-        let w_locals = self.get_w_locals();
-        if w_locals.is_null() {
-            return Ok(pyre_object::PY_NULL);
-        }
-        Ok(crate::baseobjspace::dict_storage_to_dict(
-            w_locals as *const crate::DictStorage,
-        ))
+        Ok(self.get_w_locals_object())
     }
 
     /// Create a minimal frame stub for passing to call dispatch.
@@ -1991,80 +1927,16 @@ impl PyFrame {
         self.init_cells();
     }
 
-    /// pyframe.py:601-636 locals2fast(skip_free_vars=False)
+    /// pyframe.py:601-636 locals2fast(skip_free_vars=False) — reflect the
+    /// locals mapping back into the fastlocals.  A frame with no locals
+    /// bound (a function before its first `getdictscope`) has nothing to
+    /// copy.
     pub fn locals2fast(&mut self, skip_free_vars: bool) -> Result<(), crate::PyError> {
-        let d = self.getorcreate_debug_data(-1);
-        let w_locals_object = d.w_locals_object;
-        if !w_locals_object.is_null() {
-            return self.locals2fast_object(w_locals_object, skip_free_vars);
+        let w_locals_object = self.get_w_locals_object();
+        if w_locals_object.is_null() {
+            return Ok(());
         }
-        let w_locals = d.w_locals;
-        assert!(!w_locals.is_null());
-        let w_locals_ref = unsafe { &*w_locals };
-
-        let code_ptr = unsafe { pyframe_get_pycode(self) };
-        let code = unsafe { &*code_ptr };
-        let numlocals = code.varnames.len();
-
-        // pyframe.py:609-615: copy locals from dict to fast slots
-        let mut new_fastlocals_w = vec![PY_NULL; numlocals];
-        for i in 0..numlocals {
-            // CO_FAST_HIDDEN slots are not reflected in the locals mapping —
-            // preserve the current fast value instead of clearing it.
-            if hidden_local(code, i) {
-                new_fastlocals_w[i] = self.locals_w()[i];
-                continue;
-            }
-            let name = &code.varnames[i];
-            if let Some(&w_value) = w_locals_ref.get(name.as_ref()) {
-                new_fastlocals_w[i] = w_value;
-            }
-        }
-        self.setfastscope(&new_fastlocals_w);
-
-        // pyframe.py:619-636: freevarnames = co_cellvars
-        // if CO_OPTIMIZED and not skip_free_vars: freevarnames += co_freevars.
-        // CPython 3.11+ unified layout: cellvars that overlap with
-        // varnames live in their varname slot (handled by `setfastscope`
-        // above), so iterate only the *pure* cellvars (cellvars not in
-        // varnames) followed by freevars — same shape as
-        // `npure_cellvars`.
-        let pure_cells: Vec<&_> = code
-            .cellvars
-            .iter()
-            .filter(|c| {
-                let cs: &str = c.as_ref();
-                !code.varnames.iter().any(|v| {
-                    let vs: &str = v.as_ref();
-                    vs == cs
-                })
-            })
-            .collect();
-        let npure = pure_cells.len();
-        let include_freevars = code.flags.contains(CodeFlags::OPTIMIZED) && !skip_free_vars;
-        let freevarnames_len = if include_freevars {
-            npure + code.freevars.len()
-        } else {
-            npure
-        };
-        for i in 0..freevarnames_len {
-            let name: &str = if i < npure {
-                pure_cells[i].as_ref()
-            } else {
-                code.freevars[i - npure].as_ref()
-            };
-            let idx = numlocals + i;
-            if idx < self.locals_w().len() {
-                let w_value = w_locals_ref.get(name).copied().unwrap_or(PY_NULL);
-                let slot = self.locals_w()[idx];
-                if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
-                    unsafe { pyre_object::w_cell_set(slot, w_value) };
-                } else {
-                    self.locals_w_mut()[idx] = w_value;
-                }
-            }
-        }
-        Ok(())
+        self.locals2fast_object(w_locals_object, skip_free_vars)
     }
 
     /// pyframe.py:601-636 locals2fast — non-dict mapping branch.
@@ -2150,102 +2022,13 @@ impl PyFrame {
     #[inline]
     pub fn init_cells(&mut self) {}
 
-    /// pyframe.py:554-598 fast2locals
+    /// pyframe.py:554-598 fast2locals — copy the fastlocals into the locals
+    /// mapping.  A function frame with no locals bound yet lazily allocates a
+    /// fresh dict (pyframe.py:557 `self.space.newdict(instance=True)`) and
+    /// caches it, so `locals() is locals()` holds.
     pub fn fast2locals(&mut self) -> Result<(), crate::PyError> {
-        let d = self.getorcreate_debug_data(-1);
-        let w_locals_object = d.w_locals_object;
-        if !w_locals_object.is_null() {
-            return self.fast2locals_object(w_locals_object);
-        }
-        let mut w_locals = d.w_locals;
-        let mut write = false;
-        if w_locals.is_null() {
-            w_locals = pyre_object::lltype::malloc_raw(DictStorage::new());
-            write = true;
-        }
-        let w_locals_ref = unsafe { &mut *w_locals };
-
-        let code_ptr = unsafe { pyframe_get_pycode(self) };
-        let code = unsafe { &*code_ptr };
-        let varnames = &code.varnames;
-        let numlocals = varnames.len();
-
-        // pyframe.py:564-575: copy local variables
-        for i in 0..numlocals {
-            // CO_FAST_HIDDEN slots — an inlined comprehension's iteration
-            // variable at module/class scope — are not user-visible and must
-            // not be synced to the locals mapping. For a module frame whose
-            // `w_locals` is its globals dict, the slot stays NULL (the name is
-            // bound by STORE_NAME in the dict, not the fast array), so the
-            // delitem branch below would otherwise erase the binding on every
-            // getdictscope. frameobject.c skips CO_FAST_HIDDEN in both
-            // directions.
-            if hidden_local(code, i) {
-                continue;
-            }
-            let name = &varnames[i];
-            let w_value = self.locals_w()[i];
-            if !w_value.is_null() {
-                w_locals_ref.insert(name.to_string(), w_value);
-            } else {
-                // pyframe.py:571-574: space.delitem(w_locals, w_name)
-                w_locals_ref.remove(name.as_ref());
-            }
-        }
-
-        // pyframe.py:580-581: freevarnames = co_cellvars
-        // if CO_OPTIMIZED: freevarnames += co_freevars.
-        // CPython 3.11+ unified slot layout: cellvars that overlap with
-        // varnames already had their value emitted by the varname loop
-        // above (their slot is the local slot, optionally wrapped by
-        // MAKE_CELL).  Iterate only pure cellvars (cellvars not in
-        // varnames) here so the cell-region indices match the layout
-        // chosen by `npure_cellvars`.
-        let pure_cells: Vec<&_> = code
-            .cellvars
-            .iter()
-            .filter(|c| {
-                let cs: &str = c.as_ref();
-                !varnames.iter().any(|v| {
-                    let vs: &str = v.as_ref();
-                    vs == cs
-                })
-            })
-            .collect();
-        let npure = pure_cells.len();
-        let include_freevars = code.flags.contains(CodeFlags::OPTIMIZED);
-        let freevarnames_len = if include_freevars {
-            npure + code.freevars.len()
-        } else {
-            npure
-        };
-        // pyframe.py:584-596: copy cell/free variables
-        for i in 0..freevarnames_len {
-            let name: &str = if i < npure {
-                pure_cells[i].as_ref()
-            } else {
-                code.freevars[i - npure].as_ref()
-            };
-            let idx = numlocals + i;
-            if idx < self.locals_w().len() {
-                let slot = self.locals_w()[idx];
-                let w_value = if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
-                    unsafe { pyre_object::w_cell_get(slot) }
-                } else {
-                    slot
-                };
-                if !w_value.is_null() {
-                    w_locals_ref.insert(name.to_string(), w_value);
-                } else {
-                    w_locals_ref.remove(name);
-                }
-            }
-        }
-
-        if write {
-            self.getorcreate_debug_data(-1).w_locals = w_locals;
-        }
-        Ok(())
+        let w_locals_object = self.get_or_create_w_locals_object();
+        self.fast2locals_object(w_locals_object)
     }
 
     /// pyframe.py:554-598 fast2locals — non-dict mapping branch.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14361,12 +14361,12 @@ fn emit_namespace_cell_fold(
 
 /// LoadName cell fold — module-scope LOAD_NAME mirror of
 /// [`try_walker_load_global_cell_fold`].  At module scope the frame's
-/// `w_locals_object` is null and `w_locals` aliases `w_globals`
+/// `w_locals` is null and `w_locals` aliases `w_globals`
 /// (`createframe` sets `debugdata.w_locals = w_globals_storage`,
 /// pyframe.rs:1323), so `load_name_value`'s probe + LOAD_GLOBAL fallthrough
 /// both resolve in `w_globals` — the same dict the global cell fold reads.
 /// A non-module frame (class body / `exec(code, g, l)` with separate locals)
-/// has a non-null `w_locals_object`, so the gate routes it to the live
+/// has a non-null `w_locals`, so the gate routes it to the live
 /// residual `bh_load_name_fn`.
 fn try_walker_load_name_cell_fold(
     ctx: &mut WalkContext<'_, '_>,
@@ -14385,14 +14385,14 @@ fn try_walker_load_name_cell_fold(
         return Ok(false);
     }
     // Only module scope (w_locals IS w_globals) is foldable. Module frames bind
-    // `w_locals_object = w_globals` (pyframe.py:216-218); a `w_locals_object`
+    // `w_locals = w_globals` (pyframe.py:216-218); a `w_locals`
     // that is a DIFFERENT object means the LOAD_NAME probe targets a separate
     // locals namespace the module-dict cell fold (keyed on `w_globals`) would
     // skip. (Class bodies / `exec(code, g, l)` set a separate one; they also do
     // not portal-trace, so the only LOAD_NAME the walker reaches in practice is
     // module-scope.)
-    let w_locals_object = frame.get_w_locals_object();
-    if !w_locals_object.is_null() && !std::ptr::eq(w_locals_object, w_globals) {
+    let w_locals = frame.get_w_locals();
+    if !w_locals.is_null() && !std::ptr::eq(w_locals, w_globals) {
         return Ok(false);
     }
     let name = unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14380,16 +14380,19 @@ fn try_walker_load_name_cell_fold(
         return Ok(false);
     }
     let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::pyframe::PyFrame) };
-    // Only module scope (w_locals IS w_globals) is foldable: a non-null
-    // `w_locals_object` means the LOAD_NAME probe targets a separate locals
-    // namespace the module-dict cell fold (keyed on `w_globals`) would skip.
-    // (Class bodies / `exec(code, g, l)` set it; they also do not portal-trace,
-    // so the only LOAD_NAME the walker reaches in practice is module-scope.)
-    if !frame.get_w_locals_object().is_null() {
-        return Ok(false);
-    }
     let w_globals = frame.get_w_globals();
     if w_globals.is_null() {
+        return Ok(false);
+    }
+    // Only module scope (w_locals IS w_globals) is foldable. Module frames bind
+    // `w_locals_object = w_globals` (pyframe.py:216-218); a `w_locals_object`
+    // that is a DIFFERENT object means the LOAD_NAME probe targets a separate
+    // locals namespace the module-dict cell fold (keyed on `w_globals`) would
+    // skip. (Class bodies / `exec(code, g, l)` set a separate one; they also do
+    // not portal-trace, so the only LOAD_NAME the walker reaches in practice is
+    // module-scope.)
+    let w_locals_object = frame.get_w_locals_object();
+    if !w_locals_object.is_null() && !std::ptr::eq(w_locals_object, w_globals) {
         return Ok(false);
     }
     let name = unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14156,32 +14156,15 @@ fn try_walker_load_global_cell_fold(
             None => return Ok(false),
         }
     };
-    // Cell fast path applies only to a module dict still in strategy mode
-    // whose slot holds a raw value or an `ObjectMutableCell`; null/absent
-    // keys and `IntMutableCell` slots fall through to the residual.
-    if let Some(slot) = crate::state::module_dict_cell_slot_direct(w_globals, &name) {
-        if let Some(stored) = crate::state::module_dict_cell_value_direct(w_globals, slot) {
-            if !stored.is_null() && !unsafe { pyre_object::celldict::is_int_mutable_cell(stored) } {
-                // The fast path const-folds `stored` (the slot's raw value, or
-                // the `ObjectMutableCell`) as the elidable
-                // `jit_namespace_cell_lookup` result.  That bakes its address
-                // into the trace / guard resume data.  The collector is
-                // moving, so a `stored` still in the nursery at trace time
-                // relocates nursery->oldgen afterwards and the baked address
-                // dangles (a `memo` dict grown in the loop is the canonical
-                // case).  Fall through to the residual live lookup, which
-                // re-reads the slot each call and follows the relocation, when
-                // `stored` can still move.
-                if !majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
-                    emit_namespace_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, slot, stored)?;
-                    return Ok(true);
-                }
-            }
-        }
-        // The name is present in the module dict but unfoldable
-        // (IntMutableCell / null / movable / strategy-switched); keep the
-        // residual rather than misreaching into the builtins fallback below
-        // (the residual reads the live globals slot, which is correct).
+    if emit_module_dict_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, &name)? {
+        return Ok(true);
+    }
+    // `emit_module_dict_cell_fold` returns `false` for BOTH an absent name and
+    // a present-but-unfoldable one (`IntMutableCell` / movable / strategy
+    // switched).  Only an ABSENT name may fall through to the builtins fold — a
+    // present global shadows the builtin, so keep the residual (which reads the
+    // live globals slot) when the slot still exists.
+    if crate::state::module_dict_cell_slot_direct(w_globals, &name).is_some() {
         return Ok(false);
     }
 
@@ -14253,6 +14236,51 @@ fn try_walker_load_global_cell_fold(
     // builtin bumps the builtins-dict `version` and fails the loop.
     emit_namespace_cell_fold(ctx, op_pc, dst, dst_bank, w_builtin_dict, b_slot, b_stored)?;
     Ok(true)
+}
+
+/// Shared module-dict cell fast path for the LOAD_GLOBAL / LOAD_NAME folds:
+/// const-fold a module-global name read to a `QuasiimmutField` version guard
+/// + elidable `jit_namespace_cell_lookup`, reading an `ObjectMutableCell`'s
+/// `w_value` live.  Returns `false` (fall through to the residual) for a
+/// missing / `IntMutableCell` / still-movable slot.
+fn emit_module_dict_cell_fold(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    dst: usize,
+    dst_bank: char,
+    w_globals: pyre_object::PyObjectRef,
+    name: &str,
+) -> Result<bool, DispatchError> {
+    // Cell fast path applies only to a module dict still in strategy mode
+    // whose slot holds a raw value or an `ObjectMutableCell`; null/absent
+    // keys and `IntMutableCell` slots fall through to the residual.
+    if let Some(slot) = crate::state::module_dict_cell_slot_direct(w_globals, name) {
+        if let Some(stored) = crate::state::module_dict_cell_value_direct(w_globals, slot) {
+            if !stored.is_null() && !unsafe { pyre_object::celldict::is_int_mutable_cell(stored) } {
+                // The fast path const-folds `stored` (the slot's raw value, or
+                // the `ObjectMutableCell`) as the elidable
+                // `jit_namespace_cell_lookup` result.  That bakes its address
+                // into the trace / guard resume data.  The collector is
+                // moving, so a `stored` still in the nursery at trace time
+                // relocates nursery->oldgen afterwards and the baked address
+                // dangles (a `memo` dict grown in the loop is the canonical
+                // case).  Fall through to the residual live lookup, which
+                // re-reads the slot each call and follows the relocation, when
+                // `stored` can still move.
+                if !majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
+                    emit_namespace_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, slot, stored)?;
+                    return Ok(true);
+                }
+            }
+        }
+        // The name is present in the module dict but unfoldable
+        // (IntMutableCell / null / movable / strategy-switched); keep the
+        // residual rather than misreaching into the builtins fallback (the
+        // residual reads the live globals slot, which is correct).
+        return Ok(false);
+    }
+    // Name absent from this module dict.
+    Ok(false)
 }
 
 /// Emit the `QUASIIMMUT_FIELD(ns, slot)` + elidable `jit_namespace_cell_lookup`
@@ -14329,6 +14357,45 @@ fn emit_namespace_cell_fold(
     ctx.last_exc_value = None;
     ctx.last_exc_value_concrete = ConcreteValue::Null;
     Ok(())
+}
+
+/// LoadName cell fold — module-scope LOAD_NAME mirror of
+/// [`try_walker_load_global_cell_fold`].  At module scope the frame's
+/// `w_locals_object` is null and `w_locals` aliases `w_globals`
+/// (`createframe` sets `debugdata.w_locals = w_globals_storage`,
+/// pyframe.rs:1323), so `load_name_value`'s probe + LOAD_GLOBAL fallthrough
+/// both resolve in `w_globals` — the same dict the global cell fold reads.
+/// A non-module frame (class body / `exec(code, g, l)` with separate locals)
+/// has a non-null `w_locals_object`, so the gate routes it to the live
+/// residual `bh_load_name_fn`.
+fn try_walker_load_name_cell_fold(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    dst: usize,
+    dst_bank: char,
+    frame_ptr: usize,
+    w_name_ptr: usize,
+) -> Result<bool, DispatchError> {
+    if frame_ptr == 0 {
+        return Ok(false);
+    }
+    let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+    // Only module scope (w_locals IS w_globals) is foldable: a non-null
+    // `w_locals_object` means the LOAD_NAME probe targets a separate locals
+    // namespace the module-dict cell fold (keyed on `w_globals`) would skip.
+    // (Class bodies / `exec(code, g, l)` set it; they also do not portal-trace,
+    // so the only LOAD_NAME the walker reaches in practice is module-scope.)
+    if !frame.get_w_locals_object().is_null() {
+        return Ok(false);
+    }
+    let w_globals = frame.get_w_globals();
+    if w_globals.is_null() {
+        return Ok(false);
+    }
+    let name = unsafe {
+        pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)
+    };
+    emit_module_dict_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, name)
 }
 
 #[allow(non_snake_case)]
@@ -14485,6 +14552,35 @@ fn dispatch_residual_call_iIRd_kind(
             ) {
                 if try_walker_load_global_cell_fold(
                     ctx, op.pc, dst, dst_bank, ns_ptr, w_code_ptr, frame_ptr, namei,
+                )? {
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
+            }
+        }
+    }
+
+    // LoadName fold: module-scope LOAD_NAME mirror of the LoadGlobal fold
+    // above.  The residual is `bh_load_name_fn(frame, w_name, namei)`, so
+    // r_args = [frame, w_name].  Same handler-free gate (the fold elides a
+    // CanRaise residual a `catch_exception` could otherwise resume into);
+    // `try_walker_load_name_cell_fold` gates module scope at runtime and
+    // routes non-module frames back to this residual.
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && ei.pyre_helper == majit_ir::PyreHelperKind::LoadName
+        && !jitcode_has_exception_handler(code)
+        && std::env::var("PYRE_FBW_LOADNAME_FOLD").as_deref() != Ok("0")
+    {
+        if let (Some(&frame_opref), Some(&name_opref)) = (r_args.first(), r_args.get(1)) {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_name_ptr))),
+            ) = (
+                ctx.trace_ctx.box_value(frame_opref),
+                ctx.trace_ctx.box_value(name_opref),
+            ) {
+                if try_walker_load_name_cell_fold(
+                    ctx, op.pc, dst, dst_bank, frame_ptr, w_name_ptr,
                 )? {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -4967,19 +4967,51 @@ fn try_execute_residual_call_via_executor(
     if allboxes.len() - 1 > majit_translate::codewriter::insns::MAX_HOST_CALL_ARITY {
         return Ok(None);
     }
+    // A void residual (CALL_N family) is a side effect with no result box, so
+    // `do_residual_call` executes it EAGERLY during the walk and resumes the
+    // compiled loop at iteration N+1 (the commit-invariant note below) — a
+    // deferred void store is lost (its symbolic op fires only for N+1+).  When a
+    // void call's arg cannot be resolved to a concrete (`GcRef(usize::MAX)` =
+    // "no concrete known", or `None` = unbound), eager execution is impossible
+    // AND deferral drops the store, so neither path is correct: abort the trace
+    // gracefully (interpreter fallback) rather than silently drop it.  This is
+    // the off-by-one for a module-global loop that builds and stores a heap
+    // object then reads it back (`g = [n]; ... g[0]`): the `STORE_NAME` is a
+    // void `CallN` whose value is the still-virtual `BUILD_LIST` result, so the
+    // iteration-N store never reaches the cell.  A value-returning call with a
+    // non-concrete arg is safe to leave symbolic — the compiled loop computes
+    // its result at runtime with no lost side effect.
+    let is_void = matches!(
+        call_opcode,
+        OpCode::CallN | OpCode::CallMayForceN | OpCode::CallLoopinvariantN
+    );
     let mut args = Vec::with_capacity(allboxes.len() - 1);
-    for &arg in &allboxes[1..] {
+    for (arg_index, &arg) in allboxes[1..].iter().enumerate() {
         let v = match ctx.trace_ctx.box_value(arg) {
             Some(majit_ir::Value::Int(n)) => n,
             Some(majit_ir::Value::Ref(r)) => {
                 if r == majit_ir::GcRef(usize::MAX) {
+                    if is_void {
+                        return Err(DispatchError::ResidualCallArgUnbound {
+                            pc: op_pc,
+                            arg_index,
+                        });
+                    }
                     return Ok(None);
                 }
                 r.as_usize() as i64
             }
             Some(majit_ir::Value::Float(f)) => f.to_bits() as i64,
             Some(majit_ir::Value::Void) => 0,
-            None => return Ok(None),
+            None => {
+                if is_void {
+                    return Err(DispatchError::ResidualCallArgUnbound {
+                        pc: op_pc,
+                        arg_index,
+                    });
+                }
+                return Ok(None);
+            }
         };
         args.push(v);
     }
@@ -14582,9 +14614,8 @@ fn dispatch_residual_call_iIRd_kind(
                 ctx.trace_ctx.box_value(frame_opref),
                 ctx.trace_ctx.box_value(name_opref),
             ) {
-                if try_walker_load_name_cell_fold(
-                    ctx, op.pc, dst, dst_bank, frame_ptr, w_name_ptr,
-                )? {
+                if try_walker_load_name_cell_fold(ctx, op.pc, dst, dst_bank, frame_ptr, w_name_ptr)?
+                {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
                 }
             }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2046,8 +2046,6 @@ unsafe fn is_trace_plain_float(obj: PyObjectRef) -> bool {
     w_class.is_null() || std::ptr::eq(w_class, float_typeobj)
 }
 
-use pyre_interpreter::DictStorage;
-
 use crate::descr::{
     PY_OBJECT_ARRAY_GC_TYPE_ID, float_floatval_descr, int_intval_descr, make_array_descr_with_type,
     w_float_size_descr, w_int_size_descr,
@@ -9879,12 +9877,8 @@ mod tests {
         frame
             .execute_frame(None, None)
             .expect("module body should execute");
-        let ty = unsafe {
-            (*frame.fget_w_globals_storage())
-                .get("x")
-                .copied()
-                .expect("namespace should contain x")
-        };
+        let ty = unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), "x") }
+            .expect("namespace should contain x");
 
         let mut ctx = TraceCtx::for_test(1);
         let ty_ref = ctx.const_ref(ty as i64);
@@ -9925,12 +9919,8 @@ mod tests {
         frame
             .execute_frame(None, None)
             .expect("module body should execute");
-        let callable = unsafe {
-            (*frame.fget_w_globals_storage())
-                .get("x")
-                .copied()
-                .expect("namespace should contain x")
-        };
+        let callable = unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), "x") }
+            .expect("namespace should contain x");
 
         let mut ctx = TraceCtx::for_test(1);
         let callable_ref = ctx.const_ref(callable as i64);
@@ -10061,12 +10051,9 @@ mod tests {
         lookup_frame
             .execute_frame(None, None)
             .expect("lookup module should execute");
-        let int_type = unsafe {
-            (*lookup_frame.fget_w_globals_storage())
-                .get("x")
-                .copied()
-                .expect("globals should contain int")
-        };
+        let int_type =
+            unsafe { pyre_object::w_dict_getitem_str(lookup_frame.get_w_globals(), "x") }
+                .expect("globals should contain int");
 
         let code = compile_exec("try:\n    raise int\nexcept TypeError:\n    pass\n")
             .expect("trace code should compile");
@@ -10587,12 +10574,8 @@ mod tests {
         frame
             .execute_frame(None, None)
             .expect("class body should execute");
-        let instance = unsafe {
-            (*frame.fget_w_globals_storage())
-                .get("c")
-                .copied()
-                .expect("namespace should contain c")
-        };
+        let instance = unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), "c") }
+            .expect("namespace should contain c");
 
         install_test_jitcode(&code, frame.pycode);
         let mut ctx = TraceCtx::for_test(1);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -11954,12 +11954,8 @@ mod tests {
         frame
             .execute_frame(None, None)
             .expect("module body should execute");
-        let exc_class = unsafe {
-            (*frame.fget_w_globals_storage())
-                .get("x")
-                .copied()
-                .expect("namespace should contain ValueError")
-        };
+        let exc_class = unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), "x") }
+            .expect("namespace should contain ValueError");
 
         let result = normalize_raise_varargs_jit(0, exc_class as i64, pyre_object::PY_NULL as i64);
 

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5078,12 +5078,8 @@ mod tests_bh_normalize_raise {
         frame
             .execute_frame(None, None)
             .expect("module body should execute");
-        let callable = unsafe {
-            (*frame.fget_w_globals_storage())
-                .get("x")
-                .copied()
-                .expect("namespace should contain x")
-        };
+        let callable = unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), "x") }
+            .expect("namespace should contain x");
 
         let frame_ptr = (&*frame as *const pyre_interpreter::PyFrame) as i64;
         let result = bh_normalize_raise_varargs_with_frame(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7411,11 +7411,10 @@ impl majit_metainterp::resume::BlackholeAllocator for PyreBlackholeAllocator {
 mod tests {
     use super::*;
 
-    /// The frame's globals `DictStorage`, resolved through the canonical
-    /// `w_globals`'s `dict_storage_proxy`.
-    unsafe fn frame_globals_storage(frame: &PyFrame) -> *const pyre_interpreter::DictStorage {
-        pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(frame.w_globals)
-            as *const pyre_interpreter::DictStorage
+    /// Read a global by name from the frame's canonical `w_globals` object.
+    fn frame_global(frame: &PyFrame, name: &str) -> pyre_object::PyObjectRef {
+        unsafe { pyre_object::w_dict_getitem_str(frame.get_w_globals(), name) }
+            .unwrap_or_else(|| panic!("namespace should contain {name}"))
     }
 
     struct TestJitParamsGuard;
@@ -9085,7 +9084,7 @@ mod tests {
         let mut frame = PyFrame::new(code);
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let x = *(*frame_globals_storage(&frame)).get("x").unwrap();
+            let x = frame_global(&frame, "x");
             assert_eq!(pyre_object::intobject::w_int_get_value(x), 3);
         }
     }
@@ -9103,7 +9102,7 @@ while i < 20:
         let mut frame = PyFrame::new(code);
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let s = *(*frame_globals_storage(&frame)).get("s").unwrap();
+            let s = frame_global(&frame, "s");
             assert_eq!(pyre_object::intobject::w_int_get_value(s), 190);
         }
     }
@@ -9167,18 +9166,17 @@ r = acc",
         let mut frame = PyFrame::new(code);
         let result = eval_with_jit(&mut frame);
         if std::env::var_os("MAJIT_DUMP_BYTECODE").is_some() {
-            let mut keys: Vec<String> = unsafe {
-                (*frame_globals_storage(&frame))
-                    .keys()
-                    .map(|k| k.to_string())
-                    .collect()
-            };
+            let mut keys: Vec<String> =
+                unsafe { pyre_object::w_dict_str_entries(frame.get_w_globals()) }
+                    .into_iter()
+                    .map(|(k, _)| k)
+                    .collect();
             keys.sort();
             eprintln!("module result: {:?}", result);
             eprintln!("module namespace keys: {:?}", keys);
         }
         unsafe {
-            let r = *(*frame_globals_storage(&frame)).get("r").unwrap();
+            let r = frame_global(&frame, "r");
             assert_eq!(pyre_object::intobject::w_int_get_value(r), 6);
         }
     }
@@ -9206,7 +9204,7 @@ result = fib(12)
         let mut frame = PyFrame::new(code);
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let result = *(*frame_globals_storage(&frame)).get("result").unwrap();
+            let result = frame_global(&frame, "result");
             assert_eq!(
                 pyre_object::intobject::w_int_get_value(result),
                 144,
@@ -9255,8 +9253,8 @@ second = g(9)";
                 .expect("frame construction failed");
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let first = *(*frame_globals_storage(&frame)).get("first").unwrap();
-            let second = *(*frame_globals_storage(&frame)).get("second").unwrap();
+            let first = frame_global(&frame, "first");
+            let second = frame_global(&frame, "second");
             assert_eq!(pyre_object::intobject::w_int_get_value(first), 88);
             assert_eq!(pyre_object::intobject::w_int_get_value(second), 176);
         }
@@ -9291,7 +9289,7 @@ while i < 40:
                 .expect("frame construction failed");
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let s = *(*frame_globals_storage(&frame)).get("s").unwrap();
+            let s = frame_global(&frame, "s");
             assert_eq!(pyre_object::intobject::w_int_get_value(s), 3_900);
         }
     }
@@ -9332,7 +9330,7 @@ while i < 40:
                 .expect("frame construction failed");
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let s = *(*frame_globals_storage(&frame)).get("s").unwrap();
+            let s = frame_global(&frame, "s");
             assert_eq!(pyre_object::intobject::w_int_get_value(s), 21_320);
         }
     }
@@ -9458,8 +9456,8 @@ while i < 40:
         let mut frame = PyFrame::new(code);
         let _ = eval_with_jit(&mut frame);
         unsafe {
-            let s = *(*frame_globals_storage(&frame)).get("s").unwrap();
-            let q = *(*frame_globals_storage(&frame)).get("q").unwrap();
+            let s = frame_global(&frame, "s");
+            let q = frame_global(&frame, "q");
             assert_eq!(pyre_object::intobject::w_int_get_value(s), 220);
             assert_eq!(
                 pyre_object::intobject::w_int_get_value(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -381,15 +381,24 @@ unsafe fn set_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_
 /// elements and rewrites the block. The block is exact-size for tuples
 /// (`capacity == len`, every slot written by `alloc_tuple_items_block`).
 unsafe fn tuple_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
-    let tuple = unsafe { &*(obj_addr as *const pyre_object::tupleobject::W_TupleObject) };
+    let tuple_ptr = obj_addr as *mut pyre_object::tupleobject::W_TupleObject;
+    let tuple = unsafe { &*tuple_ptr };
     let block = tuple.wrappeditems;
     if block.is_null() {
         return;
     }
-    let cap = unsafe { pyre_object::object_array::items_block_capacity(block) };
-    let base = unsafe { pyre_object::object_array::items_block_items_base(block) };
-    for i in 0..cap {
-        f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+    if pyre_object::gc_hook::try_gc_owns_object(block as *mut u8) {
+        // Phase L2: forward the `wrappeditems` field slot; the type-9 varsize
+        // walker forwards items[0..capacity] (tuples are exact-size).
+        let items_slot = unsafe { std::ptr::addr_of_mut!((*tuple_ptr).wrappeditems) };
+        f(items_slot as *mut majit_ir::GcRef);
+    } else {
+        // std::alloc stationary block: forward each element in place.
+        let cap = unsafe { pyre_object::object_array::items_block_capacity(block) };
+        let base = unsafe { pyre_object::object_array::items_block_items_base(block) };
+        for i in 0..cap {
+            f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+        }
     }
 }
 
@@ -407,13 +416,25 @@ unsafe fn tuple_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maji
 /// spare tail past the live length may hold stale pointers a shrink left
 /// behind.
 unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
-    let list = unsafe { &*(obj_addr as *const pyre_object::listobject::W_ListObject) };
+    let list_ptr = obj_addr as *mut pyre_object::listobject::W_ListObject;
+    let list = unsafe { &*list_ptr };
     if list.strategy != pyre_object::listobject::ListStrategy::Object || list.items.is_null() {
         return;
     }
-    let base = unsafe { pyre_object::object_array::items_block_items_base(list.items) };
-    for i in 0..list.length {
-        f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+    if pyre_object::gc_hook::try_gc_owns_object(list.items as *mut u8) {
+        // Phase L2: a GC-managed (moving) block is forwarded by handing the
+        // collector the `items` field slot itself; the type-9 varsize walker
+        // then forwards items[0..capacity] (spare slots are NULL). This is
+        // the `gc_ptr_offsets = [offset_of!(items)]` edge that collector.rs:377
+        // declines while the block stays std::alloc.
+        let items_slot = unsafe { std::ptr::addr_of_mut!((*list_ptr).items) };
+        f(items_slot as *mut majit_ir::GcRef);
+    } else {
+        // std::alloc stationary block: forward each live element in place.
+        let base = unsafe { pyre_object::object_array::items_block_items_base(list.items) };
+        for i in 0..list.length {
+            f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+        }
     }
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1367,14 +1367,16 @@ thread_local! {
         // guard below.  This keeps the net register-call count up to
         // `W_MODULE_DICT_GC_TYPE_ID = 48` unchanged (one explicit
         // registration here, one fewer from the loop), so no downstream
-        // hardcoded tid shifts.  `PyCode` carries only raw /
-        // non-GC pointers today (`code_ptr`, `w_globals`,
-        // `globals_caches`), so it registers with empty gc_ptr offsets;
-        // it has no `w_globals` PyObjectRef slot to trace.
-        // Allocation still routes through `Box::into_raw`
-        // (`w_code_new` → `malloc_typed`), so this registration is inert
-        // — the collector never reaches a code object until `w_code_new`
-        // is switched to `try_gc_alloc_stable`.
+        // hardcoded tid shifts.  Allocation routes through `Box::into_raw`
+        // (`w_code_new`), so this TypeInfo trace never fires and it registers
+        // with empty gc_ptr offsets.  Its one movable GCREF slot, `w_globals`
+        // (the cached globals dict object — movable for `exec`/custom-globals
+        // dicts), is instead forwarded as a root by
+        // `pyre_interpreter::eval::walk_raw_code_roots`, reached through
+        // `walk_raw_function_roots` (`func.code`) and the frame root walk
+        // (`frame.pycode`); a Box-immortal code object is never reachable by
+        // tracing into it.  This registration stays inert until `w_code_new`
+        // switches to `try_gc_alloc_stable`.
         let w_code_tid = gc.register_type(TypeInfo::object_subclass(
             std::mem::size_of::<pyre_interpreter::pycode::PyCode>(),
             object_tid,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -3998,7 +3998,10 @@ where
         frame_operand,
         name_operand,
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        // Tag so the full-body walker can try the module-scope cell fold
+        // (`try_walker_load_name_cell_fold`); the fold falls through to this
+        // residual for non-module frames (`w_locals_object` set).
+        majit_ir::PyreHelperKind::LoadName,
         dst_reg,
     ))
 }

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4000,7 +4000,7 @@ where
         CallFlavor::Plain,
         // Tag so the full-body walker can try the module-scope cell fold
         // (`try_walker_load_name_cell_fold`); the fold falls through to this
-        // residual for non-module frames (`w_locals_object` set).
+        // residual for non-module frames (`w_locals` set).
         majit_ir::PyreHelperKind::LoadName,
         dst_reg,
     ))

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -9,7 +9,7 @@
 #![allow(dead_code)]
 
 use crate::object_array::{
-    ItemsBlock, alloc_list_items_block, dealloc_list_items_block, grow_list_items_block,
+    ItemsBlock, alloc_list_items_block_gc, dealloc_list_items_block, grow_list_items_block_gc,
     items_block_capacity, items_block_items_base,
 };
 use crate::pyobject::*;
@@ -107,7 +107,11 @@ impl W_ListObject {
     unsafe fn object_grow(&mut self, min_cap: usize) {
         let current_cap = self.object_items_capacity();
         let target_cap = min_cap.max(current_cap.saturating_mul(2).max(4));
-        self.items = grow_list_items_block(self.items, target_cap, self.length);
+        // Phase L2: a GC-managed grow allocates the new block in the moving
+        // nursery and may collect; `grow_list_items_block_gc` roots the old
+        // block's live items across that allocation. Callers that hold an
+        // incoming `value` across this call root it themselves before grow.
+        self.items = grow_list_items_block_gc(self.items, target_cap, self.length);
     }
 
     /// Upstream list.append equivalent for the object strategy.
@@ -115,18 +119,33 @@ impl W_ListObject {
     /// Object case: no unwrap, just append.)
     unsafe fn object_push(&mut self, value: PyObjectRef) {
         if self.length == self.object_items_capacity() {
+            // Root the incoming value across the (collecting) grow, then read
+            // it back relocated. No-op under the std::alloc fallback.
+            let _roots = crate::gc_roots::push_roots();
+            let save = crate::gc_roots::shadow_stack_len();
+            crate::gc_roots::pin_root(value);
             self.object_grow(self.length + 1);
+            let value = crate::gc_roots::shadow_stack_get(save);
+            let base = items_block_items_base(self.items);
+            *base.add(self.length) = value;
+        } else {
+            let base = items_block_items_base(self.items);
+            *base.add(self.length) = value;
         }
-        let base = items_block_items_base(self.items);
-        *base.add(self.length) = value;
         self.length += 1;
     }
 
     unsafe fn object_insert(&mut self, index: usize, value: PyObjectRef) {
         assert!(index <= self.length);
-        if self.length == self.object_items_capacity() {
+        let value = if self.length == self.object_items_capacity() {
+            let _roots = crate::gc_roots::push_roots();
+            let save = crate::gc_roots::shadow_stack_len();
+            crate::gc_roots::pin_root(value);
             self.object_grow(self.length + 1);
-        }
+            crate::gc_roots::shadow_stack_get(save)
+        } else {
+            value
+        };
         let base = items_block_items_base(self.items);
         let p = base.add(index);
         std::ptr::copy(p, p.add(1), self.length - index);
@@ -140,6 +159,9 @@ impl W_ListObject {
         let value = *base.add(index);
         let p = base.add(index);
         std::ptr::copy(p.add(1), p, self.length - index - 1);
+        // Phase L2: the varsize walker forwards items[0..capacity], so clear the
+        // vacated tail slot the shift left holding a stale duplicate.
+        *base.add(self.length - 1) = PY_NULL;
         self.length -= 1;
         value
     }
@@ -148,6 +170,7 @@ impl W_ListObject {
         assert!(self.length > 0);
         let base = items_block_items_base(self.items);
         let value = *base.add(self.length - 1);
+        *base.add(self.length - 1) = PY_NULL;
         self.length -= 1;
         value
     }
@@ -167,7 +190,13 @@ impl W_ListObject {
         let base = items_block_items_base(self.items);
         let p = base.add(start);
         std::ptr::copy(p.add(count), p, self.length - end);
+        let old_len = self.length;
         self.length -= count;
+        // Phase L2: clear the vacated tail [new_len..old_len] the shift left
+        // holding stale duplicates, so the varsize walker (0..capacity) skips them.
+        for i in self.length..old_len {
+            *base.add(i) = PY_NULL;
+        }
     }
 
     unsafe fn object_splice(
@@ -181,6 +210,14 @@ impl W_ListObject {
         let slicelength = remove_count.min(old_len - s);
         let len2 = new_values.len();
         let new_len = old_len - slicelength + len2;
+        // Root the incoming values across a possible (collecting) grow, then
+        // write them from the relocated slots. No-op under the std::alloc
+        // fallback; covers both the grow and no-grow branches uniformly.
+        let _roots = crate::gc_roots::push_roots();
+        let save = crate::gc_roots::shadow_stack_len();
+        for &v in new_values {
+            crate::gc_roots::pin_root(v);
+        }
         if len2 > slicelength {
             if new_len > self.object_items_capacity() {
                 self.object_grow(new_len);
@@ -199,10 +236,17 @@ impl W_ListObject {
                 base.add(s + len2),
                 old_len - s - slicelength,
             );
+            // Shrinking splice: clear the vacated tail [new_len..old_len].
+            for i in new_len..old_len {
+                *base.add(i) = PY_NULL;
+            }
             self.length = new_len;
         }
         if len2 > 0 {
-            self.object_items_slice_mut()[s..s + len2].copy_from_slice(new_values);
+            let base = items_block_items_base(self.items);
+            for i in 0..len2 {
+                *base.add(s + i) = crate::gc_roots::shadow_stack_get(save + i);
+            }
         }
     }
 
@@ -214,8 +258,11 @@ impl W_ListObject {
     /// one populated with `values`. `length` is reset to `values.len()`.
     unsafe fn set_object_items_from_vec(&mut self, values: Vec<PyObjectRef>) {
         dealloc_list_items_block(self.items);
-        self.items = alloc_list_items_block(&values);
+        self.items = alloc_list_items_block_gc(&values);
         self.length = values.len();
+        // Phase L2: the freshly seeded block holds the (possibly young) values;
+        // remember the list so the next minor GC forwards them.
+        list_write_barrier(self as *mut W_ListObject as PyObjectRef);
     }
 
     /// Drop the object-strategy backing (used when switching to a typed
@@ -372,6 +419,19 @@ pub fn list_strategy_for(items: &[PyObjectRef]) -> ListStrategy {
 #[inline]
 fn list_write_barrier(obj: PyObjectRef) {
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    // Phase L2: when the block is a GC-managed array, the list-ptr forward in
+    // `list_object_custom_trace` relocates a young block but does NOT re-scan an
+    // already-old block's items — a young element just stored into an old block
+    // would be missed. Barrier the block too so its varsize walker re-runs; the
+    // collector no-ops the barrier on a still-young block (`TRACK_YOUNG_PTRS`
+    // unset). Inert while the block stays std::alloc (`try_gc_owns_object` false).
+    let list = unsafe { &*(obj as *const W_ListObject) };
+    if list.strategy == ListStrategy::Object
+        && !list.items.is_null()
+        && crate::gc_hook::try_gc_owns_object(list.items as *mut u8)
+    {
+        crate::gc_hook::try_gc_write_barrier(list.items as *mut u8);
+    }
 }
 
 /// Allocate a new W_ListObject from a Vec of items.
@@ -402,7 +462,7 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
         crate::gc_roots::pin_root(item);
     }
 
-    let (length, items_block, int_items, float_items) = match strategy {
+    let (length, mut items_block, int_items, float_items) = match strategy {
         ListStrategy::Empty | ListStrategy::Integer | ListStrategy::Float => {
             let int_items = if let ListStrategy::Integer = strategy {
                 let values = items
@@ -426,7 +486,7 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
         }
         ListStrategy::Object => {
             let length = items.len();
-            let items_block = unsafe { alloc_list_items_block(&items) };
+            let items_block = unsafe { alloc_list_items_block_gc(&items) };
             (
                 length,
                 items_block,
@@ -434,6 +494,17 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
                 FloatArray::from_vec(Vec::new()),
             )
         }
+    };
+    // Phase L2: pin the (possibly young, GC-managed) items block across the
+    // W_ListObject header allocation below — `try_gc_alloc_stable` may trigger a
+    // collection that relocates the nursery block, so re-read its moved address
+    // before storing it into the wrapper. Inert for a null or std::alloc block.
+    let block_root: Option<usize> = if !items_block.is_null() {
+        let s = crate::gc_roots::shadow_stack_len();
+        crate::gc_roots::pin_root(items_block as PyObjectRef);
+        Some(s)
+    } else {
+        None
     };
     let header = PyObject {
         ob_type: &LIST_TYPE as *const PyType,
@@ -463,6 +534,10 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
             return Box::into_raw(boxed) as PyObjectRef;
         }
     };
+    // Re-read the (possibly relocated) block address the header alloc may have moved.
+    if let Some(s) = block_root {
+        items_block = crate::gc_roots::shadow_stack_get(s) as *mut ItemsBlock;
+    }
     unsafe {
         std::ptr::write(
             raw as *mut W_ListObject,

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -258,6 +258,30 @@ pub unsafe fn grow_list_items_block_gc(
     new_block
 }
 
+/// Tuple-construction allocator on the Phase L2 nursery path. Exact-size
+/// (`cap == len` — tuples are immutable and every slot is written, no
+/// overallocation). Pins each element across the (collecting) block
+/// allocation and fills from the relocated shadow-stack slots, mirroring
+/// `w_tuple_new_array_backed`'s read-back. Degrades to the `std::alloc`
+/// [`alloc_tuple_items_block`] when the gate is off.
+pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlock {
+    if !itemsblock_gc_enabled() {
+        return unsafe { alloc_tuple_items_block(values) };
+    }
+    let cap = values.len();
+    let _roots = crate::gc_roots::push_roots();
+    let save = crate::gc_roots::shadow_stack_len();
+    for &v in values {
+        crate::gc_roots::pin_root(v);
+    }
+    let block = unsafe { alloc_items_block_gc(cap) };
+    let base = unsafe { items_block_items_base(block) };
+    for i in 0..cap {
+        unsafe { *base.add(i) = crate::gc_roots::shadow_stack_get(save + i) };
+    }
+    block
+}
+
 /// Allocate a fresh `ItemsBlock` with the given capacity.
 ///
 /// STEPPING-STONE: still uses `std::alloc::alloc`. The

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -163,6 +163,101 @@ pub unsafe fn dealloc_list_items_block(block: *mut ItemsBlock) {
     unsafe { dealloc_items_block(block) }
 }
 
+/// Phase L2 gate: route object-strategy `ItemsBlock` allocations through
+/// the moving nursery (`PY_OBJECT_ARRAY_GC_TYPE_ID`) instead of
+/// `std::alloc`. Read once; default off keeps the std::alloc stepping
+/// stone provably identical to pre-L2 behaviour, so the nursery path can
+/// be validated under GC stress before it becomes the default.
+fn itemsblock_gc_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_GC_ITEMSBLOCK").is_some())
+}
+
+/// Phase L2 nursery allocation of a fresh `ItemsBlock` with `cap` slots,
+/// as a `PY_OBJECT_ARRAY_GC_TYPE_ID` varsize GcArray. The collector reads
+/// its length from the offset-0 `capacity` header and forwards
+/// items[0..capacity], so the caller MUST write every slot (value or
+/// NULL) before a collection can observe the block. Falls back to the
+/// `std::alloc` [`alloc_items_block`] when the gate is off or no GC hook
+/// is installed (pure interpreter / early startup). Items are left
+/// uninitialised either way.
+unsafe fn alloc_items_block_gc(cap: usize) -> *mut ItemsBlock {
+    if itemsblock_gc_enabled() {
+        let payload = ITEMS_BLOCK_ITEMS_OFFSET + cap * std::mem::size_of::<PyObjectRef>();
+        if let Some(raw) = crate::gc_hook::try_gc_alloc(PY_OBJECT_ARRAY_GC_TYPE_ID, payload) {
+            if !raw.is_null() {
+                let block = raw as *mut ItemsBlock;
+                unsafe { (*block).capacity = cap };
+                return block;
+            }
+        }
+    }
+    unsafe { alloc_items_block(cap) }
+}
+
+/// List-construction allocator on the Phase L2 nursery path. Pins each
+/// element across the (collecting) block allocation and fills from the
+/// relocated shadow-stack slots — the `pop_roots` read-back of
+/// `w_tuple_new_array_backed` — because the local `values` slice still
+/// holds pre-collection addresses. Capacity is `len.max(1)`
+/// (overallocation policy); spare slots are NULL. Degrades to the
+/// `std::alloc` [`alloc_list_items_block`] when the gate is off.
+pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlock {
+    if !itemsblock_gc_enabled() {
+        return unsafe { alloc_list_items_block(values) };
+    }
+    let len = values.len();
+    let cap = len.max(1);
+    let _roots = crate::gc_roots::push_roots();
+    let save = crate::gc_roots::shadow_stack_len();
+    for &v in values {
+        crate::gc_roots::pin_root(v);
+    }
+    let block = unsafe { alloc_items_block_gc(cap) };
+    let base = unsafe { items_block_items_base(block) };
+    for i in 0..len {
+        unsafe { *base.add(i) = crate::gc_roots::shadow_stack_get(save + i) };
+    }
+    for i in len..cap {
+        unsafe { *base.add(i) = PY_NULL };
+    }
+    block
+}
+
+/// List-grow allocator on the Phase L2 nursery path. Pins the old block's
+/// `live_len` items across the new (collecting) allocation, copies from
+/// the relocated shadow-stack slots, NULL-fills the spare tail, then
+/// hands the old block to [`dealloc_list_items_block`] (which no-ops on a
+/// GC-managed block — the collector reclaims it). `old` may be null with
+/// `live_len == 0` (fresh allocation). Degrades to the `std::alloc`
+/// [`grow_list_items_block`] when the gate is off.
+pub unsafe fn grow_list_items_block_gc(
+    old: *mut ItemsBlock,
+    new_cap: usize,
+    live_len: usize,
+) -> *mut ItemsBlock {
+    if !itemsblock_gc_enabled() {
+        return unsafe { grow_list_items_block(old, new_cap, live_len) };
+    }
+    let _roots = crate::gc_roots::push_roots();
+    let save = crate::gc_roots::shadow_stack_len();
+    let old_base = unsafe { items_block_items_base(old) };
+    for i in 0..live_len {
+        crate::gc_roots::pin_root(unsafe { *old_base.add(i) });
+    }
+    let new_block = unsafe { alloc_items_block_gc(new_cap) };
+    let new_base = unsafe { items_block_items_base(new_block) };
+    for i in 0..live_len {
+        unsafe { *new_base.add(i) = crate::gc_roots::shadow_stack_get(save + i) };
+    }
+    for i in live_len..new_cap {
+        unsafe { *new_base.add(i) = PY_NULL };
+    }
+    unsafe { dealloc_list_items_block(old) };
+    new_block
+}
+
 /// Allocate a fresh `ItemsBlock` with the given capacity.
 ///
 /// STEPPING-STONE: still uses `std::alloc::alloc`. The
@@ -196,13 +291,17 @@ unsafe fn alloc_items_block(cap: usize) -> *mut ItemsBlock {
 }
 
 /// Deallocate an `ItemsBlock` previously allocated via
-/// [`alloc_items_block`] or [`grow_items_block`]. STEPPING-STONE:
-/// still bound to the matching `std::alloc` allocator above. Once
-/// the alloc path migrates, this should discriminate via
-/// `crate::gc_hook::try_gc_owns_object` so GC-managed blocks are
-/// left for the major sweep instead of being dealloc'd directly.
+/// [`alloc_items_block`] or [`grow_items_block`]. Phase L2: a
+/// GC-managed block (nursery / old-gen) is reclaimed by the collector
+/// and must never be freed here — its allocation is prefixed by a
+/// `GcHeader` the `std::alloc` layout knows nothing about, so handing
+/// it to `dealloc` would corrupt the allocator. `try_gc_owns_object`
+/// discriminates the two block origins during cutover.
 unsafe fn dealloc_items_block(block: *mut ItemsBlock) {
     if block.is_null() {
+        return;
+    }
+    if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
         return;
     }
     unsafe {

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -27,7 +27,7 @@ use crate::floatobject::{w_float_get_value, w_float_new};
 use crate::intobject::w_int_new;
 use crate::listobject::{is_plain_int1, plain_int_w};
 use crate::object_array::{
-    ItemsBlock, alloc_tuple_items_block, items_block_capacity, items_block_items_base,
+    ItemsBlock, alloc_tuple_items_block_gc, items_block_capacity, items_block_items_base,
 };
 use crate::pyobject::*;
 use crate::specialisedtupleobject::{
@@ -122,11 +122,15 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         .filter(|p| !p.is_null());
 
     // pop_roots: read the relocated item pointers back out of the shadow
-    // stack, then build the (std::alloc'd, non-collecting) items block.
+    // stack, then build the items block. On the Phase L2 nursery path
+    // (`PYRE_GC_ITEMSBLOCK`) the block itself is GC-managed and is the
+    // last allocation here, so it stays put until `wrappeditems` is set;
+    // `alloc_tuple_items_block_gc` re-pins the relocated values across its
+    // own (collecting) block malloc. Gate off it is the std::alloc block.
     let relocated: Vec<PyObjectRef> = (0..len)
         .map(|i| crate::gc_roots::shadow_stack_get(save_point + i))
         .collect();
-    let items_block = unsafe { alloc_tuple_items_block(&relocated) };
+    let items_block = unsafe { alloc_tuple_items_block_gc(&relocated) };
 
     if let Some(raw) = raw {
         unsafe {


### PR DESCRIPTION
#128

Eight commits on the `nbody` branch (rebased onto `main`).

## Frame locals object-ification (blocker #2)
`FrameDebugData` carried two locals fields — a raw `*mut DictStorage` fast path
and a `PyObjectRef` companion. These commits collapse them onto a single
`w_locals` object matching `pyframe.py:44`:

- **remove dead DictStorage-storage fallback arms in eval.rs**
- **bind module-scope frame locals to the w_globals object** (pyframe.py:216-218)
- **execute class bodies against a namespace object** (`setdictscope_object`;
  fresh dict + rebuild, avoiding a dangling `mirror_target`)
- **drop the raw DictStorage locals fast path** — remove the `w_locals` field,
  raw `fast2locals`/`locals2fast` bodies, raw accessors, and the dead raw
  store/load/delete_name/setup_annotations/import_star arms; function-scope
  `locals()` materialises a dict object (pyframe.py:557)
- **rename `w_locals_object` → `w_locals`**, merging the dispatcher/`_object`
  method pairs (pyframe.py:44/554/601 parity)

## JIT
- **fold module-scope LOAD_NAME through the module-dict cell fast path** —
  read-heavy module loops 2.7x (dynasm) / 2.9x (cranelift)
- **inline callee-frame allocation for N-arg CALL_ASSEMBLER**
- **forward W_CodeObject cached globals as a GC root**

## Verification
check.py 144/144 ×2 (dynasm, cranelift); nbody byte-correct both backends; GC
stress (nursery 4096) on class/exec/module locals paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `exec`, `eval`, and class-body execution so `locals`/`globals` handling and name resolution are more consistent.
  * Improved JIT handling for module-scope `LOAD_NAME` and related name-folding behavior.
* **Bug Fixes**
  * Fixed inconsistencies in frame inspection and builtins like `locals()` and `dir()` when locals are missing or updated.
  * Updated `import *` to always target mappings for imported names.
  * Improved GC safety for lists/tuples and frame locals/globals rooting to reduce incorrect behavior during allocation and tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->