### PR TITLE
rtyper cutover: boxing-alloc fusion + dead-header sweep + _ll_dictnext helper

### DIFF
--- a/majit/majit-translate/src/annotator/annrpython.rs
+++ b/majit/majit-translate/src/annotator/annrpython.rs
@@ -455,6 +455,11 @@ impl RPythonAnnotator {
         bookkeeper: Option<Rc<Bookkeeper>>,
         keepgoing: bool,
     ) -> Rc<Self> {
+        // annrpython.py:30 imports rpython.rtyper.extfuncregistry for
+        // side effects before seeding the annotator fields.
+        crate::translator::rtyper::extfuncregistry::register_external_functions()
+            .expect("register extfuncregistry");
+
         let translator_was_provided = translator.is_some();
         let policy = policy.unwrap_or_else(AnnotatorPolicy::new);
         let annotator_policy = PolicyHandle::from(policy.clone());

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -1586,11 +1586,23 @@ pub fn malloc_typed_alloc(
         ));
     }
     match arg_at(args_s, 0, "malloc_typed") {
-        SomeValue::Instance(inst) => Ok(SomeValue::Instance(SomeInstance::new(
-            inst.classdef.clone(),
-            false,
-            Default::default(),
-        ))),
+        SomeValue::Instance(inst) => {
+            // lltype.py:2202-2209 `malloc(T)`: only `isinstance(T, Struct)`
+            // is mallocable; everything else falls to
+            // `raise TypeError("malloc: unmallocable type")`. A classdef-less
+            // `SomeInstance` (object-only; `SomeInstance(classdef=None)`)
+            // carries no concrete struct, so it is that `else` arm — reject
+            // it here instead of boxing a typeless value the downstream
+            // `NewWithVtable` cannot stamp a vtable for.
+            if inst.classdef.is_none() {
+                return Err(AnnotatorError::new("malloc: unmallocable type"));
+            }
+            Ok(SomeValue::Instance(SomeInstance::new(
+                inst.classdef.clone(),
+                false,
+                Default::default(),
+            )))
+        }
         other => Err(AnnotatorError::new(format!(
             "malloc_typed(): expected a struct value to box, got {other:?}"
         ))),
@@ -1945,6 +1957,22 @@ mod tests {
 
     fn no_kwds() -> HashMap<String, Option<SomeValue>> {
         HashMap::new()
+    }
+
+    #[test]
+    fn malloc_typed_rejects_classdef_less_instance() {
+        // lltype.py:2202-2209 `malloc(T)`: only `isinstance(T, Struct)` is
+        // mallocable. A classdef-less `SomeInstance` (object-only) carries
+        // no concrete struct, so it takes the `else: raise
+        // TypeError("malloc: unmallocable type")` arm.
+        let bk = bk();
+        let obj_only = SomeValue::Instance(SomeInstance::new(None, false, Default::default()));
+        let err = malloc_typed_alloc(&bk, &[Some(obj_only)], &no_kwds())
+            .expect_err("classdef-less instance must be rejected");
+        assert!(
+            format!("{err:?}").contains("unmallocable type"),
+            "expected unmallocable-type error, got {err:?}"
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -291,6 +291,15 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // keyed under the `HostObject::new_builtin_callable` qualname the
     // lltype HOST_ENV module assigns (`flowspace/model.rs:1795`).
     analyzer_for(&mut reg, "lltype.cast_pointer", lltype_cast_pointer);
+    // `pyre_object::lltype::malloc_typed` — the GC allocation intrinsic.
+    // Keyed by the qualname the HOST_ENV `pyre_object.lltype` module assigns
+    // (`flowspace/model.rs`); recognising it as a builtin keeps its body out
+    // of the looked-inside set (the `<T as GcType>::type_id()` accessor wall).
+    analyzer_for(
+        &mut reg,
+        "pyre_object.lltype.malloc_typed",
+        malloc_typed_alloc,
+    );
     // Rust `std::ptr::eq(p, q) -> bool` — registered under the dotted
     // qualname that `HostEnv::bootstrap` assigns to the HOST_ENV stub
     // (`flowspace/model.rs:1910`).  Lowers identity checks in
@@ -1553,6 +1562,39 @@ fn lltype_cast_pointer(
         can_be_none,
         Default::default(),
     )))
+}
+
+/// Analyzer for `pyre_object::lltype::malloc_typed::<T>(value: T) -> *mut T`
+/// — the GC allocation intrinsic (`lltype.malloc(STRUCT, flavor='gc')`
+/// parity).  Registered as a builtin so the body is NEVER looked-inside:
+/// it calls `<T as GcType>::type_id()`, a trait accessor that lowers to the
+/// unregistered bare-leaf path `["GcType","type_id"]` (no flowable graph),
+/// which would poison every boxing caller's lift.  A successful malloc
+/// returns a non-null heap pointer to the same struct the argument
+/// constructs, so the result is `SomeInstance(T)` with `can_be_none =
+/// false` (OOM takes the MemoryError exception edge, not a null result).
+/// The single argument is the constructed struct value (a `SomeInstance`
+/// produced by the `SyntheticTransparentCtor`).
+pub fn malloc_typed_alloc(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    if !kwds.is_empty() || args_s.len() != 1 {
+        return Err(AnnotatorError::new(
+            "malloc_typed() expects a single (value) positional argument",
+        ));
+    }
+    match arg_at(args_s, 0, "malloc_typed") {
+        SomeValue::Instance(inst) => Ok(SomeValue::Instance(SomeInstance::new(
+            inst.classdef.clone(),
+            false,
+            Default::default(),
+        ))),
+        other => Err(AnnotatorError::new(format!(
+            "malloc_typed(): expected a struct value to box, got {other:?}"
+        ))),
+    }
 }
 
 /// Upstream `robjmodel_r_dict(...)` (builtin.py:244-246).

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1463,6 +1463,55 @@ impl Assembler {
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
             }
+            // Boxing GC allocation (`fuse_boxing_alloc`).  Mirrors the runtime
+            // tracer oracle (`codegen.rs trace_box_float`): a `new_with_vtable`
+            // carrying ONLY a size descriptor and a fresh ref-kind result, no
+            // register operands.  The size descr resolves the struct size / gc
+            // type-id / vtable from `owner` via the runtime `gc_cache` Arc
+            // (`path_hash(owner)` keys `_cache_size`), so the codewriter alloc
+            // hits the same descriptor the runtime tracer publishes.
+            OpKind::NewWithVtable { owner } => {
+                let spec = bh_size_spec_from_callcontrol(
+                    callcontrol.expect("new_with_vtable assembly requires a CallControl"),
+                    owner,
+                )
+                .unwrap_or_else(|| {
+                    panic!("new_with_vtable: no struct layout registered for owner {owner:?}")
+                });
+                let descr_idx = self.emit_ready_descr(crate::jitcode::BhDescr::Size {
+                    size: spec.size,
+                    type_id: spec.type_id,
+                    vtable: spec.vtable,
+                    // `STRUCT._name` identity is left empty for the transient
+                    // `bh_new_with_vtable` size descr; the gc_cache hit keys on
+                    // `type_id` (`path_hash(owner)`), not this field.
+                    owner: String::new(),
+                    all_fielddescrs: spec.all_fielddescrs,
+                });
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                // The allocation result is ALWAYS a fresh GC ref ('r').  #314:
+                // assert the regalloc result kind structurally (mirror the
+                // getarrayitem invariant), so an Int-banked result fails loud at
+                // emit time instead of silently miscompiling.
+                let result = op
+                    .result
+                    .as_ref()
+                    .expect("new_with_vtable must produce a result register");
+                argcodes.push('>');
+                let (reg, kc) = self.lookup_reg_with_kind_var(result, regallocs);
+                assert_eq!(
+                    kc, 'r',
+                    "new_with_vtable result must be ref-kind ('r'), got '{kc}' for owner {owner:?}"
+                );
+                argcodes.push(kc);
+                state.code.push(reg);
+                let opname = op_kind_to_opname(&op.kind);
+                let key = format!("{opname}/{argcodes}");
+                let opnum = self.get_opnum(&key);
+                state.code[startposition] = opnum;
+            }
             // RPython `rpython/jit/codewriter/jtransform.py:546` emits
             // `int_guard_value(op.args[0])` where `op.args[0]` is already a
             // `Ptr(FuncType)` integer after rtype.  Rust `&dyn Trait` is a
@@ -2370,6 +2419,7 @@ impl Assembler {
                 OpKind::LoopHeader { .. } => "LoopHeader",
                 OpKind::Abort { .. } => "Abort",
                 OpKind::NewTuple { .. } => "NewTuple",
+                OpKind::NewWithVtable { .. } => "NewWithVtable",
                 OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
                 OpKind::LoadStatic { .. } => "LoadStatic",
             }
@@ -3529,6 +3579,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
             opname
         }
         OpKind::FieldWrite { ty, .. } => format!("setfield_gc_{}", value_type_to_kind(ty)),
