### PR TITLE
#47: re-key optimizer to box identity, migrate BoxRef wrapper to Operand carriers

### DIFF
--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -921,14 +921,15 @@ impl BoxRef {
     /// Delegates to the canonical [`Operand::get_box_replacement`] walker;
     /// the result re-wraps as a `BoxRef` for callers still on the wrapper.
     pub fn get_box_replacement(&self, not_const: bool) -> BoxRef {
-        // An unbound position-only box (and the `None` sentinel) has no
-        // `_forwarded` host, so the chain is the identity — return `self`
-        // without an `Operand` round-trip, since `Operand::from_boxref`
-        // rejects a position-only box.
-        if self.bound_op().is_none()
-            && self.bound_inputarg().is_none()
-            && !matches!(self.0.kind, BoxKind::Const { .. })
-        {
+        // A box with no bound producer has no `_forwarded` host, so the
+        // chain is the identity — return `self` directly. This covers the
+        // unbound position-only box, the `None` sentinel, and `Const`: a
+        // Const never carries a forwarded slot (see `clear_forwarded`), and
+        // `Operand::get_box_replacement` returns a bare Const unchanged, so
+        // the `Operand` round-trip would only remint an identity-breaking
+        // fresh Const (and also panics on a position-only box). Returning
+        // `self.clone()` preserves the `Rc` identity callers compare on.
+        if self.bound_op().is_none() && self.bound_inputarg().is_none() {
             return self.clone();
         }
         crate::operand::Operand::from_boxref(self)

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2749,19 +2749,13 @@ mod tests {
             op.pos.set(OpRef::ref_op(10));
             std::rc::Rc::new(op)
         };
-        let op0_result = BoxRef::from_bound_op(&op0);
+        let op0_result = majit_ir::operand::Operand::from_bound_op(&op0);
         let op1: majit_ir::OpRc = std::rc::Rc::new(Op::new(
             OpCode::Label,
-            &[
-                rooted_inputarg_operand(Type::Ref, 0),
-                majit_ir::operand::Operand::from_boxref(&op0_result),
-            ],
+            &[rooted_inputarg_operand(Type::Ref, 0), op0_result.clone()],
         ));
         let op2: majit_ir::OpRc = {
-            let mut op = Op::new(
-                OpCode::GetfieldGcPureI,
-                &[majit_ir::operand::Operand::from_boxref(&op0_result)],
-            );
+            let mut op = Op::new(OpCode::GetfieldGcPureI, &[op0_result]);
             op.pos.set(OpRef::int_op(11));
             op.setdescr(majit_ir::descr::make_field_descr(
                 16,

--- a/majit/majit-metainterp/src/graphpage.rs
+++ b/majit/majit-metainterp/src/graphpage.rs
@@ -579,7 +579,7 @@ fn safename(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::history::test_support::rooted_resop_box;
+    use crate::history::test_support::rooted_resop_operand;
     use majit_ir::{Op, OpCode, OpRef, Type, box_ref::BoxRef, operand::Operand, value::InputArg};
 
     #[test]
@@ -594,10 +594,7 @@ mod tests {
             ],
         );
         op.pos.set(OpRef::int_op(2));
-        let jump = Op::new(
-            OpCode::Jump,
-            &[Operand::from_boxref(&rooted_resop_box(Type::Int, 2))],
-        );
+        let jump = Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 2)]);
         let procedure = vec![op, jump];
 
         let source = display_procedures(&[&procedure], None, &[]);

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -667,19 +667,20 @@ impl TreeLoop {
             ) {
                 match inputargs.get(r.raw() as usize) {
                     Some(ia) => return Operand::from_bound_inputarg(ia),
-                    None => {
-                        debug_assert!(false, "cut-trace operand references missing inputarg {r:?}");
-                        return Operand::from_opref(r);
-                    }
+                    // Re-emission keeps SSA order, so the inputarg always
+                    // exists by the time a consumer is bound; a miss is a hard
+                    // invariant violation, not a recoverable fallback.
+                    None => unreachable!("cut-trace operand references missing inputarg {r:?}"),
                 }
             }
             let idx = (r.raw() - new_inputargs_count) as usize;
             match producers.get(idx) {
                 Some(rc) => Operand::from_bound_op(rc),
-                None => {
-                    debug_assert!(false, "cut-trace operand references unbuilt producer {r:?}");
-                    Operand::from_opref(r)
-                }
+                // Producers are re-emitted in program order, so a consumer's
+                // producer Rc always exists by the time the consumer is built;
+                // a miss is a hard invariant violation, not a recoverable
+                // fallback.
+                None => unreachable!("cut-trace operand references unbuilt producer {r:?}"),
             }
         };
 

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -654,35 +654,33 @@ impl TreeLoop {
         // (history.py cut_trace_from re-emission keeps SSA order). NONE
         // and Const positions carry their value inline.
         use majit_ir::operand::Operand;
-        let bind_remapped = |r: OpRef,
-                             producers: &[OpRc],
-                             inputargs: &[majit_ir::InputArgRc]|
-         -> Operand {
-            if r.is_none() || r.is_constant() {
-                return Operand::from_opref(r);
-            }
-            if matches!(
-                r,
-                OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
-            ) {
-                match inputargs.get(r.raw() as usize) {
-                    Some(ia) => return Operand::from_bound_inputarg(ia),
-                    // Re-emission keeps SSA order, so the inputarg always
-                    // exists by the time a consumer is bound; a miss is a hard
-                    // invariant violation, not a recoverable fallback.
-                    None => unreachable!("cut-trace operand references missing inputarg {r:?}"),
+        let bind_remapped =
+            |r: OpRef, producers: &[OpRc], inputargs: &[majit_ir::InputArgRc]| -> Operand {
+                if r.is_none() || r.is_constant() {
+                    return Operand::from_opref(r);
                 }
-            }
-            let idx = (r.raw() - new_inputargs_count) as usize;
-            match producers.get(idx) {
-                Some(rc) => Operand::from_bound_op(rc),
-                // Producers are re-emitted in program order, so a consumer's
-                // producer Rc always exists by the time the consumer is built;
-                // a miss is a hard invariant violation, not a recoverable
-                // fallback.
-                None => unreachable!("cut-trace operand references unbuilt producer {r:?}"),
-            }
-        };
+                if matches!(
+                    r,
+                    OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_)
+                ) {
+                    match inputargs.get(r.raw() as usize) {
+                        Some(ia) => return Operand::from_bound_inputarg(ia),
+                        // Re-emission keeps SSA order, so the inputarg always
+                        // exists by the time a consumer is bound; a miss is a hard
+                        // invariant violation, not a recoverable fallback.
+                        None => unreachable!("cut-trace operand references missing inputarg {r:?}"),
+                    }
+                }
+                let idx = (r.raw() - new_inputargs_count) as usize;
+                match producers.get(idx) {
+                    Some(rc) => Operand::from_bound_op(rc),
+                    // Producers are re-emitted in program order, so a consumer's
+                    // producer Rc always exists by the time the consumer is built;
+                    // a miss is a hard invariant violation, not a recoverable
+                    // fallback.
+                    None => unreachable!("cut-trace operand references unbuilt producer {r:?}"),
+                }
+            };
 
         // Phase 5: Re-emit escaped ops as prefix, assigning fresh OpRefs.
         // Result type comes from the original op's opcode so the new OpRef

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -2905,13 +2905,29 @@ mod tests {
         }
     }
 
+    /// `Operand`-returning twin of [`box_arg`]: identical resolution, but yields
+    /// the `Operand` directly (== `Operand::from_boxref(&box_arg(opref))`).
+    fn box_arg_operand(opref: OpRef) -> majit_ir::operand::Operand {
+        use crate::history::test_support::{rooted_inputarg_operand, rooted_resop_operand};
+        use majit_ir::Type;
+        match opref {
+            OpRef::InputArgInt(x) => rooted_inputarg_operand(Type::Int, x),
+            OpRef::InputArgFloat(x) => rooted_inputarg_operand(Type::Float, x),
+            OpRef::InputArgRef(x) => rooted_inputarg_operand(Type::Ref, x),
+            OpRef::IntOp(x) => rooted_resop_operand(Type::Int, x),
+            OpRef::FloatOp(x) => rooted_resop_operand(Type::Float, x),
+            OpRef::RefOp(x) => rooted_resop_operand(Type::Ref, x),
+            OpRef::VoidOp(x) => rooted_resop_operand(Type::Void, x),
+            // Constants / None shed without minting Operand::Box.
+            _ => majit_ir::operand::Operand::from_opref(opref),
+        }
+    }
+
     /// Helper: build an Op with a specific trace position and the same
     /// typed result class RPython's `opclasses[opnum]` would instantiate.
     fn op_at(pos: u32, opcode: majit_ir::OpCode, args: &[OpRef]) -> majit_ir::Op {
-        let op_args: Vec<majit_ir::operand::Operand> = args
-            .iter()
-            .map(|a| majit_ir::operand::Operand::from_boxref(&box_arg(*a)))
-            .collect();
+        let op_args: Vec<majit_ir::operand::Operand> =
+            args.iter().map(|a| box_arg_operand(*a)).collect();
         let mut op = majit_ir::Op::new(opcode, &op_args);
         op.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         op
@@ -2938,10 +2954,7 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(
-                majit_ir::OpCode::Finish,
-                &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))],
-            ),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg_operand(iop(3))]),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -2984,10 +2997,7 @@ mod tests {
         let ops = vec![
             op_at(2, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(1)]),
             op_at(3, majit_ir::OpCode::IntAdd, &[iop(2), iarg(0)]),
-            majit_ir::Op::new(
-                majit_ir::OpCode::Finish,
-                &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(3)))],
-            ),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg_operand(iop(3))]),
         ];
         let inputarg_types = vec![majit_ir::Type::Int; 2];
 
@@ -3063,10 +3073,7 @@ mod tests {
         let ops = vec![
             op_at(1, majit_ir::OpCode::IntAdd, &[iarg(0), iarg(0)]),
             op_at(2, majit_ir::OpCode::IntAdd, &[iop(1), iarg(0)]),
-            majit_ir::Op::new(
-                majit_ir::OpCode::Finish,
-                &[majit_ir::operand::Operand::from_boxref(&box_arg(iop(2)))],
-            ),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg_operand(iop(2))]),
         ];
         // Shifted phase: start_fresh = 100 so any confusion between
         // _index (raw trace position) and _fresh (fresh OpRef counter)
@@ -3124,10 +3131,7 @@ mod tests {
         let ops = vec![
             op_at(3, majit_ir::OpCode::GetfieldRawI, &[rarg(0)]),
             op_at(1, majit_ir::OpCode::GetarrayitemGcR, &[iop(3), rarg(1)]),
-            majit_ir::Op::new(
-                majit_ir::OpCode::Finish,
-                &[majit_ir::operand::Operand::from_boxref(&box_arg(rop(1)))],
-            ),
+            majit_ir::Op::new(majit_ir::OpCode::Finish, &[box_arg_operand(rop(1))]),
         ];
         let inputarg_types = vec![
             majit_ir::Type::Ref,

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -109,8 +109,9 @@ impl Optimization for OptEarlyForce {
                     // `arg_is_virtual` is only set when it is `Some` and virtual,
                     // so re-walking its OpRef would return the same info-host.
                     let arg_box = arg_box.expect("arg_is_virtual implies a resolved box");
-                    let mut info = ctx.take_ptr_info(&Operand::from_boxref(&arg_box)).unwrap();
-                    let _forced = info.force_box(arg_box, ctx);
+                    let arg_op = Operand::from_boxref(&arg_box);
+                    let mut info = ctx.take_ptr_info(&arg_op).unwrap();
+                    let _forced = info.force_box(&arg_op, ctx);
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -8,7 +8,6 @@
 /// earlyforce.py:32: self.optimizer.optearlyforce = self
 /// The pass registers itself so force_at_the_end_of_preamble can route
 /// forced operations starting from earlyforce.next (= heap).
-use majit_ir::operand::Operand;
 use majit_ir::{Op, OpCode};
 
 use crate::optimizeopt::info::PtrInfoExt;
@@ -99,17 +98,18 @@ impl Optimization for OptEarlyForce {
                     }
                 }
                 // optimizer.py:363-366: if the arg carries a virtual PtrInfo,
-                // force it into the trace.
-                let arg_is_virtual = arg_box
-                    .as_ref()
-                    .map_or(false, |b| ctx.is_virtual(&Operand::from_boxref(b)));
+                // force it into the trace. `is_virtual` / `take_ptr_info`
+                // chain-walk the operand themselves (get_box_replacement), so
+                // the raw arg drives them directly — no box round-trip.
+                let arg_is_virtual = ctx.is_virtual(&op.arg(i));
                 if arg_is_virtual {
-                    // `arg_box` is the box-native resolution of `op.arg(i)`
-                    // (resolve_box_box_opt), already a chain terminal, and
-                    // `arg_is_virtual` is only set when it is `Some` and virtual,
-                    // so re-walking its OpRef would return the same info-host.
-                    let arg_box = arg_box.expect("arg_is_virtual implies a resolved box");
-                    let arg_op = Operand::from_boxref(&arg_box);
+                    // A virtual resolves to a bound alloc op, so the native
+                    // resolver yields its terminal operand with no from_boxref
+                    // bridge; force_box reads the operand's own opref and
+                    // drives every make_equal_to / set_ptr_info receiver off it.
+                    let arg_op = ctx
+                        .resolve_operand_operand_opt(&op.arg(i))
+                        .expect("arg_is_virtual implies a resolved box");
                     let mut info = ctx.take_ptr_info(&arg_op).unwrap();
                     let _forced = info.force_box(&arg_op, ctx);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -800,8 +800,7 @@ mod tests {
 
     #[test]
     fn test_overflow_guards_preserved_in_full_pipeline() {
-        use crate::history::test_support::rooted_inputarg_box;
-        use majit_ir::box_ref::BoxRef;
+        use crate::history::test_support::rooted_inputarg_operand;
         use majit_ir::{OpRc, Type};
 
         // oparser-faithful bound DAG (`rpython/jit/tool/oparser.py`): header
@@ -811,22 +810,16 @@ mod tests {
         // position-only `Operand::Box`. The producers are threaded through
         // `optimize_with_constants_and_inputs_oprc` so they are the canonical
         // ops the OptContext indexes.
-        let i0 = rooted_inputarg_box(Type::Int, 0);
-        let i1 = rooted_inputarg_box(Type::Int, 1);
-        let i2 = rooted_inputarg_box(Type::Int, 2);
+        let i0 = rooted_inputarg_operand(Type::Int, 0);
+        let i1 = rooted_inputarg_operand(Type::Int, 1);
+        let i2 = rooted_inputarg_operand(Type::Int, 2);
 
         // Producer ops carry their result positions (base 100) so they do not
         // collide with the inputarg slots `[0, num_inputs)`.
-        let guard_true = std::rc::Rc::new(Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&i1)]));
-        let sub = std::rc::Rc::new(Op::new(
-            OpCode::IntSubOvf,
-            &[Operand::from_boxref(&i0), Operand::from_boxref(&i2)],
-        ));
+        let guard_true = std::rc::Rc::new(Op::new(OpCode::GuardTrue, &[i1.clone()]));
+        let sub = std::rc::Rc::new(Op::new(OpCode::IntSubOvf, &[i0.clone(), i2.clone()]));
         let guard_ovf1 = std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[]));
-        let mul = std::rc::Rc::new(Op::new(
-            OpCode::IntMulOvf,
-            &[Operand::from_boxref(&i2), Operand::from_boxref(&i1)],
-        ));
+        let mul = std::rc::Rc::new(Op::new(OpCode::IntMulOvf, &[i2.clone(), i1.clone()]));
         let guard_ovf2 = std::rc::Rc::new(Op::new(OpCode::GuardNoOverflow, &[]));
 
         // Sequential positions from base 100 + a fresh ResumeGuardDescr on
@@ -839,15 +832,11 @@ mod tests {
             seed_guard_descrs(op);
         }
 
-        let sub_box = BoxRef::from_bound_op(&sub);
-        let mul_box = BoxRef::from_bound_op(&mul);
+        let sub_box = Operand::from_bound_op(&sub);
+        let mul_box = Operand::from_bound_op(&mul);
         let jump = std::rc::Rc::new(Op::new(
             OpCode::Jump,
-            &[
-                Operand::from_boxref(&sub_box),
-                Operand::from_boxref(&sub_box),
-                Operand::from_boxref(&mul_box),
-            ],
+            &[sub_box.clone(), sub_box.clone(), mul_box],
         ));
         jump.pos.set(OpRef::op_typed(105, jump.result_type()));
 
@@ -898,8 +887,7 @@ mod tests {
         opt.add_pass(Box::new(crate::optimizeopt::rewrite::OptRewrite::new()));
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 2]);
 
-        use crate::history::test_support::rooted_inputarg_box;
-        use majit_ir::box_ref::BoxRef;
+        use crate::history::test_support::rooted_inputarg_operand;
         use majit_ir::{OpRc, Type, Value};
 
         // oparser-faithful bound DAG: i0/i1 are header `InputArg` boxes; the
