### PR TITLE
jit: specialize W_LongObject binary ops, comparison, shift and true-divide in the trace

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2962,6 +2962,69 @@ impl TraceCtx {
             effect_info.check_is_elidable() && !effect_info.check_can_raise(false),
             "call_typed_with_effect_pure requires EF_ELIDABLE_CANNOT_RAISE"
         );
+        self.record_elidable_pure_call(
+            opcode,
+            func_ptr,
+            args,
+            arg_types,
+            ret_type,
+            effect_info,
+            concrete_arg_values,
+            concrete_result,
+        )
+    }
+
+    /// Elidable-can-raise (`EF_ELIDABLE_CAN_RAISE`) counterpart of
+    /// [`call_typed_with_effect_pure`]: records the `Call{I,R,F,N}` and patches
+    /// it to `CallPure*` via [`record_result_of_call_pure`] (same pure-folding
+    /// path), but the callee may raise, so the **caller must emit a trailing
+    /// `GuardNoException`** (`pyjitpl.py:2082 handle_possible_exception`,
+    /// `do_residual_call`'s `elif cr:` branch). Used for the long division
+    /// payload helpers (`rbigint.divmod`, `@jit.elidable`, raises
+    /// ZeroDivisionError) — `longobject.py:409/426`.
+    pub fn call_typed_with_effect_pure_can_raise(
+        &mut self,
+        opcode: OpCode,
+        func_ptr: *const (),
+        args: &[OpRef],
+        arg_types: &[Type],
+        ret_type: Type,
+        effect_info: majit_ir::EffectInfo,
+        concrete_arg_values: &[Value],
+        concrete_result: Value,
+    ) -> OpRef {
+        debug_assert!(
+            effect_info.check_is_elidable() && effect_info.check_can_raise(false),
+            "call_typed_with_effect_pure_can_raise requires EF_ELIDABLE_CAN_RAISE"
+        );
+        self.record_elidable_pure_call(
+            opcode,
+            func_ptr,
+            args,
+            arg_types,
+            ret_type,
+            effect_info,
+            concrete_arg_values,
+            concrete_result,
+        )
+    }
+
+    /// Shared body for [`call_typed_with_effect_pure`] /
+    /// [`call_typed_with_effect_pure_can_raise`]: record the call and patch it
+    /// to `CallPure*` via `record_result_of_call_pure`. Does NOT emit
+    /// `GuardNoException`; can-raise callers add it.
+    #[allow(clippy::too_many_arguments)]
+    fn record_elidable_pure_call(
+        &mut self,
+        opcode: OpCode,
+        func_ptr: *const (),
+        args: &[OpRef],
+        arg_types: &[Type],
+        ret_type: Type,
+        effect_info: majit_ir::EffectInfo,
+        concrete_arg_values: &[Value],
+        concrete_result: Value,
+    ) -> OpRef {
         let func_ref = OpRef::const_int(func_ptr as usize as i64);
         let descr =
             crate::call_descr::make_call_descr_with_effect(arg_types, ret_type, effect_info);

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -321,6 +321,47 @@ unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     Ok(bigint_result(as_bigint(a).mod_floor(&vb)))
 }
 
+/// `rbigint.floordiv` payload half (`longobject.py:409 _floordiv` →
+/// `rbigint.floordiv` → `divmod`, `rbigint.py:1001 @jit.elidable`). Elidable
+/// but CAN raise ZeroDivisionError on a zero divisor → `EF_ELIDABLE_CAN_RAISE`:
+/// the trace records `CALL_PURE` + `GUARD_NO_EXCEPTION`. Returns a bare
+/// `*mut BigInt` (Int) on success; on a zero divisor publishes the exception
+/// and returns 0 so the trailing `GUARD_NO_EXCEPTION` deopts.
+#[majit_macros::elidable]
+pub extern "C" fn jit_w_long_floordiv_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        let vb = w_long_get_value(b);
+        if vb.sign() == malachite_bigint::Sign::NoSign {
+            crate::runtime_ops::jit_publish_exception(
+                PyError::zero_division("integer division or modulo by zero").to_exc_object(),
+            );
+            return 0;
+        }
+        pyre_object::lltype::malloc_raw(w_long_get_value(a).div_floor(vb)) as i64
+    }
+}
+
+/// `rbigint.mod` payload half (`longobject.py:426 _mod` → `rbigint.mod` →
+/// `divmod`). Same `EF_ELIDABLE_CAN_RAISE` contract as
+/// [`jit_w_long_floordiv_raw`].
+#[majit_macros::elidable]
+pub extern "C" fn jit_w_long_mod_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        let vb = w_long_get_value(b);
+        if vb.sign() == malachite_bigint::Sign::NoSign {
+            crate::runtime_ops::jit_publish_exception(
+                PyError::zero_division("integer division or modulo by zero").to_exc_object(),
+            );
+            return 0;
+        }
+        pyre_object::lltype::malloc_raw(w_long_get_value(a).mod_floor(vb)) as i64
+    }
+}
+
 // ── Float arithmetic operations ──────────────────────────────────────
 
 /// Coerce an operand to f64. Works for int, long, and float objects.
@@ -3197,6 +3238,22 @@ mod tests {
         unsafe {
             assert!(is_int(result));
             assert_eq!(w_int_get_value(result), i64::MAX);
+        }
+    }
+
+    #[test]
+    fn test_jit_w_long_floordiv_mod_raw() {
+        // Both operands out of i64 range → long // long / long % long fast path
+        // payload helpers return a bare `*mut BigInt` of the quotient/remainder.
+        let x = BigInt::from(i64::MAX) * BigInt::from(1000) + BigInt::from(7);
+        let y = BigInt::from(i64::MAX) + BigInt::from(3);
+        let a = w_long_new(x.clone());
+        let b = w_long_new(y.clone());
+        unsafe {
+            let d = jit_w_long_floordiv_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*d, x.div_floor(&y));
+            let m = jit_w_long_mod_raw(a as i64, b as i64) as *mut BigInt;
+            assert_eq!(*m, x.mod_floor(&y));
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -209,7 +209,7 @@ fn bigint_truediv(a: BigInt, b: BigInt) -> Result<f64, PyError> {
         }
     };
 
-    let exponent = a_bits - b_bits - MANT_DIG + 1 + extra_shift;
+    let exponent = a_bits - b_bits - MANT_DIG + extra_shift;
     let result = (mantissa as f64) * (2.0_f64).powi(exponent as i32);
 
     if result.is_infinite() {
@@ -359,6 +359,92 @@ pub extern "C" fn jit_w_long_mod_raw(a: i64, b: i64) -> i64 {
             return 0;
         }
         pyre_object::lltype::malloc_raw(w_long_get_value(a).mod_floor(vb)) as i64
+    }
+}
+
+/// `rbigint.lshift` payload half (`longobject.py:372-380 _lshift`). Elidable
+/// but CAN raise ValueError (negative shift) / OverflowError (shift too large
+/// and base nonzero) → `EF_ELIDABLE_CAN_RAISE`: `CALL_PURE` + `GUARD_NO_EXCEPTION`.
+/// Returns a bare `*mut BigInt` (Int) on success; on a raising input publishes
+/// the exception and returns 0 so the trailing guard deopts. Walker-only (the
+/// trait path defers shift to the generic residual), so the concrete invocation
+/// only runs after the walker proved the op authentic.
+#[majit_macros::elidable]
+pub extern "C" fn jit_w_long_lshift_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        let vb = w_long_get_value(b);
+        if vb.sign() == malachite_bigint::Sign::Minus {
+            crate::runtime_ops::jit_publish_exception(
+                PyError::value_error("negative shift count").to_exc_object(),
+            );
+            return 0;
+        }
+        let shift = match vb.to_usize() {
+            Some(v) => v,
+            None => {
+                if w_long_get_value(a).sign() == malachite_bigint::Sign::NoSign {
+                    return pyre_object::lltype::malloc_raw(BigInt::from(0)) as i64;
+                }
+                crate::runtime_ops::jit_publish_exception(
+                    PyError::overflow_error("shift count too large").to_exc_object(),
+                );
+                return 0;
+            }
+        };
+        pyre_object::lltype::malloc_raw(bigint_lshift(w_long_get_value(a).clone(), shift)) as i64
+    }
+}
+
+/// `rbigint.rshift` payload half (`longobject.py:390-398 _rshift`). Like
+/// [`jit_w_long_lshift_raw`] but a shift too large yields 0 / -1 (all bits
+/// shifted out) instead of OverflowError; only a negative shift raises.
+#[majit_macros::elidable]
+pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        let vb = w_long_get_value(b);
+        if vb.sign() == malachite_bigint::Sign::Minus {
+            crate::runtime_ops::jit_publish_exception(
+                PyError::value_error("negative shift count").to_exc_object(),
+            );
+            return 0;
+        }
+        let shift = match vb.to_usize() {
+            Some(v) => v,
+            None => {
+                let val = if w_long_get_value(a).sign() == malachite_bigint::Sign::Minus {
+                    -1
+                } else {
+                    0
+                };
+                return pyre_object::lltype::malloc_raw(BigInt::from(val)) as i64;
+            }
+        };
+        pyre_object::lltype::malloc_raw(bigint_rshift(w_long_get_value(a).clone(), shift)) as i64
+    }
+}
+
+/// `rbigint.truediv` payload half (`longobject.py:62-70 _truediv`). Elidable
+/// but CAN raise ZeroDivisionError / OverflowError → `EF_ELIDABLE_CAN_RAISE`:
+/// `CALL_PURE` + `GUARD_NO_EXCEPTION`. Returns the correctly-rounded quotient
+/// as raw f64 bits (carried in the Int register, boxed to `W_FloatObject` by
+/// `jit_w_float_new`); on a raising input publishes the exception and returns 0.
+/// Walker-only, like the shift helpers.
+#[majit_macros::elidable]
+pub extern "C" fn jit_w_long_truediv_raw(a: i64, b: i64) -> i64 {
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        match bigint_truediv(w_long_get_value(a).clone(), w_long_get_value(b).clone()) {
+            Ok(f) => f.to_bits() as i64,
+            Err(e) => {
+                crate::runtime_ops::jit_publish_exception(e.to_exc_object());
+                0
+            }
+        }
     }
 }
 
