### PR TITLE
#131 rtyper: foreign-value modeling (list/container params, checked-arith *_ovf, stdlib externals)

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -466,6 +466,26 @@ pub fn strip_instantiation_suffix(name: &str) -> &str {
     }
 }
 
+/// Whether `spelling` is a list-shaped container type (`Vec<T>`,
+/// `VecDeque<T>`, `&[T]`, `[T; N]`) that the annotator's
+/// `project_pyre_field_type` maps to a `SomeList` element model rather
+/// than a class instance.  The named-ADT root resolver
+/// (`adt_node_class_root`) answers `None` for the core/std/alloc
+/// container family, so a list-typed parameter would otherwise seed the
+/// classdef-less `SomeInstance(None)` shell; this recognizer lets the
+/// parameter seam route it through the list model instead.  Mirrors the
+/// `Vec<` / `[` arms of `project_pyre_field_type`.
+pub fn is_list_container_spelling(spelling: &str) -> bool {
+    let stripped = spelling
+        .trim()
+        .trim_start_matches('&')
+        .trim_start_matches("mut ")
+        .trim_start_matches("*const ")
+        .trim_start_matches("*mut ")
+        .trim();
+    stripped.starts_with("Vec<") || stripped.starts_with("VecDeque<") || stripped.starts_with('[')
+}
+
 /// Remove the first balanced generic-argument group from a (possibly
 /// variant-qualified) name, preserving any trailing path segment:
 /// `Result<Tuple>::Ok` → `Result::Ok`, `Result<Tuple>` → `Result`,

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2245,6 +2245,26 @@ impl Bookkeeper {
                 return self.project_pyre_field_type(parts[1]);
             }
         }
+        // `FixedObjectArray { len: usize, _items: [PyObjectRef; 0] }` is a
+        // flexible object array.  An `arr[idx]` access lowers (front-end
+        // ArrayRead -> flowspace `getitem`) onto the receiver, so the
+        // receiver must model as the element list — not the wrapping
+        // struct, whose `getitem` over `SomeInstance(None)` would rewrite
+        // to `getattr("__getitem__")` and dead-end.  Project the `_items`
+        // flexible-array tail: `[PyObjectRef; 0]` resolves through the
+        // array arm above to `SomeList(item=SomeInstance(PyObjectRef),
+        // resized=false)`, giving a typed element rather than a
+        // classdef-less stub.
+        if majit_ir::descr::canonical_struct_name(stripped) == "object_array::FixedObjectArray" {
+            let items_ty = self
+                .pyre_struct_fields
+                .borrow()
+                .as_ref()
+                .and_then(|reg| reg.field_type(stripped, "_items").map(str::to_string));
+            if let Some(items_ty) = items_ty {
+                return self.project_pyre_field_type(&items_ty);
+            }
+        }
         let registered = {
             let guard = self.pyre_struct_fields.borrow();
             guard

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -354,6 +354,9 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     analyzer_for(&mut reg, "i64.from", primitive_integer_conversion);
     analyzer_for(&mut reg, "i64.try_from", primitive_integer_conversion);
     analyzer_for(&mut reg, "usize.try_from", primitive_integer_conversion);
+    // `BigInt::from(i64)` — boxes a machine int into the foreign opaque
+    // `BigInt` (Python `long`); returns the classdef-less GcRef shell.
+    analyzer_for(&mut reg, "BigInt.from", bigint_from);
     // `rarithmetic.r_uint` is routed via
     // `ExtRegistryEntry::ForType` (rarithmetic.py:572-582 `ForTypeEntry`):
     // bookkeeper's BUILTIN_ANALYZERS miss falls through to
@@ -1366,6 +1369,38 @@ fn string_constructor(
     _kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
     Ok(SomeValue::String(SomeString::new(false, false)))
+}
+
+/// Analyzer for `BigInt::from(i64)` — the `From<i64>` impl that boxes a
+/// machine integer into the arbitrary-precision `BigInt` the interpreter
+/// uses for Python `long`.  `BigInt` is a foreign Rust value with no
+/// Repr: in the JIT the overflow→long arm is the cold `guard_no_overflow`
+/// bailout (`@jit.dont_look_inside` in `rbigint`), never traced inline,
+/// so the value stays opaque.  Model the result as a classdef-less
+/// `SomeInstance` — the same foreign-opaque GcRef shell
+/// `annotation_state::ref_fallback_instance` gives an unregistered
+/// host-struct pointee.  It projects to `ValueType::Ref(None)`
+/// (`somevalue_to_valuetype`), matching the `result_kind = 'r'` the
+/// `bigint_add`/`bigint_sub`/`bigint_mul` residuals produce.
+///
+/// This retires the `SomeBuiltin.call(): no analyser registered for
+/// BigInt.from` wall.  It does not by itself carry the cold long arm to
+/// Match: the next operation on the boxed value (the `+`/`-`/`*` operator
+/// → a `<BigInt as Add>::add` method call, or `as_bigint`/`bigint_result`'s
+/// `.to_i64()`/`.div_floor()`/`.sign()` …) is a method/operator call on
+/// the opaque shell that `SomeInstance.getattr` rejects as classdef-less.
+/// Residualizing those foreign-method calls on an opaque instance is a
+/// separate port.
+fn bigint_from(
+    _bk: &Rc<Bookkeeper>,
+    _args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(SomeValue::Instance(SomeInstance::new(
+        None,
+        false,
+        std::collections::BTreeMap::new(),
+    )))
 }
 
 /// Analyzer for the `majit_metainterp` crate's `pub fn -> bool` flag

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -300,6 +300,12 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         "pyre_object.lltype.malloc_typed",
         malloc_typed_alloc,
     );
+    // `pyre_object::lltype::malloc_raw` — the raw (non-GC) allocation
+    // intrinsic (`lltype.malloc(T, flavor='raw')` parity).  Recognising it
+    // as a builtin keeps its `Box::new` / `Box::into_raw` body out of the
+    // looked-inside set (neither has an analyser), the same boundary the
+    // `malloc_typed` registration draws around `GcType::type_id`.
+    analyzer_for(&mut reg, "pyre_object.lltype.malloc_raw", malloc_raw_alloc);
     // Rust `std::ptr::eq(p, q) -> bool` — registered under the dotted
     // qualname that `HostEnv::bootstrap` assigns to the HOST_ENV stub
     // (`flowspace/model.rs:1910`).  Lowers identity checks in
@@ -1641,6 +1647,43 @@ pub fn malloc_typed_alloc(
         other => Err(AnnotatorError::new(format!(
             "malloc_typed(): expected a struct value to box, got {other:?}"
         ))),
+    }
+}
+
+/// Analyzer for `pyre_object::lltype::malloc_raw::<T>(value: T) -> *mut T`
+/// — the raw (`lltype.malloc(T, flavor='raw')` parity) heap allocation.
+/// Registered as a builtin so the body is NEVER looked-inside: it calls
+/// `Box::new` / `Box::into_raw`, neither of which carries an analyser (the
+/// `Box.*` HOST_ENV stubs have no analyzer wired), so a body lift would
+/// poison every raw-allocating caller with "no analyser registered for
+/// Box.new".  Unlike `malloc_typed` (struct-only, `flavor='gc'`), the raw
+/// flavor allocates ANY `T` — an opaque foreign payload (`*mut BigInt`, the
+/// `int` overflow path), a `*mut String`, a `*mut Vec`, or a pyre struct
+/// (`DictStorage`, `FrameBlock`, …) — so the `*mut T` result carries the
+/// same value identity as the argument and the arg shape is passed through
+/// unchanged.  A successful raw malloc returns a non-null pointer to that
+/// payload, so an `Instance` result drops its `can_be_none` (OOM takes the
+/// MemoryError edge, not a null result).
+pub fn malloc_raw_alloc(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    if !kwds.is_empty() || args_s.len() != 1 {
+        return Err(AnnotatorError::new(
+            "malloc_raw() expects a single (value) positional argument",
+        ));
+    }
+    match arg_at(args_s, 0, "malloc_raw") {
+        SomeValue::Instance(inst) => Ok(SomeValue::Instance(SomeInstance::new(
+            inst.classdef.clone(),
+            false,
+            Default::default(),
+        ))),
+        // Any other payload shape (`SomeString`, `SomeList`, …) round-trips
+        // through the `*mut T` pointer unchanged — the raw flavor does not
+        // narrow the pointee.
+        other => Ok(other.clone()),
     }
 }
 

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -1664,6 +1664,12 @@ pub fn malloc_typed_alloc(
 /// unchanged.  A successful raw malloc returns a non-null pointer to that
 /// payload, so an `Instance` result drops its `can_be_none` (OOM takes the
 /// MemoryError edge, not a null result).
+///
+/// Like [`malloc_typed_alloc`], the result models the freshly-allocated
+/// object by its value/instance shape, not `ann_malloc`'s `SomePtr(Ptr(T))`
+/// (lltype.py:2242): the allocation feeds the boxing / `NewWithVtable` path
+/// that consumes the object directly, so a `SomePtr` wrapper here would
+/// diverge from the established `malloc_typed` result modeling.
 pub fn malloc_raw_alloc(
     _bk: &Rc<Bookkeeper>,
     args_s: &[Option<SomeValue>],

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1501,6 +1501,10 @@ impl Assembler {
                     // `type_id` (`path_hash(owner)`), not this field.
                     owner: String::new(),
                     all_fielddescrs: spec.all_fielddescrs,
+                    // Round-trip the GC-header flag off the resolved struct
+                    // layout: a `new_with_vtable` boxes a header-carrying
+                    // object, so its size descr must keep `GUARD_GC_TYPE`
+                    // gating (a header-less raw struct would clear it).
                     is_gc_managed: spec.is_gc_managed,
                 });
                 state.code.push((descr_idx & 0xFF) as u8);

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -859,6 +859,21 @@ pub struct CallControl {
         crate::flowspace::argument::Signature,
         crate::translator::rtyper::lltypesystem::lltype::LowLevelType,
     )>,
+    /// `(path-segments, Signature, result ValueType)` for every method on
+    /// a foreign **opaque** ADT owner (`malachite_bigint::bigint::BigInt`,
+    /// …).  `impl_method_owner` declines the `CallTarget::Method` hint for
+    /// an opaque owner so the call lowers as `CallTarget::FunctionPath`;
+    /// these entries declare each path external so the residual lookup
+    /// resolves instead of panicking `SomeInstance.getattr` on the
+    /// classdef-less receiver.  Populated by `lib.rs` from
+    /// `program.foreign_opaque_method_externals` via
+    /// `front::mir::collect_foreign_opaque_method_externals`; consumed by
+    /// `cutover::register_foreign_opaque_method_externals`.
+    pub foreign_opaque_method_externals: Vec<(
+        Vec<String>,
+        crate::flowspace::argument::Signature,
+        crate::model::ValueType,
+    )>,
 }
 
 /// Heuristic struct layout — NOT equivalent to RPython's `symbolic.get_field_token()`.