@@ -907,22 +895,16 @@ mod tests {
         // feeds `guard_value`; the guarded constant `1` is an inline `ConstInt`
         // box (sheds to `Operand::Const`). Every op-arg sheds to
         // `Operand::{InputArg,Op,Const}`, never the position-only `Operand::Box`.
-        let i0 = rooted_inputarg_box(Type::Int, 0);
-        let i1 = rooted_inputarg_box(Type::Int, 1);
+        let i0 = rooted_inputarg_operand(Type::Int, 0);
+        let i1 = rooted_inputarg_operand(Type::Int, 1);
         // v = (i0 > i1): intbounds bounds the comparison result to [0,1].
-        let int_gt = std::rc::Rc::new(Op::new(
-            OpCode::IntGt,
-            &[Operand::from_boxref(&i0), Operand::from_boxref(&i1)],
-        ));
+        let int_gt = std::rc::Rc::new(Op::new(OpCode::IntGt, &[i0, i1]));
         int_gt.pos.set(OpRef::int_op(100));
-        let v = BoxRef::from_bound_op(&int_gt);
+        let v = Operand::from_bound_op(&int_gt);
         // guard_value(v, 1)
         let guard_value = std::rc::Rc::new(Op::new(
             OpCode::GuardValue,
-            &[
-                Operand::from_boxref(&v),
-                Operand::const_from_value(Value::Int(1)),
-            ],
+            &[v, Operand::const_from_value(Value::Int(1))],
         ));
         guard_value.pos.set(OpRef::void_op(0));
 

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2109,8 +2109,8 @@ impl OptHeap {
                     // MUST_ALIAS: lazy_set targets the same struct → return rhs
                     let cached = lazy_op.arg(1).to_opref();
                     let b_old = Operand::from_bound_op(op_rc);
-                    let b_cached = ctx.get_box_replacement(cached);
-                    ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                    let b_cached = ctx.get_box_replacement_operand(cached);
+                    ctx.make_equal_to(&b_old, &b_cached);
                     return OptimizationResult::Remove;
                 }
                 // heap.py:67-75 possible_aliasing_two_infos:
@@ -2147,15 +2147,15 @@ impl OptHeap {
                                 .unwrap_or_else(|| Operand::from_opref(obj));
                             self.field_cache(&descr).register_info(&obj_box);
                             let b_old = Operand::from_bound_op(op_rc);
-                            let b_cached = ctx.get_box_replacement(cached);
-                            ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                            let b_cached = ctx.get_box_replacement_operand(cached);
+                            ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
                                 let b_old = Operand::from_bound_op(op_rc);
-                                let b_cached = ctx.get_box_replacement(cached.to_opref());
-                                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                                let b_cached = ctx.get_box_replacement_operand(cached.to_opref());
+                                ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
                         }
@@ -2225,15 +2225,15 @@ impl OptHeap {
                             .unwrap_or_else(|| Operand::from_opref(obj));
                         self.field_cache(&descr).register_info(&obj_box);
                         let b_old = Operand::from_bound_op(op_rc);
-                        let b_cached = ctx.get_box_replacement(cached);
-                        ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                        let b_cached = ctx.get_box_replacement_operand(cached);
+                        ctx.make_equal_to(&b_old, &b_cached);
                         return OptimizationResult::Remove;
                     }
                     crate::optimizeopt::info::FieldEntry::Value(cached) => {
                         if !cached.is_none() {
                             let b_old = Operand::from_bound_op(op_rc);
-                            let b_cached = ctx.get_box_replacement(cached.to_opref());
-                            ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                            let b_cached = ctx.get_box_replacement_operand(cached.to_opref());
+                            ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
                     }
@@ -2250,8 +2250,8 @@ impl OptHeap {
                 if !qi_cached.is_none() {
                     // Subsequent read: reuse the cached value.
                     let b_old = Operand::from_bound_op(op_rc);
-                    let b_qi = ctx.get_box_replacement(qi_cached);
-                    ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_qi));
+                    let b_qi = ctx.get_box_replacement_operand(qi_cached);
+                    ctx.make_equal_to(&b_old, &b_qi);
                     return OptimizationResult::Remove;
                 }
                 // First read after QUASIIMMUT_FIELD: emit the load, then cache
@@ -2753,15 +2753,15 @@ impl OptHeap {
                                     .register_info(&array_box);
                                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
                                 let b_old = Operand::from_bound_op(op_rc);
-                                let b_cached = ctx.get_box_replacement(cached);
-                                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                                let b_cached = ctx.get_box_replacement_operand(cached);
+                                ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
                             crate::optimizeopt::info::FieldEntry::Value(cached) => {
                                 if !cached.is_none() {
                                     let b_old = Operand::from_bound_op(op_rc);
-                                    let b_cached = ctx.get_box_replacement(cached.to_opref());
-                                    ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                                    let b_cached = ctx.get_box_replacement_operand(cached.to_opref());
+                                    ctx.make_equal_to(&b_old, &b_cached);
                                     return OptimizationResult::Remove;
                                 }
                             }
@@ -2823,8 +2823,8 @@ impl OptHeap {
                     .register_info(&array_box);
                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_cached = ctx.get_box_replacement(cached);
-                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                let b_cached = ctx.get_box_replacement_operand(cached);
+                ctx.make_equal_to(&b_old, &b_cached);
                 return OptimizationResult::Remove;
             }
             if let Some(cai) = self
@@ -2843,15 +2843,15 @@ impl OptHeap {
                                 .register_info(&array_box);
                             ctx.arrayinfo_setitem(op, const_index as usize, cached);
                             let b_old = Operand::from_bound_op(op_rc);
-                            let b_cached = ctx.get_box_replacement(cached);
-                            ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                            let b_cached = ctx.get_box_replacement_operand(cached);
+                            ctx.make_equal_to(&b_old, &b_cached);
                             return OptimizationResult::Remove;
                         }
                         crate::optimizeopt::info::FieldEntry::Value(cached) => {
                             if !cached.is_none() {
                                 let b_old = Operand::from_bound_op(op_rc);
-                                let b_cached = ctx.get_box_replacement(cached.to_opref());
-                                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                                let b_cached = ctx.get_box_replacement_operand(cached.to_opref());
+                                ctx.make_equal_to(&b_old, &b_cached);
                                 return OptimizationResult::Remove;
                             }
                         }
@@ -2917,8 +2917,8 @@ impl OptHeap {
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
                     let b_old = Operand::from_bound_op(op_rc);
-                    let b_cached = ctx.get_box_replacement(cached);
-                    ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                    let b_cached = ctx.get_box_replacement_operand(cached);
+                    ctx.make_equal_to(&b_old, &b_cached);
                     return OptimizationResult::Remove;
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3660,9 +3660,9 @@ impl Optimization for OptHeap {
             //             structinfo.init_fields(parent_descr, descr.get_index())
             //             box1.set_forwarded(structinfo)
             let resolved_is_virtual = ctx
-                .get_box_replacement_box(*box1)
+                .get_box_replacement_operand_opt(*box1)
                 .as_ref()
-                .map_or(false, |b| ctx.is_virtual(&Operand::from_boxref(b)));
+                .map_or(false, |b| ctx.is_virtual(b));
             let needs_install = !ctx
                 .get_box_replacement_box(resolved)
                 .and_then(|cb| cb.const_value())
@@ -3802,9 +3802,9 @@ impl Optimization for OptHeap {
             //             arrayinfo = info.ArrayPtrInfo(descr)
             //             box1.set_forwarded(arrayinfo)
             let resolved_is_virtual = ctx
-                .get_box_replacement_box(*box1)
+                .get_box_replacement_operand_opt(*box1)
                 .as_ref()
-                .map_or(false, |b| ctx.is_virtual(&Operand::from_boxref(b)));
+                .map_or(false, |b| ctx.is_virtual(b));
             let needs_install = !ctx
                 .get_box_replacement_box(resolved)
                 .and_then(|cb| cb.const_value())

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1366,9 +1366,7 @@ impl OptHeap {
             // heap.py:142-143: put_field_back_to_info — restore cache + PtrInfo.
             // Struct base = op.getarg(0) (args already resolved above).
             let struct_ref = put_back_op.arg(0).to_opref();
-            let obj_box = ctx
-                .get_box_replacement_operand_opt(struct_ref)
-                .unwrap_or_else(|| Operand::from_opref(struct_ref));
+            let obj_box = ctx.get_box_replacement_operand(struct_ref);
             self.cache_field(&obj_box, &descr);
             ctx.structinfo_setfield(&put_back_op, field_idx, final_value.to_opref());
         }
@@ -1854,9 +1852,7 @@ impl OptHeap {
             let final_value = pending_op.arg(1);
             let put_back_op = pending_op.clone();
             ctx.emit_extra(heap_pass_idx, pending_op);
-            let obj_box = ctx
-                .get_box_replacement_operand_opt(obj)
-                .unwrap_or_else(|| Operand::from_opref(obj));
+            let obj_box = ctx.get_box_replacement_operand(obj);
             self.cache_field(&obj_box, &descr);
             ctx.structinfo_setfield(&put_back_op, field_idx, final_value.to_opref());
         }
@@ -2142,9 +2138,7 @@ impl OptHeap {
                             // then walk forwarding for the body replace.
                             let cached = ctx.force_op_from_preamble_op(&pop);
                             ctx.structinfo_setfield(op, field_idx, cached);
-                            let obj_box = ctx
-                                .get_box_replacement_operand_opt(obj)
-                                .unwrap_or_else(|| Operand::from_opref(obj));
+                            let obj_box = ctx.get_box_replacement_operand(obj);
                             self.field_cache(&descr).register_info(&obj_box);
                             let b_old = Operand::from_bound_op(op_rc);
                             let b_cached = ctx.get_box_replacement_operand(cached);
@@ -2192,9 +2186,7 @@ impl OptHeap {
                 let lazy_descr = lazy_op.getdescr().unwrap().clone();
                 let lazy_field_idx = Self::field_slot_index(&lazy_descr);
                 let lazy_struct = lazy_op.arg(0).to_opref();
-                let lazy_obj_box = ctx
-                    .get_box_replacement_operand_opt(lazy_struct)
-                    .unwrap_or_else(|| Operand::from_opref(lazy_struct));
+                let lazy_obj_box = ctx.get_box_replacement_operand(lazy_struct);
                 self.field_cache(&lazy_descr).register_info(&lazy_obj_box);
                 // heap.py:122 (force_lazy_set → put_field_back_to_info):
                 //     opinfo.setfield(...) on the structinfo of lazy_obj.
@@ -2220,9 +2212,7 @@ impl OptHeap {
                         // heap.py:185-186 force-then-setfield (see above).
                         let cached = ctx.force_op_from_preamble_op(&pop);
                         ctx.structinfo_setfield(op, field_idx, cached);
-                        let obj_box = ctx
-                            .get_box_replacement_operand_opt(obj)
-                            .unwrap_or_else(|| Operand::from_opref(obj));
+                        let obj_box = ctx.get_box_replacement_operand(obj);
                         self.field_cache(&descr).register_info(&obj_box);
                         let b_old = Operand::from_bound_op(op_rc);
                         let b_cached = ctx.get_box_replacement_operand(cached);
@@ -2258,9 +2248,7 @@ impl OptHeap {
                 // the result so it survives calls (unlike normal mutable fields).
                 self.quasi_immut_cache.insert(qi_key, op.pos.get());
                 make_nonnull_box(ctx, &op.arg(0));
-                let obj_box = ctx
-                    .get_box_replacement_operand_opt(obj)
-                    .unwrap_or_else(|| Operand::from_opref(obj));
+                let obj_box = ctx.get_box_replacement_operand(obj);
                 self.cache_field(&obj_box, &descr);
                 ctx.structinfo_setfield(op, field_idx, op.pos.get());
                 return OptimizationResult::Emit(op.clone());
@@ -2274,9 +2262,7 @@ impl OptHeap {
         // heap.py optimize_GETFIELD_GC_I default path also marks the base:
         //     self.make_nonnull(op.getarg(0))
         make_nonnull_box(ctx, &op.arg(0));
-        let obj_box = ctx
-            .get_box_replacement_operand_opt(obj)
-            .unwrap_or_else(|| Operand::from_opref(obj));
+        let obj_box = ctx.get_box_replacement_operand(obj);
         self.cache_field(&obj_box, &descr);
         // heap.py postprocess_GETFIELD_GC_I: structinfo.setfield(descr, op)
         //
@@ -2297,15 +2283,9 @@ impl OptHeap {
             ctx.emit(op.clone());
             let zero_ref = ctx.make_constant_int(0);
             let cmp_pos = ctx.alloc_op_position_typed(OpCode::IntNe.result_type());
-            let cmp_arg0 = ctx.materialize_box_at(op.pos.get());
-            let cmp_arg1 = ctx.materialize_box_at(zero_ref);
-            let mut cmp_op = Op::new(
-                OpCode::IntNe,
-                &[
-                    Operand::from_boxref(&cmp_arg0),
-                    Operand::from_boxref(&cmp_arg1),
-                ],
-            );
+            let cmp_arg0 = ctx.materialize_operand_at(op.pos.get());
+            let cmp_arg1 = ctx.materialize_operand_at(zero_ref);
+            let mut cmp_op = Op::new(OpCode::IntNe, &[cmp_arg0, cmp_arg1]);
             cmp_op.pos.set(cmp_pos);
             ctx.emit(cmp_op);
             // unroll.py:409 parity: synthetic guards inherit
@@ -2313,8 +2293,8 @@ impl OptHeap {
             // running GUARD_FUTURE_CONDITION). Without this, the guard
             // arrives at store_final_boxes_in_guard with -1 and would
             // be silently dropped under the patchguardop-only fallback.
-            let guard_arg = ctx.materialize_box_at(cmp_pos);
-            let guard_op = Op::new(OpCode::GuardTrue, &[Operand::from_boxref(&guard_arg)]);
+            let guard_arg = ctx.materialize_operand_at(cmp_pos);
+            let guard_op = Op::new(OpCode::GuardTrue, &[guard_arg]);
             if let Some(ref patch) = ctx.patchguardop {
                 guard_op
                     .rd_resume_position
@@ -2414,9 +2394,7 @@ impl OptHeap {
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
                         ctx.structinfo_setfield(op, field_idx, cached);
-                        let obj_box = ctx
-                            .get_box_replacement_operand_opt(obj)
-                            .unwrap_or_else(|| Operand::from_opref(obj));
+                        let obj_box = ctx.get_box_replacement_operand(obj);
                         self.field_cache(descr).register_info(&obj_box);
                         // heap.py:100 self._lazy_set = None
                         self.field_cache(descr).lazy_set = None;
@@ -2505,9 +2483,7 @@ impl OptHeap {
                 let final_value = lazy_op.arg(2);
                 let lazy_descr = put_back_op.getdescr();
                 let lazy_struct = put_back_op.arg(0).to_opref();
-                let lazy_obj_box = ctx
-                    .get_box_replacement_operand_opt(lazy_struct)
-                    .unwrap_or_else(|| Operand::from_opref(lazy_struct));
+                let lazy_obj_box = ctx.get_box_replacement_operand(lazy_struct);
                 self.cache_arrayitem(&lazy_obj_box, descr_idx, const_index, lazy_descr.as_ref());
                 ctx.arrayinfo_setitem(&put_back_op, const_index as usize, final_value.to_opref());
             }
@@ -2565,9 +2541,7 @@ impl OptHeap {
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
-                        let array_box = ctx
-                            .get_box_replacement_operand_opt(array)
-                            .unwrap_or_else(|| Operand::from_opref(array));
+                        let array_box = ctx.get_box_replacement_operand(array);
                         self.arrayitem_cache(descr, const_index)
                             .register_info(&array_box);
                         ctx.arrayinfo_setitem(op, const_index as usize, cached);
@@ -2662,9 +2636,7 @@ impl OptHeap {
                 let lazy_descr = put_back_op.getdescr().unwrap();
                 let lazy_field_idx = Self::field_slot_index(&lazy_descr);
                 let lazy_struct = put_back_op.arg(0).to_opref();
-                let lazy_obj_box = ctx
-                    .get_box_replacement_operand_opt(lazy_struct)
-                    .unwrap_or_else(|| Operand::from_opref(lazy_struct));
+                let lazy_obj_box = ctx.get_box_replacement_operand(lazy_struct);
                 self.cache_field(&lazy_obj_box, &lazy_descr);
                 ctx.structinfo_setfield(&put_back_op, lazy_field_idx, final_value.to_opref());
             }
@@ -2746,9 +2718,7 @@ impl OptHeap {
                                 //   res = optheap.optimizer.force_op_from_preamble(res)
                                 //   opinfo.setitem(descr, index, None, res, optheap=optheap)
                                 let cached = ctx.force_op_from_preamble_op(&pop);
-                                let array_box = ctx
-                                    .get_box_replacement_operand_opt(array)
-                                    .unwrap_or_else(|| Operand::from_opref(array));
+                                let array_box = ctx.get_box_replacement_operand(array);
                                 self.arrayitem_cache(&descr, const_index)
                                     .register_info(&array_box);
                                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
@@ -2816,9 +2786,7 @@ impl OptHeap {
             if let Some(pop) = pop {
                 // heap.py:243-249 force-then-setitem (see above).
                 let cached = ctx.force_op_from_preamble_op(&pop);
-                let array_box = ctx
-                    .get_box_replacement_operand_opt(array)
-                    .unwrap_or_else(|| Operand::from_opref(array));
+                let array_box = ctx.get_box_replacement_operand(array);
                 self.arrayitem_cache(&descr, const_index)
                     .register_info(&array_box);
                 ctx.arrayinfo_setitem(op, const_index as usize, cached);
@@ -2836,9 +2804,7 @@ impl OptHeap {
                         crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
                             // heap.py:243-249 force-then-setitem (see above).
                             let cached = ctx.force_op_from_preamble_op(&pop);
-                            let array_box = ctx
-                                .get_box_replacement_operand_opt(array)
-                                .unwrap_or_else(|| Operand::from_opref(array));
+                            let array_box = ctx.get_box_replacement_operand(array);
                             self.arrayitem_cache(&descr, const_index)
                                 .register_info(&array_box);
                             ctx.arrayinfo_setitem(op, const_index as usize, cached);
@@ -2858,9 +2824,7 @@ impl OptHeap {
                     }
                 }
             }
-            let array_box = ctx
-                .get_box_replacement_operand_opt(array)
-                .unwrap_or_else(|| Operand::from_opref(array));
+            let array_box = ctx.get_box_replacement_operand(array);
             self.cache_arrayitem(&array_box, descr_idx, const_index, op.getdescr().as_ref());
             // heap.py:676-681:
             //     arrayinfo = self.ensure_ptr_info_arg0(op)

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2730,7 +2730,8 @@ impl OptHeap {
                             crate::optimizeopt::info::FieldEntry::Value(cached) => {
                                 if !cached.is_none() {
                                     let b_old = Operand::from_bound_op(op_rc);
-                                    let b_cached = ctx.get_box_replacement_operand(cached.to_opref());
+                                    let b_cached =
+                                        ctx.get_box_replacement_operand(cached.to_opref());
                                     ctx.make_equal_to(&b_old, &b_cached);
                                     return OptimizationResult::Remove;
                                 }
@@ -3651,17 +3652,16 @@ impl Optimization for OptHeap {
                 .is_some()
             {
                 let box2 = ctx.materialize_operand_at(*box2);
-                if let Some(info) = resolved_box.as_ref().and_then(|cb| {
-                    ctx.get_const_info_mut_box(cb, parent_descr.clone())
-                }) {
+                if let Some(info) = resolved_box
+                    .as_ref()
+                    .and_then(|cb| ctx.get_const_info_mut_box(cb, parent_descr.clone()))
+                {
                     info.setfield(field_idx, box2);
                 }
             } else {
                 let box2 = ctx.materialize_operand_at(*box2);
                 if let Some(b) = resolved_box.as_ref() {
-                    ctx.with_ptr_info_mut(b, |info| {
-                        info.setfield(field_idx, box2.clone())
-                    });
+                    ctx.with_ptr_info_mut(b, |info| info.setfield(field_idx, box2.clone()));
                 }
             }
         }
@@ -3797,18 +3797,17 @@ impl Optimization for OptHeap {
             {
                 // info.py:746-748 ConstPtrInfo.setitem → _get_array_info
                 let box2 = ctx.materialize_operand_at(*box2);
-                if let Some(info) = resolved_box.as_ref().and_then(|b| {
-                    ctx.get_const_info_array_mut_box(b, descr.clone())
-                }) {
+                if let Some(info) = resolved_box
+                    .as_ref()
+                    .and_then(|b| ctx.get_const_info_array_mut_box(b, descr.clone()))
+                {
                     info.setitem(*index as usize, box2);
                 }
             } else {
                 let idx = *index as usize;
                 let box2 = ctx.materialize_operand_at(*box2);
                 if let Some(b) = &resolved_box {
-                    ctx.with_ptr_info_mut(b, |info| {
-                        info.setitem(idx, box2.clone())
-                    });
+                    ctx.with_ptr_info_mut(b, |info| info.setitem(idx, box2.clone()));
                 }
             }
         }
@@ -3841,10 +3840,7 @@ mod tests {
     use majit_ir::operand::Operand;
 
     use super::OptHeap;
-    use crate::history::test_support::{
-        rooted_inputarg_box, rooted_inputarg_operand, rooted_resop_box, rooted_resop_operand,
-    };
-    use majit_ir::box_ref::BoxRef;
+    use crate::history::test_support::{rooted_inputarg_operand, rooted_resop_operand};
 
     /// oparser-faithful drop-in for `BoxRef::from_opref(o)` at op-arg /
     /// fail-arg sites where `o` is a bound-at-runtime `OpRef`. Constants shed
@@ -3855,18 +3851,18 @@ mod tests {
     /// to `from_opref(o)` either way, preserving every position-keyed
     /// assertion / cache key / trace-inputarg auto-seed.
     fn bound_arg(o: OpRef) -> Operand {
-        Operand::from_boxref(&match o {
-            OpRef::InputArgInt(i) => rooted_inputarg_box(Type::Int, i),
-            OpRef::InputArgFloat(i) => rooted_inputarg_box(Type::Float, i),
-            OpRef::InputArgRef(i) => rooted_inputarg_box(Type::Ref, i),
-            OpRef::IntOp(p) => rooted_resop_box(Type::Int, p),
-            OpRef::FloatOp(p) => rooted_resop_box(Type::Float, p),
-            OpRef::RefOp(p) => rooted_resop_box(Type::Ref, p),
-            OpRef::VoidOp(p) => rooted_resop_box(Type::Void, p),
+        match o {
+            OpRef::InputArgInt(i) => rooted_inputarg_operand(Type::Int, i),
+            OpRef::InputArgFloat(i) => rooted_inputarg_operand(Type::Float, i),
+            OpRef::InputArgRef(i) => rooted_inputarg_operand(Type::Ref, i),
+            OpRef::IntOp(p) => rooted_resop_operand(Type::Int, p),
+            OpRef::FloatOp(p) => rooted_resop_operand(Type::Float, p),
+            OpRef::RefOp(p) => rooted_resop_operand(Type::Ref, p),
+            OpRef::VoidOp(p) => rooted_resop_operand(Type::Void, p),
             // Const* (shed to Operand::Const), None, TempVar: no producer to
             // bind — the bare from_opref path does not mint.
-            _ => BoxRef::from_opref(o),
-        })
+            _ => Operand::from_opref(o),
+        }
     }
 
     /// Test SizeDescr that pretends to wrap a struct with `is_object()` matching
@@ -4659,10 +4655,10 @@ mod tests {
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::Emit(_)));
         let arr_box = ctx
-            .get_box_replacement_box(OpRef::ref_op(100))
+            .get_box_replacement_operand_opt(OpRef::ref_op(100))
             .expect("array box");
         assert_eq!(
-            ctx.peek_ptr_info(&Operand::from_boxref(&arr_box))
+            ctx.peek_ptr_info(&arr_box)
                 .and_then(|info| info.getitem(3))
                 .and_then(|e| e.as_opref()),
             Some(OpRef::int_op(200))
@@ -4716,10 +4712,10 @@ mod tests {
         // becomes the rhs value via put_field_back_to_info.
         pass.flush(&mut ctx);
         let arr_box = ctx
-            .get_box_replacement_box(OpRef::int_op(100))
+            .get_box_replacement_operand_opt(OpRef::int_op(100))
             .expect("array box");
         assert_eq!(
-            ctx.peek_ptr_info(&Operand::from_boxref(&arr_box))
+            ctx.peek_ptr_info(&arr_box)
                 .and_then(|info| info.getitem(3))
                 .and_then(|e| e.as_opref()),
             Some(OpRef::int_op(101))
@@ -7050,11 +7046,11 @@ mod tests {
         op1.setdescr(descr.clone());
         op1.pos.set(pos1);
         // Pretend the result is known >= 0.
-        // `reserve_pos_typed` does not pre-mint a canonical host; `materialize_box_at`
-        // materializes the BoxRef for the reserved position here.
-        let pos1_box = ctx.materialize_box_at(pos1);
+        // `reserve_pos_typed` does not pre-mint a canonical host; `materialize_operand_at`
+        // materializes the operand for the reserved position here.
+        let pos1_box = ctx.materialize_operand_at(pos1);
         ctx.setintbound(
-            &Operand::from_boxref(&pos1_box),
+            &pos1_box,
             &crate::optimizeopt::intutils::IntBound::from_constant(5),
         );
         assert!(!heap._optimize_call_dict_lookup(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx));

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3634,11 +3634,8 @@ impl Optimization for OptHeap {
                 && !resolved_is_virtual;
             if needs_install {
                 // info.py:175-188 InstancePtrInfo + init_fields
-                if let Some(b) = ctx.get_box_replacement_box(resolved) {
-                    ctx.set_ptr_info(
-                        &Operand::from_boxref(&b),
-                        PtrInfo::instance(parent_descr.clone(), None),
-                    );
+                if let Some(b) = ctx.get_box_replacement_operand_opt(resolved) {
+                    ctx.set_ptr_info(&b, PtrInfo::instance(parent_descr.clone(), None));
                 }
             }
             // heap.py:882-883: cf = self.field_cache(&descr)
@@ -3647,7 +3644,7 @@ impl Optimization for OptHeap {
                 .get_box_replacement_box(*box1)
                 .unwrap_or_else(|| BoxRef::from_opref(*box1));
             self.cache_field(&Operand::from_boxref(&box1_box), descr);
-            let resolved_box = ctx.get_box_replacement_box(resolved);
+            let resolved_box = ctx.get_box_replacement_operand_opt(resolved);
             if resolved_box
                 .as_ref()
                 .and_then(|cb| cb.const_value())
@@ -3655,14 +3652,14 @@ impl Optimization for OptHeap {
             {
                 let box2 = ctx.materialize_operand_at(*box2);
                 if let Some(info) = resolved_box.as_ref().and_then(|cb| {
-                    ctx.get_const_info_mut_box(&Operand::from_boxref(cb), parent_descr.clone())
+                    ctx.get_const_info_mut_box(cb, parent_descr.clone())
                 }) {
                     info.setfield(field_idx, box2);
                 }
             } else {
                 let box2 = ctx.materialize_operand_at(*box2);
                 if let Some(b) = resolved_box.as_ref() {
-                    ctx.with_ptr_info_mut(&Operand::from_boxref(b), |info| {
+                    ctx.with_ptr_info_mut(b, |info| {
                         info.setfield(field_idx, box2.clone())
                     });
                 }
@@ -3775,9 +3772,9 @@ impl Optimization for OptHeap {
                 .is_some()
                 && !resolved_is_virtual;
             if needs_install {
-                if let Some(b) = ctx.get_box_replacement_box(resolved) {
+                if let Some(b) = ctx.get_box_replacement_operand_opt(resolved) {
                     ctx.set_ptr_info(
-                        &Operand::from_boxref(&b),
+                        &b,
                         PtrInfo::array(
                             descr.clone(),
                             crate::optimizeopt::intutils::IntBound::nonnegative(),
@@ -3792,7 +3789,7 @@ impl Optimization for OptHeap {
                 .unwrap_or_else(|| BoxRef::from_opref(*box1));
             let cai = self.arrayitem_cache(descr, *index);
             cai.register_info(&Operand::from_boxref(&box1_box));
-            let resolved_box = ctx.get_box_replacement_box(resolved);
+            let resolved_box = ctx.get_box_replacement_operand_opt(resolved);
             if resolved_box
                 .as_ref()
                 .and_then(|cb| cb.const_value())
@@ -3801,7 +3798,7 @@ impl Optimization for OptHeap {
                 // info.py:746-748 ConstPtrInfo.setitem → _get_array_info
                 let box2 = ctx.materialize_operand_at(*box2);
                 if let Some(info) = resolved_box.as_ref().and_then(|b| {
-                    ctx.get_const_info_array_mut_box(&Operand::from_boxref(b), descr.clone())
+                    ctx.get_const_info_array_mut_box(b, descr.clone())
                 }) {
                     info.setitem(*index as usize, box2);
                 }
@@ -3809,7 +3806,7 @@ impl Optimization for OptHeap {
                 let idx = *index as usize;
                 let box2 = ctx.materialize_operand_at(*box2);
                 if let Some(b) = &resolved_box {
-                    ctx.with_ptr_info_mut(&Operand::from_boxref(b), |info| {
+                    ctx.with_ptr_info_mut(b, |info| {
                         info.setitem(idx, box2.clone())
                     });
                 }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1049,11 +1049,8 @@ fn force_box_impl(
                 );
             }
             if opref != alloc_ref {
-                let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(
-                    op,
-                    &Operand::from_boxref(&b_alloc),
-                );
+                let b_alloc = ctx.get_box_replacement_operand(alloc_ref);
+                ctx.make_equal_to(op, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
                 let value_ref = force_child(&value_ref.to_boxref(), ctx);
@@ -1106,11 +1103,8 @@ fn force_box_impl(
                 );
             }
             if opref != alloc_ref {
-                let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(
-                    op,
-                    &Operand::from_boxref(&b_alloc),
-                );
+                let b_alloc = ctx.get_box_replacement_operand(alloc_ref);
+                ctx.make_equal_to(op, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
                 let value_ref = force_child(&value_ref.to_boxref(), ctx);
@@ -1153,11 +1147,8 @@ fn force_box_impl(
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
             if opref != alloc_ref {
-                let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(
-                    op,
-                    &Operand::from_boxref(&b_alloc),
-                );
+                let b_alloc = ctx.get_box_replacement_operand(alloc_ref);
+                ctx.make_equal_to(op, &b_alloc);
             }
 
             // info.py:542: const = optforce.optimizer.new_const_item(self.descr)
@@ -1218,11 +1209,8 @@ fn force_box_impl(
             alloc_op.setdescr(vinfo.descr.clone());
             let alloc_ref = emit_op(ctx, alloc_op);
             if opref != alloc_ref {
-                let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(
-                    op,
-                    &Operand::from_boxref(&b_alloc),
-                );
+                let b_alloc = ctx.get_box_replacement_operand(alloc_ref);
+                ctx.make_equal_to(op, &b_alloc);
             }
 
             // info.py:672: fielddescrs = op.getdescr().get_all_fielddescrs()
@@ -1303,11 +1291,8 @@ fn force_box_impl(
                 ctx.set_ptr_info(&b, PtrInfo::nonnull());
             }
             if opref != alloc_ref {
-                let b_alloc = ctx.get_box_replacement(alloc_ref);
-                ctx.make_equal_to(
-                    op,
-                    &Operand::from_boxref(&b_alloc),
-                );
+                let b_alloc = ctx.get_box_replacement_operand(alloc_ref);
+                ctx.make_equal_to(op, &b_alloc);
             }
 
             // info.py:425: CHECK_MEMORY_ERROR
@@ -1384,8 +1369,8 @@ fn force_box_impl(
                 );
             }
             if opref != new_ref {
-                let b_new = ctx.get_box_replacement(new_ref);
-                ctx.make_equal_to(op, &Operand::from_boxref(&b_new));
+                let b_new = ctx.get_box_replacement_operand(new_ref);
+                ctx.make_equal_to(op, &b_new);
             }
             new_ref
         }
@@ -1469,11 +1454,8 @@ fn force_box_impl(
 
             // vstring.py:99-100: op.set_forwarded(newop)
             if opref != newop {
-                let b_newop = ctx.get_box_replacement(newop);
-                ctx.make_equal_to(
-                    op,
-                    &Operand::from_boxref(&b_newop),
-                );
+                let b_newop = ctx.get_box_replacement_operand(newop);
+                ctx.make_equal_to(op, &b_newop);
             }
 
             // vstring.py:101-102: initialize_forced_string(op, optstring, op, CONST_0, mode)

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -614,7 +614,14 @@ impl PtrInfoExt for PtrInfo {
                 eq_op.pos.set(ctx.alloc_op_position_typed(Type::Int));
                 let eq_pos = eq_op.pos.get();
                 short.push(eq_op);
-                short.push(Op::new(OpCode::GuardFalse, &[Operand::from_opref(eq_pos)]));
+                // info.py:381 reuses the INT_EQ ResOperation object as the
+                // GUARD_FALSE arg by identity. The producer lives in `short`,
+                // not in ctx's registries, so bind the position to its
+                // canonical stand-in (resolved at replay) the same way the
+                // sibling array/str/IntBound arms do, rather than minting a
+                // position-only operand that has no producer to bind.
+                let arg_eq = ctx.materialize_operand_at(eq_pos);
+                short.push(Op::new(OpCode::GuardFalse, &[arg_eq]));
             }
             PtrInfo::Str(sinfo) => {
                 // vstring.py:116-126: StrPtrInfo.make_guards

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -356,11 +356,11 @@ pub trait PtrInfoExt {
 
     /// info.py:137-160 / 222-226: force_box() emits the allocation and
     /// field writes via emit_extra(), recursively forcing child virtuals.
-    /// `box_` is the (bound) BoxRef of the virtual being forced — RPython
-    /// `force_box(self, op, optforce)` passes the box object directly
+    /// `op` is the (bound) operand of the virtual being forced — RPython
+    /// `force_box(self, op, optforce)` passes the op directly
     /// (info.py:148-152), so the make_equal_to / set_forwarded receiver
     /// needs no lookup.
-    fn force_box(&mut self, box_: BoxRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef;
+    fn force_box(&mut self, op: &Operand, ctx: &mut crate::optimizeopt::OptContext) -> OpRef;
 
     /// info.py:273-303: `_is_immutable_and_filled_with_constants`
     /// — used by `force_box` to decide whether a virtual can be
@@ -768,8 +768,8 @@ impl PtrInfoExt for PtrInfo {
     ///
     /// Generated ops are routed via emit_extra() (RPython
     /// emit_extra parity) so downstream passes can observe them.
-    fn force_box(&mut self, box_: BoxRef, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
-        force_box_impl(self, box_, ctx)
+    fn force_box(&mut self, op: &Operand, ctx: &mut crate::optimizeopt::OptContext) -> OpRef {
+        force_box_impl(self, op, ctx)
     }
 
     /// info.py:273-303: _is_immutable_and_filled_with_constants
@@ -838,17 +838,17 @@ impl PtrInfoExt for PtrInfo {
 
 fn force_box_impl(
     self_: &mut PtrInfo,
-    box_: BoxRef,
+    op: &Operand,
     ctx: &mut crate::optimizeopt::OptContext,
 ) -> OpRef {
     use majit_ir::{Op, OpCode};
 
-    // `box_` is the bound BoxRef of the virtual being forced (callers resolve
-    // op -> box before delegating). The OpRef view drives op identity (pos,
-    // logging, alloc-vs-original comparisons); the box drives every
+    // `op` is the bound operand of the virtual being forced (callers resolve to
+    // the chain terminal before delegating). The OpRef view drives op identity
+    // (pos, logging, alloc-vs-original comparisons); the operand drives every
     // make_equal_to / set_ptr_info receiver, so no `materialize_box_at` round-trip is
     // needed for the forwarding writes.
-    let opref = box_.to_opref();
+    let opref = op.to_opref();
 
     // info.py:307: subbox = optimizer.force_box(fld) — `fld` is the field's
     // own box. Force it (materialising a nested virtual) and return the
@@ -890,7 +890,7 @@ fn force_box_impl(
             let value_box = value_box.expect("recorder-populated");
             let vb_op = ctx.operand_of_box(&value_box);
             let mut info = ctx.take_ptr_info(&vb_op).unwrap();
-            let forced = force_box_impl(&mut info, value_box, ctx);
+            let forced = force_box_impl(&mut info, &vb_op, ctx);
             return ctx
                 .get_box_replacement_box(forced)
                 .unwrap_or_else(|| ctx.materialize_box_at(forced));
@@ -996,12 +996,12 @@ fn force_box_impl(
                         }
                     }
                     // info.py:142: op.set_forwarded(constptr) — write
-                    // unconditional. `set_ptr_info` on `box_` walks the
+                    // unconditional. `set_ptr_info` on `op` walks the
                     // chain to the just-installed Const target (where it
                     // is a no-op per Const-box invariant).
                     let const_ref = GcRef(ptr.0);
-                    ctx.make_constant_arg(&Operand::from_boxref(&box_), Value::Ref(const_ref));
-                    ctx.set_ptr_info(&Operand::from_boxref(&box_), PtrInfo::Constant(const_ref));
+                    ctx.make_constant_arg(op, Value::Ref(const_ref));
+                    ctx.set_ptr_info(op, PtrInfo::Constant(const_ref));
                     return opref;
                 }
             }
@@ -1044,7 +1044,7 @@ fn force_box_impl(
             if opref != alloc_ref {
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(
-                    &Operand::from_boxref(&box_),
+                    op,
                     &Operand::from_boxref(&b_alloc),
                 );
             }
@@ -1101,7 +1101,7 @@ fn force_box_impl(
             if opref != alloc_ref {
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(
-                    &Operand::from_boxref(&box_),
+                    op,
                     &Operand::from_boxref(&b_alloc),
                 );
             }
@@ -1132,7 +1132,7 @@ fn force_box_impl(
             // gate at the `matches!(PtrInfo::VirtualArray(_))` sites in
             // virtualize.rs (same shape as the RawBuffer size=-1 sentinel).
             let len = vinfo.items.len();
-            ctx.set_ptr_info(&Operand::from_boxref(&box_), PtrInfo::nonnull());
+            ctx.set_ptr_info(op, PtrInfo::nonnull());
 
             let len_ref = ctx.emit_constant_int(len as i64);
             let alloc_opcode = if vinfo.clear {
@@ -1148,7 +1148,7 @@ fn force_box_impl(
             if opref != alloc_ref {
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(
-                    &Operand::from_boxref(&box_),
+                    op,
                     &Operand::from_boxref(&b_alloc),
                 );
             }
@@ -1202,7 +1202,7 @@ fn force_box_impl(
             // `nonnull()`, dropping the array-struct identity — same convergence
             // path as VirtualArray (an `is_virtual` flag + gated match sites).
             let num_elements = vinfo.element_fields.len();
-            ctx.set_ptr_info(&Operand::from_boxref(&box_), PtrInfo::nonnull());
+            ctx.set_ptr_info(op, PtrInfo::nonnull());
 
             let len_ref = ctx.emit_constant_int(num_elements as i64);
             let arg_len = ctx.materialize_operand_at(len_ref);
@@ -1213,7 +1213,7 @@ fn force_box_impl(
             if opref != alloc_ref {
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(
-                    &Operand::from_boxref(&box_),
+                    op,
                     &Operand::from_boxref(&b_alloc),
                 );
             }
@@ -1298,7 +1298,7 @@ fn force_box_impl(
             if opref != alloc_ref {
                 let b_alloc = ctx.get_box_replacement(alloc_ref);
                 ctx.make_equal_to(
-                    &Operand::from_boxref(&box_),
+                    op,
                     &Operand::from_boxref(&b_alloc),
                 );
             }
@@ -1378,7 +1378,7 @@ fn force_box_impl(
             }
             if opref != new_ref {
                 let b_new = ctx.get_box_replacement(new_ref);
-                ctx.make_equal_to(&Operand::from_boxref(&box_), &Operand::from_boxref(&b_new));
+                ctx.make_equal_to(op, &Operand::from_boxref(&b_new));
             }
             new_ref
         }
@@ -1405,7 +1405,7 @@ fn force_box_impl(
             };
             if let Some(gcref) = c_s {
                 // vstring.py:83: get_box_replacement(op).set_forwarded(c_s)
-                ctx.make_constant_arg(&Operand::from_boxref(&box_), Value::Ref(gcref));
+                ctx.make_constant_arg(op, Value::Ref(gcref));
                 return opref;
             }
 
@@ -1464,7 +1464,7 @@ fn force_box_impl(
             if opref != newop {
                 let b_newop = ctx.get_box_replacement(newop);
                 ctx.make_equal_to(
-                    &Operand::from_boxref(&box_),
+                    op,
                     &Operand::from_boxref(&b_newop),
                 );
             }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1583,7 +1583,7 @@ mod tests {
     /// Bound-producer `Operand` at position `int_op(pos)` / `ref_op(pos)`,
     /// the field-value analog of the old `BoxRef::from_opref` test stand-ins.
     fn field_op(tp: Type, pos: u32) -> Operand {
-        Operand::from_boxref(&crate::history::test_support::rooted_resop_box(tp, pos))
+        crate::history::test_support::rooted_resop_operand(tp, pos)
     }
 
     #[test]
@@ -1730,8 +1730,8 @@ mod tests {
     fn test_str_ptr_info_plain_constant_string_spec_rejects_intbound_constant_chars() {
         let mut ctx = OptContext::new(16);
         let ch = OpRef::int_op(10);
-        let ch_box = ctx.materialize_box_at(ch);
-        ctx.setintbound(&Operand::from_boxref(&ch_box), &IntBound::from_constant(97));
+        let ch_box = ctx.materialize_operand_at(ch);
+        ctx.setintbound(&ch_box, &IntBound::from_constant(97));
 
         assert_eq!(
             ctx.get_box_replacement_operand_opt(ch)
@@ -1772,14 +1772,14 @@ mod tests {
         ctx.make_constant_box(&b, Value::Int(2));
 
         let source = OpRef::int_op(1);
-        let source_box = ctx.materialize_box_at(source);
+        let source_box = ctx.materialize_operand_at(source);
         let source_chars = vec![
             Some(ctx.materialize_operand_at(OpRef::int_op(10))),
             Some(ctx.materialize_operand_at(OpRef::int_op(11))),
             Some(ctx.materialize_operand_at(OpRef::int_op(12))),
         ];
         ctx.set_ptr_info(
-            &Operand::from_boxref(&source_box),
+            &source_box,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,
@@ -1823,13 +1823,13 @@ mod tests {
             last_guard_pos: -1,
             avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
         });
-        let pos2 = ctx.materialize_box_at(OpRef::int_op(2));
+        let pos2 = ctx.materialize_operand_at(OpRef::int_op(2));
         let pos2_chars = vec![
             Some(ctx.materialize_operand_at(OpRef::int_op(11))),
             Some(ctx.materialize_operand_at(OpRef::int_op(12))),
         ];
         ctx.set_ptr_info(
-            &Operand::from_boxref(&pos2),
+            &pos2,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -48,9 +48,7 @@ impl OptIntBounds {
         // every operand, so `get_box_replacement` resolves to a BOUND terminal
         // on which `getintbound_handle`'s lazy install is safe.
         let b = ctx.get_box_replacement_operand(opref);
-        ctx.getintbound_handle(&b)
-            .borrow()
-            .clone()
+        ctx.getintbound_handle(&b).borrow().clone()
     }
 
     /// `BoxRef`-terminal variant of [`getintbound_box`]: reads the bound off
@@ -593,9 +591,7 @@ impl OptIntBounds {
             let start = -(1i64 << (numbits - 1));
             let stop = 1i64 << (numbits - 1);
             let op_pos_box = ctx.get_box_replacement_operand(op.pos.get());
-            let _ = ctx.with_intbound_mut(&op_pos_box, |bm| {
-                bm.intersect_const(start, stop - 1)
-            });
+            let _ = ctx.with_intbound_mut(&op_pos_box, |bm| bm.intersect_const(start, stop - 1));
         }
     }
 
@@ -2063,9 +2059,7 @@ mod tests {
         // The result should have bounds [5, 30]
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert_eq!(b.lower, 5);
         assert_eq!(b.upper, 30);
@@ -2151,9 +2145,7 @@ mod tests {
         // After the guard, i0 should be < 10, meaning upper <= 9
         let b0 = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(
             b0.upper <= 9,
@@ -2179,9 +2171,7 @@ mod tests {
 
         let b0 = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(
             b0.lower >= 5,
@@ -2348,9 +2338,7 @@ mod tests {
         // The constant should be set
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant() && b.get_constant_int() == 1);
     }
@@ -2374,9 +2362,7 @@ mod tests {
         );
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant() && b.get_constant_int() == 0);
     }
@@ -2396,9 +2382,7 @@ mod tests {
         );
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant() && b.get_constant_int() == 1);
     }
@@ -2418,9 +2402,7 @@ mod tests {
         );
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant() && b.get_constant_int() == 0);
     }
@@ -2481,9 +2463,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // [10, 20] - [0, 5] = [5, 20]
         assert_eq!(b.lower, 5);
@@ -2506,9 +2486,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // [2, 5] * [3, 7] = [6, 35]
         assert_eq!(b.lower, 6);
@@ -2531,9 +2509,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // AND of [0, 255] and [0, 15] -> [0, 15]
         assert!(b.lower >= 0);
@@ -2561,9 +2537,7 @@ mod tests {
         );
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant(), "result should be constant");
         assert_eq!(b.get_constant_int(), 0x0f);
@@ -2633,9 +2607,7 @@ mod tests {
         );
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant(), "result should be constant");
         assert_eq!(b.get_constant_int(), 0xff);
@@ -2694,9 +2666,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(
             b.lower >= 0,
@@ -2719,9 +2689,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.lower >= 0, "ARRAYLEN_GC result should be non-negative");
     }
@@ -2733,9 +2701,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.lower >= 0, "STRLEN result should be non-negative");
     }
@@ -2748,9 +2714,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // neg([3, 10]) = [-10, -3]
         assert_eq!(b.lower, -10);
@@ -2765,9 +2729,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // invert([3, 10]) = [!10, !3] = [-11, -4]
         assert_eq!(b.lower, -11);
@@ -2788,9 +2750,7 @@ mod tests {
         assert!(result.is_empty(), "INT_SUB_OVF(x, x) should be removed");
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.is_constant() && b.get_constant_int() == 0);
     }
@@ -2833,9 +2793,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // [1, 4] << 2 = [4, 16]
         assert_eq!(b.lower, 4);
@@ -2859,9 +2817,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         // [8, 20] >> 2 = [2, 5]
         assert_eq!(b.lower, 2);
@@ -2952,9 +2908,7 @@ mod tests {
         // Result should have bounds [-128, 127]
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.lower >= -128);
         assert!(b.upper <= 127);
@@ -3005,9 +2959,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b0 = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(
             b0.lower >= 1,
@@ -3031,9 +2983,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b0 = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(
             b0.is_constant() && b0.get_constant_int() == 0,
@@ -3058,9 +3008,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.lower >= 6, "lower should be >= 6, got {}", b.lower);
         assert!(b.upper <= 10, "upper should be <= 10, got {}", b.upper);
@@ -3087,9 +3035,7 @@ mod tests {
         pass.propagate_bounds_backward(&i1_box, &mut ctx);
         let b0 = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(
             b0.lower >= 1,
@@ -3114,9 +3060,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert!(b.lower >= 0, "STRGETITEM lower should be >= 0");
         assert!(b.upper <= 255, "STRGETITEM upper should be <= 255");
@@ -3141,9 +3085,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&[call], &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert_eq!(b.lower, -50);
         assert_eq!(b.upper, -3);
@@ -3167,9 +3109,7 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&[call], &initial_bounds);
         let b = {
             let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&__mb)
-                .borrow()
-                .clone()
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
         assert_eq!(b.lower, -3);
         assert_eq!(b.upper, 0);

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1896,9 +1896,9 @@ mod tests {
 
         pass.setup();
         for (opref, bound) in initial_bounds {
-            // Materialize the BoxRef host before installing the initial bound.
-            let op_box = ctx.materialize_box_at(*opref);
-            ctx.setintbound(&majit_ir::operand::Operand::from_boxref(&op_box), bound);
+            // Materialize the canonical host before installing the initial bound.
+            let op_box = ctx.materialize_operand_at(*opref);
+            ctx.setintbound(&op_box, bound);
         }
 
         for op in ops.iter() {
@@ -1922,11 +1922,9 @@ mod tests {
                     // `get_box_replacement` resolves to that bound terminal
                     // rather than re-minting an unbound `from_opref` box. Then
                     // resolve any forwarding box-native.
-                    let canonical = ctx.materialize_box_at(ar);
-                    majit_ir::operand::Operand::from_boxref(
-                        &ctx.resolve_box_box_opt(&canonical)
-                            .unwrap_or_else(|| canonical.get_box_replacement(false)),
-                    )
+                    let canonical = ctx.materialize_operand_at(ar);
+                    ctx.resolve_operand_operand_opt(&canonical)
+                        .unwrap_or_else(|| canonical.get_box_replacement(false))
                 };
                 resolved_op.setarg(i, resolved);
             }
@@ -2064,8 +2062,8 @@ mod tests {
 
         // The result should have bounds [5, 30]
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2152,8 +2150,8 @@ mod tests {
 
         // After the guard, i0 should be < 10, meaning upper <= 9
         let b0 = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2180,8 +2178,8 @@ mod tests {
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
 
         let b0 = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2349,8 +2347,8 @@ mod tests {
         );
         // The constant should be set
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2375,8 +2373,8 @@ mod tests {
             "INT_LT should be removed when known false"
         );
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2397,8 +2395,8 @@ mod tests {
             "INT_EQ(x, x) should be removed (always 1)"
         );
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2419,8 +2417,8 @@ mod tests {
             "INT_NE(x, x) should be removed (always 0)"
         );
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2482,8 +2480,8 @@ mod tests {
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert_eq!(result.len(), 1);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2507,8 +2505,8 @@ mod tests {
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert_eq!(result.len(), 1);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2532,8 +2530,8 @@ mod tests {
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert_eq!(result.len(), 1);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2562,8 +2560,8 @@ mod tests {
             result.iter().map(|o| o.opcode).collect::<Vec<_>>()
         );
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2634,8 +2632,8 @@ mod tests {
             result.iter().map(|o| o.opcode).collect::<Vec<_>>()
         );
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2695,8 +2693,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2720,8 +2718,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2734,8 +2732,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2749,8 +2747,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2766,8 +2764,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2789,8 +2787,8 @@ mod tests {
         let (result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         assert!(result.is_empty(), "INT_SUB_OVF(x, x) should be removed");
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2834,8 +2832,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2860,8 +2858,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -2953,8 +2951,8 @@ mod tests {
         assert_eq!(result[0].opcode, OpCode::IntSignext);
         // Result should have bounds [-128, 127]
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3006,8 +3004,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b0 = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3032,8 +3030,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b0 = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3059,8 +3057,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(1));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(1));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3088,8 +3086,8 @@ mod tests {
         ctx.setintbound(&i1_box, &IntBound::bounded(-5, -1));
         pass.propagate_bounds_backward(&i1_box, &mut ctx);
         let b0 = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(0));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(0));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3115,8 +3113,8 @@ mod tests {
         )];
         let (_result, mut ctx) = run_pass_with_bounds(&ops, &[]);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3142,8 +3140,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&[call], &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };
@@ -3168,8 +3166,8 @@ mod tests {
 
         let (_result, mut ctx) = run_pass_with_bounds(&[call], &initial_bounds);
         let b = {
-            let __mb = ctx.materialize_box_at(OpRef::int_op(2));
-            ctx.getintbound_handle(&majit_ir::operand::Operand::from_boxref(&__mb))
+            let __mb = ctx.materialize_operand_at(OpRef::int_op(2));
+            ctx.getintbound_handle(&__mb)
                 .borrow()
                 .clone()
         };

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -47,8 +47,8 @@ impl OptIntBounds {
         // (propagate_from_pass_range) mints + registers a canonical host for
         // every operand, so `get_box_replacement` resolves to a BOUND terminal
         // on which `getintbound_handle`'s lazy install is safe.
-        let b = ctx.get_box_replacement(opref);
-        ctx.getintbound_handle(&Operand::from_boxref(&b))
+        let b = ctx.get_box_replacement_operand(opref);
+        ctx.getintbound_handle(&b)
             .borrow()
             .clone()
     }
@@ -90,8 +90,8 @@ impl OptIntBounds {
         // before writing. The dispatch-entry rebind registers a canonical host
         // for every operand, so `get_box_replacement` resolves to a bound
         // terminal the bound can install onto.
-        let op_box = ctx.get_box_replacement(opref);
-        ctx.setintbound(&Operand::from_boxref(&op_box), bound);
+        let op_box = ctx.get_box_replacement_operand(opref);
+        ctx.setintbound(&op_box, bound);
     }
 
     /// optimizer.py:434: make_constant_int(box, intvalue) — RPython just
@@ -514,8 +514,8 @@ impl OptIntBounds {
             // `get_box_replacement` resolves `op.pos` to its bound host
             // (always registered post-emit), matching RPython's
             // unconditional setintbound call.
-            let pos_box = ctx.get_box_replacement(op.pos.get());
-            ctx.setintbound(&Operand::from_boxref(&pos_box), &bound);
+            let pos_box = ctx.get_box_replacement_operand(op.pos.get());
+            ctx.setintbound(&pos_box, &bound);
         }
     }
 
@@ -538,8 +538,8 @@ impl OptIntBounds {
         // so the BoxRef-held StrPtrInfo is updated in place.
         let bound = ctx.with_ensured_ptr_info_arg0(op, |mut info| info.getlenbound(Some(0)));
         if let Some(bound) = bound {
-            let pos_box = ctx.get_box_replacement(op.pos.get());
-            ctx.setintbound(&Operand::from_boxref(&pos_box), &bound);
+            let pos_box = ctx.get_box_replacement_operand(op.pos.get());
+            ctx.setintbound(&pos_box, &bound);
         }
     }
 
@@ -554,8 +554,8 @@ impl OptIntBounds {
         // mutation on StrPtrInfo.lenbound needs BoxRef mirror.
         let bound = ctx.with_ensured_ptr_info_arg0(op, |mut info| info.getlenbound(Some(1)));
         if let Some(bound) = bound {
-            let pos_box = ctx.get_box_replacement(op.pos.get());
-            ctx.setintbound(&Operand::from_boxref(&pos_box), &bound);
+            let pos_box = ctx.get_box_replacement_operand(op.pos.get());
+            ctx.setintbound(&pos_box, &bound);
         }
     }
 
@@ -592,8 +592,8 @@ impl OptIntBounds {
             let numbits = byte_size * 8;
             let start = -(1i64 << (numbits - 1));
             let stop = 1i64 << (numbits - 1);
-            let op_pos_box = ctx.get_box_replacement(op.pos.get());
-            let _ = ctx.with_intbound_mut(&Operand::from_boxref(&op_pos_box), |bm| {
+            let op_pos_box = ctx.get_box_replacement_operand(op.pos.get());
+            let _ = ctx.with_intbound_mut(&op_pos_box, |bm| {
                 bm.intersect_const(start, stop - 1)
             });
         }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3176,14 +3176,14 @@ impl OptContext {
                 // itself — a const-folded entry carries an inline-Const
                 // pos/key, which must not bind to the replay op.
                 if r.is_constant() {
-                    return ctx.materialize_box_at(r);
+                    return ctx.materialize_operand_at(r);
                 }
                 produced
                     .iter()
                     .rev()
                     .find(|(k, _)| *k == r)
-                    .map(|(_, dep)| majit_ir::box_ref::BoxRef::from_bound_op(&dep.preamble_op))
-                    .unwrap_or_else(|| ctx.materialize_box_at(r))
+                    .map(|(_, dep)| Operand::from_bound_op(&dep.preamble_op))
+                    .unwrap_or_else(|| ctx.materialize_operand_at(r))
             };
 
         for (source, produced_op) in short_boxes {
@@ -3208,16 +3208,13 @@ impl OptContext {
                         };
                         resolved_args.push(resolved);
                     }
-                    let resolved_arg_boxes: Vec<majit_ir::box_ref::BoxRef> = resolved_args
+                    let resolved_arg_boxes: Vec<Operand> = resolved_args
                         .iter()
                         .map(|a| dep_or_materialize(self, &produced, *a))
                         .collect();
                     let mut op = Op::new(
                         pure_call_opcode(produced_op.preamble_op.opcode),
-                        &resolved_arg_boxes
-                            .iter()
-                            .map(Operand::from_boxref)
-                            .collect::<Vec<_>>(),
+                        &resolved_arg_boxes,
                     );
                     op.pos.set(replay_pos(*source, produced_op));
                     if let Some(d) = produced_op.preamble_op.getdescr() {
@@ -3263,7 +3260,7 @@ impl OptContext {
                                 majit_ir::Type::Void => return false,
                             };
                             let obj_b = dep_or_materialize(self, &produced, obj);
-                            let mut op = Op::new(opcode, &[Operand::from_boxref(&obj_b)]);
+                            let mut op = Op::new(opcode, &[obj_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             let res = self.materialize_box_at(op.pos.get());
@@ -3304,10 +3301,7 @@ impl OptContext {
                             };
                             let obj_b = dep_or_materialize(self, &produced, obj);
                             let index_b = dep_or_materialize(self, &produced, index_opref);
-                            let mut op = Op::new(
-                                opcode,
-                                &[Operand::from_boxref(&obj_b), Operand::from_boxref(&index_b)],
-                            );
+                            let mut op = Op::new(opcode, &[obj_b, index_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
                             let res = self.materialize_box_at(op.pos.get());
@@ -3347,10 +3341,7 @@ impl OptContext {
                         return false;
                     }
                     let func_b = dep_or_materialize(self, &produced, func_opref);
-                    let mut op = Op::new(
-                        loop_invariant_opcode(result_type),
-                        &[Operand::from_boxref(&func_b)],
-                    );
+                    let mut op = Op::new(loop_invariant_opcode(result_type), &[func_b]);
                     op.pos.set(replay_pos(*source, produced_op));
                     let res = self.materialize_box_at(op.pos.get());
                     let new_pop = ProducedShortOp {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6580,9 +6580,9 @@ impl OptContext {
                     let boxref = boxref.opref();
                     let resolved = self.get_replacement_opref(boxref);
                     let is_virtual = self
-                        .get_box_replacement_box(boxref)
+                        .get_box_replacement_operand_opt(boxref)
                         .as_ref()
-                        .map_or(false, |b| self.is_virtual(&Operand::from_boxref(b)));
+                        .map_or(false, |b| self.is_virtual(b));
                     let tp = majit_ir::BoxEnv::get_type(&env, boxref);
                     (boxref, resolved, is_virtual, tp)
                 })
@@ -6594,9 +6594,9 @@ impl OptContext {
                     let boxref = boxref.opref();
                     let resolved = self.get_replacement_opref(boxref);
                     let is_virtual = self
-                        .get_box_replacement_box(boxref)
+                        .get_box_replacement_operand_opt(boxref)
                         .as_ref()
-                        .map_or(false, |b| self.is_virtual(&Operand::from_boxref(b)));
+                        .map_or(false, |b| self.is_virtual(b));
                     let tp = majit_ir::BoxEnv::get_type(&env, boxref);
                     (boxref, resolved, is_virtual, tp)
                 })
@@ -7234,10 +7234,10 @@ impl OptContext {
         //    Int-typed: VirtualRawBuffer / VirtualRawSlice
         //    (info.py:865 RawBufferPtrInfo + getrawptrinfo() — these
         //    describe raw pointers stored in 'i' Boxes).
-        let resolved_box = self.get_box_replacement_box(opref);
+        let resolved_box = self.get_box_replacement_operand_opt(opref);
         if let Some(info) = resolved_box
             .as_ref()
-            .and_then(|b| self.peek_ptr_info(&Operand::from_boxref(b)))
+            .and_then(|b| self.peek_ptr_info(b))
         {
             return Some(match info {
                 crate::optimizeopt::info::PtrInfo::VirtualRawBuffer(_)

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -8640,9 +8640,9 @@ impl OptContext {
     /// Replace old opref AND emit the new op.
     pub fn replace_op_with(&mut self, old: OpRef, new_op: Op) -> OpRef {
         let new_ref = self.emit(new_op);
-        let b_old = self.get_box_replacement(old);
-        let b_new = self.get_box_replacement(new_ref);
-        self.make_equal_to(&Operand::from_boxref(&b_old), &Operand::from_boxref(&b_new));
+        let b_old = self.get_box_replacement_operand(old);
+        let b_new = self.get_box_replacement_operand(new_ref);
+        self.make_equal_to(&b_old, &b_new);
         new_ref
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2289,12 +2289,9 @@ impl OptContext {
         majit_ir::box_ref::BoxRef::from_bound_op(&synthetic)
     }
 
-    pub(crate) fn reserve_virtual_box(
-        &mut self,
-        tp: majit_ir::Type,
-    ) -> (OpRef, majit_ir::box_ref::BoxRef) {
+    pub(crate) fn reserve_virtual_box(&mut self, tp: majit_ir::Type) -> (OpRef, Operand) {
         let opref = self.reserve_pos_typed(tp);
-        let b = self.mint_box_at(opref);
+        let b = Operand::from_boxref(&self.mint_box_at(opref));
         (opref, b)
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6377,16 +6377,13 @@ impl OptContext {
                 }
             }
         }
-        let resolved_box = self.get_box_replacement_box(opref);
-        if let Some(mut info) = resolved_box
-            .as_ref()
-            .and_then(|b| self.peek_ptr_info(&Operand::from_boxref(b)))
-        {
+        let resolved_op = self.get_box_replacement_operand_opt(opref);
+        if let Some(mut info) = resolved_op.as_ref().and_then(|b| self.peek_ptr_info(b)) {
             if info.is_virtual() {
-                let box_ = resolved_box
+                let resolved_op = resolved_op
                     .clone()
-                    .expect("is_virtual implies resolved_box is Some");
-                let forced = info.force_box(box_, self);
+                    .expect("is_virtual implies resolved_op is Some");
+                let forced = info.force_box(&resolved_op, self);
                 return self.get_replacement_opref(forced);
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2443,11 +2443,11 @@ impl OptContext {
             // vstring.py:286-293
             let left_len = self.getstrlen_for(vleft, vleft, mode);
             let right_len = self.getstrlen_for(vright, vright, mode);
-            let left_len = self.materialize_box_at(left_len);
-            let right_len = self.materialize_box_at(right_len);
+            let left_len = self.materialize_operand_at(left_len);
+            let right_len = self.materialize_operand_at(right_len);
             let result = crate::optimizeopt::vstring::_int_add(
-                &Operand::from_boxref(&left_len),
-                &Operand::from_boxref(&right_len),
+                &left_len,
+                &right_len,
                 self,
             )
             .to_opref();
@@ -2466,8 +2466,8 @@ impl OptContext {
         } else {
             majit_ir::OpCode::Strlen
         };
-        let arg1 = self.materialize_box_at(op_resolved);
-        let strlen_op = majit_ir::Op::new(strlen_opcode, &[Operand::from_boxref(&arg1)]);
+        let arg1 = self.materialize_operand_at(op_resolved);
+        let strlen_op = majit_ir::Op::new(strlen_opcode, &[arg1]);
         let result = self.emit_extra(self.current_pass_idx, strlen_op);
         // vstring.py:116: lengthop.set_forwarded(self.getlenbound(mode))
         // `set_forwarded` writes the bound unconditionally; route through
@@ -4061,8 +4061,8 @@ impl OptContext {
             // unroll.py:93-96 IntBound with widen(): intersect unconditionally.
             OpInfo::IntBound(bound) => {
                 let widened = bound.borrow().widen();
-                let target_box = self.materialize_box_at(target);
-                self.with_intbound_mut(&Operand::from_boxref(&target_box), |bm| {
+                let target_box = self.materialize_operand_at(target);
+                self.with_intbound_mut(&target_box, |bm| {
                     let _ = bm.intersect(&widened);
                 });
             }
@@ -4111,8 +4111,8 @@ impl OptContext {
             }
             OpInfo::IntBound(bound) => {
                 let widened = bound.borrow().widen();
-                let target_box = self.materialize_box_at(target);
-                self.with_intbound_mut(&Operand::from_boxref(&target_box), |bm| {
+                let target_box = self.materialize_operand_at(target);
+                self.with_intbound_mut(&target_box, |bm| {
                     let _ = bm.intersect(&widened);
                 });
             }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -425,17 +425,11 @@ impl ImportedShortPureOp {
                 ImportedShortPureArg::Const(_, src) => *src,
             })
             .collect();
-        let replay_arg_boxes: Vec<majit_ir::box_ref::BoxRef> = replay_args
+        let replay_arg_boxes: Vec<Operand> = replay_args
             .iter()
-            .map(|a| ctx.materialize_box_at(*a))
+            .map(|a| ctx.materialize_operand_at(*a))
             .collect();
-        let mut replay = majit_ir::Op::new(
-            opcode,
-            &replay_arg_boxes
-                .iter()
-                .map(Operand::from_boxref)
-                .collect::<Vec<_>>(),
-        );
+        let mut replay = majit_ir::Op::new(opcode, &replay_arg_boxes);
         // shortpreamble.py:112-126 PureOp.produce_op constructs TWO distinct
         // RPython Op objects:
         //
@@ -2445,12 +2439,8 @@ impl OptContext {
             let right_len = self.getstrlen_for(vright, vright, mode);
             let left_len = self.materialize_operand_at(left_len);
             let right_len = self.materialize_operand_at(right_len);
-            let result = crate::optimizeopt::vstring::_int_add(
-                &left_len,
-                &right_len,
-                self,
-            )
-            .to_opref();
+            let result =
+                crate::optimizeopt::vstring::_int_add(&left_len, &right_len, self).to_opref();
             // vstring.py:293: self.lgtop = _int_add(optstring, len1box, len2box)
             if let Some(b) = self.get_box_replacement_operand_opt(info_opref) {
                 self.set_str_lgtop(&b, result);
@@ -3631,12 +3621,9 @@ impl OptContext {
             };
             // ConstInt/Float/Ptr value rides inline on `c` (history.py:227/
             // 268/314); no `seed_constant` step (its const arm is a no-op).
-            let arg_b = ctx.materialize_box_at(arg);
-            let c_b = ctx.materialize_box_at(c);
-            guards.push(Op::new(
-                OpCode::GuardValue,
-                &[Operand::from_boxref(&arg_b), Operand::from_boxref(&c_b)],
-            ));
+            let arg_b = ctx.materialize_operand_at(arg);
+            let c_b = ctx.materialize_operand_at(c);
+            guards.push(Op::new(OpCode::GuardValue, &[arg_b, c_b]));
         };
         for entry in &arg_entries {
             match &entry.info {
@@ -3877,26 +3864,17 @@ impl OptContext {
         // unroll.py:69-74: Struct/Instance with descr → set_forwarded
         if preamble_info.get_descr().is_some() {
             if let PtrInfo::Struct(sinfo) = preamble_info {
-                self.set_ptr_info(
-                    &op_box,
-                    PtrInfo::struct_ptr(sinfo.descr.clone()),
-                );
+                self.set_ptr_info(&op_box, PtrInfo::struct_ptr(sinfo.descr.clone()));
             }
             if let PtrInfo::Instance(iinfo) = preamble_info {
-                self.set_ptr_info(
-                    &op_box,
-                    PtrInfo::instance(iinfo.descr.clone(), None),
-                );
+                self.set_ptr_info(&op_box, PtrInfo::instance(iinfo.descr.clone(), None));
             }
         }
 
         // unroll.py:75-77: known_class → make_constant_class(op, class, False)
         if let Some(cls) = preamble_info.get_known_class(self.cpu.as_ref()) {
             crate::optimizeopt::optimizer::Optimizer::make_constant_class(
-                self,
-                &op_box,
-                cls,
-                false, // update_last_guard=False (unroll.py:77)
+                self, &op_box, cls, false, // update_last_guard=False (unroll.py:77)
             );
         }
 
@@ -7226,10 +7204,7 @@ impl OptContext {
         //    (info.py:865 RawBufferPtrInfo + getrawptrinfo() — these
         //    describe raw pointers stored in 'i' Boxes).
         let resolved_box = self.get_box_replacement_operand_opt(opref);
-        if let Some(info) = resolved_box
-            .as_ref()
-            .and_then(|b| self.peek_ptr_info(b))
-        {
+        if let Some(info) = resolved_box.as_ref().and_then(|b| self.peek_ptr_info(b)) {
             return Some(match info {
                 crate::optimizeopt::info::PtrInfo::VirtualRawBuffer(_)
                 | crate::optimizeopt::info::PtrInfo::VirtualRawSlice(_) => majit_ir::Type::Int,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3829,7 +3829,7 @@ impl OptContext {
         // chain-resolved and checked non-forwarded / non-constant above, so
         // `materialize_box_at` returns its canonical `_forwarded` host
         // (minting one only for an unbound preamble/test slot).
-        let op_box = self.materialize_box_at(op);
+        let op_box = self.materialize_operand_at(op);
 
         // unroll.py:60-64: virtual — set_forwarded + recurse, then return.
         // Identity-preserving install: clone the `Rc` (not the inner
@@ -3887,13 +3887,13 @@ impl OptContext {
         if preamble_info.get_descr().is_some() {
             if let PtrInfo::Struct(sinfo) = preamble_info {
                 self.set_ptr_info(
-                    &Operand::from_boxref(&op_box),
+                    &op_box,
                     PtrInfo::struct_ptr(sinfo.descr.clone()),
                 );
             }
             if let PtrInfo::Instance(iinfo) = preamble_info {
                 self.set_ptr_info(
-                    &Operand::from_boxref(&op_box),
+                    &op_box,
                     PtrInfo::instance(iinfo.descr.clone(), None),
                 );
             }
@@ -3903,7 +3903,7 @@ impl OptContext {
         if let Some(cls) = preamble_info.get_known_class(self.cpu.as_ref()) {
             crate::optimizeopt::optimizer::Optimizer::make_constant_class(
                 self,
-                &Operand::from_boxref(&op_box),
+                &op_box,
                 cls,
                 false, // update_last_guard=False (unroll.py:77)
             );
@@ -3912,7 +3912,7 @@ impl OptContext {
         // unroll.py:79-84: ArrayPtrInfo → set_forwarded(ArrayPtrInfo(descr, lenbound))
         if let PtrInfo::Array(ainfo) = preamble_info {
             self.set_ptr_info(
-                &Operand::from_boxref(&op_box),
+                &op_box,
                 PtrInfo::array(ainfo.descr.clone(), ainfo.lenbound.clone()),
             );
         }
@@ -3934,13 +3934,13 @@ impl OptContext {
             if new_info.lenbound.is_none() {
                 new_info.lenbound = Some(crate::optimizeopt::intutils::IntBound::nonnegative());
             }
-            self.set_ptr_info(&Operand::from_boxref(&op_box), PtrInfo::Str(new_info));
+            self.set_ptr_info(&op_box, PtrInfo::Str(new_info));
             return;
         }
 
         // unroll.py:91-92: is_nonnull → make_nonnull
         if preamble_info.is_nonnull() {
-            self.make_nonnull(&Operand::from_boxref(&op_box));
+            self.make_nonnull(&op_box);
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -8924,11 +8924,8 @@ mod boxref_forwarding_tests {
         let const_box = ctx.materialize_box_at(const_opref);
         assert!(const_box.get_box_replacement(false).is_constant());
         // (b) `Forwarded::Const(constval)` chain on a non-Const-namespace OpRef.
-        let b0_iarg = ctx.materialize_box_at(OpRef::input_arg_int(0));
-        ctx.make_equal_to(
-            &Operand::from_boxref(&b0_iarg),
-            &Operand::from_boxref(&const_box),
-        );
+        let b0_iarg = ctx.materialize_operand_at(OpRef::input_arg_int(0));
+        ctx.make_equal_to(&b0_iarg, &Operand::from_boxref(&const_box));
         let b0_after = ctx.materialize_box_at(OpRef::input_arg_int(0));
         assert!(b0_after.get_box_replacement(false).is_constant());
         // `Forwarded::Const(constval)` planted directly via set_forwarded_const.
@@ -9075,15 +9072,13 @@ mod boxref_forwarding_tests {
         // then calls `set_ptr_info(target_p1, info)`. Replicate the
         // post-walk write directly.
         let info = PtrInfo::NonNull { last_guard_pos: -1 };
-        let target_p1_box = ctx.materialize_box_at(target_p1);
-        ctx.set_ptr_info(&Operand::from_boxref(&target_p1_box), info.clone());
+        let target_p1_box = ctx.materialize_operand_at(target_p1);
+        ctx.set_ptr_info(&target_p1_box, info.clone());
 
         // Read via BoxRef-routing path: walk source's chain to placeholder.
-        let source_p2_box = ctx
-            .get_box_replacement_box(source_p2)
-            .expect("source BoxRef populated");
+        let source_p2_box = ctx.get_box_replacement_operand(source_p2);
         let via_box = ctx
-            .peek_ptr_info(&Operand::from_boxref(&source_p2_box))
+            .peek_ptr_info(&source_p2_box)
             .expect("BoxRef path must see info");
         assert!(matches!(via_box, PtrInfo::NonNull { .. }));
 
@@ -9142,13 +9137,8 @@ mod boxref_forwarding_tests {
         );
 
         // BoxRef-routing reader: chain walks source → placeholder → None.
-        let source_p2_box = ctx
-            .get_box_replacement_box(source_p2)
-            .expect("source BoxRef populated");
-        assert!(
-            ctx.peek_ptr_info(&Operand::from_boxref(&source_p2_box))
-                .is_none()
-        );
+        let source_p2_box = ctx.get_box_replacement_operand(source_p2);
+        assert!(ctx.peek_ptr_info(&source_p2_box).is_none());
 
         // Legacy Vec reader: chain walks source → target_p1 → None
         // (the body's fresh Vec has no entry for target_p1).
@@ -9909,9 +9899,9 @@ mod constant_ptr_info_tests {
     fn getptrinfo_returns_constant_for_value_ref() {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::ref_op(10_000);
-        let b = ctx.materialize_box_at(opref);
-        ctx.seed_constant(&Operand::from_boxref(&b), Value::Ref(GcRef(0xdead_beef)));
-        match ctx.getptrinfo(&Operand::from_boxref(&b)) {
+        let b = ctx.materialize_operand_at(opref);
+        ctx.seed_constant(&b, Value::Ref(GcRef(0xdead_beef)));
+        match ctx.getptrinfo(&b) {
             Some(PtrInfo::Constant(g)) => assert_eq!(g.0, 0xdead_beef),
             other => panic!("expected ConstPtrInfo(0xdeadbeef), got {other:?}"),
         }
@@ -9926,9 +9916,9 @@ mod constant_ptr_info_tests {
     fn getptrinfo_wraps_int_constant_as_const_ptr_info() {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::int_op(10_002);
-        let b = ctx.materialize_box_at(opref);
-        ctx.seed_constant(&Operand::from_boxref(&b), Value::Int(42));
-        match ctx.getptrinfo(&Operand::from_boxref(&b)) {
+        let b = ctx.materialize_operand_at(opref);
+        ctx.seed_constant(&b, Value::Int(42));
+        match ctx.getptrinfo(&b) {
             Some(PtrInfo::Constant(g)) => assert_eq!(g.0, 42),
             other => panic!("expected ConstPtrInfo(42), got {other:?}"),
         }
@@ -9943,11 +9933,8 @@ mod constant_ptr_info_tests {
     fn const_info_mut_returns_same_slot_for_value_ref() {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::ref_op(10_004);
-        let seed_box = ctx.materialize_box_at(opref);
-        ctx.seed_constant(
-            &Operand::from_boxref(&seed_box),
-            Value::Ref(GcRef(0xa5a5_a5a5)),
-        );
+        let seed_box = ctx.materialize_operand_at(opref);
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0xa5a5_a5a5)));
         // First lookup: install Instance via the Vacant entry path,
         // then mark a known class so the second lookup observes it.
         {
@@ -9979,8 +9966,8 @@ mod constant_ptr_info_tests {
     fn const_info_mut_signals_invalid_loop_on_null_value_ref_constant() {
         let mut ctx = OptContext::new(0);
         let ref_null = OpRef::ref_op(10_007);
-        let seed_box = ctx.materialize_box_at(ref_null);
-        ctx.seed_constant(&Operand::from_boxref(&seed_box), Value::Ref(GcRef(0)));
+        let seed_box = ctx.materialize_operand_at(ref_null);
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0)));
         let info = ctx.get_const_info_mut(ref_null, None);
         assert!(info.is_none(), "null constant base must not yield ptr info");
         let invalid = ctx
@@ -9998,8 +9985,8 @@ mod constant_ptr_info_tests {
     fn const_info_mut_signals_invalid_loop_on_null_int_constant() {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::int_op(10_010);
-        let seed_box = ctx.materialize_box_at(opref);
-        ctx.seed_constant(&Operand::from_boxref(&seed_box), Value::Int(0));
+        let seed_box = ctx.materialize_operand_at(opref);
+        ctx.seed_constant(&seed_box, Value::Int(0));
         let info = ctx.get_const_info_mut(opref, None);
         assert!(info.is_none(), "null constant base must not yield ptr info");
         let invalid = ctx
@@ -10018,30 +10005,26 @@ mod constant_ptr_info_tests {
         let parent = OpRef::ref_op(10_010);
         let slice = OpRef::ref_op(10_011);
 
-        let parent_box = ctx.materialize_box_at(parent);
-        let slice_box = ctx.materialize_box_at(slice);
+        let parent_box = ctx.materialize_operand_at(parent);
+        let slice_box = ctx.materialize_operand_at(slice);
         ctx.set_ptr_info(
-            &Operand::from_boxref(&parent_box),
+            &parent_box,
             PtrInfo::VirtualRawBuffer(RawBufferPtrInfo::new(0, 32, None)),
         );
         ctx.set_ptr_info(
-            &Operand::from_boxref(&slice_box),
+            &slice_box,
             PtrInfo::VirtualRawSlice(RawSlicePtrInfo {
                 offset: 8,
-                parent: Operand::from_boxref(&parent_box),
+                parent: parent_box,
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
         );
 
-        let parent_box = ctx
-            .get_box_replacement_box(parent)
-            .expect("set_ptr_info bound a BoxRef");
-        let slice_box = ctx
-            .get_box_replacement_box(slice)
-            .expect("set_ptr_info bound a BoxRef");
-        assert!(ctx.is_raw_ptr(&Operand::from_boxref(&parent_box)));
-        assert!(ctx.is_raw_ptr(&Operand::from_boxref(&slice_box)));
+        let parent_box = ctx.get_box_replacement_operand(parent);
+        let slice_box = ctx.get_box_replacement_operand(slice);
+        assert!(ctx.is_raw_ptr(&parent_box));
+        assert!(ctx.is_raw_ptr(&slice_box));
     }
 
     /// vstring.py:50 `StrPtrInfo.__init__(mode, is_virtual=False, length=-1)`
@@ -10054,11 +10037,11 @@ mod constant_ptr_info_tests {
         // Synthetic-OpRef test fixture: lazy-allocate the BoxRef so the
         // BoxRef-direct `make_nonnull_str` can write through it. Production
         // callers obtain the box via `get_box_replacement_box`.
-        let op_box = ctx.materialize_box_at(opref);
+        let op_box = ctx.materialize_operand_at(opref);
 
-        ctx.make_nonnull_str(&Operand::from_boxref(&op_box), 0);
+        ctx.make_nonnull_str(&op_box, 0);
 
-        match ctx.peek_ptr_info(&Operand::from_boxref(&op_box)) {
+        match ctx.peek_ptr_info(&op_box) {
             Some(PtrInfo::Str(sinfo)) => {
                 assert_eq!(sinfo.mode, 0);
                 assert_eq!(sinfo.length, -1);
@@ -10200,11 +10183,8 @@ mod ensure_ptr_info_arg0_tests {
     #[test]
     fn ensure_ptr_info_arg0_returns_constant_for_value_ref() {
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let seed_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
-        ctx.seed_constant(
-            &Operand::from_boxref(&seed_box),
-            Value::Ref(GcRef(0xdead_beef)),
-        );
+        let seed_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0xdead_beef)));
         let op = field_op_with_parent(struct_parent_descr());
         let info = ctx.ensure_ptr_info_arg0(&op);
         match info {
@@ -10225,8 +10205,8 @@ mod ensure_ptr_info_arg0_tests {
         // The Box class is still Ref because the receiver position is Ref;
         // the inner i64 value just happens to be tagged Int by the trace.
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let seed_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
-        ctx.seed_constant(&Operand::from_boxref(&seed_box), Value::Int(1));
+        let seed_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.seed_constant(&seed_box, Value::Int(1));
         let op = field_op_with_parent(struct_parent_descr());
         let info = ctx.ensure_ptr_info_arg0(&op);
         assert!(matches!(info, EnsuredPtrInfo::Constant { .. }));
@@ -10240,8 +10220,8 @@ mod ensure_ptr_info_arg0_tests {
     fn ensure_ptr_info_arg0_constant_string_returns_exact_length_via_resolver() {
         use std::sync::Arc;
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let seed_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
-        ctx.seed_constant(&Operand::from_boxref(&seed_box), Value::Ref(GcRef(0xC0FE)));
+        let seed_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0xC0FE)));
         // Resolver pretends every constant has byte-string length 5 in
         // mode_string and unicode length 7 in mode_unicode.
         ctx.string_length_resolver = Some(Arc::new(|gcref: GcRef, mode: u8| {
@@ -10287,8 +10267,8 @@ mod ensure_ptr_info_arg0_tests {
     fn ensure_ptr_info_arg0_constant_string_falls_back_to_nonnegative_without_resolver() {
         use std::sync::Arc;
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let seed_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
-        ctx.seed_constant(&Operand::from_boxref(&seed_box), Value::Ref(GcRef(0x1234)));
+        let seed_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0x1234)));
         let op = {
             let descr: DescrRef = Arc::new(TestSizeDescr {
                 index: 1,
@@ -10370,8 +10350,8 @@ mod ensure_ptr_info_arg0_tests {
     #[test]
     fn ensure_ptr_info_arg0_constant_arraylen_returns_nonnegative() {
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let seed_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
-        ctx.seed_constant(&Operand::from_boxref(&seed_box), Value::Ref(GcRef(0xfeed)));
+        let seed_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0xfeed)));
         let op = array_op();
         let mut info = ctx.ensure_ptr_info_arg0(&op);
         let bound = info
@@ -10424,11 +10404,8 @@ mod ensure_ptr_info_arg0_tests {
     fn ensure_ptr_info_arg0_upgrades_nonnull_to_struct() {
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
         // Pre-install a NonNullPtrInfo with a specific last_guard_pos.
-        let pos0_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
-        ctx.set_ptr_info(
-            &Operand::from_boxref(&pos0_box),
-            PtrInfo::NonNull { last_guard_pos: 7 },
-        );
+        let pos0_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
+        ctx.set_ptr_info(&pos0_box, PtrInfo::NonNull { last_guard_pos: 7 });
         let _parent = struct_parent_descr();
         let op = field_op_with_parent(_parent.clone());
         let mut info = ctx.ensure_ptr_info_arg0(&op);
@@ -10449,9 +10426,9 @@ mod ensure_ptr_info_arg0_tests {
     #[test]
     fn ensure_ptr_info_arg0_does_not_overwrite_existing_instance() {
         let mut ctx = OptContext::with_inputarg_types(4, &[Type::Ref]);
-        let pos0_box = ctx.materialize_box_at(OpRef::input_arg_ref(0));
+        let pos0_box = ctx.materialize_operand_at(OpRef::input_arg_ref(0));
         ctx.set_ptr_info(
-            &Operand::from_boxref(&pos0_box),
+            &pos0_box,
             PtrInfo::instance(Some(instance_parent_descr()), Some(0xc0de)),
         );
         let op = field_op_with_parent(struct_parent_descr());
@@ -10583,16 +10560,11 @@ mod intbound_invariant_tests {
     fn getintbound_rejects_non_int_boxes() {
         let mut ctx = OptContext::new(0);
         let opref = OpRef::ref_op(20_000);
-        let seed_box = ctx.materialize_box_at(opref);
-        ctx.seed_constant(
-            &Operand::from_boxref(&seed_box),
-            Value::Ref(GcRef(0xdead_beef)),
-        );
+        let seed_box = ctx.materialize_operand_at(opref);
+        ctx.seed_constant(&seed_box, Value::Ref(GcRef(0xdead_beef)));
         let _ = {
-            let __mb = ctx.materialize_box_at(opref);
-            ctx.getintbound_handle(&Operand::from_boxref(&__mb))
-                .borrow()
-                .clone()
+            let __mb = ctx.materialize_operand_at(opref);
+            ctx.getintbound_handle(&__mb).borrow().clone()
         };
     }
 
@@ -10712,14 +10684,11 @@ mod opt_box_env_tests {
         let mut ctx = OptContext::with_num_inputs(16, 0);
         let source = OpRef::ref_op(12);
         let target = OpRef::ref_op(21);
-        let source_box = ctx.materialize_box_at(source);
-        let target_box = ctx.materialize_box_at(target);
-        ctx.make_equal_to(
-            &Operand::from_boxref(&source_box),
-            &Operand::from_boxref(&target_box),
-        );
+        let source_box = ctx.materialize_operand_at(source);
+        let target_box = ctx.materialize_operand_at(target);
+        ctx.make_equal_to(&source_box, &target_box);
         ctx.set_ptr_info(
-            &Operand::from_boxref(&target_box),
+            &target_box,
             PtrInfo::Virtual(VirtualInfo {
                 descr: Arc::new(DummySizeDescr),
                 known_class: Some(0x1234),

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -8007,8 +8007,8 @@ impl OptContext {
         // Resolve the position to its canonical box, then delegate to the
         // box-native form. `get_box_replacement_box` returns `None` for an
         // unresolved position (the old `and_then`/`_ => return None` arm).
-        let op = self.get_box_replacement_box(opref)?;
-        self.get_const_info_mut_if_exists_box(&Operand::from_boxref(&op))
+        let op = self.get_box_replacement_operand_opt(opref)?;
+        self.get_const_info_mut_if_exists_box(&op)
     }
 
     /// info.py:715-726 `ConstPtrInfo._get_info(descr, optheap)` parity.
@@ -8026,8 +8026,8 @@ impl OptContext {
     ) -> Option<&mut crate::optimizeopt::info::PtrInfo> {
         // Resolve the position to its canonical box, then delegate to the
         // box-native form.
-        let op = self.get_box_replacement_box(opref)?;
-        self.get_const_info_mut_box(&Operand::from_boxref(&op), parent_descr)
+        let op = self.get_box_replacement_operand_opt(opref)?;
+        self.get_const_info_mut_box(&op, parent_descr)
     }
 
     /// Box-native form of `get_const_info_mut_if_exists`: the caller already
@@ -8113,8 +8113,8 @@ impl OptContext {
     ) -> Option<&mut crate::optimizeopt::info::PtrInfo> {
         // Resolve the position to its canonical box, then delegate to the
         // box-native form.
-        let op = self.get_box_replacement_box(opref)?;
-        self.get_const_info_array_mut_box(&Operand::from_boxref(&op), descr)
+        let op = self.get_box_replacement_operand_opt(opref)?;
+        self.get_const_info_array_mut_box(&op, descr)
     }
 
     /// Box-native form of `get_const_info_array_mut` (info.py:728-735

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2878,8 +2878,8 @@ impl Optimizer {
                         // allowing Ref -> Float/Int type substitution at the JUMP.
                     }
                 } else {
-                    let arg = ctx.materialize_box_at(resolved);
-                    terminal_op.setarg(i, majit_ir::operand::Operand::from_boxref(&arg));
+                    let arg = ctx.materialize_operand_at(resolved);
+                    terminal_op.setarg(i, arg);
                 }
             }
             for i in force_needed {
@@ -4432,9 +4432,9 @@ impl Optimizer {
             OpCode::SameAsI | OpCode::SameAsR | OpCode::SameAsF
         ) {
             let new = current_op.arg(0).to_opref();
-            let b_old = BoxRef::from_bound_op(op_rc);
-            let b_new = ctx.get_box_replacement(new);
-            ctx.make_equal_to(&Operand::from_boxref(&b_old), &Operand::from_boxref(&b_new));
+            let b_old = Operand::from_bound_op(op_rc);
+            let b_new = ctx.get_box_replacement_operand(new);
+            ctx.make_equal_to(&b_old, &b_new);
             return Ok(());
         }
 
@@ -5433,9 +5433,9 @@ mod tests {
                     // Replace with first arg
                     let old = op.pos.get();
                     let new = op.arg(0).to_opref();
-                    let b_old = ctx.materialize_box_at(old);
-                    let b_new = ctx.materialize_box_at(new);
-                    ctx.make_equal_to(&Operand::from_boxref(&b_old), &Operand::from_boxref(&b_new));
+                    let b_old = ctx.materialize_operand_at(old);
+                    let b_new = ctx.materialize_operand_at(new);
+                    ctx.make_equal_to(&b_old, &b_new);
                     return OptimizationResult::Remove;
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -694,7 +694,7 @@ impl Optimizer {
                 &format!("import_virtual_state_value {opref:?} <= {info:?}"),
             );
         }
-        Self::apply_imported_virtual_state(info, &Operand::from_boxref(&box_), ctx);
+        Self::apply_imported_virtual_state(info, &box_, ctx);
         opref
     }
 
@@ -1216,7 +1216,7 @@ impl Optimizer {
                     .collect();
                 let _ = field_descrs; // descr.all_fielddescrs() is authoritative
                 ctx.set_ptr_info(
-                    &Operand::from_boxref(&head_box),
+                    &head_box,
                     crate::optimizeopt::info::PtrInfo::Virtual(
                         crate::optimizeopt::info::VirtualInfo {
                             descr: descr.clone(),
@@ -1249,7 +1249,7 @@ impl Optimizer {
                     })
                     .collect();
                 ctx.set_ptr_info(
-                    &Operand::from_boxref(&head_box),
+                    &head_box,
                     crate::optimizeopt::info::PtrInfo::VirtualArray(
                         crate::optimizeopt::info::VirtualArrayInfo {
                             descr: descr.clone(),
@@ -1286,7 +1286,7 @@ impl Optimizer {
                     .collect();
                 let _ = field_descrs; // descr.all_fielddescrs() is authoritative
                 ctx.set_ptr_info(
-                    &Operand::from_boxref(&head_box),
+                    &head_box,
                     crate::optimizeopt::info::PtrInfo::VirtualStruct(
                         crate::optimizeopt::info::VirtualStructInfo {
                             descr: descr.clone(),
@@ -1326,7 +1326,7 @@ impl Optimizer {
                     })
                     .collect();
                 ctx.set_ptr_info(
-                    &Operand::from_boxref(&head_box),
+                    &head_box,
                     crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(
                         crate::optimizeopt::info::ArrayStructInfo {
                             descr: descr.clone(),
@@ -2688,7 +2688,7 @@ impl Optimizer {
                         let b_source = ctx
                             .get_box_replacement_operand_opt(source)
                             .expect("Phase 2 source inputarg must have a materialized BoxRef slot");
-                        ctx.make_equal_to(&b_source, &Operand::from_boxref(&b_fresh));
+                        ctx.make_equal_to(&b_source, &b_fresh);
                         fresh
                     } else {
                         source
@@ -3115,13 +3115,10 @@ impl Optimizer {
                                         // bound box up front and forward it to the
                                         // original field box.
                                         let (ff, b_ff) = ctx.reserve_virtual_box(tp);
-                                        let b_orig = ctx.get_box_replacement(orig_field);
-                                        ctx.make_equal_to(
-                                            &Operand::from_boxref(&b_ff),
-                                            &Operand::from_boxref(&b_orig),
-                                        );
+                                        let b_orig = ctx.get_box_replacement_operand(orig_field);
+                                        ctx.make_equal_to(&b_ff, &b_orig);
                                         let _ = ff;
-                                        field.1 = Operand::from_boxref(&b_ff);
+                                        field.1 = b_ff;
                                     }
                                     crate::optimizeopt::info::PtrInfo::Virtual(vinfo)
                                 }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2889,11 +2889,11 @@ impl Optimizer {
                 // terminal, materializing the host when the forced position
                 // has no producer yet (mirrors the materialize_box_at arm
                 // above; never a position-only fabrication).
-                let b_forced = match ctx.get_box_replacement_box(forced) {
+                let b_forced = match ctx.get_box_replacement_operand_opt(forced) {
                     Some(b) => b,
-                    None => ctx.materialize_box_at(forced),
+                    None => ctx.materialize_operand_at(forced),
                 };
-                terminal_op.setarg(i, majit_ir::operand::Operand::from_boxref(&b_forced));
+                terminal_op.setarg(i, b_forced);
             }
             if self.skip_flush {
                 // flush=False: store for caller to consume.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -980,17 +980,14 @@ impl Optimizer {
                         .get_box_replacement_operand_opt(field_ref)
                         .as_ref()
                         .map_or(false, |b| ctx.is_virtual(b));
+                    let field_is_const = ctx
+                        .get_box_replacement_operand_opt(field_ref)
+                        .and_then(|cb| cb.const_value())
+                        .is_some();
                     if ctx.skip_flush_mode
                         && !field_ref.is_none()
-                        && !ctx
-                            .get_box_replacement_operand_opt(field_ref)
-                            .and_then(|cb| cb.const_value())
-                            .is_some()
+                        && !field_is_const
                         && !field_is_virtual
-                        && ctx
-                            .get_box_replacement_operand_opt(field_ref)
-                            .and_then(|cb| cb.const_value())
-                            .is_none()
                     {
                         same_as_targets.push((field_ref, entries.len(), field_idx));
                     }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5684,15 +5684,9 @@ mod tests {
                 self.queued = true;
 
                 let alloc = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
-                let alloc_box = ctx.materialize_box_at(alloc);
-                let value = ctx.materialize_box_at(OpRef::int_op(0));
-                let mut set = Op::new(
-                    OpCode::SetfieldGc,
-                    &[
-                        Operand::from_boxref(&alloc_box),
-                        Operand::from_boxref(&value),
-                    ],
-                );
+                let alloc_box = ctx.materialize_operand_at(alloc);
+                let value = ctx.materialize_operand_at(OpRef::int_op(0));
+                let mut set = Op::new(OpCode::SetfieldGc, &[alloc_box, value]);
                 set.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set);
             }
@@ -6410,28 +6404,16 @@ mod tests {
                 self.queued = true;
 
                 let alloc_a = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
-                let alloc_a_box = ctx.materialize_box_at(alloc_a);
-                let value_a = ctx.materialize_box_at(OpRef::int_op(0));
-                let mut set_a = Op::new(
-                    OpCode::SetfieldGc,
-                    &[
-                        Operand::from_boxref(&alloc_a_box),
-                        Operand::from_boxref(&value_a),
-                    ],
-                );
+                let alloc_a_box = ctx.materialize_operand_at(alloc_a);
+                let value_a = ctx.materialize_operand_at(OpRef::int_op(0));
+                let mut set_a = Op::new(OpCode::SetfieldGc, &[alloc_a_box, value_a]);
                 set_a.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set_a);
 
                 let alloc_b = ctx.emit_extra(ctx.current_pass_idx, Op::new(OpCode::New, &[]));
-                let alloc_b_box = ctx.materialize_box_at(alloc_b);
-                let value_b = ctx.materialize_box_at(OpRef::int_op(1));
-                let mut set_b = Op::new(
-                    OpCode::SetfieldGc,
-                    &[
-                        Operand::from_boxref(&alloc_b_box),
-                        Operand::from_boxref(&value_b),
-                    ],
-                );
+                let alloc_b_box = ctx.materialize_operand_at(alloc_b);
+                let value_b = ctx.materialize_operand_at(OpRef::int_op(1));
+                let mut set_b = Op::new(OpCode::SetfieldGc, &[alloc_b_box, value_b]);
                 set_b.setdescr(self.field_descr.clone());
                 ctx.emit_extra(ctx.current_pass_idx, set_b);
             }
@@ -6840,22 +6822,22 @@ mod tests {
         // for the test, every slot uses Ref to match the producer-side shape
         // (`inputarg_from_tp` per opencoder.py:259 with all Ref args).
         let mut ctx = OptContext::with_inputarg_types(32, &vec![Type::Ref; 1024]);
-        let b10 = ctx.materialize_box_at(OpRef::int_op(10));
+        let b10 = ctx.materialize_operand_at(OpRef::int_op(10));
         ctx.set_ptr_info(
-            &Operand::from_boxref(&b10),
+            &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(1, Operand::from_boxref(&rooted_resop_box(Type::Int, 11)))],
+                fields: vec![(1, rooted_resop_operand(Type::Int, 11))],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
         );
-        let b11 = ctx.materialize_box_at(OpRef::int_op(11));
-        let b20 = ctx.materialize_box_at(OpRef::int_op(20));
-        ctx.make_equal_to(&Operand::from_boxref(&b11), &Operand::from_boxref(&b20));
-        let b20 = ctx.materialize_box_at(OpRef::int_op(20));
+        let b11 = ctx.materialize_operand_at(OpRef::int_op(11));
+        let b20 = ctx.materialize_operand_at(OpRef::int_op(20));
+        ctx.make_equal_to(&b11, &b20);
+        let b20 = ctx.materialize_operand_at(OpRef::int_op(20));
         ctx.set_ptr_info(
-            &Operand::from_boxref(&b20),
+            &b20,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
                 fields: Vec::new(),
@@ -6900,17 +6882,17 @@ mod tests {
                 .with_all_fielddescrs(vec![field_descr_typed]),
         );
         let mut ctx = OptContext::with_inputarg_types(16, &[Type::Ref]);
-        let b10 = ctx.materialize_box_at(OpRef::ref_op(10));
+        let b10 = ctx.materialize_operand_at(OpRef::ref_op(10));
         // The field value box is materialized THROUGH the context so it binds
         // to the context's producer host; force_box's `resolve_box_box` then
         // resolves it to a bound box (sheds to Operand::Op), not a fresh
         // position-only `from_opref` box.
-        let field_value = ctx.materialize_box_at(OpRef::int_op(11));
+        let field_value = ctx.materialize_operand_at(OpRef::int_op(11));
         ctx.set_ptr_info(
-            &Operand::from_boxref(&b10),
+            &b10,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
-                fields: vec![(0, Operand::from_boxref(&field_value))],
+                fields: vec![(0, field_value)],
                 last_guard_pos: -1,
                 avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
             }),
@@ -6919,9 +6901,7 @@ mod tests {
         let mut opt = Optimizer::new();
         let op = Op::new(
             OpCode::GuardNonnull,
-            &[Operand::from_boxref(
-                &ctx.materialize_box_at(OpRef::ref_op(10)),
-            )],
+            &[ctx.materialize_operand_at(OpRef::ref_op(10))],
         );
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&op));

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1071,9 +1071,9 @@ impl Optimizer {
         let mut installed_heads: majit_ir::vec_set::VecSet<majit_ir::operand::Operand> =
             majit_ir::vec_set::VecSet::new();
         for entry in entries {
-            let head_box = ctx.get_box_replacement_box(entry.head);
+            let head_box = ctx.get_box_replacement_operand_opt(entry.head);
             if let Some(hk) = &head_box {
-                let head_key = majit_ir::operand::Operand::from_boxref(hk);
+                let head_key = hk.clone();
                 if installed_heads.contains(&head_key) {
                     continue;
                 }
@@ -1094,7 +1094,7 @@ impl Optimizer {
                             .map(|(i, r)| (*i, ctx.materialize_operand_at(*r)))
                             .collect();
                         ctx.set_ptr_info(
-                            &Operand::from_boxref(b),
+                            b,
                             crate::optimizeopt::info::PtrInfo::Virtual(
                                 crate::optimizeopt::info::VirtualInfo {
                                     descr: entry.size_descr,
@@ -1116,7 +1116,7 @@ impl Optimizer {
                             .map(|(i, r)| (*i, ctx.materialize_operand_at(*r)))
                             .collect();
                         ctx.set_ptr_info(
-                            &Operand::from_boxref(b),
+                            b,
                             crate::optimizeopt::info::PtrInfo::VirtualStruct(
                                 crate::optimizeopt::info::VirtualStructInfo {
                                     descr: entry.size_descr,
@@ -1856,7 +1856,10 @@ impl Optimizer {
             // virtual (no allocation to emit); it just tracks field state
             // for the standard frame. Calling force_box on it would destroy
             // the tracked state via take_ptr_info.
-            if resolved_op.as_ref().map_or(false, |b| ctx.is_virtualizable(b)) {
+            if resolved_op
+                .as_ref()
+                .map_or(false, |b| ctx.is_virtualizable(b))
+            {
                 return resolved;
             }
             // RPython: info.force_box() sets _is_virtual=False in-place.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1851,31 +1851,23 @@ impl Optimizer {
                 }
             }
         }
-        let resolved_box = ctx.get_box_replacement_box(opref);
-        if resolved_box
-            .as_ref()
-            .map_or(false, |b| ctx.is_virtual(&Operand::from_boxref(b)))
-        {
+        let resolved_op = ctx.get_box_replacement_operand_opt(opref);
+        if resolved_op.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             // Virtualizable represents an existing heap object with tracked
             // fields — not a deferred allocation. force_box must not take
             // its PtrInfo. RPython parity: Virtualizable is never a "true"
             // virtual (no allocation to emit); it just tracks field state
             // for the standard frame. Calling force_box on it would destroy
             // the tracked state via take_ptr_info.
-            if resolved_box
-                .as_ref()
-                .map_or(false, |b| ctx.is_virtualizable(&Operand::from_boxref(b)))
-            {
+            if resolved_op.as_ref().map_or(false, |b| ctx.is_virtualizable(b)) {
                 return resolved;
             }
             // RPython: info.force_box() sets _is_virtual=False in-place.
             // Take ownership so the Virtual PtrInfo is removed. force_box_impl
             // installs a non-virtual (Instance/Struct) at the alloc_ref.
-            let resolved_box = resolved_box.expect("recorder-populated");
-            let mut info = ctx
-                .take_ptr_info(&Operand::from_boxref(&resolved_box))
-                .unwrap();
-            let forced = info.force_box(resolved_box, ctx);
+            let resolved_op = resolved_op.expect("recorder-populated");
+            let mut info = ctx.take_ptr_info(&resolved_op).unwrap();
+            let forced = info.force_box(&resolved_op, ctx);
             return ctx.get_replacement_opref(forced);
         }
         resolved

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -913,7 +913,7 @@ impl Optimization for OptPure {
                 // with the preamble's cached result.
                 if let Some(cached_ref) = self.force_preamble_op(&postponed, ctx) {
                     let b_old = Operand::from_boxref(&postponed_box);
-                    let b_cached = Operand::from_boxref(&ctx.get_box_replacement(cached_ref));
+                    let b_cached = ctx.get_box_replacement_operand(cached_ref);
                     ctx.make_equal_to(&b_old, &b_cached);
                     self.last_emitted_was_removed = true;
                     return OptimizationResult::Remove; // guard also removed
@@ -927,7 +927,7 @@ impl Optimization for OptPure {
                 if let Some(cached_ref) = self.lookup_pure(&key, ctx) {
                     if Self::_can_reuse_oldop(postponed.opcode, postponed.opcode, true) {
                         let b_old = Operand::from_boxref(&postponed_box);
-                        let b_cached = Operand::from_boxref(&ctx.get_box_replacement(cached_ref));
+                        let b_cached = ctx.get_box_replacement_operand(cached_ref);
                         ctx.make_equal_to(&b_old, &b_cached);
                         self.last_emitted_was_removed = true;
                         return OptimizationResult::Remove; // guard also removed
@@ -1063,7 +1063,7 @@ impl Optimization for OptPure {
 
             if let Some(cached_ref) = self.force_preamble_op(op, ctx) {
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_cached = Operand::from_boxref(&ctx.get_box_replacement(cached_ref));
+                let b_cached = ctx.get_box_replacement_operand(cached_ref);
                 ctx.make_equal_to(&b_old, &b_cached);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;
@@ -1124,7 +1124,7 @@ impl Optimization for OptPure {
                     ) {
                         let cached_src = old_op.pos.get();
                         let b_old = Operand::from_bound_op(op_rc);
-                        let b_cached = Operand::from_boxref(&ctx.get_box_replacement(cached_src));
+                        let b_cached = ctx.get_box_replacement_operand(cached_src);
                         ctx.make_equal_to(&b_old, &b_cached);
                         self.last_emitted_was_removed = true;
                         return OptimizationResult::Remove;
@@ -1181,7 +1181,7 @@ impl Optimization for OptPure {
                     }
                 };
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_cached = Operand::from_boxref(&ctx.get_box_replacement(entry_result));
+                let b_cached = ctx.get_box_replacement_operand(entry_result);
                 ctx.make_equal_to(&b_old, &b_cached);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;
@@ -1189,7 +1189,7 @@ impl Optimization for OptPure {
             // pure.py:211-220: known_result_call_pure.
             if let Some(result_ref) = self.lookup_known_result(op, start_index, ctx) {
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_result = Operand::from_boxref(&ctx.get_box_replacement(result_ref));
+                let b_result = ctx.get_box_replacement_operand(result_ref);
                 ctx.make_equal_to(&b_old, &b_result);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1361,8 +1361,7 @@ mod tests {
                 .and_then(|b| b.produced_short_op(&source_box.clone()))
                 .map(|p| p.preamble_op)
                 .unwrap_or_else(|| {
-                    let mut same_as =
-                        Op::new(OpCode::SameAsI, &[source_box.clone()]);
+                    let mut same_as = Op::new(OpCode::SameAsI, &[source_box.clone()]);
                     same_as.pos.set(source);
                     std::rc::Rc::new(same_as)
                 });
@@ -1807,20 +1806,14 @@ mod tests {
         let b = crate::history::test_support::rooted_inputarg_operand(Type::Int, 1);
 
         // Simulate: op0 = int_add(a, b)
-        let op0 = Op::new(
-            OpCode::IntAdd,
-            &[a.clone(), b.clone()],
-        );
+        let op0 = Op::new(OpCode::IntAdd, &[a.clone(), b.clone()]);
         let mut op0 = op0;
         op0.pos.set(OpRef::int_op(2));
         let result0 = pass.propagate_forward(&op0, &std::rc::Rc::new(op0.clone()), &mut ctx);
         assert!(matches!(result0, OptimizationResult::PassOn));
 
         // Simulate: op1 = int_add(a, b) with same args
-        let op1 = Op::new(
-            OpCode::IntAdd,
-            &[a.clone(), b.clone()],
-        );
+        let op1 = Op::new(OpCode::IntAdd, &[a.clone(), b.clone()]);
         let mut op1 = op1;
         op1.pos.set(OpRef::int_op(3));
         let result1 = pass.propagate_forward(&op1, &std::rc::Rc::new(op1.clone()), &mut ctx);
@@ -2375,10 +2368,7 @@ mod tests {
 
         let mut q = Op::new(
             OpCode::IntAdd,
-            &[
-                Operand::const_from_value(Value::Int(5)),
-                x_box.clone(),
-            ],
+            &[Operand::const_from_value(Value::Int(5)), x_box.clone()],
         );
         q.pos.set(OpRef::int_op(99));
         assert_eq!(
@@ -2390,10 +2380,7 @@ mod tests {
         // A non-constant slot mismatch must still miss.
         let mut q_miss = Op::new(
             OpCode::IntAdd,
-            &[
-                Operand::const_from_value(Value::Int(5)),
-                x8_box.clone(),
-            ],
+            &[Operand::const_from_value(Value::Int(5)), x8_box.clone()],
         );
         q_miss.pos.set(OpRef::int_op(100));
         assert_eq!(pass.get_pure_result(&q_miss, &ctx), None);
@@ -2412,23 +2399,14 @@ mod tests {
         let result = OpRef::int_op(42);
         let b_query = ctx.materialize_operand_at(query_arg);
         let b_canonical = ctx.materialize_operand_at(canonical_arg);
-        ctx.make_equal_to(
-            &b_query.clone(),
-            &b_canonical.clone(),
-        );
+        ctx.make_equal_to(&b_query.clone(), &b_canonical.clone());
         let b_other = ctx.materialize_operand_at(other_arg);
 
         pass.pure_from_args2(OpCode::IntAdd, canonical_arg, other_arg, result);
 
         // Query op carries the canonical ctx boxes (query_arg forwards to
         // canonical_arg via make_equal_to) — no position-only mint.
-        let mut q = Op::new(
-            OpCode::IntAdd,
-            &[
-                b_query.clone(),
-                b_other.clone(),
-            ],
-        );
+        let mut q = Op::new(OpCode::IntAdd, &[b_query.clone(), b_other.clone()]);
         q.pos.set(OpRef::int_op(99));
         assert_eq!(
             pass.get_pure_result(&q, &ctx),
@@ -2450,18 +2428,12 @@ mod tests {
         let b40 = ctx.materialize_operand_at(OpRef::int_op(40));
 
         // Manually record a pure operation via the API
-        let mut op = Op::new(
-            OpCode::IntAdd,
-            &[b10.clone(), b20.clone()],
-        );
+        let mut op = Op::new(OpCode::IntAdd, &[b10.clone(), b20.clone()]);
         op.pos.set(OpRef::int_op(0));
         pass.pure(&op);
 
         // Should find it via get_pure_result
-        let lookup_op = Op::new(
-            OpCode::IntAdd,
-            &[b10.clone(), b20.clone()],
-        );
+        let lookup_op = Op::new(OpCode::IntAdd, &[b10.clone(), b20.clone()]);
         assert!(pass.get_pure_result(&lookup_op, &ctx).is_some());
 
         // pure_from_args
@@ -2470,10 +2442,7 @@ mod tests {
             &[OpRef::int_op(30), OpRef::int_op(40)],
             OpRef::int_op(5),
         );
-        let mut lookup_mul = Op::new(
-            OpCode::IntMul,
-            &[b30.clone(), b40.clone()],
-        );
+        let mut lookup_mul = Op::new(OpCode::IntMul, &[b30.clone(), b40.clone()]);
         lookup_mul.pos.set(OpRef::int_op(99));
         assert!(pass.get_pure_result(&lookup_mul, &ctx).is_some());
     }
@@ -2522,10 +2491,7 @@ mod tests {
         });
 
         // CALL_PURE lookup: start_index=0, descr matches (both None), args match
-        let op = Op::new(
-            OpCode::CallPureI,
-            &[b100.clone(), b101.clone()],
-        );
+        let op = Op::new(OpCode::CallPureI, &[b100.clone(), b101.clone()]);
         assert_eq!(
             pass.lookup_known_result(&op, 0, &ctx),
             Some(OpRef::int_op(50))
@@ -2534,11 +2500,7 @@ mod tests {
         // COND_CALL_VALUE lookup: start_index=1, skip arg(0)
         let cond_op = Op::new(
             OpCode::CondCallValueI,
-            &[
-                b999.clone(),
-                b100.clone(),
-                b101.clone(),
-            ],
+            &[b999.clone(), b100.clone(), b101.clone()],
         );
         assert_eq!(
             pass.lookup_known_result(&cond_op, 1, &ctx),
@@ -2546,10 +2508,7 @@ mod tests {
         );
 
         // Args mismatch → None
-        let bad_args = Op::new(
-            OpCode::CallPureI,
-            &[b100.clone(), b999.clone()],
-        );
+        let bad_args = Op::new(OpCode::CallPureI, &[b100.clone(), b999.clone()]);
         assert_eq!(pass.lookup_known_result(&bad_args, 0, &ctx), None);
     }
 
@@ -2673,10 +2632,7 @@ mod tests {
 
         let mut op = Op::new(
             OpCode::CallPureI,
-            &[
-                Operand::const_from_value(Value::Int(0x1234)),
-                arg0.clone(),
-            ],
+            &[Operand::const_from_value(Value::Int(0x1234)), arg0.clone()],
         );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(call_descr);
@@ -2703,10 +2659,7 @@ mod tests {
 
         let a0 = ctx.materialize_operand_at(OpRef::int_op(0));
         let a1 = ctx.materialize_operand_at(OpRef::int_op(1));
-        let mut op = Op::new(
-            OpCode::IntAdd,
-            &[a0.clone(), a1.clone()],
-        );
+        let mut op = Op::new(OpCode::IntAdd, &[a0.clone(), a1.clone()]);
         op.pos.set(OpRef::int_op(2));
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
         assert!(matches!(result, OptimizationResult::PassOn));
@@ -2745,14 +2698,7 @@ mod tests {
         let a100 = ctx.materialize_operand_at(OpRef::int_op(100));
         let a0 = ctx.materialize_operand_at(OpRef::int_op(0));
         let a1 = ctx.materialize_operand_at(OpRef::int_op(1));
-        let mut op = Op::new(
-            OpCode::CallPureI,
-            &[
-                a100.clone(),
-                a0.clone(),
-                a1.clone(),
-            ],
-        );
+        let mut op = Op::new(OpCode::CallPureI, &[a100.clone(), a0.clone(), a1.clone()]);
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(
             vec![
@@ -2804,18 +2750,12 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(6, 0);
         // func pointer arg must be a known constant for OptRewrite tracking
         let func_box = ctx.materialize_operand_at(OpRef::int_op(100));
-        ctx.seed_constant(
-            &func_box.clone(),
-            majit_ir::Value::Int(0xCAFE),
-        );
+        ctx.seed_constant(&func_box.clone(), majit_ir::Value::Int(0xCAFE));
         rewrite.setup();
         pass.setup();
 
         let a0 = ctx.materialize_operand_at(OpRef::int_op(0));
-        let mut op = Op::new(
-            OpCode::CallLoopinvariantI,
-            &[func_box.clone(), a0.clone()],
-        );
+        let mut op = Op::new(OpCode::CallLoopinvariantI, &[func_box.clone(), a0.clone()]);
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(
             vec![majit_ir::Type::Int, majit_ir::Type::Int],

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -316,7 +316,7 @@ pub struct OptPure {
     /// is never bound by the emit path; capturing it here (where the op
     /// object is live) gives `make_equal_to` a bound receiver without an
     /// `materialize_box_at` round-trip through the opref.
-    postponed_box: Option<majit_ir::box_ref::BoxRef>,
+    postponed_box: Option<Operand>,
     /// Indices into new_operations of emitted CALL_PURE ops.
     /// pure.py: call_pure_positions — tracked for short preamble generation.
     call_pure_positions: Vec<usize>,
@@ -878,7 +878,7 @@ impl Optimization for OptPure {
         // GUARD_NO_OVERFLOW, so we can try CSE on the OVF op + guard pair.
         if op.opcode.is_ovf() {
             self.postponed_op = Some(op.clone());
-            self.postponed_box = Some(BoxRef::from_bound_op(op_rc));
+            self.postponed_box = Some(Operand::from_bound_op(op_rc));
             return OptimizationResult::Remove;
         }
 
@@ -912,7 +912,7 @@ impl Optimization for OptPure {
                 // pure.py:50-55: force_preamble_op replaces the OVF op
                 // with the preamble's cached result.
                 if let Some(cached_ref) = self.force_preamble_op(&postponed, ctx) {
-                    let b_old = Operand::from_boxref(&postponed_box);
+                    let b_old = postponed_box.clone();
                     let b_cached = ctx.get_box_replacement_operand(cached_ref);
                     ctx.make_equal_to(&b_old, &b_cached);
                     self.last_emitted_was_removed = true;
@@ -926,7 +926,7 @@ impl Optimization for OptPure {
                 let key = PureOpKey::from_op(&postponed);
                 if let Some(cached_ref) = self.lookup_pure(&key, ctx) {
                     if Self::_can_reuse_oldop(postponed.opcode, postponed.opcode, true) {
-                        let b_old = Operand::from_boxref(&postponed_box);
+                        let b_old = postponed_box.clone();
                         let b_cached = ctx.get_box_replacement_operand(cached_ref);
                         ctx.make_equal_to(&b_old, &b_cached);
                         self.last_emitted_was_removed = true;

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -803,7 +803,7 @@ impl OptPure {
         if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
-            let forced = info.force_box(resolved_box.to_boxref(), ctx);
+            let forced = info.force_box(&resolved_box, ctx);
             return ctx
                 .get_box_replacement_box(forced)
                 .map(|b| b.to_opref())

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1349,7 +1349,7 @@ mod tests {
         // imported short preamble path does after unroll import.
         if source != OpRef::NONE {
             // PreambleOp.op carries the Box itself (shortpreamble.py:12).
-            let source_box = ctx.materialize_box_at(source);
+            let source_box = ctx.materialize_operand_at(source);
             // Production threads the builder's replay Rc into the pop
             // (produce_op family); mirror that here so use_box receives
             // the same object the builder entry carries. The builder keys by
@@ -1358,16 +1358,16 @@ mod tests {
             let replay = ctx
                 .imported_short_preamble_builder
                 .as_ref()
-                .and_then(|b| b.produced_short_op(&Operand::from_boxref(&source_box)))
+                .and_then(|b| b.produced_short_op(&source_box.clone()))
                 .map(|p| p.preamble_op)
                 .unwrap_or_else(|| {
                     let mut same_as =
-                        Op::new(OpCode::SameAsI, &[Operand::from_boxref(&source_box)]);
+                        Op::new(OpCode::SameAsI, &[source_box.clone()]);
                     same_as.pos.set(source);
                     std::rc::Rc::new(same_as)
                 });
             let pop = crate::optimizeopt::info::PreambleOp {
-                op: source_box,
+                op: ctx.materialize_box_at(source),
                 invented_name: false,
                 preamble_op: replay,
                 // Non-invented imported pure re-export: no SameAs alias.
@@ -1803,13 +1803,13 @@ mod tests {
         // Production binds the input operands a, b before the int_add is
         // processed; bind bound InputArg boxes here and reuse them across both
         // ops so same_box resolves both ops' args to one shared identity.
-        let a = crate::history::test_support::rooted_inputarg_box(Type::Int, 0);
-        let b = crate::history::test_support::rooted_inputarg_box(Type::Int, 1);
+        let a = crate::history::test_support::rooted_inputarg_operand(Type::Int, 0);
+        let b = crate::history::test_support::rooted_inputarg_operand(Type::Int, 1);
 
         // Simulate: op0 = int_add(a, b)
         let op0 = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&a), Operand::from_boxref(&b)],
+            &[a.clone(), b.clone()],
         );
         let mut op0 = op0;
         op0.pos.set(OpRef::int_op(2));
@@ -1819,7 +1819,7 @@ mod tests {
         // Simulate: op1 = int_add(a, b) with same args
         let op1 = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&a), Operand::from_boxref(&b)],
+            &[a.clone(), b.clone()],
         );
         let mut op1 = op1;
         op1.pos.set(OpRef::int_op(3));
@@ -2369,15 +2369,15 @@ mod tests {
         // Cache `IntAdd(c5_a, x)` and look up `IntAdd(c5_b, x)`. `x` is the
         // canonical box materialized in ctx; the constants are Const operands.
         let x = OpRef::int_op(7);
-        let x_box = ctx.materialize_box_at(x);
-        let x8_box = ctx.materialize_box_at(OpRef::int_op(8));
+        let x_box = ctx.materialize_operand_at(x);
+        let x8_box = ctx.materialize_operand_at(OpRef::int_op(8));
         pass.pure_from_args2(OpCode::IntAdd, c5_a, x, OpRef::int_op(42));
 
         let mut q = Op::new(
             OpCode::IntAdd,
             &[
                 Operand::const_from_value(Value::Int(5)),
-                Operand::from_boxref(&x_box),
+                x_box.clone(),
             ],
         );
         q.pos.set(OpRef::int_op(99));
@@ -2392,7 +2392,7 @@ mod tests {
             OpCode::IntAdd,
             &[
                 Operand::const_from_value(Value::Int(5)),
-                Operand::from_boxref(&x8_box),
+                x8_box.clone(),
             ],
         );
         q_miss.pos.set(OpRef::int_op(100));
@@ -2410,13 +2410,13 @@ mod tests {
         let canonical_arg = OpRef::int_op(8);
         let other_arg = OpRef::int_op(9);
         let result = OpRef::int_op(42);
-        let b_query = ctx.materialize_box_at(query_arg);
-        let b_canonical = ctx.materialize_box_at(canonical_arg);
+        let b_query = ctx.materialize_operand_at(query_arg);
+        let b_canonical = ctx.materialize_operand_at(canonical_arg);
         ctx.make_equal_to(
-            &Operand::from_boxref(&b_query),
-            &Operand::from_boxref(&b_canonical),
+            &b_query.clone(),
+            &b_canonical.clone(),
         );
-        let b_other = ctx.materialize_box_at(other_arg);
+        let b_other = ctx.materialize_operand_at(other_arg);
 
         pass.pure_from_args2(OpCode::IntAdd, canonical_arg, other_arg, result);
 
@@ -2425,8 +2425,8 @@ mod tests {
         let mut q = Op::new(
             OpCode::IntAdd,
             &[
-                Operand::from_boxref(&b_query),
-                Operand::from_boxref(&b_other),
+                b_query.clone(),
+                b_other.clone(),
             ],
         );
         q.pos.set(OpRef::int_op(99));
@@ -2444,15 +2444,15 @@ mod tests {
         let mut ctx = OptContext::new(0);
         // Bind the operand positions canonically so same_box resolves the
         // looked-up op's args to the same boxes the cache recorded.
-        let b10 = ctx.materialize_box_at(OpRef::int_op(10));
-        let b20 = ctx.materialize_box_at(OpRef::int_op(20));
-        let b30 = ctx.materialize_box_at(OpRef::int_op(30));
-        let b40 = ctx.materialize_box_at(OpRef::int_op(40));
+        let b10 = ctx.materialize_operand_at(OpRef::int_op(10));
+        let b20 = ctx.materialize_operand_at(OpRef::int_op(20));
+        let b30 = ctx.materialize_operand_at(OpRef::int_op(30));
+        let b40 = ctx.materialize_operand_at(OpRef::int_op(40));
 
         // Manually record a pure operation via the API
         let mut op = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&b10), Operand::from_boxref(&b20)],
+            &[b10.clone(), b20.clone()],
         );
         op.pos.set(OpRef::int_op(0));
         pass.pure(&op);
@@ -2460,7 +2460,7 @@ mod tests {
         // Should find it via get_pure_result
         let lookup_op = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&b10), Operand::from_boxref(&b20)],
+            &[b10.clone(), b20.clone()],
         );
         assert!(pass.get_pure_result(&lookup_op, &ctx).is_some());
 
@@ -2472,7 +2472,7 @@ mod tests {
         );
         let mut lookup_mul = Op::new(
             OpCode::IntMul,
-            &[Operand::from_boxref(&b30), Operand::from_boxref(&b40)],
+            &[b30.clone(), b40.clone()],
         );
         lookup_mul.pos.set(OpRef::int_op(99));
         assert!(pass.get_pure_result(&lookup_mul, &ctx).is_some());
@@ -2510,9 +2510,9 @@ mod tests {
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(4, 0);
         // Bind the matched call args canonically so same_box resolves them.
-        let b100 = ctx.materialize_box_at(OpRef::int_op(100));
-        let b101 = ctx.materialize_box_at(OpRef::int_op(101));
-        let b999 = ctx.materialize_box_at(OpRef::int_op(999));
+        let b100 = ctx.materialize_operand_at(OpRef::int_op(100));
+        let b101 = ctx.materialize_operand_at(OpRef::int_op(101));
+        let b999 = ctx.materialize_operand_at(OpRef::int_op(999));
 
         // pure.py:214: self.known_result_call_pure.append(op)
         pass.known_result_call_pure.push(super::KnownResultEntry {
@@ -2524,7 +2524,7 @@ mod tests {
         // CALL_PURE lookup: start_index=0, descr matches (both None), args match
         let op = Op::new(
             OpCode::CallPureI,
-            &[Operand::from_boxref(&b100), Operand::from_boxref(&b101)],
+            &[b100.clone(), b101.clone()],
         );
         assert_eq!(
             pass.lookup_known_result(&op, 0, &ctx),
@@ -2535,9 +2535,9 @@ mod tests {
         let cond_op = Op::new(
             OpCode::CondCallValueI,
             &[
-                Operand::from_boxref(&b999),
-                Operand::from_boxref(&b100),
-                Operand::from_boxref(&b101),
+                b999.clone(),
+                b100.clone(),
+                b101.clone(),
             ],
         );
         assert_eq!(
@@ -2548,7 +2548,7 @@ mod tests {
         // Args mismatch → None
         let bad_args = Op::new(
             OpCode::CallPureI,
-            &[Operand::from_boxref(&b100), Operand::from_boxref(&b999)],
+            &[b100.clone(), b999.clone()],
         );
         assert_eq!(pass.lookup_known_result(&bad_args, 0, &ctx), None);
     }
@@ -2565,8 +2565,8 @@ mod tests {
         // `is_constant()`, so the short-preamble producer re-exports the op
         // without any const_pool / known_constants bridge.
         let const_opref = OpRef::const_int(7);
-        let const_box = ctx.materialize_box_at(const_opref);
-        ctx.seed_constant(&Operand::from_boxref(&const_box), majit_ir::Value::Int(7));
+        let const_box = ctx.materialize_operand_at(const_opref);
+        ctx.seed_constant(&const_box.clone(), majit_ir::Value::Int(7));
         let imported = crate::optimizeopt::ImportedShortPureOp::new(
             &mut ctx,
             OpCode::IntAdd,
@@ -2620,7 +2620,7 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(8, 0);
         // Bind the non-const call arg position so same_box resolves the
         // dispatched op's arg to the same box the imported op recorded.
-        let arg0 = ctx.materialize_box_at(OpRef::int_op(0));
+        let arg0 = ctx.materialize_operand_at(OpRef::int_op(0));
         let const_opref = OpRef::const_int(0x1234);
         let call_descr = majit_ir::descr::make_call_descr_full(
             77,
@@ -2658,11 +2658,11 @@ mod tests {
         // (produce_pure); mirror it so use_box sees one object. #146/S8: the
         // builder keys by the entry res box (`materialize_box_at(pos)`); the
         // memoized box for the same position hits.
-        let src1 = ctx.materialize_box_at(OpRef::int_op(1));
+        let src1 = ctx.materialize_operand_at(OpRef::int_op(1));
         if let Some(p) = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(&Operand::from_boxref(&src1)))
+            .and_then(|b| b.produced_short_op(&src1.clone()))
         {
             imported.pop.preamble_op = p.preamble_op;
         }
@@ -2675,7 +2675,7 @@ mod tests {
             OpCode::CallPureI,
             &[
                 Operand::const_from_value(Value::Int(0x1234)),
-                Operand::from_boxref(&arg0),
+                arg0.clone(),
             ],
         );
         op.pos.set(OpRef::int_op(2));
@@ -2701,11 +2701,11 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(4, 0);
         pass.setup();
 
-        let a0 = ctx.materialize_box_at(OpRef::int_op(0));
-        let a1 = ctx.materialize_box_at(OpRef::int_op(1));
+        let a0 = ctx.materialize_operand_at(OpRef::int_op(0));
+        let a1 = ctx.materialize_operand_at(OpRef::int_op(1));
         let mut op = Op::new(
             OpCode::IntAdd,
-            &[Operand::from_boxref(&a0), Operand::from_boxref(&a1)],
+            &[a0.clone(), a1.clone()],
         );
         op.pos.set(OpRef::int_op(2));
         let result = pass.propagate_forward(&op, &std::rc::Rc::new(op.clone()), &mut ctx);
@@ -2742,15 +2742,15 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs(6, 0);
         pass.setup();
 
-        let a100 = ctx.materialize_box_at(OpRef::int_op(100));
-        let a0 = ctx.materialize_box_at(OpRef::int_op(0));
-        let a1 = ctx.materialize_box_at(OpRef::int_op(1));
+        let a100 = ctx.materialize_operand_at(OpRef::int_op(100));
+        let a0 = ctx.materialize_operand_at(OpRef::int_op(0));
+        let a1 = ctx.materialize_operand_at(OpRef::int_op(1));
         let mut op = Op::new(
             OpCode::CallPureI,
             &[
-                Operand::from_boxref(&a100),
-                Operand::from_boxref(&a0),
-                Operand::from_boxref(&a1),
+                a100.clone(),
+                a0.clone(),
+                a1.clone(),
             ],
         );
         op.pos.set(OpRef::int_op(2));
@@ -2803,18 +2803,18 @@ mod tests {
         let mut pass = OptPure::new();
         let mut ctx = OptContext::with_num_inputs(6, 0);
         // func pointer arg must be a known constant for OptRewrite tracking
-        let func_box = ctx.materialize_box_at(OpRef::int_op(100));
+        let func_box = ctx.materialize_operand_at(OpRef::int_op(100));
         ctx.seed_constant(
-            &Operand::from_boxref(&func_box),
+            &func_box.clone(),
             majit_ir::Value::Int(0xCAFE),
         );
         rewrite.setup();
         pass.setup();
 
-        let a0 = ctx.materialize_box_at(OpRef::int_op(0));
+        let a0 = ctx.materialize_operand_at(OpRef::int_op(0));
         let mut op = Op::new(
             OpCode::CallLoopinvariantI,
-            &[Operand::from_boxref(&func_box), Operand::from_boxref(&a0)],
+            &[func_box.clone(), a0.clone()],
         );
         op.pos.set(OpRef::int_op(2));
         op.setdescr(majit_ir::descr::make_call_descr(

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1127,9 +1127,7 @@ impl OptRewrite {
                     let shiftvar = ctx.resolve_operand_box(&shift_op.arg(1)).to_opref();
                     let shiftbound = {
                         let b = ctx.get_box_replacement_operand(shiftvar);
-                        ctx.getintbound_handle(&b)
-                            .borrow()
-                            .clone()
+                        ctx.getintbound_handle(&b).borrow().clone()
                     };
                     if shiftbound.known_nonnegative() && shiftbound.known_lt_const(63) {
                         let arg_shift = ctx.materialize_operand_at(shiftvar);
@@ -2369,12 +2367,11 @@ mod tests {
     fn build_specs(specs: &[OpSpec]) -> Vec<majit_ir::OpRc> {
         let mut ops: Vec<majit_ir::OpRc> = Vec::new();
         for (pos, spec) in specs.iter().enumerate() {
-            let args: Vec<BoxRef> = spec
+            let arg_ops: Vec<Operand> = spec
                 .args
                 .iter()
-                .map(|&p| BoxRef::from_bound_op(&ops[p as usize]))
+                .map(|&p| Operand::from_bound_op(&ops[p as usize]))
                 .collect();
-            let arg_ops: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
             let op = std::rc::Rc::new(Op::new(spec.opcode, &arg_ops));
             op.pos
                 .set(OpRef::op_typed(pos as u32, spec.opcode.result_type()));
@@ -3488,20 +3485,24 @@ mod tests {
         // a live producer, and GUARD_VALUE's expected operand is the literal
         // ConstInt(0) — so every arg sheds to Operand::{InputArg,Op,Const}.
         use crate::history::test_support::bound_inputarg_box;
-        let (i0, _i0_rc) = bound_inputarg_box(majit_ir::Type::Int, 0);
-        let (i1, _i1_rc) = bound_inputarg_box(majit_ir::Type::Int, 1);
+        let (_i0, i0_rc) = bound_inputarg_box(majit_ir::Type::Int, 0);
+        let (_i1, i1_rc) = bound_inputarg_box(majit_ir::Type::Int, 1);
         // A live producer for v (IntGt result) at int_op(2); the OpRc is held
         // in `int_gt` so the from_bound_op box's Weak upgrade stays live.
         let int_gt = std::rc::Rc::new(Op::new(
             OpCode::IntGt,
-            &[Operand::from_boxref(&i0), Operand::from_boxref(&i1)],
+            &[
+                Operand::from_bound_inputarg(&i0_rc),
+                Operand::from_bound_inputarg(&i1_rc),
+            ],
         ));
         int_gt.pos.set(OpRef::int_op(2));
-        let v = BoxRef::from_bound_op(&int_gt);
-        let zero = BoxRef::new_const(Value::Int(0));
         let guard_value = Op::new(
             OpCode::GuardValue,
-            &[Operand::from_boxref(&v), Operand::from_boxref(&zero)],
+            &[
+                Operand::from_bound_op(&int_gt),
+                Operand::const_from_value(Value::Int(0)),
+            ],
         );
         let finish = Op::new(OpCode::Finish, &[]);
         let ops = {

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1852,10 +1852,7 @@ impl Optimization for OptRewrite {
                     if c != 0 {
                         let mut call_op = Op::new(
                             OpCode::CallN,
-                            &op.getarglist()[1..]
-                                .iter()
-                                .map(Operand::from_boxref)
-                                .collect::<Vec<_>>(),
+                            &(1..op.num_args()).map(|i| op.arg(i)).collect::<Vec<_>>(),
                         );
                         call_op.pos.set(op.pos.get());
                         if let Some(d) = op.getdescr() {
@@ -1888,10 +1885,7 @@ impl Optimization for OptRewrite {
                     };
                     let mut call_op = Op::new(
                         call_opcode,
-                        &op.getarglist()[1..]
-                            .iter()
-                            .map(Operand::from_boxref)
-                            .collect::<Vec<_>>(),
+                        &(1..op.num_args()).map(|i| op.arg(i)).collect::<Vec<_>>(),
                     );
                     call_op.pos.set(op.pos.get());
                     if let Some(d) = op.getdescr() {

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -187,8 +187,8 @@ impl OptRewrite {
                 let arg_shift = ctx.materialize_operand_at(shift_ref);
                 let result_ref = ctx.emit(Op::new(OpCode::IntRshift, &[arg0, arg_shift.clone()]));
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_res = ctx.get_box_replacement(result_ref);
-                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_res));
+                let b_res = ctx.get_box_replacement_operand(result_ref);
+                ctx.make_equal_to(&b_old, &b_res);
                 return OptimizationResult::Remove;
             }
 
@@ -208,8 +208,8 @@ impl OptRewrite {
                     ctx,
                 );
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_res = ctx.get_box_replacement(result);
-                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_res));
+                let b_res = ctx.get_box_replacement_operand(result);
+                ctx.make_equal_to(&b_old, &b_res);
                 return OptimizationResult::Remove;
             }
         }
@@ -303,8 +303,8 @@ impl OptRewrite {
                     ctx,
                 );
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_res = ctx.get_box_replacement(result);
-                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_res));
+                let b_res = ctx.get_box_replacement_operand(result);
+                ctx.make_equal_to(&b_old, &b_res);
                 return OptimizationResult::Remove;
             }
         }
@@ -1078,8 +1078,8 @@ impl OptRewrite {
             ctx,
         );
         let b_old = Operand::from_bound_op(op_rc);
-        let b_res = ctx.get_box_replacement(result_ref);
-        ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_res));
+        let b_res = ctx.get_box_replacement_operand(result_ref);
+        ctx.make_equal_to(&b_old, &b_res);
         ctx.last_op_removed = true;
         Some(OptimizationResult::Remove)
     }
@@ -1126,8 +1126,8 @@ impl OptRewrite {
                 {
                     let shiftvar = ctx.resolve_operand_box(&shift_op.arg(1)).to_opref();
                     let shiftbound = {
-                        let b = ctx.get_box_replacement(shiftvar);
-                        ctx.getintbound_handle(&Operand::from_boxref(&b))
+                        let b = ctx.get_box_replacement_operand(shiftvar);
+                        ctx.getintbound_handle(&b)
                             .borrow()
                             .clone()
                     };
@@ -1187,8 +1187,8 @@ impl OptRewrite {
             ctx,
         );
         let b_old = Operand::from_bound_op(op_rc);
-        let b_res = ctx.get_box_replacement(result_ref);
-        ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_res));
+        let b_res = ctx.get_box_replacement_operand(result_ref);
+        ctx.make_equal_to(&b_old, &b_res);
         ctx.last_op_removed = true;
         Some(OptimizationResult::Remove)
     }
@@ -1521,8 +1521,8 @@ impl OptRewrite {
             let key = (reflex_opcode, arg1.to_opref(), arg0.to_opref());
             if let Some(&cached_ref) = self.bool_result_cache.get(&key) {
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_cached = ctx.get_box_replacement(cached_ref);
-                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                let b_cached = ctx.get_box_replacement_operand(cached_ref);
+                ctx.make_equal_to(&b_old, &b_cached);
                 return Some(OptimizationResult::Remove);
             }
 
@@ -2109,8 +2109,8 @@ impl Optimization for OptRewrite {
                             LoopInvariantEntry::Direct(r) => r,
                         };
                         let b_old = Operand::from_bound_op(op_rc);
-                        let b_cached = ctx.get_box_replacement(cached_result);
-                        ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_cached));
+                        let b_cached = ctx.get_box_replacement_operand(cached_result);
+                        ctx.make_equal_to(&b_old, &b_cached);
                         ctx.last_op_removed = true;
                         return OptimizationResult::Remove;
                     }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2963,8 +2963,10 @@ impl ExtendedShortPreambleBuilder {
                 self.extra_same_as.push(same_as);
             }
             self.label_args.push(resolved_op.clone());
-            self.short_jump_args
-                .push(BoxRef::from_opref(replay_op.pos.get()));
+            // Bind the live preamble producer: `to_opref` is unchanged
+            // (replay_op.pos), and the box now roots replay_op (already held
+            // by short_preamble_jump), so the flattened struct is identical.
+            self.short_jump_args.push(BoxRef::from_bound_op(replay_op));
             self.short_preamble_jump.push(replay_op.clone());
         }
     }
@@ -2994,9 +2996,14 @@ impl ExtendedShortPreambleBuilder {
             self.extra_same_as.push(op);
         }
         self.label_args.push(result.clone());
-        self.used_boxes.push(BoxRef::from_opref(current_result));
+        // Bind the live preamble producer (current_result == preamble_op.pos):
+        // `to_opref` is unchanged and the box roots produced.preamble_op
+        // (already held by short_preamble_jump), so the flattened struct is
+        // identical.
+        self.used_boxes
+            .push(BoxRef::from_bound_op(&produced.preamble_op));
         self.short_jump_args
-            .push(BoxRef::from_opref(produced.preamble_op.pos.get()));
+            .push(BoxRef::from_bound_op(&produced.preamble_op));
         self.short_preamble_jump.push(produced.preamble_op.clone());
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -4211,18 +4211,17 @@ mod tests {
             .iter()
             .map(|(_, p)| (p.res.clone(), p.clone()))
             .collect();
-        let res10 = produced
-            .iter()
-            .find(|(r, _)| *r == OpRef::int_op(10))
-            .unwrap()
-            .1
-            .res
-            .clone();
+        let res10 = Operand::from_boxref(
+            &produced
+                .iter()
+                .find(|(r, _)| *r == OpRef::int_op(10))
+                .unwrap()
+                .1
+                .res,
+        );
         let mut builder = ShortPreambleBuilder::new(&label_arg_oprefs, &entries, &short_inputargs);
-        let used = builder
-            .add_op_to_short(&Operand::from_boxref(&res10))
-            .unwrap();
-        assert!(builder.add_preamble_op(&Operand::from_boxref(&res10)));
+        let used = builder.add_op_to_short(&res10).unwrap();
+        assert!(builder.add_preamble_op(&res10));
         assert_eq!(used.opcode, OpCode::IntAddOvf);
         assert_eq!(builder.used_boxes(), &[OpRef::int_op(10)]);
 
@@ -4268,7 +4267,7 @@ mod tests {
         let (alias_result, alias_res) = produced
             .iter()
             .find(|(result, pop)| *result != OpRef::int_op(20) && pop.invented_name)
-            .map(|(result, pop)| (*result, pop.res.clone()))
+            .map(|(result, pop)| (*result, Operand::from_boxref(&pop.res)))
             .unwrap();
 
         // #146/S8: re-key the produced_ops list to res for new() + look up the
@@ -4282,7 +4281,7 @@ mod tests {
             &entries,
             &[rooted_resop_box(Type::Int, 20)],
         );
-        assert!(builder.add_preamble_op(&Operand::from_boxref(&alias_res)));
+        assert!(builder.add_preamble_op(&alias_res));
         let extra = builder.extra_same_as();
         assert_eq!(extra.len(), 1);
         assert_eq!(extra[0].opcode, OpCode::SameAsI);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3650,9 +3650,9 @@ impl OptUnroll {
             if let Some(label) = current_label_args {
                 for (i, &jump_arg) in short_jump_args.iter().enumerate() {
                     let resolved_has_info = ctx
-                        .get_box_replacement_box(jump_arg)
+                        .get_box_replacement_operand_opt(jump_arg)
                         .as_ref()
-                        .map_or(false, |b| ctx.has_ptr_info(&Operand::from_boxref(b)));
+                        .map_or(false, |b| ctx.has_ptr_info(b));
                     if !resolved_has_info {
                         // Try label arg at same index
                         if let Some(&label_arg) = label.get(i) {
@@ -3750,14 +3750,11 @@ impl OptUnroll {
             // unroll.py:357-359: emit JUMP to target
             let mut jump_args = target_args;
             jump_args.extend(extra);
-            let mut jump_args_box: Vec<BoxRef> = Vec::with_capacity(jump_args.len());
+            let mut jump_args_box_operand: Vec<majit_ir::operand::Operand> =
+                Vec::with_capacity(jump_args.len());
             for a in &jump_args {
-                jump_args_box.push(ctx.materialize_box_at(*a));
+                jump_args_box_operand.push(ctx.materialize_operand_at(*a));
             }
-            let jump_args_box_operand: Vec<majit_ir::operand::Operand> = jump_args_box
-                .iter()
-                .map(majit_ir::operand::Operand::from_boxref)
-                .collect();
             let mut jump = Op::new(OpCode::Jump, &jump_args_box_operand);
             jump.setdescr(target_token.as_jump_target_descr());
             // unroll.py:357 lets send_extra_operation raise InvalidLoop. This
@@ -3839,9 +3836,9 @@ impl OptUnroll {
                 // shortpreamble.py:414-425 parity: propagate PtrInfo from
                 // Phase 1 export to jump_args so guards are redundant.
                 let resolved_has_info = ctx
-                    .get_box_replacement_box(jump_arg)
+                    .get_box_replacement_operand_opt(jump_arg)
                     .as_ref()
-                    .map_or(false, |b| ctx.has_ptr_info(&Operand::from_boxref(b)));
+                    .map_or(false, |b| ctx.has_ptr_info(b));
                 if !resolved_has_info {
                     let jump_box = ctx.get_box_replacement_operand_opt(jump_arg);
                     let short_box = ctx.get_box_replacement_operand_opt(short_inputarg);
@@ -3995,12 +3992,7 @@ impl OptUnroll {
                         // unroll.py:367: mapping values are the replayed op
                         // objects; bind to the registered producer (memoized
                         // on box_cache) rather than minting an unbound box.
-                        Some(&mapped) => new_op.setarg(
-                            i,
-                            majit_ir::operand::Operand::from_boxref(
-                                &ctx.materialize_box_at(mapped),
-                            ),
-                        ),
+                        Some(&mapped) => new_op.setarg(i, ctx.materialize_operand_at(mapped)),
                         None => {
                             // RPython: _map_args raises KeyError for unmapped
                             // args. This is equivalent to InvalidLoop — the
@@ -4060,9 +4052,7 @@ impl OptUnroll {
                                 "non-guard short-preamble op carried fail_args: {:?}",
                                 new_op.opcode
                             );
-                            *arg = majit_ir::operand::Operand::from_boxref(
-                                &ctx.materialize_box_at(mapped),
-                            );
+                            *arg = ctx.materialize_operand_at(mapped);
                         }
                     }
                 }
@@ -4200,7 +4190,7 @@ impl OptUnroll {
             // `reserve_virtual_box`-minted alias — both resolve without
             // minting here.
             let b_source = ctx
-                .get_box_replacement_box(source)
+                .get_box_replacement_operand_opt(source)
                 .expect("import_state source must have a materialized BoxRef slot");
             // `target` is a Phase-1 next-iteration ref whose producer may not
             // be carried into this rebuilt context; materialize its canonical
@@ -4208,14 +4198,11 @@ impl OptUnroll {
             // would re-materialize the unbound target internally anyway —
             // resolve-or-materialize here keeps the chain target canonical
             // from the start).
-            let b_target = match ctx.get_box_replacement_box(target) {
-                Some(b) => b,
-                None => ctx.materialize_box_at(target),
+            let b_target = match ctx.get_box_replacement_operand_opt(target) {
+                Some(o) => o,
+                None => ctx.materialize_operand_at(target),
             };
-            ctx.make_equal_to(
-                &Operand::from_boxref(&b_source),
-                &Operand::from_boxref(&b_target),
-            );
+            ctx.make_equal_to(&b_source, &b_target);
             if crate::debug::have_debug_prints() {
                 crate::debug::log_one(
                     "jit-optimizer",

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4812,14 +4812,11 @@ fn assemble_peeled_trace_with_jump_args(
     };
 
     if let Some(start_label_descr) = start_label_descr {
-        let mut start_label_args_box: Vec<BoxRef> = Vec::with_capacity(start_label_args.len());
+        let mut start_label_args_box_operand: Vec<majit_ir::operand::Operand> =
+            Vec::with_capacity(start_label_args.len());
         for a in start_label_args {
-            start_label_args_box.push(ctx.materialize_box_at(*a));
+            start_label_args_box_operand.push(ctx.materialize_operand_at(*a));
         }
-        let start_label_args_box_operand: Vec<majit_ir::operand::Operand> = start_label_args_box
-            .iter()
-            .map(majit_ir::operand::Operand::from_boxref)
-            .collect();
         let mut start_label = Op::new(OpCode::Label, &start_label_args_box_operand);
         start_label.pos.set(OpRef::NONE);
         start_label.setdescr(start_label_descr);
@@ -5011,11 +5008,8 @@ fn assemble_peeled_trace_with_jump_args(
                             )
                         });
                     if tp != Type::Void {
-                        let arg_source = ctx.materialize_box_at(source);
-                        let mut same_as = Op::new(
-                            OpCode::same_as_for_type(tp),
-                            &[majit_ir::operand::Operand::from_boxref(&arg_source)],
-                        );
+                        let arg_source = ctx.materialize_operand_at(source);
+                        let mut same_as = Op::new(OpCode::same_as_for_type(tp), &[arg_source]);
                         same_as.pos.set(arg);
                         fallthrough_aliases.push(same_as);
                     }
@@ -5029,14 +5023,11 @@ fn assemble_peeled_trace_with_jump_args(
         }
     }
 
-    let mut full_label_args_box: Vec<BoxRef> = Vec::with_capacity(full_label_args.len());
+    let mut full_label_args_box_operand: Vec<majit_ir::operand::Operand> =
+        Vec::with_capacity(full_label_args.len());
     for a in &full_label_args {
-        full_label_args_box.push(ctx.materialize_box_at(*a));
+        full_label_args_box_operand.push(ctx.materialize_operand_at(*a));
     }
-    let full_label_args_box_operand: Vec<majit_ir::operand::Operand> = full_label_args_box
-        .iter()
-        .map(majit_ir::operand::Operand::from_boxref)
-        .collect();
     let mut label_op = Op::new(OpCode::Label, &full_label_args_box_operand);
     // resoperation.py:260 AbstractResOp.type = 'v' default — Label has no
     // result Box, so its OpRef position carries the Void tag rather than
@@ -5122,16 +5113,16 @@ fn assemble_peeled_trace_with_jump_args(
         );
         if let Some(&jump_source) = filtered_extra_jump_args.get(i) {
             if !jump_source.is_none() && jump_source != source_slot {
-                let b_js = ctx.materialize_box_at(jump_source);
+                let b_js = ctx.materialize_operand_at(jump_source);
                 // Chain target: resolve-or-materialize the canonical host
                 // (make_equal_to materializes an unbound target internally;
                 // doing it here keeps the target off the position-only
                 // fabrication path).
-                let b_ela = match ctx.get_box_replacement_box(extended_label_arg) {
+                let b_ela = match ctx.get_box_replacement_operand_opt(extended_label_arg) {
                     Some(b) => b,
-                    None => ctx.materialize_box_at(extended_label_arg),
+                    None => ctx.materialize_operand_at(extended_label_arg),
                 };
-                ctx.make_equal_to(&Operand::from_boxref(&b_js), &Operand::from_boxref(&b_ela));
+                ctx.make_equal_to(&b_js, &b_ela);
                 assembly_alias_remap.insert(jump_source, extended_label_arg);
             }
         }
@@ -5210,10 +5201,10 @@ fn assemble_peeled_trace_with_jump_args(
                 // position-only box. `materialize_box_at(mapped).to_opref() ==
                 // mapped`, so the rewritten arg is OpRef-identical.
                 let boxed = match emitted_at.get(&mapped) {
-                    Some(rc) => BoxRef::from_bound_op(rc),
-                    None => ctx.materialize_box_at(mapped),
+                    Some(rc) => majit_ir::operand::Operand::from_bound_op(rc),
+                    None => ctx.materialize_operand_at(mapped),
                 };
-                new_op.setarg(i, majit_ir::operand::Operand::from_boxref(&boxed));
+                new_op.setarg(i, boxed);
             }
         }
         if new_op.opcode == OpCode::Label {
@@ -5305,9 +5296,7 @@ fn assemble_peeled_trace_with_jump_args(
             let mut extended_args_box: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
                 smallvec::SmallVec::with_capacity(extended_args.len());
             for a in &extended_args {
-                extended_args_box.push(majit_ir::operand::Operand::from_boxref(
-                    &ctx.materialize_box_at(*a),
-                ));
+                extended_args_box.push(ctx.materialize_operand_at(*a));
             }
             new_op.initarglist(extended_args_box);
         }
@@ -5387,9 +5376,7 @@ fn assemble_peeled_trace_with_jump_args(
             let mut jump_args_box: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
                 smallvec::SmallVec::with_capacity(jump_args.len());
             for a in &jump_args {
-                jump_args_box.push(majit_ir::operand::Operand::from_boxref(
-                    &ctx.materialize_box_at(*a),
-                ));
+                jump_args_box.push(ctx.materialize_operand_at(*a));
             }
             new_op.initarglist(jump_args_box);
         }
@@ -5447,11 +5434,9 @@ fn assemble_peeled_trace_with_jump_args(
                     .iter()
                     .map(|a| a.to_opref())
                     .collect();
-                let new_args_boxref = result[label_idx].getarglist_copy();
                 let mut new_args: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> =
-                    new_args_boxref
-                        .iter()
-                        .map(majit_ir::operand::Operand::from_boxref)
+                    (0..result[label_idx].num_args())
+                        .map(|i| result[label_idx].arg(i))
                         .collect();
                 new_args.extend(
                     extra_live_args
@@ -5620,11 +5605,8 @@ impl OptUnroll {
         // Emit Label between peeled and original body.
         // The Label's args match the Jump's args, forming the loop header.
         let label_pos = ctx.reserve_pos_typed(OpCode::Label.result_type());
-        let jump_label_args: Vec<majit_ir::operand::Operand> = jump_op
-            .getarglist()
-            .iter()
-            .map(majit_ir::operand::Operand::from_boxref)
-            .collect();
+        let jump_label_args: Vec<majit_ir::operand::Operand> =
+            (0..jump_op.num_args()).map(|i| jump_op.arg(i)).collect();
         let mut label_op = Op::new(OpCode::Label, &jump_label_args);
         label_op.pos.set(label_pos);
         ctx.emit(label_op);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3657,9 +3657,8 @@ impl OptUnroll {
                         // Try label arg at same index
                         if let Some(&label_arg) = label.get(i) {
                             let label_box = ctx.get_box_replacement_operand_opt(label_arg);
-                            if let Some(info) = label_box
-                                .as_ref()
-                                .and_then(|b| ctx.peek_ptr_info(b))
+                            if let Some(info) =
+                                label_box.as_ref().and_then(|b| ctx.peek_ptr_info(b))
                             {
                                 ctx.ensure_ptr_info_preserve_forwarding(jump_arg, info);
                             }
@@ -3845,11 +3844,7 @@ impl OptUnroll {
                     let info = jump_box
                         .as_ref()
                         .and_then(|b| ctx.peek_ptr_info(b))
-                        .or_else(|| {
-                            short_box
-                                .as_ref()
-                                .and_then(|b| ctx.peek_ptr_info(b))
-                        })
+                        .or_else(|| short_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)))
                         .or_else(|| {
                             short_preamble
                                 .inputarg_infos
@@ -6771,12 +6766,9 @@ mod tests {
         // Key by the canonical box identity the consumer resolves `int_op(21)`
         // to, so the BoxRef-keyed lookup hits by `Rc::ptr_eq`.
         let box21 = ctx
-            .get_box_replacement_box(OpRef::int_op(21))
+            .get_box_replacement_operand_opt(OpRef::int_op(21))
             .expect("int_op(21) bound to a box");
-        exported_bounds.insert(
-            majit_ir::operand::Operand::from_boxref(&box21),
-            IntBound::bounded(10, 20),
-        );
+        exported_bounds.insert(box21, IntBound::bounded(10, 20));
 
         let exported = export_state(
             &[OpRef::int_op(21)],
@@ -6816,10 +6808,8 @@ mod tests {
         // widen() relaxes bounds: lower < MININT/2 → MININT, upper > MAXINT/2 → MAXINT.
         // For [10, 20], both are within MININT/2..MAXINT/2 so widen() preserves them.
         let imported_bound = {
-            let __mb = ctx2.materialize_box_at(OpRef::int_op(21));
-            ctx2.getintbound_handle(&Operand::from_boxref(&__mb))
-                .borrow()
-                .clone()
+            let __mb = ctx2.materialize_operand_at(OpRef::int_op(21));
+            ctx2.getintbound_handle(&__mb).borrow().clone()
         };
         assert_eq!((imported_bound.lower, imported_bound.upper), (10, 20));
     }
@@ -6928,11 +6918,11 @@ mod tests {
         // RPython PreambleOp parity: PreambleOp stored in PtrInfo._fields.
         // No imported_short_fields for heap fields — PtrInfo is the single
         // source of truth, matching RPython's HeapOp.produce_op → opinfo.setfield.
-        let obj_box = ctx2.get_box_replacement_box(OpRef::int_op(10)).unwrap();
+        let obj_box = ctx2
+            .get_box_replacement_operand_opt(OpRef::int_op(10))
+            .unwrap();
         let pop = ctx2
-            .with_ptr_info_mut(&Operand::from_boxref(&obj_box), |info| {
-                info.take_preamble_field(0)
-            })
+            .with_ptr_info_mut(&obj_box, |info| info.take_preamble_field(0))
             .flatten();
         assert!(pop.is_some(), "PreambleOp must be in PtrInfo._fields");
         let pop = pop.unwrap();
@@ -6950,8 +6940,8 @@ mod tests {
         // ConstPtr.value inline (history.py:314): the producer seeds the
         // inline variant that carries the pointer directly; the consumer
         // reads it back without any pool lookup.
-        let ptr_box = ctx.materialize_box_at(OpRef::const_ptr(ptr));
-        ctx.seed_constant(&Operand::from_boxref(&ptr_box), Value::Ref(ptr));
+        let ptr_box = ctx.materialize_operand_at(OpRef::const_ptr(ptr));
+        ctx.seed_constant(&ptr_box, Value::Ref(ptr));
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
@@ -7019,8 +7009,8 @@ mod tests {
         // reads it back without any pool lookup.
         let func_ptr = 0xCAFE;
         let func = OpRef::const_int(func_ptr);
-        let func_box = ctx.materialize_box_at(func);
-        ctx.seed_constant(&Operand::from_boxref(&func_box), Value::Int(func_ptr));
+        let func_box = ctx.materialize_operand_at(func);
+        ctx.seed_constant(&func_box, Value::Int(func_ptr));
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
@@ -7109,8 +7099,8 @@ mod tests {
             8,
             &[Type::Int, Type::Int, Type::Int, Type::Int],
         );
-        let func_box = ctx.materialize_box_at(func);
-        ctx.seed_constant(&Operand::from_boxref(&func_box), Value::Int(func_ptr));
+        let func_box = ctx.materialize_operand_at(func);
+        ctx.seed_constant(&func_box, Value::Int(func_ptr));
 
         import_short_preamble_state(&[OpRef::int_op(0)], &[phase2_result], &exported, &mut ctx);
 
@@ -7165,12 +7155,12 @@ mod tests {
             }],
         );
 
-        let src20 = ctx.materialize_box_at(OpRef::int_op(20));
+        let src20 = ctx.materialize_operand_at(OpRef::int_op(20));
         let produced = ctx
             .imported_short_preamble_builder
             .as_ref()
             .unwrap()
-            .produced_short_op(&Operand::from_boxref(&src20))
+            .produced_short_op(&src20)
             .unwrap();
         let pop = crate::optimizeopt::info::PreambleOp {
             op: rooted_resop_box(Type::Int, 20),
@@ -7266,12 +7256,12 @@ mod tests {
                 same_as_source: None,
             }],
         );
-        let src19 = ctx.materialize_box_at(OpRef::ref_op(19));
+        let src19 = ctx.materialize_operand_at(OpRef::ref_op(19));
         let produced = ctx
             .imported_short_preamble_builder
             .as_ref()
             .unwrap()
-            .produced_short_op(&Operand::from_boxref(&src19))
+            .produced_short_op(&src19)
             .unwrap();
         // Path B (B.6.7-heap-field): produce_heap_field no longer installs
         // make_equal_to, but the test still walks the get_box_replacement

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3656,10 +3656,10 @@ impl OptUnroll {
                     if !resolved_has_info {
                         // Try label arg at same index
                         if let Some(&label_arg) = label.get(i) {
-                            let label_box = ctx.get_box_replacement_box(label_arg);
+                            let label_box = ctx.get_box_replacement_operand_opt(label_arg);
                             if let Some(info) = label_box
                                 .as_ref()
-                                .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                                .and_then(|b| ctx.peek_ptr_info(b))
                             {
                                 ctx.ensure_ptr_info_preserve_forwarding(jump_arg, info);
                             }
@@ -3843,15 +3843,15 @@ impl OptUnroll {
                     .as_ref()
                     .map_or(false, |b| ctx.has_ptr_info(&Operand::from_boxref(b)));
                 if !resolved_has_info {
-                    let jump_box = ctx.get_box_replacement_box(jump_arg);
-                    let short_box = ctx.get_box_replacement_box(short_inputarg);
+                    let jump_box = ctx.get_box_replacement_operand_opt(jump_arg);
+                    let short_box = ctx.get_box_replacement_operand_opt(short_inputarg);
                     let info = jump_box
                         .as_ref()
-                        .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                        .and_then(|b| ctx.peek_ptr_info(b))
                         .or_else(|| {
                             short_box
                                 .as_ref()
-                                .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                                .and_then(|b| ctx.peek_ptr_info(b))
                         })
                         .or_else(|| {
                             short_preamble

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5608,12 +5608,7 @@ impl OptUnroll {
             for i in 0..peeled.num_args() {
                 let arg = peeled.arg(i);
                 if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                    peeled.setarg(
-                        i,
-                        majit_ir::operand::Operand::from_boxref(&remapped_producer_box(
-                            ctx, new_ref,
-                        )),
-                    );
+                    peeled.setarg(i, remapped_producer_operand(ctx, new_ref));
                 }
                 // Args referencing ops outside the buffer (e.g., input args)
                 // are kept as-is.
@@ -5621,8 +5616,7 @@ impl OptUnroll {
             if let Some(fa) = peeled.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = ref_map.get(&arg.to_opref()) {
-                        let new_box = remapped_producer_box(ctx, new_ref);
-                        *arg = majit_ir::operand::Operand::from_boxref(&new_box);
+                        *arg = remapped_producer_operand(ctx, new_ref);
                     }
                 }
             }
@@ -5667,19 +5661,13 @@ impl OptUnroll {
             for i in 0..body_op.num_args() {
                 let arg = body_op.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    body_op.setarg(
-                        i,
-                        majit_ir::operand::Operand::from_boxref(&remapped_producer_box(
-                            ctx, new_ref,
-                        )),
-                    );
+                    body_op.setarg(i, remapped_producer_operand(ctx, new_ref));
                 }
             }
             if let Some(fa) = body_op.fail_args_mut() {
                 for arg in fa.iter_mut() {
                     if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                        let new_box = remapped_producer_box(ctx, new_ref);
-                        *arg = majit_ir::operand::Operand::from_boxref(&new_box);
+                        *arg = remapped_producer_operand(ctx, new_ref);
                     }
                 }
             }
@@ -5696,17 +5684,18 @@ impl OptUnroll {
     }
 }
 
-/// Resolve a remapped peel position to its canonical producer box, mirroring
-/// the import-path binding (`get_box_replacement_box`, else `materialize_box_at`
-/// — unroll.rs:2997-3024 / S10). The peeled / body producer emitted at
-/// `new_ref` precedes its consumers' arg writes (SSA def-before-use), so the
-/// read resolves to the bound `Op`; the `materialize_box_at` arm mints a
-/// registered stand-in that the producer's later `emit` catches up (mod.rs
-/// forward-reference path), never a position-only `Operand::Box`.
-fn remapped_producer_box(ctx: &mut OptContext, new_ref: OpRef) -> BoxRef {
-    match ctx.get_box_replacement_box(new_ref) {
-        Some(b) => b,
-        None => ctx.materialize_box_at(new_ref),
+/// Resolve a remapped peel position to its canonical producer operand,
+/// mirroring the import-path binding (`get_box_replacement_operand_opt`, else
+/// `materialize_operand_at` — unroll.rs:2997-3024 / S10). The peeled / body
+/// producer emitted at `new_ref` precedes its consumers' arg writes (SSA
+/// def-before-use), so the read resolves to the bound `Op`; the
+/// `materialize_operand_at` arm mints a registered stand-in that the producer's
+/// later `emit` catches up (mod.rs forward-reference path), never a
+/// position-only operand.
+fn remapped_producer_operand(ctx: &mut OptContext, new_ref: OpRef) -> Operand {
+    match ctx.get_box_replacement_operand_opt(new_ref) {
+        Some(o) => o,
+        None => ctx.materialize_operand_at(new_ref),
     }
 }
 
@@ -5805,12 +5794,7 @@ impl Optimization for OptUnroll {
             for i in 0..jump.num_args() {
                 let arg = jump.arg(i);
                 if let Some(&new_ref) = orig_ref_map.get(&arg.to_opref()) {
-                    jump.setarg(
-                        i,
-                        majit_ir::operand::Operand::from_boxref(&remapped_producer_box(
-                            ctx, new_ref,
-                        )),
-                    );
+                    jump.setarg(i, remapped_producer_operand(ctx, new_ref));
                 }
             }
             // Reserve the Jump's own position so it lands above any

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -2528,18 +2528,18 @@ mod tests {
     /// `None` shed to `Operand::Const` / none as before. Replaces the position-only
     /// `BoxRef::from_opref` that minted `Operand::Box` at `Op::new`.
     fn bx(r: OpRef) -> Operand {
-        use crate::history::test_support::{rooted_inputarg_box, rooted_resop_box};
-        Operand::from_boxref(&match r {
-            OpRef::InputArgInt(n) => rooted_inputarg_box(Type::Int, n),
-            OpRef::InputArgFloat(n) => rooted_inputarg_box(Type::Float, n),
-            OpRef::InputArgRef(n) => rooted_inputarg_box(Type::Ref, n),
-            OpRef::IntOp(n) => rooted_resop_box(Type::Int, n),
-            OpRef::FloatOp(n) => rooted_resop_box(Type::Float, n),
-            OpRef::RefOp(n) => rooted_resop_box(Type::Ref, n),
-            OpRef::VoidOp(n) => rooted_resop_box(Type::Void, n),
+        use crate::history::test_support::{rooted_inputarg_operand, rooted_resop_operand};
+        match r {
+            OpRef::InputArgInt(n) => rooted_inputarg_operand(Type::Int, n),
+            OpRef::InputArgFloat(n) => rooted_inputarg_operand(Type::Float, n),
+            OpRef::InputArgRef(n) => rooted_inputarg_operand(Type::Ref, n),
+            OpRef::IntOp(n) => rooted_resop_operand(Type::Int, n),
+            OpRef::FloatOp(n) => rooted_resop_operand(Type::Float, n),
+            OpRef::RefOp(n) => rooted_resop_operand(Type::Ref, n),
+            OpRef::VoidOp(n) => rooted_resop_operand(Type::Void, n),
             // Const* / None shed to Operand::Const / none — no Operand::Box mint.
-            _ => BoxRef::from_opref(r),
-        })
+            _ => Operand::from_opref(r),
+        }
     }
 
     fn assign_positions(ops: &mut [Op], base: u32) {

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -872,8 +872,8 @@ impl OptVirtualize {
                         .and_then(|widx| get_field(&vinfo.fields, widx));
                     if let Some(val_ref) = stored {
                         let b_old = Operand::from_bound_op(op_rc);
-                        let b_val = ctx.get_box_replacement(val_ref);
-                        ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_val));
+                        let b_val = ctx.get_box_replacement_operand(val_ref);
+                        ctx.make_equal_to(&b_old, &b_val);
                         return OptimizationResult::Remove;
                     }
                     if let Some(w_class) = vinfo
@@ -1511,8 +1511,8 @@ impl OptVirtualize {
                             if let Ok(val_ref) = vinfo.read_value(lookup_offset, itemsize_u, &descr)
                             {
                                 let b_old = Operand::from_bound_op(op_rc);
-                                let b_val = ctx.get_box_replacement(val_ref);
-                                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_val));
+                                let b_val = ctx.get_box_replacement_operand(val_ref);
+                                ctx.make_equal_to(&b_old, &b_val);
                                 return OptimizationResult::Remove;
                             }
                         }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -3093,9 +3093,9 @@ mod tests {
         // result box (oparser object-identity); GetfieldRawI (ops[0]) is
         // Int-typed so its result position is `OpRef::int_op(0)`.
         let array_ptr_box =
-            crate::history::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
-        ops[1].setarg(0, Operand::from_boxref(&array_ptr_box));
-        ops[2].setarg(0, Operand::from_boxref(&array_ptr_box));
+            crate::history::test_support::rooted_resop_operand(Type::Int, ops[0].pos.get().raw());
+        ops[1].setarg(0, array_ptr_box.clone());
+        ops[2].setarg(0, array_ptr_box);
 
         for op in &ops {
             let mut resolved = op.clone();
@@ -3446,9 +3446,9 @@ mod tests {
         // vable inputarg. GetfieldRawI (ops[0]) is Int-typed so its result
         // position is `OpRef::int_op(0)`.
         let array_ptr_box =
-            crate::history::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
-        ops[1].setarg(0, Operand::from_boxref(&array_ptr_box));
-        ops[2].setarg(0, Operand::from_boxref(&array_ptr_box));
+            crate::history::test_support::rooted_resop_operand(Type::Int, ops[0].pos.get().raw());
+        ops[1].setarg(0, array_ptr_box.clone());
+        ops[2].setarg(0, array_ptr_box);
 
         for op in &ops {
             let mut resolved = op.clone();
@@ -3567,10 +3567,10 @@ mod tests {
         // GetfieldRawI (ops[0]) is Int-typed so its result position is
         // `OpRef::int_op(0)`; bind the element ops to its result box.
         let array_ptr_box =
-            crate::history::test_support::rooted_resop_box(Type::Int, ops[0].pos.get().raw());
-        ops[1].setarg(0, Operand::from_boxref(&array_ptr_box));
-        ops[2].setarg(0, Operand::from_boxref(&array_ptr_box));
-        ops[3].setarg(0, Operand::from_boxref(&array_ptr_box));
+            crate::history::test_support::rooted_resop_operand(Type::Int, ops[0].pos.get().raw());
+        ops[1].setarg(0, array_ptr_box.clone());
+        ops[2].setarg(0, array_ptr_box.clone());
+        ops[3].setarg(0, array_ptr_box);
 
         for op in &ops {
             let mut resolved = op.clone();

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -2087,8 +2087,8 @@ impl VirtualState {
         extract: impl FnOnce(&PtrInfo) -> Option<Vec<(u32, OpRef)>>,
     ) -> Option<Vec<(u32, OpRef)>> {
         parent_runtime_box?;
-        let b = ctx.get_box_replacement_box(parent_box_opref)?;
-        let info = ctx.getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))?;
+        let b = ctx.get_box_replacement_operand_opt(parent_box_opref)?;
+        let info = ctx.getptrinfo(&b)?;
         extract(&info)
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -1242,11 +1242,10 @@ impl VirtualState {
             ) {
                 if std::env::var_os("MAJIT_LOG_JTET").is_some() {
                     let runtime_value = runtime_box.and_then(|rb| {
-                        state.ctx.get_box_replacement_box(rb).and_then(|b| {
-                            state
-                                .ctx
-                                .get_constant_box(&majit_ir::operand::Operand::from_boxref(&b))
-                        })
+                        state
+                            .ctx
+                            .get_box_replacement_operand_opt(rb)
+                            .and_then(|b| state.ctx.get_constant_box(&b))
                     });
                     eprintln!(
                         "[jit][jte] virtualstate mismatch index={i} box={box_opref:?} runtime={runtime_box:?} runtime_value={runtime_value:?} expected={expected:?} incoming={incoming:?}"
@@ -1787,12 +1786,8 @@ impl VirtualState {
                 let parent_items: Option<Vec<OpRef>> = if runtime_box.is_some() {
                     state
                         .ctx
-                        .get_box_replacement_box(box_opref)
-                        .and_then(|b| {
-                            state
-                                .ctx
-                                .getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))
-                        })
+                        .get_box_replacement_operand_opt(box_opref)
+                        .and_then(|b| state.ctx.getptrinfo(&b))
                         .and_then(|info| match info {
                             PtrInfo::VirtualArray(a) => {
                                 Some(a.items.iter().map(|b| b.to_opref()).collect())
@@ -2621,8 +2616,8 @@ fn export_single_value_inner(
     // i.e. when PyPy's `info.is_constant()` is true. Mirror that:
     // export LEVEL_CONSTANT regardless of OpRef namespace.
     if let Some(value) = ctx
-        .get_box_replacement_box(opref)
-        .and_then(|b| ctx.get_constant_box(&majit_ir::operand::Operand::from_boxref(&b)))
+        .get_box_replacement_operand_opt(opref)
+        .and_then(|b| ctx.get_constant_box(&b))
     {
         return VirtualStateInfo::Constant(value);
     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -832,9 +832,9 @@ impl VirtualState {
                 // BoxRef-routing reader; cached once so the per-field walk below
                 // doesn't re-clone PtrInfo per iteration.
                 let info_snapshot = ctx
-                    .get_box_replacement_box(opref)
+                    .get_box_replacement_operand_opt(opref)
                     .as_ref()
-                    .and_then(|b| ctx.peek_ptr_info(&majit_ir::operand::Operand::from_boxref(b)));
+                    .and_then(|b| ctx.peek_ptr_info(b));
                 let is_virtual = info_snapshot.as_ref().map_or(false, |pi| pi.is_virtual());
                 if !is_virtual {
                     return Err(());
@@ -885,9 +885,9 @@ impl VirtualState {
                 // BoxRef-routing reader; cached once so the per-item walk
                 // below doesn't re-clone PtrInfo per iteration.
                 let info_snapshot = ctx
-                    .get_box_replacement_box(opref)
+                    .get_box_replacement_operand_opt(opref)
                     .as_ref()
-                    .and_then(|b| ctx.peek_ptr_info(&majit_ir::operand::Operand::from_boxref(b)));
+                    .and_then(|b| ctx.peek_ptr_info(b));
                 let is_virtual = info_snapshot.as_ref().map_or(false, |pi| pi.is_virtual());
                 if !is_virtual {
                     return Err(());
@@ -946,9 +946,11 @@ impl VirtualState {
                 // runtime's vinfo but absent from the state's element_fields,
                 // which signals a schema mismatch.
                 let runtime_fields: Vec<Vec<(u32, OpRef)>> =
-                    match ctx.get_box_replacement_box(opref).as_ref().and_then(|b| {
-                        ctx.peek_ptr_info(&majit_ir::operand::Operand::from_boxref(b))
-                    }) {
+                    match ctx
+                        .get_box_replacement_operand_opt(opref)
+                        .as_ref()
+                        .and_then(|b| ctx.peek_ptr_info(b))
+                    {
                         Some(crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(vinfo)) => vinfo
                             .element_fields
                             .iter()
@@ -1013,9 +1015,11 @@ impl VirtualState {
                 //     boxes[self.position_in_notvirtuals] = box
                 let resolved = ctx.get_replacement_opref(opref);
                 let forced =
-                    match ctx.get_box_replacement_box(opref).as_ref().and_then(|b| {
-                        ctx.peek_ptr_info(&majit_ir::operand::Operand::from_boxref(b))
-                    }) {
+                    match ctx
+                        .get_box_replacement_operand_opt(opref)
+                        .as_ref()
+                        .and_then(|b| ctx.peek_ptr_info(b))
+                    {
                         // RPython: Virtualizable refs stay virtual across iterations.
                         Some(PtrInfo::Virtualizable(_)) => resolved,
                         Some(ptr_info) if ptr_info.is_virtual() => {
@@ -2624,10 +2628,10 @@ fn export_single_value_inner(
     }
 
     // BoxRef-routing PtrInfo read (info.py:432 op.get_forwarded()).
-    let opref_box = ctx.get_box_replacement_box(opref);
+    let opref_box = ctx.get_box_replacement_operand_opt(opref);
     if let Some(info) = opref_box
         .as_ref()
-        .and_then(|b| ctx.peek_ptr_info(&majit_ir::operand::Operand::from_boxref(b)))
+        .and_then(|b| ctx.peek_ptr_info(b))
     {
         let info_fielddescrs = info.all_fielddescrs_from_descr();
         match info {

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -945,19 +945,18 @@ impl VirtualState {
                 // None" case corresponds to a field_idx present in the
                 // runtime's vinfo but absent from the state's element_fields,
                 // which signals a schema mismatch.
-                let runtime_fields: Vec<Vec<(u32, OpRef)>> =
-                    match ctx
-                        .get_box_replacement_operand_opt(opref)
-                        .as_ref()
-                        .and_then(|b| ctx.peek_ptr_info(b))
-                    {
-                        Some(crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(vinfo)) => vinfo
-                            .element_fields
-                            .iter()
-                            .map(|row| row.iter().map(|(i, b)| (*i, b.to_opref())).collect())
-                            .collect(),
-                        _ => return Err(()),
-                    };
+                let runtime_fields: Vec<Vec<(u32, OpRef)>> = match ctx
+                    .get_box_replacement_operand_opt(opref)
+                    .as_ref()
+                    .and_then(|b| ctx.peek_ptr_info(b))
+                {
+                    Some(crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(vinfo)) => vinfo
+                        .element_fields
+                        .iter()
+                        .map(|row| row.iter().map(|(i, b)| (*i, b.to_opref())).collect())
+                        .collect(),
+                    _ => return Err(()),
+                };
                 if runtime_fields.len() != element_fields.len() {
                     return Err(());
                 }
@@ -1014,22 +1013,21 @@ impl VirtualState {
                 //                 raise VirtualStatesCantMatch
                 //     boxes[self.position_in_notvirtuals] = box
                 let resolved = ctx.get_replacement_opref(opref);
-                let forced =
-                    match ctx
-                        .get_box_replacement_operand_opt(opref)
-                        .as_ref()
-                        .and_then(|b| ctx.peek_ptr_info(b))
-                    {
-                        // RPython: Virtualizable refs stay virtual across iterations.
-                        Some(PtrInfo::Virtualizable(_)) => resolved,
-                        Some(ptr_info) if ptr_info.is_virtual() => {
-                            if !force_boxes {
-                                return Err(());
-                            }
-                            optimizer.force_box(resolved, ctx)
+                let forced = match ctx
+                    .get_box_replacement_operand_opt(opref)
+                    .as_ref()
+                    .and_then(|b| ctx.peek_ptr_info(b))
+                {
+                    // RPython: Virtualizable refs stay virtual across iterations.
+                    Some(PtrInfo::Virtualizable(_)) => resolved,
+                    Some(ptr_info) if ptr_info.is_virtual() => {
+                        if !force_boxes {
+                            return Err(());
                         }
-                        _ => resolved,
-                    };
+                        optimizer.force_box(resolved, ctx)
+                    }
+                    _ => resolved,
+                };
                 // boxes[self.position_in_notvirtuals] = box
                 // virtualstate.py:421 — each non-constant NotVirtual leaf
                 // has its `position_in_notvirtuals` assigned during
@@ -2624,10 +2622,7 @@ fn export_single_value_inner(
 
     // BoxRef-routing PtrInfo read (info.py:432 op.get_forwarded()).
     let opref_box = ctx.get_box_replacement_operand_opt(opref);
-    if let Some(info) = opref_box
-        .as_ref()
-        .and_then(|b| ctx.peek_ptr_info(b))
-    {
+    if let Some(info) = opref_box.as_ref().and_then(|b| ctx.peek_ptr_info(b)) {
         let info_fielddescrs = info.all_fielddescrs_from_descr();
         match info {
             PtrInfo::Virtual(vinfo) => {
@@ -3030,9 +3025,9 @@ mod tests {
         let rb0 = ctx.make_constant_ref(GcRef(0x200));
         let rb1 = ctx.make_constant_ref(GcRef(0x300));
         let boxes = vec![OpRef::ref_op(100), OpRef::ref_op(101)];
-        let b0 = ctx.materialize_box_at(boxes[0]);
+        let b0 = ctx.materialize_operand_at(boxes[0]);
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&b0),
+            &b0,
             crate::optimizeopt::info::PtrInfo::known_class(0x100, false),
         );
         let runtime_boxes = vec![rb0, rb1];
@@ -3112,9 +3107,9 @@ mod tests {
         // virtualstate.py:185 requires `info.is_virtual()` for the
         // VStruct walker to descend; mirror by attaching a virtual
         // PtrInfo to the corresponding OpRef.
-        let b11 = ctx.materialize_box_at(OpRef::ref_op(11));
+        let b11 = ctx.materialize_operand_at(OpRef::ref_op(11));
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&b11),
+            &b11,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
                 fields: vec![],
@@ -3148,9 +3143,9 @@ mod tests {
         ]);
 
         let mut ctx = OptContext::new(16);
-        let b21 = ctx.materialize_box_at(OpRef::ref_op(21));
+        let b21 = ctx.materialize_operand_at(OpRef::ref_op(21));
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&b21),
+            &b21,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
                 fields: vec![],
@@ -3200,19 +3195,16 @@ mod tests {
         assert_eq!(state.num_boxes(), 1);
 
         let inner_field_value = OpRef::ref_op(31);
-        let inner_field_op = Operand::from_boxref(&crate::history::test_support::rooted_resop_box(
-            Type::Ref,
-            31,
-        ));
+        let inner_field_op = crate::history::test_support::rooted_resop_operand(Type::Ref, 31);
         let outer_a_ref = OpRef::ref_op(40);
         let outer_b_ref = OpRef::ref_op(41);
         let mut ctx = OptContext::new(64);
         // Both outer boxes resolve to a virtual struct whose field 0 is
         // the shared inner OpRef.
-        let outer_a_box = ctx.materialize_box_at(outer_a_ref);
-        let outer_b_box = ctx.materialize_box_at(outer_b_ref);
+        let outer_a_box = ctx.materialize_operand_at(outer_a_ref);
+        let outer_b_box = ctx.materialize_operand_at(outer_b_ref);
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&outer_a_box),
+            &outer_a_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr: descr.clone(),
                 fields: vec![(0, inner_field_op.clone())],
@@ -3221,7 +3213,7 @@ mod tests {
             }),
         );
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&outer_b_box),
+            &outer_b_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
                 fields: vec![(0, inner_field_op.clone())],
@@ -3268,10 +3260,7 @@ mod tests {
     fn test_make_inputargs_recursively_extracts_virtual_fields() {
         let descr = test_descr(11);
         let field_value = OpRef::ref_op(21);
-        let field_value_op = Operand::from_boxref(&crate::history::test_support::rooted_resop_box(
-            Type::Ref,
-            21,
-        ));
+        let field_value_op = crate::history::test_support::rooted_resop_operand(Type::Ref, 21);
         let virtual_ref = OpRef::ref_op(20);
         let state = VirtualState::new(vec![VirtualStateInfo::VStruct {
             descr: descr.clone(),
@@ -3285,9 +3274,9 @@ mod tests {
             field_descrs: Vec::new(),
         }]);
         let mut ctx = OptContext::new(32);
-        let virtual_box = ctx.materialize_box_at(virtual_ref);
+        let virtual_box = ctx.materialize_operand_at(virtual_ref);
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&virtual_box),
+            &virtual_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
                 fields: vec![(0, Operand::None), (8, field_value_op.clone())],
@@ -3344,9 +3333,9 @@ mod tests {
         let state = VirtualState::new(vec![VirtualStateInfo::NonNull]);
         // Generous Ref-typed inputarg pool for the test fixture.
         let mut ctx = OptContext::with_inputarg_types(32, &vec![Type::Ref; 1024]);
-        let virtual_box = ctx.materialize_box_at(virtual_ref);
+        let virtual_box = ctx.materialize_operand_at(virtual_ref);
         ctx.set_ptr_info(
-            &majit_ir::operand::Operand::from_boxref(&virtual_box),
+            &virtual_box,
             PtrInfo::VirtualStruct(VirtualStructInfo {
                 descr,
                 fields: vec![],

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -766,8 +766,8 @@ impl OptString {
         {
             if let Some(ch_ref) = self.strgetitem(&str_ref, idx, mode, ctx) {
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_new = ctx.get_box_replacement(ch_ref);
-                ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_new));
+                let b_new = ctx.get_box_replacement_operand(ch_ref);
+                ctx.make_equal_to(&b_old, &b_new);
                 return OptimizationResult::Remove;
             }
         }
@@ -889,8 +889,8 @@ impl OptString {
             let lgtop = ctx.getstrlen_opref(op.arg(0).to_opref(), mode);
             // vstring.py:531: self.make_equal_to(op, lgtop)
             let b_old = Operand::from_bound_op(op_rc);
-            let b_lgtop = ctx.get_box_replacement(lgtop);
-            ctx.make_equal_to(&b_old, &Operand::from_boxref(&b_lgtop));
+            let b_lgtop = ctx.get_box_replacement_operand(lgtop);
+            ctx.make_equal_to(&b_old, &b_lgtop);
             return OptimizationResult::Remove;
         }
         // vstring.py:533: return self.emit(op)
@@ -1403,8 +1403,8 @@ impl OptString {
         // vstring.py:792-805: if l2box: l2info = self.getintbound(l2box)
         if let Some(l2ref) = l2box {
             let l2info = {
-                let b = ctx.get_box_replacement(l2ref);
-                ctx.getintbound_handle(&Operand::from_boxref(&b))
+                let b = ctx.get_box_replacement_operand(l2ref);
+                ctx.getintbound_handle(&b)
                     .borrow()
                     .clone()
             };

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -330,19 +330,14 @@ pub fn string_copy_parts(
 /// base class path (vstring.py:138: srcbox = self.force_box(op, optstring)).
 fn force_child_for_string(opref: &Operand, ctx: &mut OptContext) -> Operand {
     // One chain walk; the position view falls back to the source.
-    let resolved_box = ctx.resolve_box_box_opt(&opref.to_boxref());
+    let resolved_box = ctx.resolve_operand_operand_opt(opref);
     let resolved = resolved_box
         .as_ref()
-        .map_or_else(|| opref.clone(), Operand::from_boxref);
-    if resolved_box
-        .as_ref()
-        .map_or(false, |b| ctx.is_virtual(&Operand::from_boxref(b)))
-    {
+        .map_or_else(|| opref.clone(), |b| b.clone());
+    if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
         let resolved_box = resolved_box.expect("recorder-populated");
-        let mut info = ctx
-            .take_ptr_info(&Operand::from_boxref(&resolved_box))
-            .unwrap();
-        let forced = info.force_box(resolved_box, ctx);
+        let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
+        let forced = info.force_box(&resolved_box, ctx);
         let forced_box = ctx.materialize_operand_at(forced);
         return ctx.resolve_box_operand(&forced_box.to_boxref());
     }
@@ -439,19 +434,14 @@ impl OptString {
     /// vstring.py:76-103 StrPtrInfo.force_box — delegate to PtrInfo::force_box.
     fn force_box(&mut self, op: &Operand, ctx: &mut OptContext) -> OpRef {
         // One chain walk; the position view falls back to the source.
-        let resolved_box = ctx.resolve_box_box_opt(&op.to_boxref());
+        let resolved_box = ctx.resolve_operand_operand_opt(op);
         let resolved = resolved_box
             .as_ref()
             .map_or_else(|| op.to_opref(), |b| b.to_opref());
-        if resolved_box
-            .as_ref()
-            .map_or(false, |b| ctx.is_virtual(&Operand::from_boxref(b)))
-        {
+        if resolved_box.as_ref().map_or(false, |b| ctx.is_virtual(b)) {
             let resolved_box = resolved_box.expect("recorder-populated");
-            let mut info = ctx
-                .take_ptr_info(&Operand::from_boxref(&resolved_box))
-                .unwrap();
-            let forced = info.force_box(resolved_box, ctx);
+            let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
+            let forced = info.force_box(&resolved_box, ctx);
             return ctx.get_replacement_opref(forced);
         }
         resolved

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -453,7 +453,7 @@ impl OptString {
     /// SameAsI(dummy) and record the constant in the context.
     fn emit_constant_int(&self, value: i64, ctx: &mut OptContext) -> OpRef {
         // Emit a dummy SameAsI to get an OpRef, then record the constant.
-        let op = Op::new(OpCode::SameAsI, &[Operand::from_opref(OpRef::NONE)]);
+        let op = Op::new(OpCode::SameAsI, &[Operand::none()]);
         let opref = ctx.emit(op);
         let b = ctx.materialize_operand_at(opref);
         ctx.make_constant_box(&b, Value::Int(value));
@@ -1404,9 +1404,7 @@ impl OptString {
         if let Some(l2ref) = l2box {
             let l2info = {
                 let b = ctx.get_box_replacement_operand(l2ref);
-                ctx.getintbound_handle(&b)
-                    .borrow()
-                    .clone()
+                ctx.getintbound_handle(&b).borrow().clone()
             };
             if l2info.is_constant() && l2info.get_constant_int() == 1 {
                 // vstring.py:799: vchar = self.strgetitem(None, arg2, CONST_0, mode)
@@ -1481,13 +1479,11 @@ impl OptString {
         ctx.make_constant_box(&b, Value::Int(func_addr as i64));
         let mut call_args = vec![func_const];
         call_args.extend_from_slice(args);
-        let mut call_args_box: Vec<BoxRef> = Vec::with_capacity(call_args.len());
+        let mut call_args_operand: Vec<Operand> = Vec::with_capacity(call_args.len());
         for a in &call_args {
-            call_args_box.push(ctx.materialize_box_at(*a));
+            call_args_operand.push(ctx.materialize_operand_at(*a));
         }
         // vstring.py:854: replace_op_with(result, rop.CALL_I, [...], descr=calldescr)
-        let call_args_operand: Vec<Operand> =
-            call_args_box.iter().map(Operand::from_boxref).collect();
         let mut call_op = match calldescr {
             Some(d) => Op::with_descr(OpCode::CallI, &call_args_operand, d.clone()),
             None => Op::new(OpCode::CallI, &call_args_operand),

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1841,7 +1841,7 @@ mod tests {
 
     fn set_vstring_plain(ctx: &mut OptContext, opref: OpRef, chars: Vec<Option<OpRef>>) {
         let length = chars.len() as i32;
-        let b = ctx.materialize_box_at(opref);
+        let b = ctx.materialize_operand_at(opref);
         // Materialize each char position so it carries a bound synthetic
         // producer in `resop_refs`. A later force/emit then resolves the char
         // arg to that bound box (sheds to `Operand::Op`) instead of a
@@ -1853,7 +1853,7 @@ mod tests {
             .map(|o| o.map(|r| ctx.materialize_operand_at(r)))
             .collect();
         ctx.set_ptr_info(
-            &Operand::from_boxref(&b),
+            &b,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,
@@ -1867,7 +1867,7 @@ mod tests {
     }
 
     fn set_vstring_concat(ctx: &mut OptContext, opref: OpRef, vleft: OpRef, vright: OpRef) {
-        let b = ctx.materialize_box_at(opref);
+        let b = ctx.materialize_operand_at(opref);
         // Materialize the child refs so they carry a bound synthetic producer; a
         // residual emit then sheds them to `Operand::Op` instead of panicking on
         // a position-only `from_opref` box. `materialize_box_at` keeps each
@@ -1875,7 +1875,7 @@ mod tests {
         let vleft_box = ctx.materialize_operand_at(vleft);
         let vright_box = ctx.materialize_operand_at(vright);
         ctx.set_ptr_info(
-            &Operand::from_boxref(&b),
+            &b,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,
@@ -1893,7 +1893,7 @@ mod tests {
     }
 
     fn set_vstring_slice(ctx: &mut OptContext, opref: OpRef, s: OpRef, start: OpRef, lgtop: OpRef) {
-        let b = ctx.materialize_box_at(opref);
+        let b = ctx.materialize_operand_at(opref);
         // Materialize the source/start/length refs so they carry a bound
         // synthetic producer; a residual emit then sheds them to `Operand::Op`
         // instead of panicking on a position-only `from_opref` box.
@@ -1903,7 +1903,7 @@ mod tests {
         let start_box = ctx.materialize_operand_at(start);
         let lgtop_box = ctx.materialize_operand_at(lgtop);
         ctx.set_ptr_info(
-            &Operand::from_boxref(&b),
+            &b,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: Some(lgtop_box.clone()), // vstring.py:223: self.lgtop = length
@@ -2125,8 +2125,8 @@ mod tests {
 
         // start is not a literal ConstInt box; it is only known via IntBound.
         let start_ref = OpRef::int_op(300);
-        let start_box = ctx.materialize_box_at(start_ref);
-        ctx.with_intbound_mut(&Operand::from_boxref(&start_box), |b| {
+        let start_box = ctx.materialize_operand_at(start_ref);
+        ctx.with_intbound_mut(&start_box, |b| {
             *b = IntBound::from_constant(1);
         });
         let b = ctx.materialize_operand_at(OpRef::int_op(301));
@@ -2379,8 +2379,8 @@ mod tests {
         // non-virtual StrPtrInfo with `mode = 1` so that later getstrlen
         // selects UNICODELEN instead of STRLEN.
         // Synthetic-OpRef test fixture: lazy-allocate BoxRef for the unicode_ref slot.
-        let unicode_box = ctx.materialize_box_at(unicode_ref);
-        ctx.make_nonnull_str(&Operand::from_boxref(&unicode_box), 1);
+        let unicode_box = ctx.materialize_operand_at(unicode_ref);
+        ctx.make_nonnull_str(&unicode_box, 1);
 
         let unicode_op = ctx.materialize_operand_at(unicode_ref);
         let len_ref = pass.getstrlen(&unicode_op, &mut ctx);
@@ -2702,7 +2702,7 @@ mod tests {
         let left_op_rc = std::rc::Rc::new(left_op.clone());
         ctx.bind_input_resops(std::slice::from_ref(&left_op_rc));
         let _ = pass.propagate_forward(&left_op, &left_op_rc, &mut ctx);
-        assert!(pass.is_virtual(&Operand::from_boxref(&ctx.get_box_replacement(left)), &ctx));
+        assert!(pass.is_virtual(&ctx.get_box_replacement_operand(left), &ctx));
     }
 
     // ── Box/state parity tests ──
@@ -2747,9 +2747,9 @@ mod tests {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(4, 0, 0, 50);
         let p0 = OpRef::ref_op(0);
         // Non-virtual Str with unknown length
-        let p0_box = ctx.materialize_box_at(p0);
+        let p0_box = ctx.materialize_operand_at(p0);
         ctx.set_ptr_info(
-            &Operand::from_boxref(&p0_box),
+            &p0_box,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,
@@ -2838,9 +2838,9 @@ mod tests {
 
         // srcbox (p0): non-null string, not virtual
         let p0 = OpRef::ref_op(0);
-        let p0_box = ctx.materialize_box_at(p0);
+        let p0_box = ctx.materialize_operand_at(p0);
         ctx.set_ptr_info(
-            &Operand::from_boxref(&p0_box),
+            &p0_box,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,
@@ -2855,13 +2855,13 @@ mod tests {
         // STRSETITEM target arg as a bound box (`Operand::Op`), not a
         // position-only `from_opref` box.
         let p1 = OpRef::ref_op(1);
-        let p1_box = ctx.materialize_box_at(p1);
+        let p1_box = ctx.materialize_operand_at(p1);
 
         // lengthbox (i2): int with constant intbound = 2
         // Use an OpRef with IntBound set (not a literal constant)
         let i2 = OpRef::int_op(2);
-        let i2_box = ctx.materialize_box_at(i2);
-        ctx.with_intbound_mut(&Operand::from_boxref(&i2_box), |b| {
+        let i2_box = ctx.materialize_operand_at(i2);
+        ctx.with_intbound_mut(&i2_box, |b| {
             *b = IntBound::from_constant(2);
         });
 
@@ -2872,14 +2872,7 @@ mod tests {
         // Call copy_str_content. With intbound-constant length = 2 <= M=2,
         // it should inline to STRGETITEM+STRSETITEM instead of COPYSTRCONTENT.
         let _result = copy_str_content(
-            &mut ctx,
-            &Operand::from_boxref(&p0_box),
-            &Operand::from_boxref(&p1_box),
-            &off_op,
-            &off_op,
-            &Operand::from_boxref(&i2_box),
-            0,
-            true,
+            &mut ctx, &p0_box, &p1_box, &off_op, &off_op, &i2_box, 0, true,
         );
 
         // emit_for_force routes to extra_operations_after; drain it.
@@ -2915,10 +2908,10 @@ mod tests {
     fn test_getstrlen_opref_on_nonvirtual() {
         let mut ctx = OptContext::with_num_inputs_and_start_pos(10, 0, 0, 50);
         let arg2 = OpRef::ref_op(1);
-        let arg2_box = ctx.materialize_box_at(arg2);
+        let arg2_box = ctx.materialize_operand_at(arg2);
 
         ctx.set_ptr_info(
-            &Operand::from_boxref(&arg2_box),
+            &arg2_box,
             PtrInfo::Str(StrPtrInfo {
                 lenbound: None,
                 lgtop: None,


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