@@ -3254,6 +3340,38 @@ mod tests {
             assert_eq!(*d, x.div_floor(&y));
             let m = jit_w_long_mod_raw(a as i64, b as i64) as *mut BigInt;
             assert_eq!(*m, x.mod_floor(&y));
+        }
+    }
+
+    #[test]
+    fn test_bigint_truediv_exponent() {
+        // Regression: the exponent assembly carried a spurious `+ 1` that
+        // doubled every quotient (equal operands gave 2.0, not 1.0).
+        let big = BigInt::from(10u64).pow(40);
+        assert_eq!(bigint_truediv(big.clone(), big.clone()).unwrap(), 1.0);
+        let a = BigInt::from(10u64).pow(60);
+        let b = BigInt::from(2) * BigInt::from(10u64).pow(59);
+        assert_eq!(bigint_truediv(a.clone(), b.clone()).unwrap(), 5.0);
+        assert_eq!(bigint_truediv(-a.clone(), b.clone()).unwrap(), -5.0);
+        assert_eq!(bigint_truediv(a.clone(), -b.clone()).unwrap(), -5.0);
+        assert!(bigint_truediv(a, BigInt::from(0)).is_err());
+    }
+
+    #[test]
+    fn test_jit_w_long_shift_truediv_raw() {
+        let x = BigInt::from(i64::MAX) * BigInt::from(1000) + BigInt::from(7);
+        let a = w_long_new(x.clone());
+        let two = w_long_new(BigInt::from(2));
+        let y = BigInt::from(i64::MAX) + BigInt::from(3);
+        let b = w_long_new(y.clone());
+        unsafe {
+            let l = jit_w_long_lshift_raw(a as i64, two as i64) as *mut BigInt;
+            assert_eq!(*l, bigint_lshift(x.clone(), 2));
+            let r = jit_w_long_rshift_raw(a as i64, two as i64) as *mut BigInt;
+            assert_eq!(*r, bigint_rshift(x.clone(), 2));
+            // true-divide carries the f64 bits in the Int register.
+            let bits = jit_w_long_truediv_raw(a as i64, b as i64);
+            assert_eq!(f64::from_bits(bits as u64), bigint_truediv(x, y).unwrap());
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -381,8 +381,10 @@ pub extern "C" fn jit_w_long_lshift_raw(a: i64, b: i64) -> i64 {
             );
             return 0;
         }
-        let shift = match vb.to_usize() {
-            Some(v) => v,
+        // `rbigint.toint()` is a *signed* machine int (i64), so a count above
+        // i64::MAX overflows here — not at usize::MAX — matching `_lshift`.
+        let shift = match vb.to_i64() {
+            Some(v) => v as usize,
             None => {
                 if w_long_get_value(a).sign() == malachite_bigint::Sign::NoSign {
                     return pyre_object::lltype::malloc_raw(BigInt::from(0)) as i64;
@@ -412,8 +414,10 @@ pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
             );
             return 0;
         }
-        let shift = match vb.to_usize() {
-            Some(v) => v,
+        // `toint()` overflow (count > i64::MAX) takes this branch like `_rshift`;
+        // for rshift the result (0 / -1) is the same as an actual huge shift.
+        let shift = match vb.to_i64() {
+            Some(v) => v as usize,
             None => {
                 let val = if w_long_get_value(a).sign() == malachite_bigint::Sign::Minus {
                     -1
@@ -658,10 +662,11 @@ unsafe fn long_lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if bigint_lt(vb.clone(), BigInt::from(0)) {
         return Err(PyError::value_error("negative shift count"));
     }
-    // longobject.py:375-380: shift overflows → 0 if base is zero,
-    // OverflowError otherwise.
-    let shift = match vb.to_usize() {
-        Some(v) => v,
+    // longobject.py:375-380: `toint()` (signed machine int / i64) overflows
+    // when the count exceeds i64::MAX → 0 if base is zero, OverflowError
+    // otherwise.
+    let shift = match vb.to_i64() {
+        Some(v) => v as usize,
         None => {
             let va = as_bigint(a);
             if va.sign() == malachite_bigint::Sign::NoSign {
@@ -678,10 +683,10 @@ unsafe fn long_rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     if bigint_lt(vb.clone(), BigInt::from(0)) {
         return Err(PyError::value_error("negative shift count"));
     }
-    // longobject.py:393-397: shift overflows → positive yields 0,
-    // negative yields -1 (all bits shifted out).
-    let shift = match vb.to_usize() {
-        Some(v) => v,
+    // longobject.py:393-397: `toint()` overflow (count > i64::MAX) → positive
+    // yields 0, negative yields -1 (all bits shifted out).
+    let shift = match vb.to_i64() {
+        Some(v) => v as usize,
         None => {
             let va = as_bigint(a);
             return Ok(w_int_new(if va.sign() == malachite_bigint::Sign::Minus {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -431,22 +431,25 @@ pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
     }
 }
 
-/// `rbigint.truediv` payload half (`longobject.py:62-70 _truediv`). Elidable
-/// but CAN raise ZeroDivisionError / OverflowError → `EF_ELIDABLE_CAN_RAISE`:
-/// `CALL_PURE` + `GUARD_NO_EXCEPTION`. Returns the correctly-rounded quotient
-/// as raw f64 bits (carried in the Int register, boxed to `W_FloatObject` by
-/// `jit_w_float_new`); on a raising input publishes the exception and returns 0.
-/// Walker-only, like the shift helpers.
+/// `rbigint.truediv` payload half (`longobject.py:62-70 _truediv` →
+/// `rbigint.truediv`, `rbigint.py:890`). Elidable but CAN raise
+/// ZeroDivisionError / OverflowError → `EF_ELIDABLE_CAN_RAISE`: `CALL_PURE_F` +
+/// `GUARD_NO_EXCEPTION`. Returns the correctly-rounded quotient as an `f64`
+/// directly (a `CallPureF`, the float analogue of `rbigint.truediv` returning a
+/// float); the walker then boxes it with `wrapfloat` (transparent
+/// `new_with_vtable` + `setfield_gc_f`, mirroring `space.newfloat(f)`). On a
+/// raising input publishes the exception and returns garbage (the guard
+/// deopts). Walker-only, like the shift helpers.
 #[majit_macros::elidable]
-pub extern "C" fn jit_w_long_truediv_raw(a: i64, b: i64) -> i64 {
+pub extern "C" fn jit_w_long_truediv_raw(a: i64, b: i64) -> f64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
     unsafe {
         match bigint_truediv(w_long_get_value(a).clone(), w_long_get_value(b).clone()) {
-            Ok(f) => f.to_bits() as i64,
+            Ok(f) => f,
             Err(e) => {
                 crate::runtime_ops::jit_publish_exception(e.to_exc_object());
-                0
+                0.0
             }
         }
     }
@@ -3374,9 +3377,9 @@ mod tests {
             assert_eq!(*l, bigint_lshift(x.clone(), 2));
             let r = jit_w_long_rshift_raw(a as i64, two as i64) as *mut BigInt;
             assert_eq!(*r, bigint_rshift(x.clone(), 2));
-            // true-divide carries the f64 bits in the Int register.
-            let bits = jit_w_long_truediv_raw(a as i64, b as i64);
-            assert_eq!(f64::from_bits(bits as u64), bigint_truediv(x, y).unwrap());
+            // true-divide returns the f64 quotient directly (CallPureF).
+            let f = jit_w_long_truediv_raw(a as i64, b as i64);
+            assert_eq!(f, bigint_truediv(x, y).unwrap());
         }
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11943,13 +11943,11 @@ fn try_walker_specialize_binary_op_long(
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
-    // Residual box: `jit_bigint_result_box` wraps the bigint in a Python int
-    // (demoting to W_IntObject when it fits), or `jit_w_float_new` wraps the
-    // true-divide f64 bits in a W_FloatObject. Non-elidable (`dont_look_inside`),
-    // so the wrapper object is never pure-CSE'd — a distinct result per op,
-    // matching upstream's separate `NEW`; `EF_CANNOT_RAISE` ⇒ no
-    // GuardNoException and non-forcing.
-    let box_fn = spec.box_fn as *const ();
+    // Residual `bigint_result` box: wrap the bigint in a Python int, demoting to
+    // W_IntObject when it fits. Non-elidable (`dont_look_inside`), so the wrapper
+    // object is never pure-CSE'd — a distinct result per op, matching upstream's
+    // separate `NEW`; `EF_CANNOT_RAISE` ⇒ no GuardNoException and non-forcing.
+    let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
     let result = ctx.trace_ctx.call_typed_with_effect(
         OpCode::CallR,
         box_fn,
@@ -11962,6 +11960,95 @@ fn try_walker_specialize_binary_op_long(
     // (via `concrete_from_recorded_opref`) propagates the authentic sum object
     // into the dst slot; the subsequent STORE_FAST then carries it. Without
     // this the dst shadow is Null and the local materializes unbound.
+    ctx.trace_ctx.set_opref_concrete(
+        result,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, result)?;
+    Ok(Some(()))
+}
+
+/// W_LongObject true-divide specialization — the float analogue of
+/// [`try_walker_specialize_binary_op_long`].  Both operands are `int`-typed but
+/// bigint-stored: guard each against `LONG_TYPE`, then `CallPureF` the elidable
+/// `jit_w_long_truediv_raw` (correctly-rounded f64 quotient; raises
+/// ZeroDivision/Overflow → `EF_ELIDABLE_CAN_RAISE` ⇒ trailing `GuardNoException`)
+/// and box the f64 with `wrapfloat` (transparent `new_with_vtable` +
+/// `setfield_gc_f`, the trace analogue of `_truediv`'s `space.newfloat(f)`), so a
+/// downstream float op keeps the quotient unboxed.  Walker-only — the trait path
+/// defers true-divide to the generic residual.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_truediv_op_long(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    op_tag: i64,
+    r_args: &[OpRef],
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor
+        || !ctx.is_full_body_walk
+        || r_args.len() != 2
+        || dst_bank != 'r'
+    {
+        return Ok(None);
+    }
+    use pyre_interpreter::bytecode::BinaryOperator;
+    match pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag) {
+        Some(BinaryOperator::TrueDivide) | Some(BinaryOperator::InplaceTrueDivide) => {}
+        _ => return Ok(None),
+    }
+    let lhs = r_args[0];
+    let rhs = r_args[1];
+    let (Some(lhs_obj), Some(rhs_obj)) = (
+        walker_concrete_ref_object(ctx, lhs),
+        walker_concrete_ref_object(ctx, rhs),
+    ) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) } {
+        return Ok(None);
+    }
+    // Authentic boxed float via the generic execute path; a NULL / raised result
+    // (zero divisor, float overflow) defers to the generic record.
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
+    walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
+    // Pure `rbigint.truediv` → correctly-rounded f64 (CallPureF). The op already
+    // ran authentically above, so the divisor is nonzero / non-overflowing here;
+    // the trailing GuardNoException covers a divide-by-zero / overflow on replay.
+    let truediv_fn =
+        pyre_interpreter::objspace::descroperation::jit_w_long_truediv_raw as *const ();
+    let f_concrete = pyre_interpreter::objspace::descroperation::jit_w_long_truediv_raw(
+        lhs_obj as i64,
+        rhs_obj as i64,
+    );
+    let concrete_args = [
+        majit_ir::Value::Int(truediv_fn as usize as i64),
+        majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
+        majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
+    ];
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+        OpCode::CallF,
+        truediv_fn,
+        &[lhs, rhs],
+        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+        majit_ir::Type::Float,
+        majit_metainterp::ELIDABLE_EFFECT_INFO,
+        &concrete_args,
+        majit_ir::Value::Float(f_concrete),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Float(f_concrete));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    // Box the f64 with the transparent float NEW (`new_with_vtable` +
+    // `setfield_gc_f`), mirroring `space.newfloat(f)`.
+    let result = crate::state::wrapfloat(ctx.trace_ctx, raw);
     ctx.trace_ctx.set_opref_concrete(
         result,
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
@@ -14389,10 +14476,19 @@ fn dispatch_residual_call_iIRd_kind(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                             )? {
                                 Some(()) => Some(()),
-                                None => try_walker_specialize_binary_op_float(
+                                // Two-long true-divide → float fast path
+                                // (CallPureF + wrapfloat), before the generic
+                                // float leg which only handles float operands.
+                                None => match try_walker_specialize_truediv_op_long(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
-                                )?,
+                                )? {
+                                    Some(()) => Some(()),
+                                    None => try_walker_specialize_binary_op_float(
+                                        ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                        dst_bank,
+                                    )?,
+                                },
                             },
                         }
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12437,6 +12437,107 @@ fn try_walker_fold_check_exc_match(
     Ok(Some(()))
 }
 
+/// W_LongObject (bigint) COMPARE_OP specialization — the long analogue of
+/// [`try_walker_specialize_compare_op_int`].  Both operands are `int`-typed but
+/// bigint-stored: guard each against `LONG_TYPE`, then `CallPure_I` the pure
+/// `jit_w_long_cmp` (sign of `a <=> b` in {-1,0,1}; a comparison neither
+/// allocates nor raises, so `EF_ELIDABLE_CANNOT_RAISE` and NO trailing guard)
+/// and turn the sign into the requested truth with `int_<cmp>(sign, 0)` before
+/// boxing to a `W_Bool` (same #62 dead-box elision as the int path).  Same gate
+/// + return contract as [`try_walker_specialize_binary_op_long`].
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_compare_op_long(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    op_tag: i64,
+    r_args: &[OpRef],
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    if !ctx.is_authoritative_executor
+        || !ctx.is_full_body_walk
+        || r_args.len() != 2
+        || dst_bank != 'r'
+    {
+        return Ok(None);
+    }
+    let Some(cmp_op) = pyre_interpreter::runtime_ops::compare_op_from_tag(op_tag) else {
+        return Ok(None);
+    };
+    use pyre_interpreter::bytecode::ComparisonOperator;
+    // `a <cmp> b` ⟺ `sign(a <=> b) <cmp> 0`.
+    let cmp = match cmp_op {
+        ComparisonOperator::Less => OpCode::IntLt,
+        ComparisonOperator::LessOrEqual => OpCode::IntLe,
+        ComparisonOperator::Greater => OpCode::IntGt,
+        ComparisonOperator::GreaterOrEqual => OpCode::IntGe,
+        ComparisonOperator::Equal => OpCode::IntEq,
+        ComparisonOperator::NotEqual => OpCode::IntNe,
+    };
+    let lhs = r_args[0];
+    let rhs = r_args[1];
+    let (Some(lhs_obj), Some(rhs_obj)) = (
+        walker_concrete_ref_object(ctx, lhs),
+        walker_concrete_ref_object(ctx, rhs),
+    ) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::is_long(lhs_obj) && pyre_object::is_long(rhs_obj) } {
+        return Ok(None);
+    }
+    // Authentic boxed W_Bool via the same execute path the int leg uses; also
+    // advances the concrete VM state the downstream ops read.
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
+    walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
+    // Pure `rbigint` comparison → sign in {-1,0,1}. Dead after the `int_<cmp>`
+    // below and never spans a guard, so it needs no blackhole reconstruction.
+    let cmp_fn = pyre_object::longobject::jit_w_long_cmp as *const ();
+    let sign_concrete = pyre_object::longobject::jit_w_long_cmp(lhs_obj as i64, rhs_obj as i64);
+    let concrete_args = [
+        majit_ir::Value::Int(cmp_fn as usize as i64),
+        majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
+        majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
+    ];
+    let sign = ctx.trace_ctx.call_typed_with_effect_pure(
+        OpCode::CallI,
+        cmp_fn,
+        &[lhs, rhs],
+        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+        majit_ir::Type::Int,
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO,
+        &concrete_args,
+        majit_ir::Value::Int(sign_concrete),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(sign, majit_ir::Value::Int(sign_concrete));
+    let zero = ctx.trace_ctx.const_int(0);
+    let truth = ctx.trace_ctx.record_op(cmp, &[sign, zero]);
+    let folded = majit_metainterp::eval_binop_i(cmp, sign_concrete, 0);
+    ctx.trace_ctx
+        .set_opref_concrete(truth, majit_ir::Value::Int(folded));
+    // #62: elide the dead box when the boxed Ref is consumed solely by the
+    // following `is_true` (POP_JUMP_IF_*); else box the raw truth into a W_Bool.
+    if compare_box_provably_dead(ctx, op_pc, dst as u8) {
+        bool_box_truth_record(truth, truth);
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, truth)?;
+        return Ok(Some(()));
+    }
+    let boxed = crate::helpers::emit_trace_bool_value_from_truth(ctx.trace_ctx, truth, false);
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
+    );
+    bool_box_truth_record(boxed, truth);
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
 /// #62 dead-`box_bool` proof for [`try_walker_specialize_compare_op_int`] /
 /// `_float`.  Returns `true` only when a forward JitCode lookahead proves
 /// the compare's boxed Ref dst register (`dst_reg`) is consumed *solely*
@@ -14311,15 +14412,20 @@ fn dispatch_residual_call_iIRd_kind(
                     // not a valid exception class.
                     try_walker_fold_check_exc_match(ctx, op.pc, &r_args, dst, dst_bank)?
                 } else {
-                    // int compare first; float (incl. mixed int/float) as a
-                    // fallback so two-int operands keep int comparison.
+                    // int compare first; then long (two-bigint operands keep
+                    // bigint comparison); float (incl. mixed int/float) last.
                     match try_walker_specialize_compare_op_int(
                         ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
                     )? {
                         Some(()) => Some(()),
-                        None => try_walker_specialize_compare_op_float(
+                        None => match try_walker_specialize_compare_op_long(
                             ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                        )?,
+                        )? {
+                            Some(()) => Some(()),
+                            None => try_walker_specialize_compare_op_float(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )?,
+                        },
                     }
                 };
                 if specialized.is_some() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11943,12 +11943,13 @@ fn try_walker_specialize_binary_op_long(
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
     walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
-    // Residual `bigint_result` box/demote: wrap the bigint in a Python int,
-    // demoting to W_IntObject when it fits. Non-elidable (`dont_look_inside`),
-    // so the wrapper object is never pure-CSE'd — a distinct result per add,
+    // Residual box: `jit_bigint_result_box` wraps the bigint in a Python int
+    // (demoting to W_IntObject when it fits), or `jit_w_float_new` wraps the
+    // true-divide f64 bits in a W_FloatObject. Non-elidable (`dont_look_inside`),
+    // so the wrapper object is never pure-CSE'd — a distinct result per op,
     // matching upstream's separate `NEW`; `EF_CANNOT_RAISE` ⇒ no
     // GuardNoException and non-forcing.
-    let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
+    let box_fn = spec.box_fn as *const ();
     let result = ctx.trace_ctx.call_typed_with_effect(
         OpCode::CallR,
         box_fn,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11889,7 +11889,7 @@ fn try_walker_specialize_binary_op_long(
     {
         return Ok(None);
     }
-    let Some((raw_fn, can_raise)) = pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag)
+    let Some(spec) = pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag)
         .and_then(crate::trace_opcode::long_binop_raw_helper)
     else {
         return Ok(None);
@@ -11916,51 +11916,33 @@ fn try_walker_specialize_binary_op_long(
     // Pure `rbigint` payload op: read both W_LongObject payloads and return a
     // bare `*mut BigInt` (Int). The raw pointer is consumed only by the
     // residual box below — it is dead after it and never spans a guard, so it
-    // needs no blackhole reconstruction. `walker_execute_may_force_boxed` above
-    // already executed the op authentically, so for the can-raise division
-    // helpers the divisor is guaranteed nonzero here (a zero divisor would have
-    // raised → `None` → generic defer); the trailing `GuardNoException` covers
-    // a divide-by-zero on a later replay (`pyjitpl.py:2082`).
-    let raw_concrete = raw_fn(lhs_obj as i64, rhs_obj as i64);
-    let add_fn = raw_fn as *const ();
-    let effect = if can_raise {
-        majit_metainterp::ELIDABLE_EFFECT_INFO
-    } else {
-        majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO
-    };
+    // needs no blackhole reconstruction. Every op allocates
+    // (`EF_ELIDABLE_OR_MEMORYERROR`) or divides (`EF_ELIDABLE_CAN_RAISE`), so a
+    // trailing `GuardNoException` follows (`pyjitpl.py:2110-2112`).
+    // `walker_execute_may_force_boxed` above already executed the op
+    // authentically, so for the division helpers the divisor is guaranteed
+    // nonzero here (a zero divisor would have raised → `None` → generic defer);
+    // the guard still covers a divide-by-zero / OOM on a later replay.
+    let raw_concrete = (spec.raw_fn)(lhs_obj as i64, rhs_obj as i64);
+    let add_fn = spec.raw_fn as *const ();
     let concrete_args = [
         majit_ir::Value::Int(add_fn as usize as i64),
         majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
         majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
     ];
-    let raw = if can_raise {
-        ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
-            OpCode::CallI,
-            add_fn,
-            &[lhs, rhs],
-            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
-            majit_ir::Type::Int,
-            effect,
-            &concrete_args,
-            majit_ir::Value::Int(raw_concrete),
-        )
-    } else {
-        ctx.trace_ctx.call_typed_with_effect_pure(
-            OpCode::CallI,
-            add_fn,
-            &[lhs, rhs],
-            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
-            majit_ir::Type::Int,
-            effect,
-            &concrete_args,
-            majit_ir::Value::Int(raw_concrete),
-        )
-    };
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+        OpCode::CallI,
+        add_fn,
+        &[lhs, rhs],
+        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+        majit_ir::Type::Int,
+        spec.effect,
+        &concrete_args,
+        majit_ir::Value::Int(raw_concrete),
+    );
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
-    if can_raise {
-        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
-    }
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
     // Residual `bigint_result` box/demote: wrap the bigint in a Python int,
     // demoting to W_IntObject when it fits. Non-elidable (`dont_look_inside`),
     // so the wrapper object is never pure-CSE'd — a distinct result per add,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11866,9 +11866,10 @@ fn walker_guard_class(
 /// force-token store + `GUARD_NOT_FORCED` + `GUARD_NO_EXCEPTION` from
 /// bigint-heavy loops (e.g. `fib_loop`).
 ///
-/// Specialized for add/sub/mul/and/or/xor; every may-raise operator
-/// (floordiv/mod/pow/shift), true-divide, and any non-`W_LongObject` operand
-/// returns `Ok(None)` so the caller falls through to the generic record,
+/// Specialized for add/sub/mul/and/or/xor (cannot-raise) and floordiv/mod
+/// (`rbigint.divmod`, elidable-can-raise → trailing `GUARD_NO_EXCEPTION` for
+/// the divide-by-zero bail). pow/shift, true-divide, and any non-`W_LongObject`
+/// operand return `Ok(None)` so the caller falls through to the generic record,
 /// preserving the `__op__` semantics.
 #[allow(clippy::too_many_arguments)]
 fn try_walker_specialize_binary_op_long(
@@ -11888,7 +11889,7 @@ fn try_walker_specialize_binary_op_long(
     {
         return Ok(None);
     }
-    let Some(raw_fn) = pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag)
+    let Some((raw_fn, can_raise)) = pyre_interpreter::runtime_ops::binary_op_from_tag(op_tag)
         .and_then(crate::trace_opcode::long_binop_raw_helper)
     else {
         return Ok(None);
@@ -11915,25 +11916,51 @@ fn try_walker_specialize_binary_op_long(
     // Pure `rbigint` payload op: read both W_LongObject payloads and return a
     // bare `*mut BigInt` (Int). The raw pointer is consumed only by the
     // residual box below — it is dead after it and never spans a guard, so it
-    // needs no blackhole reconstruction.
+    // needs no blackhole reconstruction. `walker_execute_may_force_boxed` above
+    // already executed the op authentically, so for the can-raise division
+    // helpers the divisor is guaranteed nonzero here (a zero divisor would have
+    // raised → `None` → generic defer); the trailing `GuardNoException` covers
+    // a divide-by-zero on a later replay (`pyjitpl.py:2082`).
     let raw_concrete = raw_fn(lhs_obj as i64, rhs_obj as i64);
     let add_fn = raw_fn as *const ();
-    let raw = ctx.trace_ctx.call_typed_with_effect_pure(
-        OpCode::CallI,
-        add_fn,
-        &[lhs, rhs],
-        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
-        majit_ir::Type::Int,
-        majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO,
-        &[
-            majit_ir::Value::Int(add_fn as usize as i64),
-            majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
-            majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
-        ],
-        majit_ir::Value::Int(raw_concrete),
-    );
+    let effect = if can_raise {
+        majit_metainterp::ELIDABLE_EFFECT_INFO
+    } else {
+        majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO
+    };
+    let concrete_args = [
+        majit_ir::Value::Int(add_fn as usize as i64),
+        majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
+        majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
+    ];
+    let raw = if can_raise {
+        ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+            OpCode::CallI,
+            add_fn,
+            &[lhs, rhs],
+            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+            majit_ir::Type::Int,
+            effect,
+            &concrete_args,
+            majit_ir::Value::Int(raw_concrete),
+        )
+    } else {
+        ctx.trace_ctx.call_typed_with_effect_pure(
+            OpCode::CallI,
+            add_fn,
+            &[lhs, rhs],
+            &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+            majit_ir::Type::Int,
+            effect,
+            &concrete_args,
+            majit_ir::Value::Int(raw_concrete),
+        )
+    };
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
+    if can_raise {
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    }
     // Residual `bigint_result` box/demote: wrap the bigint in a Python int,
     // demoting to W_IntObject when it fits. Non-elidable (`dont_look_inside`),
     // so the wrapper object is never pure-CSE'd — a distinct result per add,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -263,37 +263,36 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
     ctx.heapcache_setfield_cached(tuple, descr.index(), w_class);
 }
 
-/// The elidable `rbigint` payload helper + box + effect for a specialised
-/// W_LongObject binary op (see [`long_binop_raw_helper`]).
+/// The elidable `rbigint` payload helper + effect for a specialised
+/// W_LongObject binary op (see [`long_binop_raw_helper`]). The bigint result is
+/// boxed by the caller via `jit_bigint_result_box` (→ Python int, demoting).
+/// True-divide is NOT here — it returns a float (`CallPureF` + `wrapfloat`), so
+/// it has its own specialisation ([`try_walker_specialize_truediv_op_long`]).
 pub(crate) struct LongBinopSpec {
-    /// Pure `rbigint` payload op `[Ref, Ref] → Int`. Returns a bare
-    /// `*mut BigInt` (arithmetic / shift) or raw f64 bits (true-divide).
+    /// Pure `rbigint` payload op `[Ref, Ref] → Int`, returning a bare
+    /// `*mut BigInt` (arithmetic / divmod / shift).
     pub raw_fn: extern "C" fn(i64, i64) -> i64,
-    /// Residual box `[Int] → Ref`: `jit_bigint_result_box` (→ Python int,
-    /// demoting) for bigint payloads, `jit_w_float_new` (→ `W_FloatObject`) for
-    /// the true-divide f64 bits.
-    pub box_fn: extern "C" fn(i64) -> i64,
     pub effect: majit_ir::EffectInfo,
     /// True for the divmod ops, whose helper publishes ZeroDivisionError on a
     /// zero divisor. The trait path pre-checks the divisor with `w_long_is_zero`
     /// before invoking the helper for `call_pure_results`.
     pub is_division: bool,
-    /// False for ops whose raising inputs are not a simple divisor check
-    /// (shift: negative / over-large count; true-divide: zero or float
-    /// overflow). The trait path defers these to the generic residual rather
-    /// than risk publishing an exception mid-trace; the walker still
-    /// specialises them (it executes the authentic op first and bails on a
-    /// raise, so the concrete helper call here only runs on a non-raising op).
+    /// False for the shift ops, whose raising inputs (negative / over-large
+    /// count) are not a simple divisor check. The trait path defers these to the
+    /// generic residual rather than risk publishing an exception mid-trace; the
+    /// walker still specialises them (it executes the authentic op first and
+    /// bails on a raise, so the concrete helper call here only runs on a
+    /// non-raising op).
     pub trait_safe: bool,
 }
 
 /// Map a `BinaryOperator` to its `rbigint` payload helper, or `None` when the
-/// operator is not specialised (Power → modular/float, Subscr → non-arithmetic).
-/// Every specialised op records `CallPure*` + a trailing `GuardNoException`:
-/// the arithmetic ops (add/sub/mul/and/or/xor) allocate a new bigint so they
-/// are `EF_ELIDABLE_OR_MEMORYERROR` (`call.py:294`, `cr == "mem"`); the divmod /
-/// shift / true-divide ops also raise (ZeroDivision / ValueError·Overflow /
-/// ZeroDivision·Overflow) so they are `EF_ELIDABLE_CAN_RAISE` (`call.py:296`).
+/// operator is not specialised here (Power → modular/float, TrueDivide → float
+/// fast path, Subscr → non-arithmetic). Every specialised op records `CallPure*`
+/// + a trailing `GuardNoException`: the arithmetic ops (add/sub/mul/and/or/xor)
+/// allocate a new bigint so they are `EF_ELIDABLE_OR_MEMORYERROR` (`call.py:294`,
+/// `cr == "mem"`); the divmod / shift ops also raise (ZeroDivision /
+/// ValueError·Overflow) so they are `EF_ELIDABLE_CAN_RAISE` (`call.py:296`).
 /// Both classes have `check_can_raise()` true, so `pyjitpl.py:2110-2112` emits
 /// the guard. Shared by the trait path ([`binary_long_value`]) and the walker
 /// (`try_walker_specialize_binary_op_long`).
@@ -301,98 +300,70 @@ pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<LongBinopSpec>
     use majit_metainterp::{ELIDABLE_EFFECT_INFO, ELIDABLE_OR_MEMERROR_EFFECT_INFO};
     use pyre_interpreter::objspace::descroperation as desc;
     use pyre_object::longobject as lo;
-    let bigint_box = lo::jit_bigint_result_box as extern "C" fn(i64) -> i64;
-    let float_box = pyre_object::floatobject::jit_w_float_new as extern "C" fn(i64) -> i64;
-    // (raw_fn, box_fn, effect, is_division, trait_safe)
-    let (raw_fn, box_fn, effect, is_division, trait_safe): (
-        extern "C" fn(i64, i64) -> i64,
-        _,
-        _,
-        _,
-        _,
-    ) = match op {
-        BinaryOperator::Add | BinaryOperator::InplaceAdd => (
-            lo::jit_w_long_add_raw,
-            bigint_box,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (
-            lo::jit_w_long_sub_raw,
-            bigint_box,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (
-            lo::jit_w_long_mul_raw,
-            bigint_box,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::And | BinaryOperator::InplaceAnd => (
-            lo::jit_w_long_and_raw,
-            bigint_box,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Or | BinaryOperator::InplaceOr => (
-            lo::jit_w_long_or_raw,
-            bigint_box,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Xor | BinaryOperator::InplaceXor => (
-            lo::jit_w_long_xor_raw,
-            bigint_box,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => (
-            desc::jit_w_long_floordiv_raw,
-            bigint_box,
-            ELIDABLE_EFFECT_INFO,
-            true,
-            true,
-        ),
-        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => (
-            desc::jit_w_long_mod_raw,
-            bigint_box,
-            ELIDABLE_EFFECT_INFO,
-            true,
-            true,
-        ),
-        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => (
-            desc::jit_w_long_lshift_raw,
-            bigint_box,
-            ELIDABLE_EFFECT_INFO,
-            false,
-            false,
-        ),
-        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => (
-            desc::jit_w_long_rshift_raw,
-            bigint_box,
-            ELIDABLE_EFFECT_INFO,
-            false,
-            false,
-        ),
-        BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => (
-            desc::jit_w_long_truediv_raw,
-            float_box,
-            ELIDABLE_EFFECT_INFO,
-            false,
-            false,
-        ),
-        _ => return None,
-    };
+    // (raw_fn, effect, is_division, trait_safe)
+    let (raw_fn, effect, is_division, trait_safe): (extern "C" fn(i64, i64) -> i64, _, _, _) =
+        match op {
+            BinaryOperator::Add | BinaryOperator::InplaceAdd => (
+                lo::jit_w_long_add_raw,
+                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                false,
+                true,
+            ),
+            BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (
+                lo::jit_w_long_sub_raw,
+                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                false,
+                true,
+            ),
+            BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (
+                lo::jit_w_long_mul_raw,
+                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                false,
+                true,
+            ),
+            BinaryOperator::And | BinaryOperator::InplaceAnd => (
+                lo::jit_w_long_and_raw,
+                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                false,
+                true,
+            ),
+            BinaryOperator::Or | BinaryOperator::InplaceOr => (
+                lo::jit_w_long_or_raw,
+                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                false,
+                true,
+            ),
+            BinaryOperator::Xor | BinaryOperator::InplaceXor => (
+                lo::jit_w_long_xor_raw,
+                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+                false,
+                true,
+            ),
+            BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => (
+                desc::jit_w_long_floordiv_raw,
+                ELIDABLE_EFFECT_INFO,
+                true,
+                true,
+            ),
+            BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
+                (desc::jit_w_long_mod_raw, ELIDABLE_EFFECT_INFO, true, true)
+            }
+            BinaryOperator::Lshift | BinaryOperator::InplaceLshift => (
+                desc::jit_w_long_lshift_raw,
+                ELIDABLE_EFFECT_INFO,
+                false,
+                false,
+            ),
+            BinaryOperator::Rshift | BinaryOperator::InplaceRshift => (
+                desc::jit_w_long_rshift_raw,
+                ELIDABLE_EFFECT_INFO,
+                false,
+                false,
+            ),
+            _ => return None,
+        };
     Some(LongBinopSpec {
         raw_fn,
-        box_fn,
         effect,
         is_division,
         trait_safe,
@@ -6083,11 +6054,12 @@ impl MIFrame {
     /// per-iteration force-token store + `GUARD_NOT_FORCED`. Each op keeps a
     /// trailing `GUARD_NO_EXCEPTION`: the arithmetic ops (add/sub/mul/and/or/
     /// xor) allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the divmod / shift
-    /// / true-divide ops are `EF_ELIDABLE_CAN_RAISE`; both have
-    /// `check_can_raise()` true (`pyjitpl.py:2110-2112`). The trait path only
-    /// specialises the ops it can pre-screen for raising inputs (arithmetic +
-    /// divmod); shift / true-divide are walker-only (`trait_safe == false`).
-    /// pow still falls through to the generic residual.
+    /// ops are `EF_ELIDABLE_CAN_RAISE`; both have `check_can_raise()` true
+    /// (`pyjitpl.py:2110-2112`). The trait path only specialises the ops it can
+    /// pre-screen for raising inputs (arithmetic + divmod); shift is walker-only
+    /// (`trait_safe == false`). True-divide (float result) and pow fall through
+    /// to the generic residual here — true-divide has its own walker fast path
+    /// (`try_walker_specialize_truediv_op_long`).
     pub(crate) fn binary_long_value(
         &mut self,
         a: OpRef,
@@ -6099,10 +6071,11 @@ impl MIFrame {
         let Some(spec) = long_binop_raw_helper(op) else {
             return self.trace_binary_value(a, b, op);
         };
-        // Shift / true-divide raise on inputs the trait path cannot cheaply
-        // pre-screen (negative or over-large shift count; float overflow), so
-        // they defer to the generic residual here — the walker still
-        // specialises them, executing the authentic op first.
+        // Shift raises on inputs the trait path cannot cheaply pre-screen
+        // (negative or over-large shift count), so it defers to the generic
+        // residual here — the walker still specialises it, executing the
+        // authentic op first. (True-divide is not in `long_binop_raw_helper`
+        // at all, so it already took the early return above.)
         if !spec.trait_safe {
             return self.trace_binary_value(a, b, op);
         }
@@ -6146,7 +6119,7 @@ impl MIFrame {
             // non-elidable (`dont_look_inside`), so it is never pure-CSE'd and,
             // like upstream's NEW, carries no `GuardNoException` (a MemoryError
             // from the allocation is the GC slowpath's concern, not a guard).
-            let box_fn = spec.box_fn as *const ();
+            let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
             Ok::<_, PyError>(ctx.call_typed_with_effect(
                 OpCode::CallR,
                 box_fn,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -263,34 +263,63 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
     ctx.heapcache_setfield_cached(tuple, descr.index(), w_class);
 }
 
-/// Map a `BinaryOperator` to the elidable `rbigint` payload helper used by the
-/// W_LongObject fast path, paired with a `can_raise` flag, or `None` when the
-/// operator is not specialised (TrueDivide → float, Power/Lshift/Rshift → may
-/// raise, Subscr → non-arithmetic). The cannot-raise ops (add/sub/mul/and/or/
-/// xor, `EF_ELIDABLE_CANNOT_RAISE`) record `CallPure*` with no trailing guard;
-/// the can-raise ops (floordiv/mod via `rbigint.divmod`, raises
-/// ZeroDivisionError, `EF_ELIDABLE_CAN_RAISE`) record `CallPure*` +
-/// `GuardNoException`. Shared by the trait path ([`binary_long_value`]) and the
-/// walker (`try_walker_specialize_binary_op_long`).
-pub(crate) fn long_binop_raw_helper(
-    op: BinaryOperator,
-) -> Option<(extern "C" fn(i64, i64) -> i64, bool)> {
+/// The elidable `rbigint` payload helper + its effect for a specialised
+/// W_LongObject binary op (see [`long_binop_raw_helper`]).
+pub(crate) struct LongBinopSpec {
+    pub raw_fn: extern "C" fn(i64, i64) -> i64,
+    pub effect: majit_ir::EffectInfo,
+    /// True for the division ops (`rbigint.divmod`), whose helper publishes
+    /// ZeroDivisionError on a zero divisor. The trait path must pre-check the
+    /// divisor before invoking the helper for `call_pure_results`; the walker
+    /// is covered by executing the op authentically first.
+    pub is_division: bool,
+}
+
+/// Map a `BinaryOperator` to its `rbigint` payload helper, or `None` when the
+/// operator is not specialised (TrueDivide → float, Power/Lshift/Rshift, Subscr
+/// → non-arithmetic). Every specialised op records `CallPure*` + a trailing
+/// `GuardNoException`: the arithmetic ops (add/sub/mul/and/or/xor) allocate a
+/// new bigint so they are `EF_ELIDABLE_OR_MEMORYERROR` (`call.py:294`,
+/// `cr == "mem"`); the division ops (floordiv/mod via `rbigint.divmod`) also
+/// raise ZeroDivisionError so they are `EF_ELIDABLE_CAN_RAISE` (`call.py:296`).
+/// Both classes have `check_can_raise()` true, so `pyjitpl.py:2110-2112` emits
+/// the guard. Shared by the trait path ([`binary_long_value`]) and the walker
+/// (`try_walker_specialize_binary_op_long`).
+pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<LongBinopSpec> {
+    use majit_metainterp::{ELIDABLE_EFFECT_INFO, ELIDABLE_OR_MEMERROR_EFFECT_INFO};
     use pyre_interpreter::objspace::descroperation as desc;
     use pyre_object::longobject as lo;
-    Some(match op {
-        BinaryOperator::Add | BinaryOperator::InplaceAdd => (lo::jit_w_long_add_raw, false),
-        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (lo::jit_w_long_sub_raw, false),
-        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (lo::jit_w_long_mul_raw, false),
-        BinaryOperator::And | BinaryOperator::InplaceAnd => (lo::jit_w_long_and_raw, false),
-        BinaryOperator::Or | BinaryOperator::InplaceOr => (lo::jit_w_long_or_raw, false),
-        BinaryOperator::Xor | BinaryOperator::InplaceXor => (lo::jit_w_long_xor_raw, false),
+    let (raw_fn, effect, is_division): (extern "C" fn(i64, i64) -> i64, _, _) = match op {
+        BinaryOperator::Add | BinaryOperator::InplaceAdd => {
+            (lo::jit_w_long_add_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+        }
+        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => {
+            (lo::jit_w_long_sub_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+        }
+        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => {
+            (lo::jit_w_long_mul_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+        }
+        BinaryOperator::And | BinaryOperator::InplaceAnd => {
+            (lo::jit_w_long_and_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+        }
+        BinaryOperator::Or | BinaryOperator::InplaceOr => {
+            (lo::jit_w_long_or_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+        }
+        BinaryOperator::Xor | BinaryOperator::InplaceXor => {
+            (lo::jit_w_long_xor_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+        }
         BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => {
-            (desc::jit_w_long_floordiv_raw, true)
+            (desc::jit_w_long_floordiv_raw, ELIDABLE_EFFECT_INFO, true)
         }
         BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
-            (desc::jit_w_long_mod_raw, true)
+            (desc::jit_w_long_mod_raw, ELIDABLE_EFFECT_INFO, true)
         }
         _ => return None,
+    };
+    Some(LongBinopSpec {
+        raw_fn,
+        effect,
+        is_division,
     })
 }
 
@@ -5975,10 +6004,11 @@ impl MIFrame {
     /// `CALL_R` to `jit_bigint_result_box` (the `W_LongObject(...)` NEW /
     /// `bigint_result` demote). Unlike the generic `binary_value` residual
     /// neither is a `CALL_MAY_FORCE`, so the loop body sheds the
-    /// per-iteration force-token store + `GUARD_NOT_FORCED`. The cannot-raise
-    /// ops (add/sub/mul/and/or/xor) shed `GUARD_NO_EXCEPTION` too; the can-raise
-    /// division ops (floordiv/mod via `rbigint.divmod`) keep a trailing
-    /// `GUARD_NO_EXCEPTION` for the divide-by-zero bail. pow/shift and
+    /// per-iteration force-token store + `GUARD_NOT_FORCED`. Each op keeps a
+    /// trailing `GUARD_NO_EXCEPTION`: the arithmetic ops (add/sub/mul/and/or/
+    /// xor) allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the division ops
+    /// (floordiv/mod via `rbigint.divmod`) are `EF_ELIDABLE_CAN_RAISE`; both
+    /// have `check_can_raise()` true (`pyjitpl.py:2110-2112`). pow/shift and
     /// true-divide still fall through to the generic residual.
     pub(crate) fn binary_long_value(
         &mut self,
@@ -5988,65 +6018,49 @@ impl MIFrame {
         concrete_lhs: PyObjectRef,
         concrete_rhs: PyObjectRef,
     ) -> Result<OpRef, PyError> {
-        let Some((raw_fn, can_raise)) = long_binop_raw_helper(op) else {
+        let Some(spec) = long_binop_raw_helper(op) else {
             return self.trace_binary_value(a, b, op);
         };
-        // A zero divisor makes the can-raise payload helper publish
-        // ZeroDivisionError; that path is handled by the generic residual, so
-        // fast-path only nonzero divisors (the helper is otherwise
-        // side-effect-free when invoked for `call_pure_results` below).
-        if can_raise && unsafe { pyre_object::longobject::w_long_is_zero(concrete_rhs) } {
+        // The division helpers publish ZeroDivisionError on a zero divisor;
+        // that path is handled by the generic residual, so fast-path only
+        // nonzero divisors (the helper is otherwise side-effect-free when
+        // invoked for `call_pure_results` below). The arithmetic helpers only
+        // ever fail with MemoryError, which cannot fire during tracing.
+        if spec.is_division && unsafe { pyre_object::longobject::w_long_is_zero(concrete_rhs) } {
             return self.trace_binary_value(a, b, op);
         }
         self.with_ctx(|this, ctx| {
             this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
             this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
-            // Pure `rbigint` payload op → bare `*mut BigInt` (Int), recorded
-            // as CALL_PURE_I via `record_result_of_call_pure` (patches CALL_I and
+            // Pure `rbigint` payload op → bare `*mut BigInt` (Int), recorded as
+            // CALL_PURE_I via `record_result_of_call_pure` (patches CALL_I and
             // populates `call_pure_results`), mirroring the walker fast path.
-            // The can-raise division helpers (`rbigint.divmod`) additionally get
-            // a trailing `GuardNoException` (`pyjitpl.py:2082`).
-            let fn_ptr = raw_fn as *const ();
-            let raw_concrete = raw_fn(concrete_lhs as i64, concrete_rhs as i64);
-            let effect = if can_raise {
-                majit_metainterp::ELIDABLE_EFFECT_INFO
-            } else {
-                majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO
-            };
+            // Every op allocates (`EF_ELIDABLE_OR_MEMORYERROR`) or divides
+            // (`EF_ELIDABLE_CAN_RAISE`), so `check_can_raise()` is true and a
+            // trailing `GuardNoException` follows (`pyjitpl.py:2110-2112`).
+            let fn_ptr = spec.raw_fn as *const ();
+            let raw_concrete = (spec.raw_fn)(concrete_lhs as i64, concrete_rhs as i64);
             let concrete_args = [
                 Value::Int(fn_ptr as usize as i64),
                 Value::Ref(GcRef(concrete_lhs as usize)),
                 Value::Ref(GcRef(concrete_rhs as usize)),
             ];
-            let raw = if can_raise {
-                ctx.call_typed_with_effect_pure_can_raise(
-                    OpCode::CallI,
-                    fn_ptr,
-                    &[a, b],
-                    &[Type::Ref, Type::Ref],
-                    Type::Int,
-                    effect,
-                    &concrete_args,
-                    Value::Int(raw_concrete),
-                )
-            } else {
-                ctx.call_typed_with_effect_pure(
-                    OpCode::CallI,
-                    fn_ptr,
-                    &[a, b],
-                    &[Type::Ref, Type::Ref],
-                    Type::Int,
-                    effect,
-                    &concrete_args,
-                    Value::Int(raw_concrete),
-                )
-            };
-            if can_raise {
-                this.generate_guard(ctx, OpCode::GuardNoException, &[]);
-            }
+            let raw = ctx.call_typed_with_effect_pure_can_raise(
+                OpCode::CallI,
+                fn_ptr,
+                &[a, b],
+                &[Type::Ref, Type::Ref],
+                Type::Int,
+                spec.effect,
+                &concrete_args,
+                Value::Int(raw_concrete),
+            );
+            this.generate_guard(ctx, OpCode::GuardNoException, &[]);
             // …then the residual `bigint_result` box/demote → Python int (Ref).
-            // Non-elidable (`dont_look_inside`) and `EF_CANNOT_RAISE`, so the
-            // wrapper is never pure-CSE'd and the call stays non-forcing.
+            // Models the `W_LongObject(...)` NEW: `EF_CANNOT_RAISE` and
+            // non-elidable (`dont_look_inside`), so it is never pure-CSE'd and,
+            // like upstream's NEW, carries no `GuardNoException` (a MemoryError
+            // from the allocation is the GC slowpath's concern, not a guard).
             let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
             Ok::<_, PyError>(ctx.call_typed_with_effect(
                 OpCode::CallR,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -263,25 +263,37 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
     ctx.heapcache_setfield_cached(tuple, descr.index(), w_class);
 }
 
-/// The elidable `rbigint` payload helper + its effect for a specialised
+/// The elidable `rbigint` payload helper + box + effect for a specialised
 /// W_LongObject binary op (see [`long_binop_raw_helper`]).
 pub(crate) struct LongBinopSpec {
+    /// Pure `rbigint` payload op `[Ref, Ref] → Int`. Returns a bare
+    /// `*mut BigInt` (arithmetic / shift) or raw f64 bits (true-divide).
     pub raw_fn: extern "C" fn(i64, i64) -> i64,
+    /// Residual box `[Int] → Ref`: `jit_bigint_result_box` (→ Python int,
+    /// demoting) for bigint payloads, `jit_w_float_new` (→ `W_FloatObject`) for
+    /// the true-divide f64 bits.
+    pub box_fn: extern "C" fn(i64) -> i64,
     pub effect: majit_ir::EffectInfo,
-    /// True for the division ops (`rbigint.divmod`), whose helper publishes
-    /// ZeroDivisionError on a zero divisor. The trait path must pre-check the
-    /// divisor before invoking the helper for `call_pure_results`; the walker
-    /// is covered by executing the op authentically first.
+    /// True for the divmod ops, whose helper publishes ZeroDivisionError on a
+    /// zero divisor. The trait path pre-checks the divisor with `w_long_is_zero`
+    /// before invoking the helper for `call_pure_results`.
     pub is_division: bool,
+    /// False for ops whose raising inputs are not a simple divisor check
+    /// (shift: negative / over-large count; true-divide: zero or float
+    /// overflow). The trait path defers these to the generic residual rather
+    /// than risk publishing an exception mid-trace; the walker still
+    /// specialises them (it executes the authentic op first and bails on a
+    /// raise, so the concrete helper call here only runs on a non-raising op).
+    pub trait_safe: bool,
 }
 
 /// Map a `BinaryOperator` to its `rbigint` payload helper, or `None` when the
-/// operator is not specialised (TrueDivide → float, Power/Lshift/Rshift, Subscr
-/// → non-arithmetic). Every specialised op records `CallPure*` + a trailing
-/// `GuardNoException`: the arithmetic ops (add/sub/mul/and/or/xor) allocate a
-/// new bigint so they are `EF_ELIDABLE_OR_MEMORYERROR` (`call.py:294`,
-/// `cr == "mem"`); the division ops (floordiv/mod via `rbigint.divmod`) also
-/// raise ZeroDivisionError so they are `EF_ELIDABLE_CAN_RAISE` (`call.py:296`).
+/// operator is not specialised (Power → modular/float, Subscr → non-arithmetic).
+/// Every specialised op records `CallPure*` + a trailing `GuardNoException`:
+/// the arithmetic ops (add/sub/mul/and/or/xor) allocate a new bigint so they
+/// are `EF_ELIDABLE_OR_MEMORYERROR` (`call.py:294`, `cr == "mem"`); the divmod /
+/// shift / true-divide ops also raise (ZeroDivision / ValueError·Overflow /
+/// ZeroDivision·Overflow) so they are `EF_ELIDABLE_CAN_RAISE` (`call.py:296`).
 /// Both classes have `check_can_raise()` true, so `pyjitpl.py:2110-2112` emits
 /// the guard. Shared by the trait path ([`binary_long_value`]) and the walker
 /// (`try_walker_specialize_binary_op_long`).
@@ -289,37 +301,57 @@ pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<LongBinopSpec>
     use majit_metainterp::{ELIDABLE_EFFECT_INFO, ELIDABLE_OR_MEMERROR_EFFECT_INFO};
     use pyre_interpreter::objspace::descroperation as desc;
     use pyre_object::longobject as lo;
-    let (raw_fn, effect, is_division): (extern "C" fn(i64, i64) -> i64, _, _) = match op {
+    let bigint_box = lo::jit_bigint_result_box as extern "C" fn(i64) -> i64;
+    let float_box = pyre_object::floatobject::jit_w_float_new as extern "C" fn(i64) -> i64;
+    // (raw_fn, box_fn, effect, is_division, trait_safe)
+    let (raw_fn, box_fn, effect, is_division, trait_safe): (
+        extern "C" fn(i64, i64) -> i64,
+        _,
+        _,
+        _,
+        _,
+    ) = match op {
         BinaryOperator::Add | BinaryOperator::InplaceAdd => {
-            (lo::jit_w_long_add_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+            (lo::jit_w_long_add_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
         }
         BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => {
-            (lo::jit_w_long_sub_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+            (lo::jit_w_long_sub_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
         }
         BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => {
-            (lo::jit_w_long_mul_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+            (lo::jit_w_long_mul_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
         }
         BinaryOperator::And | BinaryOperator::InplaceAnd => {
-            (lo::jit_w_long_and_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+            (lo::jit_w_long_and_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
         }
         BinaryOperator::Or | BinaryOperator::InplaceOr => {
-            (lo::jit_w_long_or_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+            (lo::jit_w_long_or_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
         }
         BinaryOperator::Xor | BinaryOperator::InplaceXor => {
-            (lo::jit_w_long_xor_raw, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false)
+            (lo::jit_w_long_xor_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
         }
         BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => {
-            (desc::jit_w_long_floordiv_raw, ELIDABLE_EFFECT_INFO, true)
+            (desc::jit_w_long_floordiv_raw, bigint_box, ELIDABLE_EFFECT_INFO, true, true)
         }
         BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
-            (desc::jit_w_long_mod_raw, ELIDABLE_EFFECT_INFO, true)
+            (desc::jit_w_long_mod_raw, bigint_box, ELIDABLE_EFFECT_INFO, true, true)
+        }
+        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => {
+            (desc::jit_w_long_lshift_raw, bigint_box, ELIDABLE_EFFECT_INFO, false, false)
+        }
+        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => {
+            (desc::jit_w_long_rshift_raw, bigint_box, ELIDABLE_EFFECT_INFO, false, false)
+        }
+        BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => {
+            (desc::jit_w_long_truediv_raw, float_box, ELIDABLE_EFFECT_INFO, false, false)
         }
         _ => return None,
     };
     Some(LongBinopSpec {
         raw_fn,
+        box_fn,
         effect,
         is_division,
+        trait_safe,
     })
 }
 
@@ -6006,10 +6038,12 @@ impl MIFrame {
     /// neither is a `CALL_MAY_FORCE`, so the loop body sheds the
     /// per-iteration force-token store + `GUARD_NOT_FORCED`. Each op keeps a
     /// trailing `GUARD_NO_EXCEPTION`: the arithmetic ops (add/sub/mul/and/or/
-    /// xor) allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the division ops
-    /// (floordiv/mod via `rbigint.divmod`) are `EF_ELIDABLE_CAN_RAISE`; both
-    /// have `check_can_raise()` true (`pyjitpl.py:2110-2112`). pow/shift and
-    /// true-divide still fall through to the generic residual.
+    /// xor) allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the divmod / shift
+    /// / true-divide ops are `EF_ELIDABLE_CAN_RAISE`; both have
+    /// `check_can_raise()` true (`pyjitpl.py:2110-2112`). The trait path only
+    /// specialises the ops it can pre-screen for raising inputs (arithmetic +
+    /// divmod); shift / true-divide are walker-only (`trait_safe == false`).
+    /// pow still falls through to the generic residual.
     pub(crate) fn binary_long_value(
         &mut self,
         a: OpRef,
@@ -6021,6 +6055,13 @@ impl MIFrame {
         let Some(spec) = long_binop_raw_helper(op) else {
             return self.trace_binary_value(a, b, op);
         };
+        // Shift / true-divide raise on inputs the trait path cannot cheaply
+        // pre-screen (negative or over-large shift count; float overflow), so
+        // they defer to the generic residual here — the walker still
+        // specialises them, executing the authentic op first.
+        if !spec.trait_safe {
+            return self.trace_binary_value(a, b, op);
+        }
         // The division helpers publish ZeroDivisionError on a zero divisor;
         // that path is handled by the generic residual, so fast-path only
         // nonzero divisors (the helper is otherwise side-effect-free when
@@ -6061,7 +6102,7 @@ impl MIFrame {
             // non-elidable (`dont_look_inside`), so it is never pure-CSE'd and,
             // like upstream's NEW, carries no `GuardNoException` (a MemoryError
             // from the allocation is the GC slowpath's concern, not a guard).
-            let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
+            let box_fn = spec.box_fn as *const ();
             Ok::<_, PyError>(ctx.call_typed_with_effect(
                 OpCode::CallR,
                 box_fn,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -263,21 +263,33 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
     ctx.heapcache_setfield_cached(tuple, descr.index(), w_class);
 }
 
-/// Map a `BinaryOperator` to the elidable `rbigint` payload helper used by
-/// the W_LongObject fast path, or `None` when the operator is not specialised
-/// (TrueDivide → float, FloorDivide/Remainder → may raise ZeroDivisionError,
-/// Power/Lshift/Rshift → may raise, Subscr → non-arithmetic). Shared by the
-/// trait path ([`binary_long_value`]) and the walker
-/// (`try_walker_specialize_binary_op_long`).
-pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<extern "C" fn(i64, i64) -> i64> {
+/// Map a `BinaryOperator` to the elidable `rbigint` payload helper used by the
+/// W_LongObject fast path, paired with a `can_raise` flag, or `None` when the
+/// operator is not specialised (TrueDivide → float, Power/Lshift/Rshift → may
+/// raise, Subscr → non-arithmetic). The cannot-raise ops (add/sub/mul/and/or/
+/// xor, `EF_ELIDABLE_CANNOT_RAISE`) record `CallPure*` with no trailing guard;
+/// the can-raise ops (floordiv/mod via `rbigint.divmod`, raises
+/// ZeroDivisionError, `EF_ELIDABLE_CAN_RAISE`) record `CallPure*` +
+/// `GuardNoException`. Shared by the trait path ([`binary_long_value`]) and the
+/// walker (`try_walker_specialize_binary_op_long`).
+pub(crate) fn long_binop_raw_helper(
+    op: BinaryOperator,
+) -> Option<(extern "C" fn(i64, i64) -> i64, bool)> {
+    use pyre_interpreter::objspace::descroperation as desc;
     use pyre_object::longobject as lo;
     Some(match op {
-        BinaryOperator::Add | BinaryOperator::InplaceAdd => lo::jit_w_long_add_raw,
-        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => lo::jit_w_long_sub_raw,
-        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => lo::jit_w_long_mul_raw,
-        BinaryOperator::And | BinaryOperator::InplaceAnd => lo::jit_w_long_and_raw,
-        BinaryOperator::Or | BinaryOperator::InplaceOr => lo::jit_w_long_or_raw,
-        BinaryOperator::Xor | BinaryOperator::InplaceXor => lo::jit_w_long_xor_raw,
+        BinaryOperator::Add | BinaryOperator::InplaceAdd => (lo::jit_w_long_add_raw, false),
+        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (lo::jit_w_long_sub_raw, false),
+        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (lo::jit_w_long_mul_raw, false),
+        BinaryOperator::And | BinaryOperator::InplaceAnd => (lo::jit_w_long_and_raw, false),
+        BinaryOperator::Or | BinaryOperator::InplaceOr => (lo::jit_w_long_or_raw, false),
+        BinaryOperator::Xor | BinaryOperator::InplaceXor => (lo::jit_w_long_xor_raw, false),
+        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => {
+            (desc::jit_w_long_floordiv_raw, true)
+        }
+        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
+            (desc::jit_w_long_mod_raw, true)
+        }
         _ => return None,
     })
 }
@@ -5963,10 +5975,11 @@ impl MIFrame {
     /// `CALL_R` to `jit_bigint_result_box` (the `W_LongObject(...)` NEW /
     /// `bigint_result` demote). Unlike the generic `binary_value` residual
     /// neither is a `CALL_MAY_FORCE`, so the loop body sheds the
-    /// per-iteration force-token store + `GUARD_NOT_FORCED` +
-    /// `GUARD_NO_EXCEPTION`. Specialized for add/sub/mul/and/or/xor; the
-    /// may-raise operators (floordiv/mod/pow/shift) and true-divide fall
-    /// through to the generic residual.
+    /// per-iteration force-token store + `GUARD_NOT_FORCED`. The cannot-raise
+    /// ops (add/sub/mul/and/or/xor) shed `GUARD_NO_EXCEPTION` too; the can-raise
+    /// division ops (floordiv/mod via `rbigint.divmod`) keep a trailing
+    /// `GUARD_NO_EXCEPTION` for the divide-by-zero bail. pow/shift and
+    /// true-divide still fall through to the generic residual.
     pub(crate) fn binary_long_value(
         &mut self,
         a: OpRef,
@@ -5975,31 +5988,62 @@ impl MIFrame {
         concrete_lhs: PyObjectRef,
         concrete_rhs: PyObjectRef,
     ) -> Result<OpRef, PyError> {
-        let Some(raw_fn) = long_binop_raw_helper(op) else {
+        let Some((raw_fn, can_raise)) = long_binop_raw_helper(op) else {
             return self.trace_binary_value(a, b, op);
         };
+        // A zero divisor makes the can-raise payload helper publish
+        // ZeroDivisionError; that path is handled by the generic residual, so
+        // fast-path only nonzero divisors (the helper is otherwise
+        // side-effect-free when invoked for `call_pure_results` below).
+        if can_raise && unsafe { pyre_object::longobject::w_long_is_zero(concrete_rhs) } {
+            return self.trace_binary_value(a, b, op);
+        }
         self.with_ctx(|this, ctx| {
             this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
             this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
             // Pure `rbigint` payload op → bare `*mut BigInt` (Int), recorded
             // as CALL_PURE_I via `record_result_of_call_pure` (patches CALL_I and
             // populates `call_pure_results`), mirroring the walker fast path.
-            let add_fn = raw_fn as *const ();
+            // The can-raise division helpers (`rbigint.divmod`) additionally get
+            // a trailing `GuardNoException` (`pyjitpl.py:2082`).
+            let fn_ptr = raw_fn as *const ();
             let raw_concrete = raw_fn(concrete_lhs as i64, concrete_rhs as i64);
-            let raw = ctx.call_typed_with_effect_pure(
-                OpCode::CallI,
-                add_fn,
-                &[a, b],
-                &[Type::Ref, Type::Ref],
-                Type::Int,
-                majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO,
-                &[
-                    Value::Int(add_fn as usize as i64),
-                    Value::Ref(GcRef(concrete_lhs as usize)),
-                    Value::Ref(GcRef(concrete_rhs as usize)),
-                ],
-                Value::Int(raw_concrete),
-            );
+            let effect = if can_raise {
+                majit_metainterp::ELIDABLE_EFFECT_INFO
+            } else {
+                majit_metainterp::ELIDABLE_CANNOT_RAISE_EFFECT_INFO
+            };
+            let concrete_args = [
+                Value::Int(fn_ptr as usize as i64),
+                Value::Ref(GcRef(concrete_lhs as usize)),
+                Value::Ref(GcRef(concrete_rhs as usize)),
+            ];
+            let raw = if can_raise {
+                ctx.call_typed_with_effect_pure_can_raise(
+                    OpCode::CallI,
+                    fn_ptr,
+                    &[a, b],
+                    &[Type::Ref, Type::Ref],
+                    Type::Int,
+                    effect,
+                    &concrete_args,
+                    Value::Int(raw_concrete),
+                )
+            } else {
+                ctx.call_typed_with_effect_pure(
+                    OpCode::CallI,
+                    fn_ptr,
+                    &[a, b],
+                    &[Type::Ref, Type::Ref],
+                    Type::Int,
+                    effect,
+                    &concrete_args,
+                    Value::Int(raw_concrete),
+                )
+            };
+            if can_raise {
+                this.generate_guard(ctx, OpCode::GuardNoException, &[]);
+            }
             // …then the residual `bigint_result` box/demote → Python int (Ref).
             // Non-elidable (`dont_look_inside`) and `EF_CANNOT_RAISE`, so the
             // wrapper is never pure-CSE'd and the call stays non-forcing.

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -311,39 +311,83 @@ pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<LongBinopSpec>
         _,
         _,
     ) = match op {
-        BinaryOperator::Add | BinaryOperator::InplaceAdd => {
-            (lo::jit_w_long_add_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
-        }
-        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => {
-            (lo::jit_w_long_sub_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
-        }
-        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => {
-            (lo::jit_w_long_mul_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
-        }
-        BinaryOperator::And | BinaryOperator::InplaceAnd => {
-            (lo::jit_w_long_and_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
-        }
-        BinaryOperator::Or | BinaryOperator::InplaceOr => {
-            (lo::jit_w_long_or_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
-        }
-        BinaryOperator::Xor | BinaryOperator::InplaceXor => {
-            (lo::jit_w_long_xor_raw, bigint_box, ELIDABLE_OR_MEMERROR_EFFECT_INFO, false, true)
-        }
-        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => {
-            (desc::jit_w_long_floordiv_raw, bigint_box, ELIDABLE_EFFECT_INFO, true, true)
-        }
-        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
-            (desc::jit_w_long_mod_raw, bigint_box, ELIDABLE_EFFECT_INFO, true, true)
-        }
-        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => {
-            (desc::jit_w_long_lshift_raw, bigint_box, ELIDABLE_EFFECT_INFO, false, false)
-        }
-        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => {
-            (desc::jit_w_long_rshift_raw, bigint_box, ELIDABLE_EFFECT_INFO, false, false)
-        }
-        BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => {
-            (desc::jit_w_long_truediv_raw, float_box, ELIDABLE_EFFECT_INFO, false, false)
-        }
+        BinaryOperator::Add | BinaryOperator::InplaceAdd => (
+            lo::jit_w_long_add_raw,
+            bigint_box,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (
+            lo::jit_w_long_sub_raw,
+            bigint_box,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (
+            lo::jit_w_long_mul_raw,
+            bigint_box,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::And | BinaryOperator::InplaceAnd => (
+            lo::jit_w_long_and_raw,
+            bigint_box,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Or | BinaryOperator::InplaceOr => (
+            lo::jit_w_long_or_raw,
+            bigint_box,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Xor | BinaryOperator::InplaceXor => (
+            lo::jit_w_long_xor_raw,
+            bigint_box,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => (
+            desc::jit_w_long_floordiv_raw,
+            bigint_box,
+            ELIDABLE_EFFECT_INFO,
+            true,
+            true,
+        ),
+        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => (
+            desc::jit_w_long_mod_raw,
+            bigint_box,
+            ELIDABLE_EFFECT_INFO,
+            true,
+            true,
+        ),
+        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => (
+            desc::jit_w_long_lshift_raw,
+            bigint_box,
+            ELIDABLE_EFFECT_INFO,
+            false,
+            false,
+        ),
+        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => (
+            desc::jit_w_long_rshift_raw,
+            bigint_box,
+            ELIDABLE_EFFECT_INFO,
+            false,
+            false,
+        ),
+        BinaryOperator::TrueDivide | BinaryOperator::InplaceTrueDivide => (
+            desc::jit_w_long_truediv_raw,
+            float_box,
+            ELIDABLE_EFFECT_INFO,
+            false,
+            false,
+        ),
         _ => return None,
     };
     Some(LongBinopSpec {

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -207,6 +207,26 @@ pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
     unsafe { crate::lltype::malloc_raw(w_long_get_value(a) ^ w_long_get_value(b)) as i64 }
 }
 
+/// `rbigint.gt`/`lt`/`eq` payload for `W_LongObject` comparison — returns the
+/// sign of `a <=> b` as `-1` / `0` / `1`. A comparison neither allocates nor
+/// raises, so this is `EF_ELIDABLE_CANNOT_RAISE` and the fast path records
+/// `CallPure*` with NO trailing guard. The caller turns the sign into the
+/// requested truth with a plain `int_<cmp>(sign, 0)` (e.g. `a < b` ⟺
+/// `sign < 0`, `a == b` ⟺ `sign == 0`).
+#[majit_macros::elidable_cannot_raise]
+pub extern "C" fn jit_w_long_cmp(a: i64, b: i64) -> i64 {
+    use core::cmp::Ordering;
+    let a = a as PyObjectRef;
+    let b = b as PyObjectRef;
+    unsafe {
+        match w_long_get_value(a).cmp(w_long_get_value(b)) {
+            Ordering::Less => -1,
+            Ordering::Equal => 0,
+            Ordering::Greater => 1,
+        }
+    }
+}
+
 /// `bigint_result` — wrap the bigint produced by [`jit_w_long_add_raw`] in a
 /// Python int, demoting to `W_IntObject` when it fits in i64, otherwise
 /// reusing the `*mut BigInt` payload in a fresh `W_LongObject`. This is the

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -84,6 +84,19 @@ pub unsafe fn w_long_fits_int(obj: PyObjectRef) -> bool {
     }
 }
 
+/// True when the W_LongObject's BigInt is zero. Divisor guard for the
+/// can-raise floordiv/mod fast path (a zero divisor makes the payload helper
+/// publish ZeroDivisionError, which the trait path defers to the generic
+/// residual rather than triggering during tracing).
+///
+/// # Safety
+/// `obj` must point to a valid `W_LongObject`.
+#[inline]
+pub unsafe fn w_long_is_zero(obj: PyObjectRef) -> bool {
+    use malachite_bigint::Sign;
+    unsafe { w_long_get_value(obj).sign() == Sign::NoSign }
+}
+
 /// Extract a reference to the BigInt value from a known W_LongObject pointer.
 ///
 /// # Safety

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -40,9 +40,11 @@ impl crate::lltype::GcType for W_LongObject {
 }
 
 /// Wrap an already heap-allocated `*mut BigInt` in a fresh W_LongObject
-/// without copying the payload — the wrapper takes ownership of `value`.
-///
-/// Uses `Box::leak` (objects are never freed).
+/// without copying the payload — the wrapper just stores `value`, it does not
+/// take exclusive ownership. Pure-call CSE of the elidable `rbigint` helpers
+/// can fold two ops to the same `*mut BigInt`, so one payload may back more
+/// than one wrapper; that is sound only because payloads are never freed
+/// (`malloc_raw` / `Box::leak`).
 pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
     // W_LongObject shares the `int` type with W_IntObject — the two only
     // differ in their storage layout, not their Python-level identity
@@ -146,12 +148,14 @@ pub extern "C" fn jit_w_long_toint(obj: i64) -> i64 {
 /// Both operands are guaranteed `W_LongObject` by a preceding
 /// `GuardClass(LONG_TYPE)` on each, so the BigInt payloads are read
 /// directly. Returns a freshly heap-allocated `*mut BigInt` (as i64) — the
-/// arithmetic only, with no Python-object wrapper. `add` cannot raise (no
-/// division), so this is `EF_ELIDABLE_CANNOT_RAISE`: the value is a pure
-/// function of the operand payloads, so the optimizer may fold/CSE it. The
-/// result is an internal bigint never exposed to Python `is`, so sharing one
-/// payload for two equal-input adds is unobservable.
-#[majit_macros::elidable_cannot_raise]
+/// arithmetic only, with no Python-object wrapper. `add` allocates a new
+/// bigint, so its only failure mode is MemoryError: `EF_ELIDABLE_OR_MEMORYERROR`
+/// (`call.py:294`, `cr == "mem"`). The value is still a pure function of the
+/// operand payloads, so the optimizer may fold/CSE it; a trailing
+/// `GuardNoException` covers the allocation. The result is an internal bigint
+/// never exposed to Python `is`, so sharing one payload for two equal-input
+/// adds is unobservable.
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
@@ -163,40 +167,40 @@ pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
 
 /// `rbigint.sub` — the payload half of `W_LongObject._sub`
 /// (`pypy/objspace/std/longobject.py`). Like [`jit_w_long_add_raw`] but
-/// subtracts; cannot raise, so `EF_ELIDABLE_CANNOT_RAISE`.
-#[majit_macros::elidable_cannot_raise]
+/// subtracts; allocates, so `EF_ELIDABLE_OR_MEMORYERROR`.
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_sub_raw(a: i64, b: i64) -> i64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
     unsafe { crate::lltype::malloc_raw(w_long_get_value(a) - w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.mul` payload half of `W_LongObject._mul`. Cannot raise.
-#[majit_macros::elidable_cannot_raise]
+/// `rbigint.mul` payload half of `W_LongObject._mul`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_mul_raw(a: i64, b: i64) -> i64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
     unsafe { crate::lltype::malloc_raw(w_long_get_value(a) * w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.and_` payload half of `W_LongObject._and`. Cannot raise.
-#[majit_macros::elidable_cannot_raise]
+/// `rbigint.and_` payload half of `W_LongObject._and`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_and_raw(a: i64, b: i64) -> i64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
     unsafe { crate::lltype::malloc_raw(w_long_get_value(a) & w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.or_` payload half of `W_LongObject._or`. Cannot raise.
-#[majit_macros::elidable_cannot_raise]
+/// `rbigint.or_` payload half of `W_LongObject._or`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_or_raw(a: i64, b: i64) -> i64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;
     unsafe { crate::lltype::malloc_raw(w_long_get_value(a) | w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.xor_` payload half of `W_LongObject._xor`. Cannot raise.
-#[majit_macros::elidable_cannot_raise]
+/// `rbigint.xor_` payload half of `W_LongObject._xor`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+#[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
     let a = a as PyObjectRef;
     let b = b as PyObjectRef;


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