@@ -1249,6 +1264,7 @@ impl CallControl {
             immutable_fields_by_struct: HashMap::new(),
             immutable_array_types: HashSet::new(),
             unsafe_fn_stubs: Vec::new(),
+            foreign_opaque_method_externals: Vec::new(),
         }
     }
 

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -158,9 +158,18 @@ impl CodeWriter {
         // `"not registered in PyreCallRegistry"`).  Unknown errors
         // panic immediately so parity bugs surface here rather than
         // silently shifting downstream behind a Skip mask.
+        // Z2.5 Path C — metadata-only stubs for `unsafe fn` callees that
+        // `populate_call_registry_from_call_graphs` could not see
+        // (`build_flow.rs:215` rejects unsafe bodies, so they never enter
+        // `callcontrol.function_graphs()`).  The specs are registered
+        // INSIDE populate, between its Pass 1 (alias explosion) and Pass 2
+        // (callee lift), so a safe-fn body lifted in Pass 2 that references
+        // an unsafe callee (`is_cell`, `is_exception`, …) resolves it
+        // instead of recording a "not registered" lift error.
         let populate_result =
             crate::translator::rtyper::cutover::populate_call_registry_from_call_graphs(
                 callcontrol.function_graphs(),
+                &callcontrol.unsafe_fn_stubs,
                 &registry,
             );
         if let Err(err) = populate_result {
@@ -169,35 +178,12 @@ impl CodeWriter {
                 panic!("populate_call_registry_from_call_graphs failed: {msg}");
             }
         }
-        // Z2.5 Path C — register metadata-only stubs for `unsafe fn`
-        // callees that `populate_call_registry_from_call_graphs` could
-        // not see (`build_flow.rs:215` rejects unsafe bodies, so they
-        // never enter `callcontrol.function_graphs()`).  Each spec
-        // wraps through `build_stub_pygraph_for_unsafe_fn` so the
-        // annotator sees a synthetic flowed graph whose return Link
-        // carries a Constant of the declared return lltype.  Idempotent
-        // — re-entry via the cached registry path short-circuits at
-        // `lookup` on each key.  Order: AFTER populate so that
-        // populate's alias-explosion canonicalisation
-        // (`canonical_dedup_key` strip → `registry.alias`) lands
-        // first; pre-seeding would make impl-method stubs collide
-        // with populate's `registry.alias()` invariant
-        // ("alias key already a canonical entry").  The trade-off:
-        // safe-fn bodies lifted DURING populate's pass-2 that
-        // reference unsafe-fn callees see "not registered" and
-        // surface as `cachedgraph: lift failed during populate` Skip
-        // events on the safe-fn entry (one remaining event
-        // `["baseobjspace", "is_none"]` at 2026-05-23 measurement).
-        crate::translator::rtyper::cutover::register_unsafe_fn_stubs(
-            &registry,
-            &callcontrol.unsafe_fn_stubs,
-        );
         // Mirror classdesc.py:606-618 — methods live in the class
         // `__dict__`.  Install each registered `[.., Owner, method]`
         // entry's function host on the interned `Owner` class object so
         // `SomeInstance.getattr(method)` resolves to a bound MethodDesc
-        // instead of blocking.  AFTER populate + unsafe stubs so the
-        // entry set is complete.
+        // instead of blocking.  AFTER populate (which seeds the unsafe-fn
+        // stubs internally) so the entry set is complete.
         registry.seed_struct_root_method_members();
         // RPython parity: `Translator.buildannotator()` /
         // `Translator.buildrtyper()` (`translator.py:69-83`) construct

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -170,6 +170,7 @@ impl CodeWriter {
             crate::translator::rtyper::cutover::populate_call_registry_from_call_graphs(
                 callcontrol.function_graphs(),
                 &callcontrol.unsafe_fn_stubs,
+                &callcontrol.foreign_opaque_method_externals,
                 &registry,
             );
         if let Err(err) = populate_result {

--- a/majit/majit-translate/src/flowspace/model.rs
+++ b/majit/majit-translate/src/flowspace/model.rs
@@ -2194,6 +2194,16 @@ impl HostEnv {
             "malloc_typed",
             HostObject::new_builtin_callable("pyre_object.lltype.malloc_typed"),
         );
+        // `pyre_object::lltype::malloc_raw` — the raw (non-GC) allocation
+        // intrinsic (`lltype.malloc(T, flavor='raw')` parity).  Exposed as a
+        // host builtin so its `Box::new` body is never looked-inside; the
+        // `malloc_raw_alloc` analyzer types the result as the `*mut T`
+        // pointer shell.  Resolved by `translate_op`'s Layer-3b via this
+        // module (prefix `pyre_object.lltype`, leaf `malloc_raw`).
+        pyre_object_lltype.module_set(
+            "malloc_raw",
+            HostObject::new_builtin_callable("pyre_object.lltype.malloc_raw"),
+        );
 
         let mut mods = self.modules.lock().unwrap();
         mods.insert("__builtin__".into(), self.builtin_module.clone());

--- a/majit/majit-translate/src/front/checked_arith.rs
+++ b/majit/majit-translate/src/front/checked_arith.rs
@@ -1,0 +1,607 @@
+//! `i64::checked_{add,sub,mul}()` → `*_ovf` op + OverflowError handler.
+//!
+//! ## Positioning
+//!
+//! The front-end lift that turns a Rust `i64::checked_add(x, y)` call and
+//! its `Option<i64>` match into the graph's native `add_ovf` op with an
+//! OverflowError exception edge — the integer-arithmetic analogue of
+//! [`crate::front::iter_next`]'s `next()` → `next`-op rewrite, and the
+//! direct mirror of `simplify.py:70-108 transform_ovfcheck`.
+//!
+//! Rust source models the int fast path
+//! ```text
+//!     match va.checked_add(vb) {
+//!         Some(r) => Ok(w_int_new(r)),   // no overflow → box int
+//!         None    => Ok(w_long_new(bigint_add(..))),  // overflow → BigInt
+//!     }
+//! ```
+//! lowered (in MIR) as a `checked_add(va, vb) -> Option<i64>` call, a
+//! `__discriminant` read on the result, and a two-way `switchInt`
+//! (None = 0, Some = 1).  RPython spells the same idiom as
+//! ```text
+//!     try:    z = ovfcheck(x + y)
+//!     except OverflowError:  return _make_long(..)
+//!     return wrapint(space, z)
+//! ```
+//! where `ovfcheck(x + y)` is the `add_ovf` op (`operation.py:466
+//! add_operator('add', ..., ovf=True)` → its `_ovf` twin), which returns
+//! the sum directly and raises `OverflowError` on overflow
+//! (`operation.py:760-761 _add_except_ovf`; `OpKind::AddOvf.canraise() =
+//! [OverflowError]`).  This module rewrites the value-encoded `Option`
+//! diamond into that exception representation: the `Some` arm becomes the
+//! op's normal continuation (the int payload `r`) and the `None` arm
+//! becomes the OverflowError handler (the BigInt path).
+//!
+//! ## The rewrite (`rewire_one_checked_arith_site`)
+//!
+//! Block A holds the `checked_add` residual call producing `opt`; block C
+//! is its single successor — the discriminant switch.  The rewrite:
+//! 1. replaces A's residual call with the native `add_ovf` op (a `BinOp`
+//!    the [`crate::translator::rtyper::flowspace_adapter`] maps to the
+//!    raising flowspace `add_ovf` op), reusing `opt` as the sum result;
+//! 2. closes A with `LastException` exits — normal → the `Some` arm
+//!    (`opt.__pos_0` collapses to the sum), `OverflowError` → the `None`
+//!    arm (the BigInt path).
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `checked_add`
+//! callee makes the rtyper census Skip the graph (no regression vs the
+//! legacy walker).
+
+use crate::flowspace::model::{ConstValue, Constant, Variable};
+use crate::front::result_exc::{
+    assert_block_pure_besides, assert_single_pred, back_substitute, collapse_pos0_read,
+    follow_single_exit, split_diamond_exits,
+};
+use crate::model::{
+    CallTarget, ExitCase, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
+};
+
+/// The `core::num::<Impl>::checked_{add,sub,mul}` leaf the rewrite
+/// recognises, paired with the `_ovf` BinOp opname it lowers to.
+/// `checked_div` / `checked_rem` are intentionally absent: their overflow
+/// idiom is `floordiv_ovf` / `mod_ovf` (a ZeroDivisionError-carrying
+/// helper, not a bare `_ovf` twin), and the live integer fast paths spell
+/// those with explicit value guards (`int_floordiv` / `int_mod`), so they
+/// never reach this shape.
+fn checked_arith_ovf_opname(leaf: &str) -> Option<&'static str> {
+    match leaf {
+        "checked_add" => Some("add_ovf"),
+        "checked_sub" => Some("sub_ovf"),
+        "checked_mul" => Some("mul_ovf"),
+        _ => None,
+    }
+}
+
+/// `true` iff the residual call target is a
+/// `core::num::<Impl>::checked_{add,sub,mul}` — the `[.., "num",
+/// "<Impl>", "checked_*"]` FunctionPath shape Charon emits for the
+/// inherent `i64` method (core fn bodies are Opaque in the LLBC, so the
+/// call is permanently unliftable).  Combined with an `Option` return
+/// type at the recording site, this records a checked-arith candidate;
+/// the rewrite itself validates the surrounding match shape.
+pub(crate) fn is_checked_arith_target(target: &CallTarget) -> bool {
+    let CallTarget::FunctionPath { segments } = target else {
+        return false;
+    };
+    let [first, .., module, impl_seg, leaf] = segments.as_slice() else {
+        return false;
+    };
+    first == "core"
+        && module == "num"
+        && impl_seg == "<Impl>"
+        && checked_arith_ovf_opname(leaf).is_some()
+}
+
+/// The typed `OverflowError` exitcase the `_ovf` block's overflow link
+/// carries — the handler analogue of [`crate::front::iter_next`]'s
+/// `StopIteration` exitcase, narrowed to the single exception `add_ovf` /
+/// `sub_ovf` / `mul_ovf` raises (`OpKind::AddOvf.canraise() =
+/// [OverflowError]`).  `ConstValue::builtin` resolves the class to a
+/// `HostObject`, the `Constant(HostObject(class))` shape
+/// `annrpython::flowin` matches.
+fn overflowerror_exitcase() -> ExitCase {
+    ExitCase::Const(ConstValue::builtin("OverflowError"))
+}
+
+fn int_const(i: i64) -> LinkArg {
+    LinkArg::Const(Constant::new(ConstValue::Int(i)))
+}
+
+/// `true` iff `var` is read — as an op operand or an `ExitSwitch::Value`
+/// discriminator — by any block reachable from `start` (inclusive).
+/// Forwarding `var` in a `Link.args` slot is NOT a read: framestate
+/// threading reuses the same `Variable` identity for a loop-/branch-carried
+/// local, so a value that is only *forwarded* through the subgraph is
+/// dead-threaded and may be safely substituted.  Used to admit a dead
+/// `opt` thread through the overflow arm (`rewire_one_checked_arith_site`).
+fn var_read_in_reachable(
+    graph: &FunctionGraph,
+    start: crate::model::BlockId,
+    var: &Variable,
+) -> bool {
+    let mut visited = vec![false; graph.blocks.len()];
+    let mut stack = vec![start.0];
+    while let Some(bi) = stack.pop() {
+        if bi >= graph.blocks.len() || visited[bi] {
+            continue;
+        }
+        visited[bi] = true;
+        let b = &graph.blocks[bi];
+        for op in &b.operations {
+            if crate::front::result_exc::op_operand_vars(&op.kind).contains(var) {
+                return true;
+            }
+        }
+        if let Some(ExitSwitch::Value(v)) = &b.exitswitch
+            && v == var
+        {
+            return true;
+        }
+        for link in &b.exits {
+            stack.push(link.target.0);
+        }
+    }
+    false
+}
+
+/// Rewrite every recorded `checked_{add,sub,mul}()` call site into the
+/// `*_ovf` op + OverflowError handler shape.  Fail-safe: a site whose
+/// surrounding `Option` match does not fit the overflow-fallback shape is
+/// left as the residual call (Skip), so a mismatch never regresses a graph
+/// the legacy walker already handled.  Returns the number of sites
+/// rewritten.
+pub(crate) fn rewire_checked_arith_call_sites(
+    graph: &mut FunctionGraph,
+    sites: &[Variable],
+) -> usize {
+    let mut rewritten = 0;
+    for opt in sites {
+        match rewire_one_checked_arith_site(graph, opt) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                if std::env::var_os("PYRE_MIR_FRONTEND_DEBUG").is_some() {
+                    eprintln!(
+                        "[checked_arith] {} decline at {opt:?}: {_decline}",
+                        graph.name
+                    );
+                }
+                // Leave the residual `checked_*` call; the unregistered
+                // callee makes the rtyper census Skip this graph (no
+                // regression).
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_checked_arith_site(graph: &mut FunctionGraph, opt: &Variable) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `checked_*()` residual call producing `opt`, closed by
+    // lower_call with a single forwarding exit.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(opt))
+        })
+        .ok_or_else(|| format!("{name}: checked_* result var has no producer block"))?;
+
+    // The call must be A's last op (lower_call closes the block right
+    // after pushing it) so it becomes the block's `raising_op`.
+    let call_idx = graph.blocks[a].operations.len() - 1;
+    let last_is_call = graph.blocks[a].operations[call_idx].result.as_ref() == Some(opt);
+    if !last_is_call {
+        return Err(format!(
+            "{name}: checked_* call is not the last op of block {a}"
+        ));
+    }
+    // Capture the two operands (the `_ovf` op's args) and resolve the
+    // `_ovf` opname from the callee leaf.
+    let (lhs, rhs, ovf_opname) = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if args.len() == 2 => {
+            let leaf = segments
+                .last()
+                .ok_or_else(|| format!("{name}: checked_* call path is empty"))?;
+            let ovf = checked_arith_ovf_opname(leaf)
+                .ok_or_else(|| format!("{name}: call leaf {leaf} is not a checked_* arith op"))?;
+            (args[0].clone(), args[1].clone(), ovf)
+        }
+        other => {
+            return Err(format!(
+                "{name}: checked_* producer op is not a 2-arg FunctionPath call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → C (the Option discriminant switch).  Unlike the
+    // Result `?` diamond there is no intervening `branch()` block.
+    let (c, opt_c) = follow_single_exit(graph, a, opt)
+        .map_err(|e| format!("{name}: checked_* call block exit: {e}"))?;
+    assert_single_pred(graph, c, &name)?;
+
+    // Block C: `d = opt.__discriminant`; `switch d { 0 → None, 1 → Some }`.
+    let (disc_idx, disc_var) = graph.blocks[c]
+        .operations
+        .iter()
+        .enumerate()
+        .find_map(|(i, op)| match &op.kind {
+            OpKind::FieldRead { base, field, .. }
+                if *base == opt_c && field.name == "__discriminant" =>
+            {
+                op.result.clone().map(|r| (i, r))
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("{name}: block {c} lacks the Option __discriminant read"))?;
+    match &graph.blocks[c].exitswitch {
+        Some(ExitSwitch::Value(v)) if *v == disc_var => {}
+        other => {
+            return Err(format!(
+                "{name}: block {c} exitswitch {other:?} is not the Option discriminant switch"
+            ));
+        }
+    }
+    // Block C is bypassed; only the discriminant read may carry an effect.
+    assert_block_pure_besides(graph, c, &[disc_idx], "discriminant", &name)?;
+
+    // Option discriminant: None = 0, Some = 1.  `split_diamond_exits`
+    // returns `(case 0, case 1)` = `(None arm, Some arm)`.
+    let (none_link, some_link) = split_diamond_exits(&graph.blocks[c].exits, &name)?;
+    let some_target = some_link.target;
+    let none_target = none_link.target;
+
+    // Some arm (normal exit): the `_ovf` op result IS the sum.  Map the
+    // Some-link args back to A scope; the forwarded Option value becomes
+    // the sum result, the threaded discriminant the constant 1.
+    let mut normal_args: Vec<LinkArg> = Vec::with_capacity(some_link.args.len());
+    let mut payload_positions: Vec<usize> = Vec::new();
+    for (i, arg) in some_link.args.iter().enumerate() {
+        match arg {
+            LinkArg::Const(c0) => normal_args.push(LinkArg::Const(c0.clone())),
+            LinkArg::Value(v) => {
+                if *v == opt_c {
+                    normal_args.push(LinkArg::Value(opt.clone()));
+                    payload_positions.push(i);
+                } else if *v == disc_var {
+                    normal_args.push(int_const(1));
+                } else {
+                    let v_a = back_substitute(graph, &[(a, c)], v, &name)?;
+                    normal_args.push(LinkArg::Value(v_a));
+                }
+            }
+        }
+    }
+
+    // The payload collapse below (`collapse_pos0_read` per position) is
+    // the only fallible mutation; it mutates the Some target on success
+    // but can still `Err` on a later position.  With at most one position
+    // the collapse is the first mutation and itself atomic (it errs before
+    // writing), so a decline leaves the graph byte-identical.  Two or more
+    // positions (the same Option threaded into several Some-link slots)
+    // could half-collapse before a later `Err`, handing the legacy walker
+    // a partially-rewritten graph — decline that unusual shape up front to
+    // keep the "validate-before-mutate" fail-safe contract airtight.
+    if payload_positions.len() > 1 {
+        return Err(format!(
+            "{name}: Option value threaded into {} Some-arm slots — multi-slot \
+             payload collapse is not fail-safe",
+            payload_positions.len()
+        ));
+    }
+
+    // None arm (OverflowError exit): the BigInt-fallback continuation.  It
+    // recomputes from the operands (`BigInt::from(va)` …) and never reads
+    // the overflowed Option.  Framestate threading may still keep `opt`
+    // live across the match and forward it into the overflow arm as a
+    // dead phi thread; that is admissible only if no block reachable from
+    // the overflow target actually reads it (the value is genuinely
+    // undefined on the raise edge — the `_ovf` op never produced it).  A
+    // forward into a *read* site is a real consumer the rewrite cannot
+    // honour, so decline.
+    //
+    // The overflow link is the op's `c_last_exception` edge, so it must
+    // not carry the raising op's result `opt` (checkgraph:
+    // "raising operation result cannot flow into exception link" —
+    // `simplify.py` graph invariant; the result is undefined when the op
+    // raises).  Substitute the dead slot with `lhs`, a live operand
+    // defined before the op: it satisfies the link's defined-arg
+    // requirement, is never the raising result, and is dropped unread in
+    // the overflow subgraph.
+    let opt_dead_in_overflow_arm = !var_read_in_reachable(graph, none_link.target, &opt_c);
+    let mut none_args: Vec<LinkArg> = Vec::with_capacity(none_link.args.len());
+    for arg in &none_link.args {
+        match arg {
+            LinkArg::Const(c0) => none_args.push(LinkArg::Const(c0.clone())),
+            LinkArg::Value(v) => {
+                if *v == opt_c {
+                    if !opt_dead_in_overflow_arm {
+                        return Err(format!(
+                            "{name}: None arm of block {c} reads the Option value — unsupported"
+                        ));
+                    }
+                    none_args.push(LinkArg::Value(lhs.clone()));
+                } else if *v == disc_var {
+                    none_args.push(int_const(0));
+                } else {
+                    let v_a = back_substitute(graph, &[(a, c)], v, &name)?;
+                    none_args.push(LinkArg::Value(v_a));
+                }
+            }
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // The Some target reads the payload via `opt.__pos_0`; with the `_ovf`
+    // result flowing directly, that read collapses to the carried value.
+    for pos in payload_positions {
+        collapse_pos0_read(graph, some_target, pos, &name)?;
+    }
+
+    // Replace A's residual `checked_*()` call with the native `_ovf`
+    // BinOp: the two operands, `opt` reused as the sum.  The
+    // `LastException` exitswitch below makes the block a `canraise` block
+    // whose `raising_op` is this op.
+    graph.blocks[a].operations[call_idx].kind = OpKind::BinOp {
+        op: ovf_opname.to_string(),
+        lhs,
+        rhs,
+        result_ty: ValueType::Int,
+    };
+
+    // Rewire A: `LastException` exits.
+    //   normal        → Some arm (sum)
+    //   OverflowError → None arm (BigInt fallback)
+    // `OpKind::AddOvf.canraise()` is exactly `[OverflowError]`
+    // (`operation.py:760-761 _add_except_ovf`), so no catch-all
+    // propagation edge to `exceptblock` is synthesised (preserving the
+    // front graph's "exceptblock edges == MIR unwind terminators"
+    // invariant).
+    let ovf_etype = graph.alloc_value_var();
+    let ovf_evalue = graph.alloc_value_var();
+    let mut overflow_link = Link::new_mixed(none_args, none_target, Some(overflowerror_exitcase()));
+    overflow_link.last_exception = Some(LinkArg::Value(ovf_etype));
+    overflow_link.last_exc_value = Some(LinkArg::Value(ovf_evalue));
+
+    let block_a = &mut graph.blocks[a];
+    block_a.exitswitch = Some(ExitSwitch::LastException);
+    block_a.exits = vec![
+        Link::new_mixed(normal_args, some_target, None),
+        overflow_link,
+    ];
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::FieldDescriptor;
+
+    /// Build the minimal `checked_add` overflow-fallback diamond and assert
+    /// the rewrite lowers it to `add_ovf` + a `LastException` block whose
+    /// overflow exit carries the `OverflowError` exitcase.  Mirrors the
+    /// `int_add` MIR shape: block A = `checked_add(va, vb) -> opt`; block C
+    /// = `__discriminant` switch; Some arm reads `opt.__pos_0`; None arm
+    /// (overflow) dead-threads `opt`.
+    fn checked_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["core", "num", "<Impl>", "checked_add"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn rewrite_lifts_checked_add_to_add_ovf_with_overflow_edge() {
+        let mut g = FunctionGraph::new("test_checked_add");
+        let a = g.startblock;
+        let va = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let vb = g.push_op_var(a, OpKind::ConstInt(2), true).unwrap();
+        // Block A's last op = the residual `checked_add(va, vb)`.
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: checked_target(),
+                    args: vec![va.clone(), vb.clone()],
+                    result_ty: ValueType::Ref(Some("core::option::Option".into())),
+                },
+                true,
+            )
+            .unwrap();
+
+        // Block C — the discriminant switch — with `opt` rebound as its
+        // inputarg.
+        let (c, c_args) = g.create_block_with_arg_vars(1);
+        let opt_c = c_args[0].clone();
+        let disc = g
+            .push_op_var(
+                c,
+                OpKind::FieldRead {
+                    base: opt_c.clone(),
+                    field: FieldDescriptor::new("__discriminant", None),
+                    ty: ValueType::Int,
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+
+        // Some target: reads `opt.__pos_0` then `w_int_new`.
+        let (some_t, some_args) = g.create_block_with_arg_vars(1);
+        let some_opt = some_args[0].clone();
+        g.push_op_var(
+            some_t,
+            OpKind::FieldRead {
+                base: some_opt,
+                field: FieldDescriptor::new("__pos_0", None),
+                ty: ValueType::Int,
+                pure: false,
+            },
+            true,
+        );
+        g.set_return(some_t, None);
+
+        // None target (overflow): a leaf block that never reads `opt`.
+        let none_t = g.create_block();
+        g.set_return(none_t, None);
+
+        // Close A → C, threading `opt`.
+        g.set_goto(a, c, vec![opt.clone()]);
+        // Close C with the discriminant switch: case 0 → None, case 1 → Some.
+        g.block_mut(c).exitswitch = Some(ExitSwitch::Value(disc));
+        g.block_mut(c).exits = vec![
+            Link::new_mixed(
+                vec![LinkArg::Value(opt_c.clone())],
+                none_t,
+                Some(ExitCase::Const(ConstValue::Int(0))),
+            )
+            .with_prevblock(c),
+            Link::new_mixed(
+                vec![LinkArg::Value(opt_c.clone())],
+                some_t,
+                Some(ExitCase::Const(ConstValue::Int(1))),
+            )
+            .with_prevblock(c),
+        ];
+
+        let rewritten = rewire_checked_arith_call_sites(&mut g, &[opt.clone()]);
+        assert_eq!(rewritten, 1, "the checked_add site must be rewritten");
+
+        // Block A's last op is now `add_ovf(va, vb)`, reusing `opt`.
+        let last = g.blocks[a.0].operations.last().unwrap();
+        match &last.kind {
+            OpKind::BinOp { op, lhs, rhs, .. } => {
+                assert_eq!(op, "add_ovf");
+                assert_eq!(lhs, &va);
+                assert_eq!(rhs, &vb);
+                assert_eq!(last.result.as_ref(), Some(&opt));
+            }
+            other => panic!("expected add_ovf BinOp, got {other:?}"),
+        }
+
+        // Block A closes with LastException: normal → Some, OverflowError →
+        // None.
+        assert!(matches!(
+            g.blocks[a.0].exitswitch,
+            Some(ExitSwitch::LastException)
+        ));
+        let exits = &g.blocks[a.0].exits;
+        assert_eq!(exits.len(), 2);
+        assert!(
+            exits[0].exitcase.is_none(),
+            "normal arm carries no exitcase"
+        );
+        assert_eq!(exits[0].target, some_t);
+        assert_eq!(exits[1].exitcase, Some(overflowerror_exitcase()));
+        assert_eq!(exits[1].target, none_t);
+        // The overflow link must not carry the raising op result `opt`
+        // (checkgraph invariant) — the dead `opt` thread is substituted.
+        assert!(
+            !exits[1]
+                .args
+                .iter()
+                .any(|arg| matches!(arg, LinkArg::Value(v) if *v == opt)),
+            "overflow link must not carry the raising op result"
+        );
+        assert!(
+            exits[1].last_exception.is_some() && exits[1].last_exc_value.is_some(),
+            "overflow link carries the last_exception / last_exc_value pair"
+        );
+    }
+
+    #[test]
+    fn rewrite_declines_when_none_arm_reads_option() {
+        // A None arm that READS `opt` (not a dead thread) is a real
+        // consumer the rewrite cannot honour — it must decline, leaving the
+        // residual call.
+        let mut g = FunctionGraph::new("test_reads_opt");
+        let a = g.startblock;
+        let va = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let vb = g.push_op_var(a, OpKind::ConstInt(2), true).unwrap();
+        let opt = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: checked_target(),
+                    args: vec![va, vb],
+                    result_ty: ValueType::Ref(Some("core::option::Option".into())),
+                },
+                true,
+            )
+            .unwrap();
+
+        let (c, c_args) = g.create_block_with_arg_vars(1);
+        let opt_c = c_args[0].clone();
+        let disc = g
+            .push_op_var(
+                c,
+                OpKind::FieldRead {
+                    base: opt_c.clone(),
+                    field: FieldDescriptor::new("__discriminant", None),
+                    ty: ValueType::Int,
+                    pure: false,
+                },
+                true,
+            )
+            .unwrap();
+
+        let (some_t, _) = g.create_block_with_arg_vars(1);
+        g.set_return(some_t, None);
+        // None target READS opt via a FieldRead — disqualifies the rewrite.
+        // Model framestate reuse: the target's inputarg IS `opt_c` (the
+        // same identity the None link forwards), as the production
+        // framestate threading produces, so `var_read_in_reachable` sees
+        // the read.
+        let none_t = g.create_block();
+        g.push_inputarg_var(none_t, opt_c.clone());
+        g.push_op_var(
+            none_t,
+            OpKind::FieldRead {
+                base: opt_c.clone(),
+                field: FieldDescriptor::new("__pos_0", None),
+                ty: ValueType::Int,
+                pure: false,
+            },
+            true,
+        );
+        g.set_return(none_t, None);
+
+        g.set_goto(a, c, vec![opt.clone()]);
+        g.block_mut(c).exitswitch = Some(ExitSwitch::Value(disc));
+        g.block_mut(c).exits = vec![
+            Link::new_mixed(
+                vec![LinkArg::Value(opt_c.clone())],
+                none_t,
+                Some(ExitCase::Const(ConstValue::Int(0))),
+            )
+            .with_prevblock(c),
+            Link::new_mixed(
+                vec![LinkArg::Value(opt_c.clone())],
+                some_t,
+                Some(ExitCase::Const(ConstValue::Int(1))),
+            )
+            .with_prevblock(c),
+        ];
+
+        let rewritten = rewire_checked_arith_call_sites(&mut g, &[opt.clone()]);
+        assert_eq!(rewritten, 0, "a None arm that reads opt must decline");
+        // The residual call survives untouched.
+        let last = g.blocks[a.0].operations.last().unwrap();
+        assert!(matches!(
+            &last.kind,
+            OpKind::Call {
+                target: CallTarget::FunctionPath { .. },
+                ..
+            }
+        ));
+    }
+}

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1650,7 +1650,22 @@ impl<'a> Lowering<'a> {
                     // then rtypes as `pair(StringRepr, StringRepr)` rather
                     // than walling at `pair(InstanceRepr, StringRepr)`.
                     .or_else(|| tyref_strips_to_str(&local.ty, llbc).then(|| "str".to_string()))
-                    .or_else(|| tyref_generic_trait_bound_root(&local.ty, llbc, generics)),
+                    .or_else(|| tyref_generic_trait_bound_root(&local.ty, llbc, generics))
+                    // A list-typed param (`Vec<T>`, `&[T]`, …) has no
+                    // named-ADT leaf — `tyref_class_root` answers `None`
+                    // because `adt_node_class_root` excludes the
+                    // core/std/alloc container family from classdef
+                    // minting.  Carry its full monomorphic spelling so
+                    // `derive_subject_inputcells` projects it through the
+                    // annotator's list model (`project_pyre_field_type`)
+                    // instead of the classdef-less `SomeInstance(None)`
+                    // shell, on which a `len()` / iteration would wall at
+                    // `getattr` over a classdef-less instance.
+                    .or_else(|| {
+                        let spelling = tyref_to_ast_string(&local.ty, llbc);
+                        majit_ir::descr::is_list_container_spelling(&spelling)
+                            .then_some(spelling)
+                    }),
                 _ => None,
             };
             input_ops.push(SpaceOperation {
@@ -4928,6 +4943,36 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `<[T]>::len` / `Vec::len` returns the container element
+                // count.  Emit the `__len` operation on the receiver — the
+                // rtyper routes it through the `len` op
+                // (`flowspace_adapter`), which on a `SomeList` receiver
+                // lowers to `AbstractBaseListRepr.rtype_len` — instead of
+                // the `getattr("len")` the generic method fallback emits,
+                // which dead-ends at `Cannot find attribute "len"` on the
+                // list annotation.  Same routing
+                // [`is_concrete_iter_constructor`] gives the container
+                // `iter`.
+                if args.len() == 1 && self.is_container_len(&reg) {
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::Call {
+                            target: CallTarget::FunctionPath {
+                                segments: vec!["__len".to_string()],
+                            },
+                            args: vec![args[0].clone()],
+                            result_ty: ValueType::Int,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `alloc::fmt::format` of a no-placeholder constant
                 // message — `format!("literal")`, whose `format_args!`
                 // lowered to `Arguments::from_str` (aliased to its
@@ -5974,6 +6019,23 @@ impl<'a> Lowering<'a> {
                 "core::slice::iter::<Impl>::into_iter"
                     | "alloc::vec::<Impl>::into_iter"
                     | "core::array::<Impl>::into_iter"
+            )
+        })
+    }
+
+    /// `<[T]>::len` / `Vec::len` — the container element count.  Lowered
+    /// to the `__len` operation so the receiver's list annotation
+    /// supplies the length through the rtyper's `len` op, the same
+    /// routing [`is_concrete_iter_constructor`] gives the container
+    /// `iter`.
+    fn is_container_len(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::<Impl>::len" | "alloc::vec::<Impl>::len"
             )
         })
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -267,6 +267,7 @@ fn build_semantic_program_from_llbcs_with_static_addrs_filtered(
             exact_layouts: std::collections::HashMap::new(),
             struct_ids: std::collections::HashMap::new(),
             unsafe_fn_stubs: Vec::new(),
+            foreign_opaque_method_externals: Vec::new(),
         }),
     )
 }
@@ -597,6 +598,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         // Populated post-build in `build_semantic_program_via_active_frontend`
         // (it iterates the full LLBC set), mirroring `merge_hints_from_llbcs`.
         unsafe_fn_stubs: Vec::new(),
+        foreign_opaque_method_externals: Vec::new(),
     })
 }
 
