### PR TITLE
jit: exception/resume correctness follow-ups on the flatten-graph branch (#27)

### DIFF
--- a/pyre/bench/synth/exc_caught_in_callee_return_loop.py
+++ b/pyre/bench/synth/exc_caught_in_callee_return_loop.py
@@ -1,0 +1,34 @@
+# A callee catches a residual-call exception in-frame and RETURNS a sentinel
+# into a JIT-hot outer loop.  When the callee gets hot enough that a bridge is
+# compiled for the exception-guard (GUARD_NO_EXCEPTION) failure on the
+# caught-KeyError path, the bridge must not be built from the guard's
+# no-exception fallthrough resume_pc (which would record `Finish` of the NULL
+# raised-call result and hand a NULL back to the caller — "call failed").  The
+# bridge tracer declines the caught-in-frame exception-guard case so the
+# blackhole resume routes the exception to the handler and returns the sentinel.
+N = 60000
+
+
+def lookup(d, k):
+    try:
+        return d[k]
+    except KeyError:
+        return -1
+
+
+def run():
+    d = {1: 100, 2: 200, 3: 300}
+    acc = 0
+    hits = 0
+    for i in range(N):
+        k = i % 5          # 0 and 4 miss → KeyError caught → -1
+        v = lookup(d, k)
+        if v == -1:
+            acc -= 1
+        else:
+            acc += v
+            hits += 1
+    return acc, hits
+
+
+print(run())

--- a/pyre/bench/synth/exc_in_loop_divzero_continue.py
+++ b/pyre/bench/synth/exc_in_loop_divzero_continue.py
@@ -1,0 +1,67 @@
+# A try/except INSIDE a hot loop whose body raises through a may-force
+# residual call (`//`, `%`, `int("z")`) on some iterations and is CAUGHT,
+# with the loop CONTINUING afterwards.  The raising op is int-specialized
+# (`GuardFalse(int_eq(divisor, 0))` + bare `IntFloorDiv`); when the divisor
+# is 0 the precondition guard deopts, the blackhole re-executes the op, it
+# raises, and the in-frame `catch_exception` consumes the exception (v=7).
+# The blackhole then reaches the loop merge point and ContinueRunningNormally
+# re-enters compiled code.
+#
+# The raising helper publishes to BOTH the blackhole `last_exc_value` and the
+# backend `_store_exception` cells; the in-frame catch cleared only the
+# former, so the re-entered loop's first `GUARD_NO_EXCEPTION` read the stale
+# backend cell as a spurious pending exception and deopted at the loop header
+# (no handler), escaping the try-block — an uncaught ZeroDivisionError.  This
+# bench pins that a residual-call raise caught on a resume path that RE-ENTERS
+# the loop returns byte-identically (the merge-point re-entry drains the
+# backend exception cells).
+N = 120000
+M = 997
+
+
+def divzero_in_loop():
+    total = 0
+    i = 1
+    while i < N:
+        try:
+            v = i // (i % M)
+        except ZeroDivisionError:
+            v = 7
+        total = total + v
+        i = i + 1
+    return total
+
+
+def modzero_in_loop():
+    total = 0
+    i = 1
+    while i < N:
+        try:
+            v = 100 % (i % M)
+        except ZeroDivisionError:
+            v = 3
+        total = total + v
+        i = i + 1
+    return total
+
+
+def residual_raise_in_loop():
+    total = 0
+    i = 1
+    while i < N:
+        try:
+            v = int("z") if (i % M == 0) else i
+        except ValueError:
+            v = 7
+        total = total + v
+        i = i + 1
+    return total
+
+
+def main():
+    print(divzero_in_loop())
+    print(modzero_in_loop())
+    print(residual_raise_in_loop())
+
+
+main()

--- a/pyre/bench/synth/exception_bare_reraise_nested_outer.py
+++ b/pyre/bench/synth/exception_bare_reraise_nested_outer.py
@@ -1,0 +1,46 @@
+# Bare `raise` inside a nested handler whose re-raise must reach the OUTER
+# handler, exercised under a bridge resume that lands inside the inner handler.
+#
+# Unlike exception_bare_reraise_restore.py (which only restores the current-
+# exception slot), this shape adds a third inner branch (i % 3) so the catch
+# landing of the inner handler shares a resume color with the virtualizable
+# frame `f_code` scalar.  At a bridge resuming into the inner handler at the
+# bare `raise`, the walker reconstructs the PUSH_EXC_INFO operand-stack slot
+# from the per-PC resume map; if it aliases the const-folded `f_code` the
+# published current exception becomes a code object and the later blackhole
+# re-raise reports `TypeError: exceptions must derive from BaseException`
+# instead of routing ValueError to the outer handler.
+#
+#   i % 3 == 0 -> raise ValueError -> inner except (inner++)
+#                   then i % 2 == 0 -> bare raise -> outer except (outer++)
+#   i % 3 != 0 -> clean path (clean++)
+#
+# With N=200000: inner=66667, outer=33334, clean=133333; inner+clean=200000.
+# Deterministic.
+N = 200000
+
+
+def main():
+    inner = 0
+    outer = 0
+    clean = 0
+    i = 0
+    while i < N:
+        try:
+            try:
+                if i % 3 == 0:
+                    raise ValueError("v")
+                else:
+                    clean += 1
+            except ValueError:
+                inner += 1
+                if i % 2 == 0:
+                    raise
+        except ValueError:
+            outer += 1
+        i += 1
+    print(inner, outer, clean)
+    print(inner + clean)
+
+
+main()

--- a/pyre/bench/synth/float_div_zero_caught_loop.py
+++ b/pyre/bench/synth/float_div_zero_caught_loop.py
@@ -1,0 +1,28 @@
+# Float true-division by zero inside a try in a JIT-hot callee.  The walker
+# specializes `float / float` to a bare `FloatTrueDiv` llop (raw IEEE), which
+# would compute `inf` for a zero divisor instead of raising ZeroDivisionError.
+# A `float_eq(rhs, 0.0) -> guard_false` precondition (the JIT form of
+# floatobject.py:519 `_floatdiv`'s zero check) deopts a zero divisor to the
+# checked descr_truediv path, which raises and is caught in-frame.
+N = 60000
+
+
+def helper(i):
+    try:
+        return 1.5 / (i % 5)      # ZeroDivisionError every 5th iteration
+    except ZeroDivisionError:
+        return 3.25
+
+
+def run():
+    total = 0.0
+    for i in range(N):
+        r = helper(i)
+        if r > 1.0:               # guard on the returned float
+            total += r
+        else:
+            total -= r
+    return total
+
+
+print(round(run(), 4))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13566,7 +13566,7 @@ fn try_walker_lower_exc_info_residual(
     } else {
         FBW_EXC_PREV.with(|s| s.borrow_mut().pop())
     };
-    let (store_op, store_concrete) = match restore {
+    let (mut store_op, mut store_concrete) = match restore {
         // POP_EXCEPT: restore the saved prev, NOT the operand-stack value
         // (which the walker resolves to the just-caught exception).  Restoring
         // the saved prev makes the PUSH store + this restore a balanced no-op,
@@ -13582,6 +13582,32 @@ fn try_walker_lower_exc_info_residual(
             (r_args[0], exc_concrete)
         }
     };
+    // A PUSH_EXC_INFO store publishes the exception being handled, which IS the
+    // tracked active exception (`ctx.last_exc_value`, the walker's mirror of
+    // RPython `metainterp.last_exc_box`).  The graph-side codewriter binds the
+    // popped `exc_value`'s producer to a `last_exc_value` re-read for exactly
+    // this reason (`codewriter.rs` PushExcInfo arm), but that producer is
+    // graph-only — the walker reads the operand-stack slot directly on the
+    // assumption that runtime register threading already holds the caught
+    // exception there.  At a bridge resume into a handler the slot's per-PC
+    // resume reconstruction can alias a non-exception constant (e.g. the vable
+    // `f_code` scalar when the catch-landing exception slot shares its color),
+    // so the published current exception would become a code object.  When the
+    // PUSH store's operand resolves to a non-exception, recover the authoritative
+    // exception from the tracked channel, matching the graph-side producer.
+    if is_push_set
+        && !store_concrete.is_null()
+        && !unsafe { pyre_object::is_exception(store_concrete) }
+    {
+        if let (Some(tracked_op), ConcreteValue::Ref(tracked_obj)) =
+            (ctx.last_exc_value, ctx.last_exc_value_concrete)
+        {
+            if !tracked_obj.is_null() && unsafe { pyre_object::is_exception(tracked_obj) } {
+                store_op = tracked_op;
+                store_concrete = tracked_obj;
+            }
+        }
+    }
     ctx.trace_ctx.record_op_with_descr(
         OpCode::SetfieldGc,
         &[ec, store_op],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11620,6 +11620,23 @@ fn walker_int_eq_const(
     r
 }
 
+/// Record `float_eq(raw, const k)` and stamp its already-known concrete
+/// truth.  Used to build the float-div zero-divisor precondition guard
+/// walker-native (the JIT representation of `floatobject.py:519 _floatdiv`'s
+/// `if y == 0.0: raise ZeroDivisionError`).
+fn walker_float_eq_const(
+    ctx: &mut WalkContext<'_, '_>,
+    raw: OpRef,
+    k: f64,
+    concrete_truth: i64,
+) -> OpRef {
+    let k_const = ctx.trace_ctx.const_float(k.to_bits() as i64);
+    let r = ctx.trace_ctx.record_op(OpCode::FloatEq, &[raw, k_const]);
+    ctx.trace_ctx
+        .set_opref_concrete(r, majit_ir::Value::Int(concrete_truth));
+    r
+}
+
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// `generated_binary_int_value`'s structure (`guard_class` +
@@ -12658,9 +12675,28 @@ fn try_walker_specialize_binary_op_float(
         }
     }
 
+    // floatobject.py:519 `_floatdiv` raises "float division by zero" — a
+    // concrete zero divisor at trace time means the generic helper already
+    // raised, so a non-raising specialized `FloatTrueDiv` (raw IEEE → inf)
+    // would be a miscompile.  Decline so the generic CALL_MAY_FORCE leg
+    // (descr_truediv) records the raising call.
+    if matches!(op_code, Some(OpCode::FloatTrueDiv)) && rhs_f64 == 0.0 {
+        return Ok(None);
+    }
+
     // --- emit the specialized IR (walker-native) ---
     let lhs_raw = walker_coerce_operand_to_float(ctx, op_pc, lhs, lhs_obj, lhs_is_int, lhs_f64)?;
     let rhs_raw = walker_coerce_operand_to_float(ctx, op_pc, rhs, rhs_obj, rhs_is_int, rhs_f64)?;
+    // rint.py:429 `_ovf_zer` analogue for float true-division: emit a
+    // `float_eq(rhs, 0.0) → guard_false` precondition ahead of the bare
+    // `FloatTrueDiv` llop so a future zero divisor deopts to the checked
+    // descr_truediv path (which raises ZeroDivisionError) rather than
+    // computing a raw IEEE inf.  The bare llop is sound only behind this
+    // non-zero guarantee.
+    if matches!(op_code, Some(OpCode::FloatTrueDiv)) {
+        let rhs_zero = walker_float_eq_const(ctx, rhs_raw, 0.0, (rhs_f64 == 0.0) as i64);
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[rhs_zero])?;
+    }
     let raw_result = match op_code {
         Some(op_code) => {
             let r = ctx.trace_ctx.record_op(op_code, &[lhs_raw, rhs_raw]);

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2362,10 +2362,36 @@ pub fn trace_and_compile_from_bridge(
             false
         }
     };
-    if pending_exc && !last_bridge_is_exception_guard {
+    // A pending exception at an EXCEPTION guard (GUARD_NO_EXCEPTION /
+    // GUARD_EXCEPTION) whose raising op sits inside an in-frame try is the
+    // bridge-side analogue of the same fallthrough-not-catch resume gap.
+    // pyre encodes the guard's resume_pc as the no-exception semantic
+    // fallthrough (the next opcode after the call), NOT the `except`
+    // handler.  The blackhole compensates at runtime — `resume_in_blackhole`
+    // hands the pending exception to `handle_exception_in_frame`, which
+    // `find_catch_before_resume_live`-routes to the handler and runs it
+    // (e.g. `return -1`).  The bridge tracer has no such routing: it walks
+    // from the fallthrough resume_pc and records the RETURN of the (NULL)
+    // raised-call result — `Finish(<unbound box>)` — so the compiled bridge
+    // hands a NULL up to the caller ("call failed" / a corrupted kept value
+    // / a fault).  Detect the caught-in-frame case with the exact mechanism
+    // the interpreter's `handle_exception` uses — an exception-table lookup
+    // at the raising op (`last_instr` == resume_pc-1) — and decline so the
+    // always-correct blackhole resume handles it.  (Routing the bridge walk
+    // to the handler is the orthodox follow-up, gated on the in-try
+    // residual-call resume-PC epic; declining is correctness-first.)
+    let caught_in_frame = pending_exc && last_bridge_is_exception_guard && {
+        let off = if frame.last_instr < 0 {
+            0u32
+        } else {
+            (frame.last_instr as u32) * 2
+        };
+        pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
+    };
+    if pending_exc && (!last_bridge_is_exception_guard || caught_in_frame) {
         if majit_metainterp::majit_log_enabled() {
             eprintln!(
-                "[jit][bridge-trace] decline (pending exc at non-exception guard) key={} trace={} fail={} resume_pc={}",
+                "[jit][bridge-trace] decline (pending exc, caught_in_frame={caught_in_frame}) key={} trace={} fail={} resume_pc={}",
                 green_key, trace_id, fail_index, resume_pc
             );
         }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -1806,6 +1806,22 @@ pub fn blackhole_resume_via_rd_numb(
     loop {
         if let Some(args) = bh.run() {
             // blackhole.py:1068: raise ContinueRunningNormally(*args)
+            //
+            // The blackhole reached a merge point with no pending exception
+            // (an unhandled raise would have propagated through the exception
+            // path above, not reached `run()`'s ContinueRunningNormally).  A
+            // residual call that raised AND was caught in-frame
+            // (`check_residual_call_exception_after` → `route_to_catch`) cleared
+            // only `BH_LAST_EXC_VALUE`; the backend `_store_exception` cells
+            // (`store_jit_exception` writes BOTH — see
+            // `publish_residual_call_exception`) keep the consumed exception.
+            // Re-entering compiled code via this ContinueRunningNormally would
+            // then have its first `GUARD_NO_EXCEPTION` read the stale cell as a
+            // spurious pending exception and deopt at a coordinate with no
+            // handler (the loop header), escaping the original try-block.  Drain
+            // the backend cells here so the re-entry starts pristine, mirroring
+            // the walker's `execute_raised` drain (`drain_backend_jit_exc`).
+            drain_backend_jit_exc();
             let frame_ptr = bh.virtualizable_ptr as *mut PyFrame;
 
             let mut red_ref: Vec<PyObjectRef> =

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8293,8 +8293,50 @@ impl CodeWriter {
                                 // `raise/r`.
                                 emit_raise!(exc_reg, normalized_exc_fv, py_pc as i64, true);
                             } else {
-                                // reraise: re-raise exception_last_value
-                                emit_reraise!();
+                                // Bare `raise` (argc==0): re-raise the active
+                                // handler exception (`raise_varargs(0)` →
+                                // `get_current_exception()`).  When this PC is
+                                // itself inside an outer try/except range, route
+                                // the re-raise to that handler's catch landing —
+                                // the orthodox `flatten.py:make_exception_link`
+                                // catch-covered shape, identical to the
+                                // `Instruction::Reraise` arm — so blackhole
+                                // `handle_exception_in_frame` (`blackhole.py:396`)
+                                // finds the byte-adjacent `catch_exception/L`.
+                                // `emit_reraise!` unconditionally links to
+                                // `graph.exceptblock` (no catch adjacency), so a
+                                // covered bare raise escapes the frame.
+                                let covered = catch_for_pc.get(py_pc).copied().flatten().is_some();
+                                if covered && current_state.last_exception.is_some() {
+                                    // Materialize the active exception via
+                                    // `get_current_exception()` — exactly what
+                                    // `raise_varargs(0)` re-raises
+                                    // (eval.rs:2549).  The per-thread current-
+                                    // exception slot is maintained by
+                                    // `PUSH_EXC_INFO` / `POP_EXCEPT` and survives
+                                    // the compiled-trace ↔ blackhole resume
+                                    // boundary, unlike the blackhole-local
+                                    // `exception_last_value` field (only set when
+                                    // the blackhole itself routes a catch).
+                                    let reraise_value = residual_call!(
+                                        get_current_exception_fn_idx,
+                                        CallFlavor::PlainCannotRaiseNoHeap,
+                                        majit_ir::PyreHelperKind::GetCurrentException,
+                                        vec![],
+                                        vec![],
+                                        vec![],
+                                        vec![],
+                                        ResKind::Ref,
+                                        py_pc as i64,
+                                    )
+                                    .map(super::flow::FlowValue::from)
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                                    emit_raise!(0u16, reraise_value, py_pc as i64, true);
+                                } else {
+                                    // No enclosing handler (or no active
+                                    // exception): function-level exception exit.
+                                    emit_reraise!();
+                                }
                             }
                         }
 

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -1157,15 +1157,12 @@ impl Insn {
     }
 }
 
-/// Minimal production slice of `rpython/jit/codewriter/flatten.py:
-/// 60-350` `GraphFlattener`.
-///
-/// Upstream owns the whole `FunctionGraph -> SSARepr` lowering. pyre is
-/// still in the transitional dual-write phase, so this helper currently
-/// serializes individual graph-level `SpaceOperation`s into `Insn`s and is
-/// used only for the first production op migrated off direct SSA emission.
-/// Expand this helper as more ops move from `codewriter.rs` into the
-/// flow-graph + flatten pipeline.
+/// Production port of `rpython/jit/codewriter/flatten.py:60-350`
+/// `GraphFlattener`. Owns the whole `FunctionGraph -> SSARepr` lowering:
+/// `flatten_graph` builds one per graph and drives `enforce_input_args`
+/// + `generate_ssa_form`, emitting the production `ssarepr.insns` the
+/// codewriter adopts (`codewriter.rs:10800` builds it, `:10914` installs
+/// `ssarepr.insns`). The earlier direct-SSA-emission dual-write is retired.
 pub struct GraphFlattener<'a> {
     // ─── PyPy-mirror fields (in `flatten.py:77-86 __init__` order) ───
     /// `rpython/jit/codewriter/flatten.py:77 self.graph = graph`.


### PR DESCRIPTION
Refs #267.

Follow-on JIT correctness fixes on the flatten-graph branch (the #27
`flatten_graph` alignment lineage). Built on the landed SSA-repr flatten and
catch-landing structure, these resolve a cluster of exception/resume
miscompiles where an exception raised inside a `try` in a JIT-hot loop escaped
its handler, plus one stale-doc correction left over from #27.

## Summary

- **Drain backend exception cells on blackhole `ContinueRunningNormally`
  re-entry** — an int `//`/`%` (or residual-call) exception caught inside a
  `try` in a JIT-hot loop escaped the `except` handler: the blackhole caught it
  and re-entered the compiled trace, but the backend `_store_exception` cell
  still held the stale exception, which re-fired on the next guard. Drain the
  cells on re-entry.

- **Decline the bridge for in-frame-caught exception-guard failures** — a
  `GUARD_NO_EXCEPTION` whose raising residual op sits inside an in-frame `try`
  resumes at the no-exception fallthrough PC, not the handler. `resume_in_blackhole`
  compensates via `handle_exception_in_frame`; the bridge tracer did not,
  recording `Finish(<unbound NULL>)`. Extend the existing pending-exception
  bridge decline to fire when the failing guard's raising op is covered by the
  code's exception table, so the always-correct blackhole handles it.

- **Guard float true-division against a zero divisor** — the specialized walker
  `float /` path emitted a bare `FloatTrueDiv` llop (raw `a/b`), bypassing the
  checked `descr_truediv` zero-check, so `x / 0.0` produced `inf` instead of
  `ZeroDivisionError`. Emit a `float_eq(rhs, 0.0) → guard_false` precondition and
  decline the specialization when the divisor is concretely `0.0` at trace time,
  deopting to the checked path.

- **Route a covered bare `raise` to its outer handler + recover the bridge-resume
  exception** — a bare `raise` (`RAISE_VARARGS 0`) covered by an enclosing `try`
  re-raised through `graph.exceptblock` (no catch adjacency) and escaped the
  frame; route the covered case through `get_current_exception()` and the
  catch-landing shape used by `RERAISE`. At a bridge resuming into the handler the
  walker read the `PUSH_EXC_INFO` operand from the operand-stack slot, whose per-PC
  resume reconstruction can alias the const-folded virtualizable `f_code` scalar
  and publish a code object as the current exception; recover the authoritative
  exception from the tracked `last_exc_value` channel (the walker mirror of the
  graph-side producer).

- **Correct a stale `GraphFlattener` production-status doc** — the struct doc
  still described a "transitional dual-write phase"; the flattener is the sole
  production SSA producer since the #27 cutover.

Regression benches added for each: `exc_in_loop_divzero_continue`,
`exc_caught_in_callee_return_loop`, `float_div_zero_caught_loop`,
`exception_bare_reraise_nested_outer`. Full synthetic parity suite **140/140 on
both dynasm and cranelift**, byte-exact against CPython and the no-JIT oracle.

The remaining post-#27 work — retiring the walker register/slot-pinning resume
model — is tracked separately in #267.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - AI-assisted (Claude). Every commit carries an `Assisted-by: Claude` trailer. Per the template note, the parity review was not run in the code-generating session; the gpt-5.5 auto-review will run on this PR.
