### PR TITLE
for_iter #57: FBW recording-model fix — compile FOR_ITER loops for all iterators (opt-in)

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -604,6 +604,14 @@ pub enum PyreHelperKind {
     /// the in-flight iteration to the live frame instead of dropping it (the
     /// iterator advance is an irreversible side effect with no journal undo).
     ForIterNext,
+    /// `store_deref_value(cell, value)` — the STORE_DEREF residual
+    /// (`bh_store_deref_value_fn` via `cpu.store_deref_value_fn`).  It mutates
+    /// the cell's contents in place and RETURNS the slot value (`Ref`), so it
+    /// is a value-returning heap write the #57 Option C body-effect guard's
+    /// `Void`-result write proxy cannot see; the tag lets that guard flag it
+    /// (Finding #1) so an aborting FOR_ITER walk refuses delivery rather than
+    /// re-running the body and doubling the cell write.
+    StoreDeref,
 }
 
 impl EffectInfo {

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -595,6 +595,15 @@ pub enum PyreHelperKind {
     /// same descr-identity field, a balanced never-read save/restore is
     /// dead-store-eliminated so the virtual exception de-escapes and DCEs.
     SetCurrentException,
+    /// `for_iter_next(iter)` — the FOR_ITER advance residual the codewriter
+    /// emits for the continue arm (`jit_next` via `cpu.for_iter_next_fn`).
+    /// It advances the real shared heap iterator concretely during the
+    /// authoritative walk and returns the consumed item (`Ref`, or null at
+    /// exhaustion).  The full-body walker recognises this tag to stash the
+    /// consumed item + the FOR_ITER body pc so an aborting walk can DELIVER
+    /// the in-flight iteration to the live frame instead of dropping it (the
+    /// iterator advance is an irreversible side effect with no journal undo).
+    ForIterNext,
 }
 
 impl EffectInfo {

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2075,14 +2075,17 @@ impl TraceCtx {
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
     ) {
-        // This capture path never folds the after-residual-call marker
-        // (walker-emitted guards always resume at the outer Python opcode
-        // boundary — jitcode_dispatch.rs:4141-4145), so the raw pc must
-        // leave bit 14 free or `decode_resume_pc` mis-reads it as marked
-        // (resumedata.rs:48-62).
+        // A try-block after-residual-call guard folds the bit-14 marker onto
+        // its CALL pc so the resume decode routes through
+        // `after_residual_call_resume_pc_for` (the call's OWN post-call catch);
+        // `jitcode_dispatch.rs` `walker_capture_snapshot_for_last_guard_impl`
+        // produces such a pc.  Every other walker guard resumes at a plain
+        // outer-Python-opcode coordinate.  Either way the DECODED pc must leave
+        // bit 14 free, or `decode_resume_pc` mis-reads it (resumedata.rs:48-62).
         assert!(
-            pc < majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as u32,
-            "resume pc {pc} >= AFTER_RESIDUAL_CALL_PC_FLAG; \
+            majit_ir::resumedata::decode_resume_pc(pc as i32).0
+                < majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG,
+            "resume pc {pc} decodes >= AFTER_RESIDUAL_CALL_PC_FLAG; \
              function too large for bit-14 resume encoding"
         );
         let boxes = self.encode_snapshot_boxes(active_boxes);

--- a/pyre/bench/synth/foriter57/for_attr_abort.py
+++ b/pyre/bench/synth/foriter57/for_attr_abort.py
@@ -1,0 +1,35 @@
+class O:
+    pass
+
+
+def f():
+    o = O()
+    o.n = 0
+    seen = []
+    for x in range(500):
+        # `o.n += 1` is a concrete NON-journaled, NON-idempotent heap mutation
+        # (a STORE_ATTR via the residual `store_attr_fn`, which carries
+        # `PyreHelperKind::None` and is covered by NO journal) that COMMITS
+        # before a later op in the same iteration aborts the trace.
+        # `seen.append` is the abort trigger (its inline sub-walk declines);
+        # it exists only to force the in-body abort AFTER the attr store has
+        # committed.
+        #
+        # The OLD R1 guard flagged a body effect ONLY for a tiny allow-list of
+        # `PyreHelperKind`s (`StoreSubscr` / `CallFn` / `SetCurrentException`),
+        # so this `None`-tagged store was never flagged: the guard delivered the
+        # in-flight FOR_ITER item and re-ran the whole body, DOUBLING the
+        # accumulate (o.n over-counts by the number of aborts → 500 + #aborts).
+        # The inverted Finding #1 predicate flags ANY residual that is not
+        # provably side-effect-free, so the store is counted exactly once.
+        #
+        # Only `o.n` is asserted: it commits on every iteration (including the
+        # aborted ones, whose bypass still advances the loop), so the
+        # conservative refuse-and-drop fallback leaves it EXACT.  A re-run
+        # double, by contrast, is observable as 500 + (number of aborts).
+        o.n += 1
+        seen.append(x)
+    return o.n
+
+
+print(f())

--- a/pyre/bench/synth/foriter57/for_attr_abort.py
+++ b/pyre/bench/synth/foriter57/for_attr_abort.py
@@ -1,9 +1,9 @@
-class O:
+class Obj:
     pass
 
 
 def f():
-    o = O()
+    o = Obj()
     o.n = 0
     seen = []
     for x in range(500):

--- a/pyre/bench/synth/foriter57/for_deref_abort.py
+++ b/pyre/bench/synth/foriter57/for_deref_abort.py
@@ -1,0 +1,27 @@
+def make():
+    n = 0
+
+    def f():
+        nonlocal n
+        seen = []
+        for x in range(500):
+            # `n += 1` on a closure free variable lowers to STORE_DEREF, whose
+            # `store_deref_value` residual is a VALUE-returning (`Ref`) in-place
+            # cell write carrying `PyreHelperKind::StoreDeref`.  It commits a
+            # NON-journaled heap mutation before the later `seen.append` aborts
+            # the trace.
+            #
+            # The Void-result write proxy in the #57 Option C body-effect guard
+            # cannot see this residual (its result_type is `Ref`, not `Void`),
+            # so without the `StoreDeref` helper tag the guard DELIVERS the
+            # in-flight FOR_ITER item, re-runs the body, and DOUBLES the cell
+            # write (n = 500 + #aborts).  The tag flags it as a body effect so
+            # delivery is refused and the count stays EXACT.
+            n += 1
+            seen.append(x)
+        return n
+
+    return f
+
+
+print(make()())

--- a/pyre/bench/synth/foriter57/for_dict_abort.py
+++ b/pyre/bench/synth/foriter57/for_dict_abort.py
@@ -1,0 +1,25 @@
+def f():
+    cnt = {}
+    seen = []
+    for x in range(500):
+        # `cnt[0] = ...` is a concrete NON-journaled, NON-idempotent heap
+        # mutation (a dict accumulate via the residual `store_subscr_fn`, not
+        # the list[int] setitem journal) that COMMITS before a later op in the
+        # same iteration aborts the trace.  `seen.append` is the abort trigger
+        # (its inline sub-walk declines); it exists only to force the in-body
+        # abort AFTER the dict accumulate has committed.
+        #
+        # The OLD R1 guard checked only the symbolic-decline flag, so it
+        # delivered the in-flight FOR_ITER item and re-ran the whole body,
+        # DOUBLING the accumulate (cnt[0] over-counts by the number of aborts).
+        # The hardened guard refuses delivery whenever a body effect committed
+        # since the consume, so the accumulate is counted exactly once.
+        #
+        # Only `cnt[0]` is asserted: it commits on every iteration (including
+        # the aborted ones, whose bypass still advances the loop), so the
+        # conservative refuse-and-drop fallback leaves it EXACT.  A re-run
+        # double, by contrast, is observable as 500 + (number of aborts).
+        cnt[0] = cnt.get(0, 0) + 1
+        seen.append(x)
+    return cnt[0]
+print(f())

--- a/pyre/bench/synth/foriter57/for_dictkeys.py
+++ b/pyre/bench/synth/foriter57/for_dictkeys.py
@@ -1,0 +1,7 @@
+def f():
+    d = {1: "a", 2: "b", 3: "c"}
+    s = 0
+    for k in d:
+        s += k
+    return s
+print(f())

--- a/pyre/bench/synth/foriter57/for_enumerate.py
+++ b/pyre/bench/synth/foriter57/for_enumerate.py
@@ -1,0 +1,6 @@
+def f():
+    total = 0
+    for i, x in enumerate([10, 20, 30, 40]):
+        total += i * x
+    return total
+print(f())

--- a/pyre/bench/synth/foriter57/for_gen.py
+++ b/pyre/bench/synth/foriter57/for_gen.py
@@ -1,0 +1,11 @@
+def gen(n):
+    i = 0
+    while i < n:
+        yield i
+        i += 1
+def f():
+    s = 0
+    for x in gen(500):
+        s += x
+    return s
+print(f())

--- a/pyre/bench/synth/foriter57/for_hotraise.py
+++ b/pyre/bench/synth/foriter57/for_hotraise.py
@@ -1,0 +1,20 @@
+class HotBoom:
+    def __init__(self, n):
+        self.i = 0
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        self.i += 1
+        if self.i > self.n:
+            raise ValueError("boom")
+        return self.i
+def f():
+    total = 0
+    try:
+        for x in HotBoom(500):
+            total += x
+    except ValueError:
+        total += 1000000
+    return total
+print(f())

--- a/pyre/bench/synth/foriter57/for_min.py
+++ b/pyre/bench/synth/foriter57/for_min.py
@@ -1,0 +1,6 @@
+def f():
+    last = -1
+    for x in range(500):
+        last = x
+    return last
+print(f())

--- a/pyre/bench/synth/foriter57/for_monkeypatch.py
+++ b/pyre/bench/synth/foriter57/for_monkeypatch.py
@@ -17,7 +17,11 @@ def run():
     return s
 def f():
     a = run()
-    It.__next__ = lambda self: (_ for _ in ()).throw(StopIteration)  # now yields nothing
+
+    def stop(self):  # monkeypatched __next__: the iterator now yields nothing
+        raise StopIteration
+
+    It.__next__ = stop
     b = run()
     return (a, b)
 print(f())

--- a/pyre/bench/synth/foriter57/for_monkeypatch.py
+++ b/pyre/bench/synth/foriter57/for_monkeypatch.py
@@ -1,0 +1,23 @@
+class It:
+    def __init__(self, n):
+        self.i = 0
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.i >= self.n:
+            raise StopIteration
+        v = self.i
+        self.i += 1
+        return v
+def run():
+    s = 0
+    for x in It(50):
+        s += x
+    return s
+def f():
+    a = run()
+    It.__next__ = lambda self: (_ for _ in ()).throw(StopIteration)  # now yields nothing
+    b = run()
+    return (a, b)
+print(f())

--- a/pyre/bench/synth/foriter57/for_mutate.py
+++ b/pyre/bench/synth/foriter57/for_mutate.py
@@ -1,0 +1,6 @@
+def f():
+    seen = []
+    for x in range(500):
+        seen.append(x)
+    return len(seen)
+print(f())

--- a/pyre/bench/synth/foriter57/for_nested.py
+++ b/pyre/bench/synth/foriter57/for_nested.py
@@ -1,0 +1,12 @@
+def f():
+    acc = 0
+    # A nested FOR_ITER: the inner FOR_ITER is NOT the walk-entry / loop-header
+    # opcode, so its body pc cannot be derived from the walk-entry coordinate.
+    # The body_pc must come from the inner FOR_ITER op's OWN pc; a wrong body
+    # pc would deliver the consumed item to the wrong opcode → silent
+    # corruption or SIGBUS.
+    for i in range(200):
+        for j in range(50):
+            acc += i * j
+    return acc
+print(f())

--- a/pyre/bench/synth/foriter57/for_nested_kept.py
+++ b/pyre/bench/synth/foriter57/for_nested_kept.py
@@ -1,0 +1,30 @@
+def f():
+    acc = 0
+    data = [1, 2, 3, 4, 5, 6, 7, 8]
+    # A nested loop whose INNER `for x in data` is the walk-entry / loop-header
+    # FOR_ITER that the FBW walk traces and delivers an in-flight item from on a
+    # trace abort.  `base` is an operand-stack-adjacent kept temp live across the
+    # inner FOR_ITER, so the delivery's push lands only if the live frame is
+    # PROVABLY at the inner loop's header state.
+    #
+    # `deliver_inflight_foriter_item` pushes the consumed item + repositions the
+    # frame at `body_pc` (the FOR_ITER fallthrough), assuming the live frame is
+    # parked at the loop-header FOR_ITER with the iterator on TOS.  `body_pc` is
+    # nested-aware (derived from the consumed FOR_ITER op's OWN pc), so it can
+    # name an inner FOR_ITER reached deeper in a traced body — where the live
+    # frame is parked at the OUTER header, NOT the inner one.  Pushing there
+    # corrupts the operand stack (a later GET_ITER/FOR_ITER reads a wrong slot
+    # as an iterator -> "TypeError: not an iterator").  The header-state guard
+    # delivers ONLY when the frame is parked at the FOR_ITER whose fallthrough
+    # is `body_pc` (`next_instr() == body_pc - 1`, opcode there is FOR_ITER);
+    # otherwise it REFUSES (drops the stash, the conservative drop-on-abort
+    # fallback) rather than push to a non-header frame.  This case's inner
+    # consume is header-consistent, so it STILL delivers and stays exact.
+    for i in range(4000):
+        base = i * 2
+        for x in data:
+            acc = acc + x + base
+    return acc
+
+
+print(f())

--- a/pyre/bench/synth/foriter57/for_prop_abort.py
+++ b/pyre/bench/synth/foriter57/for_prop_abort.py
@@ -1,0 +1,40 @@
+class O:
+    hits = 0
+
+    @property
+    def p(self):
+        # A side-effecting getter: reading `obj.p` runs THIS Python frame,
+        # whose body mutates `O.hits` (a class-attribute STORE_ATTR).  The
+        # mutation is a concrete, NON-journaled, NON-idempotent heap write
+        # that COMMITS before a later op in the same iteration aborts.
+        O.hits += 1
+        return 1
+
+
+def f():
+    obj = O()
+    seen = []
+    for x in range(500):
+        # `obj.p` lowers to a value-returning `load_attr` residual
+        # (`PyreHelperKind::None`, `Ref` result, `MayForce`): the OLD R1
+        # write-discriminator (Void result OR a CallFn/StoreSubscr/
+        # SetCurrentException/StoreDeref tag) does NOT see it, so its
+        # getter side effect (`O.hits += 1`) escaped the body-effect flag.
+        # `seen.append` is the abort trigger (its inline sub-walk declines)
+        # AFTER the getter has already run its Python frame and committed
+        # `O.hits += 1`.  Delivering the in-flight item and re-running the
+        # body then runs the getter a SECOND time → `O.hits` DOUBLES
+        # (500 + #aborts) on a re-run.
+        #
+        # The user-frame-entry signal flags the body effect: running the
+        # getter entered a user Python frame after the in-flight FOR_ITER
+        # consume, so `fbw_foriter_inflight_take` refuses delivery and the
+        # legacy drop-on-abort fallback leaves `O.hits` EXACT at 500
+        # (the bypass still advances the loop and runs the getter once per
+        # iteration, including the aborted ones).
+        v = obj.p
+        seen.append(x)
+    return O.hits
+
+
+print(f())

--- a/pyre/bench/synth/foriter57/for_prop_abort.py
+++ b/pyre/bench/synth/foriter57/for_prop_abort.py
@@ -1,4 +1,4 @@
-class O:
+class Obj:
     hits = 0
 
     @property
@@ -7,12 +7,12 @@ class O:
         # whose body mutates `O.hits` (a class-attribute STORE_ATTR).  The
         # mutation is a concrete, NON-journaled, NON-idempotent heap write
         # that COMMITS before a later op in the same iteration aborts.
-        O.hits += 1
+        Obj.hits += 1
         return 1
 
 
 def f():
-    obj = O()
+    obj = Obj()
     seen = []
     for x in range(500):
         # `obj.p` lowers to a value-returning `load_attr` residual
@@ -23,18 +23,18 @@ def f():
         # `seen.append` is the abort trigger (its inline sub-walk declines)
         # AFTER the getter has already run its Python frame and committed
         # `O.hits += 1`.  Delivering the in-flight item and re-running the
-        # body then runs the getter a SECOND time → `O.hits` DOUBLES
+        # body then runs the getter a SECOND time → `Obj.hits` DOUBLES
         # (500 + #aborts) on a re-run.
         #
         # The user-frame-entry signal flags the body effect: running the
         # getter entered a user Python frame after the in-flight FOR_ITER
         # consume, so `fbw_foriter_inflight_take` refuses delivery and the
-        # legacy drop-on-abort fallback leaves `O.hits` EXACT at 500
+        # legacy drop-on-abort fallback leaves `Obj.hits` EXACT at 500
         # (the bypass still advances the loop and runs the getter once per
         # iteration, including the aborted ones).
         v = obj.p
         seen.append(x)
-    return O.hits
+    return Obj.hits
 
 
 print(f())

--- a/pyre/bench/synth/foriter57/for_prop_raise_abort.py
+++ b/pyre/bench/synth/foriter57/for_prop_raise_abort.py
@@ -1,0 +1,43 @@
+class Obj:
+    hits = 0
+
+    @property
+    def p(self):
+        # A side-effecting getter that MUTATES then RAISES: reading `obj.p`
+        # runs THIS Python frame, whose body first mutates `Obj.hits` (a
+        # class-attribute STORE_ATTR — a concrete, NON-journaled,
+        # NON-idempotent heap write that COMMITS) and THEN raises.  The raise
+        # routes the value-returning `load_attr` residual onto
+        # `execute_residual_call`'s Err arm.
+        Obj.hits += 1
+        raise ValueError
+
+
+def f():
+    obj = Obj()
+    seen = []
+    for x in range(500):
+        # `obj.p` lowers to a value-returning `load_attr` residual
+        # (`PyreHelperKind::None`, `Ref` result, `MayForce`).  Its getter
+        # frame mutates `Obj.hits` and raises; the raise takes the residual's
+        # Err arm.  The R1 body-effect marking used to run ONLY on the Ok arm,
+        # so the Err arm left the in-flight FOR_ITER item's body-effect flag
+        # UNSET.  `seen.append` is the abort trigger (its inline sub-walk
+        # declines) AFTER the getter already committed `Obj.hits += 1` and the
+        # local `except` swallowed the raise.  With the flag unset,
+        # `fbw_foriter_inflight_take` delivered the in-flight item and re-ran
+        # the body, running the getter a SECOND time → `Obj.hits` DOUBLES
+        # (500 + #aborts) on a re-run.
+        #
+        # Marking the body effect on BOTH arms (the raising user frame still
+        # bumped the eval-loop entry odometer) makes `take` refuse delivery, so
+        # the legacy drop-on-abort fallback leaves `Obj.hits` EXACT at 500.
+        try:
+            v = obj.p
+        except ValueError:
+            pass
+        seen.append(x)
+    return Obj.hits
+
+
+print(f())

--- a/pyre/bench/synth/foriter57/for_raise.py
+++ b/pyre/bench/synth/foriter57/for_raise.py
@@ -1,0 +1,11 @@
+def f():
+    total = 0
+    try:
+        for x in range(10):
+            if x == 5:
+                raise ValueError("stop")
+            total += x
+    except ValueError:
+        total += 1000
+    return total
+print(f())

--- a/pyre/bench/synth/foriter57/for_sum.py
+++ b/pyre/bench/synth/foriter57/for_sum.py
@@ -1,0 +1,6 @@
+def f():
+    s = 0
+    for x in range(500):
+        s += x
+    return s
+print(f())

--- a/pyre/bench/synth/foriter57/for_sum_big.py
+++ b/pyre/bench/synth/foriter57/for_sum_big.py
@@ -1,0 +1,6 @@
+def f():
+    s = 0
+    for x in range(100000):
+        s += x
+    return s
+print(f())

--- a/pyre/bench/synth/foriter57/for_user.py
+++ b/pyre/bench/synth/foriter57/for_user.py
@@ -1,0 +1,18 @@
+class Counter:
+    def __init__(self, n):
+        self.i = 0
+        self.n = n
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.i >= self.n:
+            raise StopIteration
+        v = self.i
+        self.i += 1
+        return v
+def f():
+    s = 0
+    for x in Counter(500):
+        s += x
+    return s
+print(f())

--- a/pyre/bench/synth/foriter57/for_user_raise.py
+++ b/pyre/bench/synth/foriter57/for_user_raise.py
@@ -1,0 +1,19 @@
+class Boom:
+    def __init__(self):
+        self.i = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        self.i += 1
+        if self.i == 6:
+            raise ValueError("boom")
+        return self.i
+def f():
+    total = 0
+    try:
+        for x in Boom():
+            total += x
+    except ValueError:
+        total += 1000
+    return total
+print(f())

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Usage: sh run_matrix.sh /path/to/pyre-binary
+# Oracle = interp (PYRE_NO_JIT); asserts default-JIT and PYRE_57_INLINE_NEXT match it.
+set -e
+PYRE="$1"
+DIR="$(dirname "$0")"
+for f in for_min for_sum for_sum_big; do
+    base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
+    jit="$("$PYRE" "$DIR/$f.py")"
+    inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"
+    if [ "$base" = "$jit" ] && [ "$base" = "$inl" ]; then
+        echo "OK   $f  ->  $base"
+    else
+        echo "FAIL $f"
+        echo "  interp:    $base"
+        echo "  jit:       $jit"
+        echo "  inline:    $inl"
+        exit 1
+    fi
+done
+echo "MATRIX OK"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_hotraise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_nested; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_hotraise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_nested for_nested_kept; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_nested; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_hotraise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_nested; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_nested; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_nested; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -2,9 +2,13 @@
 # Usage: sh run_matrix.sh /path/to/pyre-binary
 # Oracle = interp (PYRE_NO_JIT); asserts default-JIT and PYRE_57_INLINE_NEXT match it.
 set -e
+if [ "$#" -ne 1 ] || [ ! -x "$1" ]; then
+    echo "Usage: sh run_matrix.sh /path/to/pyre-binary" >&2
+    exit 2
+fi
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_hotraise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_nested for_nested_kept; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_hotraise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_prop_abort for_prop_raise_abort for_nested for_nested_kept; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch for_dict_abort for_nested; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big; do
+for f in for_min for_sum for_sum_big for_raise; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/bench/synth/foriter57/run_matrix.sh
+++ b/pyre/bench/synth/foriter57/run_matrix.sh
@@ -4,7 +4,7 @@
 set -e
 PYRE="$1"
 DIR="$(dirname "$0")"
-for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch for_dict_abort for_nested; do
+for f in for_min for_sum for_sum_big for_raise for_gen for_user for_enumerate for_dictkeys for_user_raise for_mutate for_monkeypatch for_dict_abort for_attr_abort for_deref_abort for_nested; do
     base="$(PYRE_NO_JIT=1 "$PYRE" "$DIR/$f.py")"
     jit="$("$PYRE" "$DIR/$f.py")"
     inl="$(PYRE_57_INLINE_NEXT=1 perl -e 'alarm shift; exec @ARGV' 30 "$PYRE" "$DIR/$f.py" || echo "TIMEOUT/CRASH($?)")"

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -100,12 +100,43 @@ thread_local! {
     /// decremented on return. Replaces the Box<dyn Any> depth bump
     /// callback with a zero-allocation TLS increment.
     static CALL_DEPTH: Cell<u32> = const { Cell::new(0) };
+
+    /// Monotonic count of Python frame eval-loop entries — bumped once per
+    /// `eval_loop` / `eval_loop_jit` entry (every user-level bytecode frame
+    /// that begins running), NEVER decremented.  Unlike [`CALL_DEPTH`] (net
+    /// zero after a balanced call returns), this is a cumulative odometer, so
+    /// a snapshot taken before a residual call and re-read after it reveals
+    /// whether ANY user Python frame ran during the call regardless of how
+    /// deeply it nested or whether it returned.  Consumed by the FBW FOR_ITER
+    /// Option-C double-apply guard (#57): a value-returning residual whose
+    /// concrete execution entered a user frame (a side-effecting `@property`
+    /// getter, a user `__add__` / `__iter__` / `__str__`, an imported
+    /// module's top level) committed a body effect the Void/helper-tag write
+    /// discriminator cannot see.
+    static FRAME_ENTRY_COUNT: Cell<u64> = const { Cell::new(0) };
 }
 
 /// Get current call depth. Used by pyre-jit for JIT_CALL_DEPTH parity.
 #[inline(always)]
 pub fn call_depth() -> u32 {
     CALL_DEPTH.with(|d| d.get())
+}
+
+/// Snapshot of the monotonic Python frame eval-loop entry odometer
+/// ([`FRAME_ENTRY_COUNT`]).  A change between two reads means user-level
+/// bytecode ran in between.
+#[inline(always)]
+pub fn frame_entry_count() -> u64 {
+    FRAME_ENTRY_COUNT.with(|c| c.get())
+}
+
+/// Bump the monotonic Python frame eval-loop entry odometer
+/// ([`FRAME_ENTRY_COUNT`]).  Called once at every `eval_loop` /
+/// `eval_loop_jit` entry, i.e. each time a user Python frame begins
+/// executing bytecode.
+#[inline(always)]
+pub fn bump_frame_entry_count() {
+    FRAME_ENTRY_COUNT.with(|c| c.set(c.get().wrapping_add(1)));
 }
 
 /// Increment call depth and return an RAII guard that decrements on drop.

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1246,6 +1246,11 @@ pub fn eval_loop_for_force(frame: &mut PyFrame) -> PyResult {
 }
 
 fn eval_loop(frame: &mut PyFrame) -> PyResult {
+    // Bump the monotonic frame eval-loop entry odometer: a user Python frame
+    // is about to run bytecode.  The FBW FOR_ITER Option-C guard snapshots
+    // this around a residual call to detect a body effect that ran through
+    // user code (a side-effecting getter / dunder / module top level).
+    crate::call::bump_frame_entry_count();
     let _current_frame_guard = if frame.execution_context.is_null() {
         install_current_frame(frame)
     } else {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1371,8 +1371,12 @@ pub fn via_space_next(iter: PyObjectRef) -> bool {
 /// return that the trailing for-iter GuardNonnull catches, side-exiting to
 /// the interpreter which re-runs FOR_ITER and ends the loop (eval.rs
 /// `iter_next` maps StopIteration to exhausted). A *real* exception is
-/// published into the backend exception cells so the GuardNoException
-/// side-exits instead; the interpreter then re-runs FOR_ITER and re-raises.
+/// published into BOTH the backend exception cells (so the compiled trace /
+/// blackhole GuardNoException side-exits) AND `BH_LAST_EXC_VALUE` (so the
+/// full-body walk's `execute_residual_call` returns Err and records the
+/// can-raise path instead of mistaking the null for exhaustion). Keeping the
+/// two seams in sync mirrors `call_jit::publish_residual_call_exception`, the
+/// dual-publish every other MayForce residual uses.
 #[majit_macros::jit_may_force]
 pub extern "C" fn jit_next(iter: i64) -> i64 {
     match crate::baseobjspace::next(iter as PyObjectRef) {
@@ -1381,7 +1385,11 @@ pub extern "C" fn jit_next(iter: i64) -> i64 {
         // null so the GuardNonnull (not GuardNoException) fires.
         Err(err) if err.kind == PyErrorKind::StopIteration => 0,
         Err(err) => {
-            jit_publish_exception(err.to_exc_object());
+            let exc_obj = err.to_exc_object();
+            if exc_obj != PY_NULL {
+                majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc_obj as i64));
+            }
+            jit_publish_exception(exc_obj);
             0
         }
     }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3350,6 +3350,15 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     "int_items.len" => return list_int_items_len_descr(),
                     "int_items.heap_cap" => return list_int_items_heap_cap_descr(),
                     "int_items.block" => return list_int_items_block_descr(),
+                    // A bare `int_items` / `float_items` read addresses the
+                    // typed-storage struct base, which is its first field
+                    // (`block`, `INT_ARRAY_BLOCK_OFFSET == 0`) — the same
+                    // offset + `Ref` type as the `.block` leaf above. The
+                    // `w_list_append` body reads `int_items` directly before
+                    // reaching `.ptr`/`.len`; bridge it to the canonical
+                    // `.block` group entry so the read resolves a parent_descr.
+                    "int_items" => return list_int_items_block_descr(),
+                    "float_items" => return list_float_items_block_descr(),
                     // The `w_list_append` body's `match list.strategy` reads the
                     // header `strategy` field directly.  The codewriter resolves
                     // its offset but produces a `SimpleFieldDescr` with no

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -2525,6 +2525,46 @@ mod tests {
     }
 
     #[test]
+    fn make_descr_from_bh_bridges_codewriter_bare_items_aliases_to_block_group() {
+        use majit_ir::descr::ArrayFlag;
+        use majit_translate::jitcode::BhDescr;
+
+        // A bare `int_items` / `float_items` read (the `w_list_append` body
+        // reads the typed-storage struct base before reaching `.ptr`/`.len`)
+        // must bridge to the same canonical `.block` group entry as the dotted
+        // `.block` leaf — a populated parent_descr and the `.block` offset, not
+        // the offset-0 list header.
+        for (name, expected) in [
+            ("int_items", list_int_items_block_descr()),
+            ("float_items", list_float_items_block_descr()),
+        ] {
+            let descr = make_descr_from_bh(&BhDescr::Field {
+                offset: 0,
+                field_size: 8,
+                field_type: Type::Ref,
+                field_flag: ArrayFlag::Signed,
+                is_field_signed: false,
+                is_immutable: false,
+                is_quasi_immutable: false,
+                index_in_parent: 0,
+                parent: None,
+                name: name.into(),
+                owner: "W_ListObject".into(),
+            });
+            let field = descr.as_field_descr().expect("Field BhDescr -> FieldDescr");
+            assert!(
+                field.get_parent_descr().is_some(),
+                "{name} must carry a parent_descr after the bridge",
+            );
+            assert_eq!(
+                field.offset(),
+                expected.as_field_descr().unwrap().offset(),
+                "{name} offset must match the `.block` W_LIST_DESCR_GROUP entry",
+            );
+        }
+    }
+
+    #[test]
     fn make_descr_from_bh_bridges_codewriter_list_header_fields_to_group() {
         use majit_ir::descr::ArrayFlag;
         use majit_translate::jitcode::BhDescr;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2301,8 +2301,13 @@ pub fn dispatch_via_miframe(
     // Phase 7: this IS the full-body walk over the outer `sym.jitcode`,
     // so guard snapshots can resolve a per-guard resume coordinate from
     // `op_pc`.  Mark the thread-local for the walk's lifetime;
-    // `walker_capture_snapshot_for_last_guard` reads it.  Reached only
-    // under `PYRE_FULL_BODY_WALK`, so production default-off is unchanged.
+    // `walker_capture_snapshot_for_last_guard` and
+    // `fbw_foriter_body_pc_from_op_pc` read it.  This is the PRODUCTION
+    // default tracer: `trace.rs` enters `full_body_walk_trace` whenever
+    // `PYRE_FULL_BODY_WALK` is not explicitly `0` (the env gate defaults ON),
+    // so `FULL_BODY_SNAPSHOT_SYM` is non-null on every default-JIT and
+    // `PYRE_57_INLINE_NEXT=1` run.  `PYRE_FULL_BODY_WALK=0` is the only opt-out
+    // (the transitional trait leg), which leaves the pointer null.
     let _full_body_guard = FullBodySnapshotSymGuard::set(sym_ptr);
 
     // RPython parity: `metainterp.last_exc_value` (pyjitpl.py:1695)
@@ -5137,28 +5142,59 @@ fn try_execute_residual_call_via_executor(
     // earlier this iteration).  The journaled list ops (setitem / append) run
     // OUTSIDE this executor (`try_walker_store_subscr_specialization` /
     // `try_walker_orthodox_list_append`) and roll back on abort, so they are
-    // not body-effect candidates here.  The residuals that DO reach this
-    // executor and can mutate live state un-journaled are:
-    //   * `StoreSubscr` — a non-list-int subscript store (a dict / object
-    //     `store_subscr_fn`); mutates the container irreversibly.
-    //   * `CallFn` — an opaque Python-level call (`bh_call_fn`); may mutate
-    //     arbitrary state, so treat it conservatively as a body effect.
-    //   * `SetCurrentException` — a TLS exc-slot write.
-    // Read-only / pure helpers (`Truth`, `LoadGlobal`, `BinaryOp`, …) and the
-    // bound-method / vable-force machinery (`pyre_helper = None`) are NOT
-    // flagged, so a clean body like `for_mutate`'s (whose only effect is the
-    // journaled append, aborted BEFORE it commits) still delivers.  The
-    // `for_iter_next` consume itself is excluded — it is the SOURCE of the
-    // capture, not a body effect.  Sampled BEFORE the call so the success arm
-    // can flag an effect that committed AFTER the in-flight consume.
-    let helper = call_descr.get_extra_info().pyre_helper;
-    let mutates_unjournaled_heap = matches!(
-        helper,
-        majit_ir::PyreHelperKind::StoreSubscr
-            | majit_ir::PyreHelperKind::CallFn
-            | majit_ir::PyreHelperKind::SetCurrentException
-    );
-    let body_effect_candidate = mutates_unjournaled_heap && fbw_foriter_inflight_active();
+    // not body-effect candidates here.
+    //
+    // The OLD allow-list (`StoreSubscr` / `CallFn` / `SetCurrentException`
+    // only) MISSED the many statement-level mutators that reach this executor
+    // concretely, succeed, and carry `PyreHelperKind::None` (`store_attr_fn` /
+    // `delete_subscr_fn` / `delete_attr_fn` / `list_extend_fn` / `store_name_fn`
+    // / `store_global` / `store_slice` …): a missed mutator is a silent double
+    // on a body re-run (correctness-FATAL).  Flag any residual that WRITES live
+    // heap state outside the journals.
+    //
+    // The write discriminator is the residual's RESULT TYPE plus the
+    // value-returning-mutator helper tags — NOT `extraeffect`, which cannot
+    // separate a write from a read: `getattr_fn` (a pure `.append` bound-method
+    // lookup) and `store_attr_fn` are BOTH `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`
+    // (the analyzer is stubbed, so `write_descrs_*` are empty for both).  A
+    // `Void`-result residual produces no value, so it is executed solely for
+    // its heap side effect → a write.  Every statement-level mutator above
+    // lowers to a `residual_call_*_v` (Void); the benign reads (`getattr`,
+    // `load_global`, `load_name`, `load_deref` …) all RETURN a value, so a
+    // Void result is a clean write proxy that does not over-refuse a read.
+    //
+    // The few VALUE-returning writes the Void test cannot see are caught by
+    // helper tag: `CallFn` (an opaque Python call returning its None ref may
+    // mutate arbitrary state), `StoreSubscr` (a dict/object `o[k]=v` returning
+    // the stored value), `SetCurrentException` (the TLS exc-slot write), and
+    // `StoreDeref` (an in-place closure-cell write returning the slot value —
+    // `nonlocal n; n += 1`).  Over-refusing only these (never a benign read)
+    // keeps the journaled-append body (`for_mutate`) delivering, since its
+    // `getattr`/append residuals return `Ref` and carry no write tag.
+    //
+    // Provably read-only/elidable residuals are exempt up front: `@jit.elidable`-
+    // class (`check_is_elidable`: `EF_ELIDABLE_*`, the pure executor folds
+    // these) or `EF_LOOPINVARIANT` (loop-hoisted).  The `for_iter_next` consume
+    // itself ([`PyreHelperKind::ForIterNext`]) is excluded — it is the SOURCE of
+    // the capture (it runs while the PRIOR iteration's item is still in flight),
+    // not a body effect for that prior iteration.  Sampled BEFORE the call so
+    // the success arm can flag an effect that committed AFTER the in-flight
+    // consume.
+    let ei = call_descr.get_extra_info();
+    let helper = ei.pyre_helper;
+    let provably_side_effect_free = ei.check_is_elidable()
+        || ei.extraeffect == majit_ir::ExtraEffect::LoopInvariant
+        || helper == majit_ir::PyreHelperKind::ForIterNext;
+    let writes_live_heap = call_descr.result_type() == majit_ir::Type::Void
+        || matches!(
+            helper,
+            majit_ir::PyreHelperKind::CallFn
+                | majit_ir::PyreHelperKind::StoreSubscr
+                | majit_ir::PyreHelperKind::SetCurrentException
+                | majit_ir::PyreHelperKind::StoreDeref
+        );
+    let body_effect_candidate =
+        !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
     let exec_result = {
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
@@ -5184,20 +5220,23 @@ fn try_execute_residual_call_via_executor(
     }
     match exec_result {
         Ok(result_i64) => {
-            // #57 Option C (Finding #1, R1): an un-journaled heap-mutating
-            // residual (`StoreSubscr` / `CallFn` / `SetCurrentException`) just
-            // committed AFTER the in-flight FOR_ITER consume.  The store/append
-            // journals roll their entries back on abort (so a body re-run
-            // re-applies them once), but a mutation outside those journals (a
-            // dict `store_subscr_fn`, a method that grows an unmodeled
-            // container) cannot be undone — delivering the in-flight item and
-            // re-running the body would double it.  Flag it so
-            // `fbw_foriter_inflight_take` refuses delivery (the legacy
+            // #57 Option C (Finding #1, R1): a residual that is not provably
+            // side-effect-free just succeeded AFTER the in-flight FOR_ITER
+            // consume.  The store/append journals roll their entries back on
+            // abort (so a body re-run re-applies them once), but a mutation
+            // outside those journals (a dict `store_subscr_fn`, an
+            // `obj.attr = …` `store_attr_fn`, a `list.extend`, a `del o[k]`,
+            // a name/global/deref store …) cannot be undone — delivering the
+            // in-flight item and re-running the body would double it.  Flag it
+            // so `fbw_foriter_inflight_take` refuses delivery (the legacy
             // drop-on-abort fallback) instead of doubling.
             if body_effect_candidate {
                 if fbw_debug_abort_enabled() {
                     eprintln!(
-                        "[fbw-foriter] body effect committed since consume (helper={helper:?})",
+                        "[fbw-foriter] body effect committed since consume (helper={helper:?} \
+                         extraeffect={:?} result_type={:?})",
+                        ei.extraeffect,
+                        call_descr.result_type(),
                     );
                 }
                 fbw_mark_foriter_body_effect_since_consume();
@@ -6798,13 +6837,23 @@ thread_local! {
     static FBW_FORITER_INFLIGHT: std::cell::RefCell<Option<(pyre_object::PyObjectRef, usize)>> =
         const { std::cell::RefCell::new(None) };
 
-    /// #57 Option C (Finding #1, R1 double-apply guard): set when a non-
-    /// elidable concrete residual committed an irreversible heap mutation
-    /// AFTER the in-flight FOR_ITER consume ([`FBW_FORITER_INFLIGHT`]) was
-    /// captured — a body effect that the store/append journals do NOT cover
-    /// (a dict `store_subscr_fn`, or any method mutating an unmodeled
-    /// container).  Unlike the journaled list ops (rolled back on abort, so a
-    /// body re-run re-applies them once) and the symbolic-decline flag
+    /// #57 Option C (Finding #1, R1 double-apply guard): set when a residual
+    /// that WRITES live heap state succeeded AFTER the in-flight FOR_ITER
+    /// consume ([`FBW_FORITER_INFLIGHT`]) was captured — a body effect the
+    /// store/append journals do NOT cover.  The executor flags by a write
+    /// discriminator (not `extraeffect`, which cannot tell a write from a read
+    /// since `getattr_fn` and `store_attr_fn` are both
+    /// `EF_FORCES_VIRTUAL_OR_VIRTUALIZABLE`): a `Void`-result residual is a
+    /// statement run for effect, PLUS the value-returning-write helper tags
+    /// (`CallFn` / `StoreSubscr` / `SetCurrentException` / `StoreDeref`).
+    /// Provably read-only/elidable residuals (`check_is_elidable` /
+    /// `EF_LOOPINVARIANT`) and the FOR_ITER `for_iter_next` consume itself (the
+    /// SOURCE of the capture) are exempt.  This catches the many
+    /// `PyreHelperKind::None` Void mutators (`store_attr_fn` /
+    /// `delete_subscr_fn` / `delete_attr_fn` / `list_extend_fn` /
+    /// `store_name_fn` / `store_global` / `store_slice` …) the OLD three-tag
+    /// allow-list missed.  Unlike the journaled list ops (rolled back on abort, so a body
+    /// re-run re-applies them once) and the symbolic-decline flag
     /// ([`FBW_UNJOURNALED_EFFECT`], applied only by the legacy replay), this
     /// mutation already stands on the live heap and is not reversible, so
     /// delivering the in-flight item and re-running the body would DOUBLE it.
@@ -6966,6 +7015,21 @@ pub(crate) fn fbw_mark_foriter_body_effect_since_consume() {
 /// consume (Finding #1, R1).
 pub(crate) fn fbw_foriter_body_effect_since_consume() -> bool {
     FBW_FORITER_BODY_EFFECT_SINCE_CONSUME.with(|c| c.get())
+}
+
+/// Whether ANY of the three R1 body-effect signals is currently present:
+/// the body-effect-since-consume flag, either journal non-empty, or the
+/// unjournaled-effect flag.  These are the exact signals
+/// [`fbw_foriter_inflight_take`] consults to REFUSE delivery, and `take`
+/// leaves them untouched.  Exposed for the deliver-path loud-failure
+/// debug-assert (#57 Finding #3): a successful take (delivery) while any
+/// signal stands would be a silent double, so the deliver site asserts this
+/// is `false` in debug builds.
+pub fn fbw_foriter_any_body_effect_signal() -> bool {
+    fbw_foriter_body_effect_since_consume()
+        || fbw_store_journal_len() != 0
+        || FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) != 0
+        || fbw_has_unjournaled_effect()
 }
 
 /// Take the in-flight FOR_ITER continuation for delivery on a trace abort

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5263,6 +5263,13 @@ fn try_execute_residual_call_via_executor(
     // `for_iter_next` consume itself is exempt (`provably_side_effect_free`
     // leaves both `body_effect_candidate` false and `user_frame_snapshot`
     // None), so a raising `__next__` never self-flags.
+    //
+    // The odometer bumps at frame ENTRY, so `entered_user_frame` cannot tell a
+    // user frame that raised AFTER mutating from one that raised BEFORE: a
+    // getter that raises before committing anything is also refused here.  That
+    // is a harmless conservative DROP (the legacy bypass still runs the
+    // iteration once), never a double — refusing a non-mutating raise costs
+    // nothing but the never-double guarantee.
     let entered_user_frame = user_frame_snapshot
         .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before);
     if body_effect_candidate || entered_user_frame {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6871,8 +6871,41 @@ pub(crate) fn fbw_foriter_inflight_capture(item: pyre_object::PyObjectRef, body_
 /// Take the in-flight FOR_ITER continuation for delivery on a trace abort
 /// (#57 Option C).  Returns `(consumed_item, body_pc)` and clears the stash
 /// so it is delivered at most once.
+///
+/// R1 (double-apply guard): delivery resumes the live frame at the FOR_ITER
+/// body, so any body op that ALREADY ran concretely during the aborted walk
+/// would be re-applied.  The journaled body effects (list setitem/append)
+/// are rolled back by [`fbw_store_journal_rollback`] before this take, so
+/// re-running re-applies them exactly once.  An UNjournaled effect
+/// (`FBW_UNJOURNALED_EFFECT` — a void/symbolic residual the rollback cannot
+/// undo) is NOT reversible, so delivering would double it.  Refuse delivery
+/// in that case (drop the stash → the legacy bypass keeps the prior
+/// drop-on-abort behaviour for that shape, never a double).  `for_mutate`
+/// aborts BEFORE the append's effect, so no journal entry and no unjournaled
+/// effect exist at the abort point — the clean continuation case.
 pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> {
-    FBW_FORITER_INFLIGHT.with(|c| c.borrow_mut().take())
+    let stash = FBW_FORITER_INFLIGHT.with(|c| c.borrow_mut().take());
+    let stash = stash?;
+    if fbw_has_unjournaled_effect() {
+        if fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-foriter] deliver REFUSED (unjournaled effect present) body_pc={} \
+                 — keeping legacy drop-on-abort to avoid a double-apply (R1)",
+                stash.1
+            );
+        }
+        return None;
+    }
+    if fbw_debug_abort_enabled() {
+        eprintln!(
+            "[fbw-foriter] deliver item=0x{:x} body_pc={} store_journal_len={} unjournaled={}",
+            stash.0 as usize,
+            stash.1,
+            fbw_store_journal_len(),
+            fbw_has_unjournaled_effect(),
+        );
+    }
+    Some(stash)
 }
 
 /// Non-commit epilogue: restore each displaced element in reverse push

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6301,6 +6301,21 @@ thread_local! {
     static INLINE_SUBWALK_CAPTURE_BOUNDARY: std::cell::Cell<bool> =
         const { std::cell::Cell::new(false) };
 
+    /// Set (`true`) only for the duration of the
+    /// `walker_capture_snapshot_for_last_guard` call that records a
+    /// FOR_ITER-next residual's `GUARD_NO_EXCEPTION`.  Tells the snapshot
+    /// helper to fold the bit-14 after-residual-call marker onto the
+    /// FOR_ITER CALL pc so a deopt resumes at the call's OWN post-call
+    /// `catch_exception` (emitted by the codewriter when the FOR_ITER sits
+    /// in a try-block) — the blackhole's `handle_exception_in_frame` then
+    /// routes the raise to the enclosing handler instead of escaping the
+    /// frame.  A FOR_ITER-next's fallthrough is the continue-arm body
+    /// (reached only on a non-null item), which carries no catch for the
+    /// call's own raise, so the generic fallthrough resume the other
+    /// residual calls use cannot find one.  Off for every other residual.
+    static FBW_FORITER_NEXT_CATCH_RESUME: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+
     /// Set (to the branch guard's own jitcode `op.pc`) only for the
     /// duration of the `walker_capture_snapshot_for_last_guard` call a
     /// kept-stack branch guard makes (#124).  The
@@ -8512,6 +8527,11 @@ fn walker_capture_snapshot_for_last_guard_impl(
         // (fresh `top_regs`), not in `sym.registers_*`.
         let sym = unsafe { &*full_body_sym };
         if !sym.jitcode.is_null() {
+            // Set to `Some(call_py_pc)` when an after-residual-call guard's
+            // residual call sits inside a try-block (its per-CodeObject jitcode
+            // emitted a post-call catch); the snapshot resume pc is then the
+            // bit-14-marked CALL pc so the blackhole resumes at that catch.
+            let mut marker_call_py_pc: Option<u32> = None;
             let (py_pc, jitcode_index, num_instrs) = unsafe {
                 let jc = &*sym.jitcode;
                 let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc);
@@ -8532,12 +8552,38 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     // after_residual_call=True (`pyjitpl.py:2599-2603`): the
                     // may-force call already executed in compiled code and
                     // consumed its Python stack operands.  Resume at the NEXT
-                    // executable opcode so the blackhole continues past the
-                    // call instead of re-executing it from a coordinate whose
-                    // stack no longer holds those operands (which drops/dups
-                    // the side effect, e.g. an in-place list swap store).
+                    // executable opcode so the blackhole continues past the call
+                    // (re-executing from the call's coordinate would drop/dup the
+                    // side effect, e.g. an in-place list swap store).  The
+                    // fallthrough resume routes a raise through the next opcode's
+                    // own `catch_exception` (still inside the same try-block) and
+                    // the bridge-decline path, which handles every sequential
+                    // residual call.
+                    //
+                    // FOR_ITER-next is the exception: its fallthrough is the
+                    // continue-arm body (reached only on a NON-null item), which
+                    // carries no catch for the call's OWN raise.  When the
+                    // FOR_ITER-next residual guard is being captured
+                    // (`FBW_FORITER_NEXT_CATCH_RESUME`) and the call's CALL pc has
+                    // a post-call catch, fold the bit-14 marker onto the CALL pc
+                    // (handled at `resume_py_pc` below) so the blackhole resumes
+                    // at the call's OWN catch and routes the raise to the
+                    // enclosing handler instead of escaping the frame.
                     if after_residual_call {
+                        let call_py_pc = py;
                         py = crate::pyjitpl::semantic_fallthrough_pc(code, py as usize) as u32;
+                        let flag = majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as u32;
+                        let foriter_catch =
+                            FBW_FORITER_NEXT_CATCH_RESUME.with(|c| c.get());
+                        if foriter_catch
+                            && call_py_pc < flag
+                            && jc
+                                .payload
+                                .after_residual_call_resume_pc_for(call_py_pc as usize)
+                                .is_some()
+                        {
+                            marker_call_py_pc = Some(call_py_pc);
+                        }
                     }
                 }
                 (py, jc.index as u32, jc.payload.metadata.pc_map.len())
@@ -8821,10 +8867,25 @@ fn walker_capture_snapshot_for_last_guard_impl(
             // — the kept operand stack is naturally live at the guard pc, so
             // the positional `kept_stack_subst` recovery (gpc == entry_py_pc)
             // is skipped.  Flag-off, `resume_py_pc` stays `py_pc`.
-            let resume_py_pc = if crate::pyjitcode::m3_jitcode_pc_enabled() {
+            let liveness_py_pc = if crate::pyjitcode::m3_jitcode_pc_enabled() {
                 guard_py_pc.unwrap_or(py_pc)
             } else {
                 py_pc
+            };
+            // The snapshot resume pc folds in the bit-14 marker for a try-block
+            // residual call so the decode routes through
+            // `after_residual_call_resume_pc_for` (the call's OWN post-call
+            // `-live-`/catch), mirroring the trait leg's `marker_aware_resume_pc`.
+            // Liveness / depth / `last_instr` (above) and `collect_outer_active_boxes`
+            // (below) keep the plain (fallthrough) `liveness_py_pc` — the same
+            // split the trait leg keeps between `snapshot_live_pc` (marked) and
+            // `saved_orgpc` (plain) — so the active-box layout stays consistent
+            // with what the decoder reads.
+            let resume_py_pc = match marker_call_py_pc {
+                Some(call_py_pc) => {
+                    majit_ir::resumedata::encode_after_residual_call_pc(call_py_pc as i32) as u32
+                }
+                None => liveness_py_pc,
             };
             let active = collect_outer_active_boxes(
                 sym,
@@ -8833,7 +8894,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 ctx.registers_r,
                 ctx.registers_f,
                 jitcode_index,
-                resume_py_pc,
+                liveness_py_pc,
                 guard_py_pc,
                 guard_jitcode_pc,
             );
@@ -11623,7 +11684,21 @@ fn dispatch_residual_call_iRd_kind(
                 return Ok((DispatchOutcome::SubRaise { exc, exc_concrete }, op.next_pc));
             } else {
                 ctx.trace_ctx.record_guard(OpCode::GuardNoException, &[], 0);
-                walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+                // FOR_ITER-next routes its no-exception-guard resume through
+                // the call's OWN post-call catch (`FBW_FORITER_NEXT_CATCH_RESUME`);
+                // every other residual keeps the fallthrough resume.  See the
+                // thread-local's doc and the marker handling in
+                // `walker_capture_snapshot_for_last_guard_impl`.
+                let is_for_iter_next =
+                    ei.pyre_helper == majit_ir::PyreHelperKind::ForIterNext;
+                if is_for_iter_next {
+                    FBW_FORITER_NEXT_CATCH_RESUME.with(|c| c.set(true));
+                }
+                let cap = walker_capture_snapshot_for_last_guard(ctx, op.pc);
+                if is_for_iter_next {
+                    FBW_FORITER_NEXT_CATCH_RESUME.with(|c| c.set(false));
+                }
+                cap?;
             }
         }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5237,39 +5237,48 @@ fn try_execute_residual_call_via_executor(
             return Err(DispatchError::VableEscapedDuringResidualCall { pc: op_pc });
         }
     }
+    // #57 Option C (Finding #1, R1): a residual that is not provably
+    // side-effect-free has now EXECUTED AFTER the in-flight FOR_ITER consume —
+    // whether it returned a value (Ok) or raised (Err).  The store/append
+    // journals roll their entries back on abort (so a body re-run re-applies
+    // them once), but a mutation outside those journals (a dict
+    // `store_subscr_fn`, an `obj.attr = …` `store_attr_fn`, a `list.extend`,
+    // a `del o[k]`, a name/global/deref store …) cannot be undone — delivering
+    // the in-flight item and re-running the body would double it.  Flag it so
+    // `fbw_foriter_inflight_take` refuses delivery (the legacy drop-on-abort
+    // fallback) instead of doubling.
+    // The user-frame signal: the residual's concrete execution entered a user
+    // Python frame (the odometer advanced), so a value-returning
+    // getter/dunder/module body may have mutated live heap outside the
+    // journals — a body effect the Void/helper-tag discriminator misses.
+    // `for_mutate`'s `seen.append` resolves its bound method at the C level (no
+    // user frame), so its snapshot is unchanged and it still DELIVERS.
+    //
+    // The marking runs on BOTH arms.  A getter that mutates and THEN raises
+    // (`for_prop_raise_abort`: `Obj.hits += 1; raise`, caught locally, walk
+    // continues, later abort) takes the Err arm but still committed the
+    // irreversible effect and still bumped the eval-loop entry odometer; if it
+    // marked only on Ok, `fbw_foriter_inflight_take` would see no signal and
+    // DELIVER, re-running the getter and DOUBLING `Obj.hits`.  The
+    // `for_iter_next` consume itself is exempt (`provably_side_effect_free`
+    // leaves both `body_effect_candidate` false and `user_frame_snapshot`
+    // None), so a raising `__next__` never self-flags.
+    let entered_user_frame = user_frame_snapshot
+        .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before);
+    if body_effect_candidate || entered_user_frame {
+        if fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-foriter] body effect committed since consume (helper={helper:?} \
+                 extraeffect={:?} result_type={:?} write_discriminator={body_effect_candidate} \
+                 entered_user_frame={entered_user_frame})",
+                ei.extraeffect,
+                call_descr.result_type(),
+            );
+        }
+        fbw_mark_foriter_body_effect_since_consume();
+    }
     match exec_result {
         Ok(result_i64) => {
-            // #57 Option C (Finding #1, R1): a residual that is not provably
-            // side-effect-free just succeeded AFTER the in-flight FOR_ITER
-            // consume.  The store/append journals roll their entries back on
-            // abort (so a body re-run re-applies them once), but a mutation
-            // outside those journals (a dict `store_subscr_fn`, an
-            // `obj.attr = …` `store_attr_fn`, a `list.extend`, a `del o[k]`,
-            // a name/global/deref store …) cannot be undone — delivering the
-            // in-flight item and re-running the body would double it.  Flag it
-            // so `fbw_foriter_inflight_take` refuses delivery (the legacy
-            // drop-on-abort fallback) instead of doubling.
-            // The user-frame signal (above): the residual's concrete
-            // execution entered a user Python frame (the odometer advanced),
-            // so a value-returning getter/dunder/module body may have mutated
-            // live heap outside the journals — a body effect the Void/helper-
-            // tag discriminator misses.  `for_mutate`'s `seen.append` resolves
-            // its bound method at the C level (no user frame), so its snapshot
-            // is unchanged and it still DELIVERS.
-            let entered_user_frame = user_frame_snapshot
-                .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before);
-            if body_effect_candidate || entered_user_frame {
-                if fbw_debug_abort_enabled() {
-                    eprintln!(
-                        "[fbw-foriter] body effect committed since consume (helper={helper:?} \
-                         extraeffect={:?} result_type={:?} write_discriminator={body_effect_candidate} \
-                         entered_user_frame={entered_user_frame})",
-                        ei.extraeffect,
-                        call_descr.result_type(),
-                    );
-                }
-                fbw_mark_foriter_body_effect_since_consume();
-            }
             // `pyjitpl.py:1685-1690 _opimpl_residual_call*` finishes its
             // success arm with `metainterp.clear_exception()` (called
             // implicitly through `do_residual_call`'s no-raise tail).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5195,6 +5195,48 @@ fn try_execute_residual_call_via_executor(
                 }
                 majit_ir::Type::Void => {}
             }
+            // #57 Option C (capture): this residual is the FOR_ITER advance
+            // (`for_iter_next`) — it just advanced the real shared heap
+            // iterator (an irreversible side effect with no journal undo).
+            // Stash the consumed item + the FOR_ITER body pc (the continue
+            // arm's `py_pc + 1` fallthrough) so an aborting walk can DELIVER
+            // the in-flight iteration to the live frame instead of dropping
+            // it.  A null result is the exhaustion arm (no item, no body
+            // runs) — nothing to deliver, leave the stash empty.
+            if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ForIterNext
+                && result_i64 != 0
+            {
+                // The body pc is the FOR_ITER continue-arm fallthrough —
+                // the Python bytecode pc of the FOR_ITER opcode (`orgpc` =
+                // `entry_py_pc`) plus one.  `op_pc` is the JitCode byte
+                // offset of the residual op, NOT a bytecode pc, so it must
+                // not be used here; the live frame's `next_instr`/`last_instr`
+                // are Python bytecode coordinates.  This matches the
+                // interpreter's `opcode_for_iter` fallthrough
+                // (`next_instr() == opcode_pc + 1`).
+                let body_pc = ctx.entry_py_pc as usize + 1;
+                fbw_foriter_inflight_capture(
+                    result_i64 as usize as pyre_object::PyObjectRef,
+                    body_pc,
+                );
+                if fbw_debug_abort_enabled() {
+                    let item = result_i64 as usize as pyre_object::PyObjectRef;
+                    let intval = if unsafe { pyre_object::pyobject::is_int(item) } {
+                        Some(unsafe { pyre_object::w_int_get_value(item) })
+                    } else {
+                        None
+                    };
+                    eprintln!(
+                        "[fbw-foriter] capture item=0x{:x} intval={intval:?} foriter_pc={} body_pc={body_pc} \
+                         store_journal_len={} append_journal_len={} unjournaled={}",
+                        result_i64 as usize,
+                        ctx.entry_py_pc,
+                        fbw_store_journal_len(),
+                        FBW_APPEND_JOURNAL.with(|j| j.borrow().len()),
+                        fbw_has_unjournaled_effect(),
+                    );
+                }
+            }
         }
         Err(bh_exc) => {
             // pyjitpl.py:1690-1696 `metainterp.execute_raised(exception,
@@ -6684,6 +6726,25 @@ thread_local! {
     static FBW_APPEND_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
+    /// In-flight FOR_ITER continuation (#57 Option C): `(consumed_item,
+    /// body_pc)` stashed when the FOR_ITER `for_iter_next` residual
+    /// ([`PyreHelperKind::ForIterNext`]) runs concretely on the
+    /// authoritative walk and advances the real shared heap iterator.  The
+    /// advance is an irreversible side effect with no journal undo
+    /// (`functional.rs` `current += step`); on a successful CloseLoop commit
+    /// the walk-end flush adopts the advanced state, so the stash is dropped
+    /// ([`fbw_store_journal_commit`]).  On a trace ABORT the walk discards
+    /// its recording but the iterator stays advanced — so the stash is
+    /// DELIVERED to the live frame (the consumed item pushed, the frame
+    /// repositioned at `body_pc`) instead of dropping the iteration, the
+    /// `_copy_data_from_miframe` continue-forward analog (blackhole.py:1711).
+    /// `body_pc` is the FOR_ITER continue-arm fallthrough (`py_pc + 1`,
+    /// codewriter.rs continue arm).  The item ref is a GC root via
+    /// [`fbw_store_journal_root_walker`].  Cleared at walk start
+    /// ([`fbw_store_journal_reset`]).
+    static FBW_FORITER_INFLIGHT: std::cell::RefCell<Option<(pyre_object::PyObjectRef, usize)>> =
+        const { std::cell::RefCell::new(None) };
+
     /// Set when the walk records a side effect that was neither executed
     /// at walk time nor undo-logged: a void residual call recorded
     /// symbolically (the `try_execute_residual_call_via_executor` void
@@ -6749,6 +6810,10 @@ pub(crate) fn fbw_store_journal_reset() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(false));
+    // #57 Option C: drop any in-flight FOR_ITER item a prior aborted walk
+    // left undelivered (its live frame already consumed the delivery), so a
+    // stale item cannot be re-delivered by this walk's abort.
+    FBW_FORITER_INFLIGHT.with(|c| *c.borrow_mut() = None);
     // B3 (`PYRE_FBW_RAISE`): drop any inline-built-exception OpRef keys a
     // prior aborted walk recorded, so they cannot match a same-numbered
     // OpRef minted by this walk's recorder.
@@ -6786,6 +6851,28 @@ pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_bef
 pub(crate) fn fbw_store_journal_commit() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
+    // #57 Option C: a committed walk's end-flush adopts the advanced
+    // iterator + the body that consumed it (counted once), so the in-flight
+    // item must NOT also be delivered — drop the stash.
+    FBW_FORITER_INFLIGHT.with(|c| *c.borrow_mut() = None);
+}
+
+/// Record the in-flight FOR_ITER continuation (#57 Option C): the consumed
+/// item the `for_iter_next` residual produced and the FOR_ITER body pc
+/// (`py_pc + 1`, the continue-arm fallthrough).  Called from the residual
+/// executor's success arm when the helper is [`PyreHelperKind::ForIterNext`]
+/// and it produced a non-null item (a null item is the exhaustion arm — no
+/// body runs, nothing to deliver).  Overwrites any prior stash: only the
+/// MOST-RECENT consume is in flight at the abort point.
+pub(crate) fn fbw_foriter_inflight_capture(item: pyre_object::PyObjectRef, body_pc: usize) {
+    FBW_FORITER_INFLIGHT.with(|c| *c.borrow_mut() = Some((item, body_pc)));
+}
+
+/// Take the in-flight FOR_ITER continuation for delivery on a trace abort
+/// (#57 Option C).  Returns `(consumed_item, body_pc)` and clears the stash
+/// so it is delivered at most once.
+pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> {
+    FBW_FORITER_INFLIGHT.with(|c| c.borrow_mut().take())
 }
 
 /// Non-commit epilogue: restore each displaced element in reverse push
@@ -6892,6 +6979,16 @@ pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRe
             // SAFETY: as above — only the `PyObjectRef` slot is a root; the
             // `usize` length is a plain scalar.
             visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
+        }
+    });
+    // #57 Option C: the captured in-flight FOR_ITER item is nursery-resident
+    // across the rest of the walk (subsequent residual calls allocate and a
+    // minor collection moves nursery objects), so forward it as a root.
+    FBW_FORITER_INFLIGHT.with(|c| {
+        if let Some((item, _body_pc)) = c.borrow_mut().as_mut() {
+            // SAFETY: as above — only the `PyObjectRef` slot is a root; the
+            // `usize` body pc is a plain scalar.
+            visitor(unsafe { &mut *(item as *mut pyre_object::PyObjectRef).cast() });
         }
     });
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5131,6 +5131,34 @@ fn try_execute_residual_call_via_executor(
     // subsequent vable token protocol / field reads see the frame being
     // traced, mirroring RPython's separate-state isolation.
     let saved_vable_heap_ptr = ctx.trace_ctx.virtualizable_heap_ptr();
+    // #57 Option C (Finding #1, R1 double-apply guard): whether THIS residual
+    // could commit an irreversible heap mutation the journals do not cover,
+    // while an in-flight FOR_ITER item is already captured (a consume ran
+    // earlier this iteration).  The journaled list ops (setitem / append) run
+    // OUTSIDE this executor (`try_walker_store_subscr_specialization` /
+    // `try_walker_orthodox_list_append`) and roll back on abort, so they are
+    // not body-effect candidates here.  The residuals that DO reach this
+    // executor and can mutate live state un-journaled are:
+    //   * `StoreSubscr` — a non-list-int subscript store (a dict / object
+    //     `store_subscr_fn`); mutates the container irreversibly.
+    //   * `CallFn` — an opaque Python-level call (`bh_call_fn`); may mutate
+    //     arbitrary state, so treat it conservatively as a body effect.
+    //   * `SetCurrentException` — a TLS exc-slot write.
+    // Read-only / pure helpers (`Truth`, `LoadGlobal`, `BinaryOp`, …) and the
+    // bound-method / vable-force machinery (`pyre_helper = None`) are NOT
+    // flagged, so a clean body like `for_mutate`'s (whose only effect is the
+    // journaled append, aborted BEFORE it commits) still delivers.  The
+    // `for_iter_next` consume itself is excluded — it is the SOURCE of the
+    // capture, not a body effect.  Sampled BEFORE the call so the success arm
+    // can flag an effect that committed AFTER the in-flight consume.
+    let helper = call_descr.get_extra_info().pyre_helper;
+    let mutates_unjournaled_heap = matches!(
+        helper,
+        majit_ir::PyreHelperKind::StoreSubscr
+            | majit_ir::PyreHelperKind::CallFn
+            | majit_ir::PyreHelperKind::SetCurrentException
+    );
+    let body_effect_candidate = mutates_unjournaled_heap && fbw_foriter_inflight_active();
     let exec_result = {
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
@@ -5156,6 +5184,24 @@ fn try_execute_residual_call_via_executor(
     }
     match exec_result {
         Ok(result_i64) => {
+            // #57 Option C (Finding #1, R1): an un-journaled heap-mutating
+            // residual (`StoreSubscr` / `CallFn` / `SetCurrentException`) just
+            // committed AFTER the in-flight FOR_ITER consume.  The store/append
+            // journals roll their entries back on abort (so a body re-run
+            // re-applies them once), but a mutation outside those journals (a
+            // dict `store_subscr_fn`, a method that grows an unmodeled
+            // container) cannot be undone — delivering the in-flight item and
+            // re-running the body would double it.  Flag it so
+            // `fbw_foriter_inflight_take` refuses delivery (the legacy
+            // drop-on-abort fallback) instead of doubling.
+            if body_effect_candidate {
+                if fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-foriter] body effect committed since consume (helper={helper:?})",
+                    );
+                }
+                fbw_mark_foriter_body_effect_since_consume();
+            }
             // `pyjitpl.py:1685-1690 _opimpl_residual_call*` finishes its
             // success arm with `metainterp.clear_exception()` (called
             // implicitly through `do_residual_call`'s no-raise tail).
@@ -5206,15 +5252,22 @@ fn try_execute_residual_call_via_executor(
             if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ForIterNext
                 && result_i64 != 0
             {
-                // The body pc is the FOR_ITER continue-arm fallthrough —
-                // the Python bytecode pc of the FOR_ITER opcode (`orgpc` =
-                // `entry_py_pc`) plus one.  `op_pc` is the JitCode byte
-                // offset of the residual op, NOT a bytecode pc, so it must
-                // not be used here; the live frame's `next_instr`/`last_instr`
-                // are Python bytecode coordinates.  This matches the
-                // interpreter's `opcode_for_iter` fallthrough
-                // (`next_instr() == opcode_pc + 1`).
-                let body_pc = ctx.entry_py_pc as usize + 1;
+                // The body pc is the FOR_ITER continue-arm fallthrough — the
+                // Python bytecode pc of the FOR_ITER opcode plus one (matching
+                // `opcode_for_iter`'s `next_instr() == opcode_pc + 1`).
+                //
+                // Finding #2: derive it from the residual op's OWN JitCode pc
+                // (`op_pc`) mapped to its containing Python opcode, NOT the
+                // walk-ENTRY coordinate (`entry_py_pc + 1`).  The entry
+                // coordinate equals the FOR_ITER fallthrough only when FOR_ITER
+                // is the loop-header / walk-entry opcode; a second/nested
+                // FOR_ITER reached deeper in a traced body has its own
+                // `op_pc`, so the entry coordinate would point at the WRONG
+                // body and deliver to the wrong pc.  The fallback (no outer
+                // full-body sym / metadata) keeps the entry coordinate, which
+                // is correct for the loop-header FOR_ITER.
+                let body_pc = fbw_foriter_body_pc_from_op_pc(op_pc)
+                    .unwrap_or(ctx.entry_py_pc as usize + 1);
                 fbw_foriter_inflight_capture(
                     result_i64 as usize as pyre_object::PyObjectRef,
                     body_pc,
@@ -6745,6 +6798,23 @@ thread_local! {
     static FBW_FORITER_INFLIGHT: std::cell::RefCell<Option<(pyre_object::PyObjectRef, usize)>> =
         const { std::cell::RefCell::new(None) };
 
+    /// #57 Option C (Finding #1, R1 double-apply guard): set when a non-
+    /// elidable concrete residual committed an irreversible heap mutation
+    /// AFTER the in-flight FOR_ITER consume ([`FBW_FORITER_INFLIGHT`]) was
+    /// captured — a body effect that the store/append journals do NOT cover
+    /// (a dict `store_subscr_fn`, or any method mutating an unmodeled
+    /// container).  Unlike the journaled list ops (rolled back on abort, so a
+    /// body re-run re-applies them once) and the symbolic-decline flag
+    /// ([`FBW_UNJOURNALED_EFFECT`], applied only by the legacy replay), this
+    /// mutation already stands on the live heap and is not reversible, so
+    /// delivering the in-flight item and re-running the body would DOUBLE it.
+    /// `fbw_foriter_inflight_take` refuses delivery when this is set.  Reset
+    /// at walk start ([`fbw_store_journal_reset`]) and at every new consume
+    /// ([`fbw_foriter_inflight_capture`]) so it reflects only effects
+    /// committed since the MOST-RECENT in-flight consume.
+    static FBW_FORITER_BODY_EFFECT_SINCE_CONSUME: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+
     /// Set when the walk records a side effect that was neither executed
     /// at walk time nor undo-logged: a void residual call recorded
     /// symbolically (the `try_execute_residual_call_via_executor` void
@@ -6814,6 +6884,9 @@ pub(crate) fn fbw_store_journal_reset() {
     // left undelivered (its live frame already consumed the delivery), so a
     // stale item cannot be re-delivered by this walk's abort.
     FBW_FORITER_INFLIGHT.with(|c| *c.borrow_mut() = None);
+    // #57 Option C (Finding #1): clear the body-effect-since-consume signal so
+    // a prior walk's committed mutation cannot block this walk's delivery.
+    FBW_FORITER_BODY_EFFECT_SINCE_CONSUME.with(|c| c.set(false));
     // B3 (`PYRE_FBW_RAISE`): drop any inline-built-exception OpRef keys a
     // prior aborted walk recorded, so they cannot match a same-numbered
     // OpRef minted by this walk's recorder.
@@ -6855,6 +6928,9 @@ pub(crate) fn fbw_store_journal_commit() {
     // iterator + the body that consumed it (counted once), so the in-flight
     // item must NOT also be delivered — drop the stash.
     FBW_FORITER_INFLIGHT.with(|c| *c.borrow_mut() = None);
+    // #57 Option C (Finding #1): the stash is gone, so the body-effect signal
+    // is moot for this walk — clear it alongside.
+    FBW_FORITER_BODY_EFFECT_SINCE_CONSUME.with(|c| c.set(false));
 }
 
 /// Record the in-flight FOR_ITER continuation (#57 Option C): the consumed
@@ -6866,6 +6942,30 @@ pub(crate) fn fbw_store_journal_commit() {
 /// MOST-RECENT consume is in flight at the abort point.
 pub(crate) fn fbw_foriter_inflight_capture(item: pyre_object::PyObjectRef, body_pc: usize) {
     FBW_FORITER_INFLIGHT.with(|c| *c.borrow_mut() = Some((item, body_pc)));
+    // The "body effect since consume" window restarts at each consume: only
+    // effects committed after THIS (most-recent) consume can double on a
+    // re-run of THIS iteration's body (Finding #1).
+    FBW_FORITER_BODY_EFFECT_SINCE_CONSUME.with(|c| c.set(false));
+}
+
+/// Whether an in-flight FOR_ITER item is currently captured (a consume ran
+/// this iteration and no commit/abort has cleared it yet).  Sampled by the
+/// residual executor to decide whether a non-elidable concrete mutation
+/// counts as a body effect committed after the consume (Finding #1).
+pub(crate) fn fbw_foriter_inflight_active() -> bool {
+    FBW_FORITER_INFLIGHT.with(|c| c.borrow().is_some())
+}
+
+/// Flag that a non-elidable concrete residual committed an irreversible heap
+/// mutation after the in-flight FOR_ITER consume (Finding #1, R1).
+pub(crate) fn fbw_mark_foriter_body_effect_since_consume() {
+    FBW_FORITER_BODY_EFFECT_SINCE_CONSUME.with(|c| c.set(true));
+}
+
+/// Whether a body effect committed since the most-recent in-flight FOR_ITER
+/// consume (Finding #1, R1).
+pub(crate) fn fbw_foriter_body_effect_since_consume() -> bool {
+    FBW_FORITER_BODY_EFFECT_SINCE_CONSUME.with(|c| c.get())
 }
 
 /// Take the in-flight FOR_ITER continuation for delivery on a trace abort
@@ -6874,22 +6974,40 @@ pub(crate) fn fbw_foriter_inflight_capture(item: pyre_object::PyObjectRef, body_
 ///
 /// R1 (double-apply guard): delivery resumes the live frame at the FOR_ITER
 /// body, so any body op that ALREADY ran concretely during the aborted walk
-/// would be re-applied.  The journaled body effects (list setitem/append)
-/// are rolled back by [`fbw_store_journal_rollback`] before this take, so
-/// re-running re-applies them exactly once.  An UNjournaled effect
-/// (`FBW_UNJOURNALED_EFFECT` — a void/symbolic residual the rollback cannot
-/// undo) is NOT reversible, so delivering would double it.  Refuse delivery
-/// in that case (drop the stash → the legacy bypass keeps the prior
-/// drop-on-abort behaviour for that shape, never a double).  `for_mutate`
-/// aborts BEFORE the append's effect, so no journal entry and no unjournaled
-/// effect exist at the abort point — the clean continuation case.
+/// would be re-applied.  C may DELIVER only when it can PROVE no body effect
+/// committed for the in-flight iteration — then re-running the body cannot
+/// double.  Three signals together cover every committed body effect:
+///
+/// * `fbw_foriter_body_effect_since_consume()` — a non-elidable concrete
+///   residual mutated the heap OUTSIDE the journals after the consume (a dict
+///   `store_subscr_fn`, an unmodeled container method).  Irreversible: the
+///   mutation already stands on the live heap, so a body re-run would double
+///   it (Finding #1).
+/// * either journal non-empty (`FBW_STORE_JOURNAL` list setitem /
+///   `FBW_APPEND_JOURNAL` list append).  On the production abort path
+///   `fbw_store_journal_rollback` empties these BEFORE this take, so this is
+///   normally false here; the check is a belt-and-suspenders refusal in case
+///   a future caller takes before the rollback.
+/// * `fbw_has_unjournaled_effect()` — a void/symbolic residual only the
+///   legacy replay applies, which the rollback cannot undo.
+///
+/// Any signal set → refuse delivery (drop the stash → the legacy bypass keeps
+/// the prior drop-on-abort behaviour for that shape, never a double).
+/// `for_mutate` aborts BEFORE the append's effect, so all three signals are
+/// clear at the abort point — the clean continuation case.
 pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> {
     let stash = FBW_FORITER_INFLIGHT.with(|c| c.borrow_mut().take());
     let stash = stash?;
-    if fbw_has_unjournaled_effect() {
+    let body_effect = fbw_foriter_body_effect_since_consume();
+    let store_len = fbw_store_journal_len();
+    let append_len = FBW_APPEND_JOURNAL.with(|j| j.borrow().len());
+    let unjournaled = fbw_has_unjournaled_effect();
+    if body_effect || store_len != 0 || append_len != 0 || unjournaled {
         if fbw_debug_abort_enabled() {
             eprintln!(
-                "[fbw-foriter] deliver REFUSED (unjournaled effect present) body_pc={} \
+                "[fbw-foriter] deliver REFUSED (body effect committed since consume) body_pc={} \
+                 body_effect={body_effect} store_journal_len={store_len} \
+                 append_journal_len={append_len} unjournaled={unjournaled} \
                  — keeping legacy drop-on-abort to avoid a double-apply (R1)",
                 stash.1
             );
@@ -6898,11 +7016,10 @@ pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> 
     }
     if fbw_debug_abort_enabled() {
         eprintln!(
-            "[fbw-foriter] deliver item=0x{:x} body_pc={} store_journal_len={} unjournaled={}",
+            "[fbw-foriter] deliver item=0x{:x} body_pc={} store_journal_len={store_len} \
+             unjournaled={unjournaled}",
             stash.0 as usize,
             stash.1,
-            fbw_store_journal_len(),
-            fbw_has_unjournaled_effect(),
         );
     }
     Some(stash)
@@ -7592,6 +7709,42 @@ fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) 
         }
     }
     best_py
+}
+
+/// #57 Option C (Finding #2): derive the FOR_ITER body pc — the continue-arm
+/// fallthrough — from the `for_iter_next` residual op's OWN JitCode pc.
+///
+/// `op_pc` is the JitCode byte offset of the `for_iter_next` residual; its
+/// containing Python opcode is the FOR_ITER itself (the codewriter emits the
+/// residual at `py_pc as i64`, codewriter.rs:9066), so the FOR_ITER body is
+/// `python_pc_for_jitcode_pc(op_pc) + 1` (the continue-arm fallthrough,
+/// `opcode_for_iter`'s `next_instr() == opcode_pc + 1`).
+///
+/// Deriving from the op's own pc — instead of the walk-ENTRY coordinate
+/// (`entry_py_pc + 1`) — keeps the body pc correct for a FOR_ITER that is NOT
+/// the walk entry (a second/nested FOR_ITER reached deeper in a traced body):
+/// the entry coordinate equals the FOR_ITER fallthrough only when FOR_ITER is
+/// the loop-header / walk-entry opcode.
+///
+/// Returns `None` when the outer full-body-walk sym / metadata is unavailable
+/// (per-opcode arm walk, test fixture); the caller then keeps the legacy
+/// walk-entry coordinate, which is correct for the loop-header FOR_ITER.
+fn fbw_foriter_body_pc_from_op_pc(op_pc: usize) -> Option<usize> {
+    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if full_body_sym.is_null() {
+        return None;
+    }
+    // SAFETY: the pointer is live for the full-body walk's lifetime
+    // (`FullBodySnapshotSymGuard`); only its `jitcode` metadata is read.
+    let sym = unsafe { &*full_body_sym };
+    if sym.jitcode.is_null() {
+        return None;
+    }
+    let foriter_py_pc = unsafe {
+        let jc = &*sym.jitcode;
+        python_pc_for_jitcode_pc(&jc.payload.metadata, op_pc) as usize
+    };
+    Some(foriter_py_pc + 1)
 }
 
 /// Forward-skip Python trivia (`Cache` / `ExtendedArg` / `Resume` / `Nop`

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5195,6 +5195,25 @@ fn try_execute_residual_call_via_executor(
         );
     let body_effect_candidate =
         !provably_side_effect_free && writes_live_heap && fbw_foriter_inflight_active();
+    // #57 Option C (Finding #1, user-frame signal): the Void/helper-tag write
+    // discriminator above cannot see a body effect committed through USER
+    // PYTHON CODE by a value-returning (`Ref`), `PyreHelperKind::None`,
+    // `MayForce` residual: `obj.prop` (a `@property` getter / `__getattr__` /
+    // descriptor `__get__`), `a + b` / `a == b` (user `__add__` / `__eq__`),
+    // `iter(obj)` (user `__iter__`), `str(obj)` / `f"{obj}"` (user `__str__` /
+    // `__format__`), `import name`.  Each RETURNS a value (so the Void proxy
+    // misses it) and carries no write tag, yet its getter/dunder/module body
+    // may mutate live heap.  Those mutations all run a USER PYTHON FRAME (the
+    // getter's bytecode); a pure builtin path (`seen.append`'s C-level
+    // bound-method lookup, `int.__add__`) does NOT.  Snapshot the monotonic
+    // frame eval-loop entry odometer before the call; if it advanced while an
+    // in-flight FOR_ITER item is active, the residual ran user bytecode that
+    // could have committed an irreversible body effect → flag it (the success
+    // arm compares post-call).  Sampled only when an item is in flight and the
+    // residual is not provably read-only (an elidable / loop-invariant fold or
+    // the `for_iter_next` consume itself never counts).
+    let user_frame_snapshot = (!provably_side_effect_free && fbw_foriter_inflight_active())
+        .then(pyre_interpreter::call::frame_entry_count);
     let exec_result = {
         let _suspend = majit_metainterp::TraceContinuationSuspendGuard::enter();
         majit_metainterp::executor::execute_residual_call(call_descr, func_ptr, &args)
@@ -5230,11 +5249,21 @@ fn try_execute_residual_call_via_executor(
             // in-flight item and re-running the body would double it.  Flag it
             // so `fbw_foriter_inflight_take` refuses delivery (the legacy
             // drop-on-abort fallback) instead of doubling.
-            if body_effect_candidate {
+            // The user-frame signal (above): the residual's concrete
+            // execution entered a user Python frame (the odometer advanced),
+            // so a value-returning getter/dunder/module body may have mutated
+            // live heap outside the journals — a body effect the Void/helper-
+            // tag discriminator misses.  `for_mutate`'s `seen.append` resolves
+            // its bound method at the C level (no user frame), so its snapshot
+            // is unchanged and it still DELIVERS.
+            let entered_user_frame = user_frame_snapshot
+                .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before);
+            if body_effect_candidate || entered_user_frame {
                 if fbw_debug_abort_enabled() {
                     eprintln!(
                         "[fbw-foriter] body effect committed since consume (helper={helper:?} \
-                         extraeffect={:?} result_type={:?})",
+                         extraeffect={:?} result_type={:?} write_discriminator={body_effect_candidate} \
+                         entered_user_frame={entered_user_frame})",
                         ei.extraeffect,
                         call_descr.result_type(),
                     );
@@ -5305,8 +5334,8 @@ fn try_execute_residual_call_via_executor(
                 // body and deliver to the wrong pc.  The fallback (no outer
                 // full-body sym / metadata) keeps the entry coordinate, which
                 // is correct for the loop-header FOR_ITER.
-                let body_pc = fbw_foriter_body_pc_from_op_pc(op_pc)
-                    .unwrap_or(ctx.entry_py_pc as usize + 1);
+                let body_pc =
+                    fbw_foriter_body_pc_from_op_pc(op_pc).unwrap_or(ctx.entry_py_pc as usize + 1);
                 fbw_foriter_inflight_capture(
                     result_i64 as usize as pyre_object::PyObjectRef,
                     body_pc,
@@ -7082,8 +7111,7 @@ pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> 
         eprintln!(
             "[fbw-foriter] deliver item=0x{:x} body_pc={} store_journal_len={store_len} \
              unjournaled={unjournaled}",
-            stash.0 as usize,
-            stash.1,
+            stash.0 as usize, stash.1,
         );
     }
     Some(stash)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6765,7 +6765,7 @@ pub(crate) fn fbw_no_replay_exit_enabled() -> bool {
 /// "abort trace at key={} (permanent={})" log (`pyjitpl.rs:6348`) only
 /// reports the key and permanence; the walker-side reason is otherwise
 /// swallowed.  Default OFF → no output, zero production effect.
-pub(crate) fn fbw_debug_abort_enabled() -> bool {
+pub fn fbw_debug_abort_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("PYRE_FBW_DEBUG_ABORT").is_some())
 }
@@ -8573,8 +8573,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                         let call_py_pc = py;
                         py = crate::pyjitpl::semantic_fallthrough_pc(code, py as usize) as u32;
                         let flag = majit_ir::resumedata::AFTER_RESIDUAL_CALL_PC_FLAG as u32;
-                        let foriter_catch =
-                            FBW_FORITER_NEXT_CATCH_RESUME.with(|c| c.get());
+                        let foriter_catch = FBW_FORITER_NEXT_CATCH_RESUME.with(|c| c.get());
                         if foriter_catch
                             && call_py_pc < flag
                             && jc
@@ -11689,8 +11688,7 @@ fn dispatch_residual_call_iRd_kind(
                 // every other residual keeps the fallthrough resume.  See the
                 // thread-local's doc and the marker handling in
                 // `walker_capture_snapshot_for_last_guard_impl`.
-                let is_for_iter_next =
-                    ei.pyre_helper == majit_ir::PyreHelperKind::ForIterNext;
+                let is_for_iter_next = ei.pyre_helper == majit_ir::PyreHelperKind::ForIterNext;
                 if is_for_iter_next {
                     FBW_FORITER_NEXT_CATCH_RESUME.with(|c| c.set(true));
                 }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4707,6 +4707,20 @@ pub extern "C" fn bh_unary_negative_fn(value: i64) -> i64 {
     }
 }
 
+/// GET_ITER residual (`residual_call_r_r`).  Computes `iter(obj)` through
+/// `baseobjspace::iter`; a user `__iter__` may run Python (`MayForce`).  On
+/// error the exception is published through `BH_LAST_EXC_VALUE` for the
+/// trailing `GuardNoException` and the call returns 0.
+pub extern "C" fn bh_get_iter_fn(obj: i64) -> i64 {
+    match pyre_interpreter::baseobjspace::iter(obj as pyre_object::PyObjectRef) {
+        Ok(result) => result as i64,
+        Err(err) => {
+            publish_residual_call_exception(err.to_exc_object() as i64);
+            0
+        }
+    }
+}
+
 /// UNARY_INVERT residual (`unary_invert` HLOp → `residual_call_r_r`).
 /// Computes `~value` through `opcode_ops::unary_invert_value` (`invert`); a
 /// user `__invert__` may run Python (`MayForce`).  On error the exception

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3321,6 +3321,11 @@ fn trace_jit_bytecode(_pc: usize, _instruction_name: &str) {
 /// recursive portal depth. Returns PyObjectRef (NULL on void/exception).
 /// JIT hooks are thin inline checks; all heavy logic is in #[cold] helpers.
 fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
+    // Bump the monotonic frame eval-loop entry odometer (mirrors the plain
+    // `eval_loop` entry): a user Python frame is about to run bytecode.  The
+    // FBW FOR_ITER Option-C guard snapshots this around a residual call to
+    // detect a body effect that ran through user code.
+    pyre_interpreter::call::bump_frame_entry_count();
     let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame) };
     let env = PyreEnv;
     let (driver, info) = driver_pair();

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3708,6 +3708,21 @@ fn deliver_inflight_foriter_item(frame: &mut PyFrame) -> bool {
     else {
         return false;
     };
+    // #57 Option C (Finding #3, loud-failure assert): the R1 guard in
+    // `fbw_foriter_inflight_take` returns `Some` (delivers) ONLY when no body
+    // effect committed for the in-flight iteration, so re-running the body
+    // cannot double.  With Finding #1's inverted predicate this is unreachable;
+    // the assert turns any future regression (a missed mutator that lets a
+    // delivery slip past a standing body-effect signal) into a loud debug
+    // abort instead of a silent double-apply.  `take` leaves the signals
+    // intact, so `fbw_foriter_any_body_effect_signal()` reads the same state
+    // the guard just checked.
+    debug_assert!(
+        !pyre_jit_trace::jitcode_dispatch::fbw_foriter_any_body_effect_signal(),
+        "Option C delivered an in-flight FOR_ITER item while a body-effect \
+         signal stands (body_pc={body_pc}) — re-running the body would double \
+         a committed effect (R1 guard regression)"
+    );
     // The continue arm keeps the iterator on the stack and pushes `next`
     // above it (codewriter.rs FOR_ITER continue arm; opcode_for_iter never
     // pops the iterator).  The live frame is still at the loop-header state

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3705,9 +3705,17 @@ pub(crate) fn dm143_advance_live_locals(
 /// advanced iterator — the `_copy_data_from_miframe` continue-forward analog
 /// (blackhole.py:1711), no drop and no double.
 ///
-/// Returns `true` when an item was delivered (the caller must then re-enter
-/// at the body, not bypass past FOR_ITER).  The R1 double-apply guard lives
-/// in `fbw_foriter_inflight_take`.
+/// The repositioning is the load-bearing effect, encoded in the frame itself
+/// (its value stack and pc), not in the return value: on delivery the frame is
+/// moved to `body_pc` with the item pushed, so the caller's
+/// `ContinueRunningNormally` re-entry runs the body once; on refusal or no
+/// in-flight item the frame is left untouched, so the SAME
+/// `ContinueRunningNormally` re-entry takes the legacy drop-on-abort (the
+/// conservative never-double fallback).  Both call sites therefore continue
+/// identically and need not branch on the result — `true` (delivered /
+/// repositioned-to-body) vs `false` (refused or empty → frame unchanged) is
+/// informational (the debug log distinguishes the two `false` cases).  The R1
+/// double-apply guard lives in `fbw_foriter_inflight_take`.
 fn deliver_inflight_foriter_item(frame: &mut PyFrame) -> bool {
     let Some((item, body_pc)) = pyre_jit_trace::jitcode_dispatch::fbw_foriter_inflight_take()
     else {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3728,6 +3728,49 @@ fn deliver_inflight_foriter_item(frame: &mut PyFrame) -> bool {
          signal stands (body_pc={body_pc}) — re-running the body would double \
          a committed effect (R1 guard regression)"
     );
+    // #57 Option C (header-state guard): the push+reposition below assumes the
+    // live frame is parked at the loop-header FOR_ITER state for `body_pc` —
+    // the iterator on TOS, the body's STORE_FAST expecting `item` one slot
+    // above.  `body_pc` is nested-aware (derived from the consumed FOR_ITER
+    // op's own pc), so it can name an INNER FOR_ITER reached deeper in a
+    // traced body.  For such an inner consume the live frame is parked at the
+    // OUTER loop header (the walk-entry / jit_merge_point pc), NOT at the
+    // inner header — its value stack carries the outer body state and the
+    // outer iterator, not the inner iterator on TOS.  Pushing there and
+    // jumping to the inner `body_pc` corrupts the operand stack (a later
+    // FOR_ITER/GET_ITER then reads a wrong slot as an iterator).  Deliver only
+    // when the frame is PROVABLY at the header for `body_pc`: it is parked at
+    // the FOR_ITER opcode whose fallthrough is `body_pc`
+    // (`next_instr() == body_pc - 1`) and that opcode really is a `FOR_ITER`.
+    // The walk parks the live frame at the loop header it entered, so a
+    // header-entry consume satisfies this and still DELIVERS; a non-header
+    // inner consume fails it and is REFUSED — the stash is dropped (already
+    // taken above) and the legacy bypass keeps the conservative drop-on-abort,
+    // never a stack-corrupting push.  This is the `fbw_foriter_inflight_take`
+    // refuse-when-not-provably-safe model applied to the stack-state axis.
+    // `body_pc` is the FOR_ITER `orgpc + 1`, so it is always >= 1; the header
+    // pc is one before it.  A `body_pc == 0` (impossible) wraps to `usize::MAX`
+    // and fails the `next_instr()` match, so the guard stays safe without a
+    // separate zero check.
+    let header_pc = body_pc.wrapping_sub(1);
+    let at_loop_header = frame.next_instr() == header_pc && {
+        let code = unsafe { &*pyre_interpreter::pyframe_get_pycode(frame) };
+        matches!(
+            pyre_interpreter::decode_instruction_at(code, header_pc),
+            Some((pyre_interpreter::Instruction::ForIter { .. }, _))
+        )
+    };
+    if !at_loop_header {
+        if pyre_jit_trace::jitcode_dispatch::fbw_debug_abort_enabled() {
+            eprintln!(
+                "[fbw-foriter] deliver REFUSED (live frame not at the loop header for \
+                 body_pc={body_pc}) frame.next_instr()={} — keeping legacy drop-on-abort \
+                 to avoid a non-header stack-corrupting push",
+                frame.next_instr()
+            );
+        }
+        return false;
+    }
     // The continue arm keeps the iterator on the stack and pushes `next`
     // above it (codewriter.rs FOR_ITER continue arm; opcode_for_iter never
     // pops the iterator).  The live frame is still at the loop-header state

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3683,6 +3683,44 @@ pub(crate) fn dm143_advance_live_locals(
     }
 }
 
+/// #57 Option C (deliver): on a FOR_ITER trace abort, deliver the in-flight
+/// iteration to the live frame instead of dropping it.
+///
+/// The aborted walk advanced the real shared heap iterator once (an
+/// irreversible side effect with no journal undo) and the recording was
+/// discarded, leaving the live frame parked at the FOR_ITER loop header with
+/// the iterator on TOS but the consumed item neither pushed nor its body run
+/// — the legacy `walker_dispatched_this_opcode` bypass would then skip past
+/// FOR_ITER and lose that item.  Instead reconstruct the interpreter resume
+/// state at the point AFTER the consume: push the already-consumed item onto
+/// the live value stack (above the kept iterator, the FOR_ITER continue-arm
+/// shape) and reposition the frame at the loop BODY (`body_pc`, the FOR_ITER
+/// fallthrough).  The `ContinueRunningNormally` re-entry then runs the body
+/// exactly once for that item and continues the loop from the already-
+/// advanced iterator — the `_copy_data_from_miframe` continue-forward analog
+/// (blackhole.py:1711), no drop and no double.
+///
+/// Returns `true` when an item was delivered (the caller must then re-enter
+/// at the body, not bypass past FOR_ITER).  The R1 double-apply guard lives
+/// in `fbw_foriter_inflight_take`.
+fn deliver_inflight_foriter_item(frame: &mut PyFrame) -> bool {
+    let Some((item, body_pc)) = pyre_jit_trace::jitcode_dispatch::fbw_foriter_inflight_take()
+    else {
+        return false;
+    };
+    // The continue arm keeps the iterator on the stack and pushes `next`
+    // above it (codewriter.rs FOR_ITER continue arm; opcode_for_iter never
+    // pops the iterator).  The live frame is still at the loop-header state
+    // with the iterator on TOS, so a single push lands `item` exactly where
+    // the body's STORE_FAST expects TOS.
+    frame.push(item);
+    // Resume at the FOR_ITER fallthrough body opcode.  `next_instr` /
+    // `last_instr` are Python bytecode coordinates, matching `body_pc`
+    // (the FOR_ITER `orgpc + 1`).
+    frame.set_last_instr_from_next_instr(body_pc);
+    true
+}
+
 /// RPython jit_merge_point slow path — only called when tracing is active.
 #[cold]
 #[inline(never)]
@@ -3839,6 +3877,13 @@ fn jit_merge_point_hook(
         // after trace compilation, restart so maybe_compile_and_run
         // (try_function_entry_jit) dispatches to compiled code.
         if was_tracing {
+            // #57 Option C (deliver): a FOR_ITER trace that aborted advanced
+            // the real iterator once but discarded its recording.  Deliver
+            // the in-flight item to the live frame (push + reposition at the
+            // body) so the ContinueRunningNormally re-entry runs the body
+            // once for it, instead of bypassing past the now-orphaned
+            // FOR_ITER and dropping the iteration.
+            deliver_inflight_foriter_item(frame);
             // No-replay portal exit for a loop-free function trace: when the
             // walk captured its concrete return (the `run_perfn_walk`
             // epilogue kept the stash only when the walk's eager side
@@ -4563,6 +4608,14 @@ fn bound_reached(
                 // directly, mirroring the `jit_merge_point_hook` tracing
                 // site (which carries the same no-replay logic for the
                 // merge-point-driven trace path).
+                // #57 Option C (deliver): a FOR_ITER trace that aborted on
+                // the back-edge `can_enter_jit` path advanced the real
+                // iterator once but discarded its recording.  Deliver the
+                // in-flight item to the live frame so the
+                // ContinueRunningNormally re-entry runs the body once for it
+                // (the same continuation as the `jit_merge_point_hook`
+                // tracing site).
+                deliver_inflight_foriter_item(frame);
                 if let Some(cv) = pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_take() {
                     let result = match cv {
                         // A void return stashes `Null`, i.e. Python `None`.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9099,6 +9099,7 @@ impl CodeWriter {
                             let next_var = residual_call!(
                                 for_iter_next_fn_idx,
                                 CallFlavor::MayForce,
+                                majit_ir::PyreHelperKind::ForIterNext,
                                 vec![],
                                 vec![iter_value],
                                 vec![],

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3909,7 +3909,11 @@ fn register_helper_fn_pointers(
     // `bh_get_iter_fn` computes `iter(obj)`; a user `__iter__` may run Python
     // and force the virtualizable → `CallFlavor::MayForce`.  Appended last to
     // preserve fn_ptr indices.
-    let get_iter_fn = bind(assembler, cpu.get_iter_fn as *const (), CallFlavor::MayForce);
+    let get_iter_fn = bind(
+        assembler,
+        cpu.get_iter_fn as *const (),
+        CallFlavor::MayForce,
+    );
     // `jit_next` advances any iterator via `space.next`; a user `__next__`
     // may run Python and force the virtualizable → `CallFlavor::MayForce`.
     let for_iter_next_fn = bind(
@@ -9028,8 +9032,7 @@ impl CodeWriter {
                         // `__iter__` may run Python → `CallFlavor::MayForce`.
                         Instruction::GetIter => {
                             let iterable_reg = emit_popvalue_ref!(current_depth, py_pc);
-                            let iterable_value =
-                                pop_ref_or_fresh(&mut current_state, &mut graph);
+                            let iterable_value = pop_ref_or_fresh(&mut current_state, &mut graph);
                             if let super::flow::FlowValue::Variable(v) = &iterable_value {
                                 pin!(Some(*v), iterable_reg);
                             }
@@ -9135,8 +9138,7 @@ impl CodeWriter {
                                 Kind::Int,
                                 py_pc as i64,
                             );
-                            let scratch_truth =
-                                ssarepr.fresh_var(Kind::Int, scratch_int_base).0;
+                            let scratch_truth = ssarepr.fresh_var(Kind::Int, scratch_int_base).0;
                             pin!(Some(truth), scratch_truth);
                             current_block.block().borrow_mut().exitswitch =
                                 Some(super::flow::ExitSwitch::Value(truth.into()));
@@ -9151,8 +9153,7 @@ impl CodeWriter {
                                 &{
                                     let mut s = current_state.clone();
                                     s.next_offset = fallthrough_py_pc;
-                                    s.blocklist =
-                                        frame_blocks_for_offset(code, fallthrough_py_pc);
+                                    s.blocklist = frame_blocks_for_offset(code, fallthrough_py_pc);
                                     s
                                 },
                                 fallthrough_py_pc,
@@ -9172,8 +9173,7 @@ impl CodeWriter {
                                     let mut s = current_state.clone();
                                     s.stack.pop();
                                     s.next_offset = exhaust_target;
-                                    s.blocklist =
-                                        frame_blocks_for_offset(code, exhaust_target);
+                                    s.blocklist = frame_blocks_for_offset(code, exhaust_target);
                                     s
                                 },
                                 exhaust_target,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9113,77 +9113,74 @@ impl CodeWriter {
                             if let super::flow::FlowValue::Variable(v) = &next_value {
                                 pin!(Some(*v), stack_base + current_depth);
                             }
-                            // [SPIKE PYRE_57_FORITER_BRANCH] emit the exhaustion
-                            // branch: ptr_nonzero(next) selects between the
-                            // continue arm (non-null → push next, fall to PC+1)
-                            // and the exhaustion arm (null → iterator kept,
-                            // side-exit to the FOR_ITER jump target).  Mirrors
-                            // the trait-leg record_for_iter_guard GuardNonnull
-                            // and the PopJumpIfFalse two-exit CFG shape.
-                            if std::env::var_os("PYRE_57_FORITER_BRANCH").is_some() {
-                                let exhaust_target = jump_target_forward(
-                                    code,
-                                    num_instrs,
-                                    py_pc + 1,
-                                    delta.get(op_arg).as_usize(),
-                                );
-                                let truth = emit_graph_op_with_result(
-                                    &mut graph,
-                                    &current_block.block(),
-                                    "ptr_nonzero",
-                                    vec![next_value.clone().into()],
-                                    Kind::Int,
-                                    py_pc as i64,
-                                );
-                                let scratch_truth =
-                                    ssarepr.fresh_var(Kind::Int, scratch_int_base).0;
-                                pin!(Some(truth), scratch_truth);
-                                current_block.block().borrow_mut().exitswitch =
-                                    Some(super::flow::ExitSwitch::Value(truth.into()));
-                                // continue arm (non-null): push next, fall to PC+1.
-                                push_and_bump!(next_value, py_pc);
-                                let fallthrough_py_pc = py_pc + 1;
-                                mergeblock(
-                                    code,
-                                    &mut graph,
-                                    &mut joinpoints,
-                                    &current_block,
-                                    &{
-                                        let mut s = current_state.clone();
-                                        s.next_offset = fallthrough_py_pc;
-                                        s.blocklist =
-                                            frame_blocks_for_offset(code, fallthrough_py_pc);
-                                        s
-                                    },
-                                    fallthrough_py_pc,
-                                    &mut pendingblocks,
-                                    &mut all_walker_blocks,
-                                );
-                                set_last_bool_exitcase(&current_block.block(), true);
-                                // exhaustion arm (null): next not pushed; the
-                                // iterator stays on the stack and the interpreter
-                                // re-runs FOR_ITER on side-exit to end the loop.
-                                mergeblock(
-                                    code,
-                                    &mut graph,
-                                    &mut joinpoints,
-                                    &current_block,
-                                    &{
-                                        let mut s = current_state.clone();
-                                        s.stack.pop();
-                                        s.next_offset = exhaust_target;
-                                        s.blocklist =
-                                            frame_blocks_for_offset(code, exhaust_target);
-                                        s
-                                    },
-                                    exhaust_target,
-                                    &mut pendingblocks,
-                                    &mut all_walker_blocks,
-                                );
-                                set_last_bool_exitcase(&current_block.block(), false);
-                            } else {
-                                push_and_bump!(next_value, py_pc);
-                            }
+                            // Emit the exhaustion branch: ptr_nonzero(next)
+                            // selects between the continue arm (non-null →
+                            // push next, fall to PC+1) and the exhaustion arm
+                            // (null → iterator kept, side-exit to the FOR_ITER
+                            // jump target so the interpreter re-runs FOR_ITER
+                            // and ends the loop).  Mirrors the trait-leg
+                            // record_for_iter_guard GuardNonnull and the
+                            // PopJumpIfFalse two-exit CFG shape.
+                            let exhaust_target = jump_target_forward(
+                                code,
+                                num_instrs,
+                                py_pc + 1,
+                                delta.get(op_arg).as_usize(),
+                            );
+                            let truth = emit_graph_op_with_result(
+                                &mut graph,
+                                &current_block.block(),
+                                "ptr_nonzero",
+                                vec![next_value.clone().into()],
+                                Kind::Int,
+                                py_pc as i64,
+                            );
+                            let scratch_truth =
+                                ssarepr.fresh_var(Kind::Int, scratch_int_base).0;
+                            pin!(Some(truth), scratch_truth);
+                            current_block.block().borrow_mut().exitswitch =
+                                Some(super::flow::ExitSwitch::Value(truth.into()));
+                            // continue arm (non-null): push next, fall to PC+1.
+                            push_and_bump!(next_value, py_pc);
+                            let fallthrough_py_pc = py_pc + 1;
+                            mergeblock(
+                                code,
+                                &mut graph,
+                                &mut joinpoints,
+                                &current_block,
+                                &{
+                                    let mut s = current_state.clone();
+                                    s.next_offset = fallthrough_py_pc;
+                                    s.blocklist =
+                                        frame_blocks_for_offset(code, fallthrough_py_pc);
+                                    s
+                                },
+                                fallthrough_py_pc,
+                                &mut pendingblocks,
+                                &mut all_walker_blocks,
+                            );
+                            set_last_bool_exitcase(&current_block.block(), true);
+                            // exhaustion arm (null): next not pushed; the
+                            // iterator stays on the stack and the interpreter
+                            // re-runs FOR_ITER on side-exit to end the loop.
+                            mergeblock(
+                                code,
+                                &mut graph,
+                                &mut joinpoints,
+                                &current_block,
+                                &{
+                                    let mut s = current_state.clone();
+                                    s.stack.pop();
+                                    s.next_offset = exhaust_target;
+                                    s.blocklist =
+                                        frame_blocks_for_offset(code, exhaust_target);
+                                    s
+                                },
+                                exhaust_target,
+                                &mut pendingblocks,
+                                &mut all_walker_blocks,
+                            );
+                            set_last_bool_exitcase(&current_block.block(), false);
                         }
 
                         Instruction::EndFor => {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3458,7 +3458,7 @@ struct FnPtrIndices {
     list_extend_fn: HelperHandle,
     store_slice_fn: HelperHandle,
     get_iter_fn: HelperHandle,
-    range_iter_next_fn: HelperHandle,
+    for_iter_next_fn: HelperHandle,
 }
 
 /// Register every blackhole helper fn pointer with the assembler in
@@ -3910,13 +3910,12 @@ fn register_helper_fn_pointers(
     // and force the virtualizable → `CallFlavor::MayForce`.  Appended last to
     // preserve fn_ptr indices.
     let get_iter_fn = bind(assembler, cpu.get_iter_fn as *const (), CallFlavor::MayForce);
-    // `jit_range_iter_next_or_null` advances a range iterator with no user
-    // dispatch (the range fast path); it allocates the boxed item (can raise
-    // MemoryError) but does not force virtuals → `CallFlavor::Plain`.
-    let range_iter_next_fn = bind(
+    // `jit_next` advances any iterator via `space.next`; a user `__next__`
+    // may run Python and force the virtualizable → `CallFlavor::MayForce`.
+    let for_iter_next_fn = bind(
         assembler,
-        cpu.range_iter_next_fn as *const (),
-        CallFlavor::Plain,
+        cpu.for_iter_next_fn as *const (),
+        CallFlavor::MayForce,
     );
     FnPtrIndices {
         call_fn,
@@ -3980,7 +3979,7 @@ fn register_helper_fn_pointers(
         store_slice_fn,
         unpack_ex_fn,
         get_iter_fn,
-        range_iter_next_fn,
+        for_iter_next_fn,
     }
 }
 
@@ -5451,10 +5450,10 @@ impl CodeWriter {
                     idx: get_iter_fn_idx,
                     flavor: _get_iter_fn_flavor,
                 },
-            range_iter_next_fn:
+            for_iter_next_fn:
                 HelperHandle {
-                    idx: range_iter_next_fn_idx,
-                    flavor: _range_iter_next_fn_flavor,
+                    idx: for_iter_next_fn_idx,
+                    flavor: _for_iter_next_fn_flavor,
                 },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 
@@ -9098,8 +9097,8 @@ impl CodeWriter {
                                     .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
                             };
                             let next_var = residual_call!(
-                                range_iter_next_fn_idx,
-                                CallFlavor::Plain,
+                                for_iter_next_fn_idx,
+                                CallFlavor::MayForce,
                                 vec![],
                                 vec![iter_value],
                                 vec![],

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9116,6 +9116,44 @@ impl CodeWriter {
                             if let super::flow::FlowValue::Variable(v) = &next_value {
                                 pin!(Some(*v), stack_base + current_depth);
                             }
+                            // `for_iter_next_fn` is `CallFlavor::MayForce`: a user
+                            // `__next__` may raise a non-StopIteration exception.
+                            // When the FOR_ITER sits inside a `try` range the
+                            // residual's `GUARD_NO_EXCEPTION` needs a byte-adjacent
+                            // `catch_exception/L`, else a real raise deopts and the
+                            // blackhole's `handle_exception_in_frame`
+                            // (`blackhole.py:396`) finds no catch and escapes the
+                            // enclosing `try` (`ExitFrameWithExceptionRef`).  The
+                            // generic per-PC catch emission below is skipped here
+                            // because the exhaustion branch closes this block
+                            // first, so split off a dedicated residual block now:
+                            // block A holds the call + the exception edge to the
+                            // handler + a normal fallthrough to a fresh block B;
+                            // the ptr_nonzero two-way exhaustion split then emits
+                            // into B.  Both blocks keep the orthodox single-
+                            // bool-or-single-exception exit shape `flatten.py:
+                            // 275-296 insert_switch_exits` requires.  StopIteration
+                            // still returns null and takes the exhaustion arm on B
+                            // — the catch fires only on a non-null backend
+                            // exception.
+                            if let Some(catch_label) = catch_for_pc[py_pc] {
+                                emit_catch_exception!(catch_label);
+                                let mut b_state = current_state.clone();
+                                b_state.next_offset = py_pc;
+                                b_state.blocklist = frame_blocks_for_offset(code, py_pc);
+                                let block_b = SpamBlockRef::new(
+                                    graph.new_block(Vec::new()),
+                                    Some(b_state.clone()),
+                                );
+                                all_walker_blocks.push(block_b.clone());
+                                block_b.block().borrow_mut().inputargs = b_state.getvariables();
+                                append_exit(
+                                    &current_block.block(),
+                                    output_link(&current_state, &b_state, block_b.block()),
+                                );
+                                restore_canraise_exit_order(&current_block.block());
+                                current_block = block_b;
+                            }
                             // Emit the exhaustion branch: ptr_nonzero(next)
                             // selects between the continue arm (non-null →
                             // push next, fall to PC+1) and the exhaustion arm

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3457,6 +3457,8 @@ struct FnPtrIndices {
     load_fast_check_fn: HelperHandle,
     list_extend_fn: HelperHandle,
     store_slice_fn: HelperHandle,
+    get_iter_fn: HelperHandle,
+    range_iter_next_fn: HelperHandle,
 }
 
 /// Register every blackhole helper fn pointer with the assembler in
@@ -3904,6 +3906,18 @@ fn register_helper_fn_pointers(
         cpu.unpack_ex_fn as *const (),
         CallFlavor::MayForce,
     );
+    // `bh_get_iter_fn` computes `iter(obj)`; a user `__iter__` may run Python
+    // and force the virtualizable → `CallFlavor::MayForce`.  Appended last to
+    // preserve fn_ptr indices.
+    let get_iter_fn = bind(assembler, cpu.get_iter_fn as *const (), CallFlavor::MayForce);
+    // `jit_range_iter_next_or_null` advances a range iterator with no user
+    // dispatch (the range fast path); it allocates the boxed item (can raise
+    // MemoryError) but does not force virtuals → `CallFlavor::Plain`.
+    let range_iter_next_fn = bind(
+        assembler,
+        cpu.range_iter_next_fn as *const (),
+        CallFlavor::Plain,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -3965,6 +3979,8 @@ fn register_helper_fn_pointers(
         list_extend_fn,
         store_slice_fn,
         unpack_ex_fn,
+        get_iter_fn,
+        range_iter_next_fn,
     }
 }
 
@@ -5429,6 +5445,16 @@ impl CodeWriter {
                 HelperHandle {
                     idx: unpack_ex_fn_idx,
                     flavor: _unpack_ex_fn_flavor,
+                },
+            get_iter_fn:
+                HelperHandle {
+                    idx: get_iter_fn_idx,
+                    flavor: _get_iter_fn_flavor,
+                },
+            range_iter_next_fn:
+                HelperHandle {
+                    idx: range_iter_next_fn_idx,
+                    flavor: _range_iter_next_fn_flavor,
                 },
         } = register_helper_fn_pointers(&mut assembler, self.cpu());
 
@@ -8993,28 +9019,176 @@ impl CodeWriter {
                             }
                         }
 
-                        // CPython 3.13 iterator protocol — emit abort_permanent
-                        // with correct depth tracking so subsequent instructions
-                        // don't underflow.
+                        // GET_ITER — pop the iterable, call `iter(obj)`, push the
+                        // iterator.  Net: 0 (replace TOS).  Residual-call lowering
+                        // (range-only spike) so the for-loop body stays on the
+                        // full-body-walk tracer like a while-loop, instead of the
+                        // `abort_permanent` decline that routed it to the weaker
+                        // trait leg (the +1 double-apply, #57).  pyopcode.rs:584
+                        // `opcode_get_iter` → `baseobjspace::iter`; a user
+                        // `__iter__` may run Python → `CallFlavor::MayForce`.
                         Instruction::GetIter => {
-                            // Pop iterable, push iterator. Net: 0. Replace shadow value.
-                            // pypy/interpreter/pyopcode.py:1281.
-                            let _ = current_state.stack.pop();
-                            push_fresh_ref(&mut current_state, &mut graph);
-                            emit_abort_permanent!(py_pc);
+                            let iterable_reg = emit_popvalue_ref!(current_depth, py_pc);
+                            let iterable_value =
+                                pop_ref_or_fresh(&mut current_state, &mut graph);
+                            if let super::flow::FlowValue::Variable(v) = &iterable_value {
+                                pin!(Some(*v), iterable_reg);
+                            }
+                            let iter_var = residual_call!(
+                                get_iter_fn_idx,
+                                CallFlavor::MayForce,
+                                vec![],
+                                vec![iterable_value],
+                                vec![],
+                                vec![Kind::Ref],
+                                ResKind::Ref,
+                                py_pc as i64,
+                            );
+                            let iter_value = iter_var
+                                .map(super::flow::FlowValue::from)
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            if let super::flow::FlowValue::Variable(v) = &iter_value {
+                                pin!(Some(*v), stack_base + current_depth);
+                            }
+                            push_and_bump!(iter_value, py_pc);
                         }
 
-                        Instruction::ForIter { .. } => {
-                            // push next item: net +1
-                            emit_abort_permanent!(py_pc);
-                            current_depth += 1;
-                            emit_vsd!(current_depth, py_pc);
+                        // FOR_ITER — peek the iterator (kept on the stack), call the
+                        // range fast-path `next(iter)`, push the next item.  Net: +1.
+                        // `opcode_for_iter` peeks but never pops the iterator
+                        // (pyopcode.rs:589-608); the iterator stays at TOS-after the
+                        // GET_ITER above, and the next item is pushed above it.
+                        // The exhaustion case (a null return) is handled by the
+                        // interpreter on side-exit; the trace only records the
+                        // continuing iteration (the loop closes at the back-edge).
+                        Instruction::ForIter { delta } => {
+                            // Read the iterator from its value-stack slot via a
+                            // loop-carried `getarrayitem_vable_r` rather than the
+                            // pre-trace register holding the GET_ITER result: the
+                            // FOR_ITER pc sits just past the loop-header
+                            // `jit_merge_point`, so a register written before the
+                            // merge is stale (the merge rebinds the slot's
+                            // loop-input).  Reading the vable slot binds the
+                            // operand from the merge-point reds.  TOS is the
+                            // iterator (`current_depth - 1`).
+                            let iter_slot_depth = current_depth.saturating_sub(1);
+                            let iter_value: super::flow::FlowValue = if is_portal {
+                                let stack_slot =
+                                    (stack_base_absolute + iter_slot_depth as usize) as i64;
+                                let v_slot: super::flow::FlowValue =
+                                    super::flow::Constant::signed(stack_slot).into();
+                                let v_iter = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "getarrayitem_vable_r",
+                                    vable_getarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_slot.into(),
+                                    ),
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                pin!(Some(v_iter), stack_base + iter_slot_depth);
+                                v_iter.into()
+                            } else {
+                                current_state
+                                    .stack
+                                    .last()
+                                    .cloned()
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                            };
+                            let next_var = residual_call!(
+                                range_iter_next_fn_idx,
+                                CallFlavor::Plain,
+                                vec![],
+                                vec![iter_value],
+                                vec![],
+                                vec![Kind::Ref],
+                                ResKind::Ref,
+                                py_pc as i64,
+                            );
+                            let next_value = next_var
+                                .map(super::flow::FlowValue::from)
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                            if let super::flow::FlowValue::Variable(v) = &next_value {
+                                pin!(Some(*v), stack_base + current_depth);
+                            }
+                            // [SPIKE PYRE_57_FORITER_BRANCH] emit the exhaustion
+                            // branch: ptr_nonzero(next) selects between the
+                            // continue arm (non-null → push next, fall to PC+1)
+                            // and the exhaustion arm (null → iterator kept,
+                            // side-exit to the FOR_ITER jump target).  Mirrors
+                            // the trait-leg record_for_iter_guard GuardNonnull
+                            // and the PopJumpIfFalse two-exit CFG shape.
+                            if std::env::var_os("PYRE_57_FORITER_BRANCH").is_some() {
+                                let exhaust_target = jump_target_forward(
+                                    code,
+                                    num_instrs,
+                                    py_pc + 1,
+                                    delta.get(op_arg).as_usize(),
+                                );
+                                let truth = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "ptr_nonzero",
+                                    vec![next_value.clone().into()],
+                                    Kind::Int,
+                                    py_pc as i64,
+                                );
+                                let scratch_truth =
+                                    ssarepr.fresh_var(Kind::Int, scratch_int_base).0;
+                                pin!(Some(truth), scratch_truth);
+                                current_block.block().borrow_mut().exitswitch =
+                                    Some(super::flow::ExitSwitch::Value(truth.into()));
+                                // continue arm (non-null): push next, fall to PC+1.
+                                push_and_bump!(next_value, py_pc);
+                                let fallthrough_py_pc = py_pc + 1;
+                                mergeblock(
+                                    code,
+                                    &mut graph,
+                                    &mut joinpoints,
+                                    &current_block,
+                                    &{
+                                        let mut s = current_state.clone();
+                                        s.next_offset = fallthrough_py_pc;
+                                        s.blocklist =
+                                            frame_blocks_for_offset(code, fallthrough_py_pc);
+                                        s
+                                    },
+                                    fallthrough_py_pc,
+                                    &mut pendingblocks,
+                                    &mut all_walker_blocks,
+                                );
+                                set_last_bool_exitcase(&current_block.block(), true);
+                                // exhaustion arm (null): next not pushed; the
+                                // iterator stays on the stack and the interpreter
+                                // re-runs FOR_ITER on side-exit to end the loop.
+                                mergeblock(
+                                    code,
+                                    &mut graph,
+                                    &mut joinpoints,
+                                    &current_block,
+                                    &{
+                                        let mut s = current_state.clone();
+                                        s.stack.pop();
+                                        s.next_offset = exhaust_target;
+                                        s.blocklist =
+                                            frame_blocks_for_offset(code, exhaust_target);
+                                        s
+                                    },
+                                    exhaust_target,
+                                    &mut pendingblocks,
+                                    &mut all_walker_blocks,
+                                );
+                                set_last_bool_exitcase(&current_block.block(), false);
+                            } else {
+                                push_and_bump!(next_value, py_pc);
+                            }
                         }
 
                         Instruction::EndFor => {
                             // Pyre's end_for() is a no-op (pyopcode.rs:999). Net: 0.
                             // The actual pop is handled by the subsequent PopIter (-1).
-                            emit_abort_permanent!(py_pc);
                         }
 
                         Instruction::PopIter => {

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -153,6 +153,13 @@ pub struct Cpu {
     /// `bh_make_cell_fn(current)` — MAKE_CELL residual: wrap a raw slot value
     /// in a fresh cell (or return an existing cell unchanged); infallible.
     pub make_cell_fn: extern "C" fn(i64) -> i64,
+    /// `bh_get_iter_fn(obj)` — GET_ITER `iter(obj)` residual
+    /// (a user `__iter__` may run Python → fallible).
+    pub get_iter_fn: extern "C" fn(i64) -> i64,
+    /// `jit_range_iter_next_or_null(iter)` — FOR_ITER range fast-path
+    /// `next(iter)` residual; returns the next item, or PY_NULL on
+    /// exhaustion (the trailing for-iter GuardNonnull catches it).
+    pub range_iter_next_fn: extern "C" fn(i64) -> i64,
     /// `bh_unary_negative_fn(value)` — UNARY_NEGATIVE `-value` residual
     /// (a user `__neg__` may run Python → fallible).
     pub unary_negative_fn: extern "C" fn(i64) -> i64,
@@ -332,6 +339,8 @@ impl Cpu {
             load_deref_value_fn: crate::call_jit::bh_load_deref_value_fn,
             store_deref_value_fn: crate::call_jit::bh_store_deref_value_fn,
             make_cell_fn: crate::call_jit::bh_make_cell_fn,
+            get_iter_fn: crate::call_jit::bh_get_iter_fn,
+            range_iter_next_fn: pyre_interpreter::runtime_ops::jit_range_iter_next_or_null,
             unary_negative_fn: crate::call_jit::bh_unary_negative_fn,
             unary_invert_fn: crate::call_jit::bh_unary_invert_fn,
             unary_not_fn: crate::call_jit::bh_unary_not_fn,

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -156,10 +156,11 @@ pub struct Cpu {
     /// `bh_get_iter_fn(obj)` — GET_ITER `iter(obj)` residual
     /// (a user `__iter__` may run Python → fallible).
     pub get_iter_fn: extern "C" fn(i64) -> i64,
-    /// `jit_range_iter_next_or_null(iter)` — FOR_ITER range fast-path
-    /// `next(iter)` residual; returns the next item, or PY_NULL on
-    /// exhaustion (the trailing for-iter GuardNonnull catches it).
-    pub range_iter_next_fn: extern "C" fn(i64) -> i64,
+    /// `jit_next(iter)` — FOR_ITER `next(iter)` residual; returns the next
+    /// item, PY_NULL on StopIteration exhaustion (the trailing for-iter
+    /// GuardNonnull catches it), or publishes a real exception into the
+    /// backend exception cells on error.
+    pub for_iter_next_fn: extern "C" fn(i64) -> i64,
     /// `bh_unary_negative_fn(value)` — UNARY_NEGATIVE `-value` residual
     /// (a user `__neg__` may run Python → fallible).
     pub unary_negative_fn: extern "C" fn(i64) -> i64,
@@ -340,7 +341,7 @@ impl Cpu {
             store_deref_value_fn: crate::call_jit::bh_store_deref_value_fn,
             make_cell_fn: crate::call_jit::bh_make_cell_fn,
             get_iter_fn: crate::call_jit::bh_get_iter_fn,
-            range_iter_next_fn: pyre_interpreter::runtime_ops::jit_range_iter_next_or_null,
+            for_iter_next_fn: pyre_interpreter::runtime_ops::jit_next,
             unary_negative_fn: crate::call_jit::bh_unary_negative_fn,
             unary_invert_fn: crate::call_jit::bh_unary_invert_fn,
             unary_not_fn: crate::call_jit::bh_unary_not_fn,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -5328,7 +5328,13 @@ where
         ctx.store_deref_value_fn_idx,
         vec![cell, value],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        // #57 Option C (Finding #1): a value-returning (`Ref`) heap WRITE — the
+        // in-place cell mutation the FOR_ITER body-effect guard's Void-result
+        // write proxy cannot see.  Tag it so the guard flags it as a body
+        // effect and an aborting FOR_ITER walk refuses delivery (else
+        // re-running the body doubles the cell write).  The tag does not change
+        // the `Plain`/`EF_CAN_RAISE` classification.
+        majit_ir::PyreHelperKind::StoreDeref,
         dst_reg,
     ))
 }


### PR DESCRIPTION
## Summary

Makes the FBW JIT correctly compile Python `for`-loops (`FOR_ITER`) for **all** iterator types — range/seq, generators, user `__next__`, enumerate/map/zip/filter, dict-views, itertools — behind the opt-in `PYRE_57_INLINE_NEXT` flag. The core is a recording-model fix so a `FOR_ITER` trace **abort** can no longer drop (or double) the in-flight iteration item.

Builds on the merged #253 (collapse to `space.next` + residual trace infra). Refs #57.

## Approach

1. **Lower the iterator protocol in the codewriter.** `GET_ITER`/`FOR_ITER`/`END_FOR` lower to residual calls; `FOR_ITER` emits a two-way exhaustion branch on `ptr_nonzero(next)` (continue arm pushes the value and falls through; exhaustion arm side-exits to the loop end). The `next` residual is unified on `jit_next` (`space.next`, `MayForce`), so every iterator family is handled and a real exception raised in `__next__` propagates through the can-raise residual machinery.

2. **Abort-commits-in-flight (the recording-model fix).** On the FBW leg the `for_iter_next` residual runs concretely and advances the real shared heap iterator with no journal entry. Previously, if the loop body's inline sub-walk aborted, the recording was discarded but the iterator advance was not undone and the live `FOR_ITER` was bypassed — silently **dropping** the consumed item (`for x in range(500): seen.append(x)` → 498). This matches RPython's blackhole-on-bailout invariant: the consumed item is now captured during the walk and **delivered** to the live frame (pushed, frame repositioned at the loop body) so the body runs exactly once. No drop.

3. **Never-double guard.** Delivery is refused (falling back to the safe path) whenever a body side-effect already committed for the in-flight iteration — detected via the store/append journals, a heap-write discriminator (`result_type == Void` + helper tags), and a `FRAME_ENTRY_COUNT` odometer that flags a residual whose concrete execution ran user-level Python bytecode (a side-effecting `__get__`/`__add__`/`__iter__`/etc.). So the body runs exactly once — never doubled.

## Status

The `FOR_ITER` lowering is gated behind `PYRE_57_INLINE_NEXT` (default OFF) — this PR is **flag-OFF-inert** for the default build. Flipping it default-on is a planned follow-up (gated on closing the known limitation below).

## Testing

- `pyre/bench/synth/foriter57/` matrix (13 repros: range/sum/big/raise, generator, user `__next__`, enumerate, dict-keys, user-raise, mutate, monkeypatch, nested, dict/attr/prop abort) — oracle = `PYRE_NO_JIT=1`, asserting the `PYRE_57_INLINE_NEXT=1` column matches. **MATRIX OK on both dynasm and cranelift.**
- `python3 pyre/check.py` — **dynasm 153/153, cranelift 153/153**, no regression. Touched-crate tests pass.

## Known limitation

Both gaps below are **gated behind the opt-in flag** (the default build is unaffected) and are the reason the default-on flip is a separate follow-up:

- A *pure-read* user dunder (a property getter that returns a value without side effects) in a hot for-body that **also** aborts the trace in the same iteration is over-conservatively dropped, because the user-frame signal cannot distinguish a pure from an impure user frame at the residual boundary (the effect analyzer's `extraeffect` is stubbed). This is the deliberate cost of the never-double invariant (never a double, only a rare drop); the faithful fix is per-callee write-sets. It does not occur in the test matrix or `check.py`.
- A nested `for y in obj:` over a user-defined iterator raises a spurious `TypeError` under `PYRE_57_INLINE_NEXT=1` — a separate, pre-existing inline-next limitation with custom iterators (not a doubling), to be addressed before the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved iteration support in the runtime, including better handling of iterators, `for` loops, and exceptions during iteration.
  * Added broader benchmark coverage for different loop and iterator patterns.

* **Bug Fixes**
  * Fixed cases where loop iterations could be dropped, repeated, or resumed incorrectly after an abort.
  * Improved handling of nested loops, property access, attribute updates, and closure updates during iteration.
  * Made exception reporting during iteration more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->