@@ -5579,6 +5581,24 @@ impl<'a> Lowering<'a> {
                     return None;
                 }
                 let td = self.llbc.type_by_id(adt_def_id)?;
+                // A foreign opaque owner (`malachite_bigint::BigInt`,
+                // `Sign`, …) has no extracted body, so the annotator never
+                // mints a `ClassDef` for it — the receiver lands as a
+                // classdef-less `SomeInstance` and a `CallTarget::Method`
+                // getattr panics ("SomeInstance.getattr on classdef-less
+                // instance").  The interpreter's overflow→long arms are the
+                // cold `@jit.dont_look_inside` bailouts that operate on this
+                // opaque value (`bigint_add`/`bigint_sub`/… call
+                // `<BigInt as Add>::add` etc.), so the faithful treatment is
+                // to residualize the call, not trace into the foreign body —
+                // the `register_external` analog.  Declining the Method hint
+                // routes the call through the `FunctionPath` form, which the
+                // call registry resolves to an opaque external
+                // (`register_foreign_opaque_method_externals`) and the
+                // codewriter emits as a residual fnaddr call.
+                if matches!(td.kind, TypeDeclKind::Opaque) {
+                    return None;
+                }
                 let owner = td
                     .item_meta
                     .name_path()
@@ -8377,6 +8397,171 @@ pub(crate) fn collect_unsafe_fn_stubs_from_llbc(
         out.push((segments, Signature::new(argnames, None, None), lltype));
     }
     out
