### PR TITLE
#171 orthodox list-append fold and #11 pure tuple subscript load

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3850,7 +3850,9 @@ mod tests {
     use majit_ir::operand::Operand;
 
     use super::OptHeap;
-    use crate::history::test_support::{rooted_inputarg_operand, rooted_resop_operand};
+    use crate::history::test_support::{
+        rooted_inputarg_operand, rooted_resop_box, rooted_resop_operand,
+    };
 
     /// oparser-faithful drop-in for `BoxRef::from_opref(o)` at op-arg /
     /// fail-arg sites where `o` is a bound-at-runtime `OpRef`. Constants shed

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4639,6 +4639,122 @@ mod tests {
         assert_eq!(opcodes, vec![OpCode::Jump]);
     }
 
+    /// #171/#11 Approach C invariant: NON-pure `getarrayitem_gc_r` is
+    /// invalidated by an intervening `setarrayitem_gc` at the same index, so
+    /// a later read MUST observe the WRITTEN value — it is NOT folded to the
+    /// earlier read.  This is exactly why list element loads stay non-pure:
+    ///
+    ///   r1 = getarrayitem_gc_r(p0, i_idx, descr=d0)
+    ///   setarrayitem_gc(p0, i_idx, r_new, descr=d0)   <- invalidates the read
+    ///   r2 = getarrayitem_gc_r(p0, i_idx, descr=d0)   <- reads r_new, NOT r1
+    ///
+    /// (A pure load would CSE `r2` to `r1` across the write — the
+    /// read-after-write miscompile `pure_listload_raw.py` guards against.)
+    #[test]
+    fn test_getarrayitem_non_pure_invalidated_by_setarrayitem() {
+        let d = descr(0);
+        let idx = OpRef::int_op(50);
+        let new_val_box = rooted_resop_box(Type::Ref, 102);
+        let mut ops = vec![
+            // r1 = getarrayitem_gc_r(p0, i_idx)
+            Op::with_descr(
+                OpCode::GetarrayitemGcR,
+                &[
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                ],
+                d.clone(),
+            ),
+            // setarrayitem_gc(p0, i_idx, r_new)
+            Op::with_descr(
+                OpCode::SetarrayitemGc,
+                &[
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                    Operand::from_boxref(&new_val_box),
+                ],
+                d.clone(),
+            ),
+            // r2 = getarrayitem_gc_r(p0, i_idx)
+            Op::with_descr(
+                OpCode::GetarrayitemGcR,
+                &[
+                    Operand::from_boxref(&rooted_resop_box(Type::Ref, 100)),
+                    Operand::from_boxref(&rooted_resop_box(Type::Int, idx.raw())),
+                ],
+                d.clone(),
+            ),
+            Op::new(OpCode::Jump, &[]),
+        ];
+        assign_positions(&mut ops);
+        let r1_pos = ops[0].pos.get();
+        let r2_pos = ops[2].pos.get();
+
+        let mut ctx = OptContext::new(ops.len());
+        let cidx = ctx.materialize_box_at(idx);
+        ctx.make_constant_box(&cidx, majit_ir::Value::Int(3));
+        ctx.materialize_box_at(OpRef::ref_op(100));
+
+        let mut pass = OptHeap::new();
+        pass.setup();
+
+        for op in &ops {
+            let mut resolved = op.clone();
+            for i in 0..resolved.num_args() {
+                let arg = resolved.arg(i);
+                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
+                    Some(b) => Operand::from_boxref(&b),
+                    None => {
+                        let __ar = arg.to_opref();
+                        if __ar.is_none() {
+                            arg.clone()
+                        } else {
+                            Operand::from_boxref(
+                                &ctx.materialize_box_at(__ar).get_box_replacement(false),
+                            )
+                        }
+                    }
+                };
+                resolved.setarg(i, rb);
+            }
+            match pass.propagate_forward(&resolved, &std::rc::Rc::new(resolved.clone()), &mut ctx) {
+                OptimizationResult::Emit(emitted) => {
+                    ctx.emit(emitted);
+                }
+                OptimizationResult::Remove => {}
+                OptimizationResult::Replace(replaced) | OptimizationResult::Restart(replaced) => {
+                    ctx.emit(replaced);
+                }
+                OptimizationResult::PassOn => {
+                    ctx.emit(resolved);
+                }
+                OptimizationResult::InvalidLoop(_) => {
+                    panic!("unexpected InvalidLoop in test");
+                }
+            }
+        }
+
+        // The intervening `setarrayitem_gc` invalidated the cached read, so the
+        // post-write read r2 is NOT folded to the pre-write read r1.  A pure
+        // load would have CSE'd r2 → r1 across the write (the read-after-write
+        // miscompile `pure_listload_raw.py` guards against), so this `!=` is
+        // the decisive non-pure property that keeps list element loads correct.
+        let r2_repl = ctx.get_replacement_opref(r2_pos);
+        let _ = new_val_box;
+        assert_ne!(
+            r2_repl, r1_pos,
+            "non-pure getarrayitem must NOT be CSE'd to the pre-write read"
+        );
+        // A live `GetarrayitemGcR` survives the optimization (the write did not
+        // let the optimizer collapse the read away to the stale pre-write box).
+        assert!(
+            ctx.new_operations
+                .iter()
+                .any(|o| o.opcode == OpCode::GetarrayitemGcR),
+            "a non-pure read must survive across the write"
+        );
+    }
+
     #[test]
     fn test_getarrayitem_postprocess_updates_ptr_info() {
         let d = descr(0);

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4691,7 +4691,7 @@ mod tests {
         let r2_pos = ops[2].pos.get();
 
         let mut ctx = OptContext::new(ops.len());
-        let cidx = ctx.materialize_box_at(idx);
+        let cidx = ctx.materialize_operand_at(idx);
         ctx.make_constant_box(&cidx, majit_ir::Value::Int(3));
         ctx.materialize_box_at(OpRef::ref_op(100));
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7552,6 +7552,20 @@ impl OptContext {
         runtime_box: OpRef,
         descr: &majit_ir::descr::DescrRef,
     ) -> Option<OpRef> {
+        // virtualstate.py:48-55 `cpu.bh_getfield_gc_*(struct, descr)` reads the
+        // field off the *struct* the runtime box points at. RPython's runtime
+        // box is always an eagerly allocated object, so `getref_base()` yields
+        // a concrete pointer. Under pyre's lazy boxing the runtime box can be
+        // an unmaterialized virtual (state.rs NewWithVtable without a W_*Object
+        // allocation), so `getref_base()` has no concrete pointer to read. The
+        // faithful equivalent is to read the field's tracked box — the
+        // `setfield_gc` source the optimizer recorded on the virtual — which is
+        // exactly the value `bh_getfield_gc_*` would observe on the eager
+        // object. Consult it before the concrete-Ref read; the concrete path is
+        // unchanged for already-materialized runtime boxes.
+        if let Some(opref) = self.get_virtual_runtime_field(runtime_box, descr) {
+            return Some(opref);
+        }
         // virtualstate.py:39 `box.getref_base()` — concrete Ref read.
         // `runtime_value_of` cascades const_pool → stamped BoxRef value
         // (RPython `InputArg*.value` analog).
@@ -7591,6 +7605,99 @@ impl OptContext {
                 Some(self.make_constant_int(val))
             }
             _ => None,
+        }
+    }
+
+    /// Lazy-boxing companion to `get_runtime_field` / `get_runtime_interiorfield`.
+    ///
+    /// virtualstate.py:48-55 reads `cpu.bh_getfield_gc_*(struct, descr)` off the
+    /// eagerly allocated struct the runtime box points at. When `runtime_box`
+    /// resolves to an unmaterialized `PtrInfo::Virtual` / `VirtualStruct`
+    /// instead of a concrete pointer (pyre keeps W_IntObject counters as
+    /// virtuals — state.rs NewWithVtable with no allocation), there is no
+    /// struct to read; the field's observed value lives on the virtual's
+    /// tracked field box (the recorded `setfield_gc` source). This mirrors what
+    /// `bh_getfield_gc_*` would observe on the eager object: look up the field
+    /// slot via `info.getfield(index_in_parent)` (the same parent-local slot
+    /// `enum_forced_boxes_for_entry` reads, virtualstate.rs:854-865), resolve
+    /// its own runtime value (`runtime_value_of`, the InputArg*.value analog),
+    /// and wrap it in a fresh const OpRef matching the concrete-read return
+    /// shape. Returns `None` when the runtime box is not a virtual, the slot is
+    /// unset, or the slot carries no observed value.
+    fn get_virtual_runtime_field(
+        &mut self,
+        runtime_box: OpRef,
+        descr: &majit_ir::descr::DescrRef,
+    ) -> Option<OpRef> {
+        let fd = descr.as_field_descr()?;
+        // virtualstate.py:162 `opinfo._fields[descr.get_index()]`: the slot key
+        // is the parent-local field index, not the global Descr.index(), and is
+        // only meaningful when a parent SizeDescr is bound (descr.rs index_in_parent).
+        let slot = fd
+            .get_parent_descr()
+            .map(|_| fd.index_in_parent() as u32)
+            .unwrap_or_else(|| descr.index());
+        // virtualstate.py:149-151 `opinfo = getptrinfo(box); assert
+        // opinfo.is_virtual()`. Read the field box only off a virtual struct
+        // ptrinfo; a concrete/instance ptrinfo falls through to the eager read.
+        let b = self.get_box_replacement_box(runtime_box)?;
+        let info = self.getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))?;
+        let field_opref = match &info {
+            crate::optimizeopt::info::PtrInfo::Virtual(_)
+            | crate::optimizeopt::info::PtrInfo::VirtualStruct(_) => {
+                info.getfield(slot)?.as_opref()?
+            }
+            _ => return None,
+        };
+        // virtualstate.py:48-55: the read produces a fresh InputArg* carrying
+        // the concrete field value. `runtime_value_of` reads the field box's
+        // own observed value (the setfield_gc source's stamped value); wrap it
+        // in the matching const OpRef.
+        self.const_opref_from_runtime_value(field_opref)
+    }
+
+    /// Lazy-boxing companion to `get_runtime_interiorfield`.
+    ///
+    /// When `runtime_box` resolves to an unmaterialized `VirtualArrayStruct`,
+    /// the interior field's observed value lives on the virtual's tracked
+    /// element-field box (info.py:663-668 `getinteriorfield_virtual`), not a
+    /// concrete struct. Read it the same way `get_virtual_runtime_field` reads a
+    /// struct field. Returns `None` when the runtime box is not a virtual
+    /// array-struct, the slot is unset, or the slot carries no observed value.
+    fn get_virtual_runtime_interiorfield(
+        &mut self,
+        runtime_box: OpRef,
+        descr: &majit_ir::descr::DescrRef,
+        i: usize,
+    ) -> Option<OpRef> {
+        let ifd = descr.as_interior_field_descr()?;
+        let fd = ifd.field_descr();
+        // virtualstate.py:321-322 reads `opinfo._fields[i][descr.get_index()]`:
+        // the parent-local field slot index (descr.rs index_in_parent), with a
+        // fallback to the global index when no parent SizeDescr is bound.
+        let slot = fd
+            .get_parent_descr()
+            .map(|_| fd.index_in_parent() as u32)
+            .unwrap_or_else(|| descr.index());
+        let b = self.get_box_replacement_box(runtime_box)?;
+        let info = self.getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))?;
+        if !matches!(info, crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(_)) {
+            return None;
+        }
+        let field_opref = info.getinteriorfield_virtual(i, slot)?;
+        self.const_opref_from_runtime_value(field_opref)
+    }
+
+    /// virtualstate.py:48-55 tail: wrap the field box's observed runtime value
+    /// (`runtime_value_of`, the `InputArg*.value` analog) in a fresh const OpRef
+    /// matching the `InputArg{Int,Float,Ref}` the concrete `bh_getfield_gc_*`
+    /// read would produce. Returns `None` for an unobserved or void slot.
+    fn const_opref_from_runtime_value(&mut self, field_opref: OpRef) -> Option<OpRef> {
+        match self.runtime_value_of(field_opref)? {
+            Value::Int(v) => Some(self.make_constant_int(v)),
+            Value::Float(v) => Some(self.make_constant_float(v)),
+            Value::Ref(v) => Some(self.make_constant_ref(v)),
+            Value::Void => None,
         }
     }
 