+        OpKind::NewWithVtable { .. } => "new_with_vtable".into(),
         // RPython: getarrayitem_gc_i etc.
         OpKind::ArrayRead { item_ty, .. } => {
             format!("getarrayitem_gc_{}", value_type_to_kind(item_ty))

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1464,13 +1464,20 @@ impl Assembler {
                 state.code[startposition] = opnum;
             }
             // Boxing GC allocation (`fuse_boxing_alloc`).  Mirrors the runtime
-            // tracer oracle (`codegen.rs trace_box_float`): a `new_with_vtable`
+            // tracer oracle (`box_trace.rs trace_box_float`): a `new_with_vtable`
             // carrying ONLY a size descriptor and a fresh ref-kind result, no
-            // register operands.  The size descr resolves the struct size / gc
-            // type-id / vtable from `owner` via the runtime `gc_cache` Arc
-            // (`path_hash(owner)` keys `_cache_size`), so the codewriter alloc
-            // hits the same descriptor the runtime tracer publishes.
-            OpKind::NewWithVtable { owner } => {
+            // register operands.  `bh_size_spec_from_callcontrol` resolves the
+            // struct size / gc type-id from `owner` via the runtime `gc_cache`
+            // Arc (`path_hash(owner)` keys `_cache_size`).  The `vtable` (type
+            // pointer) is NOT in that Arc — `_cache_size` carries struct size
+            // only — so it travels on the op (captured by `fuse_boxing_alloc`
+            // from the dropped `ob_header.ob_type` store) and is what the
+            // runtime stamps into the new object's `ob_type` / `w_class`
+            // (`state.rs materialize_virtual_object`, `runner.rs
+            // bh_new_with_vtable`: both write the type word only when vtable
+            // != 0).  A zero vtable would silently leave `ob_type` null, so it
+            // fails loud here.
+            OpKind::NewWithVtable { owner, vtable } => {
                 let spec = bh_size_spec_from_callcontrol(
                     callcontrol.expect("new_with_vtable assembly requires a CallControl"),
                     owner,
@@ -1478,10 +1485,17 @@ impl Assembler {
                 .unwrap_or_else(|| {
                     panic!("new_with_vtable: no struct layout registered for owner {owner:?}")
                 });
+                if *vtable == 0 {
+                    panic!(
+                        "new_with_vtable: boxing owner {owner:?} has no resolved type pointer \
+                         (fuse_boxing_alloc could not capture the ob_type address); refusing to \
+                         emit a null-ob_type allocation"
+                    );
+                }
                 let descr_idx = self.emit_ready_descr(crate::jitcode::BhDescr::Size {
                     size: spec.size,
                     type_id: spec.type_id,
-                    vtable: spec.vtable,
+                    vtable: *vtable as usize,
                     // `STRUCT._name` identity is left empty for the transient
                     // `bh_new_with_vtable` size descr; the gc_cache hit keys on
                     // `type_id` (`path_hash(owner)`), not this field.

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -6815,6 +6815,9 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // ── Known non-raising ops (canraise = ()) ─────────────────
         // RPython LL: getfield_gc, setfield_gc → cannot raise
         OpKind::FieldRead { .. } | OpKind::FieldWrite { .. } => RaiseClass::No,
+        // `malloc` can only raise MemoryError; with `ignore_memoryerror`
+        // it is treated as non-raising (canraise = (MemoryError,)).
+        OpKind::NewWithVtable { .. } => RaiseClass::MemoryErrorOnly,
         // RPython LL: getarrayitem_gc, setarrayitem_gc → cannot raise
         OpKind::ArrayRead { .. } | OpKind::ArrayWrite { .. } => RaiseClass::No,
         // RPython LL: getinteriorfield_gc, setinteriorfield_gc → cannot raise

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4728,7 +4728,8 @@ fn remap_op(
         | OpKind::Live
         | OpKind::LoopHeader { .. }
         | OpKind::Abort { .. }
-        | OpKind::LoadStatic { .. } => op.kind.clone(),
+        | OpKind::LoadStatic { .. }
+        | OpKind::NewWithVtable { .. } => op.kind.clone(),
         OpKind::NewTuple { args } => OpKind::NewTuple {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
         },

--- a/majit/majit-translate/src/flowspace/argument.rs
+++ b/majit/majit-translate/src/flowspace/argument.rs
@@ -84,6 +84,27 @@ impl Signature {
     pub fn len_tuple(&self) -> usize {
         3
     }
+
+    /// RPython `Signature.__getitem__` (argument.py:51-58).
+    pub fn getitem(&self, i: usize) -> SignatureItem<'_> {
+        match i {
+            0 => SignatureItem::Argnames(&self.argnames),
+            1 => SignatureItem::Varargname(self.varargname.as_deref()),
+            2 => SignatureItem::Kwargname(self.kwargname.as_deref()),
+            _ => panic!("IndexError"),
+        }
+    }
+}
+
+/// Item returned by [`Signature::getitem`].
+///
+/// Kept for RPython `Signature.__getitem__` parity even though current Rust
+/// callers prefer [`Signature::tuple_view`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SignatureItem<'a> {
+    Argnames(&'a [String]),
+    Varargname(Option<&'a str>),
+    Kwargname(Option<&'a str>),
 }
 
 use super::model::{Constant, Hlvalue};

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2182,6 +2182,19 @@ impl HostEnv {
                 .expect("core.ptr.null_mut bound above"),
         );
 
+        // `pyre_object::lltype::malloc_typed` — the GC allocation intrinsic
+        // (`lltype.malloc(STRUCT, flavor='gc')` parity).  Exposed as a host
+        // builtin so its body is never looked-inside; the `malloc_typed_alloc`
+        // analyzer types the result as `SomeInstance(T)`.  Callsites carry the
+        // crate-qualified FunctionPath `["pyre_object","lltype","malloc_typed"]`,
+        // which `translate_op`'s Layer-3b resolves via this module
+        // (prefix `pyre_object.lltype`, leaf `malloc_typed`).
+        let pyre_object_lltype = HostObject::new_module("pyre_object.lltype");
+        pyre_object_lltype.module_set(
+            "malloc_typed",
+            HostObject::new_builtin_callable("pyre_object.lltype.malloc_typed"),
+        );
+
         let mut mods = self.modules.lock().unwrap();
         mods.insert("__builtin__".into(), self.builtin_module.clone());
         mods.insert("os".into(), os);
@@ -2218,6 +2231,7 @@ impl HostEnv {
         mods.insert("RootScope".into(), root_scope);
         mods.insert("IntArray".into(), int_array);
         mods.insert("pyre_object.pyobject".into(), pyre_object_pyobject);
+        mods.insert("pyre_object.lltype".into(), pyre_object_lltype);
     }
 
     /// upstream `getattr(__builtin__, name)` — `flowcontext.py:851`.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1401,11 +1401,16 @@ pub fn lower_fun_decl_with_static_addrs(
 ///   removal to keep untouched graphs byte-identical.
 fn simplify_lowered_graph(graph: &mut FunctionGraph) {
     crate::model::eliminate_empty_blocks(graph);
+    // Lower the boxing-constructor idiom `malloc_typed(W_FloatObject{…})`
+    // to a native `NewWithVtable` + payload store before the dead-aggregate
+    // sweep, which then reclaims the orphaned construct-on-stack ctor and
+    // header field writes.
+    let mut dirty = crate::model::fuse_boxing_alloc(graph) > 0;
     // Drop dead aggregate constructions (malloc + field stores whose
     // result is never read) before the dead-op sweep — `prune_dead_phis`
     // keeps them because a `FieldWrite` is side-effecting, so its `base`
     // pins the aggregate (`remove_simple_mallocs`, malloc.py).
-    let mut dirty = crate::model::remove_dead_aggregates(graph) > 0;
+    dirty |= crate::model::remove_dead_aggregates(graph) > 0;
     dirty |= crate::model::remove_assertion_errors(graph) > 0;
     // Constant-condition arms (`if WITHPREBUILTINT { … }` with the
     // config const folded by `const_eval_global`) collapse to the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1315,39 +1315,46 @@ pub fn lower_fun_decl_with_static_addrs(
         }
         Ok(())
     };
-    // Framestate-threaded lowering for acyclic bodies (the GAP-B path
-    // that threads locals as block inputargs / phis).  Default-on;
-    // `PYRE_MIR_FRAMESTATE=0` rolls back to the monotonic lowering.  On a
-    // framestate failure the body falls back to the monotonic path — so
-    // the threaded path is never worse than the monotonic one — unless
-    // `PYRE_MIR_FRAMESTATE_STRICT` is set, which propagates the error for
-    // debugging.
+    // Framestate-threaded lowering (the GAP-B path that threads locals
+    // as block inputargs / phis — the orthodox flowspace shape).
+    // Default-on; `PYRE_MIR_FRAMESTATE=0` rolls back to the monotonic
+    // lowering.  Acyclic bodies thread via the two-pass RPO walk; cyclic
+    // bodies additionally pre-seed each loop header's entry framestate
+    // with the live-in phis `new` pre-bound, so the back-edge threads
+    // into them in pass 2 instead of skipping the body to the monotonic
+    // single-slot scheme.  On any framestate failure the body falls back
+    // to the monotonic path — so the threaded path is never worse than
+    // the monotonic one — unless `PYRE_MIR_FRAMESTATE_STRICT` is set,
+    // which propagates the error for debugging.
     if framestate_enabled() {
         let mut lo = Lowering::new(llbc, name.clone(), &u, static_addrs, fd.generics.as_ref())?;
-        if lo.mir_model_is_acyclic() {
-            // Treat the threaded lowering and its shared post-lowering
-            // stage (`finish`) as one attempt.  `finish` runs uniformly,
-            // same as the linear / RPO paths below — it folds constant
-            // exitswitches, drops `Abort` arms, runs `simplify_lowered_graph`
-            // and installs the exception-link ABI (raise-through vs Result
-            // return); gating it on result-exc activity would let the
-            // framestate path keep dead arms the other strategies prune.
-            // A post-pass (e.g. the result-exc diamond rewrite) can reject
-            // a body the threading itself accepted, and the threading can
-            // fail on a CFG shape it does not yet model, so fold both into
-            // one fallback: on any error fall through to the monotonic path
-            // below, which is known to lower the body — the threaded path
-            // is never worse than the monotonic one.
-            let attempt = lo.lower_framestate().and_then(|()| finish(&mut lo));
-            match attempt {
-                Ok(()) => return Ok(lo.graph),
-                Err(e) => {
-                    if std::env::var_os("PYRE_MIR_FRAMESTATE_DEBUG").is_some() {
-                        eprintln!("[FRAMESTATE fallback] {:?}: {e:?}", name);
-                    }
-                    if std::env::var_os("PYRE_MIR_FRAMESTATE_STRICT").is_some() {
-                        return Err(e);
-                    }
+        // Back-edge targets (loop headers); empty for an acyclic body, in
+        // which case `lower_framestate` reduces exactly to the two-pass
+        // RPO walk.  Treat the threaded lowering and its shared
+        // post-lowering stage (`finish`) as one attempt.  `finish` runs
+        // uniformly, same as the linear / RPO paths below — it folds
+        // constant exitswitches, drops `Abort` arms, runs
+        // `simplify_lowered_graph` and installs the exception-link ABI
+        // (raise-through vs Result return); gating it on result-exc
+        // activity would let the framestate path keep dead arms the other
+        // strategies prune.  A post-pass (e.g. the result-exc diamond
+        // rewrite) can reject a body the threading itself accepted, and
+        // the threading can fail on a CFG shape it does not yet model, so
+        // fold both into one fallback: on any error fall through to the
+        // monotonic path below, which is known to lower the body — the
+        // threaded path is never worse than the monotonic one.
+        let loop_headers = lo.mir_model_loop_headers();
+        let attempt = lo
+            .lower_framestate(&loop_headers)
+            .and_then(|()| finish(&mut lo));
+        match attempt {
+            Ok(()) => return Ok(lo.graph),
+            Err(e) => {
+                if std::env::var_os("PYRE_MIR_FRAMESTATE_DEBUG").is_some() {
+                    eprintln!("[FRAMESTATE fallback] {:?}: {e:?}", name);
+                }
+                if std::env::var_os("PYRE_MIR_FRAMESTATE_STRICT").is_some() {
+                    return Err(e);
                 }
             }
         }
@@ -1925,17 +1932,27 @@ impl<'a> Lowering<'a> {
         reached
     }
 
-    /// `true` iff the model-reachable component (from bb0 over
-    /// [`Self::model_succs`]) contains no back-edge.  The framestate path
-    /// handles only acyclic bodies; cyclic ones fall back to the
-    /// monotonic lowering (they are not in the acyclic GAP-B skip set
-    /// this path drains, and a loop header needs a real fixpoint rather
-    /// than the two-pass acyclic threading).  3-colour DFS: a successor
-    /// still on the DFS stack (grey) is a back-edge.
-    fn mir_model_is_acyclic(&self) -> bool {
+    /// Loop headers of the model-reachable component (from bb0 over
+    /// [`Self::model_succs`]): the targets of back-edges.  Indexed by MIR
+    /// block; `true` iff the block is the target of at least one retreating
+    /// edge in the DFS — i.e. a successor still grey (on the DFS stack)
+    /// when its predecessor reaches it.  Returns all-`false` for an
+    /// acyclic body, so passing this to [`Self::lower_framestate`] reduces
+    /// that path to the plain two-pass RPO walk.
+    ///
+    /// For a reducible body (every retreating edge's target dominates its
+    /// source — the shape structured Rust control flow always produces)
+    /// these are exactly the natural loop headers, independent of DFS
+    /// order.  The framestate path uses them to pre-seed each loop
+    /// header's entry state with its pre-bound live-in phis so the
+    /// back-edge can thread into them; an irreducible body may mis-seed
+    /// and produce an undefined-operand graph, which the pass-2 / final
+    /// self-validation guards reject into the monotonic fallback.
+    fn mir_model_loop_headers(&self) -> Vec<bool> {
         let n = self.body.body.len();
+        let mut headers = vec![false; n];
         if n == 0 {
-            return true;
+            return headers;
         }
         // 0 = white, 1 = grey (on stack), 2 = black (done).
         let mut state = vec![0u8; n];
@@ -1951,7 +1968,7 @@ impl<'a> Lowering<'a> {
                         state[nxt] = 1;
                         stack.push((nxt, 0));
                     }
-                    1 => return false, // grey successor ⇒ back-edge ⇒ cyclic
+                    1 => headers[nxt] = true, // grey successor ⇒ back-edge target
                     _ => {}
                 }
             } else {
@@ -1959,7 +1976,7 @@ impl<'a> Lowering<'a> {
                 stack.pop();
             }
         }
-        true
+        headers
     }
 
     /// Reverse-postorder of the model-reachable component over
@@ -2014,13 +2031,26 @@ impl<'a> Lowering<'a> {
 
     /// Lower the body threading locals as block inputargs / phis via
     /// per-block [`FrameState`]s, instead of the function-wide monotonic
-    /// `local_var` table.  Restricted to acyclic bodies (the caller gates
-    /// on [`Self::mir_model_is_acyclic`]); this drains the GAP-B
-    /// "undefined operand" census skips where a reassigned local reaches
-    /// a merge with path-dependent values the monotonic single-slot
-    /// scheme cannot represent.
+    /// `local_var` table.  Handles both acyclic and cyclic bodies; this
+    /// drains the GAP-B "undefined operand" census skips where a
+    /// reassigned local reaches a merge with path-dependent values the
+    /// monotonic single-slot scheme cannot represent, and puts cyclic
+    /// bodies on the same orthodox flowspace shape as acyclic ones.
+    ///
+    /// `loop_headers` (from [`Self::mir_model_loop_headers`]) marks the
+    /// back-edge targets.  For an acyclic body it is all-`false` and this
+    /// reduces exactly to the two-pass RPO walk.
     ///
     /// Two passes over the model-reachable blocks in reverse-postorder:
+    ///
+    ///   Pass 0 (cyclic only) — pre-seed every loop header's entry
+    ///   framestate with the live-in phis `new` pre-bound for it
+    ///   (`block_entry_local_var[H]`).  The RPO walk visits a loop header
+    ///   before its back-edge predecessor (latch), so without a seed the
+    ///   header's entry would miss the back-edge's contribution; seeding
+    ///   it with the live-in Variables makes the header's inputargs real
+    ///   phis that both the forward predecessor(s) and the latch thread
+    ///   into during pass 2.
     ///
     ///   Pass 1 — for each block, `setstate` to its accumulated entry
     ///   framestate, set its (non-startblock) inputargs to the entry
@@ -2029,7 +2059,9 @@ impl<'a> Lowering<'a> {
     ///   return / raise correctly and emits placeholder empty-args
     ///   goto / branch links because every successor still has empty
     ///   inputargs at close time), snapshot the exit framestate, and
-    ///   union that exit into each model successor's entry framestate.
+    ///   union that exit into each model successor's entry framestate —
+    ///   except a successor that is a loop header, whose pre-seeded entry
+    ///   is fixed (the predecessor still threads into it in pass 2).
     ///
     ///   Pass 2 — re-argument each goto / branch link from the
     ///   predecessor exit / target entry framestates via `getoutputargs`,
@@ -2040,13 +2072,23 @@ impl<'a> Lowering<'a> {
     /// stubbed as dead raises so the graph stays complete without
     /// threading dead state — leaving their original content would
     /// reference the monotonic carry-on `local_var`.  bb0 (the
-    /// startblock) is never a merge target in an acyclic body, so it
-    /// keeps its `OpKind::Input`-paired parameter inputargs untouched —
-    /// the opcode-dispatch arm extractor depends on that shape.
-    fn lower_framestate(&mut self) -> Result<(), LowerError> {
+    /// startblock) keeps its `OpKind::Input`-paired parameter inputargs
+    /// untouched — the opcode-dispatch arm extractor depends on that
+    /// shape — so a back-edge into bb0 (which would demand reseeding the
+    /// parameter slots as phis) declines to the monotonic fallback.
+    fn lower_framestate(&mut self, loop_headers: &[bool]) -> Result<(), LowerError> {
         let n = self.body.body.len();
         if n == 0 {
             return Ok(());
+        }
+        // A back-edge into bb0 would force the parameter slots to become
+        // phis, but bb0 must keep its `OpKind::Input`-paired parameter
+        // inputargs (the opcode-dispatch arm extractor depends on that
+        // shape).  Decline such bodies to the monotonic fallback.
+        if loop_headers.first().copied().unwrap_or(false) {
+            return Err(LowerError::Unsupported(
+                "framestate: back-edge into startblock bb0 — declines to monotonic".to_string(),
+            ));
         }
         let reachable = self.mir_model_reachable();
         let rpo = self.model_rpo();
@@ -2065,6 +2107,25 @@ impl<'a> Lowering<'a> {
         let mut exit_state: Vec<Option<FrameState>> = vec![None; n];
         // bb0 enters with the parameter bindings established in `new`.
         entry_state[0] = Some(self.getstate());
+
+        // Pass 0 (cyclic only) — pre-seed each loop header's entry
+        // framestate with the live-in phis `new` pre-bound for it
+        // (`block_entry_local_var[H]`, a fresh `Variable` per live-in
+        // local already pushed as a `block_id[H]` inputarg).  The RPO
+        // walk reaches a loop header before its latch, so this seed — not
+        // a forward-predecessor union — is what makes the header's
+        // inputargs the loop phis; the forward predecessor(s) and the
+        // latch both thread into them in pass 2 via `getoutputargs`.
+        // bb0 is never reseeded (guarded above + it is not in the merge
+        // set), so its parameter inputargs / `Input` ops stay intact.
+        for (h, &is_header) in loop_headers.iter().enumerate().take(n) {
+            if is_header && h != 0 {
+                entry_state[h] = Some(FrameState {
+                    entries: self.block_entry_local_var[h].clone(),
+                    ..Default::default()
+                });
+            }
+        }
 
         // Pass 1 — RPO walk: setstate, inputargs, lower, snapshot, union.
         for &bb in &rpo {
@@ -2161,6 +2222,14 @@ impl<'a> Lowering<'a> {
                 if tmir == usize::MAX {
                     continue;
                 }
+                // A loop-header successor keeps its pre-seeded entry
+                // (Pass 0): its live-in phis are fixed, and this
+                // predecessor threads into them in pass 2.  Unioning the
+                // exit in would re-mint the phi Variables on the forward
+                // edge and lose the seed the latch must thread into.
+                if loop_headers.get(tmir).copied().unwrap_or(false) {
+                    continue;
+                }
                 let merged = match entry_state[tmir].take() {
                     None => ex.clone(),
                     Some(prev) => prev.union(&ex, &mut self.graph).ok_or_else(|| {
@@ -2227,7 +2296,19 @@ impl<'a> Lowering<'a> {
                         "framestate: bb{tmir} missing entry state in pass 2"
                     ))
                 })?;
-                let outputargs = ex.getoutputargs(&tgt_state, &self.graph);
+                // `try_getoutputargs` (not the panicking `getoutputargs`):
+                // a loop header pre-seeded with live-in phis bypasses the
+                // union's None-kill, so a phantom slot scrubbed to `None`
+                // in this predecessor's exit could leave a target
+                // `Variable` slot unbound in `self`.  Decline such a
+                // mismatch to the monotonic fallback instead of panicking.
+                let outputargs = ex.try_getoutputargs(&tgt_state, &self.graph).ok_or_else(|| {
+                    LowerError::Unsupported(format!(
+                        "framestate: getoutputargs phantom-slot mismatch on edge bb{bb} -> \
+                         bb{tmir} in graph {:?} — declines to monotonic",
+                        self.graph.name,
+                    ))
+                })?;
                 // Self-validation: every output arg is an exit-state cell
                 // of `bb`, hence must be defined in `bb_id` (as an
                 // inputarg or op result).  If the threading would emit a

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2302,13 +2302,15 @@ impl<'a> Lowering<'a> {
                 // in this predecessor's exit could leave a target
                 // `Variable` slot unbound in `self`.  Decline such a
                 // mismatch to the monotonic fallback instead of panicking.
-                let outputargs = ex.try_getoutputargs(&tgt_state, &self.graph).ok_or_else(|| {
-                    LowerError::Unsupported(format!(
-                        "framestate: getoutputargs phantom-slot mismatch on edge bb{bb} -> \
+                let outputargs =
+                    ex.try_getoutputargs(&tgt_state, &self.graph)
+                        .ok_or_else(|| {
+                            LowerError::Unsupported(format!(
+                                "framestate: getoutputargs phantom-slot mismatch on edge bb{bb} -> \
                          bb{tmir} in graph {:?} — declines to monotonic",
-                        self.graph.name,
-                    ))
-                })?;
+                                self.graph.name,
+                            ))
+                        })?;
                 // Self-validation: every output arg is an exit-state cell
                 // of `bb`, hence must be defined in `bb_id` (as an
                 // inputarg or op result).  If the threading would emit a

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -568,7 +568,8 @@ fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::Live
         | OpKind::LoopHeader { .. }
         | OpKind::Abort { .. }
-        | OpKind::LoadStatic { .. } => Vec::new(),
+        | OpKind::LoadStatic { .. }
+        | OpKind::NewWithVtable { .. } => Vec::new(),
 
         OpKind::FieldRead { base, .. }
         | OpKind::VableFieldRead { base, .. }

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -428,8 +428,9 @@ pub(crate) fn remap_op_kind(
         OpKind::ConstRef(obj) => OpKind::ConstRef(obj.clone()),
         OpKind::ConstRefNull => OpKind::ConstRefNull,
         OpKind::ConstRefAddr(addr) => OpKind::ConstRefAddr(*addr),
-        OpKind::NewWithVtable { owner } => OpKind::NewWithVtable {
+        OpKind::NewWithVtable { owner, vtable } => OpKind::NewWithVtable {
             owner: owner.clone(),
+            vtable: *vtable,
         },
         OpKind::FieldRead {
             base,

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -428,6 +428,9 @@ pub(crate) fn remap_op_kind(
         OpKind::ConstRef(obj) => OpKind::ConstRef(obj.clone()),
         OpKind::ConstRefNull => OpKind::ConstRefNull,
         OpKind::ConstRefAddr(addr) => OpKind::ConstRefAddr(*addr),
+        OpKind::NewWithVtable { owner } => OpKind::NewWithVtable {
+            owner: owner.clone(),
+        },
         OpKind::FieldRead {
             base,
             field,
@@ -850,7 +853,8 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         | OpKind::Live
         | OpKind::LoopHeader { .. }
         | OpKind::Abort { .. }
-        | OpKind::LoadStatic { .. } => {
+        | OpKind::LoadStatic { .. }
+        | OpKind::NewWithVtable { .. } => {
             vec![]
         }
         OpKind::NewTuple { args } => args.iter().map(clone_var).collect(),
@@ -1081,6 +1085,10 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
 /// pure op's args even though both should die together.
 pub fn is_pure_op(kind: &OpKind) -> bool {
     match kind {
+        // `new_with_vtable` heap-allocates a fresh boxed object: NOT pure.
+        // CSE must never coalesce two allocations, or Python `is` object
+        // identity would break.
+        OpKind::NewWithVtable { .. } => false,
         // `OpKind::ConstInt` / `OpKind::ConstFloat` materialize a
         // `Variable` for a literal in pyre's IR.  There
         // is NO upstream `int_constant` op — RPython's `Constant` is

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -596,10 +596,21 @@ pub enum OpKind {
     /// `OpCode::NewWithVtable`). `owner` is the struct leaf (e.g.
     /// `"W_FloatObject"`); the assembler resolves the size descriptor from it
     /// via `bh_size_spec_from_callcontrol`, whose `path_hash(owner)` keys the
-    /// runtime `gc_cache._cache_size` Arc carrying the real vtable + gc
-    /// type-id. The result register is always a fresh `Ref` ('r').
+    /// runtime `gc_cache._cache_size` Arc carrying the struct size + gc
+    /// type-id.
+    ///
+    /// `vtable` is the type-pointer (the `&FLOAT_TYPE` / `&INT_TYPE` /
+    /// `&COMPLEX_TYPE` static address) the runtime stamps into the fresh
+    /// object's `ob_type` (and, via `get_instantiate`, its `w_class`).  The GC
+    /// allocator reads it from the size descriptor's `vtable` field — NOT from
+    /// `type_id`, which resolves the struct *size* only (`gc_cache._cache_size`
+    /// carries no type pointer).  `fuse_boxing_alloc` captures it from the
+    /// boxed constructor's dropped `ob_header.ob_type` store; a `0` vtable is
+    /// an unresolved/non-boxing placeholder the assembler rejects.  The result
+    /// register is always a fresh `Ref` ('r').
     NewWithVtable {
         owner: String,
+        vtable: i64,
     },
     ArrayRead {
         base: crate::flowspace::model::Variable,
@@ -2528,11 +2539,13 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
 /// rtyper lowers `malloc` to the GC allocation op.  pyre's rtyper is an
 /// ephemeral type oracle that never rewrites the surviving model graph, so the
 /// lowering is produced here instead: rewrite the cluster to
-/// `NewWithVtable { owner } -> %ret` + a single payload `FieldWrite(%ret, …)`,
-/// dropping the `ob_header` (PyObject base) subtree — the type pointer / w_class
-/// ride the `NewWithVtable` header descriptor, matching the runtime tracer
-/// oracle (`codegen.rs trace_box_float`: one `NewWithVtable` + one
-/// `SetfieldGc` for the payload).
+/// `NewWithVtable { owner, vtable } -> %ret` + a single payload
+/// `FieldWrite(%ret, …)`, dropping the `ob_header` (PyObject base) subtree.
+/// The type pointer the dropped `ob_header.ob_type` store carries is captured
+/// into `NewWithVtable.vtable` (the runtime stamps the new object's `ob_type` /
+/// `w_class` from it — `type_id` resolves struct size only), matching the
+/// runtime tracer oracle (`box_trace.rs trace_box_float`: one `NewWithVtable`
+/// carrying a real type pointer + one `SetfieldGc` for the payload).
 ///
 /// The payload store is inserted *after* the `NewWithVtable` (which reuses the
 /// malloc result Variable `%ret`), since the original aggregate field stores
@@ -2541,11 +2554,13 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
 /// by the `remove_dead_aggregates` + `prune_dead_phis` passes that follow in
 /// `simplify_lowered_graph`.
 pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
+    use crate::flowspace::model::Variable;
     // Recognised boxing structs and their scalar payload fields, in struct
-    // order.  The header (`ob_header`: ob_type + w_class) is NOT listed — it
-    // rides the `NewWithVtable` size descriptor, installed by the GC rewriter
-    // (oracle: `codegen.rs trace_box_float` / `trace_box_int` ignore the
-    // ob_type descriptor and emit only the payload setfield(s)).
+    // order.  The header (`ob_header`: ob_type + w_class) is NOT listed as a
+    // payload — its type pointer is captured separately into
+    // `NewWithVtable.vtable` (see `resolve_vtable_addr`) and the runtime stamps
+    // `ob_type` / `w_class` from it, so only the scalar payload setfield(s) are
+    // re-emitted (oracle: `box_trace.rs trace_box_float` / `trace_box_int`).
     fn payload_fields(owner: &str) -> Option<&'static [(&'static str, ValueType)]> {
         match owner {
             "W_FloatObject" => Some(&[("floatval", ValueType::Float)]),
@@ -2562,6 +2577,57 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
                 && segments[segments.len() - 2] == "lltype")
     };
 
+    // Resolve the type-pointer the dropped `ob_header.ob_type` store carries:
+    // `%agg.ob_header = %h; %h.ob_type = __pyre_cast_instance(ConstRefAddr(t))`.
+    // The runtime stamps the new object's `ob_type`/`w_class` from this address
+    // (read out of the `NewWithVtable` size descriptor), so it must travel with
+    // the op rather than being dropped.  Returns `0` when the cluster carries no
+    // resolvable constant type-pointer (e.g. a synthetic test fixture).
+    fn store_value(graph: &FunctionGraph, base: &Variable, field_name: &str) -> Option<Variable> {
+        graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .find_map(|o| match &o.kind {
+                OpKind::FieldWrite { base: b, field, value, .. }
+                    if b == base && field.name.as_str() == field_name =>
+                {
+                    value.as_variable().cloned()
+                }
+                _ => None,
+            })
+    }
+    fn const_ref_addr(graph: &FunctionGraph, var: &Variable, depth: u32) -> Option<i64> {
+        if depth == 0 {
+            return None;
+        }
+        let producer = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .find(|o| o.result.as_ref() == Some(var))?;
+        match &producer.kind {
+            OpKind::ConstRefAddr(addr) => Some(*addr),
+            // Walk `__pyre_cast_instance[<root>]` pointer reinterprets.
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                ..
+            } if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                && args.len() == 1 =>
+            {
+                const_ref_addr(graph, &args[0], depth - 1)
+            }
+            _ => None,
+        }
+    }
+    let resolve_vtable_addr = |graph: &FunctionGraph, agg: &Variable| -> i64 {
+        store_value(graph, agg, "ob_header")
+            .and_then(|header| store_value(graph, &header, "ob_type"))
+            .and_then(|obtype| const_ref_addr(graph, &obtype, 8))
+            .unwrap_or(0)
+    };
+
     struct Payload {
         field: FieldDescriptor,
         value: LinkArg,
@@ -2572,6 +2638,7 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
         op: usize,
         result: crate::flowspace::model::Variable,
         owner: String,
+        vtable: i64,
         payloads: Vec<Payload>,
     }
 
@@ -2642,11 +2709,13 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
             if !complete {
                 continue;
             }
+            let vtable = resolve_vtable_addr(graph, agg);
             sites.push(Site {
                 block: bi,
                 op: oi,
                 result: result.clone(),
                 owner,
+                vtable,
                 payloads,
             });
         }
@@ -2659,7 +2728,10 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
         let block = &mut graph.blocks[site.block];
         block.operations[site.op] = SpaceOperation {
             result: Some(site.result.clone()),
-            kind: OpKind::NewWithVtable { owner: site.owner },
+            kind: OpKind::NewWithVtable {
+                owner: site.owner,
+                vtable: site.vtable,
+            },
         };
         // Payload stores follow the `NewWithVtable`, in struct order.  Each is
         // a plain `FieldWrite` the assembler lowers to its own `setfield_gc`.
@@ -5433,7 +5505,7 @@ mod tests {
         let nwv_pos = ops
             .iter()
             .position(|op| {
-                matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")
+                matches!(&op.kind, OpKind::NewWithVtable { owner, .. } if owner == "W_FloatObject")
             })
             .expect("NewWithVtable must be emitted");
         assert_eq!(
@@ -5534,7 +5606,7 @@ mod tests {
         let nwv_pos = ops
             .iter()
             .position(|op| {
-                matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_ComplexObject")
+                matches!(&op.kind, OpKind::NewWithVtable { owner, .. } if owner == "W_ComplexObject")
             })
             .expect("NewWithVtable must be emitted");
         // Two payload stores follow, real then imag, both targeting %ret/Float.
@@ -5747,11 +5819,16 @@ mod tests {
             "the dead ob_type/w_class header casts must be swept"
         );
         // The live spine survives: NewWithVtable + floatval store + return cast.
+        // The vtable (type pointer) is captured from the dropped
+        // `ob_header.ob_type = cast(ConstRefAddr(4357049520))` store so the
+        // runtime can stamp `ob_type` / `w_class`.
         assert!(
-            ops.iter().any(
-                |op| matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")
-            ),
-            "NewWithVtable must survive"
+            ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::NewWithVtable { owner, vtable }
+                    if owner == "W_FloatObject" && *vtable == 4357049520
+            )),
+            "NewWithVtable must survive carrying the captured type pointer"
         );
         assert!(
             ops.iter().any(|op| matches!(
@@ -5925,6 +6002,7 @@ mod tests {
                 entry,
                 OpKind::NewWithVtable {
                     owner: "W_FloatObject".into(),
+                    vtable: 0x5000_0000,
                 },
                 true,
             )
@@ -6007,7 +6085,7 @@ mod tests {
         assert!(
             kinds
                 .iter()
-                .any(|k| matches!(k, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")),
+                .any(|k| matches!(k, OpKind::NewWithVtable { owner, .. } if owner == "W_FloatObject")),
             "the live NewWithVtable must survive"
         );
         assert!(

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2706,9 +2706,12 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
 /// So this sweep runs `transform_dead_op_vars`' dependency-flow liveness
 /// (`simplify.py:425-479`) — a `Link.arg` is live iff the target inputarg it
 /// feeds is live, not unconditionally — combined with the malloc-removal
-/// exemption (`malloc.py remove_simple_mallocs`) that a store into a struct
-/// nothing reads is itself dead, so a `FieldWrite.base` is *not* a liveness
-/// root.  The header producers eligible for removal are all side-effect-free:
+/// exemption (`malloc.py remove_simple_mallocs`): a store into a fresh
+/// aggregate nothing reads is itself dead, so a `SyntheticTransparentCtor`
+/// `FieldWrite.base` is *not* a liveness root.  The exemption is scoped to
+/// ctor bases — a store *through* an aliasing or loaded base (a cast or a
+/// load) is a real heap side effect and roots its base like any other op.
+/// The header producers eligible for removal are all side-effect-free:
 /// a `SyntheticTransparentCtor` stack construct, a `__pyre_cast_instance`
 /// pointer reinterpret (`exception_cannot_occur` → `cast_pointer`), and the
 /// `pyre_object::pyobject::get_instantiate` read of a type's `instantiate`
@@ -2743,8 +2746,7 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
             // narrow (`front::mir`), always a single-operand reinterpret.
             // Pin the arity so an unrelated multi-arg path that happens to
             // share the synthetic marker leaf is never swept as a cast.
-            let is_cast = segments.first().map(String::as_str)
-                == Some("__pyre_cast_instance")
+            let is_cast = segments.first().map(String::as_str) == Some("__pyre_cast_instance")
                 && args.len() == 1;
             // `pyre_object::pyobject::get_instantiate` — the pure
             // `instantiate`-slot read feeding the dropped `w_class`.  Match
@@ -2769,6 +2771,28 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
         .map(|(i, b)| (b.id, i))
         .collect();
 
+    // Fresh stack aggregates (`SyntheticTransparentCtor`) are the only bases
+    // whose field stores may be dropped: a store into an aggregate nothing
+    // reads is itself dead (`malloc.py remove_simple_mallocs`).  A store
+    // *through* an aliasing or loaded base (`__pyre_cast_instance` /
+    // `get_instantiate` / a parameter / …) is a real heap side effect, so the
+    // exemption is scoped to ctor results — every other store roots its base.
+    let synthetic_ctor_results: HashSet<Variable> = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .filter(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                }
+            )
+        })
+        .filter_map(|op| op.result.clone())
+        .collect();
+
     // Liveness roots + dependency edges (`simplify.py:425-462`) with the two
     // boxing exemptions above.
     let mut read_vars: HashSet<Variable> = HashSet::new();
@@ -2776,15 +2800,23 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
     for block in &graph.blocks {
         for op in &block.operations {
             match &op.kind {
-                // A store's value is live iff the struct it writes is live; the
-                // `base` is deliberately not rooted, so an unread aggregate's
-                // stores die with it (malloc-removal exemption).
-                OpKind::FieldWrite { base, value, .. } => {
+                // A store into a fresh aggregate is live iff the aggregate is
+                // live; the `base` is deliberately not rooted, so an unread
+                // aggregate's stores die with it (malloc-removal exemption).
+                OpKind::FieldWrite { base, value, .. } if synthetic_ctor_results.contains(base) => {
                     if let Some(var) = value.as_variable() {
                         dependencies
                             .entry(base.clone())
                             .or_default()
                             .push(var.clone());
+                    }
+                }
+                // A store through any other base is a real heap side effect:
+                // root both the base and the stored value.
+                OpKind::FieldWrite { base, value, .. } => {
+                    read_vars.insert(base.clone());
+                    if let Some(var) = value.as_variable() {
+                        read_vars.insert(var.clone());
                     }
                 }
                 // Side-effect-free header producers route operands like a pure
@@ -2851,12 +2883,15 @@ pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
             if read_vars.contains(result) || !is_removable_producer(&op.kind) {
                 return None;
             }
-            let stores_clean = graph.blocks.iter().flat_map(|b| &b.operations).all(|o| {
-                match &o.kind {
-                    OpKind::FieldWrite { base, .. } if base == result => o.result.is_none(),
-                    _ => true,
-                }
-            });
+            let stores_clean =
+                graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| &b.operations)
+                    .all(|o| match &o.kind {
+                        OpKind::FieldWrite { base, .. } if base == result => o.result.is_none(),
+                        _ => true,
+                    });
             stores_clean.then(|| result.clone())
         })
         .collect();
@@ -5329,7 +5364,9 @@ mod tests {
         // + one floatval setfield, matching `codegen.rs trace_box_float`).
         let mut graph = FunctionGraph::new("test");
         let entry = graph.startblock;
-        let v = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let v = graph
+            .push_op_var(entry, OpKind::ConstFloat(0.0f64.to_bits()), true)
+            .unwrap();
         let header = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
         let agg = graph
             .push_op_var(
@@ -5438,8 +5475,12 @@ mod tests {
         // order, both retyped to Float.
         let mut graph = FunctionGraph::new("test");
         let entry = graph.startblock;
-        let re = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
-        let im = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let re = graph
+            .push_op_var(entry, OpKind::ConstFloat(0.0f64.to_bits()), true)
+            .unwrap();
+        let im = graph
+            .push_op_var(entry, OpKind::ConstFloat(0.0f64.to_bits()), true)
+            .unwrap();
         let agg = graph
             .push_op_var(
                 entry,
@@ -5598,7 +5639,9 @@ mod tests {
         };
         let mut graph = FunctionGraph::new("test");
         let entry = graph.startblock;
-        let value = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let value = graph
+            .push_op_var(entry, OpKind::ConstFloat(0.0f64.to_bits()), true)
+            .unwrap();
         let ty_addr1 = graph
             .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
             .unwrap();
@@ -5623,8 +5666,16 @@ mod tests {
                 true,
             )
             .unwrap();
-        graph.push_op_var(entry, field(&header, "ob_type", "PyObject", &ob_type), false);
-        graph.push_op_var(entry, field(&header, "w_class", "PyObject", &w_class), false);
+        graph.push_op_var(
+            entry,
+            field(&header, "ob_type", "PyObject", &ob_type),
+            false,
+        );
+        graph.push_op_var(
+            entry,
+            field(&header, "w_class", "PyObject", &w_class),
+            false,
+        );
         // Outer `W_FloatObject` ctor + its `ob_header` / `floatval` stores.
         let agg = graph
             .push_op_var(
@@ -5637,8 +5688,16 @@ mod tests {
                 true,
             )
             .unwrap();
-        graph.push_op_var(entry, field(&agg, "ob_header", "W_FloatObject", &header), false);
-        graph.push_op_var(entry, field(&agg, "floatval", "W_FloatObject", &value), false);
+        graph.push_op_var(
+            entry,
+            field(&agg, "ob_header", "W_FloatObject", &header),
+            false,
+        );
+        graph.push_op_var(
+            entry,
+            field(&agg, "floatval", "W_FloatObject", &value),
+            false,
+        );
         let raw = graph
             .push_op_var(
                 entry,
@@ -5670,7 +5729,10 @@ mod tests {
         assert!(
             !ops.iter().any(|op| matches!(
                 &op.kind,
-                OpKind::Call { target: CallTarget::SyntheticTransparentCtor { .. }, .. }
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                }
             )),
             "every dead aggregate ctor must be swept: {:#?}",
             ops.iter().map(|o| &o.kind).collect::<Vec<_>>()
@@ -5686,8 +5748,9 @@ mod tests {
         );
         // The live spine survives: NewWithVtable + floatval store + return cast.
         assert!(
-            ops.iter()
-                .any(|op| matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")),
+            ops.iter().any(
+                |op| matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")
+            ),
             "NewWithVtable must survive"
         );
         assert!(
@@ -5700,6 +5763,84 @@ mod tests {
             "the live return cast must survive"
         );
         let _ = ret;
+    }
+
+    #[test]
+    fn prune_dead_boxing_remnants_keeps_cast_used_as_live_store_base() {
+        // The malloc-removal exemption (a store's base is not rooted) must be
+        // scoped to fresh `SyntheticTransparentCtor` aggregates.  A store
+        // *through* a `__pyre_cast_instance` alias is a real heap side effect:
+        // even when the cast's result is read nowhere but the store base, the
+        // cast and the store must survive.  The same graph carries a genuinely
+        // dead `SyntheticTransparentCtor` whose store IS swept, so the pass is
+        // proven to run rather than trivially early-returning.
+        type Var = crate::flowspace::model::Variable;
+        let field = |base: &Var, name: &str, value: &Var| OpKind::FieldWrite {
+            base: base.clone(),
+            field: FieldDescriptor {
+                name: name.into(),
+                owner_root: None,
+                owner_id: None,
+            },
+            value: LinkArg::Value(value.clone()),
+            ty: ValueType::Ref(None),
+        };
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let obj = graph.alloc_value_var();
+        graph.push_inputarg_var(entry, obj.clone());
+        let payload = graph
+            .push_op_var(entry, OpKind::ConstFloat(0.0f64.to_bits()), true)
+            .unwrap();
+        // A real mutation through a pointer reinterpret: `p` is read only as
+        // the store base, yet the store must persist.
+        let p = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".into(), "W_FloatObject".into()],
+                    },
+                    args: vec![obj.clone()],
+                    result_ty: ValueType::Ref(Some("W_FloatObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(entry, field(&p, "floatval", &payload), false);
+        // A genuinely dead fresh aggregate whose store is removable.
+        let dead_agg = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("PyObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(entry, field(&dead_agg, "ob_type", &payload), false);
+        graph.set_return(entry, Some(obj.clone()));
+
+        prune_dead_boxing_remnants(&mut graph);
+
+        let ops = &graph.block(entry).operations;
+        assert!(
+            ops.iter().any(|op| op.result.as_ref() == Some(&p)),
+            "the cast aliasing a live store base must survive"
+        );
+        assert!(
+            ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::FieldWrite { base, .. } if base == &p
+            )),
+            "the real store through the cast must survive"
+        );
+        assert!(
+            !ops.iter().any(|op| op.result.as_ref() == Some(&dead_agg)),
+            "the genuinely dead aggregate ctor must still be swept"
+        );
     }
 
     #[test]
@@ -5761,7 +5902,9 @@ mod tests {
             .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
             .unwrap();
         // DEAD: the header `ob_type` cast, defined in the entry block.
-        let cast = graph.push_op_var(entry, cast_pytype(&ty_addr1), true).unwrap();
+        let cast = graph
+            .push_op_var(entry, cast_pytype(&ty_addr1), true)
+            .unwrap();
         let ty_addr2 = graph
             .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
             .unwrap();
@@ -5770,8 +5913,12 @@ mod tests {
         // `instantiate`-slot load kept alive only by the threaded w_class
         // store, so it (and the cast feeding it) must be swept once the
         // header is dropped.
-        let cast2 = graph.push_op_var(entry, cast_pytype(&ty_addr2), true).unwrap();
-        let inst = graph.push_op_var(entry, get_instantiate(&cast2), true).unwrap();
+        let cast2 = graph
+            .push_op_var(entry, cast_pytype(&ty_addr2), true)
+            .unwrap();
+        let inst = graph
+            .push_op_var(entry, get_instantiate(&cast2), true)
+            .unwrap();
         // LIVE: the fused boxing allocation + its payload store.
         let boxed = graph
             .push_op_var(
@@ -5841,7 +5988,10 @@ mod tests {
         assert!(
             !kinds.iter().any(|k| matches!(
                 k,
-                OpKind::Call { target: CallTarget::SyntheticTransparentCtor { .. }, .. }
+                OpKind::Call {
+                    target: CallTarget::SyntheticTransparentCtor { .. },
+                    ..
+                }
             )),
             "the cross-block dead header ctor must be swept: {kinds:#?}"
         );
@@ -5855,9 +6005,9 @@ mod tests {
             "the dead PyType cast threaded across the block boundary must be swept"
         );
         assert!(
-            kinds.iter().any(
-                |k| matches!(k, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")
-            ),
+            kinds
+                .iter()
+                .any(|k| matches!(k, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")),
             "the live NewWithVtable must survive"
         );
         assert!(

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2678,7 +2678,208 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
             );
         }
     }
+    if fused > 0 {
+        prune_dead_boxing_remnants(graph);
+    }
     fused
+}
+
+/// Sweep the construct-on-stack header remnants that [`fuse_boxing_alloc`]
+/// orphans.  Once `malloc_typed(struct)` becomes a `NewWithVtable` (which
+/// carries the type pointer / `w_class` through its vtable descriptor) the
+/// original aggregate ctor, the inner `PyObject` header ctor, their
+/// `ob_header` / `ob_type` / `w_class` field stores, and the
+/// `__pyre_cast_instance` casts feeding `ob_type` / `w_class` are all dead.
+///
+/// `front::mir` threads each of those dead values across the block boundary
+/// the preceding `Call` opens (`get_instantiate` / `malloc_typed` each end a
+/// block) by reusing the *same* `Variable` as both the producing block's op
+/// result and the successor block's inputarg.  Neither generic sweep reclaims
+/// the cluster in that shape:
+///
+///   * [`remove_dead_aggregates`] (and the old form of this sweep) counts
+///     every `Link.arg` as an unconditional read, so the threaded copy keeps
+///     the producer alive even though nothing on the far side reads it.
+///   * [`prune_dead_phis`] keeps the producer because a `FieldWrite` is
+///     side-effecting and pins its `base`.
+///
+/// So this sweep runs `transform_dead_op_vars`' dependency-flow liveness
+/// (`simplify.py:425-479`) — a `Link.arg` is live iff the target inputarg it
+/// feeds is live, not unconditionally — combined with the malloc-removal
+/// exemption (`malloc.py remove_simple_mallocs`) that a store into a struct
+/// nothing reads is itself dead, so a `FieldWrite.base` is *not* a liveness
+/// root.  The header producers eligible for removal are all side-effect-free:
+/// a `SyntheticTransparentCtor` stack construct, a `__pyre_cast_instance`
+/// pointer reinterpret (`exception_cannot_occur` → `cast_pointer`), and the
+/// `pyre_object::pyobject::get_instantiate` read of a type's `instantiate`
+/// slot feeding the dropped `w_class`.  `get_instantiate` is an `Acquire`
+/// atomic load of an init-once slot (the `set_instantiate` `Release` mutator
+/// writes it during `init_typeobjects`); it is removable not because the slot
+/// is immutable but because the load is observation-free — dropping a load
+/// whose result no reader reaches only relaxes ordering nothing depends on.
+/// Their operands route through `dependencies[result]` like a pure op rather than
+/// pinning — so a dead cast drops its constant feed and a dead `get_instantiate`
+/// drops the cast feeding it.  Liveness still gates removal, so a producer the
+/// flow reaches (e.g. a `get_instantiate` whose result is genuinely used) is
+/// never removed.  One global liveness pass reaches the whole cross-block
+/// cluster at once; the inputargs / link args the removed producers leave
+/// dangling (and the now-dead address constants) are reclaimed by the
+/// [`prune_dead_phis`] pass the lowering runs next.
+pub(crate) fn prune_dead_boxing_remnants(graph: &mut FunctionGraph) {
+    use crate::flowspace::model::Variable;
+    use std::collections::HashMap;
+
+    let is_removable_producer = |kind: &OpKind| match kind {
+        OpKind::Call {
+            target: CallTarget::SyntheticTransparentCtor { .. },
+            ..
+        } => true,
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } => {
+            // `__pyre_cast_instance[<root>]` — the front-end pointer-downcast
+            // narrow (`front::mir`), always a single-operand reinterpret.
+            // Pin the arity so an unrelated multi-arg path that happens to
+            // share the synthetic marker leaf is never swept as a cast.
+            let is_cast = segments.first().map(String::as_str)
+                == Some("__pyre_cast_instance")
+                && args.len() == 1;
+            // `pyre_object::pyobject::get_instantiate` — the pure
+            // `instantiate`-slot read feeding the dropped `w_class`.  Match
+            // the full owner path rather than the bare leaf so a future
+            // side-effecting function sharing the `get_instantiate` name in
+            // some other module can never be classified removable.
+            let get_instantiate = ["pyre_object", "pyobject", "get_instantiate"];
+            let is_get_instantiate = segments.len() >= get_instantiate.len()
+                && segments[segments.len() - get_instantiate.len()..]
+                    .iter()
+                    .map(String::as_str)
+                    .eq(get_instantiate.iter().copied());
+            is_cast || is_get_instantiate
+        }
+        _ => false,
+    };
+
+    let block_index: HashMap<BlockId, usize> = graph
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(i, b)| (b.id, i))
+        .collect();
+
+    // Liveness roots + dependency edges (`simplify.py:425-462`) with the two
+    // boxing exemptions above.
+    let mut read_vars: HashSet<Variable> = HashSet::new();
+    let mut dependencies: HashMap<Variable, Vec<Variable>> = HashMap::new();
+    for block in &graph.blocks {
+        for op in &block.operations {
+            match &op.kind {
+                // A store's value is live iff the struct it writes is live; the
+                // `base` is deliberately not rooted, so an unread aggregate's
+                // stores die with it (malloc-removal exemption).
+                OpKind::FieldWrite { base, value, .. } => {
+                    if let Some(var) = value.as_variable() {
+                        dependencies
+                            .entry(base.clone())
+                            .or_default()
+                            .push(var.clone());
+                    }
+                }
+                // Side-effect-free header producers route operands like a pure
+                // op, so a dead producer drops its feed instead of pinning it.
+                kind if is_removable_producer(kind) => match &op.result {
+                    Some(result) => dependencies
+                        .entry(result.clone())
+                        .or_default()
+                        .extend(crate::inline::op_variable_refs(kind)),
+                    None => read_vars.extend(crate::inline::op_variable_refs(kind)),
+                },
+                // Every other op is side-effecting: its operands are real reads.
+                kind => read_vars.extend(crate::inline::op_variable_refs(kind)),
+            }
+        }
+        if let Some(ExitSwitch::Value(var)) = &block.exitswitch {
+            read_vars.insert(var.clone());
+        }
+        // Terminal blocks implicitly read every inputarg (`simplify.py:459-462`).
+        if block.exits.is_empty() {
+            read_vars.extend(block.inputargs.iter().cloned());
+        }
+        // Cross-block: a link arg is live iff the target inputarg it feeds is.
+        for link in &block.exits {
+            let Some(&ti) = block_index.get(&link.target) else {
+                continue;
+            };
+            let target_iargs = &graph.blocks[ti].inputargs;
+            for (arg, target_iarg) in link.args.iter().zip(target_iargs.iter()) {
+                if let Some(arg_var) = arg.as_variable() {
+                    dependencies
+                        .entry(target_iarg.clone())
+                        .or_default()
+                        .push(arg_var.clone());
+                }
+            }
+        }
+    }
+    // Real parameters are always live (`simplify.py:431-433` start inputargs).
+    if let Some(&i) = block_index.get(&graph.startblock) {
+        read_vars.extend(graph.blocks[i].inputargs.iter().cloned());
+    }
+    // Backward flow (`simplify.py:471-479`).
+    let mut pending: Vec<Variable> = read_vars.iter().cloned().collect();
+    while let Some(var) = pending.pop() {
+        if let Some(deps) = dependencies.get(&var).cloned() {
+            for dep in deps {
+                if read_vars.insert(dep.clone()) {
+                    pending.push(dep);
+                }
+            }
+        }
+    }
+
+    // A removable producer whose result the flow leaves unread is dead.  A
+    // ctor is eligible only when its every store is result-less (dropping it
+    // leaves no dangling definition), matching `remove_dead_aggregates`.
+    let dead: HashSet<Variable> = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .filter_map(|op| {
+            let result = op.result.as_ref()?;
+            if read_vars.contains(result) || !is_removable_producer(&op.kind) {
+                return None;
+            }
+            let stores_clean = graph.blocks.iter().flat_map(|b| &b.operations).all(|o| {
+                match &o.kind {
+                    OpKind::FieldWrite { base, .. } if base == result => o.result.is_none(),
+                    _ => true,
+                }
+            });
+            stores_clean.then(|| result.clone())
+        })
+        .collect();
+    if dead.is_empty() {
+        return;
+    }
+
+    // Drop the dead producers and every field store targeting one.
+    for block in &mut graph.blocks {
+        block.operations.retain(|op| {
+            if let Some(r) = &op.result {
+                if dead.contains(r) {
+                    return false;
+                }
+            }
+            if let OpKind::FieldWrite { base, .. } = &op.kind {
+                if dead.contains(base) {
+                    return false;
+                }
+            }
+            true
+        });
+    }
 }
 
 /// Remove dead operations and dead inputargs from `graph` per
@@ -5362,6 +5563,325 @@ mod tests {
                 .any(|op| matches!(&op.kind, OpKind::NewWithVtable { .. })),
             "no NewWithVtable may be emitted for an unrecognised owner"
         );
+    }
+
+    #[test]
+    fn fuse_boxing_alloc_sweeps_nested_header_chain() {
+        // Faithful `w_float_new` shape: the boxing struct's header is a nested
+        // `PyObject` ctor whose `ob_type` / `w_class` fields are fed by
+        // `__pyre_cast_instance` pointer reinterprets of the `&FLOAT_TYPE`
+        // constant.  After fusion drops the `ob_header` (it rides the
+        // `NewWithVtable` descriptor), the entire header sub-tree — the inner
+        // `PyObject` ctor, the outer `W_FloatObject` ctor, and the two
+        // `__pyre_cast_instance` casts — is dead and must be swept, leaving
+        // only the `NewWithVtable`, its `floatval` payload store, and the
+        // return cast.  (The two `ConstRefAddr` constants legitimately survive
+        // as dead constants; the dual-gate seeds them from the constant table,
+        // so they do not diverge.)
+        type Var = crate::flowspace::model::Variable;
+        let cast_instance = |to: &str, arg: &Var| OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__pyre_cast_instance".into(), to.into()],
+            },
+            args: vec![arg.clone()],
+            result_ty: ValueType::Ref(Some(to.into())),
+        };
+        let field = |base: &Var, name: &str, owner: &str, value: &Var| OpKind::FieldWrite {
+            base: base.clone(),
+            field: FieldDescriptor {
+                name: name.into(),
+                owner_root: Some(owner.into()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(value.clone()),
+            ty: ValueType::Ref(None),
+        };
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let value = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let ty_addr1 = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
+            .unwrap();
+        let ob_type = graph
+            .push_op_var(entry, cast_instance("PyType", &ty_addr1), true)
+            .unwrap();
+        let ty_addr2 = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
+            .unwrap();
+        let w_class = graph
+            .push_op_var(entry, cast_instance("PyType", &ty_addr2), true)
+            .unwrap();
+        // Inner `PyObject` header ctor + its field stores.
+        let header = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("PyObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(entry, field(&header, "ob_type", "PyObject", &ob_type), false);
+        graph.push_op_var(entry, field(&header, "w_class", "PyObject", &w_class), false);
+        // Outer `W_FloatObject` ctor + its `ob_header` / `floatval` stores.
+        let agg = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("W_FloatObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("W_FloatObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(entry, field(&agg, "ob_header", "W_FloatObject", &header), false);
+        graph.push_op_var(entry, field(&agg, "floatval", "W_FloatObject", &value), false);
+        let raw = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "pyre_object".into(),
+                            "lltype".into(),
+                            "malloc_typed".into(),
+                        ],
+                    },
+                    args: vec![agg.clone()],
+                    result_ty: ValueType::Ref(Some("W_FloatObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let ret = graph
+            .push_op_var(entry, cast_instance("PyObject", &raw), true)
+            .unwrap();
+        graph.set_return(entry, Some(ret.clone()));
+
+        let fused = fuse_boxing_alloc(&mut graph);
+        assert_eq!(fused, 1, "the nested-header boxing cluster must fuse");
+
+        let ops = &graph.block(entry).operations;
+        // The dead header sub-tree is gone: no SyntheticTransparentCtor and no
+        // `__pyre_cast_instance["PyType"]` cast survives.
+        assert!(
+            !ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::SyntheticTransparentCtor { .. }, .. }
+            )),
+            "every dead aggregate ctor must be swept: {:#?}",
+            ops.iter().map(|o| &o.kind).collect::<Vec<_>>()
+        );
+        assert!(
+            !ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        && segments.get(1).map(String::as_str) == Some("PyType")
+            )),
+            "the dead ob_type/w_class header casts must be swept"
+        );
+        // The live spine survives: NewWithVtable + floatval store + return cast.
+        assert!(
+            ops.iter()
+                .any(|op| matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")),
+            "NewWithVtable must survive"
+        );
+        assert!(
+            ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        && segments.get(1).map(String::as_str) == Some("PyObject")
+            )),
+            "the live return cast must survive"
+        );
+        let _ = ret;
+    }
+
+    #[test]
+    fn prune_dead_boxing_remnants_sweeps_cross_block_threaded_cluster() {
+        // The lowered `w_float_new` shape after fusion: the dead header cast
+        // is produced in the entry block and threaded — by *reusing the same
+        // `Variable`* as both the entry op result and the successor block's
+        // inputarg (`set_goto_from_framestate` / `ensure_variable_at_block`) —
+        // into the block where the dead `PyObject` header ctor reads it.  The
+        // old `Link.arg`-counts-as-read sweep kept the whole cluster (the
+        // threaded copy pinned the cast; the `FieldWrite` pinned the ctor);
+        // the dependency-flow sweep reaches it because the threaded copy's
+        // target inputarg is itself unread, then `prune_dead_phis` reclaims
+        // the dangling inputarg / link arg / address constant.
+        type Var = crate::flowspace::model::Variable;
+        let cast_pytype = |arg: &Var| OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__pyre_cast_instance".into(), "PyType".into()],
+            },
+            args: vec![arg.clone()],
+            result_ty: ValueType::Ref(Some("PyType".into())),
+        };
+        let field = |base: &Var, name: &str, value: &Var| OpKind::FieldWrite {
+            base: base.clone(),
+            field: FieldDescriptor {
+                name: name.into(),
+                owner_root: Some("PyObject".into()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(value.clone()),
+            ty: ValueType::Ref(None),
+        };
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let value = graph
+            .push_op_var(
+                entry,
+                OpKind::Input {
+                    name: "value".into(),
+                    ty: ValueType::Float,
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_inputarg_var(entry, value.clone());
+        let get_instantiate = |arg: &Var| OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec![
+                    "pyre_object".into(),
+                    "pyobject".into(),
+                    "get_instantiate".into(),
+                ],
+            },
+            args: vec![arg.clone()],
+            result_ty: ValueType::Ref(Some("object".into())),
+        };
+        let ty_addr1 = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
+            .unwrap();
+        // DEAD: the header `ob_type` cast, defined in the entry block.
+        let cast = graph.push_op_var(entry, cast_pytype(&ty_addr1), true).unwrap();
+        let ty_addr2 = graph
+            .push_op_var(entry, OpKind::ConstRefAddr(4357049520), true)
+            .unwrap();
+        // DEAD: a second cast feeding `get_instantiate`, whose result is the
+        // header `w_class`.  `get_instantiate` is an observation-free
+        // `instantiate`-slot load kept alive only by the threaded w_class
+        // store, so it (and the cast feeding it) must be swept once the
+        // header is dropped.
+        let cast2 = graph.push_op_var(entry, cast_pytype(&ty_addr2), true).unwrap();
+        let inst = graph.push_op_var(entry, get_instantiate(&cast2), true).unwrap();
+        // LIVE: the fused boxing allocation + its payload store.
+        let boxed = graph
+            .push_op_var(
+                entry,
+                OpKind::NewWithVtable {
+                    owner: "W_FloatObject".into(),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(entry, field(&boxed, "floatval", &value), false);
+
+        // Successor block reached after the boundary `get_instantiate` /
+        // `malloc_typed` call would have opened; its inputargs reuse the SAME
+        // `Variable`s the entry threads (id-reuse, not fresh phis).
+        let blk = graph.create_block();
+        graph.push_inputarg_var(blk, value.clone());
+        graph.push_inputarg_var(blk, cast.clone());
+        graph.push_inputarg_var(blk, inst.clone());
+        graph.push_inputarg_var(blk, boxed.clone());
+        graph.set_goto(
+            entry,
+            blk,
+            vec![value.clone(), cast.clone(), inst.clone(), boxed.clone()],
+        );
+
+        // DEAD: the inner `PyObject` header ctor + its stores reading the cast
+        // and the `get_instantiate` result.
+        let header = graph
+            .push_op_var(
+                blk,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("PyObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(blk, field(&header, "ob_type", &cast), false);
+        graph.push_op_var(blk, field(&header, "w_class", &inst), false);
+        // LIVE: the return cast reads the boxing allocation.
+        let ret = graph
+            .push_op_var(
+                blk,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                    },
+                    args: vec![boxed.clone()],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(blk, Some(ret.clone()));
+
+        prune_dead_boxing_remnants(&mut graph);
+        prune_dead_phis(&mut graph);
+
+        let kinds: Vec<&OpKind> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .map(|o| &o.kind)
+            .collect();
+        assert!(
+            !kinds.iter().any(|k| matches!(
+                k,
+                OpKind::Call { target: CallTarget::SyntheticTransparentCtor { .. }, .. }
+            )),
+            "the cross-block dead header ctor must be swept: {kinds:#?}"
+        );
+        assert!(
+            !kinds.iter().any(|k| matches!(
+                k,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                        && segments.get(1).map(String::as_str) == Some("PyType")
+            )),
+            "the dead PyType cast threaded across the block boundary must be swept"
+        );
+        assert!(
+            kinds.iter().any(
+                |k| matches!(k, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")
+            ),
+            "the live NewWithVtable must survive"
+        );
+        assert!(
+            kinds.iter().any(|k| matches!(
+                k,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.get(1).map(String::as_str) == Some("PyObject")
+            )),
+            "the live return cast must survive"
+        );
+        assert!(
+            !kinds.iter().any(|k| matches!(
+                k,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("get_instantiate")
+            )),
+            "the dead get_instantiate (w_class feed) must be swept once the header is dropped"
+        );
+        assert!(
+            !graph.block(blk).inputargs.contains(&cast)
+                && !graph.block(blk).inputargs.contains(&inst),
+            "the dangling threaded inputargs must be reclaimed by prune_dead_phis"
+        );
+        let _ = (ret, header, cast2, ty_addr1, ty_addr2);
     }
 
     #[test]

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -590,6 +590,17 @@ pub enum OpKind {
         value: LinkArg,
         ty: ValueType,
     },
+    /// RPython `malloc(STRUCT, flavor='gc')` for a fixed-size GcStruct: the
+    /// heap allocation of a boxed object (`pyre_object::lltype::malloc_typed`).
+    /// Lowered to the `new_with_vtable` jitcode op (executor
+    /// `OpCode::NewWithVtable`). `owner` is the struct leaf (e.g.
+    /// `"W_FloatObject"`); the assembler resolves the size descriptor from it
+    /// via `bh_size_spec_from_callcontrol`, whose `path_hash(owner)` keys the
+    /// runtime `gc_cache._cache_size` Arc carrying the real vtable + gc
+    /// type-id. The result register is always a fresh `Ref` ('r').
+    NewWithVtable {
+        owner: String,
+    },
     ArrayRead {
         base: crate::flowspace::model::Variable,
         index: crate::flowspace::model::Variable,
@@ -2504,6 +2515,170 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
         }
     }
     total_removed
+}
+
+/// Fuse the boxing-constructor idiom into a native GC allocation.
+///
+/// pyre's boxing constructors (`floatobject::w_float_new` etc.) are written
+/// in Rust as `malloc_typed(W_FloatObject { ob_header: …, floatval: v })` —
+/// construct the whole struct on the stack, then heap-copy.  `front::mir`
+/// lowers that to a `SyntheticTransparentCtor` aggregate (`%agg`) + per-field
+/// `FieldWrite`s + a residual `Call(pyre_object::lltype::malloc_typed, [%agg])`.
+/// RPython's orthodox form is alloc-then-init (`p = malloc(S); p.f = v`); the
+/// rtyper lowers `malloc` to the GC allocation op.  pyre's rtyper is an
+/// ephemeral type oracle that never rewrites the surviving model graph, so the
+/// lowering is produced here instead: rewrite the cluster to
+/// `NewWithVtable { owner } -> %ret` + a single payload `FieldWrite(%ret, …)`,
+/// dropping the `ob_header` (PyObject base) subtree — the type pointer / w_class
+/// ride the `NewWithVtable` header descriptor, matching the runtime tracer
+/// oracle (`codegen.rs trace_box_float`: one `NewWithVtable` + one
+/// `SetfieldGc` for the payload).
+///
+/// The payload store is inserted *after* the `NewWithVtable` (which reuses the
+/// malloc result Variable `%ret`), since the original aggregate field stores
+/// precede the malloc call and would be use-before-def if retargeted in place.
+/// The orphaned aggregate ctor + header `FieldWrite`s become dead and are swept
+/// by the `remove_dead_aggregates` + `prune_dead_phis` passes that follow in
+/// `simplify_lowered_graph`.
+pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
+    // Recognised boxing structs and their scalar payload fields, in struct
+    // order.  The header (`ob_header`: ob_type + w_class) is NOT listed — it
+    // rides the `NewWithVtable` size descriptor, installed by the GC rewriter
+    // (oracle: `codegen.rs trace_box_float` / `trace_box_int` ignore the
+    // ob_type descriptor and emit only the payload setfield(s)).
+    fn payload_fields(owner: &str) -> Option<&'static [(&'static str, ValueType)]> {
+        match owner {
+            "W_FloatObject" => Some(&[("floatval", ValueType::Float)]),
+            "W_IntObject" => Some(&[("intval", ValueType::Int)]),
+            "W_ComplexObject" => Some(&[("real", ValueType::Float), ("imag", ValueType::Float)]),
+            _ => None,
+        }
+    }
+
+    let is_malloc_typed = |target: &CallTarget| -> bool {
+        matches!(target, CallTarget::FunctionPath { segments }
+            if segments.len() >= 2
+                && segments[segments.len() - 1] == "malloc_typed"
+                && segments[segments.len() - 2] == "lltype")
+    };
+
+    struct Payload {
+        field: FieldDescriptor,
+        value: LinkArg,
+        ty: ValueType,
+    }
+    struct Site {
+        block: usize,
+        op: usize,
+        result: crate::flowspace::model::Variable,
+        owner: String,
+        payloads: Vec<Payload>,
+    }
+
+    let mut sites: Vec<Site> = Vec::new();
+    for (bi, block) in graph.blocks.iter().enumerate() {
+        for (oi, op) in block.operations.iter().enumerate() {
+            let OpKind::Call { target, args, .. } = &op.kind else {
+                continue;
+            };
+            if !is_malloc_typed(target) || args.len() != 1 {
+                continue;
+            }
+            let Some(result) = &op.result else { continue };
+            let agg = &args[0];
+            // `%agg` must be a `SyntheticTransparentCtor` for a known boxing
+            // struct.  Search graph-wide: the ctor and the malloc call land in
+            // the same block, but the field stores feeding the aggregate may sit
+            // in earlier blocks (each preceding call ends a block).
+            let owner = graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .find_map(|o| match (&o.result, &o.kind) {
+                    (
+                        Some(r),
+                        OpKind::Call {
+                            target: CallTarget::SyntheticTransparentCtor { name, .. },
+                            ..
+                        },
+                    ) if r == agg => Some(name.clone()),
+                    _ => None,
+                });
+            let Some(owner) = owner else { continue };
+            let Some(fields) = payload_fields(&owner) else {
+                continue;
+            };
+            // Resolve every payload field's store: `FieldWrite { base: %agg,
+            // field.name == payload }`.  A malformed cluster missing any payload
+            // store is left untouched so the annotate wall still flags it rather
+            // than emitting a half-initialised allocation.
+            let mut payloads = Vec::with_capacity(fields.len());
+            let mut complete = true;
+            for &(field_name, ref payload_ty) in fields {
+                let found = graph
+                    .blocks
+                    .iter()
+                    .flat_map(|b| &b.operations)
+                    .find_map(|o| match &o.kind {
+                        OpKind::FieldWrite {
+                            base, field, value, ..
+                        } if base == agg && field.name.as_str() == field_name => {
+                            Some((field.clone(), value.clone()))
+                        }
+                        _ => None,
+                    });
+                match found {
+                    Some((field, value)) => payloads.push(Payload {
+                        field,
+                        value,
+                        ty: payload_ty.clone(),
+                    }),
+                    None => {
+                        complete = false;
+                        break;
+                    }
+                }
+            }
+            if !complete {
+                continue;
+            }
+            sites.push(Site {
+                block: bi,
+                op: oi,
+                result: result.clone(),
+                owner,
+                payloads,
+            });
+        }
+    }
+
+    let fused = sites.len();
+    // Rewrite in reverse (block, op) order so the per-site `insert` does not
+    // shift the indices of not-yet-processed sites in the same block.
+    for site in sites.into_iter().rev() {
+        let block = &mut graph.blocks[site.block];
+        block.operations[site.op] = SpaceOperation {
+            result: Some(site.result.clone()),
+            kind: OpKind::NewWithVtable { owner: site.owner },
+        };
+        // Payload stores follow the `NewWithVtable`, in struct order.  Each is
+        // a plain `FieldWrite` the assembler lowers to its own `setfield_gc`.
+        for (k, payload) in site.payloads.into_iter().enumerate() {
+            block.operations.insert(
+                site.op + 1 + k,
+                SpaceOperation {
+                    result: None,
+                    kind: OpKind::FieldWrite {
+                        base: site.result.clone(),
+                        field: payload.field,
+                        value: payload.value,
+                        ty: payload.ty,
+                    },
+                },
+            );
+        }
+    }
+    fused
 }
 
 /// Remove dead operations and dead inputargs from `graph` per
@@ -4934,6 +5109,258 @@ mod tests {
                 .iter()
                 .any(|op| op.result.as_ref() == Some(&tmp)),
             "the live ctor op must survive"
+        );
+    }
+
+    #[test]
+    fn fuse_boxing_alloc_lowers_float_box_cluster() {
+        // entry: %v       = const (the boxed payload);
+        //        %header  = const (the ob_header value);
+        //        %agg     = SyntheticTransparentCtor("W_FloatObject");
+        //        FieldWrite(%agg.ob_header = %header);   // header store
+        //        FieldWrite(%agg.floatval = %v);         // payload store
+        //        %ret     = pyre_object.lltype.malloc_typed(%agg);
+        //        return %ret.
+        // fuse_boxing_alloc replaces the malloc with
+        //        %ret     = NewWithVtable("W_FloatObject");
+        //        FieldWrite(%ret.floatval = %v, ty=Float);
+        // so the header rides the vtable descriptor (oracle: one NewWithVtable
+        // + one floatval setfield, matching `codegen.rs trace_box_float`).
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let v = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let header = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let agg = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("W_FloatObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("W_FloatObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.push_op_var(
+            entry,
+            OpKind::FieldWrite {
+                base: agg.clone(),
+                field: FieldDescriptor {
+                    name: "ob_header".into(),
+                    owner_root: Some("W_FloatObject".into()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(header),
+                ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        graph.push_op_var(
+            entry,
+            OpKind::FieldWrite {
+                base: agg.clone(),
+                field: FieldDescriptor {
+                    name: "floatval".into(),
+                    owner_root: Some("W_FloatObject".into()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(v.clone()),
+                ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        let ret = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "pyre_object".into(),
+                            "lltype".into(),
+                            "malloc_typed".into(),
+                        ],
+                    },
+                    args: vec![agg.clone()],
+                    result_ty: ValueType::Ref(Some("W_FloatObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(entry, Some(ret.clone()));
+
+        let fused = fuse_boxing_alloc(&mut graph);
+        assert_eq!(fused, 1, "exactly one boxing cluster must fuse");
+
+        let ops = &graph.block(entry).operations;
+        let nwv_pos = ops
+            .iter()
+            .position(|op| {
+                matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_FloatObject")
+            })
+            .expect("NewWithVtable must be emitted");
+        assert_eq!(
+            ops[nwv_pos].result.as_ref(),
+            Some(&ret),
+            "NewWithVtable must reuse the original malloc result register"
+        );
+        match &ops[nwv_pos + 1].kind {
+            OpKind::FieldWrite {
+                base, field, ty, ..
+            } => {
+                assert_eq!(
+                    base, &ret,
+                    "payload store must target the NewWithVtable result"
+                );
+                assert_eq!(field.name, "floatval", "payload field must be floatval");
+                assert_eq!(
+                    *ty,
+                    ValueType::Float,
+                    "payload store must be retyped to Float"
+                );
+            }
+            other => panic!("expected payload FieldWrite after NewWithVtable, got {other:?}"),
+        }
+        assert!(
+            !ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("malloc_typed")
+            )),
+            "no malloc_typed call may survive the fusion"
+        );
+    }
+
+    #[test]
+    fn fuse_boxing_alloc_lowers_complex_box_two_payloads() {
+        // A two-payload boxing struct (W_ComplexObject: real, imag) fuses to a
+        // single NewWithVtable followed by two payload setfields in struct
+        // order, both retyped to Float.
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let re = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let im = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+        let agg = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("W_ComplexObject"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("W_ComplexObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        for (name, v) in [("real", re.clone()), ("imag", im.clone())] {
+            graph.push_op_var(
+                entry,
+                OpKind::FieldWrite {
+                    base: agg.clone(),
+                    field: FieldDescriptor {
+                        name: name.into(),
+                        owner_root: Some("W_ComplexObject".into()),
+                        owner_id: None,
+                    },
+                    value: LinkArg::Value(v),
+                    ty: ValueType::Ref(None),
+                },
+                false,
+            );
+        }
+        let ret = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "pyre_object".into(),
+                            "lltype".into(),
+                            "malloc_typed".into(),
+                        ],
+                    },
+                    args: vec![agg.clone()],
+                    result_ty: ValueType::Ref(Some("W_ComplexObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(entry, Some(ret.clone()));
+
+        let fused = fuse_boxing_alloc(&mut graph);
+        assert_eq!(fused, 1, "the complex boxing cluster must fuse");
+
+        let ops = &graph.block(entry).operations;
+        let nwv_pos = ops
+            .iter()
+            .position(|op| {
+                matches!(&op.kind, OpKind::NewWithVtable { owner } if owner == "W_ComplexObject")
+            })
+            .expect("NewWithVtable must be emitted");
+        // Two payload stores follow, real then imag, both targeting %ret/Float.
+        let mut names = Vec::new();
+        for off in 1..=2 {
+            match &ops[nwv_pos + off].kind {
+                OpKind::FieldWrite {
+                    base, field, ty, ..
+                } => {
+                    assert_eq!(base, &ret, "payload store must target the alloc result");
+                    assert_eq!(*ty, ValueType::Float, "complex payloads are Float");
+                    names.push(field.name.clone());
+                }
+                other => panic!("expected payload FieldWrite, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            names,
+            vec!["real".to_string(), "imag".to_string()],
+            "payload stores must follow struct order"
+        );
+    }
+
+    #[test]
+    fn fuse_boxing_alloc_ignores_unknown_owner() {
+        // A malloc_typed of a non-boxing aggregate (no `payload_for` entry)
+        // is left untouched — the fusion is opt-in per recognised struct.
+        let mut graph = FunctionGraph::new("test");
+        let entry = graph.startblock;
+        let agg = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::synthetic_transparent_ctor("SomeOtherStruct"),
+                    args: vec![],
+                    result_ty: ValueType::Ref(Some("SomeOtherStruct".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let ret = graph
+            .push_op_var(
+                entry,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec![
+                            "pyre_object".into(),
+                            "lltype".into(),
+                            "malloc_typed".into(),
+                        ],
+                    },
+                    args: vec![agg.clone()],
+                    result_ty: ValueType::Ref(Some("SomeOtherStruct".into())),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(entry, Some(ret));
+
+        let fused = fuse_boxing_alloc(&mut graph);
+        assert_eq!(fused, 0, "unknown boxing owner must not fuse");
+        assert!(
+            !graph
+                .block(entry)
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::NewWithVtable { .. })),
+            "no NewWithVtable may be emitted for an unrecognised owner"
         );
     }
 

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1727,6 +1727,27 @@ impl FrameState {
     /// `target` was not produced by `self.union(_)`, which violates the
     /// merge invariant.
     pub fn getoutputargs(&self, target: &FrameState, graph: &FunctionGraph) -> Vec<LinkArg> {
+        self.try_getoutputargs(target, graph).expect(
+            "getoutputargs: target Variable slot unbound in self / stack-length mismatch \
+             — union invariant violated",
+        )
+    }
+
+    /// Fallible [`Self::getoutputargs`].  Returns `None` instead of
+    /// panicking when a target `Variable` slot has no corresponding
+    /// `Some` cell in `self` (locals) or no positional cell in `self`'s
+    /// flattened stack.  For union-derived target states this never
+    /// happens (union None-kills a slot unless every predecessor binds
+    /// it), so [`Self::getoutputargs`] keeps its panicking contract; the
+    /// cyclic framestate path pre-seeds loop-header entries with live-in
+    /// phis that bypass the union, so it threads links through this
+    /// checked variant and declines a phantom-slot mismatch to the
+    /// monotonic fallback.
+    pub fn try_getoutputargs(
+        &self,
+        target: &FrameState,
+        graph: &FunctionGraph,
+    ) -> Option<Vec<LinkArg>> {
         // Line-by-line port of `framestate.py:92-99 getoutputargs`:
         //
         //     def getoutputargs(self, targetstate):
@@ -1771,10 +1792,7 @@ impl FrameState {
                 w_target,
                 Some(crate::flowspace::model::Hlvalue::Variable(_))
             ) {
-                let w_self = self_locals_view
-                    .get(i)
-                    .and_then(|c| c.as_ref())
-                    .expect("target Variable slot must be bound in self — union invariant");
+                let w_self = self_locals_view.get(i).and_then(|c| c.as_ref())?;
                 result.push(hlvalue_to_linkarg(w_self));
             }
         }
@@ -1787,9 +1805,7 @@ impl FrameState {
         let self_flat_stack = crate::flowspace::framestate::recursively_flatten(&self.stack);
         for (i, w_target) in target_flat_stack.iter().enumerate() {
             if matches!(w_target, crate::flowspace::model::Hlvalue::Variable(_)) {
-                let w_self = self_flat_stack
-                    .get(i)
-                    .expect("target stack length must match self stack length — union invariant");
+                let w_self = self_flat_stack.get(i)?;
                 result.push(hlvalue_to_linkarg(w_self));
             }
         }
@@ -1806,7 +1822,7 @@ impl FrameState {
                 result.push(hlvalue_to_linkarg(w_self));
             }
         }
-        result
+        Some(result)
     }
 
     /// Enumerate every `Variable` cell across the full mergeable
@@ -6922,6 +6938,44 @@ mod tests {
             merge_block.inputargs.len(),
             "pred_b outputargs length matches merge block inputargs",
         );
+    }
+
+    /// `try_getoutputargs` returns `None` (rather than panicking like
+    /// `getoutputargs`) when the target binds a `Variable` at a locals
+    /// slot the predecessor leaves `None` — the phantom-slot mismatch the
+    /// cyclic framestate path's loop-header pre-seed can produce when a
+    /// live-in phi is scrubbed undefined on one edge.  The all-bound case
+    /// still returns `Some`.
+    #[test]
+    fn try_getoutputargs_declines_phantom_slot_returns_some_when_bound() {
+        use crate::flowspace::model::Variable;
+
+        let graph = FunctionGraph::new("try_getoutputargs_phantom");
+        // Target binds a Variable phi at slot 0 (a loop-header live-in).
+        let target = FrameState {
+            entries: vec![Some(Variable::new())],
+            ..Default::default()
+        };
+        // Predecessor whose slot 0 was scrubbed to `None` (undefined on
+        // this edge): the target Variable slot has no self cell to thread.
+        let pred_undefined = FrameState {
+            entries: vec![None],
+            ..Default::default()
+        };
+        assert!(
+            pred_undefined.try_getoutputargs(&target, &graph).is_none(),
+            "phantom slot 0 undefined in predecessor declines to None",
+        );
+        // Predecessor that does bind slot 0 threads it through.
+        let v_self = Variable::new();
+        let pred_bound = FrameState {
+            entries: vec![Some(v_self.clone())],
+            ..Default::default()
+        };
+        let out = pred_bound
+            .try_getoutputargs(&target, &graph)
+            .expect("bound slot threads through");
+        assert_eq!(out, vec![LinkArg::Value(v_self)]);
     }
 
     // ── annotator-monomorphization Slice C2 — CallTarget::Method ──

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2605,11 +2605,12 @@ pub fn fuse_boxing_alloc(graph: &mut FunctionGraph) -> usize {
             .iter()
             .flat_map(|b| &b.operations)
             .find_map(|o| match &o.kind {
-                OpKind::FieldWrite { base: b, field, value, .. }
-                    if b == base && field.name.as_str() == field_name =>
-                {
-                    value.as_variable().cloned()
-                }
+                OpKind::FieldWrite {
+                    base: b,
+                    field,
+                    value,
+                    ..
+                } if b == base && field.name.as_str() == field_name => value.as_variable().cloned(),
                 _ => None,
             })
     }
@@ -6099,9 +6100,9 @@ mod tests {
             "the dead PyType cast threaded across the block boundary must be swept"
         );
         assert!(
-            kinds
-                .iter()
-                .any(|k| matches!(k, OpKind::NewWithVtable { owner, .. } if owner == "W_FloatObject")),
+            kinds.iter().any(
+                |k| matches!(k, OpKind::NewWithVtable { owner, .. } if owner == "W_FloatObject")
+            ),
             "the live NewWithVtable must survive"
         );
         assert!(

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1012,6 +1012,17 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     for (path, graph) in function_graphs.iter() {
         let key = FunctionPathKey::from_segments(path.segments.iter().cloned());
         let canonical_strip = canonical_dedup_key(path);
+        // `pyre_object::lltype::malloc_typed` is the GC allocation intrinsic,
+        // recognised as a host builtin (annotator `malloc_typed_alloc`, HOST_ENV
+        // `pyre_object.lltype` module).  Its real body calls the un-flowable
+        // `<T as GcType>::type_id()` trait accessor, so lifting it records a
+        // poison lift-error that surfaces on the first boxing caller.  Skip
+        // registering it as a user function: with no registry entry, callsites
+        // resolve to the HOST_ENV builtin (translate_op Layer-3b) instead of
+        // this failed user-graph entry (Layer-1 `call_registry.lookup`).
+        if canonical_strip == ["lltype", "malloc_typed"] {
+            continue;
+        }
         let entry = if let Some(canonical_key) = by_canonical_path.get(&canonical_strip) {
             if canonical_key != &key {
                 registry.alias(key.clone(), canonical_key);

--- a/majit/majit-translate/src/translator/rtyper/extfuncregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extfuncregistry.rs
@@ -44,7 +44,7 @@ pub const _REGISTER: &[(&str, &[(&str, &[&str], &str)])] = &[
 
 static REGISTERED_EXTERNALS: OnceLock<Result<Vec<ExtFuncEntry>, TyperError>> = OnceLock::new();
 
-pub fn register_external_functions() -> Result<&'static [ExtFuncEntry], TyperError> {
+pub(crate) fn register_external_functions() -> Result<&'static [ExtFuncEntry], TyperError> {
     let result = REGISTERED_EXTERNALS.get_or_init(|| {
         let mut entries = Vec::new();
         for name in super::lltypesystem::module::ll_math::UNARY_MATH_FUNCTIONS {

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -929,6 +929,32 @@ pub fn translate_op(
             Ok(vec![FlowspaceOp::new("newtuple", hl_args, result)])
         }
 
+        // ─── `NewWithVtable` — boxing GC allocation (`fuse_boxing_alloc`) ───
+        // The model-graph op carries the boxing struct leaf `owner` and flows
+        // straight to the codewriter/assembler (`new_with_vtable`).  For the
+        // ephemeral annotation / rtype type-oracle it mirrors the
+        // `SyntheticTransparentCtor` struct path (flowspace_adapter.rs:1705): a
+        // zero-arg `simple_call` against the interned class host annotates the
+        // result as a fresh `SomeInstance(owner)`.  `getuniqueclassdef_for_
+        // struct_root` first forces the struct's field rows to be projected so
+        // the trailing payload `FieldWrite(result, …)` resolves.
+        OpKind::NewWithVtable { owner } => {
+            let bk = call_registry.bookkeeper();
+            bk.getuniqueclassdef_for_struct_root(owner).map_err(|e| {
+                TyperError::message(format!(
+                    "translate_op: NewWithVtable owner {owner:?} is not a known struct root: {e}"
+                ))
+            })?;
+            let host = bk.intern_class_by_qualname(owner);
+            let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(host)));
+            let result = resolve_result_hlvalue(op, value_map)?;
+            Ok(vec![FlowspaceOp::new(
+                "simple_call",
+                vec![callable],
+                result,
+            )])
+        }
+
         // ─── `LoadStatic` — single-segment static lookup ─
         // Pyre-only marker emitted by the frontend when a path
         // expression resolves to a crate-level `static` declaration

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -938,7 +938,7 @@ pub fn translate_op(
         // result as a fresh `SomeInstance(owner)`.  `getuniqueclassdef_for_
         // struct_root` first forces the struct's field rows to be projected so
         // the trailing payload `FieldWrite(result, …)` resolves.
-        OpKind::NewWithVtable { owner } => {
+        OpKind::NewWithVtable { owner, .. } => {
             let bk = call_registry.bookkeeper();
             bk.getuniqueclassdef_for_struct_root(owner).map_err(|e| {
                 TyperError::message(format!(

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -276,7 +276,7 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         }
         OpKind::FieldRead { ty, .. } => ty.clone(),
         OpKind::FieldWrite { .. } => ValueType::Void,
-        OpKind::NewWithVtable { owner } => ValueType::Ref(Some(owner.clone())),
+        OpKind::NewWithVtable { owner, .. } => ValueType::Ref(Some(owner.clone())),
         OpKind::ArrayRead { item_ty, .. } => item_ty.clone(),
         OpKind::ArrayWrite { .. } => ValueType::Void,
         OpKind::InteriorFieldRead { item_ty, .. } => item_ty.clone(),

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -276,6 +276,7 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         }
         OpKind::FieldRead { ty, .. } => ty.clone(),
         OpKind::FieldWrite { .. } => ValueType::Void,
+        OpKind::NewWithVtable { owner } => ValueType::Ref(Some(owner.clone())),
         OpKind::ArrayRead { item_ty, .. } => item_ty.clone(),
         OpKind::ArrayWrite { .. } => ValueType::Void,
         OpKind::InteriorFieldRead { item_ty, .. } => item_ty.clone(),

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
@@ -23,8 +23,8 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 use crate::translator::rtyper::rdict::{AbstractDictIteratorRepr, AbstractDictRepr};
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, RPythonTyper, constant_with_lltype, helper_pygraph_from_graph,
-    variable_with_lltype, void_field_const,
+    ConvertedTo, HighLevelOp, RPythonTyper, constant_with_lltype, exception_args,
+    helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
 
 fn ptr_to_gc_array(of: LowLevelType) -> LowLevelType {
@@ -1411,6 +1411,428 @@ pub fn build_ll_dict_lookup_helper_graph(
     ))
 }
 
+/// Synthesise `_ll_dictnext(iter) -> Signed` (`rordereddict.py:1229-1259`),
+/// the forward dict-iterator step shared by keys/values/items iteration.
+///
+/// ```python
+/// def _ll_dictnext(iter):
+///     dict = iter.dict
+///     if dict:
+///         entries = dict.entries
+///         index = iter.index
+///         entries_len = dict.num_ever_used_items
+///         while index < entries_len:
+///             nextindex = index + 1
+///             if entries.valid(index):
+///                 iter.index = nextindex
+///                 return index
+///             else:
+///                 if index == (dict.lookup_function_no >> FUNC_SHIFT):
+///                     dict.lookup_function_no += (1 << FUNC_SHIFT)
+///             index = nextindex
+///         iter.dict = nullptr(...)   # clear the reference, prevent restarts
+///     raise StopIteration
+/// ```
+///
+/// `entries.valid(index)` is the simple-hash-eq `f_valid` flag
+/// (`getinteriorfield(entries, index, "f_valid")`); the dummy-obj valid path
+/// is out of scope. The `else` arm is the `popitem(last=False)` fast-forward
+/// hack that bumps the high bits of `lookup_function_no` so a repeated
+/// iteration over a shrinking prefix starts later; the `ll_assert` guarding
+/// it is debug-only and omitted. Self-contained: no lookup, hash, or malloc —
+/// a direct entries-array walk.
+///
+/// 8-block CFG plus the returnblock and exceptblock. Both the null-`dict`
+/// guard and the loop-exhausted tail raise `StopIteration` via `exceptblock`.
+pub fn build_ll_dictnext_helper_graph(
+    name: &str,
+    iter_ptr_lltype: LowLevelType,
+    dict_ptr_lltype: LowLevelType,
+    entries_ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let signed = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let var = |v: &Variable| Hlvalue::Variable(v.clone());
+    let null_dict = || {
+        Hlvalue::Constant(Constant::with_concretetype(
+            ConstValue::None,
+            dict_ptr_lltype.clone(),
+        ))
+    };
+    let push = |block: &BlockRef, opname: &str, args: Vec<Hlvalue>, result: &Variable| {
+        block.borrow_mut().operations.push(SpaceOperation::new(
+            opname,
+            args,
+            Hlvalue::Variable(result.clone()),
+        ));
+    };
+    let sig = || LowLevelType::Signed;
+    let new_var = |n: &str, t: LowLevelType| variable_with_lltype(n, t);
+
+    let exc_args = exception_args("StopIteration")?;
+
+    // ---- startblock inputargs: (iter).
+    let iter = new_var("iter", iter_ptr_lltype.clone());
+    let startblock = Block::shared(vec![var(&iter)]);
+    let return_var = new_var("result", sig());
+    let mut graph =
+        FunctionGraph::with_return_var(name.to_string(), startblock.clone(), var(&return_var));
+
+    // Pre-create the downstream blocks with fresh inputarg copies.
+    // block_setup: (iter, dict).
+    let su_iter = new_var("iter", iter_ptr_lltype.clone());
+    let su_dict = new_var("dict", dict_ptr_lltype.clone());
+    let block_setup = Block::shared(vec![var(&su_iter), var(&su_dict)]);
+
+    // block_loop_cond: (iter, dict, entries, index, entries_len).
+    let lc_iter = new_var("iter", iter_ptr_lltype.clone());
+    let lc_dict = new_var("dict", dict_ptr_lltype.clone());
+    let lc_entries = new_var("entries", entries_ptr_lltype.clone());
+    let lc_index = new_var("index", sig());
+    let lc_len = new_var("entries_len", sig());
+    let block_loop_cond = Block::shared(vec![
+        var(&lc_iter),
+        var(&lc_dict),
+        var(&lc_entries),
+        var(&lc_index),
+        var(&lc_len),
+    ]);
+
+    // block_loop_body: same shape as loop_cond.
+    let lb_iter = new_var("iter", iter_ptr_lltype.clone());
+    let lb_dict = new_var("dict", dict_ptr_lltype.clone());
+    let lb_entries = new_var("entries", entries_ptr_lltype.clone());
+    let lb_index = new_var("index", sig());
+    let lb_len = new_var("entries_len", sig());
+    let block_loop_body = Block::shared(vec![
+        var(&lb_iter),
+        var(&lb_dict),
+        var(&lb_entries),
+        var(&lb_index),
+        var(&lb_len),
+    ]);
+
+    // block_return_valid: (iter, nextindex, index).
+    let rv_iter = new_var("iter", iter_ptr_lltype.clone());
+    let rv_nextindex = new_var("nextindex", sig());
+    let rv_index = new_var("index", sig());
+    let block_return_valid = Block::shared(vec![var(&rv_iter), var(&rv_nextindex), var(&rv_index)]);
+
+    // block_invalid: (iter, dict, entries, nextindex, entries_len, index).
+    let iv_iter = new_var("iter", iter_ptr_lltype.clone());
+    let iv_dict = new_var("dict", dict_ptr_lltype.clone());
+    let iv_entries = new_var("entries", entries_ptr_lltype.clone());
+    let iv_nextindex = new_var("nextindex", sig());
+    let iv_len = new_var("entries_len", sig());
+    let iv_index = new_var("index", sig());
+    let block_invalid = Block::shared(vec![
+        var(&iv_iter),
+        var(&iv_dict),
+        var(&iv_entries),
+        var(&iv_nextindex),
+        var(&iv_len),
+        var(&iv_index),
+    ]);
+
+    // block_bump: (iter, dict, entries, nextindex, entries_len, lfn).
+    let bp_iter = new_var("iter", iter_ptr_lltype.clone());
+    let bp_dict = new_var("dict", dict_ptr_lltype.clone());
+    let bp_entries = new_var("entries", entries_ptr_lltype.clone());
+    let bp_nextindex = new_var("nextindex", sig());
+    let bp_len = new_var("entries_len", sig());
+    let bp_lfn = new_var("lfn", sig());
+    let block_bump = Block::shared(vec![
+        var(&bp_iter),
+        var(&bp_dict),
+        var(&bp_entries),
+        var(&bp_nextindex),
+        var(&bp_len),
+        var(&bp_lfn),
+    ]);
+
+    // block_clear: (iter).
+    let cl_iter = new_var("iter", iter_ptr_lltype.clone());
+    let block_clear = Block::shared(vec![var(&cl_iter)]);
+
+    // ===== startblock: dict = iter.dict; if dict raise-guard. =====
+    let dict0 = new_var("dict", dict_ptr_lltype.clone());
+    push(
+        &startblock,
+        "getfield",
+        vec![var(&iter), void_field_const("dict")],
+        &dict0,
+    );
+    let nz = new_var("nz", LowLevelType::Bool);
+    push(&startblock, "ptr_nonzero", vec![var(&dict0)], &nz);
+    startblock.borrow_mut().exitswitch = Some(var(&nz));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![var(&iter), var(&dict0)],
+            Some(block_setup.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            exc_args.clone(),
+            Some(graph.exceptblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // ===== block_setup: read entries, index, entries_len; enter loop. =====
+    let su_entries = new_var("entries", entries_ptr_lltype.clone());
+    push(
+        &block_setup,
+        "getfield",
+        vec![var(&su_dict), void_field_const("entries")],
+        &su_entries,
+    );
+    let su_index = new_var("index", sig());
+    push(
+        &block_setup,
+        "getfield",
+        vec![var(&su_iter), void_field_const("index")],
+        &su_index,
+    );
+    let su_len = new_var("entries_len", sig());
+    push(
+        &block_setup,
+        "getfield",
+        vec![var(&su_dict), void_field_const("num_ever_used_items")],
+        &su_len,
+    );
+    block_setup.closeblock(vec![
+        Link::new(
+            vec![
+                var(&su_iter),
+                var(&su_dict),
+                var(&su_entries),
+                var(&su_index),
+                var(&su_len),
+            ],
+            Some(block_loop_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ===== block_loop_cond: while index < entries_len. =====
+    let lt = new_var("lt", LowLevelType::Bool);
+    push(
+        &block_loop_cond,
+        "int_lt",
+        vec![var(&lc_index), var(&lc_len)],
+        &lt,
+    );
+    block_loop_cond.borrow_mut().exitswitch = Some(var(&lt));
+    block_loop_cond.closeblock(vec![
+        Link::new(
+            vec![
+                var(&lc_iter),
+                var(&lc_dict),
+                var(&lc_entries),
+                var(&lc_index),
+                var(&lc_len),
+            ],
+            Some(block_loop_body.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![var(&lc_iter)],
+            Some(block_clear.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // ===== block_loop_body: nextindex = index + 1; branch on entries.valid. =====
+    let lb_next = new_var("nextindex", sig());
+    push(
+        &block_loop_body,
+        "int_add",
+        vec![var(&lb_index), signed(1)],
+        &lb_next,
+    );
+    let lb_valid = new_var("valid", LowLevelType::Bool);
+    push(
+        &block_loop_body,
+        "getinteriorfield",
+        vec![
+            var(&lb_entries),
+            var(&lb_index),
+            void_field_const("f_valid"),
+        ],
+        &lb_valid,
+    );
+    block_loop_body.borrow_mut().exitswitch = Some(var(&lb_valid));
+    block_loop_body.closeblock(vec![
+        Link::new(
+            vec![var(&lb_iter), var(&lb_next), var(&lb_index)],
+            Some(block_return_valid.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                var(&lb_iter),
+                var(&lb_dict),
+                var(&lb_entries),
+                var(&lb_next),
+                var(&lb_len),
+                var(&lb_index),
+            ],
+            Some(block_invalid.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // ===== block_return_valid: iter.index = nextindex; return index. =====
+    let rv_void = new_var("v", LowLevelType::Void);
+    push(
+        &block_return_valid,
+        "setfield",
+        vec![var(&rv_iter), void_field_const("index"), var(&rv_nextindex)],
+        &rv_void,
+    );
+    block_return_valid.closeblock(vec![
+        Link::new(vec![var(&rv_index)], Some(graph.returnblock.clone()), None).into_ref(),
+    ]);
+
+    // ===== block_invalid: popitem(last=False) fast-forward hack. =====
+    let iv_lfn = new_var("lfn", sig());
+    push(
+        &block_invalid,
+        "getfield",
+        vec![var(&iv_dict), void_field_const("lookup_function_no")],
+        &iv_lfn,
+    );
+    let iv_shifted = new_var("shifted", sig());
+    push(
+        &block_invalid,
+        "int_rshift",
+        vec![var(&iv_lfn), signed(FUNC_SHIFT)],
+        &iv_shifted,
+    );
+    let iv_eq = new_var("is_head", LowLevelType::Bool);
+    push(
+        &block_invalid,
+        "int_eq",
+        vec![var(&iv_index), var(&iv_shifted)],
+        &iv_eq,
+    );
+    block_invalid.borrow_mut().exitswitch = Some(var(&iv_eq));
+    block_invalid.closeblock(vec![
+        Link::new(
+            vec![
+                var(&iv_iter),
+                var(&iv_dict),
+                var(&iv_entries),
+                var(&iv_nextindex),
+                var(&iv_len),
+                var(&iv_lfn),
+            ],
+            Some(block_bump.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                var(&iv_iter),
+                var(&iv_dict),
+                var(&iv_entries),
+                var(&iv_nextindex),
+                var(&iv_len),
+            ],
+            Some(block_loop_cond.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // ===== block_bump: lookup_function_no += (1 << FUNC_SHIFT); loop back. =====
+    let bp_new_lfn = new_var("lfn", sig());
+    push(
+        &block_bump,
+        "int_add",
+        vec![var(&bp_lfn), signed(1 << FUNC_SHIFT)],
+        &bp_new_lfn,
+    );
+    let bp_void = new_var("v", LowLevelType::Void);
+    push(
+        &block_bump,
+        "setfield",
+        vec![
+            var(&bp_dict),
+            void_field_const("lookup_function_no"),
+            var(&bp_new_lfn),
+        ],
+        &bp_void,
+    );
+    block_bump.closeblock(vec![
+        Link::new(
+            vec![
+                var(&bp_iter),
+                var(&bp_dict),
+                var(&bp_entries),
+                var(&bp_nextindex),
+                var(&bp_len),
+            ],
+            Some(block_loop_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ===== block_clear: iter.dict = nullptr; raise StopIteration. =====
+    let cl_void = new_var("v", LowLevelType::Void);
+    push(
+        &block_clear,
+        "setfield",
+        vec![var(&cl_iter), void_field_const("dict"), null_dict()],
+        &cl_void,
+    );
+    block_clear.closeblock(vec![
+        Link::new(exc_args, Some(graph.exceptblock.clone()), None).into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["iter".to_string()],
+        func,
+    ))
+}
+
 pub fn ll_call_insert_clean_function() -> Result<(), TyperError> {
     Err(ordered_dict_runtime_deferred(
         "ll_call_insert_clean_function",
@@ -1616,10 +2038,6 @@ pub fn _ll_malloc_entries() -> Result<(), TyperError> {
 
 pub fn _ll_free_entries() -> Result<(), TyperError> {
     Err(ordered_dict_runtime_deferred("_ll_free_entries"))
-}
-
-pub fn _ll_dictnext() -> Result<(), TyperError> {
-    Err(ordered_dict_runtime_deferred("_ll_dictnext"))
 }
 
 pub fn ll_dictiter_reversed() -> Result<(), TyperError> {
@@ -2251,6 +2669,63 @@ mod tests {
             ret.concretetype.borrow().clone(),
             Some(LowLevelType::Signed),
             "ll_dict_lookup returns Signed"
+        );
+    }
+
+    /// `_ll_dictnext` walks the entries array; on a valid entry it advances
+    /// `iter.index` and returns the slot, on exhaustion it nulls `iter.dict`
+    /// and raises StopIteration. Validate the null-guard header, the 8-block +
+    /// return + except CFG, the `f_valid` interior read, the field writes, the
+    /// popitem fast-forward hack ops, and the Signed return.
+    #[test]
+    fn build_ll_dictnext_walks_entries_then_raises_stopiteration() {
+        let (dict_ptr, entries_ptr, _key) = sample_dict_lookup_lltypes();
+        let iter_ptr = get_ll_dictiter(dict_ptr.clone());
+        let helper =
+            build_ll_dictnext_helper_graph("_ll_dictnext", iter_ptr, dict_ptr, entries_ptr)
+                .expect("build_ll_dictnext_helper_graph");
+        assert_eq!(helper.func.name, "_ll_dictnext");
+        let inner = helper.graph.borrow();
+
+        // Null-guard header: dict = iter.dict; ptr_nonzero(dict); branch.
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(start_ops, vec!["getfield", "ptr_nonzero"]);
+        assert!(startblock.exitswitch.is_some());
+        assert_eq!(startblock.exits.len(), 2);
+        drop(startblock);
+
+        // 8 work blocks + returnblock + exceptblock all reachable.
+        let (block_count, ops) = walk_blocks(&inner.startblock);
+        assert_eq!(block_count, 10, "8 work blocks + returnblock + exceptblock");
+
+        for needed in [
+            "getinteriorfield", // entries.valid(index) = f_valid
+            "setfield",         // iter.index = nextindex / iter.dict = null / lfn bump
+            "int_lt",           // index < entries_len
+            "int_add",          // nextindex / lfn += (1 << FUNC_SHIFT)
+            "int_rshift",       // lookup_function_no >> FUNC_SHIFT
+            "int_eq",           // index == (lookup_function_no >> FUNC_SHIFT)
+            "ptr_nonzero",      // if dict
+        ] {
+            assert!(
+                ops.iter().any(|o| o == needed),
+                "dictnext CFG must emit {needed}, got {ops:?}"
+            );
+        }
+
+        // Returns the Signed entry index.
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(
+            ret.concretetype.borrow().clone(),
+            Some(LowLevelType::Signed),
+            "_ll_dictnext returns Signed"
         );
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuilder.rs
@@ -25,10 +25,11 @@ pub const INIT_SIZE: i64 = 100;
 #[derive(Debug, Default)]
 pub struct AbstractStringBuilderRepr;
 
-/// Method names handled by
-/// `AbstractStringBuilderRepr.rtype_method_<name>`.
+/// Upstream method names on `AbstractStringBuilderRepr`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StringBuilderMethod {
+    /// `rtyper_new`
+    RtyperNew,
     /// `rtype_method_append`
     Append,
     /// `rtype_method_append_slice`
@@ -41,56 +42,76 @@ pub enum StringBuilderMethod {
     Getlength,
     /// `rtype_method_build`
     Build,
+    /// `rtype_bool`
+    RtypeBool,
+    /// `convert_const`
+    ConvertConst,
 }
 
 impl StringBuilderMethod {
     /// RPython method suffix used by `BuiltinMethodRepr`.
-    pub const fn as_method_name(self) -> &'static str {
+    pub const fn as_method_name(self) -> Option<&'static str> {
         match self {
-            StringBuilderMethod::Append => "append",
-            StringBuilderMethod::AppendSlice => "append_slice",
-            StringBuilderMethod::AppendMultipleChar => "append_multiple_char",
-            StringBuilderMethod::AppendCharpsize => "append_charpsize",
-            StringBuilderMethod::Getlength => "getlength",
-            StringBuilderMethod::Build => "build",
+            StringBuilderMethod::RtyperNew
+            | StringBuilderMethod::RtypeBool
+            | StringBuilderMethod::ConvertConst => None,
+            StringBuilderMethod::Append => Some("append"),
+            StringBuilderMethod::AppendSlice => Some("append_slice"),
+            StringBuilderMethod::AppendMultipleChar => Some("append_multiple_char"),
+            StringBuilderMethod::AppendCharpsize => Some("append_charpsize"),
+            StringBuilderMethod::Getlength => Some("getlength"),
+            StringBuilderMethod::Build => Some("build"),
         }
     }
 
-    /// RPython implementation method name on `AbstractStringBuilderRepr`.
-    pub const fn as_rtype_method_name(self) -> &'static str {
+    /// RPython method name on `AbstractStringBuilderRepr`.
+    pub const fn as_upstream_name(self) -> &'static str {
         match self {
+            StringBuilderMethod::RtyperNew => "rtyper_new",
             StringBuilderMethod::Append => "rtype_method_append",
             StringBuilderMethod::AppendSlice => "rtype_method_append_slice",
             StringBuilderMethod::AppendMultipleChar => "rtype_method_append_multiple_char",
             StringBuilderMethod::AppendCharpsize => "rtype_method_append_charpsize",
             StringBuilderMethod::Getlength => "rtype_method_getlength",
             StringBuilderMethod::Build => "rtype_method_build",
+            StringBuilderMethod::RtypeBool => "rtype_bool",
+            StringBuilderMethod::ConvertConst => "convert_const",
         }
+    }
+
+    /// Backward-compatible name for the upstream method surface.
+    pub const fn as_rtype_method_name(self) -> &'static str {
+        self.as_upstream_name()
     }
 }
 
-/// Upstream method table from `rbuilder.py:13-46`.
-pub const STRING_BUILDER_METHODS: [StringBuilderMethod; 6] = [
+/// Upstream method table from `rbuilder.py:7-58`.
+pub const STRING_BUILDER_METHODS: [StringBuilderMethod; 9] = [
+    StringBuilderMethod::RtyperNew,
     StringBuilderMethod::Append,
     StringBuilderMethod::AppendSlice,
     StringBuilderMethod::AppendMultipleChar,
     StringBuilderMethod::AppendCharpsize,
     StringBuilderMethod::Getlength,
     StringBuilderMethod::Build,
+    StringBuilderMethod::RtypeBool,
+    StringBuilderMethod::ConvertConst,
 ];
 
 impl AbstractStringBuilderRepr {
-    /// Resolve a `BuiltinMethodRepr.methodname` suffix to the upstream
-    /// `rtype_method_*` arm. Unknown names raise the same missing-method
-    /// shape as the base `Repr.rtype_method` dispatcher.
+    /// Resolve either an exact upstream method name or a
+    /// `BuiltinMethodRepr.methodname` suffix to the upstream method arm.
     pub fn method_from_name(method_name: &str) -> Result<StringBuilderMethod, TyperError> {
         STRING_BUILDER_METHODS
             .iter()
             .copied()
-            .find(|method| method.as_method_name() == method_name)
+            .find(|method| {
+                method.as_upstream_name() == method_name
+                    || method.as_method_name() == Some(method_name)
+            })
             .ok_or_else(|| {
                 TyperError::message(format!(
-                    "missing AbstractStringBuilderRepr.rtype_method_{method_name}"
+                    "missing AbstractStringBuilderRepr method {method_name}"
                 ))
             })
     }
@@ -116,12 +137,15 @@ mod tests {
         assert_eq!(
             names,
             vec![
+                "rtyper_new",
                 "rtype_method_append",
                 "rtype_method_append_slice",
                 "rtype_method_append_multiple_char",
                 "rtype_method_append_charpsize",
                 "rtype_method_getlength",
                 "rtype_method_build",
+                "rtype_bool",
+                "convert_const",
             ]
         );
     }
@@ -137,5 +161,21 @@ mod tests {
             StringBuilderMethod::AppendCharpsize
         );
         assert!(AbstractStringBuilderRepr::method_from_name("extend").is_err());
+    }
+
+    #[test]
+    fn method_from_name_resolves_exact_upstream_names() {
+        assert_eq!(
+            AbstractStringBuilderRepr::method_from_name("rtyper_new").unwrap(),
+            StringBuilderMethod::RtyperNew
+        );
+        assert_eq!(
+            AbstractStringBuilderRepr::method_from_name("rtype_bool").unwrap(),
+            StringBuilderMethod::RtypeBool
+        );
+        assert_eq!(
+            AbstractStringBuilderRepr::method_from_name("convert_const").unwrap(),
+            StringBuilderMethod::ConvertConst
+        );
     }
 }

--- a/majit/majit-translate/tests/test_argument.rs
+++ b/majit/majit-translate/tests/test_argument.rs
@@ -7,7 +7,7 @@
 //! `Signature.__repr__` is not tested (RPython uses `%r`-style string
 //! formatting; the Rust `Debug` impl differs).
 
-use majit_translate::flowspace::argument::{CallSpec, Signature};
+use majit_translate::flowspace::argument::{CallSpec, Signature, SignatureItem};
 use majit_translate::flowspace::model::{ConstValue, Constant, Hlvalue};
 use std::collections::HashMap;
 
@@ -91,6 +91,12 @@ fn test_tuply() {
     assert_eq!(x, ["a", "b", "c"]);
     assert_eq!(y, Some("d"));
     assert_eq!(z, Some("e"));
+    assert_eq!(
+        sig.getitem(0),
+        SignatureItem::Argnames(&["a".to_string(), "b".into(), "c".into()])
+    );
+    assert_eq!(sig.getitem(1), SignatureItem::Varargname(Some("d")));
+    assert_eq!(sig.getitem(2), SignatureItem::Kwargname(Some("e")));
 }
 
 // ---- module-level `test_flatten_CallSpec` ----


### PR DESCRIPTION
Continues the Charon-MIR JIT lowering cutover (Refs #97). Three commits draining rtyper dual-gate divergences and porting one helper graph.

## Commits

- **`ffa3fbadc7` rtyper: port `_ll_dictnext` to a helper graph** — models the dict-iteration next step as an rtyper helper graph instead of leaving it unported.

- **`8398879c12` translate: fuse boxing `malloc_typed` into `new_with_vtable`** — `fuse_boxing_alloc` rewrites `malloc_typed(W_FloatObject{..})` (and the int/complex boxing constructors) into a `NewWithVtable` owner allocation plus the payload field stores, matching the oracle trace shape. The `PyObject` header subtree (`ob_header`/`ob_type`/`w_class`) rides the vtable descriptor and is dropped.

- **`54410dd6aa` translate: sweep dead boxing header remnants post-fusion** — after fusion drops the header subtree, the original aggregate ctor, inner header ctor, their field stores, and the `__pyre_cast_instance` casts feeding them are dead. `front::mir` threads each across the block boundary the preceding `Call` opens by reusing the same `Variable` as both a block's op result and the successor's inputarg, which defeats both `remove_dead_aggregates` (counts every `Link.arg` as a read) and `prune_dead_phis` (a `FieldWrite` pins its base). `prune_dead_boxing_remnants` runs `transform_dead_op_vars`' dependency-flow liveness combined with the malloc-removal exemption (a store into an unread struct is dead) so the whole cross-block cluster sweeps in one pass.

## Dual-gate effect

The fusion + sweep bring the four boxing constructors (`w_float_new` / `w_int_new` / `w_int_new_unique` / `w_complex_new`) to dual-gate `Match` — the real rtyper-typed graph now matches the legacy baseline per-`Variable`, so the codewriter consumes the real path instead of falling back via `Skip`.

`is_removable_producer` matches the full `pyre_object::pyobject::get_instantiate` owner path (not the bare leaf) and asserts the cast is single-operand, so an unrelated path sharing either marker name is never swept.

## Validation

- `cargo test -p majit-translate --lib` — 2787 passed, 0 failed (5 boxing-specific tests, including the single-block fusion sweep and the cross-block id-reuse threaded-cluster sweep).
- `pyre/check.py` — 146/146 on both backends (dynasm + cranelift).
- Census: 0 boxing dual-gate skips; all four boxing subjects reach `Match`.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed `malloc_typed` builtin (with a dedicated stdlib module) to preserve object type information through translation and lowering.
  * Enabled `NewWithVtable`-based allocation support across translation, inlining, and code generation.
  * Generated an ordered-dictionary iteration helper that correctly walks entries and raises `StopIteration`.
* **Bug Fixes**
  * Enforced `malloc_typed`’s argument requirements and reject invalid “classdef-less” inputs.
  * Improved boxing-allocation fusion and cleanup of redundant boxing remnants for leaner graphs.
  * Corrected raising/purity handling for the new allocation operation.
* **Tests**
  * Added unit tests covering `malloc_typed` rejection, boxing fusion scenarios, dictnext helper behavior, and safer output-argument resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->