+}
+
+/// Collect, from the lowered MIR, `(path-segments, Signature, result
+/// ValueType)` for every method whose impl-owner is a **foreign opaque**
+/// ADT (`malachite_bigint::bigint::BigInt`, …) and whose result type can
+/// be modeled faithfully.
+///
+/// An opaque owner has no extracted body, so the annotator never mints a
+/// `ClassDef` for it; the receiver lands as a classdef-less
+/// `SomeInstance` and a `CallTarget::Method` getattr panics.  These
+/// methods are the foreign helpers the interpreter's cold
+/// `@jit.dont_look_inside` overflow→long arms operate on
+/// (`<BigInt as Add>::add`, `…::clone`, …), so the faithful treatment is
+/// the `register_external` analog: residualize the call rather than trace
+/// into the foreign body.  [`Lowering::impl_method_owner`] already
+/// declines the `CallTarget::Method` hint for an opaque owner (routing the
+/// call through `CallTarget::FunctionPath`); this collection feeds the
+/// matching registry entries so the `FunctionPath` lookup resolves instead
+/// of raising "not registered in PyreCallRegistry".
+///
+/// The registration key is derived through the SAME
+/// [`impl_method_owner_for_fundecl`] the declined-Method
+/// `call_target_segments` arm uses, so the key equals the call-site
+/// lookup (`[strip_crate(owner.name_path).split("::"), leaf]` —
+/// e.g. `["bigint", "BigInt", "add"]`).
+///
+/// **Faithful result shell — no blanket Ref.**  The result `ValueType` is
+/// read from the method's LLBC output signature:
+///
+/// - output is a scalar literal (`i64` / `f64` / `bool`) → that
+///   `ValueType` (the residual really produces an integer / float / bool);
+/// - output is itself a foreign **opaque** ADT (`BigInt` → `BigInt`,
+///   the `Add`/`Sub`/`Mul`/`clone` cluster) → `Ref(None)`, the
+///   classdef-less `SomeInstance` shell `bigint_from` produces;
+/// - anything else — an `Option<i64>` (`to_i64`), an enum (`sign`), a
+///   tuple, a reference, a non-opaque ADT — is **declined** (no entry),
+///   leaving the method at the original "not registered" Skip.  Modeling
+///   an `Option<i64>` return as a bare integer or as `Ref(None)` would
+///   mis-type the value and only migrate the failure to a deeper wall, so
+///   those methods stay residual until their result type can be modeled.
+pub(crate) fn collect_foreign_opaque_method_externals(
+    llbc: &Llbc,
+) -> Vec<(
+    Vec<String>,
+    crate::flowspace::argument::Signature,
+    ValueType,
+)> {
+    use crate::flowspace::argument::Signature;
+    let mut out = Vec::new();
+    for fd in llbc.iter_local_fns() {
+        if fd.is_global_initializer.is_some() {
+            continue;
+        }
+        // Owner must be an impl-block method on an opaque ADT, with the
+        // owner ADT as the first (`self`) input.  `impl_method_owner_for_fundecl`
+        // resolves the owner's qualified name; the explicit opaque-kind +
+        // self-receiver checks here mirror the gate `impl_method_owner`
+        // applies before declining the Method hint.
+        let Some((owner_qualified, leaf)) = impl_method_owner_for_fundecl(llbc, fd) else {
+            continue;
+        };
+        let Some(owner_def_id) = impl_owner_adt_def_id_for_fundecl(llbc, fd) else {
+            continue;
+        };
+        let Some(owner_td) = llbc.type_by_id(owner_def_id) else {
+            continue;
+        };
+        if !matches!(owner_td.kind, TypeDeclKind::Opaque) {
+            continue;
+        }
+        if !first_input_is_adt_free(llbc, fd, owner_def_id) {
+            continue;
+        }
+        // Faithful result shell read from the LLBC output signature; a
+        // result type that cannot be modeled (Option / enum / tuple /
+        // reference / non-opaque ADT) declines the method.
+        let Some(result_ty) = foreign_opaque_method_result_valuetype(&fd.signature.output, llbc)
+        else {
+            continue;
+        };
+        let mut segments: Vec<String> = owner_qualified.split("::").map(str::to_string).collect();
+        segments.push(leaf);
+        let body = fd.unstructured();
+        let argnames: Vec<String> = (0..fd.signature.inputs.len())
+            .map(|i| {
+                body.as_ref()
+                    .and_then(|u| u.locals.locals.get(i + 1))
+                    .and_then(|l| l.name.clone())
+                    .unwrap_or_else(|| format!("arg{i}"))
+            })
+            .collect();
+        out.push((segments, Signature::new(argnames, None, None), result_ty));
+    }
+    out
+}
+
+/// Resolve the impl-owner ADT `def_id` of an impl-block method `fd`
+/// directly from its `<Impl>` NameSeg, the free-function twin of
+/// [`Lowering::resolve_impl_owner_adt_def_id`] over the `<Impl>` segment.
+fn impl_owner_adt_def_id_for_fundecl(llbc: &Llbc, fd: &FunDecl) -> Option<u64> {
+    let segs = &fd.item_meta.name;
+    let last_idx = segs
+        .iter()
+        .rposition(|s| matches!(s, NameSeg::Ident { .. }))?;
+    if last_idx == 0 {
+        return None;
+    }
+    let impl_payload = match &segs[last_idx - 1] {
+        NameSeg::Other(v) => v.as_object()?.get("Impl")?,
+        _ => return None,
+    };
+    resolve_impl_owner_adt_def_id_free(llbc, impl_payload)
+}
+
+/// Free-function twin of [`Lowering::first_input_is_adt`]: true when the
+/// method's first input (`self`, possibly behind `&`/`&mut`/`*`) is the
+/// owner ADT.
+fn first_input_is_adt_free(llbc: &Llbc, fd: &FunDecl, adt_def_id: u64) -> bool {
+    fd.signature
+        .inputs
+        .first()
+        .and_then(|t| tyref_node(t, llbc))
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+        .and_then(adt_node_def_id)
+        .is_some_and(|id| id == adt_def_id)
+}
+
+/// Faithful result `ValueType` for a residualized foreign-opaque method,
+/// or `None` to decline (see [`collect_foreign_opaque_method_externals`]).
+/// A scalar literal output keeps its `ValueType`; an opaque-ADT output
+/// projects to `Ref(None)`; every other shape (`Option`, enum, tuple,
+/// reference, non-opaque ADT) is declined.
+fn foreign_opaque_method_result_valuetype(output: &TyRef, llbc: &Llbc) -> Option<ValueType> {
+    // A reference return (`&T`) is not the owned residual result the
+    // stub models; decline.
+    if output_type_is_ref(output, llbc) {
+        return None;
+    }
+    match tyref_to_value_type(output, llbc) {
+        // Scalar literal results are produced directly by the residual.
+        vt @ (ValueType::Int | ValueType::Unsigned | ValueType::Float | ValueType::Bool) => {
+            Some(vt)
+        }
+        // A `Ref` projection covers every non-scalar ADT shape (`BigInt`,
+        // `Option<i64>`, tuples, …).  Accept it ONLY when the result ADT
+        // is itself a foreign opaque type (the `BigInt`-returning
+        // arithmetic cluster), which the classdef-less `SomeInstance`
+        // shell models faithfully.  A non-opaque ADT (`Option`, an enum)
+        // would be mis-typed as an opaque GcRef, so decline it.
+        ValueType::Ref(_) => {
+            let def_id = output_adt_def_id_free(output, llbc)?;
+            let td = llbc.type_by_id(def_id)?;
+            matches!(td.kind, TypeDeclKind::Opaque).then_some(ValueType::Ref(None))
+        }
+        _ => None,
+    }
+}
+
+/// Free-function twin of [`Lowering::tyref_adt_def_id`]: resolve a
+/// `TyRef`'s ADT `def_id`, following the dedup index for a `Dedup` shape.
+fn output_adt_def_id_free(ty: &TyRef, llbc: &Llbc) -> Option<u64> {
+    match ty {
+        TyRef::Inline { value: (_, v) } | TyRef::Other(v) => inline_adt_def_id(v),
+        TyRef::Dedup { id } => llbc.dedup_to_adt_def_id(*id),
+    }
 }
 
 /// Free-function version of [`Lowering::resolve_impl_owner_adt_def_id`].

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1663,8 +1663,7 @@ impl<'a> Lowering<'a> {
                     // `getattr` over a classdef-less instance.
                     .or_else(|| {
                         let spelling = tyref_to_ast_string(&local.ty, llbc);
-                        majit_ir::descr::is_list_container_spelling(&spelling)
-                            .then_some(spelling)
+                        majit_ir::descr::is_list_container_spelling(&spelling).then_some(spelling)
                     }),
                 _ => None,
             };