@@ -7690,6 +7797,13 @@ impl OptContext {
         descr: &majit_ir::descr::DescrRef,
         i: usize,
     ) -> Option<OpRef> {
+        // Lazy-boxing path: when the runtime box is an unmaterialized
+        // `VirtualArrayStruct` the interior field's observed value lives on the
+        // virtual's tracked element-field box rather than a concrete struct.
+        // See `get_virtual_runtime_field` for the model this mirrors.
+        if let Some(opref) = self.get_virtual_runtime_interiorfield(runtime_box, descr, i) {
+            return Some(opref);
+        }
         // virtualstate.py:39 `box.getref_base()` — concrete Ref read.
         // `runtime_value_of` cascades const_pool → stamped BoxRef value
         // (RPython `InputArg*.value` analog).

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7681,7 +7681,10 @@ impl OptContext {
             .unwrap_or_else(|| descr.index());
         let b = self.get_box_replacement_box(runtime_box)?;
         let info = self.getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))?;
-        if !matches!(info, crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(_)) {
+        if !matches!(
+            info,
+            crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(_)
+        ) {
             return None;
         }
         let field_opref = info.getinteriorfield_virtual(i, slot)?;

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1709,6 +1709,67 @@ mod tests {
         assert_eq!(result[0].opcode, OpCode::SetfieldGc);
     }
 
+    /// #171/#11 Approach C: two `getarrayitem_gc_pure_r(arr, const_i, descr)`
+    /// against the SAME (immutable) array, index, and descr are CSE'd by
+    /// OptPure — the second is folded to the first (`make_equal_to`).  This
+    /// is the producer-side invariant the canonical-tuple `t[i]` arm relies
+    /// on: purity is carried by the `GetarrayitemGcPureR` OPCODE (the descr
+    /// stays the shared non-pure singleton), and OptPure never invalidates a
+    /// pure load on an intervening write.
+    #[test]
+    fn test_cse_getarrayitem_gc_pure_r() {
+        let arr_descr = majit_ir::descr::make_array_descr(8, 8, Type::Ref);
+        let result = run_pure(
+            1,
+            &[
+                op_spec_descr(
+                    OpCode::GetarrayitemGcPureR,
+                    &[Arg::In(0), Arg::Const(Value::Int(0))],
+                    arr_descr.clone(),
+                ),
+                op_spec_descr(
+                    OpCode::GetarrayitemGcPureR,
+                    &[Arg::In(0), Arg::Const(Value::Int(0))],
+                    arr_descr.clone(),
+                ),
+            ],
+            &mut majit_ir::VecMap::new(),
+            &[],
+            false,
+        );
+
+        // Only the first pure load survives; the second is CSE'd away.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].opcode, OpCode::GetarrayitemGcPureR);
+    }
+
+    /// Negative control for the pure CSE above: two pure loads at DIFFERENT
+    /// indices are NOT folded together (the index discriminates the slot).
+    #[test]
+    fn test_cse_getarrayitem_gc_pure_r_distinct_index_not_folded() {
+        let arr_descr = majit_ir::descr::make_array_descr(8, 8, Type::Ref);
+        let result = run_pure(
+            1,
+            &[
+                op_spec_descr(
+                    OpCode::GetarrayitemGcPureR,
+                    &[Arg::In(0), Arg::Const(Value::Int(0))],
+                    arr_descr.clone(),
+                ),
+                op_spec_descr(
+                    OpCode::GetarrayitemGcPureR,
+                    &[Arg::In(0), Arg::Const(Value::Int(1))],
+                    arr_descr.clone(),
+                ),
+            ],
+            &mut majit_ir::VecMap::new(),
+            &[],
+            false,
+        );
+
+        assert_eq!(result.len(), 2);
+    }
+
     #[test]
     fn test_cse_unary_ops() {
         // i1 = int_neg(i0)

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -578,6 +578,33 @@ struct PreparedBridgeTrace {
     snapshot_vref_boxes: SnapshotBoxes,
     snapshot_frame_pcs: SnapshotFramePcs,
     pending_bridge_rd: Option<PendingBridgeRd>,
+    runtime_boxes: Vec<OpRef>,
+}
+
+/// Wrap a recorded `&[Op]` bridge trace into the `Vec<OpRc>` the
+/// `prepare_bridge_trace_for_optimizer` boundary consumes, preserving each
+/// result box's observed runtime value across the clone.
+///
+/// `Op::clone` resets the result box's value (`_resint`/`_resref`,
+/// resoperation.py:243-247 fresh-identity reset), which is correct for the
+/// trace ops the optimizer re-mints. But the bridge's `runtime_boxes` (the
+/// closing JUMP's live boxes) carry observed values that the IntBound runtime
+/// fallback reads un-forwarded (`runtime_box.getint()`, virtualstate.py:494);
+/// RPython keeps them because `runtime_boxes` are the separate original history
+/// boxes (pyjitpl.py:3213). Pyre resolves a runtime box's value through its
+/// producing op, so this carries the observed value onto the cloned snapshot op
+/// to expose the same un-forwarded value on the runtime-box channel.
+fn clone_bridge_ops_preserving_value(bridge_ops: &[majit_ir::Op]) -> Vec<majit_ir::OpRc> {
+    bridge_ops
+        .iter()
+        .map(|op| {
+            let cloned = op.clone();
+            if let Some(value) = op.get_value() {
+                cloned.set_value(value);
+            }
+            std::rc::Rc::new(cloned)
+        })
+        .collect()
 }
 
 fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<majit_ir::box_ref::BoxRef>]) -> OpRef {
@@ -637,6 +664,7 @@ fn prepare_bridge_trace_for_optimizer(
     snapshot_vref_boxes: SnapshotBoxes,
     snapshot_frame_pcs: SnapshotFramePcs,
     pending_bridge_rd: Option<PendingBridgeRd>,
+    runtime_boxes: Vec<OpRef>,
     bridge_inputarg_base: u32,
 ) -> PreparedBridgeTrace {
     // unroll.py:187 `trace = trace.get_iter()` parity for bridge traces.
@@ -656,6 +684,23 @@ fn prepare_bridge_trace_for_optimizer(
     while let Some(op) = iter.next() {
         ops.push(op);
     }
+    // opencoder.py:367-405 `TraceIterator.next` re-mints each op via a fresh
+    // `cls()` whose result box defaults `_resint`/`_resref` to 0/NULL — it does
+    // NOT carry the recorded box's observed runtime value. RPython tolerates
+    // this because `runtime_boxes` are the SEPARATE original history boxes
+    // (pyjitpl.py:3213 `live_arg_boxes[num_green_args:]`), whose `_resint` is
+    // intact and read un-forwarded by `runtime_box.getint()`
+    // (virtualstate.py:494). Pyre resolves a runtime box's value through its
+    // producing op, so the re-minted op must keep the recorded value to expose
+    // the same un-forwarded `_resint` that drives the IntBound runtime fallback
+    // (`get_virtual_runtime_field` / virtualstate.py:493-498). The source/
+    // re-minted op lists are 1:1 (one `next()` per recorded op), so copy each
+    // observed value across.
+    for (src, dst) in bridge_ops.iter().zip(ops.iter()) {
+        if let Some(value) = src.get_value() {
+            dst.set_value(value);
+        }
+    }
     let inputargs = bridge_inputargs
         .iter()
         .zip(iter.inputargs.iter())
@@ -673,6 +718,15 @@ fn prepare_bridge_trace_for_optimizer(
             .collect();
         prd
     });
+    // unroll.py:105/153/166 `runtime_boxes` are the closing JUMP's live boxes.
+    // They are harvested from the pre-iterator trace and must be rewritten into
+    // the fresh-iterator namespace alongside `liveboxes` / snapshot feeds —
+    // otherwise `runtime_value_of` / `getptrinfo` lookups in optimize_bridge
+    // (which runs in the re-minted namespace) miss the producing op.
+    let runtime_boxes = runtime_boxes
+        .into_iter()
+        .map(|opref| translate_trace_iter_opref(opref, &cache))
+        .collect();
     PreparedBridgeTrace {
         ops,
         inputargs,
@@ -682,6 +736,7 @@ fn prepare_bridge_trace_for_optimizer(
         snapshot_vref_boxes,
         snapshot_frame_pcs,
         pending_bridge_rd,
+        runtime_boxes,
     }
 }
 
@@ -9041,11 +9096,9 @@ impl<M: Clone> MetaInterp<M> {
         // ResOperation objects in a disjoint OpRef namespace
         // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`).
         // Wrap `&[Op]` into `Vec<OpRc>` for the prepare_bridge_trace_for_optimizer
-        // boundary (history.py:528 identity at trace level).
-        let bridge_ops_rc: Vec<majit_ir::OpRc> = bridge_ops
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
+        // boundary (history.py:528 identity at trace level), keeping the
+        // runtime-box channel's observed values intact across the clone.
+        let bridge_ops_rc = clone_bridge_ops_preserving_value(bridge_ops);
         let prepared = prepare_bridge_trace_for_optimizer(
             &bridge_ops_rc,
             bridge_inputargs,
@@ -9055,10 +9108,15 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_vref_boxes,
             snapshot_frame_pcs,
             None,
+            bridge_runtime_boxes,
             bridge_inputarg_base,
         );
         let bridge_inputargs = prepared.inputargs.as_slice();
         let bridge_ops = prepared.ops.as_slice();
+        // unroll.py:187 `trace = trace.get_iter()` rewrote the runtime boxes
+        // into the fresh-iterator namespace; consume the translated list so
+        // optimize_bridge's generate_guards reads them in the re-minted space.
+        let bridge_runtime_boxes = prepared.runtime_boxes.as_slice();
 
         let mut optimizer = self.make_optimizer();
         optimizer.all_descrs = std::mem::take(&mut *self.staticdata.all_descrs.lock().unwrap());
@@ -9127,7 +9185,7 @@ impl<M: Clone> MetaInterp<M> {
                 &mut constants,
                 bridge_inputargs.len(),
                 &mut compiled.front_target_tokens,
-                &bridge_runtime_boxes,
+                bridge_runtime_boxes,
                 true,
                 retraced_count,
                 retrace_limit,
@@ -9628,11 +9686,10 @@ impl<M: Clone> MetaInterp<M> {
         };
         // unroll.py:187 `trace = trace.get_iter()`: mint fresh InputArg /
         // ResOperation objects in a disjoint OpRef namespace
-        // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`).
-        let bridge_ops_rc: Vec<majit_ir::OpRc> = bridge_ops
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
+        // (`opencoder.py:259-262 self.inputargs = [rop.inputarg_from_tp(...)]`),
+        // keeping the runtime-box channel's observed values intact across the
+        // clone.
+        let bridge_ops_rc = clone_bridge_ops_preserving_value(bridge_ops);
         let prepared = prepare_bridge_trace_for_optimizer(
             &bridge_ops_rc,
             bridge_inputargs,
@@ -9642,6 +9699,7 @@ impl<M: Clone> MetaInterp<M> {
             snapshot_vref_boxes,
             snapshot_frame_pcs,
             pending_bridge_rd,
+            bridge_runtime_boxes,
             bridge_inputarg_base,
         );
         let bridge_inputarg_types: Vec<majit_ir::OpRef> = prepared
@@ -9653,6 +9711,10 @@ impl<M: Clone> MetaInterp<M> {
         let bridge_inputargs = prepared.inputargs.as_slice();
         let bridge_ops = prepared.ops.as_slice();
         let pending_bridge_rd = prepared.pending_bridge_rd;
+        // unroll.py:187 `trace = trace.get_iter()` rewrote the runtime boxes
+        // into the fresh-iterator namespace; consume the translated list so
+        // optimize_bridge's generate_guards reads them in the re-minted space.
+        let bridge_runtime_boxes = prepared.runtime_boxes.as_slice();
 
         let mut optimizer = self.make_optimizer();
         optimizer.all_descrs = std::mem::take(&mut *self.staticdata.all_descrs.lock().unwrap());
@@ -9726,7 +9788,7 @@ impl<M: Clone> MetaInterp<M> {
                 &mut constants,
                 bridge_inputargs.len(),
                 &mut compiled.front_target_tokens,
-                &bridge_runtime_boxes,
+                bridge_runtime_boxes,
                 bridge_inline_short_preamble,
                 retraced_count,
                 retrace_limit,
@@ -18234,10 +18296,10 @@ mod tests {
             cpu: crate::cpu::default_cpu(),
         };
 
-        let bridge_ops_rc: Vec<majit_ir::OpRc> = bridge_ops
-            .iter()
-            .map(|op| std::rc::Rc::new(op.clone()))
-            .collect();
+        let bridge_ops_rc = clone_bridge_ops_preserving_value(&bridge_ops);
+        // The closing JUMP's args are the bridge `runtime_boxes`; they must be
+        // rewritten into the fresh-iterator namespace like the snapshot feeds.
+        let bridge_runtime_boxes = vec![OpRef::ref_op(2), OpRef::int_op(3)];
         let prepared = prepare_bridge_trace_for_optimizer(
             &bridge_ops_rc,
             &bridge_inputargs,
@@ -18247,6 +18309,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(pending_bridge_rd),
+            bridge_runtime_boxes,
             10,
         );
 
@@ -18312,6 +18375,11 @@ mod tests {
                 .liveboxes
                 .clone(),
             vec![OpRef::input_arg_int(10), OpRef::input_arg_ref(11)]
+        );
+        // runtime_boxes are translated into the fresh-iterator namespace.
+        assert_eq!(
+            prepared.runtime_boxes,
+            vec![OpRef::ref_op(12), OpRef::int_op(13)]
         );
     }
 

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1501,6 +1501,7 @@ impl Assembler {
                     // `type_id` (`path_hash(owner)`), not this field.
                     owner: String::new(),
                     all_fielddescrs: spec.all_fielddescrs,
+                    is_gc_managed: spec.is_gc_managed,
                 });
                 state.code.push((descr_idx & 0xFF) as u8);
                 state.code.push((descr_idx >> 8) as u8);

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1657,6 +1657,7 @@ impl Assembler {
                 item_ty,
                 array_type_id,
                 nolength,
+                pure,
             } => {
                 let (reg, kc) = self.lookup_reg_with_kind_var(base, regallocs);
                 state.code.push(reg);
@@ -1699,7 +1700,16 @@ impl Assembler {
                 } else {
                     'v'
                 };
-                let opname = format!("getarrayitem_gc_{result_kind}");
+                // `getarrayitem_gc_{i,r,f}_pure` for a foldable/immutable
+                // element load (`ll_getitem_foldable_nonneg`, rlist.py:724);
+                // `blackhole.py:1339-1341` aliases `bhimpl_getarrayitem_gc_*_pure
+                // = bhimpl_getarrayitem_gc_*`, so the `rid>X` argcodes are
+                // identical to the non-pure form — only the opname differs.
+                let opname = if *pure {
+                    format!("getarrayitem_gc_{result_kind}_pure")
+                } else {
+                    format!("getarrayitem_gc_{result_kind}")
+                };
                 let key = format!("{opname}/{argcodes}");
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
@@ -5155,6 +5165,7 @@ mod tests {
                     item_ty: ValueType::Unknown,
                     array_type_id: None,
                     nolength: false,
+                    pure: false,
                 },
                 true,
             )
@@ -5223,6 +5234,113 @@ mod tests {
         assert!(
             !asm.insns.contains_key("getarrayitem_gc_v/ird>i"),
             "unexpected getarrayitem_gc_v/ird>i key: {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// A `pure: true` ArrayRead assembles to the foldable
+    /// `getarrayitem_gc_i_pure` opcode (rlist.py:724
+    /// `ll_getitem_foldable_nonneg`); a `pure: false` ArrayRead keeps the
+    /// non-pure `getarrayitem_gc_i`.  The `rid>i` argcodes are byte-identical
+    /// either way (`blackhole.py:1339-1341` aliases the pure handler) — only
+    /// the opname/byte differs.
+    fn assemble_arrayread_pure(pure: bool) -> Assembler {
+        use crate::flatten::flatten_graph;
+        use crate::jtransform::{GraphTransformConfig, Transformer};
+        use crate::model::{FunctionGraph, OpKind, ValueType};
+
+        let mut graph = FunctionGraph::new("arrayread_pure");
+        let base_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "block".into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let index_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "i".into(),
+                    ty: ValueType::Int,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let array_result_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::ArrayRead {
+                    base: base_var.clone(),
+                    index: index_var.clone(),
+                    item_ty: ValueType::Int,
+                    array_type_id: None,
+                    nolength: false,
+                    pure,
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(array_result_var.clone()));
+        // `assemble` derives every operand kind from the variable
+        // concretetype + regallocs coloring — color the base (GcRef array
+        // pointer) and index (Signed) inputs as well as the result, else
+        // `lookup_coloring` finds no class for them.
+        FunctionGraph::set_concretetype_of_inline(
+            &base_var,
+            crate::codewriter::type_state::ConcreteType::GcRef,
+        );
+        FunctionGraph::set_concretetype_of_inline(
+            &index_var,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+        FunctionGraph::set_concretetype_of_inline(
+            &array_result_var,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+
+        let config = GraphTransformConfig::default();
+        let mut rewritten = Transformer::new(&config).transform(&graph).graph;
+        regalloc::augment_canonical_exceptblock_on_graph(&mut rewritten);
+        let mut regallocs = regalloc::perform_all_register_allocations(&rewritten);
+        let mut flat = flatten_graph(&rewritten, &mut regallocs);
+
+        let mut asm = Assembler::new();
+        let _ = asm.assemble(&mut flat, &regallocs);
+        asm
+    }
+
+    #[test]
+    fn assemble_pure_arrayread_uses_pure_opcode() {
+        let asm = assemble_arrayread_pure(true);
+        assert!(
+            asm.insns.contains_key("getarrayitem_gc_i_pure/rid>i"),
+            "expected foldable getarrayitem_gc_i_pure key, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !asm.insns.contains_key("getarrayitem_gc_i/rid>i"),
+            "unexpected non-pure getarrayitem_gc_i key for pure ArrayRead: {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn assemble_non_pure_arrayread_uses_non_pure_opcode() {
+        let asm = assemble_arrayread_pure(false);
+        assert!(
+            asm.insns.contains_key("getarrayitem_gc_i/rid>i"),
+            "expected non-pure getarrayitem_gc_i key, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !asm.insns.contains_key("getarrayitem_gc_i_pure/rid>i"),
+            "unexpected pure getarrayitem_gc_i_pure key for non-pure ArrayRead: {:?}",
             asm.insns.keys().collect::<Vec<_>>()
         );
     }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2485,6 +2485,13 @@ impl<'a> Transformer<'a> {
                         OpKind::ArrayRead { nolength, .. } => *nolength,
                         _ => unreachable!("rewrite_op_getarrayitem called on non-ArrayRead op"),
                     },
+                    // Preserve the source foldable/immutable flag through
+                    // the item_ty re-type — never hardcode it (rlist.py:724
+                    // ll_getitem_foldable_nonneg).
+                    pure: match &op.kind {
+                        OpKind::ArrayRead { pure, .. } => *pure,
+                        _ => unreachable!("rewrite_op_getarrayitem called on non-ArrayRead op"),
+                    },
                 },
             }]);
         }
@@ -3076,6 +3083,49 @@ impl<'a> Transformer<'a> {
                                 item_ty: ValueType::Int,
                                 array_type_id: None,
                                 nolength: false,
+                                pure: false,
+                            },
+                        },
+                    ],
+                )
+            }
+            // `ll_getitem_foldable_nonneg` (rlist.py:721-724, `oopspec =
+            // 'list.getitem_foldable(l, index)'`) — selected by
+            // `rtype_getitem` when `not listdef.listitem.mutated`
+            // (rlist.py:256-258).  Same block-then-element decomposition
+            // as `list.int_getitem`, except the element load is the
+            // foldable `getarrayitem_gc_i_pure` (`pure: true`).  The
+            // `int_items.block` FieldRead stays `pure: false` — only the
+            // element load is foldable; the backing block pointer may
+            // still move under a resize.
+            "list.int_getitem_foldable" => {
+                let l = args.first()?.clone();
+                let index = args.get(1)?.clone();
+                let block = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+                (
+                    "list.int_getitem_foldable → getfield_gc_r(int_items.block) + getarrayitem_gc_i_pure",
+                    vec![
+                        SpaceOperation {
+                            result: Some(block.clone()),
+                            kind: OpKind::FieldRead {
+                                base: l,
+                                field: FieldDescriptor::new(
+                                    "int_items.block",
+                                    Some(LIST_OWNER.to_string()),
+                                ),
+                                ty: ValueType::Ref(None),
+                                pure: false,
+                            },
+                        },
+                        SpaceOperation {
+                            result: op.result.clone(),
+                            kind: OpKind::ArrayRead {
+                                base: block,
+                                index,
+                                item_ty: ValueType::Int,
+                                array_type_id: None,
+                                nolength: false,
+                                pure: true,
                             },
                         },
                     ],
@@ -4828,12 +4878,17 @@ fn remap_op(
             item_ty,
             array_type_id,
             nolength,
+            pure,
         } => OpKind::ArrayRead {
             base: remap_value(base, aliases),
             index: remap_value(index, aliases),
             item_ty: item_ty.clone(),
             array_type_id: array_type_id.clone(),
             nolength: *nolength,
+            // Preserve the source foldable/immutable flag through the
+            // alias remap — never hardcode it (rlist.py:724
+            // ll_getitem_foldable_nonneg).
+            pure: *pure,
         },
         OpKind::ArrayWrite {
             base,
@@ -5988,6 +6043,7 @@ mod tests {
                 item_ty: ValueType::Int,
                 array_type_id: None,
                 nolength: false,
+                pure: false,
             },
             true,
         );
@@ -6161,6 +6217,7 @@ mod tests {
                     item_ty: ValueType::Unknown,
                     array_type_id: None,
                     nolength: false,
+                    pure: false,
                 },
                 true,
             )
@@ -8651,12 +8708,85 @@ mod tests {
                 item_ty,
                 array_type_id,
                 nolength,
+                pure,
             } => {
                 assert_eq!(base, &block);
                 assert_eq!(idx, &index);
                 assert!(matches!(item_ty, ValueType::Int));
                 assert_eq!(array_type_id, &None);
                 assert!(!nolength);
+                // `list.int_getitem` is the mutable (non-foldable) read.
+                assert!(!pure);
+            }
+            other => panic!("expected ArrayRead, got {other:?}"),
+        }
+        assert_eq!(ops[1].result, Some(result));
+    }
+
+    /// `list.int_getitem_foldable(l, i)` lowers to `getfield_gc_r(l,
+    /// int_items.block)` feeding the foldable `getarrayitem_gc_i_pure(block,
+    /// i)` (rlist.py:721-724 `ll_getitem_foldable_nonneg`, oopspec
+    /// `list.getitem_foldable`).  The element load is `pure: true`; the
+    /// block FieldRead stays `pure: false`.
+    #[test]
+    fn handle_list_call_int_getitem_foldable_emits_pure_arrayread() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("list_int_getitem_foldable");
+        let l = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let index = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let result = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "list.int_getitem_foldable",
+                &op,
+                &[l.clone(), index.clone()],
+                &mut graph,
+                "list_int_getitem_foldable",
+            )
+            .expect("list.int_getitem_foldable must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 2);
+        let block = match &ops[0].kind {
+            OpKind::FieldRead {
+                base,
+                field,
+                ty,
+                pure,
+            } => {
+                assert_eq!(base, &l);
+                assert_eq!(field.name, "int_items.block");
+                assert_eq!(field.owner_root.as_deref(), Some("W_ListObject"));
+                assert!(matches!(ty, ValueType::Ref(None)));
+                // Only the element load is foldable; the block pointer read
+                // is not.
+                assert!(!pure);
+                ops[0].result.clone().expect("block result var")
+            }
+            other => panic!("expected FieldRead, got {other:?}"),
+        };
+        match &ops[1].kind {
+            OpKind::ArrayRead {
+                base,
+                index: idx,
+                item_ty,
+                array_type_id,
+                nolength,
+                pure,
+            } => {
+                assert_eq!(base, &block);
+                assert_eq!(idx, &index);
+                assert!(matches!(item_ty, ValueType::Int));
+                assert_eq!(array_type_id, &None);
+                assert!(!nolength);
+                // The foldable element load — `getarrayitem_gc_i_pure`.
+                assert!(pure);
             }
             other => panic!("expected ArrayRead, got {other:?}"),
         }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3587,6 +3587,7 @@ impl<'a> Lowering<'a> {
                             item_ty: tyref_to_value_type(&place_ty, self.llbc),
                             array_type_id: None,
                             nolength: false,
+                            pure: false,
                         },
                     });
                     return Ok(res);
