### PR TITLE
long: bigint floordiv/mod/truediv parity + skip dead GuardNoException on folded pure long ops

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2978,7 +2978,11 @@ impl TraceCtx {
     /// it to `CallPure*` via [`record_result_of_call_pure`] (same pure-folding
     /// path), but the callee may raise, so the **caller must emit a trailing
     /// `GuardNoException`** (`pyjitpl.py:2082 handle_possible_exception`,
-    /// `do_residual_call`'s `elif cr:` branch). Used for the long division
+    /// `do_residual_call`'s `elif cr:` branch) — **except when the returned
+    /// `OpRef` is a constant**: an all-`Const`-args pure call folds to a `Const`
+    /// here and records no guard, mirroring `pyjitpl.py:1946`'s
+    /// `exc = exc and not isinstance(op, Const)`. Callers gate the guard on
+    /// `returned.inline_const_to_value().is_none()`. Used for the long division
     /// payload helpers (`rbigint.divmod`, `@jit.elidable`, raises
     /// ZeroDivisionError) — `longobject.py:409/426`.
     pub fn call_typed_with_effect_pure_can_raise(

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -302,7 +302,9 @@ unsafe fn int_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let va = int_value(a);
     let vb = int_value(b);
     if vb == 0 {
-        return Err(PyError::zero_division("integer division or modulo by zero"));
+        // `%` alone reports "integer modulo by zero"; only `//`/divmod say
+        // "integer division or modulo by zero".
+        return Err(PyError::zero_division("integer modulo by zero"));
     }
     // Python modulo: result has the same sign as the divisor.
     let r = va % vb;
@@ -327,17 +329,24 @@ unsafe fn long_mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 unsafe fn long_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let vb = as_bigint(b);
     if bigint_eq(vb.clone(), BigInt::from(0)) {
+        // 3.x reports "integer division or modulo by zero" for every int; the
+        // int path raises the same. PyPy's `_floordiv` still carries the 2.x
+        // "long ..." wording (longobject.py:409), which a 3.x runtime does not.
         return Err(PyError::zero_division("integer division or modulo by zero"));
     }
-    Ok(bigint_result(as_bigint(a).div_floor(&vb)))
+    // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
+    Ok(bigint_result(as_bigint(a).div_mod_floor(&vb).0))
 }
 
 unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     let vb = as_bigint(b);
     if bigint_eq(vb.clone(), BigInt::from(0)) {
-        return Err(PyError::zero_division("integer division or modulo by zero"));
+        // `%` alone reports "integer modulo by zero" (not the floordiv/divmod
+        // "division or modulo" wording).
+        return Err(PyError::zero_division("integer modulo by zero"));
     }
-    Ok(bigint_result(as_bigint(a).mod_floor(&vb)))
+    // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
+    Ok(bigint_result(as_bigint(a).div_mod_floor(&vb).1))
 }
 
 /// `rbigint.floordiv` payload half (`longobject.py:409 _floordiv` →
@@ -358,7 +367,8 @@ pub extern "C" fn jit_w_long_floordiv_raw(a: i64, b: i64) -> i64 {
             );
             return 0;
         }
-        pyre_object::lltype::malloc_raw(w_long_get_value(a).div_floor(vb)) as i64
+        // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
+        pyre_object::lltype::malloc_raw(w_long_get_value(a).div_mod_floor(vb).0) as i64
     }
 }
 
@@ -372,12 +382,14 @@ pub extern "C" fn jit_w_long_mod_raw(a: i64, b: i64) -> i64 {
     unsafe {
         let vb = w_long_get_value(b);
         if vb.sign() == malachite_bigint::Sign::NoSign {
+            // `%` alone reports "integer modulo by zero".
             crate::runtime_ops::jit_publish_exception(
-                PyError::zero_division("integer division or modulo by zero").to_exc_object(),
+                PyError::zero_division("integer modulo by zero").to_exc_object(),
             );
             return 0;
         }
-        pyre_object::lltype::malloc_raw(w_long_get_value(a).mod_floor(vb)) as i64
+        // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
+        pyre_object::lltype::malloc_raw(w_long_get_value(a).div_mod_floor(vb).1) as i64
     }
 }
 

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -130,10 +130,6 @@ fn bigint_mod(a: BigInt, b: BigInt) -> BigInt {
     a % b
 }
 