@@ -4973,6 +4972,21 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `Vec::as_slice` / `<[T]>::as_slice` borrows the same
+                // elements as a slice — identity on the list model.  Alias
+                // the result to the receiver so the slice consumer reads
+                // the list directly, instead of the `getattr("as_slice")`
+                // the generic method fallback emits, which dead-ends at
+                // `Cannot find attribute "as_slice"` on the list
+                // annotation.  Same shape as the reflexive identity
+                // aliases below.
+                if args.len() == 1 && self.is_container_as_slice(&reg) {
+                    self.local_var[dest_local] = Some(args[0].clone());
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `alloc::fmt::format` of a no-placeholder constant
                 // message — `format!("literal")`, whose `format_args!`
                 // lowered to `Arguments::from_str` (aliased to its
@@ -6036,6 +6050,21 @@ impl<'a> Lowering<'a> {
             matches!(
                 fd.item_meta.name_path().as_str(),
                 "core::slice::<Impl>::len" | "alloc::vec::<Impl>::len"
+            )
+        })
+    }
+
+    /// `Vec::as_slice` / `<[T]>::as_slice` — a borrowed slice view of the
+    /// same elements.  Identity on the list model, so the callsite aliases
+    /// its receiver instead of leaving the unregistered method callee.
+    fn is_container_as_slice(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::<Impl>::as_slice" | "alloc::vec::<Impl>::as_slice"
             )
         })
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1208,6 +1208,7 @@ pub fn lower_fun_decl_with_static_addrs(
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || !lo.next_call_results.is_empty()
+            || !lo.checked_arith_call_results.is_empty()
         {
             // The exception-link transforms run on a simplified graph,
             // as exceptiontransform.py does (graphs reach it after
@@ -1272,7 +1273,27 @@ pub fn lower_fun_decl_with_static_addrs(
         } else {
             crate::front::iter_next::rewire_next_call_sites(&mut lo.graph, &lo.next_call_results)
         };
-        if !lo.result_exc_call_results.is_empty() || result_exc_callee || next_rewritten > 0 {
+        // The checked-arith rewrite (`front::checked_arith`) runs on the
+        // same simplified graph as the `next`-diamond rewrite: the Option
+        // discriminant switch's default→Abort arm must be pruned first,
+        // identically.  It is fail-safe — a non-overflow-fallback `Option`
+        // match is left as the residual call — so it runs over every
+        // recorded site and reports how many it actually rewrote.  Only an
+        // actual rewrite detaches the discriminant switch's block, so the
+        // unreachable-block sweep is gated on that count.
+        let checked_arith_rewritten = if lo.checked_arith_call_results.is_empty() {
+            0
+        } else {
+            crate::front::checked_arith::rewire_checked_arith_call_sites(
+                &mut lo.graph,
+                &lo.checked_arith_call_results,
+            )
+        };
+        if !lo.result_exc_call_results.is_empty()
+            || result_exc_callee
+            || next_rewritten > 0
+            || checked_arith_rewritten > 0
+        {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
         simplify_lowered_graph(&mut lo.graph);
@@ -1589,6 +1610,11 @@ struct Lowering<'a> {
     /// the `next`-diamond rewiring pass (`front::iter_next`) that runs
     /// after the body lowering completes.
     next_call_results: Vec<Variable>,
+    /// `i64::checked_{add,sub,mul}()` call results (`Option<i64>`-typed)
+    /// recorded for the checked-arith rewiring pass
+    /// (`front::checked_arith`) that runs after the body lowering
+    /// completes, rewriting each into an `*_ovf` op + OverflowError edge.
+    checked_arith_call_results: Vec<Variable>,
 }
 
 impl<'a> Lowering<'a> {
@@ -1743,6 +1769,7 @@ impl<'a> Lowering<'a> {
             multi_assigned_locals: compute_multi_assigned_locals(body),
             result_exc_call_results: Vec::new(),
             next_call_results: Vec::new(),
+            checked_arith_call_results: Vec::new(),
         })
     }
 
@@ -5341,6 +5368,20 @@ impl<'a> Lowering<'a> {
             && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
         {
             self.next_call_results.push(result_var.clone());
+        }
+        // Capture `i64::checked_{add,sub,mul}()` results (`Option<i64>`-
+        // typed) for the checked-arith rewiring pass
+        // (`front::checked_arith`), which rewrites each into the native
+        // `*_ovf` op + OverflowError edge.  Recognition is liberal — any
+        // `core::num::<Impl>::checked_*` call returning `Option` — because
+        // the rewrite itself validates the surrounding overflow-fallback
+        // match and declines (leaving the residual call) on any other
+        // shape.
+        if let OpKind::Call { target, .. } = &op_kind
+            && crate::front::checked_arith::is_checked_arith_target(target)
+            && crate::front::result_exc::tyref_is_option(&call.dest.ty, self.llbc)
+        {
+            self.checked_arith_call_results.push(result_var.clone());
         }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var),

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4513,6 +4513,14 @@ impl<'a> Lowering<'a> {
         }
 
         let class = call.func.classify();
+        // Full `name_path()` of a `CallKind::Fun` callee, captured for the
+        // `Result<T, PyError>` scope decision at the `?`-diamond capture
+        // site below: the built `CallTarget::Method` keeps only the leaf,
+        // losing the module path the scope predicate keys on.  It is the
+        // same string the callee-side gate sees (`fd.item_meta.name_path()`,
+        // `lower_fun_decl_with_static_addrs`), so caller and callee agree on
+        // whether a given callee is scoped.
+        let mut callee_name_path: Option<String> = None;
         let op_kind = match (class, call.func) {
             (CallClass::Direct, CallFunc::Regular(reg))
             | (CallClass::Trait, CallFunc::Regular(reg)) => {
@@ -4954,6 +4962,10 @@ impl<'a> Lowering<'a> {
                 // `unaryop.rs:3587` (lib test
                 // `generic_handler_graphs_keep_symbolic_fnaddr_surface`).
                 let (segments, method_hint) = self.call_target_segments(mir_bb, &reg)?;
+                // For a method/direct callee this equals the callee's
+                // `name_path()`; the scope predicate keys on the module
+                // path, which the built `CallTarget::Method` drops.
+                callee_name_path = Some(segments.join("::"));
                 if self.try_lower_checked_neg(
                     mir_bb,
                     &reg.kind,
@@ -5243,8 +5255,10 @@ impl<'a> Lowering<'a> {
         // Capture scoped `Result<T, PyError>` call results for the
         // `?`-diamond rewiring pass (`front::result_exc`) that runs
         // after the body lowering completes.
-        if let OpKind::Call { target, .. } = &op_kind
-            && crate::front::result_exc::call_target_in_scope(target)
+        if let OpKind::Call { .. } = &op_kind
+            && callee_name_path
+                .as_deref()
+                .is_some_and(crate::front::result_exc::in_result_exc_scope)
             && crate::front::result_exc::tyref_is_result_of_pyerror(&call.dest.ty, self.llbc)
         {
             // The per-instantiation suffix of the callee's `Result<T,

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -67,6 +67,7 @@
 //! the only extraction gap is std `thread_local!` accessor stubs,
 //! treated as opaque ops.
 
+pub(crate) mod checked_arith;
 pub(crate) mod iter_next;
 pub mod llbc_hints;
 pub mod mir;

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -550,7 +550,7 @@ fn count_var_uses(graph: &FunctionGraph, var: &Variable) -> UseCounts {
 /// a new `OpKind` variant is a compile error here until its operands are
 /// declared, keeping the pass fail-closed.  Producer / constant / marker
 /// kinds carry no operand `Variable` and return empty.
-fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
+pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
     let extend_all = |dst: &mut Vec<Variable>, lists: &[&Vec<Variable>]| {
         for list in lists {
             dst.extend(list.iter().cloned());

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -86,6 +86,20 @@ const RESULT_EXC_LOWERING_SCOPE: &[&str] = &[
     "store_fast_store_fast",
     "close_loop_args",
     "null_value",
+    // Read/load checked-value cluster — the symmetric read counterpart
+    // of the store cluster above.  Each `*_checked_value` is a sink
+    // (`load_*_value()?; guard_nonnull_value()?; Ok(value)`) whose two
+    // `?`-diamonds lower over the residual `load_*_value` /
+    // `guard_nonnull_value` leaves; `load_global_value` tail-forwards
+    // `load_name_value`.  None reach `push_value`, so the cluster is a
+    // self-contained connected component.
+    "load_local_value",
+    "load_name_value",
+    "load_global_value",
+    "guard_nonnull_value",
+    "load_local_checked_value",
+    "load_name_checked_value",
+    "load_global_checked_value",
 ];
 
 /// Dispatch-wrapper family rule: every `pyopcode::execute_*` wrapper —

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -125,19 +125,6 @@ pub(crate) fn in_result_exc_scope(name_path: &str) -> bool {
         || in_execute_wrapper_family(name_path, leaf)
 }
 
-/// True when a call target's leaf names a scoped callee.
-pub(crate) fn call_target_in_scope(target: &CallTarget) -> bool {
-    match target {
-        CallTarget::Method { name, .. } => RESULT_EXC_LOWERING_SCOPE.contains(&name.as_str()),
-        CallTarget::FunctionPath { segments } => {
-            let leaf = segments.last().map(String::as_str).unwrap_or("");
-            RESULT_EXC_LOWERING_SCOPE.contains(&leaf)
-                || (segments.iter().any(|s| s == "pyopcode") && leaf.starts_with("execute_"))
-        }
-        _ => false,
-    }
-}
-
 /// Resolve the JSON body behind a generics slot — `{"Deduplicated":
 /// id}` indirections through the dedup table, `{"HashConsedValue":
 /// [id, body]}` inline pairs, anything else as-is.

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -299,6 +299,21 @@ pub struct SemanticProgram {
         crate::flowspace::argument::Signature,
         crate::translator::rtyper::lltypesystem::lltype::LowLevelType,
     )>,
+    /// `(path-segments, Signature, result ValueType)` for every method on
+    /// a foreign **opaque** ADT owner (`malachite_bigint::bigint::BigInt`,
+    /// …) whose result is faithfully modelable, harvested from the LLBC by
+    /// `front::mir::collect_foreign_opaque_method_externals`.  Feeds
+    /// `CallControl.foreign_opaque_method_externals` →
+    /// `cutover::register_foreign_opaque_method_externals` so the
+    /// `CallTarget::FunctionPath` form (which `impl_method_owner` falls
+    /// back to for an opaque owner) resolves instead of panicking
+    /// `SomeInstance.getattr` on the classdef-less receiver — the
+    /// `register_external` / `@jit.dont_look_inside` analog.
+    pub foreign_opaque_method_externals: Vec<(
+        Vec<String>,
+        crate::flowspace::argument::Signature,
+        crate::model::ValueType,
+    )>,
 }
 
 /// Graph lookup table built from a `SemanticProgram` so the

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -176,6 +176,15 @@ fn build_semantic_program_via_active_frontend(
                 .iter()
                 .flat_map(front::mir::collect_unsafe_fn_stubs_from_llbc)
                 .collect();
+            // Foreign opaque-ADT methods (`<BigInt as Add>::add`, …) that
+            // `impl_method_owner` routes through `CallTarget::FunctionPath`
+            // for an opaque owner.  Declared external here so the residual
+            // `FunctionPath` lookup resolves rather than panicking
+            // `SomeInstance.getattr` on the classdef-less receiver.
+            program.foreign_opaque_method_externals = llbcs
+                .iter()
+                .flat_map(front::mir::collect_foreign_opaque_method_externals)
+                .collect();
             // Whole-program type metadata (`known_struct_names`,
             // `known_trait_names`, `struct_fields`) comes from the MIR
             // builder's `derive_program_metadata` walk over Charon's
@@ -819,6 +828,11 @@ fn analyze_pipeline_from_module_paths(
     // `front::mir::collect_unsafe_fn_stubs_from_llbc`, populated on the
     // SemanticProgram in `build_semantic_program_via_active_frontend`.
     call_control.unsafe_fn_stubs = program.unsafe_fn_stubs.clone();
+    // Parallel carrier for foreign opaque-ADT method externals
+    // (`<BigInt as Add>::add`, …) — `populate_call_registry_from_call_graphs`
+    // registers each as an opaque external so the residual `FunctionPath`
+    // form resolves; see `cutover::register_foreign_opaque_method_externals`.
+    call_control.foreign_opaque_method_externals = program.foreign_opaque_method_externals.clone();
     // Populate CallControl with layouts from the provider.  Where Charon
     // resolved an exact layout (`program.exact_layouts`), use the true Rust
     // offsets and total size — `#[repr(Rust)]` reorders/repacks fields, so

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -956,6 +956,7 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
 ///    rtyper's `direct_call`.
 pub(crate) fn populate_call_registry_from_call_graphs(
     function_graphs: &crate::codewriter::call::GraphStore,
+    unsafe_fn_stubs: &[(Vec<String>, Signature, LowLevelType)],
     registry: &PyreCallRegistry,
 ) -> Result<(), TyperError> {
     // Dedupe by canonical path — RPython `Bookkeeper.getdesc(pyobj)`
@@ -1038,6 +1039,19 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         };
         pending.push((key, graph, entry));
     }
+    // Register `unsafe fn` stubs between Pass 1 (alias explosion) and
+    // Pass 2 (callee lift).  `build_flow.rs:215` rejects unsafe bodies so
+    // they never enter `function_graphs`; without a stub a safe-fn body
+    // lifted in Pass 2 that calls an unsafe callee (`is_cell`,
+    // `is_exception`, …) records a "not registered" lift error and the
+    // caller Skips.  Seeding here — not before Pass 1 — keeps Pass 1's
+    // `registry.alias()` invariant ("alias key already a canonical entry")
+    // intact: the alias explosion has already landed, and neither Pass 2
+    // (lift) nor Pass 3 (class-member binding) calls `alias()`, so a
+    // verbatim single-key stub cannot collide.  `register_unsafe_fn_stubs`
+    // is non-overwriting (skips keys the `function_graphs` pass already
+    // registered) and idempotent.
+    register_unsafe_fn_stubs(registry, unsafe_fn_stubs);
     // Pass 2 — prefill the default-cache once per *unique* registry
     // entry.  Aliases already point at the same `Rc<PyreFunctionEntry>`
     // so their `prefill_default_cache` would be redundant; identify

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -967,6 +967,7 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
 pub(crate) fn populate_call_registry_from_call_graphs(
     function_graphs: &crate::codewriter::call::GraphStore,
     unsafe_fn_stubs: &[(Vec<String>, Signature, LowLevelType)],
+    foreign_opaque_method_externals: &[(Vec<String>, Signature, crate::model::ValueType)],
     registry: &PyreCallRegistry,
 ) -> Result<(), TyperError> {
     // Dedupe by canonical path — RPython `Bookkeeper.getdesc(pyobj)`
@@ -1069,6 +1070,13 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // non-overwriting, between-passes seeding contract as the unsafe-fn
     // stubs above.
     register_foreign_stdlib_externals(registry);
+    // Foreign opaque-ADT method externals (`<BigInt as Add>::add`, …) the
+    // LLBC collected.  `impl_method_owner` declines the Method hint for an
+    // opaque owner, so these residualize as `FunctionPath` calls; declare
+    // each external here with its faithful result shell.  Same
+    // non-overwriting, between-passes seeding contract as the foreign-stdlib
+    // and unsafe-fn stubs above.
+    register_foreign_opaque_method_externals(registry, foreign_opaque_method_externals);
     // Pass 2 — prefill the default-cache once per *unique* registry
     // entry.  Aliases already point at the same `Rc<PyreFunctionEntry>`
     // so their `prefill_default_cache` would be redundant; identify
@@ -1346,6 +1354,27 @@ pub(crate) fn build_stub_pygraph_for_unsafe_fn(
     return_lltype: LowLevelType,
 ) -> Option<Rc<PyGraph>> {
     let return_someval = default_someshell_for_lltype(&return_lltype)?;
+    Some(build_stub_pygraph_with_result_shell(
+        name,
+        signature,
+        return_someval,
+    ))
+}
+
+/// Build an annotator-only stub PyGraph whose return Variable carries
+/// `return_someval` directly.  Shared core of
+/// [`build_stub_pygraph_for_unsafe_fn`] (which projects an lltype through
+/// [`default_someshell_for_lltype`]) and the foreign-opaque-method
+/// registration (which carries a `SomeValue` shell built from the
+/// method's faithful result `ValueType` — including the classdef-less
+/// `SomeInstance` that an lltype cannot express).  See
+/// [`build_stub_pygraph_for_unsafe_fn`] for the annotator-only carrier
+/// contract.
+fn build_stub_pygraph_with_result_shell(
+    name: String,
+    signature: Signature,
+    return_someval: crate::annotator::model::SomeValue,
+) -> Rc<PyGraph> {
     let inputargs: Vec<Hlvalue> = signature
         .argnames
         .iter()
@@ -1367,13 +1396,13 @@ pub(crate) fn build_stub_pygraph_for_unsafe_fn(
         None,
     )));
     startblock.closeblock(vec![link]);
-    Some(Rc::new(PyGraph {
+    Rc::new(PyGraph {
         graph: Rc::new(RefCell::new(graph_inner)),
         func,
         signature: RefCell::new(signature),
         defaults: RefCell::new(Some(Vec::new())),
         access_directly: Cell::new(false),
-    }))
+    })
 }
 
 /// Project a `LowLevelType` to a `SomeValue` shell suitable for
@@ -1563,6 +1592,49 @@ pub(crate) fn register_foreign_stdlib_externals(registry: &PyreCallRegistry) {
             continue;
         }
         registry.register_callee(key, signature, stub_pygraph);
+    }
+}
+
+/// Register the foreign opaque-ADT method externals
+/// [`crate::front::mir::collect_foreign_opaque_method_externals`] harvested
+/// from the LLBC.
+///
+/// Faithful analog of `register_external` for a method on a foreign opaque
+/// type: the JIT does not trace into `<BigInt as Add>::add` (the
+/// interpreter's cold `@jit.dont_look_inside` overflow→long arm), it emits
+/// a residual call.  [`crate::front::mir::Lowering::impl_method_owner`]
+/// declines the `CallTarget::Method` hint for an opaque owner so the call
+/// lowers as `CallTarget::FunctionPath`; registering each path here lets
+/// the residual lookup resolve instead of raising "not registered in
+/// PyreCallRegistry" (and avoids the classdef-less `SomeInstance.getattr`
+/// panic the Method form would surface).
+///
+/// The result shell comes from the per-method faithful `ValueType` the
+/// collector read off the LLBC output signature — a `Ref(None)`
+/// classdef-less `SomeInstance` for a `BigInt`-returning method (matching
+/// `bigint_from`), or a scalar shell for an integer/float/bool return.
+/// Same non-overwriting, annotator-only-carrier contract as
+/// [`register_foreign_stdlib_externals`].
+pub(crate) fn register_foreign_opaque_method_externals(
+    registry: &PyreCallRegistry,
+    externals: &[(Vec<String>, Signature, crate::model::ValueType)],
+) {
+    for (segments, signature, result_ty) in externals {
+        let Some(return_someval) =
+            crate::codewriter::annotation_state::valuetype_to_someshell(result_ty)
+        else {
+            continue;
+        };
+        let key = FunctionPathKey::from_segments(segments.iter().cloned());
+        if registry.lookup(&key).is_some() {
+            continue;
+        }
+        let stub_pygraph = build_stub_pygraph_with_result_shell(
+            segments.last().cloned().unwrap_or_default(),
+            signature.clone(),
+            return_someval,
+        );
+        registry.register_callee(key, signature.clone(), stub_pygraph);
     }
 }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1062,6 +1062,13 @@ pub(crate) fn populate_call_registry_from_call_graphs(
     // is non-overwriting (skips keys the `function_graphs` pass already
     // registered) and idempotent.
     register_unsafe_fn_stubs(registry, unsafe_fn_stubs);
+    // Foreign Rust-stdlib externals (`core::*` / `std::*` / `fmt::*`)
+    // the interpreter calls inline.  Declared opaque here — the rtyper
+    // residualizes them rather than tracing into low-level plumbing, the
+    // `register_external` / `@jit.dont_look_inside` analog.  Same
+    // non-overwriting, between-passes seeding contract as the unsafe-fn
+    // stubs above.
+    register_foreign_stdlib_externals(registry);
     // Pass 2 — prefill the default-cache once per *unique* registry
     // entry.  Aliases already point at the same `Rc<PyreFunctionEntry>`
     // so their `prefill_default_cache` would be redundant; identify
@@ -1466,6 +1473,96 @@ pub(crate) fn register_unsafe_fn_stubs(
             continue;
         }
         registry.register_callee(key, signature.clone(), stub_pygraph);
+    }
+}
+
+/// Foreign Rust-stdlib helper paths the interpreter source calls inline
+/// (`core::*` / `std::*` / `alloc::*` / `fmt::*`) that the rtyper must
+/// treat as opaque externals rather than trace into.
+///
+/// RPython's interpreter never traces into its low-level plumbing — C
+/// helpers are declared with `register_external` / `rffi.llexternal`
+/// (`extfunc.py` / `rffi.py`) so the annotator sees a
+/// `SomeExternalFunction` with a *declared* result annotation and the
+/// JIT residualizes the call (the same effect `@jit.dont_look_inside`
+/// has on a graph).  pyre's interpreter is written in Rust, so the Rust
+/// stdlib is pulled into the lifted call tree; the analog is to declare
+/// these foreign paths external here.  Each entry mirrors a
+/// `register_external(function, args, result)` declaration: a callee
+/// path, the call-site arity, and the result lltype the residual call
+/// produces.
+///
+/// The entries are recurring foreign paths the prepass reaches on cold /
+/// opaque plumbing branches whose declared result lltype is faithful to
+/// the Rust signature (the residual call really does produce that type):
+///
+/// - `core::mem::swap(&mut T, &mut T)` returns `()` — an in-place swap,
+///   `Void` result.
+/// - `core::f64::<Impl>::is_infinite` / `core::slice::<Impl>::is_empty`
+///   return `bool` — `Bool` result.
+/// - `std::f64::<Impl>::floor` returns `f64` — `Float` result.
+///
+/// Paths whose faithful result is a non-scalar value the stub carrier
+/// cannot express (`alloc::fmt::format` → `String`,
+/// `core::array::iter::<Impl>::into_iter` → an iterator with no Repr,
+/// `core::slice::<Impl>::as_ptr` → a raw `*const T`, `core::num::<Impl>::
+/// checked_*` → `Option<i64>`) are intentionally absent: registering
+/// them with a placeholder `Void`/`Signed` result mis-models the value
+/// and only migrates the failure to a deeper annotation wall (union
+/// pollution / raw-pointer modeling), so they stay residual at the
+/// "not registered" Skip until their result type can be modeled.
+const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
+    (&["core", "mem", "swap"], &["x", "y"], LowLevelType::Void),
+    (
+        &["core", "f64", "<Impl>", "is_infinite"],
+        &["self"],
+        LowLevelType::Bool,
+    ),
+    (
+        &["core", "slice", "<Impl>", "is_empty"],
+        &["self"],
+        LowLevelType::Bool,
+    ),
+    (
+        &["std", "f64", "<Impl>", "floor"],
+        &["self"],
+        LowLevelType::Float,
+    ),
+];
+
+/// Register the [`FOREIGN_STDLIB_EXTERNALS`] table into `registry`.
+///
+/// Faithful analog of `extfuncregistry.py`'s `_register` table being
+/// walked into the annotator's external registry: each foreign path is
+/// declared as an opaque external with a fixed signature, registered
+/// through the same opaque stub-pygraph carrier
+/// [`register_unsafe_fn_stubs`] uses, so subsequent
+/// `flowspace_adapter::translate_op` `FunctionPath` lookups resolve the
+/// callee instead of raising "not registered in PyreCallRegistry".  Like
+/// `register_unsafe_fn_stubs` the registration is annotator-only and
+/// non-overwriting: a path already registered by the `function_graphs`
+/// or unsafe-fn pass wins, and the codewriter residualizes the call
+/// through its fnaddr lowering (these foreign stubs are never present in
+/// `CallControl::function_graphs`, so they never compile into JITCode).
+pub(crate) fn register_foreign_stdlib_externals(registry: &PyreCallRegistry) {
+    for (segments, argnames, return_lltype) in FOREIGN_STDLIB_EXTERNALS {
+        let signature = Signature::new(
+            argnames.iter().map(|n| (*n).to_string()).collect(),
+            None,
+            None,
+        );
+        let Some(stub_pygraph) = build_stub_pygraph_for_unsafe_fn(
+            segments.last().copied().unwrap_or_default().to_string(),
+            signature.clone(),
+            return_lltype.clone(),
+        ) else {
+            continue;
+        };
+        let key = FunctionPathKey::from_segments(segments.iter().map(|s| s.to_string()));
+        if registry.lookup(&key).is_some() {
+            continue;
+        }
+        registry.register_callee(key, signature, stub_pygraph);
     }
 }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1035,6 +1035,18 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         if canonical_strip == ["lltype", "malloc_typed"] {
             continue;
         }
+        // `pyre_object::lltype::malloc_raw` is the raw (non-GC) allocation
+        // intrinsic (`lltype.malloc(T, flavor='raw')` parity), recognised as
+        // a host builtin (annotator `malloc_raw_alloc`, HOST_ENV
+        // `pyre_object.lltype` module).  Its body calls the analyser-less
+        // `Box::new` / `Box::into_raw`, so lifting it records a poison
+        // lift-error that surfaces on the first raw-allocating caller.  Skip
+        // registering it as a user function for the same reason as
+        // `malloc_typed`: callsites resolve to the HOST_ENV builtin
+        // (translate_op Layer-3b) instead of this failed user-graph entry.
+        if canonical_strip == ["lltype", "malloc_raw"] {
+            continue;
+        }
         let entry = if let Some(canonical_key) = by_canonical_path.get(&canonical_strip) {
             if canonical_key != &key {
                 registry.alias(key.clone(), canonical_key);

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -656,8 +656,18 @@ fn compare_real_against_legacy(
 /// envelope — closed only by giving slices a class root plus an
 /// iterator Repr (the rlist iterator Repr extended past `SomeList`).
 /// The sibling classdef-less hitters
-/// (`getattr("deref"/"__len__"/"as_str"/"__getitem__")`) close
-/// instead via typed-Ref ClassDef projection.
+/// (`getattr("deref"/"__len__"/"as_str"/"__getitem__")`) close via
+/// foreign-value-type modeling, NOT ClassDef projection: the
+/// receivers are foreign value types (a `Deref` wrapper / `Vec` /
+/// `Wtf8` / a slice), and `deref`/`__len__`/`as_str`/`__getitem__`
+/// are Rust trait methods, not `ClassDef.attrs` field rows.
+/// `ClassDef::find_attribute` (`classdesc.rs`) reads only `attrs[..]`
+/// field rows, so attaching a ClassDef to the receiver cannot
+/// resolve a trait method.  Every classdef-less-instance hitter in
+/// the prepass histogram accesses a foreign-value method
+/// (`to_f64`/`deref`/`__iter__`/`len`/`as_str`/`to_i64`/`index`); none
+/// reads an object struct field, so typed-Ref ClassDef projection
+/// (the object-pointer epic) moves none of them.
 ///
 /// PyPy `bookkeeper.py:108-127` propagates fixpoint failures uncaught;
 /// pyre's dual-gate Skip defers exactly the categories enumerated

--- a/majit/majit-translate/src/translator/rtyper/extregistry.rs
+++ b/majit/majit-translate/src/translator/rtyper/extregistry.rs
@@ -163,6 +163,27 @@ pub enum ExtRegistryEntry {
     /// path; its `compute_annotation` is unreachable in practice and
     /// fails closed to surface a bypassed early-return loudly.
     WeAreJitted,
+    /// `BigInt::from(i64) -> BigInt` — the `From<i64>` impl that boxes a
+    /// machine int into the foreign opaque `BigInt` (Python `long`) on the
+    /// cold `int_add`/`int_sub`/… overflow→long arm.  Modeled as a
+    /// residual external, mirroring `register_external` for a foreign C
+    /// helper (extfunc.py): the JIT never traces into the arbitrary-
+    /// precision body, it emits a `direct_call` whose result is the opaque
+    /// classdef-less GcRef (`Ptr(OBJECT)`), not a scalar.
+    ///
+    /// `From::from` has no `self` receiver, so the front-end lowers it as a
+    /// `simple_call` against the `BigInt.from` host callable (not a
+    /// `CallTarget::FunctionPath` the `PyreCallRegistry` callee-stub path
+    /// handles).  The annotation half is served by the `BigInt.from`
+    /// `BUILTIN_ANALYZERS` entry (`annotator/builtin.rs`, `bigint_from` →
+    /// the classdef-less `SomeInstance` shell), which
+    /// `Bookkeeper.immutablevalue_hostobject` resolves and returns *before*
+    /// the `extregistry.is_registered` fall-through (bookkeeper.py:309-314).
+    /// So this entry only ever fires on the rtyper's `findbltintyper` →
+    /// `specialize_call` path (the same dual-registration shape as
+    /// [`Self::WeAreJitted`]); its `compute_annotation` is unreachable in
+    /// practice and returns the same opaque shell to stay a faithful port.
+    BigIntFrom,
 }
 
 /// Small Send-able annotation payload for static HostObject type
@@ -268,6 +289,10 @@ pub enum ExtRegistryEntryKey {
     /// (rlib/jit.py:396). No per-instance identity — the variant tag
     /// alone supplies `self.__class__` and there is no `self.instance`.
     WeAreJitted,
+    /// Singleton key for the `BigInt.from` residual-external entry. No
+    /// per-instance identity — the variant tag alone supplies
+    /// `self.__class__` and there is no `self.instance`.
+    BigIntFrom,
 }
 
 impl ExtRegistryEntry {
@@ -303,6 +328,7 @@ impl ExtRegistryEntry {
                 instance_identity: instance.identity_id(),
             },
             ExtRegistryEntry::WeAreJitted => ExtRegistryEntryKey::WeAreJitted,
+            ExtRegistryEntry::BigIntFrom => ExtRegistryEntryKey::BigIntFrom,
         }
     }
 
@@ -419,6 +445,20 @@ impl ExtRegistryEntry {
             // (bookkeeper.py:309-314).  Returning it here keeps the
             // entry a faithful port for any path that consults it.
             ExtRegistryEntry::WeAreJitted => Ok(SomeValue::Bool(Default::default())),
+            // The annotation half is served by the `BigInt.from`
+            // `BUILTIN_ANALYZERS` entry (`bigint_from`), which
+            // `immutablevalue_hostobject` resolves before the
+            // `extregistry.is_registered` fall-through. This entry only
+            // fires on the rtyper path; returning the same classdef-less
+            // `SomeInstance` shell keeps it a faithful port for any path
+            // that consults it.
+            ExtRegistryEntry::BigIntFrom => Ok(SomeValue::Instance(
+                crate::annotator::model::SomeInstance::new(
+                    None,
+                    false,
+                    std::collections::BTreeMap::new(),
+                ),
+            )),
         }
     }
 
@@ -549,6 +589,13 @@ impl ExtRegistryEntry {
             // at the result repr's lltype.
             ExtRegistryEntry::WeAreJitted => {
                 Ok(super::rbuiltin::rtype_we_are_jitted as BuiltinTyperFn)
+            }
+            // `BigInt.from` lowers to a residual `direct_call` to the
+            // external `bigint_from` (extfunc.py:55-64
+            // `ExternalFunctionRepr.rtype_simple_call` shape) whose result
+            // is the opaque GcRef; `rtype_bigint_from` emits it.
+            ExtRegistryEntry::BigIntFrom => {
+                Ok(super::rbuiltin::rtype_bigint_from as BuiltinTyperFn)
             }
         }
     }
@@ -784,6 +831,13 @@ fn lookup_host_object(host: &HostObject) -> Option<ExtRegistryEntry> {
     if host.qualname() == "majit_metainterp.jit.we_are_jitted" {
         return Some(ExtRegistryEntry::WeAreJitted);
     }
+    // `BigInt.from` residual external — keyed by the qualname the
+    // `BigInt.from` `BUILTIN_ANALYZERS` annotation entry uses, so the
+    // rtyper's `findbltintyper` → `extregistry.lookup` resolves the same
+    // host callable the annotator typed as `SomeBuiltin`.
+    if host.qualname() == "BigInt.from" {
+        return Some(ExtRegistryEntry::BigIntFrom);
+    }
     if let Some(entry) = host_value_registry().lock().unwrap().get(host).cloned() {
         return Some(entry);
     }
@@ -962,6 +1016,26 @@ mod tests {
         assert!(matches!(entry, ExtRegistryEntry::WeAreJitted));
         assert!(entry.specialize_call().is_ok());
         assert!(matches!(entry.compute_annotation(), Ok(SomeValue::Bool(_))));
+    }
+
+    /// `BigInt.from` — the foreign opaque `From<i64>` conversion surfaces
+    /// the `BigIntFrom` residual-external entry, keyed by the same qualname
+    /// the `BUILTIN_ANALYZERS` annotation entry uses. `specialize_call`
+    /// resolves the rtyper residual lowering; `compute_annotation` returns
+    /// the classdef-less `SomeInstance` opaque shell (the same one
+    /// `bigint_from` produces).
+    #[test]
+    fn bigint_from_resolves_specialize_call() {
+        let host = HostObject::new_builtin_callable("BigInt.from");
+        let cv = ConstValue::HostObject(host);
+        assert!(is_registered(&cv));
+        let entry = lookup(&cv).expect("BigInt.from must surface an entry");
+        assert!(matches!(entry, ExtRegistryEntry::BigIntFrom));
+        assert!(entry.specialize_call().is_ok());
+        assert!(matches!(
+            entry.compute_annotation(),
+            Ok(SomeValue::Instance(_))
+        ));
     }
 
     /// Type-level lookup returns None for unregistered host classes.

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2355,6 +2355,17 @@ pub(crate) fn derive_subject_inputcells(
                         .as_ref()
                         .is_some_and(|reg| reg.fields.contains_key(root));
                     if known {
+                        // A `&FixedObjectArray` receiver models as its
+                        // `_items` element list, not the wrapping struct
+                        // (project_pyre_field_type), so an `arr[idx]` access
+                        // resolves as a list `getitem` rather than rewriting
+                        // to `getattr("__getitem__")`.
+                        if majit_ir::descr::canonical_struct_name(root)
+                            == "object_array::FixedObjectArray"
+                        {
+                            cells.push(bk.project_pyre_field_type(root));
+                            continue;
+                        }
                         let cd = bk.getuniqueclassdef_for_struct_root(root).map_err(|e| {
                             TyperError::message(format!(
                                 "derive_subject_inputcells: startblock.inputargs[{idx}] \

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2315,6 +2315,21 @@ pub(crate) fn derive_subject_inputcells(
             // classdef-less shell, narrowed by call-propagation as before
             // (`description.py:283-305 FunctionDesc.pycall`).
             if matches!(ty, crate::model::ValueType::Ref(_)) {
+                // A list-typed param (`Vec<T>`, `&[T]`, …) carries its
+                // full monomorphic spelling as `class_root` (the named-ADT
+                // root resolver excludes the core/std/alloc container
+                // family precisely so the receiver projects to the
+                // annotator's list model here, not a minted classdef).
+                // `project_pyre_field_type` maps the spelling to
+                // `SomeList(elem)` so a `len()` / iteration on the receiver
+                // resolves as a list op instead of `getattr` over the
+                // classdef-less `SomeInstance(None)` shell.
+                if let (Some(bk), Some(root)) = (bookkeeper, class_root.as_deref()) {
+                    if majit_ir::descr::is_list_container_spelling(root) {
+                        cells.push(bk.project_pyre_field_type(root));
+                        continue;
+                    }
+                }
                 // String-typed params are string values, not class
                 // instances: `String` and `str` both map to the byte
                 // string type (`s_str0` = `SomeString(no_nul=True)`,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -784,6 +784,15 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
                 | "pow"
                 | "lshift"
                 | "rshift"
+                // The `_ovf` arithmetic twins carry `[OverflowError]`
+                // (operation.py:760-761 `_add_except_ovf`;
+                // `OpKind::{Add,Sub,Mul}Ovf.canraise()`).  The front-end
+                // emits them only at a `LastException` block whose
+                // `raising_op` is the `_ovf` op (`front::checked_arith`),
+                // so they must classify as raising.
+                | "add_ovf"
+                | "sub_ovf"
+                | "mul_ovf"
                 | "add_assign"
                 | "sub_assign"
                 | "mul_assign"

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -1421,6 +1421,83 @@ pub(super) fn rtype_we_are_jitted(
     Ok(Some(Hlvalue::Constant(c)))
 }
 
+/// `BigInt::from(i64) -> BigInt` residual lowering, reached through
+/// `BuiltinFunctionRepr.findbltintyper` →
+/// `extregistry.lookup(BigInt.from).specialize_call`
+/// ([`super::extregistry::ExtRegistryEntry::BigIntFrom`]).
+///
+/// Mirrors `extfunc.py:55-64 ExternalFunctionRepr.rtype_simple_call`:
+///
+/// ```python
+/// def rtype_simple_call(self, hop):
+///     args_r = [rtyper.getrepr(s_arg) for s_arg in self.s_func.args_s]
+///     r_result = rtyper.getrepr(self.s_func.s_result)
+///     obj = self.get_funcptr(rtyper, args_r, r_result)
+///     hop2 = hop.copy(); hop2.r_s_popfirstarg()
+///     vlist = [hop2.inputconst(typeOf(obj), obj)] + hop2.inputargs(*args_r)
+///     hop2.exception_is_here()
+///     return hop2.genop('direct_call', vlist, r_result)
+/// ```
+///
+/// The callee has already been popped off `hop` by
+/// `BuiltinFunctionRepr._call` (`rbuiltin.py:94-97
+/// rtype_simple_call` → `r_s_popfirstarg`), so `hop.args_r[0]` is the
+/// `i64` source repr and `hop.r_result` is the classdef-less
+/// `SomeInstance` result repr (root `InstanceRepr`, lltype
+/// `Ptr(OBJECT)` — the opaque GcRef `bigint_from` projects to).  The
+/// residual funcptr carries the conversion's true `(Signed) -> Ptr(OBJECT)`
+/// signature; the result lltype is the opaque pointer, never a scalar.
+///
+/// `BigInt::from(i64)` is infallible, so `exception_cannot_occur` (vs the
+/// generic external's `exception_is_here`): the cold long arm has no
+/// exception edge off this conversion.
+pub fn rtype_bigint_from(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeResult {
+    use crate::translator::rtyper::lltypesystem::lltype::{
+        self, FuncType, functionptr_with_external_name,
+    };
+    use crate::translator::rtyper::rtyper::GenopResult;
+
+    let r_arg = hop
+        .args_r
+        .borrow()
+        .first()
+        .cloned()
+        .flatten()
+        .ok_or_else(|| {
+            TyperError::message("rtype_bigint_from: argument repr missing".to_string())
+        })?;
+    let arg_lltype = r_arg.lowleveltype().clone();
+    let r_result =
+        hop.r_result.borrow().clone().ok_or_else(|| {
+            TyperError::message("rtype_bigint_from: r_result missing".to_string())
+        })?;
+    let result_lltype = r_result.lowleveltype().clone();
+
+    // extfunc.py:66-89 `get_funcptr` — `functionptr(FT, name,
+    // _external_name=name, _callable=...)`.  `_callable` carries the host
+    // callable's qualname (`BigInt.from`) for the llinterp/backend label.
+    let funcptr = functionptr_with_external_name(
+        FuncType {
+            args: vec![arg_lltype],
+            result: result_lltype,
+        },
+        "bigint_from",
+        Some("BigInt.from".to_string()),
+    );
+    let funcptr_lltype = LowLevelType::Ptr(Box::new(lltype::typeOf(&funcptr)));
+
+    hop.exception_cannot_occur()?;
+
+    // extfunc.py:62 — `vlist = [hop2.inputconst(typeOf(obj), obj)] +
+    // hop2.inputargs(*args_r)`.
+    let v_func = HighLevelOp::inputconst(&funcptr_lltype, &ConstValue::LLPtr(Box::new(funcptr)))?;
+    let mut vlist = vec![Hlvalue::Constant(v_func)];
+    vlist.extend(hop.inputargs(vec![ConvertedTo::Repr(r_arg.as_ref())])?);
+
+    // extfunc.py:64 — `hop2.genop('direct_call', vlist, r_result)`.
+    Ok(hop.genop("direct_call", vlist, GenopResult::Repr(r_result)))
+}
+
 /// RPython `@typer_for(hasattr) def rtype_builtin_hasattr(hop)`
 /// (rbuiltin.py:709-715).
 ///

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1615,9 +1615,15 @@ impl NamespaceOpcodeHandler for PyFrame {
 
 impl StackOpcodeHandler for PyFrame {
     fn swap_values(&mut self, depth: usize) -> Result<(), PyError> {
+        // `localsplus[top], localsplus[other] = localsplus[other], localsplus[top]`
+        // spelled element-wise so the flow lowers to getitem/setitem instead of a
+        // `<[T]>::swap` method call (the localsplus list carries no class row).
         let top_idx = self.valuestackdepth - 1;
         let other_idx = self.valuestackdepth - depth;
-        self.locals_w_mut().swap(top_idx, other_idx);
+        let w_top = self.locals_w_mut()[top_idx];
+        let w_other = self.locals_w_mut()[other_idx];
+        self.locals_w_mut()[top_idx] = w_other;
+        self.locals_w_mut()[other_idx] = w_top;
         Ok(())
     }
 }


### PR DESCRIPTION
#254

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