@@ -4667,6 +4668,7 @@ impl<'a> Lowering<'a> {
                             item_ty: ValueType::Ref(None),
                             array_type_id: None,
                             nolength: false,
+                            pure: false,
                         },
                     });
                     self.index_elem_alias.insert(
@@ -4718,6 +4720,7 @@ impl<'a> Lowering<'a> {
                             item_ty: ValueType::Ref(None),
                             array_type_id: None,
                             nolength: false,
+                            pure: false,
                         },
                     });
                     self.index_elem_alias.insert(
@@ -4763,6 +4766,7 @@ impl<'a> Lowering<'a> {
                             item_ty: ValueType::Ref(None),
                             array_type_id: None,
                             nolength: false,
+                            pure: false,
                         },
                     });
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
@@ -4773,6 +4777,7 @@ impl<'a> Lowering<'a> {
                             item_ty: ValueType::Ref(None),
                             array_type_id: None,
                             nolength: false,
+                            pure: false,
                         },
                     });
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -831,6 +831,17 @@ fn derive_program_metadata(
                 // payload, which is not the tag width, so keep the wide
                 // `i64` model there (the tag still sits in the low bytes; a
                 // switch key compares equal under the wide read).
+                // The fieldless tag is modeled at an UNSIGNED width (u8/u16/u32).
+                // This is correct only while every variant discriminant is
+                // non-negative: a signed-repr / negative-discriminant enum would
+                // zero-extend the tag on read (e.g. `-1` → `255`) while Charon's
+                // variant key stays the negative `discriminant_i64()`, so the
+                // JIT switch/guard would take the wrong arm. All fieldless enums
+                // lowered here today (ListStrategy / ArrayKind / DictViewKind /
+                // StrategyKind / ExcKind …) use the default non-negative
+                // discriminants, so unsigned is exact. A negative-discriminant
+                // enum would need a signed width here AND a sign-extending field
+                // read; revisit if one is introduced.
                 let disc_ty = if variants.iter().all(|v| v.fields.is_empty()) {
                     match td.layout_for_target(&target).and_then(|l| l.size) {
                         Some(1) => "u8",

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -460,12 +460,17 @@ pub(crate) fn remap_op_kind(
             item_ty,
             array_type_id,
             nolength,
+            pure,
         } => OpKind::ArrayRead {
             base: remap_var(base),
             index: remap_var(index),
             item_ty: item_ty.clone(),
             array_type_id: array_type_id.clone(),
             nolength: *nolength,
+            // Preserve the source foldable/immutable flag through the
+            // inline clone — never hardcode it (rlist.py:724
+            // ll_getitem_foldable_nonneg).
+            pure: *pure,
         },
         OpKind::ArrayWrite {
             base,
@@ -1524,6 +1529,7 @@ mod tests {
                 item_ty: ValueType::Ref(None),
                 array_type_id: None,
                 nolength: false,
+                pure: false,
             },
             true,
         );

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -626,6 +626,17 @@ pub enum OpKind {
         /// length-prefixed shape) lays the length word at offset 0
         /// and items past it.
         nolength: bool,
+        /// RPython: the foldable/immutable element load
+        /// `getarrayitem_gc_{i,r,f}_pure`.  `ll_getitem_foldable_nonneg`
+        /// (rlist.py:721-724, `oopspec = 'list.getitem_foldable(l,
+        /// index)'`) is selected by `rtype_getitem` when `not
+        /// listdef.listitem.mutated` (rlist.py:256-258), and the
+        /// `FixedSizeListRepr` iterator next is `ll_listnext_foldable`
+        /// when `not r_list.listitem.mutated`
+        /// (lltypesystem/rlist.py:462-466).  `true` only for such a
+        /// foldable/unmutated selection or an immutable container —
+        /// NEVER for a mutable list element.
+        pure: bool,
     },
     ArrayWrite {
         base: crate::flowspace::model::Variable,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -4160,6 +4160,7 @@ mod tests {
                 item_ty: ValueType::Int,
                 array_type_id: None,
                 nolength: false,
+                pure: false,
             },
         };
         let translated = translate_op(&op, &value_map, &empty_call_registry())

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -2979,12 +2979,18 @@ impl Repr for ListIteratorRepr {
     /// ```
     ///
     /// `ll_listnext` (the `index >= ll_length()` bounds-check that raises
-    /// `StopIteration`) lowers to [`build_ll_listnext_helper_graph`]. The
-    /// foldable vs non-foldable selection (`ll_listnext_foldable`,
-    /// `lltypesystem/rlist.py:462-466`) is NOT an rtyper-level distinction:
-    /// both lower to the bare `getarrayitem` op, and the `getitem_foldable`
-    /// oopspec is a tracing-time hint the codewriter applies — exactly as
-    /// `rtype_len` lowers both `ll_len` / `ll_len_foldable` to `getarraysize`.
+    /// `StopIteration`) lowers to [`build_ll_listnext_helper_graph`], whose
+    /// element read is a plain `getarrayitem` (non-pure). The
+    /// `ll_listnext_foldable` selection (`lltypesystem/rlist.py:462-466`,
+    /// gated on `FixedSizeListRepr AND not listitem.mutated`) routes the read
+    /// through the `list.getitem_foldable` oopspec, which upstream lowers to a
+    /// PURE `getarrayitem` the optimizer can fold/CSE across iterations. pyre
+    /// does NOT yet produce that pure list load — the list-getitem oopspec
+    /// lowering hardcodes `pure: false` and there is no `ArraylenGcPure` /
+    /// pure-getarrayitem on the list path — so the foldable optimization is
+    /// uniformly absent for BOTH `ll_len_foldable` (a non-pure `ArraylenGc`)
+    /// and iteration. Restoring it is a cross-cutting codewriter feature, not
+    /// a `listitem.mutated`-threading slice; see the `list_is_fixed` field doc.
     /// The upstream result `recast` (`rlist.py:449` `self.r_list.recast`,
     /// `rlist.py:67`) converts the `ll_listnext` result back to
     /// `external_item_repr` via [`list_recast`] — identity for primitive

--- a/pyre/bench/synth/list_append_funcentry_helper.py
+++ b/pyre/bench/synth/list_append_funcentry_helper.py
@@ -1,0 +1,33 @@
+# #171/#34: the orthodox list.append fold fires in function-entry (no-loop)
+# helper traces, not only loop traces.  `push` is a no-loop helper called in a
+# hot loop on two alternating receivers, so it traces from entry (header_pc==0)
+# and its spare-capacity guard resume must reconstruct the alternating receiver
+# correctly across the many realloc deopts — a wrong receiver box would route an
+# append into the other list and corrupt the cross-checked sums below.
+N = 200000
+
+
+def push(a, v):
+    a.append(v)
+
+
+def main():
+    xs = []
+    ys = []
+    i = 0
+    while i < N:
+        push(xs, i)
+        push(ys, -i)
+        i = i + 1
+    ok = (
+        len(xs) == N
+        and len(ys) == N
+        and xs[0] == 0
+        and ys[1] == -1
+        and xs[N - 1] == N - 1
+        and ys[N // 2] == -(N // 2)
+    )
+    print(sum(xs) + sum(ys), len(xs) + len(ys), ok)
+
+
+main()

--- a/pyre/bench/synth/pure_listload_raw.py
+++ b/pyre/bench/synth/pure_listload_raw.py
@@ -1,0 +1,22 @@
+# #171/#11 Approach C read-after-write miscompile guard: LISTS stay NON-pure.
+#
+# If a list element load were ever folded to GetarrayitemGcPure{R,I,F}, OptPure
+# would CSE the `b = lst[0]` read against the earlier `a = lst[0]` read across
+# the intervening `lst[0] = a + 1` write (mutable list body), so `b - a` would
+# collapse to 0 and the sum would print 0. Lists are mutable, so their element
+# loads MUST remain non-pure (heap-cache invalidated on SetarrayitemGc) and this
+# MUST print 1000.
+
+
+def main():
+    lst = [0]
+    s = 0
+    for _ in range(1000):
+        a = lst[0]
+        lst[0] = a + 1
+        b = lst[0]
+        s += b - a
+    print(s)
+
+
+main()

--- a/pyre/bench/synth/pure_tupleload.py
+++ b/pyre/bench/synth/pure_tupleload.py
@@ -1,0 +1,29 @@
+# #171/#11 Approach C, SUBSCRIPT slice: canonical-tuple `t[i]` emits a PURE
+# getarrayitem in the JIT walker (OptPure CSEs / const-folds the element load).
+#
+# Case A exercises the canonical array-backed `W_TupleObject` (arity > 2) on the
+# hot path — the pure element load is the point of this slice.
+#
+# Case B reads a 2-element literal tuple in a loop. A 2-int literal tuple may be
+# stored as SPECIALISED_TUPLE_II (inline value0/value1, NO wrappeditems block);
+# the trace-time `ob_type == &TUPLE_TYPE` gate declines it to the non-pure /
+# residual path. It MUST NOT SIGSEGV and MUST stay correct.
+
+
+def main():
+    # Case A: canonical array-backed tuple (arity 5 > 2).
+    t = (10, 20, 30, 40, 50)
+    s = 0
+    for _ in range(200000):
+        s += t[0] + t[1] + t[2] + t[3] + t[4]
+    print(s)
+
+    # Case B: 2-element tuple (specialised-tuple path must be safe + correct).
+    t2 = (1, 2)
+    s2 = 0
+    for _ in range(200000):
+        s2 += t2[0] + t2[1]
+    print(s2)
+
+
+main()

--- a/pyre/bench/synth/seqiter_getitem_lazy.py
+++ b/pyre/bench/synth/seqiter_getitem_lazy.py
@@ -1,0 +1,42 @@
+# #171/PR248 §3a: generic sequence-protocol iteration must be LAZY.
+# An object with `__getitem__` but no `__iter__` iterates through a sequence
+# cursor (iterobject.py W_SeqIterObject.descr_next: `space.getitem` per step,
+# ending on IndexError), NOT by materialising the whole sequence up front.
+# Two properties a materialising path gets wrong:
+#   * `__len__` must NOT bound the walk -- the cursor advances until
+#     `__getitem__` raises IndexError, even when `__len__` under-reports.
+#   * items are fetched one-at-a-time as the loop body runs, so a side effect
+#     in `__getitem__` interleaves with the body instead of running in a batch.
+# A WHILE loop drives a hot FOR_ITER over the cursor so the trace compiles.
+
+
+class Seq:
+    def __len__(self):
+        # Under-reports the real length; a `__len__`-bounded walk would stop
+        # after one item, a lazy walk runs to the IndexError at index 5.
+        return 1
+
+    def __getitem__(self, i):
+        if i >= 5:
+            raise IndexError
+        return i
+
+
+def main():
+    total = 0
+    order = 0
+    n = 0
+    while n < 20000:
+        step = 0
+        for x in Seq():
+            # Fold the visit order in so a batch-then-iterate path (which would
+            # run every __getitem__ before the first body) diverges.
+            total += x
+            order += (step + 1) * x
+            step += 1
+        n += 1
+    return total, order
+
+
+t, o = main()
+print(t, o)

--- a/pyre/bench/synth/subscr_negative_index_deopt.py
+++ b/pyre/bench/synth/subscr_negative_index_deopt.py
@@ -1,0 +1,27 @@
+# #171/#11 negative-index regression: a canonical-tuple / list subscript that
+# the JIT specializes on a NON-NEGATIVE observed index must DEOPT (the
+# lower-bound guard `0 <= idx`) when a later NEGATIVE index flows through the
+# compiled trace, instead of reading the backing array out of range.  Python
+# negative indexing (`seq[-1] == seq[len - 1]`) must hold across the
+# specialize -> deopt edge.  A WHILE loop is used so the loop actually traces
+# (a `for ... in range()` loop is declined to a single frame).
+
+
+def main():
+    t = (10, 20, 30, 40, 50)
+    lst = [11, 22, 33, 44, 55]
+    s = 0
+    k = 0
+    n = 0
+    while n < 8000:
+        # Subscript first, on the loop-carried index `k`.  The first half runs
+        # with k = 0 (specializes the subscript on a non-negative index); after
+        # the flip, k = -1 must deopt to Python negative indexing, not OOB-read.
+        s += t[k] + lst[k]
+        n += 1
+        if n == 4000:
+            k = -1
+    print(s)
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8894,48 +8894,15 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                 && (lookup_in_type_where(w_type, "__getitem__").is_some()
                     || getattr_str(obj, "__getitem__").is_ok())
             {
-                // Try to use __len__ to bound the iteration.
-                let mut items = Vec::new();
-                if let Ok(len_result) = len(obj) {
-                    if is_int(len_result) {
-                        let n = w_int_get_value(len_result);
-                        for i in 0..n {
-                            match getitem(obj, w_int_new(i)) {
-                                Ok(item) => items.push(item),
-                                Err(e)
-                                    if e.kind == crate::PyErrorKind::IndexError
-                                        || e.kind == crate::PyErrorKind::StopIteration =>
-                                {
-                                    break;
-                                }
-                                Err(e) => return Err(e),
-                            }
-                        }
-                        let count = items.len();
-                        let list = w_list_new(items);
-                        return Ok(pyre_object::w_seq_iter_new(list, count));
-                    }
-                }
-                // No __len__: probe up to a reasonable bound.
-                // `W_SeqIterObject.descr_next` (iterobject.py) ends the
-                // iteration only on IndexError; `iter_iternext`
-                // (iterobject.c) also treats StopIteration as the end.
-                // Any other `__getitem__` error propagates.
-                for i in 0..1_000_000i64 {
-                    match getitem(obj, w_int_new(i)) {
-                        Ok(item) => items.push(item),
-                        Err(e)
-                            if e.kind == crate::PyErrorKind::IndexError
-                                || e.kind == crate::PyErrorKind::StopIteration =>
-                        {
-                            break;
-                        }
-                        Err(e) => return Err(e),
-                    }
-                }
-                let count = items.len();
-                let list = w_list_new(items);
-                return Ok(pyre_object::w_seq_iter_new(list, count));
+                // descroperation.py:334 — `space.newseqiter(w_obj)` wraps the
+                // live object in an index cursor (iterobject.py
+                // W_SeqIterObject) that fetches each item lazily through
+                // `space.getitem` in `next` and ends on IndexError.  The
+                // sequence is not materialised and `__len__` does not bound
+                // the walk: the cursor advances until `__getitem__` raises
+                // IndexError, so an unbounded `__getitem__` iterates forever
+                // exactly as the builtin sequence iterator does.
+                return Ok(pyre_object::w_seq_iter_new(obj, 0));
             }
         }
         // Type object: check metaclass __iter__ (NOT the type's own MRO)
@@ -8980,6 +8947,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         if is_seq_iter(obj) {
             let iter = &mut *(obj as *mut pyre_object::W_SeqIterObject);
             let seq = iter.seq;
+            // iterobject.py W_SeqIterObject.descr_next — a None (null) seq
+            // marks an iterator already exhausted by an earlier IndexError.
+            if seq.is_null() {
+                return Err(PyError::stop_iteration());
+            }
             let idx = iter.index;
             let item = if is_list(seq) {
                 pyre_object::w_list_getitem(seq, idx)
@@ -9012,7 +8984,22 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     None
                 }
             } else {
-                None
+                // Generic sequence-protocol object: fetch lazily through
+                // `space.getitem` (iterobject.py descr_next).  IndexError /
+                // StopIteration ends the walk and clears w_seq so a later
+                // next() short-circuits without re-invoking __getitem__; any
+                // other error propagates.
+                match getitem(seq, w_int_new(idx)) {
+                    Ok(v) => Some(v),
+                    Err(e)
+                        if e.kind == crate::PyErrorKind::IndexError
+                            || e.kind == crate::PyErrorKind::StopIteration =>
+                    {
+                        iter.seq = std::ptr::null_mut();
+                        None
+                    }
+                    Err(e) => return Err(e),
+                }
             };
             if let Some(v) = item {
                 iter.index += 1;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8985,10 +8985,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 }
             } else {
                 // Generic sequence-protocol object: fetch lazily through
-                // `space.getitem` (iterobject.py descr_next).  IndexError /
-                // StopIteration ends the walk and clears w_seq so a later
-                // next() short-circuits without re-invoking __getitem__; any
-                // other error propagates.
+                // `space.getitem`.  The sequence iterator's `iter_iternext`
+                // treats IndexError or StopIteration as exhaustion (clearing
+                // w_seq so a later next() short-circuits without re-invoking
+                // __getitem__) and propagates every other error with w_seq
+                // left intact.
                 match getitem(seq, w_int_new(idx)) {
                     Ok(v) => Some(v),
                     Err(e)

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1318,14 +1318,35 @@ pub extern "C" fn jit_range_iter_next_or_null(iter: i64) -> i64 {
     }
 }
 
+/// A sequence iterator whose payload is not one of the inline fast types
+/// (list/tuple/str/array, see `seq_iter_current_len`) is a generic
+/// sequence-protocol iterator: `next` fetches each item through
+/// `space.getitem` (iterobject.py W_SeqIterObject.descr_next), so it is
+/// driven by `baseobjspace::next` rather than the inline range helper.  An
+/// exhausted cursor (null seq) routes here too so the trailing StopIteration
+/// is raised by `next`.
+///
+/// # Safety
+/// `iter` must be a valid object pointer.
+unsafe fn is_generic_seq_iter(iter: PyObjectRef) -> bool {
+    unsafe {
+        is_seq_iter(iter) && {
+            let seq = (*(iter as *const W_SeqIterObject)).seq;
+            seq.is_null() || seq_iter_current_len(seq).is_none()
+        }
+    }
+}
+
 /// FOR_ITER iterator kinds that advance through `space.next` rather than
-/// the inline range helper: generators, itertools/enumerate/reversed/
-/// filter/map/zip/dictview/sre, callable iterators, and user `__next__`
-/// instances. Shared so the interpreter `iter_next` and the tracer agree
-/// on which iterators take the `space.next` leg.
+/// the inline range helper: generic sequence-protocol iterators, generators,
+/// itertools/enumerate/reversed/filter/map/zip/dictview/sre, callable
+/// iterators, and user `__next__` instances. Shared so the interpreter
+/// `iter_next` and the tracer agree on which iterators take the `space.next`
+/// leg.
 pub fn via_space_next(iter: PyObjectRef) -> bool {
     unsafe {
-        is_instance(iter)
+        is_generic_seq_iter(iter)
+            || is_instance(iter)
             || pyre_object::generator::is_generator(iter)
             || pyre_object::interp_itertools::is_repeat(iter)
             || pyre_object::interp_itertools::is_count(iter)

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -14,6 +14,8 @@ const CODEGEN_OUTPUTS: &[&str] = &[
     "opcode_insns.bin",
     "opcode_descrs.bin",
     "opcode_fnaddr_bindings.bin",
+    "static_pytype_bindings.bin",
+    "static_ref_bindings.bin",
 ];
 
 /// Build script for pyre-jit: runs majit-translate on the active pyre

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13114,15 +13114,24 @@ fn try_walker_specialize_subscr(
     ctx.trace_ctx
         .set_opref_concrete(raw_index, majit_ir::Value::Int(index));
 
-    // Bounds guard (non-negative index path): IntLt(raw_index, len).
-    // Object storage keeps the inline `length` field (rlist.py:116); int/float
-    // storage read the typed items-array length field.
+    // Two-sided bounds guard `0 <= raw_index < len`.  Object storage keeps the
+    // inline `length` field (rlist.py:116); int/float storage read the typed
+    // items-array length field.  The trace is recorded from a non-negative
+    // observed index, but a later NEGATIVE index would still satisfy
+    // `raw_index < len` and reach the element load out of range; `space.getitem`
+    // treats a negative index as `index + len` (listobject.py), so the
+    // lower-bound guard deopts to re-execute that remap generically.
     let len_descr = match sid {
         0 => crate::descr::list_length_descr(),
         1 => crate::descr::list_int_items_len_descr(),
         _ => crate::descr::list_float_items_len_descr(),
     };
     let lenbox = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr);
+    let zero = ctx.trace_ctx.const_int(0);
+    let nonneg = ctx.trace_ctx.record_op(OpCode::IntGe, &[raw_index, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(nonneg, majit_ir::Value::Int((index >= 0) as i64));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[nonneg])?;
     let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
     ctx.trace_ctx.set_opref_concrete(
         in_bounds,
@@ -13267,6 +13276,17 @@ fn try_walker_specialize_subscr_tuple(
         items_block,
         crate::state::pyobject_gcarray_descr(),
     );
+    // Two-sided bounds guard `0 <= raw_index < len`.  The trace is recorded
+    // from a non-negative observed index, but a later NEGATIVE index would
+    // still satisfy `raw_index < len` and reach the PURE element load out of
+    // range.  `space.getitem` treats a negative index as `index + len`
+    // (tupleobject.py:468); the lower-bound guard deopts so that remap
+    // re-executes generically instead of reading before the array.
+    let zero = ctx.trace_ctx.const_int(0);
+    let nonneg = ctx.trace_ctx.record_op(OpCode::IntGe, &[raw_index, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(nonneg, majit_ir::Value::Int((index >= 0) as i64));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[nonneg])?;
     let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
     ctx.trace_ctx.set_opref_concrete(
         in_bounds,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13030,6 +13030,23 @@ fn try_walker_specialize_subscr(
         return Ok(None);
     };
 
+    // #171/#11 Approach C: canonical array-backed `W_TupleObject[i]`.  A
+    // canonical tuple is gated on `ob_type == &TUPLE_TYPE` (tupleobject.py
+    // / tupleobject.rs:222) — NOT `is_tuple()` (which accepts the three
+    // SPECIALISED_TUPLE_{II,FF,OO} variants) and NOT a `w_class` compare
+    // (specialised tuples carry the canonical tuple `w_class`).  Specialised
+    // tuples store `value0`/`value1` inline with no `wrappeditems` block, so
+    // a `getfield(wrappeditems)` on one yields garbage — they MUST fall to
+    // the generic residual.  The runtime `guard_class(&TUPLE_TYPE)` deopts
+    // any later non-canonical tuple flowing in.
+    let tuple_canonical =
+        unsafe { std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::TUPLE_TYPE) };
+    if tuple_canonical {
+        return try_walker_specialize_subscr_tuple(
+            ctx, op_pc, list_op, key_op, list_obj, key_obj, allboxes, call_descr, dst, dst_bank,
+        );
+    }
+
     // Gate: list[int], non-negative index in bounds, int- or float-storage.
     // A bool index (`is_int` accepts `W_BoolObject`) is fine: bool shares
     // int's `intval`, so it unboxes through its own &BOOL_TYPE guard below.
@@ -13155,6 +13172,112 @@ fn try_walker_specialize_subscr(
             crate::state::wrapfloat(ctx.trace_ctx, raw)
         }
     };
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// #171/#11 Approach C, SUBSCRIPT slice: walker-native PURE element load
+/// for a canonical array-backed `W_TupleObject[i]` (the tuple analogue of
+/// the object-storage list arm of [`try_walker_specialize_subscr`]).
+///
+/// Recognition (caller already verified `ob_type == &TUPLE_TYPE`): a
+/// non-negative int (or bool, which shares `intval`) index in bounds.
+/// Specialised tuples never reach here — the caller gates them out — so
+/// reading `wrappeditems` is always sound.
+///
+/// IR shape: `guard_class(&TUPLE_TYPE)` → `getfield(wrappeditems)` →
+/// `arraylen_gc(wrappeditems)` for the bounds length → `IntLt` +
+/// `GuardTrue` (NON-pure, so an out-of-range deopt still fires) →
+/// `getarrayitem_gc_pure_r(wrappeditems, idx)` (the ONLY pure op; the
+/// body is immutable per `_immutable_fields_ = ['wrappeditems[*]']`).
+/// Object storage → the element is a boxed Ref read directly (no
+/// unbox/rebox).  The authentic boxed result is taken from the same
+/// `execute_may_force` path the generic leg uses.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_subscr_tuple(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    list_op: OpRef,
+    key_op: OpRef,
+    tuple_obj: pyre_object::PyObjectRef,
+    key_obj: pyre_object::PyObjectRef,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    // Gate: non-negative int index in bounds.  `w_tuple_len` reads the
+    // GcArray header of `wrappeditems` (no inline length field).
+    let (index, concrete_len) = unsafe {
+        if !pyre_object::is_int(key_obj) {
+            return Ok(None);
+        }
+        let index = pyre_object::w_int_get_value(key_obj);
+        if index < 0 {
+            return Ok(None);
+        }
+        let concrete_len = pyre_object::w_tuple_len(tuple_obj);
+        if index as usize >= concrete_len {
+            return Ok(None);
+        }
+        (index, concrete_len)
+    };
+
+    // Authentic boxed result from the same may-force path the generic leg uses.
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+
+    // --- emit the specialized IR (walker-native) ---
+    // guard_class TUPLE (skip when class already known / operand is constant).
+    let tuple_type_addr = &pyre_object::pyobject::TUPLE_TYPE as *const _ as i64;
+    if !list_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(list_op) {
+        let type_const = ctx.trace_ctx.const_int(tuple_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[list_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(list_op, tuple_type_addr);
+
+    // Unbox the index operand (guard_class + getfield intval).  bool shares
+    // int's `intval`, so a bool index guards its own &BOOL_TYPE.
+    let (idx_type, idx_descr) = crate::state::int_or_bool_unbox_type_descr(key_obj);
+    let raw_index = walker_unbox_int_typed(ctx, op_pc, key_op, idx_type, idx_descr)?;
+    ctx.trace_ctx
+        .set_opref_concrete(raw_index, majit_ir::Value::Int(index));
+
+    // getfield(wrappeditems): Ptr(GcArray(OBJECTPTR)) body.
+    let items_block = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        list_op,
+        crate::descr::tuple_wrappeditems_descr(),
+    );
+
+    // Bounds length: arraylen_gc against the wrappeditems GcArray header
+    // (no inline length cache).  NON-pure (G2): an out-of-range index must
+    // still deopt.
+    let lenbox = crate::state::opimpl_arraylen_gc(
+        ctx.trace_ctx,
+        items_block,
+        crate::state::pyobject_gcarray_descr(),
+    );
+    let in_bounds = ctx.trace_ctx.record_op(OpCode::IntLt, &[raw_index, lenbox]);
+    ctx.trace_ctx.set_opref_concrete(
+        in_bounds,
+        majit_ir::Value::Int(((index as usize) < concrete_len) as i64),
+    );
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[in_bounds])?;
+
+    // PURE element load.  Object storage reads the boxed Ref directly from
+    // the immutable `Ptr(GcArray(OBJECTPTR))` body (no unbox/rebox).
+    let boxed =
+        crate::state::trace_items_block_getitem_value_pure(ctx.trace_ctx, items_block, raw_index);
     ctx.trace_ctx.set_opref_concrete(
         boxed,
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13226,6 +13226,16 @@ fn try_walker_orthodox_list_append(
         if pyre_interpreter::lookup_in_type(list_type, "append") != Some(inner_func) {
             return Ok(None);
         }
+        // `is_plain_int1` accepts a fits-int `W_LongObject` (it implies
+        // `_fits_int()`), but a long is declined here: the commit path pins
+        // `guard_class(value, INT_TYPE)` and a long has `ob_type == LONG_TYPE`,
+        // so supporting it needs the trait-path `unbox_long` machinery
+        // (guard_class LONG_TYPE + `_fits_int` residual guard + long
+        // extraction) threaded through the sub-walk (PR248 §2). Empirically a
+        // fits-int `W_LongObject` does not reach this append: pyre normalizes
+        // fits-int results to `W_IntObject` across arithmetic / `int(str)` /
+        // literals, so the long arm is an unreachable optimization and the
+        // decline is correctness-safe (the generic residual handles it).
         if !pyre_object::pyobject::is_list(inner_self)
             || !pyre_object::w_list_uses_int_storage(inner_self)
             || !pyre_object::is_plain_int1(value)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10925,24 +10925,26 @@ fn dispatch_residual_call_iRd_kind(
     // An inlined append falls back to the generic residual, which resumes
     // *past* the call (after_residual_call) and so re-runs nothing extra.
     //
-    // Also restrict to loop traces (`header_pc != 0`): in a function-entry
-    // trace (a no-loop helper compiled from entry, e.g. `def push(a, v):
-    // a.append(v)` called in a hot loop) the spare-capacity guard's
-    // blackhole resume reconstructs the re-executed append's receiver from a
-    // wrong box and re-runs `LOAD_METHOD` on a garbage pointer — the
-    // function-entry exit-layout numbering does not preserve the receiver
-    // local across the fold's mid-statement guards.  Loop traces resume
-    // through the loop-header pc_map coordinate and reconstruct it correctly
-    // (a no-loop helper's append falls back to the generic residual).
+    // Both loop and function-entry (no-loop) traces are eligible.  A
+    // no-loop helper compiled from entry (e.g. `def push(a, v): a.append(v)`
+    // called in a hot loop) traces with `header_pc == 0`; its spare-capacity
+    // guard's resume reconstructs the receiver from the call-site coordinate
+    // published below (`collect_outer_active_boxes` at the CALL py_pc), which
+    // preserves the receiver local across the fold's mid-statement guards in
+    // both trace kinds.  The earlier loop-only restriction was a carryover
+    // from the retired hand-rolled fold (#227), whose function-entry exit
+    // layout dropped the receiver; the orthodox descent's resume coordinate
+    // does not, verified by a two-list alternating-receiver append stress
+    // (any wrong receiver box corrupts the cross-checked lists) and the
+    // parity suite folding function-entry helper appends on both backends.
     // #171 ORTHODOX descent (default ON — `PYRE_171_ORTHODOX=0` opts out):
     // descend the real `w_list_append` body, recording its array ops native.
     // A decline (`None`) falls through to the generic residual below; an
     // un-lowered in-body helper aborts the trace (graceful interpreter
-    // fallback).  Gated to loop full-body frames, not inside a sub-walk.
+    // fallback).  Gated to top full-body frames, not inside a sub-walk.
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
-        && ctx.trace_ctx.header_pc != 0
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && pyre_171_orthodox_enabled()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1877,6 +1877,31 @@ fn read_ref_var_list_concrete(
         .collect()
 }
 
+/// Read concrete shadow values for an Int-bank variadic operand list.
+/// Int twin of [`read_ref_var_list_concrete`] — same byte indices,
+/// resolved through `ctx.concrete_registers_i`.  Used by `inline_call_*`
+/// to propagate each int arg's concrete shadow into the callee's fresh
+/// shadow Vec (`setup_call` int-bank parity), so a callee body can fold
+/// a `goto_if_not/iL` / `switch/id` over a concrete primitive-int arg.
+fn read_int_var_list_concrete(
+    code: &[u8],
+    op: &DecodedOp,
+    operand_offset: usize,
+    ctx: &WalkContext<'_, '_>,
+) -> Vec<ConcreteValue> {
+    let len_pc = op.pc + 1 + operand_offset;
+    let len = code[len_pc] as usize;
+    (0..len)
+        .map(|i| {
+            let reg = code[len_pc + 1 + i] as usize;
+            ctx.concrete_registers_i
+                .get(reg)
+                .copied()
+                .unwrap_or(ConcreteValue::Null)
+        })
+        .collect()
+}
+
 /// Read an Int-bank variadic operand list (`I` argcode). Same shape as
 /// [`read_ref_var_list`] but indexes into `registers_i`. RPython
 /// `assembler.py:write_varlist` emits a single shape regardless of
@@ -13404,6 +13429,7 @@ fn try_walker_orthodox_list_append(
             op.pc,
             &sub_body,
             &[],
+            &[],
             &[self_ref, value_op],
             &[self_concrete, value_concrete],
             &[],
@@ -15042,6 +15068,7 @@ fn run_sub_jitcode_walk(
     pc: usize,
     sub_body: &SubJitCodeBody,
     int_args: &[OpRef],
+    int_arg_concretes: &[ConcreteValue],
     ref_args: &[OpRef],
     ref_arg_concretes: &[ConcreteValue],
     float_args: &[OpRef],
@@ -15083,6 +15110,15 @@ fn run_sub_jitcode_walk(
     }
     for (i, arg) in float_args.iter().enumerate() {
         callee_regs_f[i] = *arg;
+    }
+    // Seed the callee's concrete shadows from the caller's per-arg
+    // shadows (`setup_call` parity for the Int + Ref banks; the Float
+    // bank has no concrete shadow companion).  A callee body folds a
+    // `goto_if_not/iL` / `switch/id` over a concrete int arg, or a
+    // `guard_class` over a concrete ref arg, only when its shadow is
+    // seeded here.
+    for (i, concrete) in int_arg_concretes.iter().enumerate() {
+        callee_concrete_i[i] = *concrete;
     }
     for (i, concrete) in ref_arg_concretes.iter().enumerate() {
         callee_concrete_r[i] = *concrete;
@@ -15168,7 +15204,7 @@ fn dispatch_inline_call_dr_kind(
     let arg_concretes = read_ref_var_list_concrete(code, op, 2, ctx);
 
     let callee_outcome =
-        run_sub_jitcode_walk(ctx, op.pc, &sub_body, &[], &args, &arg_concretes, &[])?;
+        run_sub_jitcode_walk(ctx, op.pc, &sub_body, &[], &[], &args, &arg_concretes, &[])?;
 
     match callee_outcome {
         DispatchOutcome::SubReturn {
@@ -15310,6 +15346,7 @@ fn dispatch_inline_call_dir_kind(
         })?;
     // I-list at offset 2 (skip descr).
     let (int_args, int_width) = read_int_var_list(code, op, 2, ctx)?;
+    let int_arg_concretes = read_int_var_list_concrete(code, op, 2, ctx);
     // R-list immediately after the I-list.
     let (ref_args, ref_width) = read_ref_var_list(code, op, 2 + int_width, ctx)?;
     let ref_arg_concretes = read_ref_var_list_concrete(code, op, 2 + int_width, ctx);
@@ -15319,6 +15356,7 @@ fn dispatch_inline_call_dir_kind(
         op.pc,
         &sub_body,
         &int_args,
+        &int_arg_concretes,
         &ref_args,
         &ref_arg_concretes,
         &[],
@@ -15449,6 +15487,7 @@ fn dispatch_inline_call_dirf_kind(
             jitcode_index: sub_index,
         })?;
     let (int_args, int_width) = read_int_var_list(code, op, 2, ctx)?;
+    let int_arg_concretes = read_int_var_list_concrete(code, op, 2, ctx);
     let (ref_args, ref_width) = read_ref_var_list(code, op, 2 + int_width, ctx)?;
     let ref_arg_concretes = read_ref_var_list_concrete(code, op, 2 + int_width, ctx);
     let (float_args, float_width) = read_float_var_list(code, op, 2 + int_width + ref_width, ctx)?;
@@ -15458,6 +15497,7 @@ fn dispatch_inline_call_dirf_kind(
         op.pc,
         &sub_body,
         &int_args,
+        &int_arg_concretes,
         &ref_args,
         &ref_arg_concretes,
         &float_args,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3314,6 +3314,11 @@ pub(crate) fn trace_items_block_getitem_value(
 /// non-invalidatable). `OptPure` CSEs / const-folds the pure op and
 /// never invalidates it on an intervening write, which is sound here
 /// because the tuple body is immutable.
+///
+/// Recording the pure op directly is the walker-native analogue of the
+/// codewriter, which reaches `getarrayitem_gc_*_pure` through the
+/// oopspec lowering of an immutable/foldable read (`jtransform.py:1891`);
+/// the opcode-level effect is identical.
 pub(crate) fn trace_items_block_getitem_value_pure(
     ctx: &mut TraceCtx,
     block: OpRef,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3302,6 +3302,33 @@ pub(crate) fn trace_items_block_getitem_value(
     result
 }
 
+/// Pure variant of [`trace_items_block_getitem_value`] — emits
+/// `getarrayitem_gc_pure_r(block, index)` against the SAME
+/// `pyobject_gcarray_descr` (`Ptr(GcArray(OBJECTPTR))`) for an
+/// IMMUTABLE backing array (`W_TupleObject.wrappeditems`,
+/// `tupleobject.py:381` `_immutable_fields_ = ['wrappeditems[*]']`).
+///
+/// Purity is carried ONLY by selecting `GetarrayitemGcPureR`; the descr
+/// is the unchanged shared singleton (the items/gcarray descr must NOT
+/// be marked pure — that would make every container of this strategy
+/// non-invalidatable). `OptPure` CSEs / const-folds the pure op and
+/// never invalidates it on an intervening write, which is sound here
+/// because the tuple body is immutable.
+pub(crate) fn trace_items_block_getitem_value_pure(
+    ctx: &mut TraceCtx,
+    block: OpRef,
+    index: OpRef,
+) -> OpRef {
+    let descr = pyobject_gcarray_descr();
+    let result =
+        ctx.record_op_with_descr(OpCode::GetarrayitemGcPureR, &[block, index], descr.clone());
+    let live_value = array_load_for_cache(ctx, block, index, &descr, majit_ir::Type::Ref);
+    if !matches!(live_value, majit_ir::Value::Void) {
+        ctx.set_opref_concrete(result, live_value);
+    }
+    result
+}
+
 /// Companion of [`trace_items_block_getitem_value`] — emits
 /// `setarrayitem_gc(block, index, value)` against `pyobject_gcarray_descr`.
 pub(crate) fn trace_items_block_setitem_value(


### PR DESCRIPTION
#171

## Summary

#171 list-oopspec JIT follow-ups, closed with a Codex parity review.

- **#171 orthodox list-append fold (function-entry):** the `w_list_append`
  orthodox descent now fires in function-entry (no-loop) helper traces, and
  `run_sub_jitcode_walk` seeds the callee int/ref concrete shadows
  (`setup_call` parity) so the inlined body folds its strategy `switch` and
  type guards over the concrete receiver.
- **#11 pure tuple subscript (Approach C):** a canonical array-backed
  `W_TupleObject[i]` emits a PURE `getarrayitem_gc_pure_r` (the immutable
  `wrappeditems` body; `OptPure` CSEs / const-folds it), gated on
  `ob_type == &TUPLE_TYPE` so the inline `SPECIALISED_TUPLE_*` variants fall to
  the residual. Both the new tuple path and the pre-existing list subscript
  path now carry a lower-bound `0 <= idx` guard so a runtime negative index
  deopts instead of reading the backing array out of range.
- **build:** `static_{pytype,ref}_bindings.bin` added to `CODEGEN_OUTPUTS`.

## Self-review

Local `gpt-5.5` parity review (`git diff upstream/main`) dispositions:

- §1 (parity regressions): none.
- §2 (tuple subscript missing lower-bound guard): fixed in-session.
- §3a (list subscript, same one-sided guard, pre-existing): fixed in-session
  (same fix class, adjacent code, latent OOB this patch reaches).
- §3b (rtyper `ll_listnext_foldable` selection for `FixedSizeListRepr`):
  deferred — tracked follow-up.
- §4 (structural adaptations: direct pure-op record, `setup_call` shadow copy,
  build→runtime address relocation): documented in-code.

`pyre/check.py`: dynasm 148/148 + cranelift 148/148.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