-/// longobject.py:62-70 `_truediv` → rbigint.truediv parity.
-/// Produces the correctly-rounded IEEE 754 double for a/b.
-/// Port of CPython `Objects/longobject.c long_true_divide`.
-#[majit_macros::elidable]
 /// `m * 2^exp`, splitting the power-of-two factor so neither side over- nor
 /// under-flows before a single correctly-rounded final multiply. A lone
 /// `2f64.powi(exp)` would flush to zero in the subnormal range and lose the
@@ -151,6 +147,10 @@ fn ldexp_pow2(m: f64, mut exp: i64) -> f64 {
     x * 2.0_f64.powi(exp as i32)
 }
 
+/// longobject.py:62-70 `_truediv` → rbigint.truediv parity.
+/// Produces the correctly-rounded IEEE 754 double for a/b.
+/// Port of CPython `Objects/longobject.c long_true_divide`.
+#[majit_macros::elidable]
 fn bigint_truediv(a: BigInt, b: BigInt) -> Result<f64, PyError> {
     use malachite_bigint::Sign;
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11978,7 +11978,10 @@ fn try_walker_specialize_binary_op_long(
     );
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    // pyjitpl.py:1946: no GuardNoException when the pure call folded to a Const.
+    if raw.inline_const_to_value().is_none() {
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    }
     // Residual `bigint_result` box: wrap the bigint in a Python int, demoting to
     // W_IntObject when it fits. Non-elidable (`dont_look_inside`), so the wrapper
     // object is never pure-CSE'd — a distinct result per op, matching upstream's
@@ -12081,7 +12084,10 @@ fn try_walker_specialize_truediv_op_long(
     );
     ctx.trace_ctx
         .set_opref_concrete(raw, majit_ir::Value::Float(f_concrete));
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    // pyjitpl.py:1946: no GuardNoException when the pure call folded to a Const.
+    if raw.inline_const_to_value().is_none() {
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+    }
     // Box the f64 with the transparent float NEW (`new_with_vtable` +
     // `setfield_gc_f`), mirroring `space.newfloat(f)`.
     let result = crate::state::wrapfloat(ctx.trace_ctx, raw);

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -6113,7 +6113,12 @@ impl MIFrame {
                 &concrete_args,
                 Value::Int(raw_concrete),
             );
-            this.generate_guard(ctx, OpCode::GuardNoException, &[]);
+            // pyjitpl.py:1946: exc = exc and not isinstance(op, Const). When all
+            // args were constant the pure call folds to a Const, so no
+            // GuardNoException is recorded.
+            if raw.inline_const_to_value().is_none() {
+                this.generate_guard(ctx, OpCode::GuardNoException, &[]);
+            }
             // …then the residual `bigint_result` box/demote → Python int (Ref).
             // Models the `W_LongObject(...)` NEW: `EF_CANNOT_RAISE` and
             // non-elidable (`dont_look_inside`), so it is never pure-CSE'd and,

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -207,12 +207,15 @@ pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
     unsafe { crate::lltype::malloc_raw(w_long_get_value(a) ^ w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.gt`/`lt`/`eq` payload for `W_LongObject` comparison — returns the
-/// sign of `a <=> b` as `-1` / `0` / `1`. A comparison neither allocates nor
-/// raises, so this is `EF_ELIDABLE_CANNOT_RAISE` and the fast path records
-/// `CallPure*` with NO trailing guard. The caller turns the sign into the
-/// requested truth with a plain `int_<cmp>(sign, 0)` (e.g. `a < b` ⟺
-/// `sign < 0`, `a == b` ⟺ `sign == 0`).
+/// `rbigint` comparison payload for `W_LongObject` — returns the sign of
+/// `a <=> b` as `-1` / `0` / `1`. RPython exposes the comparison as six methods
+/// (`lt`/`le`/`eq`/`ne`/`gt`/`ge`, the latter built as `other.lt(self)`
+/// wrappers, `rbigint.py:573/664`); Rust's total `Ord::cmp` collapses them into
+/// one three-way result, and the caller recovers each relation with a plain
+/// `int_<cmp>(sign, 0)` (e.g. `a < b` ⟺ `sign < 0`, `a == b` ⟺ `sign == 0`).
+/// A comparison neither allocates nor raises, so this is
+/// `EF_ELIDABLE_CANNOT_RAISE` and the fast path records `CallPure*` with NO
+/// trailing guard.
 #[majit_macros::elidable_cannot_raise]
 pub extern "C" fn jit_w_long_cmp(a: i64, b: i64) -> i64 {
     use core::cmp::Ordering;
@@ -235,6 +238,12 @@ pub extern "C" fn jit_w_long_cmp(a: i64, b: i64) -> i64 {
 /// via the `dont_look_inside` `jit_w_int_new`). Marked `dont_look_inside`, not
 /// elidable, so the wrapper object is never pure-CSE'd and each add yields a
 /// distinct boxed result, matching `W_LongObject(op(...))`.
+///
+/// The i64-range demotion to `W_IntObject` is pyre's two-class `int`
+/// representation (small-int fast object + bigint object); PyPy's default
+/// `newlong` (`longobject.py:495`, `withsmalllong=False`) keeps a
+/// `W_LongObject`. Both denote the same `int` value — this is a representation
+/// choice spanning every int path, not specific to this helper.
 #[majit_macros::dont_look_inside]
 pub extern "C" fn jit_bigint_result_box(num: i64) -> i64 {
     let num = num as *mut BigInt;


### PR DESCRIPTION
Follow-up commits on the `long-truediv-sticky` branch after #279 merged.

## Changes

- **floordiv/mod structured as divmod, fix `%`-by-zero message** — route the floordiv/mod payloads (interpreter and JIT raw helpers) through `div_mod_floor`, taking the quotient/remainder half, matching `rbigint.floordiv`/`mod` → `_divmod` (rbigint.py:1001). Report `"integer modulo by zero"` for `%` by zero (int and long), distinct from the `"integer division or modulo by zero"` that `//` and `divmod` raise.
- **skip `GuardNoException` when a pure long op folds to a constant** — `record_result_of_call_pure` already cuts an all-Const-args elidable call down to a Const, but the long add/sub/mul/and/or/xor, floordiv/mod/shift and true-divide fast paths emitted the trailing `GuardNoException` unconditionally. Gate each on the returned OpRef not being a constant, porting pyjitpl.py:1946 `exc = exc and not isinstance(op, Const)`, so the all-const IR matches main (no dead guard).
- **restore `#[elidable]` on `bigint_truediv`** — inserting the `ldexp_pow2` helper directly above `bigint_truediv` had displaced the `#[majit_macros::elidable]` attribute onto the helper; move the helper above the attribute so it decorates `bigint_truediv` again (`rbigint.truediv` is `@jit.elidable`, rbigint.py:891).
- **parity citations** for the compare and result-box helpers (`jit_w_long_cmp` collapsing rbigint's six comparison methods into one `Ord::cmp`; `jit_bigint_result_box`'s i64-range demotion to `W_IntObject`); no behavior change.

## Files
- `majit/majit-metainterp/src/history.rs`
- `pyre/pyre-interpreter/src/objspace/descroperation.rs`
- `pyre/pyre-jit-trace/src/jitcode_dispatch.rs`
- `pyre/pyre-jit-trace/src/trace_opcode.rs`
- `pyre/pyre-object/src/longobject.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)