### PR TITLE
#47: strip box_cache memo + retype box-object channels to Operand (E6/E7)

### DIFF
--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -10,7 +10,6 @@
 ///
 /// Reference: rpython/jit/backend/llsupport/rewrite.py GcRewriterAssembler.
 use majit_ir::Type;
-use majit_ir::box_ref::BoxRef;
 use majit_ir::descr::{DescrRef, FieldDescr, SizeDescr};
 use majit_ir::operand::Operand;
 use majit_ir::resoperation::{Op, OpCode, OpRef};
@@ -18,78 +17,11 @@ use majit_ir::{Const, GcRef, Value, VecMap, VecSet};
 
 use crate::{GcRewriter, WriteBarrierDescr};
 
-/// Reconstruct the flat `OpRef` view of a `BoxRef` for the GC rewriter's
-/// position-keyed side tables and `op.pos` comparisons.
-///
-/// The GC rewriter runs post-optimization and keys its bookkeeping by
-/// result position (a faithful identity proxy here, since positions are
-/// globally unique).  A `ConstInt/ConstFloat/ConstPtr` box maps to the
-/// matching inline-const `OpRef` (history.py:227/268/314); an InputArg or
-/// ResOp box maps to its typed position.
-fn box_to_opref(b: &BoxRef) -> OpRef {
-    if b.is_none() {
-        return OpRef::NONE;
-    }
-    match b.const_value() {
-        Some(Value::Int(v)) => return OpRef::const_int(v),
-        Some(Value::Float(v)) => return OpRef::const_float(v),
-        Some(Value::Ref(v)) => return OpRef::const_ptr(v),
-        Some(Value::Void) => return OpRef::NONE,
-        None => {}
-    }
-    let pos = b.position().expect("non-const box must carry a position");
-    let ty = b.type_();
-    if b.is_inputarg() {
-        OpRef::input_arg_typed(pos, ty)
-    } else {
-        OpRef::op_typed(pos, ty)
-    }
+fn mk_op(opcode: OpCode, args: &[Operand]) -> Op {
+    Op::new(opcode, args)
 }
-
-/// Materialize the `BoxRef` view of an `OpRef` held in a position-keyed
-/// side table (the inverse of `box_to_opref`).  ResOp positions become a
-/// position-carrying `new_resop` box (no live op handle — identity by
-/// position, sufficient for the post-optimization GC + backend consumers).
-fn opref_to_box(r: OpRef) -> BoxRef {
-    if r.is_none() {
-        return BoxRef::none();
-    }
-    if r.is_constant() {
-        return match r {
-            OpRef::ConstInt(v) => BoxRef::new_const(Value::Int(v)),
-            OpRef::ConstFloat(v) => BoxRef::new_const(Value::Float(v)),
-            OpRef::ConstPtr(v) => BoxRef::new_const(Value::Ref(v)),
-            _ => unreachable!("is_constant but not a Const variant"),
-        };
-    }
-    let ty = r.ty().unwrap_or(Type::Void);
-    let pos = r.raw();
-    match r {
-        OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-            BoxRef::new_inputarg(ty, pos)
-        }
-        _ => BoxRef::new_resop(ty, pos),
-    }
-}
-
-fn mk_op(opcode: OpCode, args: &[BoxRef]) -> Op {
-    Op::new(
-        opcode,
-        &args
-            .iter()
-            .map(|b| Operand::from_boxref(b))
-            .collect::<Vec<Operand>>(),
-    )
-}
-fn mk_op_descr(opcode: OpCode, args: &[BoxRef], descr: DescrRef) -> Op {
-    Op::with_descr(
-        opcode,
-        &args
-            .iter()
-            .map(|b| Operand::from_boxref(b))
-            .collect::<Vec<Operand>>(),
-        descr,
-    )
+fn mk_op_descr(opcode: OpCode, args: &[Operand], descr: DescrRef) -> Op {
+    Op::with_descr(opcode, args, descr)
 }
 
 /// Alignment for nursery allocations (8 bytes).
@@ -360,7 +292,7 @@ impl JitFrameDescrs {
 ///                      OpRef back as the final indexed-op `index` arg.
 enum ScaledIndex {
     Const,
-    Passthrough(BoxRef),
+    Passthrough(Operand),
     PreScale(Op),
 }
 
@@ -408,7 +340,7 @@ struct RewriteState {
     /// NURSERY_PTR_INCREMENT offset).
     previous_size: usize,
     /// The last object produced by the current nursery batch.
-    last_malloced_ref: BoxRef,
+    last_malloced_ref: Operand,
 
     // ── Write barrier tracking ──
     /// rewrite.py:41-45: _write_barrier_applied — set of OpRef indices
@@ -417,7 +349,7 @@ struct RewriteState {
     /// we emit an operation that can trigger a collection or on LABEL.
     wb_applied: VecSet<OpRef>,
     /// Forwarding map from original result OpRefs to rewritten result boxes.
-    forwarding: VecMap<OpRef, BoxRef>,
+    forwarding: VecMap<OpRef, Operand>,
 
     // ── Array length tracking (rewrite.py:59 _known_lengths) ──
     /// Maps array OpRef → known length. Populated when NEW_ARRAY has a
@@ -456,7 +388,7 @@ struct RewriteState {
     /// ported.  The parity skeleton is kept here so the structural
     /// presence matches upstream and the consumer can be wired without
     /// re-introducing the field.
-    _constant_additions: VecMap<OpRef, (BoxRef, i64)>,
+    _constant_additions: VecMap<OpRef, (Operand, i64)>,
     /// Reserved next constant index in the passed-in constant namespace.
     /// Current GC-rewrite parity emits fresh `ConstInt` values inline
     /// (`history.py:227`) instead of allocating pool entries, so this is
@@ -504,7 +436,7 @@ struct RewriteState {
     /// across a can-collect point is sound: the load result is a Ref box,
     /// so the register allocator keeps it in the GC map and the collector
     /// forwards the held copy.
-    gcrefs_recently_loaded: VecMap<u32, BoxRef>,
+    gcrefs_recently_loaded: VecMap<u32, Operand>,
 }
 
 impl RewriteState {
@@ -516,7 +448,7 @@ impl RewriteState {
             pending_malloc_idx: None,
             pending_malloc_total: 0,
             previous_size: 0,
-            last_malloced_ref: BoxRef::none(),
+            last_malloced_ref: Operand::none(),
             wb_applied: VecSet::new(),
             forwarding: VecMap::new(),
             known_lengths: VecMap::new(),
@@ -555,7 +487,7 @@ impl RewriteState {
     /// passes the Box; `isinstance(box, ConstInt) and box.getint()`).
     /// history.py:227/268/314 — inline-Const variants carry their value
     /// directly; legacy pool-indexed variants look up via the snapshot.
-    fn resolve_constant(&self, b: &BoxRef) -> Option<i64> {
+    fn resolve_constant(&self, b: &Operand) -> Option<i64> {
         // rewrite.py:548/590/1013 gate these reads on `isinstance(arg,
         // ConstInt)` → `getint()`. ConstFloat/ConstPtr have
         // no `getint` (history.py:268/314), so a Float/Ptr constant is
@@ -582,8 +514,8 @@ impl RewriteState {
     /// `ConstInt.value` is inline on the Box; pyre mints
     /// `OpRef::ConstInt(value)` with the value carried inline
     /// per history.py:220 `ConstInt.type = 'i'`.
-    fn const_int(&mut self, value: i64) -> BoxRef {
-        BoxRef::new_const(Value::Int(value))
+    fn const_int(&mut self, value: i64) -> Operand {
+        Operand::const_from_value(Value::Int(value))
     }
 
     /// rewrite.py:1033-1043 `_gcref_index` — dedup a reference constant
@@ -602,12 +534,12 @@ impl RewriteState {
     /// constant with the result of a `LoadFromGcTable(index)` load,
     /// reusing one already emitted in this basic block (CSE) when
     /// possible.
-    fn remove_constptr(&mut self, gcref: GcRef) -> BoxRef {
+    fn remove_constptr(&mut self, gcref: GcRef) -> Operand {
         let index = self.gcref_index(gcref);
         if let Some(load) = self.gcrefs_recently_loaded.get(&index) {
             return load.clone();
         }
-        let index_box = BoxRef::new_const(Value::Int(index as i64));
+        let index_box = Operand::const_from_value(Value::Int(index as i64));
         let load = self.emit(mk_op(OpCode::LoadFromGcTable, &[index_box]));
         self.gcrefs_recently_loaded.insert(index, load.clone());
         load
@@ -634,7 +566,7 @@ impl RewriteState {
             if let Some(Value::Ref(gcref)) = op.arg(i).const_value() {
                 if !gcref.is_null() {
                     let load = self.remove_constptr(gcref);
-                    op.setarg(i, Operand::from_boxref(&load));
+                    op.setarg(i, load);
                 }
             }
         }
@@ -645,7 +577,7 @@ impl RewriteState {
     /// The result OpRef carries its own type via the variant tag
     /// (`int_op`/`float_op`/`ref_op`) — rewrite.py:930 `v.type` parity —
     /// so no separate type table is maintained.
-    fn emit(&mut self, op: Op) -> BoxRef {
+    fn emit(&mut self, op: Op) -> Operand {
         self.remove_constptrs_in(&op);
         let rt = op.result_type();
         let pos = if rt == Type::Void {
@@ -664,9 +596,9 @@ impl RewriteState {
         let rc = std::rc::Rc::new(op);
         self.out.push(rc.clone());
         if pos.is_none() {
-            BoxRef::none()
+            Operand::none()
         } else {
-            BoxRef::from_bound_op(&rc)
+            Operand::from_bound_op(&rc)
         }
     }
 
@@ -675,7 +607,7 @@ impl RewriteState {
     ///
     /// The result OpRef carries its own type via the variant tag, so no
     /// separate type table is maintained — see `emit()` doc.
-    fn emit_result(&mut self, op: Op, preferred_pos: OpRef) -> BoxRef {
+    fn emit_result(&mut self, op: Op, preferred_pos: OpRef) -> Operand {
         self.remove_constptrs_in(&op);
         let rt = op.result_type();
         let pos = if preferred_pos.is_none() {
@@ -688,7 +620,7 @@ impl RewriteState {
         op.pos.set(pos);
         let rc = std::rc::Rc::new(op);
         self.out.push(rc.clone());
-        BoxRef::from_bound_op(&rc)
+        Operand::from_bound_op(&rc)
     }
 
     /// rewrite.py:699-711 emitting_an_operation_that_can_collect
@@ -713,8 +645,8 @@ impl RewriteState {
     /// `is_subtraction` distinguishes INT_SUB (negate the constant
     /// before storing) from INT_ADD.  Mirrors rewrite.py:1015.
     fn record_int_add_or_sub(&mut self, op: &Op, is_subtraction: bool) {
-        let v_arg0 = op.arg(0).to_boxref();
-        let v_arg1 = op.arg(1).to_boxref();
+        let v_arg0 = op.arg(0);
+        let v_arg1 = op.arg(1);
         let (box_arg, mut constant) = if let Some(c) = self.resolve_constant(&v_arg1) {
             let signed = if is_subtraction { -c } else { c };
             (v_arg0, signed)
@@ -730,7 +662,7 @@ impl RewriteState {
         // rewrite.py:1026-1030 invariant: if box itself is a recorded
         // sum, fold its constant in and chain to the older origin.
         let box_arg =
-            if let Some((older, extra)) = self._constant_additions.get(&box_to_opref(&box_arg)) {
+            if let Some((older, extra)) = self._constant_additions.get(&box_arg.to_opref()) {
                 constant += *extra;
                 older.clone()
             } else {
@@ -745,38 +677,38 @@ impl RewriteState {
     /// If `index_box` is a recorded `_constant_additions` entry, replace
     /// it with the older box and add `factor * extra_offset` to
     /// `offset`.
-    fn _try_use_older_box(&self, index_box: &BoxRef, factor: i64, offset: i64) -> (BoxRef, i64) {
-        if let Some((older, extra)) = self._constant_additions.get(&box_to_opref(index_box)) {
+    fn _try_use_older_box(&self, index_box: &Operand, factor: i64, offset: i64) -> (Operand, i64) {
+        if let Some((older, extra)) = self._constant_additions.get(&index_box.to_opref()) {
             return (older.clone(), offset + factor * *extra);
         }
         (index_box.clone(), offset)
     }
 
-    fn remember_wb(&mut self, r: &BoxRef) {
-        self.wb_applied.insert(box_to_opref(r));
+    fn remember_wb(&mut self, r: &Operand) {
+        self.wb_applied.insert(r.to_opref());
     }
 
     /// rewrite.py:66-67: remember_known_length
-    fn remember_known_length(&mut self, op: &BoxRef, length: usize) {
-        self.known_lengths.insert(box_to_opref(op), length);
+    fn remember_known_length(&mut self, op: &Operand, length: usize) {
+        self.known_lengths.insert(op.to_opref(), length);
     }
 
     /// rewrite.py:81-82: known_length(op, default)
-    fn known_length(&self, op: &BoxRef, default: usize) -> usize {
+    fn known_length(&self, op: &Operand, default: usize) -> usize {
         self.known_lengths
-            .get(&box_to_opref(op))
+            .get(&op.to_opref())
             .copied()
             .unwrap_or(default)
     }
 
     /// rewrite.py:714: write_barrier_applied(op)
-    fn wb_already_applied(&self, r: &BoxRef) -> bool {
-        self.wb_applied.contains(&box_to_opref(r))
+    fn wb_already_applied(&self, r: &Operand) -> bool {
+        self.wb_applied.contains(&r.to_opref())
     }
 
     /// rewrite.py:930 parity: `v.type` — the Box carries its type
     /// intrinsically (history.py:220/261/307).
-    fn result_type_of(&self, b: &BoxRef) -> Option<Type> {
+    fn result_type_of(&self, b: &Operand) -> Option<Type> {
         if b.is_none() {
             return None;
         }
@@ -785,7 +717,7 @@ impl RewriteState {
 
     /// rewrite.py:930 parity: `isinstance(v, ConstPtr) and not needs_write_barrier(v.value)`.
     /// A null ConstPtr never needs a write barrier.
-    fn is_null_constant(&self, b: &BoxRef) -> bool {
+    fn is_null_constant(&self, b: &Operand) -> bool {
         // history.py:314 ConstPtr.value inline — null sentinel directly readable.
         match b.const_value() {
             Some(Value::Ref(r)) => r.0 == 0,
@@ -794,11 +726,11 @@ impl RewriteState {
         }
     }
 
-    fn resolve(&self, r: BoxRef) -> BoxRef {
+    fn resolve(&self, r: Operand) -> Operand {
         if r.is_none() {
             return r;
         }
-        self.forwarding.get(&box_to_opref(&r)).cloned().unwrap_or(r)
+        self.forwarding.get(&r.to_opref()).cloned().unwrap_or(r)
     }
 
     fn rewrite_op(&self, op: &Op) -> Op {
@@ -806,29 +738,26 @@ impl RewriteState {
         // optimizer.py:651-652 force_box loop parity:
         //   for i in range(op.numargs()): op.setarg(i, ...)
         for i in 0..rewritten.num_args() {
-            rewritten.setarg(
-                i,
-                Operand::from_boxref(&self.resolve(rewritten.arg(i).to_boxref())),
-            );
+            rewritten.setarg(i, self.resolve(rewritten.arg(i)));
         }
         if let Some(fail_args) = rewritten.fail_args_mut() {
             for arg in fail_args.iter_mut() {
                 // Same shed as `setarg` above: a forwarding target bound to
                 // its producer stays a live-tracking operand.
-                *arg = Operand::from_boxref(&self.resolve(arg.to_boxref()));
+                *arg = self.resolve(arg.clone());
             }
         }
         rewritten.pos.set(OpRef::NONE);
         rewritten
     }
 
-    fn record_result_mapping(&mut self, old_pos: OpRef, new_box: BoxRef) {
+    fn record_result_mapping(&mut self, old_pos: OpRef, new_box: Operand) {
         if !old_pos.is_none() {
             self.forwarding.insert(old_pos, new_box);
         }
     }
 
-    fn emit_rewritten_from(&mut self, original: &Op, rewritten: Op) -> BoxRef {
+    fn emit_rewritten_from(&mut self, original: &Op, rewritten: Op) -> Operand {
         let result = if original.result_type() == Type::Void {
             self.emit(rewritten)
         } else {
@@ -852,7 +781,7 @@ impl RewriteState {
     /// previously stashed via `set_forwarded` (if any) or the rewritten
     /// original.  Preserves the original's position mapping so downstream
     /// uses of the original's `OpRef` resolve to the lowered op's result.
-    fn emit_maybe_forwarded(&mut self, original: &Op) -> BoxRef {
+    fn emit_maybe_forwarded(&mut self, original: &Op) -> Operand {
         if let Some(lowered) = self.forwarded_ops.remove(&self.current_i) {
             let result = if original.result_type() == Type::Void {
                 self.emit(lowered)
@@ -872,15 +801,15 @@ impl RewriteState {
     /// rewrite.py:84-91 `delayed_zero_setfields(op)` — get-or-create the
     /// per-base byte-offset set, resolving `r` through the forwarding
     /// map first (RPython calls `get_box_replacement(op)` here).
-    fn delayed_zero_setfields(&mut self, r: &BoxRef) -> &mut VecSet<i64> {
-        let key = box_to_opref(&self.resolve(r.clone()));
+    fn delayed_zero_setfields(&mut self, r: &Operand) -> &mut VecSet<i64> {
+        let key = self.resolve(r.clone()).to_opref();
         self._delayed_zero_setfields.entry(key).or_default()
     }
 
     /// Record that a SETARRAYITEM wrote to `array_ref[index]`,
     /// so the pending zero for that slot can be skipped.
-    fn record_setarrayitem_index(&mut self, array_ref: &BoxRef, index: usize) {
-        let key = box_to_opref(array_ref);
+    fn record_setarrayitem_index(&mut self, array_ref: &Operand, index: usize) {
+        let key = array_ref.to_opref();
         if self.pending_zeros.iter().any(|pz| pz.array_ref == key) {
             self.initialized_indices
                 .entry(key)
@@ -920,10 +849,10 @@ impl RewriteState {
 
             let op = &self.out[pz.out_index];
             // resoperation.py:290 AbstractResOp.setarg parity.
-            op.setarg(1, Operand::from_boxref(&scaled_start));
-            op.setarg(2, Operand::from_boxref(&scaled_len));
-            op.setarg(3, Operand::from_boxref(&one.clone()));
-            op.setarg(4, Operand::from_boxref(&one));
+            op.setarg(1, scaled_start);
+            op.setarg(2, scaled_len);
+            op.setarg(3, one.clone());
+            op.setarg(4, one);
         }
 
         // rewrite.py:760-766 — NULL-pointer writes still pending for
@@ -941,16 +870,16 @@ impl RewriteState {
             // The pending-zero base is the result of an earlier malloc/New
             // already emitted into `self.out`; bind the GC_STORE base to that
             // producer so the arg sheds to `Operand::Op` (RPython keeps the
-            // base Box object). `opref_to_box` only synthesises a
-            // position-only box for GC/backend reads that never reach
-            // `from_boxref`; used as an op arg it would be rejected, so resolve
-            // the producer here. `to_opref()` is unchanged either way.
+            // base Box object). `Operand::from_opref` only materialises the
+            // None/Const arms; a position-only ref has no producer and would
+            // panic, so resolve the producer here. `to_opref()` is unchanged
+            // either way.
             let ptr_box = self
                 .out
                 .iter()
                 .find(|o| o.pos.get() == ptr)
-                .map(|o| BoxRef::from_bound_op(o))
-                .unwrap_or_else(|| opref_to_box(ptr));
+                .map(Operand::from_bound_op)
+                .unwrap_or_else(|| Operand::from_opref(ptr));
             for ofs in entries.iter().copied() {
                 let ofs_ref = self.const_int(ofs);
                 let zero_ref = self.const_int(0);
@@ -1009,7 +938,7 @@ impl GcRewriterImpl {
         }
         // rewrite.py:445 `next_op.getarg(0) is not op` — in pyre OpRef
         // carries the same identity role as RPython's box object.
-        if box_to_opref(&next_op.arg(0).to_boxref()) != op.pos.get() {
+        if next_op.arg(0).to_opref() != op.pos.get() {
             return false;
         }
         self.remove_tested_failarg(next_op, i + 1, st);
@@ -1036,9 +965,9 @@ impl GcRewriterImpl {
             Some(fa) if !fa.is_empty() => fa,
             _ => return,
         };
-        let target = box_to_opref(&op.arg(0).to_boxref());
+        let target = op.arg(0).to_opref();
         // rewrite.py:456-459: guard's failargs contain the tested box?
-        let Some(idx) = fail_args.iter().position(|a| box_to_opref(a) == target) else {
+        let Some(idx) = fail_args.iter().position(|a| a.to_opref() == target) else {
             return;
         };
         // rewrite.py:463 `value = int(opnum == rop.GUARD_FALSE)`
@@ -1057,7 +986,7 @@ impl GcRewriterImpl {
             // `Operand::Box` (#9): the failarg then auto-tracks the producer's
             // `op.pos` if it is renumbered, matching RPython's box-identity
             // failarg.
-            fa[idx] = Operand::from_boxref(&same_pos);
+            fa[idx] = same_pos;
         }
         // pos is reassigned when emit/emit_result runs on the substituted op.
         new_guard.pos.set(OpRef::NONE);
@@ -1147,7 +1076,7 @@ impl GcRewriterImpl {
     /// SETFIELD_GC overwrites it first.  Early-returns when the
     /// allocator already zero-fills payload bytes
     /// (`self.malloc_zero_filled`, rewrite.py:499-500).
-    fn clear_gc_fields(&self, descr: &dyn SizeDescr, result: BoxRef, st: &mut RewriteState) {
+    fn clear_gc_fields(&self, descr: &dyn SizeDescr, result: Operand, st: &mut RewriteState) {
         if self.malloc_zero_filled {
             return;
         }
@@ -1185,7 +1114,7 @@ impl GcRewriterImpl {
             .expect("handle_new_array descr must be ArrayDescr");
 
         let item_size = descr.item_size();
-        let v_length = st.resolve(op.arg(0).to_boxref()); // the length operand
+        let v_length = st.resolve(op.arg(0)); // the length operand
         let length_const = st.resolve_constant(&v_length);
 
         // rewrite.py:548-558 — total_size for the constant-size /
@@ -1322,8 +1251,8 @@ impl GcRewriterImpl {
         kind: i64,
         arraydescr: DescrRef,
         ad_itemsize: i64,
-        result: BoxRef,
-        v_length: BoxRef,
+        result: Operand,
+        v_length: Operand,
         opnum: OpCode,
         st: &mut RewriteState,
     ) {
@@ -1367,8 +1296,8 @@ impl GcRewriterImpl {
         &self,
         arraydescr: DescrRef,
         ad_itemsize: i64,
-        v_arr: BoxRef,
-        v_length: BoxRef,
+        v_arr: Operand,
+        v_length: Operand,
         st: &mut RewriteState,
     ) {
         // rewrite.py:589 assert v_length is not None.
@@ -1413,7 +1342,7 @@ impl GcRewriterImpl {
         if let Some(n) = length_const {
             st.pending_zeros.push(PendingZero {
                 out_index,
-                array_ref: box_to_opref(&v_arr),
+                array_ref: v_arr.to_opref(),
                 length: n as usize,
                 scale,
             });
@@ -1436,10 +1365,10 @@ impl GcRewriterImpl {
         &self,
         arraydescr: DescrRef,
         kind: i64,
-        v_length: BoxRef,
+        v_length: Operand,
         result_pos: OpRef,
         st: &mut RewriteState,
-    ) -> Option<BoxRef> {
+    ) -> Option<Operand> {
         let ad = arraydescr
             .as_array_descr()
             .expect("gen_malloc_nursery_varsize descr must be ArrayDescr");
@@ -1473,11 +1402,11 @@ impl GcRewriterImpl {
     /// rewrite.py:768-776 `_gen_call_malloc_gc`.
     fn gen_call_malloc_gc(
         &self,
-        args: &[BoxRef],
+        args: &[Operand],
         result_pos: OpRef,
         calldescr: DescrRef,
         st: &mut RewriteState,
-    ) -> BoxRef {
+    ) -> Operand {
         st.emitting_an_operation_that_can_collect();
         let call_op = mk_op(OpCode::CallR, args);
         call_op.setdescr(calldescr);
@@ -1490,10 +1419,10 @@ impl GcRewriterImpl {
     fn gen_malloc_array(
         &self,
         arraydescr: DescrRef,
-        v_num_elem: BoxRef,
+        v_num_elem: Operand,
         result_pos: OpRef,
         st: &mut RewriteState,
-    ) -> BoxRef {
+    ) -> Operand {
         let ad = arraydescr
             .as_array_descr()
             .expect("gen_malloc_array descr must be ArrayDescr");
@@ -1554,7 +1483,7 @@ impl GcRewriterImpl {
         type_id: u32,
         result_pos: OpRef,
         st: &mut RewriteState,
-    ) -> BoxRef {
+    ) -> Operand {
         debug_assert_eq!(
             size & (std::mem::size_of::<usize>() - 1),
             0,
@@ -1583,10 +1512,10 @@ impl GcRewriterImpl {
     /// `malloc_str_calldescr` Signed/Signed signature documented there.
     fn gen_malloc_str(
         &self,
-        v_num_elem: BoxRef,
+        v_num_elem: Operand,
         result_pos: OpRef,
         st: &mut RewriteState,
-    ) -> BoxRef {
+    ) -> Operand {
         let fn_ref = st.const_int(self.malloc_str_fn);
         let type_id = self
             .str_descr
@@ -1609,10 +1538,10 @@ impl GcRewriterImpl {
     /// `unicode_type_id = self.unicode_descr.tid`).
     fn gen_malloc_unicode(
         &self,
-        v_num_elem: BoxRef,
+        v_num_elem: Operand,
         result_pos: OpRef,
         st: &mut RewriteState,
-    ) -> BoxRef {
+    ) -> Operand {
         let fn_ref = st.const_int(self.malloc_unicode_fn);
         let type_id = self
             .unicode_descr
@@ -1693,10 +1622,10 @@ impl GcRewriterImpl {
         }
 
         // rewrite.py:1065-1068 — effective source / destination addresses.
-        let src_gcptr = st.resolve(op.arg(0).to_boxref());
-        let dst_gcptr = st.resolve(op.arg(1).to_boxref());
-        let src_index = st.resolve(op.arg(2).to_boxref());
-        let dst_index = st.resolve(op.arg(3).to_boxref());
+        let src_gcptr = st.resolve(op.arg(0));
+        let dst_gcptr = st.resolve(op.arg(1));
+        let src_index = st.resolve(op.arg(2));
+        let dst_index = st.resolve(op.arg(3));
 
         let i1 = self.emit_load_effective_address(src_gcptr, src_index, basesize, itemscale, st);
         let i2 = self.emit_load_effective_address(dst_gcptr, dst_index, basesize, itemscale, st);
@@ -1706,9 +1635,9 @@ impl GcRewriterImpl {
         //   UNICODE: arg = ConstInt(op.getarg(4).getint() << itemscale)
         //            or INT_LSHIFT(op.getarg(4), ConstInt(itemscale))
         let arg = if op.opcode == OpCode::Copystrcontent {
-            st.resolve(op.arg(4).to_boxref())
+            st.resolve(op.arg(4))
         } else {
-            let v_length = st.resolve(op.arg(4).to_boxref());
+            let v_length = st.resolve(op.arg(4));
             if let Some(c) = st.resolve_constant(&v_length) {
                 // rewrite.py:1073-1074 — constant-fold the shift.
                 st.const_int(c << itemscale)
@@ -1736,12 +1665,12 @@ impl GcRewriterImpl {
     /// resoperation.py:1052-1054.
     fn emit_load_effective_address(
         &self,
-        v_gcptr: BoxRef,
-        v_index: BoxRef,
+        v_gcptr: Operand,
+        v_index: Operand,
         base: i64,
         itemscale: i64,
         st: &mut RewriteState,
-    ) -> BoxRef {
+    ) -> Operand {
         if self.supports_load_effective_address {
             // rewrite.py:1083-1088 — single LEA op.
             let base_ref = st.const_int(base);
@@ -1784,7 +1713,7 @@ impl GcRewriterImpl {
     /// the lowered GC_STORE (forwarded by `transform_to_gc_load`) lands
     /// after the WB.
     fn handle_write_barrier_setfield(&self, op: &Op, st: &mut RewriteState) {
-        let obj = st.resolve(op.arg(0).to_boxref());
+        let obj = st.resolve(op.arg(0));
         if st.wb_already_applied(&obj) {
             return;
         }
@@ -1802,7 +1731,7 @@ impl GcRewriterImpl {
             .getdescr()
             .and_then(|d| d.as_field_descr().map(|fd| fd.is_pointer_field()))
             .unwrap_or(false);
-        let val = st.resolve(op.arg(1).to_boxref());
+        let val = st.resolve(op.arg(1));
         let val_is_ref = if field_is_ptr {
             match st.result_type_of(&val) {
                 Some(tp) => tp == Type::Ref,
@@ -1822,7 +1751,7 @@ impl GcRewriterImpl {
     }
 
     /// rewrite.py:948-953 `gen_write_barrier`.
-    fn gen_write_barrier(&self, v_base: BoxRef, st: &mut RewriteState) {
+    fn gen_write_barrier(&self, v_base: Operand, st: &mut RewriteState) {
         let wb_op = mk_op(OpCode::CondCallGcWb, &[v_base.clone()]);
         st.emit(wb_op);
         st.remember_wb(&v_base);
@@ -1847,8 +1776,8 @@ impl GcRewriterImpl {
             return;
         };
         let offset = fd.offset() as i64;
-        let base = st.resolve(op.arg(0).to_boxref());
-        if let Some(entries) = st._delayed_zero_setfields.get_mut(&box_to_opref(&base)) {
+        let base = st.resolve(op.arg(0));
+        if let Some(entries) = st._delayed_zero_setfields.get_mut(&base.to_opref()) {
             entries.remove(&offset);
         }
     }
@@ -1866,8 +1795,8 @@ impl GcRewriterImpl {
     ///     self.remember_setarrayitem_occurred(array_box, index_box.getint())
     /// ```
     fn consider_setarrayitem_gc(&self, op: &Op, st: &mut RewriteState) {
-        let array_ref = st.resolve(op.arg(0).to_boxref());
-        let index_ref = op.arg(1).to_boxref();
+        let array_ref = st.resolve(op.arg(0));
+        let index_ref = op.arg(1);
         if st.resolve_constant(&array_ref).is_some() {
             return;
         }
@@ -1884,10 +1813,10 @@ impl GcRewriterImpl {
     /// and then `self.emit_op(op)` follows the forwarding. We do the
     /// equivalent in the caller by invoking handle_setarrayitem after WB.
     fn handle_write_barrier_setarrayitem(&self, op: &Op, st: &mut RewriteState) {
-        let val = st.resolve(op.arg(0).to_boxref());
+        let val = st.resolve(op.arg(0));
         // rewrite.py:938-942
         if !st.wb_already_applied(&val) {
-            let v = st.resolve(op.arg(2).to_boxref());
+            let v = st.resolve(op.arg(2));
             let val_is_ref = match st.result_type_of(&v) {
                 Some(tp) => tp == Type::Ref,
                 // None only for the OpRef::None / virtual marker (no type
@@ -1899,7 +1828,7 @@ impl GcRewriterImpl {
                     .unwrap_or(false),
             };
             if val_is_ref && !st.is_null_constant(&v) {
-                self.gen_write_barrier_array(val, st.resolve(op.arg(1).to_boxref()), st);
+                self.gen_write_barrier_array(val, st.resolve(op.arg(1)), st);
             }
         }
     }
@@ -1917,9 +1846,9 @@ impl GcRewriterImpl {
             .expect("SETARRAYITEM descr must be ArrayDescr");
         let itemsize = ad.item_size() as i64;
         let basesize = ad.base_size() as i64;
-        let ptr = st.resolve(op.arg(0).to_boxref());
-        let index = st.resolve(op.arg(1).to_boxref());
-        let value = st.resolve(op.arg(2).to_boxref());
+        let ptr = st.resolve(op.arg(0));
+        let index = st.resolve(op.arg(1));
+        let value = st.resolve(op.arg(2));
         self.emit_gc_store_or_indexed(
             Some(op),
             ptr,
@@ -1947,9 +1876,9 @@ impl GcRewriterImpl {
     fn emit_gc_store_or_indexed(
         &self,
         original: Option<&Op>,
-        ptr: BoxRef,
-        index: BoxRef,
-        value: BoxRef,
+        ptr: Operand,
+        index: Operand,
+        value: Operand,
         itemsize: i64,
         factor: i64,
         offset: i64,
@@ -1999,11 +1928,11 @@ impl GcRewriterImpl {
     /// GC_LOAD / GC_STORE form.
     fn _emit_mul_if_factor_offset_not_supported(
         &self,
-        index_box: BoxRef,
+        index_box: Operand,
         factor: i64,
         offset: i64,
         st: &mut RewriteState,
-    ) -> (i64, i64, Option<BoxRef>) {
+    ) -> (i64, i64, Option<Operand>) {
         let (factor, offset, scaled) = self.cpu_simplify_scale(&index_box, factor, offset, st);
         let index_opt = match scaled {
             ScaledIndex::Const => None,
@@ -2027,7 +1956,7 @@ impl GcRewriterImpl {
     /// backend/llsupport/vector_ext.py:127, :157) emit it themselves.
     fn cpu_simplify_scale(
         &self,
-        index_box: &BoxRef,
+        index_box: &Operand,
         factor: i64,
         offset: i64,
         st: &mut RewriteState,
@@ -2067,8 +1996,8 @@ impl GcRewriterImpl {
         let itemsize = ad.item_size() as i64;
         let ofs = ad.base_size() as i64;
         let sign = ad.is_item_signed();
-        let ptr = st.resolve(op.arg(0).to_boxref());
-        let index = st.resolve(op.arg(1).to_boxref());
+        let ptr = st.resolve(op.arg(0));
+        let index = st.resolve(op.arg(1));
         self.emit_gc_load_or_indexed(op, ptr, index, itemsize, itemsize, ofs, sign, st);
     }
 
@@ -2088,8 +2017,8 @@ impl GcRewriterImpl {
     fn emit_gc_load_or_indexed(
         &self,
         original: &Op,
-        ptr: BoxRef,
-        index: BoxRef,
+        ptr: Operand,
+        index: Operand,
         itemsize: i64,
         factor: i64,
         offset: i64,
@@ -2142,8 +2071,8 @@ impl GcRewriterImpl {
     /// lowered op is emitted directly rather than forwarded.
     fn emit_setfield(
         &self,
-        ptr: BoxRef,
-        value: BoxRef,
+        ptr: Operand,
+        value: Operand,
         fd: &dyn FieldDescr,
         st: &mut RewriteState,
     ) {
@@ -2165,8 +2094,8 @@ impl GcRewriterImpl {
     /// directly.
     fn emit_setfield_raw(
         &self,
-        ptr: BoxRef,
-        value: BoxRef,
+        ptr: Operand,
+        value: Operand,
         ofs: i64,
         size: i64,
         st: &mut RewriteState,
@@ -2219,9 +2148,9 @@ impl GcRewriterImpl {
                 .expect("RAW_STORE descr must be ArrayDescr");
             let itemsize = ad.item_size() as i64;
             let ofs = ad.base_size() as i64;
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
-            let value = st.resolve(op.arg(2).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
+            let value = st.resolve(op.arg(2));
             self.emit_gc_store_or_indexed(Some(op), ptr, index, value, itemsize, 1, ofs, st);
             return false;
         }
@@ -2234,8 +2163,8 @@ impl GcRewriterImpl {
             let itemsize = ad.item_size() as i64;
             let ofs = ad.base_size() as i64;
             let sign = ad.is_item_signed();
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
             self.emit_gc_load_or_indexed(op, ptr, index, itemsize, 1, ofs, sign, st);
             return false;
         }
@@ -2256,8 +2185,8 @@ impl GcRewriterImpl {
             let itemsize = ad.item_size() as i64;
             let fieldsize = fd.field_size() as i64;
             let sign = fd.is_field_signed();
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
             self.emit_gc_load_or_indexed(op, ptr, index, fieldsize, itemsize, ofs, sign, st);
             return false;
         }
@@ -2277,9 +2206,9 @@ impl GcRewriterImpl {
             let ofs = (ad.base_size() + fd.offset()) as i64;
             let itemsize = ad.item_size() as i64;
             let fieldsize = fd.field_size() as i64;
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
-            let value = st.resolve(op.arg(2).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
+            let value = st.resolve(op.arg(2));
             self.emit_gc_store_or_indexed(
                 Some(op),
                 ptr,
@@ -2316,7 +2245,7 @@ impl GcRewriterImpl {
             let ofs = fd.offset() as i64;
             let itemsize = fd.field_size() as i64;
             let sign = fd.is_field_signed();
-            let ptr = st.resolve(op.arg(0).to_boxref());
+            let ptr = st.resolve(op.arg(0));
             let cint_zero = st.const_int(0);
             let is_gc = matches!(
                 opnum,
@@ -2342,8 +2271,8 @@ impl GcRewriterImpl {
                 .expect("SETFIELD descr must be FieldDescr");
             let ofs = fd.offset() as i64;
             let itemsize = fd.field_size() as i64;
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let value = st.resolve(op.arg(1).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let value = st.resolve(op.arg(1));
             let cint_zero = st.const_int(0);
             self.emit_gc_store_or_indexed(Some(op), ptr, cint_zero, value, itemsize, 1, ofs, st);
             return false;
@@ -2360,7 +2289,7 @@ impl GcRewriterImpl {
                 .offset() as i64;
             // rewrite.py:272 WORD itemsize, unsigned.
             let word = std::mem::size_of::<usize>() as i64;
-            let ptr = st.resolve(op.arg(0).to_boxref());
+            let ptr = st.resolve(op.arg(0));
             let cint_zero = st.const_int(0);
             self.emit_gc_load_or_indexed(op, ptr, cint_zero, word, 1, ofs, NOT_SIGNED, st);
             return false;
@@ -2381,7 +2310,7 @@ impl GcRewriterImpl {
                 .len_descr()
                 .expect("STR/UNICODE ArrayDescr must carry lendescr");
             let ofs = ld.offset() as i64;
-            let ptr = st.resolve(op.arg(0).to_boxref());
+            let ptr = st.resolve(op.arg(0));
             let cint_zero = st.const_int(0);
             self.emit_gc_load_or_indexed(op, ptr, cint_zero, word, 1, ofs, NOT_SIGNED, st);
             return false;
@@ -2400,7 +2329,7 @@ impl GcRewriterImpl {
                 .expect("STRHASH/UNICODEHASH descr must be a FieldDescr");
             assert_eq!(fd.field_size() as i64, word, "rewrite.py:286/292 assert");
             let ofs = fd.offset() as i64;
-            let ptr = st.resolve(op.arg(0).to_boxref());
+            let ptr = st.resolve(op.arg(0));
             let cint_zero = st.const_int(0);
             self.emit_gc_load_or_indexed(op, ptr, cint_zero, word, 1, ofs, true, st);
             return false;
@@ -2411,8 +2340,8 @@ impl GcRewriterImpl {
         // asserted upstream at rewrite.py:298.
         if matches!(opnum, OpCode::Strgetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ true);
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
             self.emit_gc_load_or_indexed(
                 op, ptr, index, itemsize, itemsize, basesize, NOT_SIGNED, st,
             );
@@ -2422,8 +2351,8 @@ impl GcRewriterImpl {
         // extra_item_after_alloc, so basesize is used as-is.
         if matches!(opnum, OpCode::Unicodegetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ false);
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
             self.emit_gc_load_or_indexed(
                 op, ptr, index, itemsize, itemsize, basesize, NOT_SIGNED, st,
             );
@@ -2432,9 +2361,9 @@ impl GcRewriterImpl {
         // rewrite.py:307-313 STRSETITEM.
         if matches!(opnum, OpCode::Strsetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ true);
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
-            let value = st.resolve(op.arg(2).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
+            let value = st.resolve(op.arg(2));
             self.emit_gc_store_or_indexed(
                 Some(op),
                 ptr,
@@ -2450,9 +2379,9 @@ impl GcRewriterImpl {
         // rewrite.py:314-318 UNICODESETITEM.
         if matches!(opnum, OpCode::Unicodesetitem) {
             let (itemsize, basesize) = strgetsetitem_token(op, /*is_str=*/ false);
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
-            let value = st.resolve(op.arg(2).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
+            let value = st.resolve(op.arg(2));
             self.emit_gc_store_or_indexed(
                 Some(op),
                 ptr,
@@ -2471,32 +2400,32 @@ impl GcRewriterImpl {
             OpCode::GcLoadIndexedI | OpCode::GcLoadIndexedR | OpCode::GcLoadIndexedF
         ) {
             let scale = st
-                .resolve_constant(&op.arg(2).to_boxref())
+                .resolve_constant(&op.arg(2))
                 .expect("GC_LOAD_INDEXED scale must be ConstInt");
             let offset = st
-                .resolve_constant(&op.arg(3).to_boxref())
+                .resolve_constant(&op.arg(3))
                 .expect("GC_LOAD_INDEXED offset must be ConstInt");
             let size = st
-                .resolve_constant(&op.arg(4).to_boxref())
+                .resolve_constant(&op.arg(4))
                 .expect("GC_LOAD_INDEXED size must be ConstInt");
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
             self.emit_gc_load_or_indexed(op, ptr, index, size.abs(), scale, offset, size < 0, st);
             return false;
         }
         if matches!(opnum, OpCode::GcStoreIndexed) {
             let scale = st
-                .resolve_constant(&op.arg(3).to_boxref())
+                .resolve_constant(&op.arg(3))
                 .expect("GC_STORE_INDEXED scale must be ConstInt");
             let offset = st
-                .resolve_constant(&op.arg(4).to_boxref())
+                .resolve_constant(&op.arg(4))
                 .expect("GC_STORE_INDEXED offset must be ConstInt");
             let size = st
-                .resolve_constant(&op.arg(5).to_boxref())
+                .resolve_constant(&op.arg(5))
                 .expect("GC_STORE_INDEXED size must be ConstInt");
-            let ptr = st.resolve(op.arg(0).to_boxref());
-            let index = st.resolve(op.arg(1).to_boxref());
-            let value = st.resolve(op.arg(2).to_boxref());
+            let ptr = st.resolve(op.arg(0));
+            let index = st.resolve(op.arg(1));
+            let value = st.resolve(op.arg(2));
             // rewrite.py:338: use abs(size) for safety even though store
             // size is expected to be positive.
             self.emit_gc_store_or_indexed(
@@ -2519,7 +2448,7 @@ impl GcRewriterImpl {
     // rewrite.py:955-973 gen_write_barrier_array
     // ────────────────────────────────────────────────────────
 
-    fn gen_write_barrier_array(&self, v_base: BoxRef, v_index: BoxRef, st: &mut RewriteState) {
+    fn gen_write_barrier_array(&self, v_base: Operand, v_index: Operand, st: &mut RewriteState) {
         if self.wb_descr.jit_wb_cards_set != 0 {
             // If we know statically the length of 'v_base', and it is not
             // too big, then produce a regular write_barrier. If it's
@@ -2561,7 +2490,7 @@ impl GcRewriterImpl {
         size: usize,
         result_pos: OpRef,
         st: &mut RewriteState,
-    ) -> Option<BoxRef> {
+    ) -> Option<Operand> {
         let size = round_up(size);
 
         // rewrite.py:884-886 — caller picks a slow path when nursery
@@ -2575,7 +2504,7 @@ impl GcRewriterImpl {
             let new_total = st.pending_malloc_total + size;
             if self.can_use_nursery(new_total) {
                 let new_total_ref = st.const_int(new_total as i64);
-                st.out[prev_idx].setarg(0, Operand::from_boxref(&new_total_ref));
+                st.out[prev_idx].setarg(0, new_total_ref);
                 st.pending_malloc_total = new_total;
 
                 // rewrite.py:896: NURSERY_PTR_INCREMENT(last, ConstInt(previous_size))
@@ -2639,7 +2568,7 @@ impl GcRewriterImpl {
     /// remembered-set machinery, dropping any subsequent young pointer
     /// written into it.  Restricting the GC_STORE width to
     /// `field_size = 4` keeps the upper half intact.
-    fn gen_initialize_tid(&self, obj: BoxRef, tid: u32, st: &mut RewriteState) {
+    fn gen_initialize_tid(&self, obj: Operand, tid: u32, st: &mut RewriteState) {
         let Some(tid_fd_ref) = self.fielddescr_tid.as_ref() else {
             return;
         };
@@ -2662,7 +2591,7 @@ impl GcRewriterImpl {
     /// vtable pointer sits at offset 0 with `Signed` size.
     fn gen_initialize_vtable(
         &self,
-        obj: BoxRef,
+        obj: Operand,
         vtable: usize,
         vtable_fd_ref: &DescrRef,
         st: &mut RewriteState,
@@ -2683,8 +2612,8 @@ impl GcRewriterImpl {
     /// path.
     fn gen_initialize_len(
         &self,
-        obj: BoxRef,
-        length: BoxRef,
+        obj: Operand,
+        length: Operand,
         len_descr: &dyn FieldDescr,
         st: &mut RewriteState,
     ) {
@@ -2808,8 +2737,8 @@ impl GcRewriterImpl {
 
         // rewrite.py:672-683 — store each arg at _ll_initial_locs[i] with
         // per-arg itemsize from getarraydescr_for_frame(arg.type).
-        let arglist: Vec<BoxRef> = op
-            .getarglist()
+        let arglist: Vec<Operand> = op
+            .getarglist_operand()
             .iter()
             .map(|a| st.resolve(a.clone()))
             .collect();
@@ -2841,12 +2770,17 @@ impl GcRewriterImpl {
         } else {
             vec![frame]
         };
-        let call_asm = mk_op(op.opcode, &new_args);
+        let mut call_asm = mk_op(op.opcode, &new_args);
         if let Some(d) = op.getdescr() {
             call_asm.setdescr(d);
         }
         if let Some(fa) = op.getfailargs() {
-            call_asm.setfailargs(fa.iter().map(|a| st.resolve(a.clone())).collect());
+            call_asm.setfailargs(fa);
+            if let Some(slot) = call_asm.fail_args_mut() {
+                for a in slot.iter_mut() {
+                    *a = st.resolve(a.clone());
+                }
+            }
         }
         st.emit_rewritten_from(op, call_asm);
     }
@@ -3043,11 +2977,8 @@ impl GcRewriter for GcRewriterImpl {
                     let one = st.const_int(1);
                     let same = mk_op(OpCode::SameAsI, &[zero]);
                     let same_pos = st.emit_result(same, OpRef::NONE);
-                    let newop = op.copy_and_change(
-                        OpCode::GuardValue,
-                        Some(&[Operand::from_boxref(&same_pos), Operand::from_boxref(&one)]),
-                        None,
-                    );
+                    let newop =
+                        op.copy_and_change(OpCode::GuardValue, Some(&[same_pos, one]), None);
                     let rewritten = st.rewrite_op(&newop);
                     st.emit(rewritten);
                 }
@@ -3073,7 +3004,7 @@ impl GcRewriter for GcRewriterImpl {
                 // ── Everything else: pass through unchanged. ──
                 OpCode::CondCallGcWb => {
                     let rewritten = st.rewrite_op(op);
-                    let obj = rewritten.arg(0).to_boxref();
+                    let obj = rewritten.arg(0);
                     st.emit(rewritten);
                     st.remember_wb(&obj);
                 }
@@ -5158,7 +5089,7 @@ mod tests {
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![Op::new(
             OpCode::GuardNonnull,
-            &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+            &[Operand::const_from_value(Value::Ref(r))],
         )];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
@@ -5181,11 +5112,11 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+                &[Operand::const_from_value(Value::Ref(r))],
             ),
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+                &[Operand::const_from_value(Value::Ref(r))],
             ),
         ];
 
@@ -5218,11 +5149,11 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r0)))],
+                &[Operand::const_from_value(Value::Ref(r0))],
             ),
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r1)))],
+                &[Operand::const_from_value(Value::Ref(r1))],
             ),
         ];
 
@@ -5247,7 +5178,7 @@ mod tests {
         let null = majit_ir::GcRef(0);
         let ops = vec![Op::new(
             OpCode::GuardNonnull,
-            &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(null)))],
+            &[Operand::const_from_value(Value::Ref(null))],
         )];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
@@ -5269,12 +5200,12 @@ mod tests {
         let ops = vec![
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+                &[Operand::const_from_value(Value::Ref(r))],
             ),
             Op::new(OpCode::Label, &[]),
             Op::new(
                 OpCode::GuardNonnull,
-                &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+                &[Operand::const_from_value(Value::Ref(r))],
             ),
         ];
 
@@ -5296,7 +5227,7 @@ mod tests {
         let r = majit_ir::GcRef(0x4000);
         let ops = vec![Op::new(
             OpCode::JitDebug,
-            &[Operand::from_boxref(&BoxRef::new_const(Value::Ref(r)))],
+            &[Operand::const_from_value(Value::Ref(r))],
         )];
 
         let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -1153,10 +1153,23 @@ impl PartialEq for BoxRef {
         // only, via explicit [`same_box`](Self::same_box) calls
         // (history.py:211) or an `r_dict` built on it (the
         // optimizeopt/util.py:126-128 `args_dict` shape).
-        // Two `none()` sentinels mirror Python's singleton `None`
-        // (`None is None`), keeping that arm identity-faithful.
+        //
+        // The identity of a bound box IS its producer (`Op`/`InputArg`):
+        // two wrappers bound to the same producer ARE the same box, so the
+        // compare short-circuits on producer identity (`Rc::ptr_eq` of the
+        // bound `Op`/`InputArg`) — independent of the `box_cache` memo
+        // handing out one wrapper per producer, mirroring [`same_box`]. A
+        // `Const` / position-only box has no producer host and keeps wrapper
+        // identity. Two `none()` sentinels mirror Python's singleton `None`
+        // (`None is None`).
         if Rc::ptr_eq(&self.0, &other.0) {
             return true;
+        }
+        if let (Some(a), Some(b)) = (self.bound_op(), other.bound_op()) {
+            return Rc::ptr_eq(&a, &b);
+        }
+        if let (Some(a), Some(b)) = (self.bound_inputarg(), other.bound_inputarg()) {
+            return Rc::ptr_eq(&a, &b);
         }
         matches!(
             (&self.0.kind, &other.0.kind),
@@ -1171,13 +1184,24 @@ impl std::hash::Hash for BoxRef {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         // `AbstractValue._get_hash_` defaults to `compute_identity_hash`
         // (resoperation.py:33-35): plain hashing follows object identity,
-        // matching `eq`. The `none()` sentinel hashes to one bucket so
-        // its identity-free equality upholds the Hash/Eq contract.
+        // matching `eq`. A bound box hashes on its PRODUCER pointer (so two
+        // wrappers of one producer hash equal — memo-independent, upholding
+        // the Hash/Eq contract with the producer-identity `eq`); a `Const` /
+        // position-only box hashes on wrapper identity; the `none()` sentinel
+        // hashes to one bucket so its identity-free equality is consistent.
         match &self.0.kind {
             BoxKind::None => 1u8.hash(state),
             _ => {
-                2u8.hash(state);
-                (Rc::as_ptr(&self.0) as usize).hash(state);
+                if let Some(op) = self.bound_op() {
+                    2u8.hash(state);
+                    (Rc::as_ptr(&op) as usize).hash(state);
+                } else if let Some(ia) = self.bound_inputarg() {
+                    3u8.hash(state);
+                    (Rc::as_ptr(&ia) as usize).hash(state);
+                } else {
+                    4u8.hash(state);
+                    (Rc::as_ptr(&self.0) as usize).hash(state);
+                }
             }
         }
     }

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -340,10 +340,12 @@ impl ForwardingHost for InputArg {
 /// `==` / `Hash` follow object identity: `AbstractValue` defines no
 /// `__eq__` / `__hash__`, and `_get_hash_` defaults to
 /// `compute_identity_hash` (resoperation.py:29-39), so every plain
-/// box-keyed dict keys by `is`. A memoized wrapper per op / inputarg
-/// (`Op::box_cache` / `InputArg::box_cache`) makes `Rc::ptr_eq` a
-/// faithful `is`; the `none()` sentinel mirrors Python's singleton
-/// `None`. Value equality for `Const` is opt-in, never `==`: explicit
+/// box-keyed dict keys by `is`. A bound box's `==` / `Hash` compare its
+/// producer (`bound_op()` / `bound_inputarg()`), so two wrappers over the
+/// same `Op` / `InputArg` are a faithful `is` even though each
+/// `from_bound_*` call mints a distinct `Rc<Box>`; the `none()` sentinel
+/// mirrors Python's singleton `None`. Value equality for `Const` is opt-in,
+/// never `==`: explicit
 /// [`same_box`](Self::same_box) calls (`history.py:211` →
 /// `same_constant`), the `r_dict` shape RPython builds on `same_box` /
 /// `_get_hash_` (optimizeopt/util.py:126-128 `args_dict`).
@@ -381,27 +383,20 @@ impl BoxRef {
     /// `bound_op` answers with the same `Rc<Op>` and its `_forwarded`
     /// slot reads via the bound op per `get_forwarded`.
     ///
-    /// The wrapper is MEMOIZED on the op (`Op::box_cache`): the op object
-    /// IS its own `AbstractValue`, so every call for the same `Rc<Op>`
-    /// returns the SAME `Rc<Box>`, giving stable pointer identity
-    /// (`Rc::ptr_eq` == `self is other`). The cached box's `position`
-    /// (`BoxKind::ResOp`) is refreshed from the current `op.pos` on every
-    /// call, since `op.pos` is mutable (recorder `op.pos.set`, unroll
-    /// resume-retarget, const-pool compaction). `type_` is not refreshed —
-    /// `Op.type_` is immutable and `op.pos`'s variant kind never changes
-    /// type for a given op.
+    /// Each call mints a FRESH wrapper bound to `op` (via `op_handle`);
+    /// pointer identity is not stable across calls. Box identity (PyPy `is`)
+    /// is recovered from the bound producer instead — `==` / `Hash` /
+    /// `same_box` compare `bound_op()`, and `position()` / `to_opref` read
+    /// the producer's live `op.pos` (mutable: recorder `op.pos.set`, unroll
+    /// resume-retarget, const-pool compaction). The mint-time `position` cell
+    /// is only a fallback for the position-only (unbound) case. `type_` is
+    /// read once — `Op.type_` is immutable and `op.pos`'s variant kind never
+    /// changes type for a given op.
     pub fn from_bound_op(op: &crate::resoperation::OpRc) -> Self {
-        {
-            let cache = op.box_cache.borrow();
-            if let Some(cached) = cache.as_ref() {
-                cached.set_position(op.pos.get().raw());
-                return cached.clone();
-            }
-        }
         let opref = op.pos.get();
         let type_ = opref.ty().unwrap_or(Type::Void);
         let position = opref.raw();
-        let boxref = Self(Rc::new(Box {
+        Self(Rc::new(Box {
             type_,
             kind: BoxKind::ResOp {
                 position: std::cell::Cell::new(position),
@@ -409,36 +404,26 @@ impl BoxRef {
             value: Cell::new(None),
             op_handle: RefCell::new(Some(Rc::downgrade(op))),
             inputarg_handle: RefCell::new(None),
-        }));
-        *op.box_cache.borrow_mut() = Some(boxref.clone());
-        boxref
+        }))
     }
 
     /// `AbstractInputArg` Box wrapping an already-bound `InputArgRc`.
     /// Mirror of `from_bound_op` for the chain walker's
     /// `Forwarded::InputArg` terminal materialization and for
-    /// `resolve_to_boxref`. MEMOIZED on the input arg
-    /// (`InputArg::box_cache`) so every call for the same `Rc<InputArg>`
-    /// returns the SAME `Rc<Box>`. No position refresh: `InputArg.index`
-    /// is immutable (`resoperation.py:699 AbstractInputArg.position`).
+    /// `resolve_to_boxref`. Each call mints a FRESH wrapper bound to `ia`;
+    /// box identity is recovered from the bound `InputArg` (`==` / `Hash` /
+    /// `same_box` compare `bound_inputarg()`). `InputArg.index` is immutable
+    /// (`resoperation.py:699 AbstractInputArg.position`).
     pub fn from_bound_inputarg(ia: &crate::value::InputArgRc) -> Self {
-        {
-            let cache = ia.box_cache.borrow();
-            if let Some(cached) = cache.as_ref() {
-                return cached.clone();
-            }
-        }
         let type_ = ia.tp;
         let position = ia.index;
-        let boxref = Self(Rc::new(Box {
+        Self(Rc::new(Box {
             type_,
             kind: BoxKind::InputArg { position },
             value: Cell::new(None),
             op_handle: RefCell::new(None),
             inputarg_handle: RefCell::new(Some(Rc::downgrade(ia))),
-        }));
-        *ia.box_cache.borrow_mut() = Some(boxref.clone());
-        boxref
+        }))
     }
 
     /// New `AbstractInputArg` Box.
@@ -728,26 +713,22 @@ impl BoxRef {
     /// `resoperation.py:38 AbstractResOpOrInputArg.same_box`: `self is other`
     /// for ResOp / InputArg; `history.py:211 Const.same_box` delegates to
     /// `same_constant` (value comparison, `history.py:251/292/338`).
-    /// ResOp / InputArg boxes compare by `Rc` pointer identity:
-    /// `from_bound_op` / `from_bound_inputarg` memoize one wrapper per op /
-    /// inputarg (`Op::box_cache` / `InputArg::box_cache`), so every
-    /// resolution of the same op / inputarg shares one `Rc<Box>`, making
-    /// `Rc::ptr_eq` a faithful `self is other`. Const boxes are minted
-    /// fresh per resolution (no op to memoize on), so they compare by
-    /// value. Two `none()` sentinels denote the same absent reference. A
-    /// shared `Rc` short-circuits every arm. Unlike `==` (object
-    /// identity), `same_box` is the explicit value-aware comparison —
-    /// callers opt in, exactly where RPython spells out `same_box(...)`.
+    /// ResOp / InputArg boxes compare by PRODUCER identity: each
+    /// `from_bound_*` call mints a distinct wrapper, so two wrappers bound to
+    /// the same op / inputarg are `self is other` via `Rc::ptr_eq` on the
+    /// bound `Op` / `InputArg`. Const boxes are minted fresh per resolution
+    /// (no producer), so they compare by value. Two `none()` sentinels denote
+    /// the same absent reference. A shared wrapper `Rc` short-circuits every
+    /// arm. Unlike `==` (object identity), `same_box` is the explicit
+    /// value-aware comparison — callers opt in, exactly where RPython spells
+    /// out `same_box(...)`.
     pub fn same_box(&self, other: &BoxRef) -> bool {
         if Rc::ptr_eq(&self.0, &other.0) {
             return true;
         }
-        // Producer-identity compare, independent of the `box_cache` memo: two
-        // distinct wrappers bound to the same op / inputarg ARE the same box
-        // (`self is other` on the producer). Mirrors `Operand::same_box`. While
-        // the memo is present this is unreachable (one wrapper per producer, so
-        // the `Rc::ptr_eq` fast-path already fired), so it is behavior-neutral
-        // today and makes `same_box` ready for the memo strip.
+        // Producer-identity compare: two distinct wrappers bound to the same
+        // op / inputarg ARE the same box (`self is other` on the producer).
+        // Mirrors `Operand::same_box`.
         if let (Some(a), Some(b)) = (self.bound_op(), other.bound_op()) {
             return Rc::ptr_eq(&a, &b);
         }
@@ -1167,13 +1148,12 @@ impl PartialEq for BoxRef {
         // optimizeopt/util.py:126-128 `args_dict` shape).
         //
         // The identity of a bound box IS its producer (`Op`/`InputArg`):
-        // two wrappers bound to the same producer ARE the same box, so the
-        // compare short-circuits on producer identity (`Rc::ptr_eq` of the
-        // bound `Op`/`InputArg`) — independent of the `box_cache` memo
-        // handing out one wrapper per producer, mirroring [`same_box`]. A
-        // `Const` / position-only box has no producer host and keeps wrapper
-        // identity. Two `none()` sentinels mirror Python's singleton `None`
-        // (`None is None`).
+        // each `from_bound_*` call mints a distinct wrapper, so two wrappers
+        // bound to the same producer ARE the same box — the compare resolves
+        // on producer identity (`Rc::ptr_eq` of the bound `Op`/`InputArg`),
+        // mirroring [`same_box`]. A `Const` / position-only box has no
+        // producer host and keeps wrapper identity. Two `none()` sentinels
+        // mirror Python's singleton `None` (`None is None`).
         if Rc::ptr_eq(&self.0, &other.0) {
             return true;
         }
@@ -1381,11 +1361,10 @@ mod tests {
         };
         let op = std::rc::Rc::new(Op::new(opcode, &[]));
         op.pos.set(OpRef::op_typed(position, tp));
-        // Canonical resolver: binds the box AND memoizes it on
-        // `op.box_cache`, so the chain walker's `from_bound_op`
-        // re-resolution of a `Forwarded::Op` step returns this same
-        // `Rc<Box>` (matches production, where every box comes from
-        // `from_bound_op`).
+        // Canonical resolver: binds the box to `op`, so the chain walker's
+        // `from_bound_op` re-resolution of a `Forwarded::Op` step yields a
+        // box equal by producer identity (matches production, where every
+        // box comes from `from_bound_op`).
         let b = BoxRef::from_bound_op(&op);
         (b, op)
     }
@@ -1482,48 +1461,49 @@ mod tests {
         assert_ne!(a, other);
     }
 
-    /// Goal D identity stabilization: `from_bound_op` memoizes the box
-    /// wrapper on the op (`Op::box_cache`), so two resolutions of the SAME
-    /// `Rc<Op>` yield the SAME `Rc<Box>` (`Rc::ptr_eq` == `self is other`),
-    /// while a distinct (cloned) op gets its own. The cached box's position
-    /// is refreshed from the (mutable) `op.pos` on every call.
+    /// Goal D identity stabilization: `from_bound_op` mints a fresh wrapper
+    /// per call, so two resolutions of the SAME `Rc<Op>` are DISTINCT
+    /// `Rc<Box>` allocations that nonetheless compare equal — `==` routes
+    /// through the bound producer (PyPy box `is`) — while a distinct (cloned)
+    /// op is a distinct box. `position()` reads the producer's live `op.pos`,
+    /// so a held reference reflects a later mutation without re-resolving.
     #[test]
-    fn from_bound_op_memoizes_identity_per_op() {
+    fn from_bound_op_resolves_producer_identity() {
         let op = std::rc::Rc::new(Op::new(OpCode::SameAsI, &[]));
         op.pos.set(OpRef::op_typed(3, Type::Int));
 
         let a = BoxRef::from_bound_op(&op);
         let b = BoxRef::from_bound_op(&op);
-        // Same op -> same wrapper identity (pointer equality).
-        assert_eq!(a.as_ptr(), b.as_ptr());
+        // Same op -> distinct wrappers, equal by bound-producer identity.
+        assert_ne!(a.as_ptr(), b.as_ptr());
         assert_eq!(a, b);
 
-        // A fresh-identity clone (box_cache reset to None) gets its own wrapper.
+        // A distinct (cloned) op is a distinct box.
         let op2 = std::rc::Rc::new((*op).clone());
         let c = BoxRef::from_bound_op(&op2);
         assert_ne!(a.as_ptr(), c.as_ptr());
         assert_ne!(a, c);
 
-        // Position refresh: mutating op.pos is reflected on the next resolve,
-        // and through the already-held reference (shared Rc<Box>).
+        // position() tracks the producer's live op.pos through the bound
+        // handle, so a held reference reflects a later mutation.
         op.pos.set(OpRef::op_typed(9, Type::Int));
         let d = BoxRef::from_bound_op(&op);
-        assert_eq!(a.as_ptr(), d.as_ptr());
         assert_eq!(d.position(), Some(9));
         assert_eq!(a.position(), Some(9));
     }
 
-    /// `from_bound_inputarg` memoizes identically on `InputArg::box_cache`
-    /// (no position refresh — `InputArg.index` is immutable).
+    /// `from_bound_inputarg` mirrors `from_bound_op`: a fresh wrapper per
+    /// call, equal by bound-`InputArg` identity; a distinct InputArg (even at
+    /// equal tp/index) is a distinct box.
     #[test]
-    fn from_bound_inputarg_memoizes_identity_per_inputarg() {
+    fn from_bound_inputarg_resolves_producer_identity() {
         let ia = std::rc::Rc::new(InputArg::from_type(Type::Ref, 2));
         let a = BoxRef::from_bound_inputarg(&ia);
         let b = BoxRef::from_bound_inputarg(&ia);
-        assert_eq!(a.as_ptr(), b.as_ptr());
+        assert_ne!(a.as_ptr(), b.as_ptr());
         assert_eq!(a, b);
 
-        // A distinct InputArg (even with equal tp/index) gets its own wrapper.
+        // A distinct InputArg (even with equal tp/index) is a distinct box.
         let ia2 = std::rc::Rc::new(InputArg::from_type(Type::Ref, 2));
         let c = BoxRef::from_bound_inputarg(&ia2);
         assert_ne!(a.as_ptr(), c.as_ptr());

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -730,6 +730,18 @@ impl BoxRef {
         if Rc::ptr_eq(&self.0, &other.0) {
             return true;
         }
+        // Producer-identity compare, independent of the `box_cache` memo: two
+        // distinct wrappers bound to the same op / inputarg ARE the same box
+        // (`self is other` on the producer). Mirrors `Operand::same_box`. While
+        // the memo is present this is unreachable (one wrapper per producer, so
+        // the `Rc::ptr_eq` fast-path already fired), so it is behavior-neutral
+        // today and makes `same_box` ready for the memo strip.
+        if let (Some(a), Some(b)) = (self.bound_op(), other.bound_op()) {
+            return Rc::ptr_eq(&a, &b);
+        }
+        if let (Some(a), Some(b)) = (self.bound_inputarg(), other.bound_inputarg()) {
+            return Rc::ptr_eq(&a, &b);
+        }
         match (&self.0.kind, &other.0.kind) {
             (BoxKind::Const { .. }, BoxKind::Const { .. }) => {
                 self.const_value() == other.const_value()

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -601,7 +601,19 @@ impl BoxRef {
     /// `_pos`). `Const` has no canonical position and returns `None`.
     pub fn position(&self) -> Option<u32> {
         match &self.0.kind {
-            BoxKind::ResOp { position, .. } => Some(position.get()),
+            // A bound ResOp box reports its producer's live `op.pos`. The memo
+            // keeps the stored cell synced to `op.pos` (`from_bound_op`
+            // refreshes it on every call), so this matches the stored read
+            // while the memo holds; reading `op.pos` directly keeps `to_opref`
+            // correct independent of the memo — a fresh, un-memoized wrapper
+            // would otherwise freeze the cell at creation-time position even
+            // after const-pool compaction moved `op.pos`. A position-only
+            // ResOp box (no live producer — test fixtures, `from_opref`
+            // re-mints) reads its stored cell.
+            BoxKind::ResOp { position, .. } => Some(
+                self.bound_op()
+                    .map_or_else(|| position.get(), |op| op.pos.get().raw()),
+            ),
             BoxKind::InputArg { position, .. } => Some(*position),
             BoxKind::Const { .. } | BoxKind::None => None,
         }

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -291,6 +291,12 @@ impl Op {
         self.args.borrow().iter().map(|o| o.to_boxref()).collect()
     }
 
+    /// `Operand`-yielding form of [`getarglist`](Self::getarglist): the stored
+    /// `Operand` args directly, with no `to_boxref` round-trip.
+    pub fn getarglist_operand(&self) -> smallvec::SmallVec<[crate::operand::Operand; 3]> {
+        self.args.borrow().iter().cloned().collect()
+    }
+
     /// `resoperation.py:284 AbstractResOp.getarglist_copy` parity —
     /// `N_aryOp.getarglist_copy` returns `self._args[:]`; pyre returns
     /// an owned `SmallVec` of `BoxRef`s (convert-on-read).

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -725,9 +725,9 @@ mod tests {
     fn to_boxref_preserves_identity_and_value() {
         let op = op_at(8, Type::Int);
         let via_operand = Operand::from_bound_op(&op).to_boxref();
-        // The BoxRef bridge round-trips to the SAME memoized Rc<Box> as a
-        // direct from_bound_op (box_cache identity).
-        assert_eq!(via_operand.as_ptr(), BoxRef::from_bound_op(&op).as_ptr());
+        // The BoxRef bridge round-trips to a box equal (by bound-producer
+        // identity) to a direct from_bound_op, though each is a distinct Rc.
+        assert_eq!(via_operand, BoxRef::from_bound_op(&op));
         assert_eq!(via_operand.to_opref(), OpRef::op_typed(8, Type::Int));
 
         let c = Operand::const_(Const::Int(11)).to_boxref();
@@ -739,15 +739,15 @@ mod tests {
     #[test]
     fn from_boxref_sheds_bound_keeps_const_and_position_only() {
         // Bound op -> Operand::Op (live-tracking). is_resop stays true;
-        // is_bound is true. to_boxref re-resolves through the memoized
-        // from_bound_op, so the canonical box is ptr-equal to the original.
+        // is_bound is true. to_boxref re-resolves through from_bound_op, so
+        // the canonical box is equal (by bound producer) to the original.
         let op = op_at(8, Type::Int);
         let bound = BoxRef::from_bound_op(&op);
         let o = Operand::from_boxref(&bound);
         assert!(matches!(o, Operand::Op(_)));
         assert!(o.is_resop());
         assert!(o.is_bound());
-        assert_eq!(o.to_boxref().as_ptr(), bound.as_ptr());
+        assert_eq!(o.to_boxref(), bound);
 
         // Bound input arg -> Operand::InputArg (live-tracking, bound).
         let ia = Rc::new(InputArg::from_type(Type::Ref, 2));
@@ -756,7 +756,7 @@ mod tests {
         assert!(matches!(o, Operand::InputArg(_)));
         assert!(o.is_inputarg());
         assert!(o.is_bound());
-        assert_eq!(o.to_boxref().as_ptr(), bia.as_ptr());
+        assert_eq!(o.to_boxref(), bia);
 
         // Const -> Operand::Const carrying the const VALUE in a fresh
         // Rc<Cell<Value>> (Cell-backed GC walk); NOT bound. to_boxref

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1161,14 +1161,14 @@ pub trait BoxEnv {
         self.get_box_replacement(opref)
     }
     /// resume.py:202 `box.get_box_replacement()` returning the canonical box
-    /// OBJECT, not just its OpRef. The resume-numbering maps (#160/S11
-    /// `LiveboxMap`, `cached_boxes`, `cached_virtuals`) key by box identity —
-    /// RPython's dict-by-`is` — so two reaches of one box must compare equal.
-    /// A bound box's `==` / `Hash` route through its producer
-    /// (`Op`/`InputArg`), so distinct `from_bound_*` wrappers over the same
-    /// producer are equal. Const is classified by `is_const` / `getconst`
-    /// before any map insert and never reaches here.
-    fn get_box_replacement_boxref(&self, opref: OpRef) -> BoxRef;
+    /// OBJECT as an [`Operand`] (the producer `Op`/`InputArg` host), not just
+    /// its OpRef. The resume-numbering maps (#160/S11 `LiveboxMap`,
+    /// `cached_boxes`, `cached_virtuals`) key by box identity — RPython's
+    /// dict-by-`is` — so two reaches of one box must compare equal. An
+    /// `Operand`'s `==` / `Hash` route through its producer Rc, so two reaches
+    /// of one logical box are `ptr_eq`. Const is classified by `is_const` /
+    /// `getconst` before any map insert and never reaches here.
+    fn get_box_replacement_operand(&self, opref: OpRef) -> Operand;
     /// resume.py:204 — isinstance(box, Const)
     fn is_const(&self, opref: OpRef) -> bool;
     /// Constant value + type. Only valid when is_const returns true.

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1163,10 +1163,11 @@ pub trait BoxEnv {
     /// resume.py:202 `box.get_box_replacement()` returning the canonical box
     /// OBJECT, not just its OpRef. The resume-numbering maps (#160/S11
     /// `LiveboxMap`, `cached_boxes`, `cached_virtuals`) key by box identity —
-    /// RPython's dict-by-`is` — so this must return the ONE canonical `Rc`
-    /// per logical box (memoized per producer `Op`/`InputArg` via `box_cache`)
-    /// so two reaches of one box compare `Rc::ptr_eq`. Const is classified by
-    /// `is_const` / `getconst` before any map insert and never reaches here.
+    /// RPython's dict-by-`is` — so two reaches of one box must compare equal.
+    /// A bound box's `==` / `Hash` route through its producer
+    /// (`Op`/`InputArg`), so distinct `from_bound_*` wrappers over the same
+    /// producer are equal. Const is classified by `is_const` / `getconst`
+    /// before any map insert and never reaches here.
     fn get_box_replacement_boxref(&self, opref: OpRef) -> BoxRef;
     /// resume.py:204 — isinstance(box, Const)
     fn is_const(&self, opref: OpRef) -> bool;
@@ -1325,17 +1326,6 @@ pub struct Op {
     /// `set_opref_concrete`); residual calls / guards keep it `None`
     /// until blackhole runs them.
     pub value: std::cell::Cell<Option<crate::value::Value>>,
-
-    /// Canonical `AbstractResOp` box wrapper for this op (`resoperation.py`:
-    /// the op object IS its own `AbstractValue`, so there is exactly one
-    /// identity per op). Lazily minted by [`BoxRef::from_bound_op`] and
-    /// memoized here so every resolution of this op yields the SAME
-    /// `Rc<Box>` — making `Rc::ptr_eq` a faithful `self is other` probe.
-    /// `None` until first bound resolution; reset to `None` for every
-    /// fresh-identity `Op` (`clone` / `copy_and_change`). Holds a strong
-    /// `Rc<Box>`; the `Box` holds only a `Weak<Op>` back-reference, so no
-    /// reference cycle forms.
-    pub box_cache: std::cell::RefCell<Option<crate::box_ref::BoxRef>>,
 }
 
 impl Clone for Op {
@@ -1360,9 +1350,6 @@ impl Clone for Op {
             vecinfo: std::cell::RefCell::new(self.vecinfo.borrow().clone()),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
-            // Fresh identity gets a fresh (empty) box wrapper, mirroring the
-            // `forwarded` reset above.
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 }
@@ -1487,7 +1474,6 @@ impl Op {
             vecinfo: std::cell::RefCell::new(None),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -1504,7 +1490,6 @@ impl Op {
             vecinfo: std::cell::RefCell::new(None),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -1584,9 +1569,6 @@ impl Op {
             vecinfo: std::cell::RefCell::new(self.vecinfo.borrow().clone()),
             forwarded: std::cell::RefCell::new(Forwarded::None),
             value: std::cell::Cell::new(None),
-            // copy_and_change yields a fresh-identity op, so it gets a fresh
-            // (empty) box wrapper rather than aliasing self's.
-            box_cache: std::cell::RefCell::new(None),
         };
         // resoperation.py:498-503 GuardResOp.copy_and_change:
         //   newop.setfailargs(self.getfailargs())
@@ -3686,7 +3668,6 @@ mod tests {
                 type_: Type::Void,
                 forwarded: std::cell::RefCell::new(crate::box_ref::Forwarded::None),
                 value: std::cell::Cell::new(None),
-                box_cache: std::cell::RefCell::new(None),
             };
             __op.type_ = __op.opcode.result_type();
             __op

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -286,15 +286,6 @@ pub struct InputArg {
     /// box; `BoxRef::get_value`/`set_value` route here. `None` until a
     /// writer stamps it (trace-time `set_opref_concrete`).
     pub value: std::cell::Cell<Option<Value>>,
-
-    /// Canonical `AbstractInputArg` box wrapper for this input arg.
-    /// Symmetric to [`Op::box_cache`](crate::resoperation::Op): lazily
-    /// minted by [`BoxRef::from_bound_inputarg`] and memoized so every
-    /// resolution of this input arg yields the SAME `Rc<Box>`. `None`
-    /// until first bound resolution; a fresh-identity copy
-    /// (`fresh_value_copy`) starts with `None`. Excluded from `PartialEq`
-    /// (identity is `(tp, index)`; the cache is incidental memoization).
-    pub box_cache: std::cell::RefCell<Option<crate::box_ref::BoxRef>>,
 }
 
 impl InputArg {
@@ -318,7 +309,6 @@ impl InputArg {
             index: self.index,
             forwarded: std::cell::RefCell::new(crate::box_ref::Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 }
@@ -341,7 +331,6 @@ impl InputArg {
             index,
             forwarded: std::cell::RefCell::new(crate::box_ref::Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -351,7 +340,6 @@ impl InputArg {
             index,
             forwarded: std::cell::RefCell::new(crate::box_ref::Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -361,7 +349,6 @@ impl InputArg {
             index,
             forwarded: std::cell::RefCell::new(crate::box_ref::Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -378,7 +365,6 @@ impl InputArg {
             index,
             forwarded: std::cell::RefCell::new(crate::box_ref::Forwarded::None),
             value: std::cell::Cell::new(None),
-            box_cache: std::cell::RefCell::new(None),
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -911,8 +911,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             let slot = ref_identity_base + ref_idx;
             quote! {
                 if #slot < frame.ref_regs.len() {
-                    frame.ref_regs[#slot] =
-                        Some(majit_ir::box_ref::BoxRef::from_opref(self.#fname));
+                    frame.ref_regs[#slot] = Some(self.#fname);
                     frame.ref_values[#slot] = Some(self.#value_name);
                 }
             }
@@ -1930,7 +1929,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // scalars stay clobbered in the live frame after the
                 // jitdriver-level GuardAlwaysFails snapshot is built.
                 let __rn = sym.ref_identity_slots_end().min(__root.ref_regs.len());
-                let __saved_ref_regs: Vec<Option<majit_ir::box_ref::BoxRef>> =
+                let __saved_ref_regs: Vec<Option<majit_ir::OpRef>> =
                     __root.ref_regs[..__rn].to_vec();
                 let __saved_ref_values: Vec<Option<i64>> =
                     __root.ref_values[..__rn].to_vec();
@@ -1952,7 +1951,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 let __root = &mut frames.frames[0];
                 __root.int_regs[..__n].copy_from_slice(&__saved_int_regs);
                 __root.int_values[..__n].copy_from_slice(&__saved_int_values);
-                __root.ref_regs[..__rn].clone_from_slice(&__saved_ref_regs);
+                __root.ref_regs[..__rn].copy_from_slice(&__saved_ref_regs);
                 __root.ref_values[..__rn].copy_from_slice(&__saved_ref_values);
                 Some(__snapshot)
             }

--- a/majit/majit-metainterp/src/graphpage.rs
+++ b/majit/majit-metainterp/src/graphpage.rs
@@ -18,19 +18,23 @@ pub struct LinkInfo {
 
 #[derive(Default)]
 pub struct ResOpMemo {
-    names: Vec<(usize, String)>,
+    // Keyed by the box's `to_opref` (a stable position/value identity)
+    // rather than the wrapper `Rc` pointer: `from_bound_*` mints a fresh
+    // wrapper per resolution, so two reaches of one op carry distinct
+    // pointers but share one `to_opref`.
+    names: Vec<(majit_ir::OpRef, String)>,
 }
 
 impl ResOpMemo {
     pub fn get(&self, box_: &BoxRef) -> Option<&str> {
-        let key = box_.as_ptr() as usize;
+        let key = box_.to_opref();
         self.names
             .iter()
             .find_map(|(k, v)| (*k == key).then_some(v.as_str()))
     }
 
     pub fn set(&mut self, box_: &BoxRef, value: String) {
-        let key = box_.as_ptr() as usize;
+        let key = box_.to_opref();
         if let Some((_, old)) = self.names.iter_mut().find(|(k, _)| *k == key) {
             *old = value;
         } else {

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -2,6 +2,7 @@
 //! stream trace recorder + iterator + snapshot chain reader used by
 //! the meta-interpreter.
 use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 use majit_ir::{InputArg, OPCODE_COUNT, Op, OpCode, OpRef, Type, Value};
 
 fn u16_to_opcode(v: u16) -> OpCode {
@@ -205,8 +206,10 @@ pub struct TraceIterator<'a> {
     /// position to the fresh box OBJECT materialized for this iteration.
     /// In RPython this is `[None] * trace._index` holding the fresh
     /// `cls()` ResOperation / `inputarg_from_tp` objects themselves;
-    /// here `Vec<Option<BoxRef>>` carrying the bound `Rc` handles.
-    pub _cache: Vec<Option<BoxRef>>,
+    /// here `Vec<Option<Operand>>` carrying the bound producer `Rc`
+    /// directly (`Operand` IS the producer object, matching RPython's
+    /// stored `cls()` instance — the cache slot owns it outright).
+    pub _cache: Vec<Option<Operand>>,
     /// opencoder.py:259-262 self.inputargs: fresh inputarg boxes for this
     /// iteration. Each is a freshly allocated `InputArg` object whose
     /// position comes from the iterator's `_fresh` counter at
@@ -273,7 +276,7 @@ impl<'a> TraceIterator<'a> {
             .max()
             .unwrap_or(0);
         let cache_size = ((max_pos as usize) + 1).max(num_inputargs);
-        let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
+        let mut _cache: Vec<Option<Operand>> = vec![None; cache_size];
         let mut _fresh = start_fresh;
         let inputargs: Vec<majit_ir::InputArgRc>;
         if let Some(force) = force_inputargs {
@@ -304,7 +307,7 @@ impl<'a> TraceIterator<'a> {
                 if p >= _cache.len() {
                     _cache.resize(p + 1, None);
                 }
-                _cache[p] = Some(BoxRef::from_bound_inputarg(&inputargs[i]));
+                _cache[p] = Some(Operand::from_bound_inputarg(&inputargs[i]));
             }
         } else {
             // opencoder.py:264-267 self.inputargs =
@@ -320,7 +323,7 @@ impl<'a> TraceIterator<'a> {
                 })
                 .collect();
             for i in 0..num_inputargs {
-                _cache[i] = Some(BoxRef::from_bound_inputarg(&inputargs[i]));
+                _cache[i] = Some(Operand::from_bound_inputarg(&inputargs[i]));
             }
         }
         TraceIterator {
@@ -338,7 +341,7 @@ impl<'a> TraceIterator<'a> {
     }
 
     /// opencoder.py:286-289 _get(self, i).
-    fn _get(&self, i: usize) -> BoxRef {
+    fn _get(&self, i: usize) -> Operand {
         match self._cache.get(i).cloned().flatten() {
             Some(res) => res,
             None => panic!(
@@ -366,9 +369,9 @@ impl<'a> TraceIterator<'a> {
     /// have `OpRef >= CONST_BASE`, NONE is `u32::MAX`. Both pass through
     /// unchanged (value-inline const box); only TAGBOX-equivalent OpRefs
     /// go through `_get`, which returns the cached fresh box object.
-    fn _untag(&self, opref: OpRef) -> BoxRef {
+    fn _untag(&self, opref: OpRef) -> Operand {
         if opref.is_none() || opref.is_constant() {
-            BoxRef::from_opref(opref)
+            Operand::from_opref(opref)
         } else {
             self._get(opref.raw() as usize)
         }
@@ -387,7 +390,7 @@ impl<'a> TraceIterator<'a> {
     /// trace position (which is monotonic for non-void ops in a
     /// well-formed trace), so `_index - 1` lands on the same cache slot
     /// the previous `next()` call wrote.
-    pub fn replace_last_cached(&mut self, oldbox: OpRef, new_box: BoxRef) {
+    pub fn replace_last_cached(&mut self, oldbox: OpRef, new_box: Operand) {
         let last_idx = (self._index - 1) as usize;
         // opencoder.py:283 `assert self._cache[self._index - 1] is oldbox`
         // — checked by encoding here since callers identify the old box
@@ -414,14 +417,11 @@ impl<'a> TraceIterator<'a> {
         // opencoder.py:379-387: for i in range(argnum):
         //     res.setarg(i, self._untag(self._next()))
         for i in 0..res.num_args() {
-            res.setarg(
-                i,
-                majit_ir::operand::Operand::from_boxref(&self._untag(res.arg(i).to_opref())),
-            );
+            res.setarg(i, self._untag(res.arg(i).to_opref()));
         }
         if let Some(fa) = res.fail_args_mut() {
             for arg in fa.iter_mut() {
-                *arg = majit_ir::operand::Operand::from_boxref(&self._untag(arg.to_opref()));
+                *arg = self._untag(arg.to_opref());
             }
         }
         // RPython opencoder.py:399-401:
@@ -486,7 +486,7 @@ impl<'a> TraceIterator<'a> {
         // the fresh op OBJECT itself so later references resolve to the
         // same identity.
         if let Some(orig) = cache_slot {
-            self._cache[orig] = Some(BoxRef::from_bound_op(&res));
+            self._cache[orig] = Some(Operand::from_bound_op(&res));
         }
         // self._count += 1
         self._count += 1;
@@ -570,24 +570,17 @@ pub struct ByteTraceIter<'a> {
     /// `_floats`, `_descrs`, `metainterp_sd.all_descrs`.
     pub trace: &'a TraceRecordBuffer,
     /// opencoder.py:255 `self._cache` — raw trace position → fresh
-    /// per-iteration box OBJECT (bound `BoxRef`), mirroring
+    /// per-iteration producer `Operand`, mirroring
     /// `TraceIterator::_cache`. A later TAGBOX arg resolves through
-    /// `_get` to the same bound producer handle instead of a
-    /// position-only `Operand::Box`.
-    pub _cache: Vec<Option<BoxRef>>,
+    /// `_get` to the same bound producer (`Operand::Op` /
+    /// `Operand::InputArg`). The slot holds the producer `Rc` strongly,
+    /// so it owns the cached op for the walk's lifetime — RPython's
+    /// `self._cache[self._index] = res` stored the ResOperation OBJECT
+    /// outright.
+    pub _cache: Vec<Option<Operand>>,
     /// opencoder.py:259-263 `self.inputargs` — fresh iterator-local
     /// `InputArg` objects bound to the trace's inputargs.
     pub inputargs: Vec<majit_ir::InputArgRc>,
-    /// Strong roots for every produced op cached in `_cache`. RPython's
-    /// `self._cache[self._index] = res` stores the ResOperation OBJECT, so
-    /// the cache itself owns it for the walk's lifetime; pyre's `_cache`
-    /// holds a `BoxRef` whose bound handle is only a `Weak<Op>`, so without
-    /// a strong root the producer `Rc` returned by `next()` is dropped by
-    /// the caller between iterations and a later TAGBOX arg's `_get` would
-    /// upgrade to `None` and re-mint a position-only box. Rooting each
-    /// cached producer here keeps the `Weak` upgradeable so the arg binds to
-    /// `Operand::Op` (parity with RPython's strong cache slot).
-    _produced_roots: Vec<majit_ir::OpRc>,
     pub start: usize,
     pub pos: usize,
     pub end: usize,
@@ -613,7 +606,7 @@ impl<'a> ByteTraceIter<'a> {
     /// opencoder-local `_refs` / `_bigints` / `_floats` pools.
     pub fn new(trace: &'a TraceRecordBuffer, start: usize, end: usize, start_fresh: u32) -> Self {
         let cache_size = (trace._index as usize).max(trace.max_num_inputargs as usize);
-        let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
+        let mut _cache: Vec<Option<Operand>> = vec![None; cache_size];
         let mut _fresh = start_fresh;
         // opencoder.py:264-265 `[rop.inputarg_from_tp(arg.type) for arg in
         // self.trace.inputargs]` — type comes from each `InputArg.tp`.
@@ -631,13 +624,12 @@ impl<'a> ByteTraceIter<'a> {
             if p >= _cache.len() {
                 _cache.resize(p + 1, None);
             }
-            _cache[p] = Some(BoxRef::from_bound_inputarg(&inputargs[i]));
+            _cache[p] = Some(Operand::from_bound_inputarg(&inputargs[i]));
         }
         ByteTraceIter {
             trace,
             _cache,
             inputargs,
-            _produced_roots: Vec::new(),
             start,
             pos: start,
             end,
@@ -666,7 +658,7 @@ impl<'a> ByteTraceIter<'a> {
         inputarg_templates: &[OpRef],
     ) -> Self {
         let cache_size = (trace._index as usize).max(trace.max_num_inputargs as usize);
-        let mut _cache: Vec<Option<BoxRef>> = vec![None; cache_size];
+        let mut _cache: Vec<Option<Operand>> = vec![None; cache_size];
         let mut inputargs: Vec<majit_ir::InputArgRc> = Vec::with_capacity(inputarg_templates.len());
         let mut _fresh = 0u32;
         for &template in inputarg_templates {
@@ -694,14 +686,13 @@ impl<'a> ByteTraceIter<'a> {
             if slot >= _cache.len() {
                 _cache.resize(slot + 1, None);
             }
-            _cache[slot] = Some(BoxRef::from_bound_inputarg(&fresh_ia));
+            _cache[slot] = Some(Operand::from_bound_inputarg(&fresh_ia));
             inputargs.push(fresh_ia);
         }
         ByteTraceIter {
             trace,
             _cache,
             inputargs,
-            _produced_roots: Vec::new(),
             start,
             pos: start,
             end,
@@ -734,7 +725,7 @@ impl<'a> ByteTraceIter<'a> {
     }
 
     /// opencoder.py:286-289 `_get`.
-    fn _get(&self, i: usize) -> BoxRef {
+    fn _get(&self, i: usize) -> Operand {
         self._cache[i]
             .clone()
             .expect("ByteTraceIter._get: cache miss")
@@ -752,7 +743,7 @@ impl<'a> ByteTraceIter<'a> {
     ///
     /// `pub` because `SnapshotIterator::get` / `unpack_array`
     /// (opencoder.py:222-231) dispatch through `main_iter._untag`.
-    pub fn _untag(&mut self, tagged: i64) -> BoxRef {
+    pub fn _untag(&mut self, tagged: i64) -> Operand {
         // RPython opencoder.py:321-322 uses arithmetic shift on a
         // Python int; in Rust we preserve sign by going through i64
         // rather than u32 for the value.
@@ -767,7 +758,7 @@ impl<'a> ByteTraceIter<'a> {
                 // opencoder.py:326-327 ConstInt(v) — signed small int.
                 // history.py:227 ConstInt.value inline. A const OpRef
                 // sheds to `Operand::Const`, never a position-only box.
-                BoxRef::from_opref(OpRef::const_int(v))
+                Operand::from_opref(OpRef::const_int(v))
             }
             TAGCONSTPTR => {
                 // opencoder.py:328-329 ConstPtr(self.trace._refs[v]) —
@@ -775,7 +766,7 @@ impl<'a> ByteTraceIter<'a> {
                 // op-graph walker forwards `OpRef::ConstPtr(GcRef)`
                 // slots across minor collection.
                 let addr = self.trace._refs[v as usize];
-                BoxRef::from_opref(OpRef::const_ptr(majit_ir::GcRef(addr as usize)))
+                Operand::from_opref(OpRef::const_ptr(majit_ir::GcRef(addr as usize)))
             }
             TAGCONSTOTHER => {
                 // opencoder.py:330-334 bigint vs float split on bit 0.
@@ -783,11 +774,11 @@ impl<'a> ByteTraceIter<'a> {
                 if v & 1 != 0 {
                     // history.py:268 ConstFloat.value inline.
                     let bits = self.trace._floats[pool_idx];
-                    BoxRef::from_opref(OpRef::const_float(f64::from_bits(bits as u64)))
+                    Operand::from_opref(OpRef::const_float(f64::from_bits(bits as u64)))
                 } else {
                     // history.py:227 ConstInt.value inline.
                     let val = self.trace._bigints[pool_idx];
-                    BoxRef::from_opref(OpRef::const_int(val))
+                    Operand::from_opref(OpRef::const_int(val))
                 }
             }
             other => unreachable!("ByteTraceIter: unknown tag {}", other),
@@ -812,7 +803,7 @@ impl<'a> Iterator for ByteTraceIter<'a> {
             None => self._next() as usize,
         };
         // opencoder.py:395-408 — read `argnum` tagged args and untag.
-        let mut args: smallvec::SmallVec<[BoxRef; 3]> = smallvec::SmallVec::new();
+        let mut args: smallvec::SmallVec<[Operand; 3]> = smallvec::SmallVec::new();
         for _ in 0..arity {
             let tagged = self._next();
             args.push(self._untag(tagged));
@@ -854,16 +845,12 @@ impl<'a> Iterator for ByteTraceIter<'a> {
         // is a fresh Python object; the cache only receives non-void
         // results.  majit allocates an OpRef for every op (void or not)
         // so later non-void ops get contiguous positions. `args` are
-        // already bound boxes (`_untag` → `_get` bound producer / inline
-        // const), so building the op binds each arg to its producer and
-        // mints no position-only `Operand::Box`.
-        let args_operand: smallvec::SmallVec<[majit_ir::operand::Operand; 3]> = args
-            .iter()
-            .map(majit_ir::operand::Operand::from_boxref)
-            .collect();
+        // already bound producers (`_untag` → `_get` bound `Operand::Op` /
+        // `Operand::InputArg` / inline const), so building the op binds
+        // each arg to its producer directly.
         let op = match descr {
-            Some(d) => majit_ir::Op::with_descr(opcode, &args_operand, d),
-            None => majit_ir::Op::new(opcode, &args_operand),
+            Some(d) => majit_ir::Op::with_descr(opcode, &args, d),
+            None => majit_ir::Op::new(opcode, &args),
         };
         op.rd_resume_position.set(rd_resume_position);
         // opencoder.py:373-374 `cls = opclasses[opnum]; res = cls()` —
@@ -884,12 +871,9 @@ impl<'a> Iterator for ByteTraceIter<'a> {
             if slot >= self._cache.len() {
                 self._cache.resize(slot + 1, None);
             }
-            self._cache[slot] = Some(BoxRef::from_bound_op(&op));
-            // Root the producer strongly so the `_cache` Weak stays
-            // upgradeable for the rest of the walk even after the caller
-            // drops the `Rc` returned below (RPython's cache slot owns the
-            // ResOperation object outright).
-            self._produced_roots.push(op.clone());
+            // The slot owns the producer `Rc` strongly, keeping the
+            // cached op alive for the rest of the walk.
+            self._cache[slot] = Some(Operand::from_bound_op(&op));
             self._index += 1;
         }
         // opencoder.py:432 `self._count += 1`.
@@ -3088,7 +3072,7 @@ mod tests {
         // replace_last_cached(oldbox=BoxInt(101), new_box=BoxInt(999))
         // must target _cache[_index - 1] = _cache[1], where the last
         // write placed BoxInt(101).
-        iter.replace_last_cached(iop(101), box_arg(iop(999)));
+        iter.replace_last_cached(iop(101), box_arg_operand(iop(999)));
         assert_eq!(cache_opref(&iter, 1), Some(iop(999)));
 
         // The next op references raw pos 1 as its first arg, so the

--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -68,7 +68,7 @@ pub fn serialize_optimizer_knowledge(
         .filter(|opref| {
             numb_state
                 .liveboxes
-                .contains_key(&env.get_box_replacement_boxref(*opref))
+                .contains_key(&env.get_box_replacement_operand(*opref))
         })
         .collect();
 

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1654,19 +1654,16 @@ impl OptHeap {
             && op.num_args() >= 6
             && op
                 .arg(3)
-                .to_boxref()
                 .get_box_replacement(false)
                 .const_int()
                 .is_some()
             && op
                 .arg(4)
-                .to_boxref()
                 .get_box_replacement(false)
                 .const_int()
                 .is_some()
             && op
                 .arg(5)
-                .to_boxref()
                 .get_box_replacement(false)
                 .const_int()
                 .is_some()
@@ -1678,19 +1675,16 @@ impl OptHeap {
             && op.num_args() >= 5
             && op
                 .arg(2)
-                .to_boxref()
                 .get_box_replacement(false)
                 .const_int()
                 .is_some()
             && op
                 .arg(3)
-                .to_boxref()
                 .get_box_replacement(false)
                 .const_int()
                 .is_some()
             && op
                 .arg(4)
-                .to_boxref()
                 .get_box_replacement(false)
                 .const_int()
                 .is_some()

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -51,7 +51,6 @@ use majit_ir::{
 
 use crate::optimizeopt::info::PtrInfoExt;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 
 #[inline]
@@ -69,29 +68,29 @@ fn make_nonnull_box(ctx: &mut OptContext, arg: &Operand) {
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 enum DictArgKey {
     Const(Value),
-    Op(BoxRef),
+    Op(Operand),
 }
 
 impl DictArgKey {
-    fn from_arg(arg: OpRef, ctx: &OptContext) -> Self {
+    fn from_arg(arg: &Operand, ctx: &OptContext) -> Self {
         // One chain walk to the terminal box; a constant terminal keys by
-        // value, anything else by its resolved box identity.
-        match ctx.get_box_replacement_box(arg) {
+        // value, anything else by its resolved producer identity.
+        match ctx.get_box_replacement_operand_opt(arg.to_opref()) {
             Some(b) => match b.const_value() {
                 Some(value) => DictArgKey::Const(value),
                 None => DictArgKey::Op(b),
             },
-            // Defensive: an arg with no bound box has no stable canonical
-            // identity. `from_opref` mints a fresh Rc, so two such args do not
-            // dedup — a missed cache hit, never a correctness issue (the lookup
-            // is simply re-emitted). Production dict-lookup args are recorded
-            // CALL operands and are always bound.
+            // Defensive: an arg with no resolved terminal has no canonical
+            // identity. Key by the arg's own producer identity — two distinct
+            // unresolved args do not dedup, a missed cache hit and never a
+            // correctness issue (the lookup is simply re-emitted). Production
+            // dict-lookup args are recorded CALL operands and are always bound.
             None => {
                 debug_assert!(
                     false,
                     "cached_dict_reads: unbound dict-lookup arg {arg:?} — bind-at-alloc invariant"
                 );
-                DictArgKey::Op(BoxRef::from_opref(arg))
+                DictArgKey::Op(arg.clone())
             }
         }
     }
@@ -393,9 +392,7 @@ impl CachedField {
                     let parent_descr = descr.as_field_descr().and_then(|fd| fd.get_parent_descr());
                     structbox_box
                         .as_ref()
-                        .and_then(|b| {
-                            ctx.get_const_info_mut_box(b, parent_descr)
-                        })
+                        .and_then(|b| ctx.get_const_info_mut_box(b, parent_descr))
                         .and_then(|info| info.getfield(descr_idx))
                         .map(|entry| entry.as_seen_opref())
                 }) {
@@ -645,9 +642,7 @@ impl ArrayCachedItem {
                 .or_else(|| {
                     arraybox_box
                         .as_ref()
-                        .and_then(|b| {
-                            ctx.get_const_info_array_mut_box(b, descr.clone())
-                        })
+                        .and_then(|b| ctx.get_const_info_array_mut_box(b, descr.clone()))
                         .and_then(|info| info.getitem(self.index as usize))
                         .map(|entry| entry.as_seen_opref())
                 }) {
@@ -1554,8 +1549,8 @@ impl OptHeap {
         // arg through DictArgKey so two ConstInt slots with the same value
         // hash and compare equal.
         let key = [
-            DictArgKey::from_arg(op.arg(1).to_opref(), ctx),
-            DictArgKey::from_arg(op.arg(2).to_opref(), ctx),
+            DictArgKey::from_arg(&op.arg(1), ctx),
+            DictArgKey::from_arg(&op.arg(2), ctx),
         ];
 
         if let Some(res_v) = d.get(&key).copied() {
@@ -1647,42 +1642,18 @@ impl OptHeap {
         if oopspec == OopSpecIndex::Arraycopy
             && has_single_write_descr
             && op.num_args() >= 6
-            && op
-                .arg(3)
-                .get_box_replacement(false)
-                .const_int()
-                .is_some()
-            && op
-                .arg(4)
-                .get_box_replacement(false)
-                .const_int()
-                .is_some()
-            && op
-                .arg(5)
-                .get_box_replacement(false)
-                .const_int()
-                .is_some()
+            && op.arg(3).get_box_replacement(false).const_int().is_some()
+            && op.arg(4).get_box_replacement(false).const_int().is_some()
+            && op.arg(5).get_box_replacement(false).const_int().is_some()
         {
             return;
         }
         if oopspec == OopSpecIndex::Arraymove
             && has_single_write_descr
             && op.num_args() >= 5
-            && op
-                .arg(2)
-                .get_box_replacement(false)
-                .const_int()
-                .is_some()
-            && op
-                .arg(3)
-                .get_box_replacement(false)
-                .const_int()
-                .is_some()
-            && op
-                .arg(4)
-                .get_box_replacement(false)
-                .const_int()
-                .is_some()
+            && op.arg(2).get_box_replacement(false).const_int().is_some()
+            && op.arg(3).get_box_replacement(false).const_int().is_some()
+            && op.arg(4).get_box_replacement(false).const_int().is_some()
         {
             return;
         }
@@ -3557,9 +3528,7 @@ impl Optimization for OptHeap {
                     .or_else(|| {
                         resolved_box
                             .as_ref()
-                            .and_then(|b| {
-                                ctx.get_const_info_mut_box(b, parent.clone())
-                            })
+                            .and_then(|b| ctx.get_const_info_mut_box(b, parent.clone()))
                             .and_then(|info| info.getfield(*field_idx))
                             .map(|entry| entry.as_seen_opref())
                     })
@@ -3654,10 +3623,7 @@ impl Optimization for OptHeap {
     /// heap.py:847-868 serialize_optheap (array half) — emit array-item quads.
     /// The `available_boxes` filter (heap.py:855,866) is applied later, in
     /// `bridgeopt::serialize_optimizer_knowledge`; this raw export accepts all.
-    fn export_cached_arrayitems(
-        &self,
-        ctx: &mut OptContext,
-    ) -> Vec<(OpRef, i64, DescrRef, OpRef)> {
+    fn export_cached_arrayitems(&self, ctx: &mut OptContext) -> Vec<(OpRef, i64, DescrRef, OpRef)> {
         let mut result = Vec::new();
         for (_, descr, submap) in &self.cached_arrayitems {
             // heap.py:849: if descr.get_descr_index() == -1: continue
@@ -3687,9 +3653,7 @@ impl Optimization for OptHeap {
                         .or_else(|| {
                             resolved_box
                                 .as_ref()
-                                .and_then(|b| {
-                                    ctx.get_const_info_array_mut_box(b, descr.clone())
-                                })
+                                .and_then(|b| ctx.get_const_info_array_mut_box(b, descr.clone()))
                                 .and_then(|info| info.getitem(index as usize))
                                 .map(|entry| entry.as_seen_opref())
                         })

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -130,7 +130,7 @@ struct CachedField {
     /// for this descr. Replaces RPython's parallel `cached_infos`;
     /// the PtrInfo itself is read on-demand from
     /// `ctx.get_ptr_info(opref)` / `ctx.get_const_info(opref)`.
-    cached_structs: Vec<BoxRef>,
+    cached_structs: Vec<Operand>,
     /// heap.py:40 _lazy_set — at most one pending SetfieldGc per descr.
     /// Stores only the pending `Op` (`_lazy_set = op`); the struct base
     /// is `op.getarg(0)`, resolved on demand by the consumers.
@@ -152,7 +152,7 @@ impl CachedField {
     /// `cached_structs` and `cached_infos`; the Rust port skips
     /// `cached_infos` and reads PtrInfo on-demand.
     fn register_info(&mut self, struct_box: &Operand) {
-        self.cached_structs.push(struct_box.to_boxref());
+        self.cached_structs.push(struct_box.clone());
     }
 
     /// heap.py:59-65 AbstractCachedEntry.possible_aliasing
@@ -208,8 +208,7 @@ impl CachedField {
         for obj in &self.cached_structs {
             // One chain walk: an unresolved position has no PtrInfo and no
             // const_infos slot (the box-native resolver yields None there).
-            if let Some(b) = ctx.resolve_box_box_opt(obj) {
-                let b_op = Operand::from_boxref(&b);
+            if let Some(b_op) = ctx.resolve_operand_operand_opt(obj) {
                 ctx.with_ptr_info_mut(&b_op, |info| info.clear_field(descr_idx));
                 // Clear existing const_infos slot if present; do NOT create.
                 if let Some(info) = ctx.get_const_info_mut_if_exists_box(&b_op) {
@@ -377,8 +376,8 @@ impl CachedField {
         debug_assert!(self.lazy_set.is_none());
         for cached in &self.cached_structs {
             // One chain walk; the position view falls back to the stored
-            // key when no terminal box resolves (resolve_box_box_opt).
-            let structbox_box = ctx.resolve_box_box_opt(cached);
+            // key when no terminal box resolves (resolve_operand_operand_opt).
+            let structbox_box = ctx.resolve_operand_operand_opt(cached);
             let structbox = structbox_box
                 .as_ref()
                 .map_or(cached.to_opref(), |b| b.to_opref());
@@ -387,7 +386,7 @@ impl CachedField {
             }
             let cached_val = match structbox_box
                 .as_ref()
-                .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                .and_then(|b| ctx.peek_ptr_info(b))
                 .and_then(|info| info.getfield(descr_idx))
                 .map(|entry| entry.as_seen_opref())
                 .or_else(|| {
@@ -395,7 +394,7 @@ impl CachedField {
                     structbox_box
                         .as_ref()
                         .and_then(|b| {
-                            ctx.get_const_info_mut_box(&Operand::from_boxref(b), parent_descr)
+                            ctx.get_const_info_mut_box(b, parent_descr)
                         })
                         .and_then(|info| info.getfield(descr_idx))
                         .map(|entry| entry.as_seen_opref())
@@ -428,7 +427,7 @@ struct ArrayCachedItem {
     index: i64,
     /// heap.py:39 cached_structs — array boxes whose `_items[index]`
     /// slot holds a cached value. Replaces RPython's `cached_infos`.
-    cached_structs: Vec<BoxRef>,
+    cached_structs: Vec<Operand>,
     /// heap.py:40 _lazy_set — at most one pending SetarrayitemGc.
     /// Stores only the pending `Op` (`_lazy_set = op`); the array base
     /// is `op.getarg(0)`, resolved on demand by the consumers.
@@ -448,7 +447,7 @@ impl ArrayCachedItem {
 
     /// heap.py:42-49 AbstractCachedEntry.register_info(structop, info)
     fn register_info(&mut self, array_box: &Operand) {
-        self.cached_structs.push(array_box.to_boxref());
+        self.cached_structs.push(array_box.clone());
     }
 
     /// heap.py:59-65 AbstractCachedEntry.possible_aliasing
@@ -548,8 +547,7 @@ impl ArrayCachedItem {
         for obj in &self.cached_structs {
             // One chain walk: an unresolved position has no PtrInfo and no
             // const_infos slot (the box-native resolver yields None there).
-            if let Some(b) = ctx.resolve_box_box_opt(obj) {
-                let b_op = Operand::from_boxref(&b);
+            if let Some(b_op) = ctx.resolve_operand_operand_opt(obj) {
                 ctx.with_ptr_info_mut(&b_op, |info| info.clear_item(index));
                 // info.py:728 ConstPtrInfo._get_array_info — only clear
                 // an existing ArrayPtrInfo slot; do NOT create on miss.
@@ -631,8 +629,8 @@ impl ArrayCachedItem {
         debug_assert!(self.lazy_set.is_none());
         for cached in &self.cached_structs {
             // One chain walk; the position view falls back to the stored
-            // key when no terminal box resolves (resolve_box_box_opt).
-            let arraybox_box = ctx.resolve_box_box_opt(cached);
+            // key when no terminal box resolves (resolve_operand_operand_opt).
+            let arraybox_box = ctx.resolve_operand_operand_opt(cached);
             let arraybox = arraybox_box
                 .as_ref()
                 .map_or(cached.to_opref(), |b| b.to_opref());
@@ -641,17 +639,14 @@ impl ArrayCachedItem {
             }
             let cached_val = match arraybox_box
                 .as_ref()
-                .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                .and_then(|b| ctx.peek_ptr_info(b))
                 .and_then(|info| info.getitem(self.index as usize))
                 .map(|entry| entry.as_seen_opref())
                 .or_else(|| {
                     arraybox_box
                         .as_ref()
                         .and_then(|b| {
-                            ctx.get_const_info_array_mut_box(
-                                &Operand::from_boxref(b),
-                                descr.clone(),
-                            )
+                            ctx.get_const_info_array_mut_box(b, descr.clone())
                         })
                         .and_then(|info| info.getitem(self.index as usize))
                         .map(|entry| entry.as_seen_opref())
@@ -3519,12 +3514,11 @@ impl Optimization for OptHeap {
         "heap"
     }
 
-    /// heap.py:825-846 OptHeap.serialize_optheap(available_boxes)
-    fn export_cached_fields(
-        &self,
-        ctx: &mut OptContext,
-        available_boxes: Option<&[BoxRef]>,
-    ) -> Vec<(OpRef, DescrRef, OpRef)> {
+    /// heap.py:825-846 OptHeap.serialize_optheap — emit struct field triples.
+    /// The `available_boxes` filter (heap.py:836,845) is applied later, in
+    /// `bridgeopt::serialize_optimizer_knowledge`, once the live-box set is
+    /// known; this raw export accepts every cached field.
+    fn export_cached_fields(&self, ctx: &mut OptContext) -> Vec<(OpRef, DescrRef, OpRef)> {
         let mut result = Vec::new();
         // heap.py:827-846: for descr, cf in cached_fields.iteritems():
         for (field_idx, descr, cf) in &self.cached_fields {
@@ -3552,25 +3546,19 @@ impl Optimization for OptHeap {
                 if obj.is_none() {
                     continue;
                 }
-                // heap.py:836: if not box1.is_constant() and box1 not in available_boxes: continue
-                if let Some(ab) = available_boxes {
-                    if !obj.is_constant() && !ab.contains(obj) {
-                        continue;
-                    }
-                }
                 // heap.py:838-839: structinfo = cf.cached_infos[i]
                 //                  box2 = structinfo.getfield(descr)
-                let resolved_box = ctx.resolve_box_box_opt(obj);
+                let resolved_box = ctx.resolve_operand_operand_opt(obj);
                 let Some(val) = resolved_box
                     .as_ref()
-                    .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                    .and_then(|b| ctx.peek_ptr_info(b))
                     .and_then(|info| info.getfield(*field_idx))
                     .map(|entry| entry.as_seen_opref())
                     .or_else(|| {
                         resolved_box
                             .as_ref()
                             .and_then(|b| {
-                                ctx.get_const_info_mut_box(&Operand::from_boxref(b), parent.clone())
+                                ctx.get_const_info_mut_box(b, parent.clone())
                             })
                             .and_then(|info| info.getfield(*field_idx))
                             .map(|entry| entry.as_seen_opref())
@@ -3586,15 +3574,9 @@ impl Optimization for OptHeap {
                 // chain walk; the position view falls back to the source.
                 let val_box = ctx.get_box_replacement_box(val);
                 let val = val_box.as_ref().map_or(val, |b| b.to_opref());
-                // heap.py:845: if box2.is_constant() or box2 in available_boxes:
-                let val_ok = available_boxes.map_or(true, |ab| {
-                    val.is_constant()
-                        || val_box.as_ref().and_then(|cb| cb.const_value()).is_some()
-                        || val_box.as_ref().map_or(false, |b| ab.contains(b))
-                });
-                if val_ok {
-                    result.push((obj.to_opref(), descr.clone(), val));
-                }
+                // heap.py:845 `box2 in available_boxes` is enforced later in
+                // bridgeopt; here the resolved field is exported unconditionally.
+                result.push((obj.to_opref(), descr.clone(), val));
             }
         }
         result
@@ -3669,11 +3651,12 @@ impl Optimization for OptHeap {
         }
     }
 
-    /// heap.py:847-868 serialize_optheap(available_boxes) (array half)
+    /// heap.py:847-868 serialize_optheap (array half) — emit array-item quads.
+    /// The `available_boxes` filter (heap.py:855,866) is applied later, in
+    /// `bridgeopt::serialize_optimizer_knowledge`; this raw export accepts all.
     fn export_cached_arrayitems(
         &self,
         ctx: &mut OptContext,
-        available_boxes: Option<&[BoxRef]>,
     ) -> Vec<(OpRef, i64, DescrRef, OpRef)> {
         let mut result = Vec::new();
         for (_, descr, submap) in &self.cached_arrayitems {
@@ -3690,31 +3673,22 @@ impl Optimization for OptHeap {
                     if obj.is_none() {
                         continue;
                     }
-                    // heap.py:855: if not box1.is_constant() and box1 not in available_boxes: continue
-                    if let Some(ab) = available_boxes {
-                        if !obj.is_constant() && !ab.contains(obj) {
-                            continue;
-                        }
-                    }
                     // heap.py:858: if index >= 2**15: continue
                     if index >= (1 << 15) {
                         continue;
                     }
-                    let resolved_box = ctx.resolve_box_box_opt(obj);
+                    let resolved_box = ctx.resolve_operand_operand_opt(obj);
                     // heap.py:860: box2 = arrayinfo.getitem(descr, index)
                     let Some(val) = resolved_box
                         .as_ref()
-                        .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+                        .and_then(|b| ctx.peek_ptr_info(b))
                         .and_then(|info| info.getitem(index as usize))
                         .map(|entry| entry.as_seen_opref())
                         .or_else(|| {
                             resolved_box
                                 .as_ref()
                                 .and_then(|b| {
-                                    ctx.get_const_info_array_mut_box(
-                                        &Operand::from_boxref(b),
-                                        descr.clone(),
-                                    )
+                                    ctx.get_const_info_array_mut_box(b, descr.clone())
                                 })
                                 .and_then(|info| info.getitem(index as usize))
                                 .map(|entry| entry.as_seen_opref())
@@ -3730,15 +3704,9 @@ impl Optimization for OptHeap {
                     // chain walk; the position view falls back to the source.
                     let val_box = ctx.get_box_replacement_box(val);
                     let val = val_box.as_ref().map_or(val, |b| b.to_opref());
-                    // heap.py:866: if box2.is_constant() or box2 in available_boxes:
-                    let val_ok = available_boxes.map_or(true, |ab| {
-                        val.is_constant()
-                            || val_box.as_ref().and_then(|cb| cb.const_value()).is_some()
-                            || val_box.as_ref().map_or(false, |b| ab.contains(b))
-                    });
-                    if val_ok {
-                        result.push((obj.to_opref(), index, descr.clone(), val));
-                    }
+                    // heap.py:866 `box2 in available_boxes` is enforced later in
+                    // bridgeopt; here the resolved item is exported unconditionally.
+                    result.push((obj.to_opref(), index, descr.clone(), val));
                 }
             }
         }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -835,11 +835,11 @@ pub struct OptHeap {
     /// check, so duplicates are rare anyway — see `_optimize_call_dict_lookup`).
     corresponding_array_descrs: majit_ir::VecMap<u32, (DescrRef, usize)>,
     /// Fields known to be quasi-immutable: (obj box, field_idx) -> cached value
-    /// OpRef. Keyed by the object's `BoxRef` identity (heap keys structs by box,
+    /// OpRef. Keyed by the object's `Operand` identity (heap keys structs by box,
     /// not by the retired `opref.raw()` slot). Populated by QUASIIMMUT_FIELD,
     /// consumed by subsequent GETFIELD_GC_*. Survives calls (guarded by
     /// GUARD_NOT_INVALIDATED).
-    quasi_immut_cache: majit_ir::VecMap<(BoxRef, usize), OpRef>,
+    quasi_immut_cache: majit_ir::VecMap<(Operand, usize), OpRef>,
 }
 
 impl OptHeap {
@@ -2244,7 +2244,7 @@ impl OptHeap {
         // Check quasi-immutable cache: if this field was marked by
         // QUASIIMMUT_FIELD, the value is stable (guarded by GUARD_NOT_INVALIDATED).
         // Keyed by the object's canonical box identity.
-        if let Some(qi_obj) = ctx.get_box_replacement_box(key.0) {
+        if let Some(qi_obj) = ctx.get_box_replacement_operand_opt(key.0) {
             let qi_key = (qi_obj, key.1);
             if let Some(qi_cached) = self.quasi_immut_cache.get(&qi_key).copied() {
                 if !qi_cached.is_none() {
@@ -3271,7 +3271,7 @@ impl OptHeap {
                     }
                 }
                 if let Some(key) = cache_field_key {
-                    if let Some(obj_box) = ctx.get_box_replacement_box(obj) {
+                    if let Some(obj_box) = ctx.get_box_replacement_operand_opt(obj) {
                         self.quasi_immut_cache.insert((obj_box, key), OpRef::NONE);
                     }
                 }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3645,10 +3645,8 @@ impl Optimization for OptHeap {
             }
             // heap.py:882-883: cf = self.field_cache(&descr)
             //                  structinfo.setfield(descr, box1, box2, optheap, cf=cf)
-            let box1_box = ctx
-                .get_box_replacement_box(*box1)
-                .unwrap_or_else(|| BoxRef::from_opref(*box1));
-            self.cache_field(&Operand::from_boxref(&box1_box), descr);
+            let box1_op = ctx.materialize_operand_at(*box1);
+            self.cache_field(&box1_op, descr);
             let resolved_box = ctx.get_box_replacement_operand_opt(resolved);
             if resolved_box
                 .as_ref()
@@ -3788,11 +3786,9 @@ impl Optimization for OptHeap {
             }
             // heap.py:893-894: cf = self.arrayitem_cache(descr, index)
             //                  arrayinfo.setitem(descr, index, box1, box2, optheap, cf=cf)
-            let box1_box = ctx
-                .get_box_replacement_box(*box1)
-                .unwrap_or_else(|| BoxRef::from_opref(*box1));
+            let box1_op = ctx.materialize_operand_at(*box1);
             let cai = self.arrayitem_cache(descr, *index);
-            cai.register_info(&Operand::from_boxref(&box1_box));
+            cai.register_info(&box1_op);
             let resolved_box = ctx.get_box_replacement_operand_opt(resolved);
             if resolved_box
                 .as_ref()

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1497,7 +1497,7 @@ fn force_box_impl(
                                 .map(|b| b.to_opref())
                                 .unwrap_or(ch_ref);
                             let arg_newop = ctx.materialize_operand_at(newop);
-                            let arg_offset = ctx.resolve_box_operand(&offset.to_boxref());
+                            let arg_offset = ctx.resolve_operand_operand(&offset);
                             let arg_ch = ctx.materialize_operand_at(ch_resolved);
                             let setitem_op = Op::new(
                                 set_opcode,

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -879,11 +879,8 @@ fn force_box_impl(
     // resulting box, which the parent uses as a SETFIELD/SETARRAYITEM value
     // operand. Box-native: the field box is passed and returned directly,
     // matching `force_box(fld)` rather than an OpRef round-trip.
-    fn force_child(
-        orig: &majit_ir::box_ref::BoxRef,
-        ctx: &mut crate::optimizeopt::OptContext,
-    ) -> BoxRef {
-        let value_box = ctx.resolve_box_box_opt(orig);
+    fn force_child(orig: &Operand, ctx: &mut crate::optimizeopt::OptContext) -> Operand {
+        let value_box = ctx.resolve_operand_operand_opt(orig);
         // optimizer.py:356-357: `info = op.get_forwarded()` then `if op.type ==
         // 'i' and info.is_constant(): return ConstInt(info.get_constant_int())`.
         // The const-int synthesis is gated on an info that is ALREADY forwarded
@@ -894,30 +891,25 @@ fn force_box_impl(
         // fresh unbounded slot.
         if let Some(b) = &value_box {
             if b.const_value().is_none() && b.type_() == majit_ir::Type::Int {
-                let b_op = ctx.operand_of_box(b);
-                if let Some(bound) = ctx.peek_intbound_box(&b_op) {
+                if let Some(bound) = ctx.peek_intbound_box(b) {
                     if bound.is_constant() {
                         let c = ctx.make_constant_int(bound.get_constant_int());
-                        return ctx.materialize_box_at(c);
+                        return ctx.materialize_operand_at(c);
                     }
                 }
             }
         }
         let value_is_virtual = match &value_box {
-            Some(b) => {
-                let b_op = ctx.operand_of_box(b);
-                ctx.is_virtual(&b_op)
-            }
+            Some(b) => ctx.is_virtual(b),
             None => false,
         };
         if value_is_virtual {
-            let value_box = value_box.expect("recorder-populated");
-            let vb_op = ctx.operand_of_box(&value_box);
+            let vb_op = value_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&vb_op).unwrap();
             let forced = force_box_impl(&mut info, &vb_op, ctx);
             return ctx
-                .get_box_replacement_box(forced)
-                .unwrap_or_else(|| ctx.materialize_box_at(forced));
+                .get_box_replacement_operand_opt(forced)
+                .unwrap_or_else(|| ctx.materialize_operand_at(forced));
         }
         value_box.unwrap_or_else(|| orig.clone())
     }
@@ -971,7 +963,7 @@ fn force_box_impl(
                     .and_then(|b| b.const_value())
                     .is_none()
                 {
-                    force_child(&fb.to_boxref(), ctx);
+                    force_child(&fb, ctx);
                     if ctx
                         .resolve_operand_operand_opt(&fb)
                         .and_then(|b| b.const_value())
@@ -1070,7 +1062,7 @@ fn force_box_impl(
                 ctx.make_equal_to(op, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
-                let value_ref = force_child(&value_ref.to_boxref(), ctx);
+                let value_ref = force_child(&value_ref, ctx);
                 let descr = lookup_field_descr(&cached_fielddescrs, field_idx);
                 debug_assert!(
                     descr.is_some(),
@@ -1082,7 +1074,7 @@ fn force_box_impl(
                     "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i]",
                 );
                 let arg_alloc = ctx.materialize_operand_at(alloc_ref);
-                let arg_value = ctx.resolve_box_operand(&value_ref);
+                let arg_value = ctx.resolve_operand_operand(&value_ref);
                 let mut set_op =
                     Op::new(OpCode::SetfieldGc, &[arg_alloc.clone(), arg_value.clone()]);
                 set_op.setdescr(descr);
@@ -1124,13 +1116,13 @@ fn force_box_impl(
                 ctx.make_equal_to(op, &b_alloc);
             }
             for (field_idx, value_ref) in std::mem::take(&mut vinfo.fields) {
-                let value_ref = force_child(&value_ref.to_boxref(), ctx);
+                let value_ref = force_child(&value_ref, ctx);
                 let descr = lookup_field_descr(&cached_fielddescrs, field_idx);
                 let descr = descr.expect(
                     "force_box: field_idx must resolve through descr.get_all_fielddescrs()[i]",
                 );
                 let arg_alloc = ctx.materialize_operand_at(alloc_ref);
-                let arg_value = ctx.resolve_box_operand(&value_ref);
+                let arg_value = ctx.resolve_operand_operand(&value_ref);
                 let mut set_op =
                     Op::new(OpCode::SetfieldGc, &[arg_alloc.clone(), arg_value.clone()]);
                 set_op.setdescr(descr);
@@ -1191,11 +1183,11 @@ fn force_box_impl(
                         continue;
                     }
                 }
-                let subbox = force_child(&item_ref.to_boxref(), ctx);
+                let subbox = force_child(&item_ref, ctx);
                 let idx_ref = ctx.emit_constant_int(i as i64);
                 let arg_alloc = ctx.materialize_operand_at(alloc_ref);
                 let arg_idx = ctx.materialize_operand_at(idx_ref);
-                let arg_sub = ctx.resolve_box_operand(&subbox);
+                let arg_sub = ctx.resolve_operand_operand(&subbox);
                 let mut set_op = Op::new(
                     OpCode::SetarrayitemGc,
                     &[arg_alloc.clone(), arg_idx.clone(), arg_sub.clone()],
@@ -1254,10 +1246,10 @@ fn force_box_impl(
                     if value_ref.is_none() {
                         continue;
                     }
-                    let subbox = force_child(&value_ref.to_boxref(), ctx);
+                    let subbox = force_child(&value_ref, ctx);
                     let arg_alloc = ctx.materialize_operand_at(alloc_ref);
                     let arg_idx = ctx.materialize_operand_at(idx_ref);
-                    let arg_sub = ctx.resolve_box_operand(&subbox);
+                    let arg_sub = ctx.resolve_operand_operand(&subbox);
                     let mut set_op = Op::new(
                         OpCode::SetinteriorfieldGc,
                         &[arg_alloc.clone(), arg_idx.clone(), arg_sub.clone()],
@@ -1326,11 +1318,11 @@ fn force_box_impl(
             // force_child would force-box it and synthesize a ConstInt for a
             // constant-bound int, neither of which upstream does here.
             for (offset, _length, descr, value) in entries {
-                let value_box = ctx.materialize_box_at(value);
+                let value_box = ctx.materialize_operand_at(value);
                 let offset_ref = ctx.emit_constant_int(offset);
                 let arg_alloc = ctx.materialize_operand_at(alloc_ref);
                 let arg_offset = ctx.materialize_operand_at(offset_ref);
-                let arg_value = ctx.resolve_box_operand(&value_box);
+                let arg_value = ctx.resolve_operand_operand(&value_box);
                 let mut store_op = Op::new(
                     OpCode::RawStore,
                     &[arg_alloc.clone(), arg_offset.clone(), arg_value.clone()],
@@ -1363,9 +1355,9 @@ fn force_box_impl(
             // Overwriting with `PtrInfo::nonnull()` would lose the
             // raw-slice identity and mis-route any later
             // `get_virtual_fields` / raw-guard path.
-            let parent_forced = force_child(&slice.parent.to_boxref(), ctx);
+            let parent_forced = force_child(&slice.parent, ctx);
             let offset_ref = ctx.emit_constant_int(slice.offset as i64);
-            let arg_parent = ctx.resolve_box_operand(&parent_forced);
+            let arg_parent = ctx.resolve_operand_operand(&parent_forced);
             let arg_offset = ctx.materialize_operand_at(offset_ref);
             let mut add_op = Op::new(OpCode::IntAdd, &[arg_parent.clone(), arg_offset.clone()]);
             add_op.pos.set(opref);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4576,7 +4576,23 @@ impl OptContext {
     /// `Operand::Const` for a const-namespace OpRef. `materialize_box_at` never
     /// returns a position-only box, so the lowering is panic-free.
     pub(crate) fn materialize_operand_at(&mut self, opref: OpRef) -> Operand {
-        Operand::from_boxref(&self.materialize_box_at(opref))
+        // `materialize_box_at` always yields a box bound to a canonical host
+        // (a producing `Op`, an `InputArg`, or a `Const`). Read that host
+        // directly to build the `Operand` natively — the same lowering
+        // `Operand::from_boxref` performs for a bound box, but without the
+        // wrapper round-trip and without leaning on the `box_cache` memo for
+        // identity (the `Rc<Op>` / `Rc<InputArg>` itself is the identity).
+        let b = self.materialize_box_at(opref);
+        if let Some(op) = b.bound_op() {
+            Operand::from_bound_op(&op)
+        } else if let Some(ia) = b.bound_inputarg() {
+            Operand::from_bound_inputarg(&ia)
+        } else {
+            Operand::const_from_value(
+                b.const_value()
+                    .expect("materialize_box_at yields a bound or const box"),
+            )
+        }
     }
 
     /// Migration bridge: lower a (possibly position-only) box to its canonical

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -950,22 +950,24 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
         self.ctx.get_replacement_opref(opref)
     }
 
-    fn get_box_replacement_boxref(&self, opref: OpRef) -> majit_ir::box_ref::BoxRef {
+    fn get_box_replacement_operand(&self, opref: OpRef) -> Operand {
         // resume.py:202 box.get_box_replacement() as a box OBJECT. The canonical
         // host is the producer Op / InputArg, so two reaches of one logical box
-        // return the same memoized Rc (ptr_eq) — the #160/S11 livebox dedup key.
-        self.ctx.get_box_replacement_box(opref).unwrap_or_else(|| {
-            // #160/S11 tripwire: a non-Const numbering key that resolves through
-            // the from_opref fallback would mint a fresh, non-ptr_eq box and
-            // corrupt the livebox dedup. #157 drained these fires to zero;
-            // PYRE_S11_TRIPWIRE surfaces any regression across the corpus.
-            if std::env::var_os("PYRE_S11_TRIPWIRE").is_some() {
-                eprintln!(
-                    "[s11-tripwire] get_box_replacement_boxref from_opref fallback on {opref:?}"
-                );
-            }
-            majit_ir::box_ref::BoxRef::from_opref(self.ctx.get_replacement_opref(opref))
-        })
+        // return the same producer Rc (ptr_eq) — the #160/S11 livebox dedup key.
+        // `get_box_replacement_operand_opt` carries the debug-build tripwire that
+        // the native Operand walk agrees with the BoxRef form on presence and
+        // identity, so the resume-numbering path validates the BoxRef→Operand
+        // equivalence across the corpus. The fallback PANICS on a producerless
+        // position (E3 dropped the position-only Operand variant), the armed
+        // hazard-5 tripwire: a non-Const numbering key with no findable producer
+        // would otherwise mint a fresh, non-ptr_eq box and corrupt the livebox
+        // dedup. #157 drained these fires to zero across the corpus.
+        if opref.is_none() {
+            return Operand::None;
+        }
+        self.ctx
+            .get_box_replacement_operand_opt(opref)
+            .unwrap_or_else(|| Operand::from_opref(self.ctx.get_replacement_opref(opref)))
     }
 
     fn get_box_replacement_not_const(&self, opref: OpRef) -> OpRef {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4760,16 +4760,6 @@ impl OptContext {
         }
     }
 
-    /// Operand-yielding sibling of [`OptContext::resolve_box_box`]: resolve a
-    /// `BoxRef` to its canonical producer and shed it to an [`Operand`]. For
-    /// op-emission sites that consume the resolved box only as an `Op::new`
-    /// argument, this drops the `Operand::from_boxref(&resolve_box_box(..))`
-    /// round-trip. `resolve_box_box` returns a bound / const box for a bound or
-    /// constant input, so the lowering is panic-free for those callers.
-    pub fn resolve_box_operand(&self, arg: &majit_ir::box_ref::BoxRef) -> Operand {
-        Operand::from_boxref(&self.resolve_box_box(arg))
-    }
-
     /// `Option`-returning sibling of [`OptContext::resolve_box_box`], the
     /// box-native form of `get_box_replacement_box`. resoperation.py:58
     /// `get_box_replacement(op)` walks the box's `_forwarded` chain; a bound

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -9727,12 +9727,11 @@ mod boxref_forwarding_tests {
     #[test]
     fn int_bound_handle_const_arms_are_not_ptr_eq() {
         use majit_ir::Value;
-        use majit_ir::box_ref::BoxRef;
 
         let mut ctx = OptContext::with_num_inputs(0, 0);
-        let b = BoxRef::new_const(Value::Int(7));
-        let h1 = ctx.getintbound_handle(&Operand::from_boxref(&b));
-        let h2 = ctx.getintbound_handle(&Operand::from_boxref(&b));
+        let c = Operand::const_from_value(Value::Int(7));
+        let h1 = ctx.getintbound_handle(&c);
+        let h2 = ctx.getintbound_handle(&c);
         assert!(
             !h1.ptr_eq(&h2),
             "Const arms must be fresh independent objects, never ptr_eq"
@@ -9750,11 +9749,10 @@ mod boxref_forwarding_tests {
     #[test]
     fn int_bound_handle_const_arm_is_locally_mutable() {
         use majit_ir::Value;
-        use majit_ir::box_ref::BoxRef;
 
         let mut ctx = OptContext::with_num_inputs(0, 0);
-        let b = BoxRef::new_const(Value::Int(7));
-        let h = ctx.getintbound_handle(&Operand::from_boxref(&b));
+        let c = Operand::const_from_value(Value::Int(7));
+        let h = ctx.getintbound_handle(&c);
         // Direct field mutation through the RefMut — `make_ge_const`
         // would reject 20 on `from_constant(7)` (empty interval); the
         // parity claim is "borrow_mut succeeds and writes land in the
@@ -9773,7 +9771,7 @@ mod boxref_forwarding_tests {
         // A fresh getintbound_handle call mints an independent cell —
         // mutations on `h` do not leak across calls (PyPy: each
         // `IntBound.from_constant(7)` is a distinct object).
-        let h_fresh = ctx.getintbound_handle(&Operand::from_boxref(&b));
+        let h_fresh = ctx.getintbound_handle(&c);
         assert_eq!(
             h_fresh.borrow().upper,
             7,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -128,12 +128,11 @@ pub trait Optimization {
         // Default: no contribution
     }
 
-    /// heap.py:825-846 serialize_optheap(available_boxes) — export struct field triples.
-    /// `available_boxes`: None = no filter (accept all), Some = RPython filter.
+    /// heap.py:825-846 serialize_optheap — export struct field triples. The
+    /// `available_boxes` filter (heap.py:836,845) is applied in bridgeopt.
     fn export_cached_fields(
         &self,
         _ctx: &mut OptContext,
-        _available_boxes: Option<&[majit_ir::box_ref::BoxRef]>,
     ) -> Vec<(OpRef, majit_ir::DescrRef, OpRef)> {
         Vec::new()
     }
@@ -146,12 +145,11 @@ pub trait Optimization {
     ) {
     }
 
-    /// heap.py:847-868 serialize_optheap(available_boxes) — export array item triples.
-    /// `available_boxes`: None = no filter (accept all), Some = RPython filter.
+    /// heap.py:847-868 serialize_optheap — export array item triples. The
+    /// `available_boxes` filter (heap.py:855,866) is applied in bridgeopt.
     fn export_cached_arrayitems(
         &self,
         _ctx: &mut OptContext,
-        _available_boxes: Option<&[majit_ir::box_ref::BoxRef]>,
     ) -> Vec<(OpRef, i64, majit_ir::DescrRef, OpRef)> {
         Vec::new()
     }
@@ -1652,32 +1650,6 @@ impl Optimizer {
         for pass in &self.passes {
             pass.produce_potential_short_preamble_ops(sb, ctx);
         }
-    }
-
-    /// heap.py:825 serialize_optheap(available_boxes) — struct half.
-    pub fn export_all_cached_fields(
-        &self,
-        ctx: &mut OptContext,
-        available_boxes: Option<&[BoxRef]>,
-    ) -> Vec<(OpRef, majit_ir::DescrRef, OpRef)> {
-        let mut result = Vec::new();
-        for pass in &self.passes {
-            result.extend(pass.export_cached_fields(ctx, available_boxes));
-        }
-        result
-    }
-
-    /// heap.py:847 serialize_optheap(available_boxes) — array half.
-    pub fn export_all_cached_arrayitems(
-        &self,
-        ctx: &mut OptContext,
-        available_boxes: Option<&[BoxRef]>,
-    ) -> Vec<(OpRef, i64, majit_ir::DescrRef, OpRef)> {
-        let mut result = Vec::new();
-        for pass in &self.passes {
-            result.extend(pass.export_cached_arrayitems(ctx, available_boxes));
-        }
-        result
     }
 
     /// Pre-tag Phase 1 JUMP arg OpRefs as generation 0.
@@ -5181,12 +5153,12 @@ impl Optimizer {
     ) -> crate::resume::OptimizerKnowledgeForResume {
         let mut heap_fields_raw = Vec::new();
         let mut heap_arrayitems_raw = Vec::new();
-        // Guard resume: export all cached fields (no available_boxes filter).
-        // RPython only calls serialize_optheap from bridgeopt.py; this
-        // guard-resume path has no RPython-equivalent filter.
+        // Guard resume: export all cached fields. The available_boxes filter
+        // (serialize_optheap, bridgeopt.py) is applied later in bridgeopt once
+        // the live-box set is known; this raw export accepts every cached field.
         for pass in &self.passes {
-            let fields = pass.export_cached_fields(ctx, None);
-            let items = pass.export_cached_arrayitems(ctx, None);
+            let fields = pass.export_cached_fields(ctx);
+            let items = pass.export_cached_arrayitems(ctx);
             if !fields.is_empty() || !items.is_empty() {
                 heap_fields_raw = fields;
                 heap_arrayitems_raw = items;

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1912,10 +1912,7 @@ impl Optimizer {
     ) -> OpRef {
         let resolved = ctx.get_replacement_opref(opref);
         let resolved_operand = ctx.get_box_replacement_operand_opt(opref);
-        let Some(mut info) = resolved_operand
-            .as_ref()
-            .and_then(|o| ctx.peek_ptr_info(o))
-        else {
+        let Some(mut info) = resolved_operand.as_ref().and_then(|o| ctx.peek_ptr_info(o)) else {
             return resolved;
         };
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -327,11 +327,11 @@ pub struct Optimizer {
     /// optimizer.py:241/304/632-634 `replaces_guard` — maps an emitted
     /// guard op to its replacement. RPython keys this dict by the guard
     /// `op` object itself (object identity); pyre keys by the guard op's
-    /// canonical box (`BoxRef`, compared by `Rc::ptr_eq`), the box-identity
-    /// analog of `op is op`. Every key is resolved through
-    /// `ctx.get_box_replacement(op.pos)` so insert and lookup agree on the
-    /// canonical box. Guard ops are never Const, so the key is always a
-    /// ptr-stable ResOp box.
+    /// canonical producer `Operand` (compared by `Rc::ptr_eq`), the
+    /// box-identity analog of `op is op`. Every key is resolved through
+    /// `ctx.resolve_to_operand(op.pos)` so insert and lookup agree on the
+    /// canonical producer. Guard ops are never Const, so the key is always a
+    /// ptr-stable ResOp producer.
     replaces_guard: majit_ir::VecMap<majit_ir::operand::Operand, Op>,
     /// optimizer.py: `pendingfields` — heap fields that need to be
     /// written back before the next guard (lazy set forcing).
@@ -1487,11 +1487,8 @@ impl Optimizer {
         guard_pos: OpRef,
         replacement: Op,
     ) {
-        if let Some(box_ref) = ctx.resolve_to_boxref(guard_pos) {
-            self.replaces_guard.insert(
-                majit_ir::operand::Operand::from_boxref(&box_ref),
-                replacement,
-            );
+        if let Some(op) = ctx.resolve_to_operand(guard_pos) {
+            self.replaces_guard.insert(op, replacement);
         }
     }
 
@@ -1506,17 +1503,14 @@ impl Optimizer {
         let new_pos = new_guard.pos.get();
         // replaces_guard is keyed by the raw `op` identity (optimizer.py:307),
         // so resolve to the producer box without following `_forwarded`.
-        if let Some(box_ref) = ctx.resolve_to_boxref(old_pos) {
-            self.replaces_guard
-                .insert(majit_ir::operand::Operand::from_boxref(&box_ref), new_guard);
+        if let Some(op) = ctx.resolve_to_operand(old_pos) {
+            self.replaces_guard.insert(op, new_guard);
         }
         // optimizer.py:747 `self._emittedoperations[new_op] = None` — new_op is
         // the canonical (get_box_replacement'd) emitted op, so this insert stays
         // canonical, matching the emit-set keying in `_emit_operation`.
         self.emitted_operations
-            .insert(majit_ir::operand::Operand::from_boxref(
-                &ctx.get_box_replacement(new_pos),
-            ));
+            .insert(ctx.get_box_replacement_operand(new_pos));
     }
 
     /// optimizer.py:369-377 `as_operation(op, required_opnum=-1)`:
@@ -1558,14 +1552,8 @@ impl Optimizer {
         if opref.is_constant() {
             return None;
         }
-        match ctx.resolve_to_boxref(opref) {
-            Some(box_ref)
-                if self
-                    .emitted_operations
-                    .contains(&majit_ir::operand::Operand::from_boxref(&box_ref)) =>
-            {
-                Some(opref)
-            }
+        match ctx.resolve_to_operand(opref) {
+            Some(op) if self.emitted_operations.contains(&op) => Some(opref),
             _ => None,
         }
     }
@@ -1951,10 +1939,10 @@ impl Optimizer {
         rec: &mut majit_ir::vec_set::VecSet<majit_ir::operand::Operand>,
     ) -> OpRef {
         let resolved = ctx.get_replacement_opref(opref);
-        let resolved_box = ctx.get_box_replacement_box(opref);
-        let Some(mut info) = resolved_box
+        let resolved_operand = ctx.get_box_replacement_operand_opt(opref);
+        let Some(mut info) = resolved_operand
             .as_ref()
-            .and_then(|b| ctx.peek_ptr_info(&Operand::from_boxref(b)))
+            .and_then(|o| ctx.peek_ptr_info(o))
         else {
             return resolved;
         };
@@ -1992,10 +1980,9 @@ impl Optimizer {
             // info.py:231 `rec[self] = None` keys the recursion guard by the
             // virtual's PtrInfo object identity; in pyre one virtual head box
             // <-> one PtrInfo, so key by the canonical resolved box.
-            let resolved_box_key = resolved_box
+            let rec_key = resolved_operand
                 .clone()
-                .expect("virtual PtrInfo implies a resolved box");
-            let rec_key = majit_ir::operand::Operand::from_boxref(&resolved_box_key);
+                .expect("virtual PtrInfo implies a resolved operand");
             if rec.contains(&rec_key) {
                 return resolved;
             }
@@ -2004,8 +1991,8 @@ impl Optimizer {
                 let forced = self.force_at_the_end_of_preamble_rec(child.to_opref(), ctx, rec);
                 ctx.materialize_operand_at(forced)
             });
-            if let Some(b) = resolved_box.as_ref() {
-                ctx.set_ptr_info(&Operand::from_boxref(b), info);
+            if let Some(o) = resolved_operand.as_ref() {
+                ctx.set_ptr_info(o, info);
             }
             return resolved;
         }
@@ -2544,8 +2531,8 @@ impl Optimizer {
             let opref = OptContext::op_ref_for_value(idx, value);
             // seed_constant takes the canonical `_forwarded` host; resolve
             // the body OpRef to its producing `Op` / `InputArg` box first.
-            let box_ = ctx.materialize_box_at(opref);
-            ctx.seed_constant(&Operand::from_boxref(&box_), value.clone());
+            let op_ = ctx.materialize_operand_at(opref);
+            ctx.seed_constant(&op_, value.clone());
         }
 
         // Setup all passes
@@ -4661,10 +4648,10 @@ impl Optimizer {
             // `orig_op` identity (before get_box_replacement), so resolve to the
             // producer box without following `_forwarded`.
             if self.can_replace_guards {
-                if let Some(replacement) = ctx.resolve_to_boxref(op.pos.get()).and_then(|box_ref| {
-                    self.replaces_guard
-                        .remove(&majit_ir::operand::Operand::from_boxref(&box_ref))
-                }) {
+                if let Some(replacement) = ctx
+                    .resolve_to_operand(op.pos.get())
+                    .and_then(|op_key| self.replaces_guard.remove(&op_key))
+                {
                     let target_pos = replacement.pos.get().raw() as usize;
                     if target_pos < ctx.new_operations.len() {
                         if std::env::var_os("MAJIT_LOG").is_some() {
@@ -4754,9 +4741,7 @@ impl Optimizer {
         // descriptor-sharing or other emit-bound state. Keyed by the
         // emitted op's canonical box (the box-identity analog of `op`).
         self.emitted_operations
-            .insert(majit_ir::operand::Operand::from_boxref(
-                &ctx.get_box_replacement(emitted),
-            ));
+            .insert(ctx.get_box_replacement_operand(emitted));
         // optimizer.py:84-92 `_emit_operation` clears the REMOVED
         // sentinel on each successful emit. Cross-pass readers
         // (rewrite.py:712-718 `optimize_GUARD_NO_EXCEPTION`) see the
@@ -5282,7 +5267,7 @@ impl Optimizer {
             return op;
         }
         // optimizer.py:762: constvalue = op.getarg(1).getint()
-        let Some(constvalue) = op.arg(1).to_boxref().get_box_replacement(false).const_int() else {
+        let Some(constvalue) = op.arg(1).get_box_replacement(false).const_int() else {
             return op;
         };
         // optimizer.py:763-775: 0 → GUARD_FALSE, 1 → GUARD_TRUE, else give up.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3655,6 +3655,15 @@ impl Optimizer {
                     }
                 };
                 let remap_boxref = |arg: &mut majit_ir::box_ref::BoxRef| {
+                    // A bound box live-tracks its producer's `op.pos`, already
+                    // moved to the new dense slot by the main loop above, so it
+                    // needs no rewrite — and a `from_opref` re-mint would sever
+                    // the bound carry into a stale position-only box. Only
+                    // position-only boxes (test fixtures) carry a pre-remap
+                    // position the table must rewrite.
+                    if arg.bound_op().is_some() || arg.bound_inputarg().is_some() {
+                        return;
+                    }
                     let mut opref = arg.to_opref();
                     remap_opref(&mut opref);
                     *arg = majit_ir::box_ref::BoxRef::from_opref(opref);
@@ -3665,6 +3674,14 @@ impl Optimizer {
                 // compaction: a `from_opref` re-mint would sever the ptr_eq carry
                 // that import_state's exported_infos lookup depends on.
                 for arg in &state.next_iteration_args {
+                    // A bound arg live-tracks its producer's `op.pos`, already
+                    // remapped by the main loop, so it needs no `set_position`;
+                    // its Rc identity (the exported_infos key) is preserved
+                    // untouched. Only position-only args (test fixtures) carry a
+                    // pre-remap position the table must rewrite.
+                    if arg.bound_op().is_some() || arg.bound_inputarg().is_some() {
+                        continue;
+                    }
                     let opref = arg.to_opref();
                     // Const args carry their value inline (no body position):
                     // `set_position` is a Const no-op and `opref.raw()` panics on
@@ -3684,10 +3701,13 @@ impl Optimizer {
                     remap_boxref(arg);
                 }
                 for arg in &state.short_inputargs {
-                    // Renamed-box positions track op compaction through the
-                    // shared `set_position` Cell (no-op for InputArg/Const
-                    // kinds, whose positions are not subject to compaction);
-                    // every holder of the same box object sees the update.
+                    // A bound short inputarg live-tracks its producer's
+                    // `op.pos`, already remapped by the main loop, so it needs
+                    // no rewrite. Only position-only boxes (test fixtures) carry
+                    // a pre-remap position the table must rewrite.
+                    if arg.bound_op().is_some() || arg.bound_inputarg().is_some() {
+                        continue;
+                    }
                     let mut opref = arg.to_opref();
                     remap_opref(&mut opref);
                     arg.set_position(opref.raw());

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1264,14 +1264,8 @@ impl Optimization for OptPure {
             // (shortpreamble.py:425 — the replay op carries the same Box
             // objects); reuse them instead of re-deriving position-only
             // echoes from the OpRef table.
-            let imported_args = entry.pop.preamble_op.getarglist();
-            let mut imported_op = Op::new(
-                entry.opcode,
-                &imported_args
-                    .iter()
-                    .map(Operand::from_boxref)
-                    .collect::<Vec<_>>(),
-            );
+            let imported_args = entry.pop.preamble_op.getarglist_operand();
+            let mut imported_op = Op::new(entry.opcode, &imported_args);
             imported_op.pos.set(entry.result);
             if let Some(d) = entry.descr.clone() {
                 imported_op.setdescr(d);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1560,18 +1560,13 @@ impl ProducedShortOp {
         // and corrupts the SAME_AS in `extra_same_as`.
         // Non-invented re-uses self.res directly without forwarding.
         if self.invented_name {
-            let b_source = match ctx.get_box_replacement_box(source) {
-                Some(b) => b,
-                None => ctx.mint_box_at(source),
-            };
-            let b_result = match ctx.get_box_replacement_box(result_opref) {
-                Some(b) => b,
-                None => ctx.mint_box_at(result_opref),
-            };
-            ctx.make_equal_to(
-                &Operand::from_boxref(&b_source),
-                &Operand::from_boxref(&b_result),
-            );
+            let op_source = ctx
+                .get_box_replacement_operand_opt(source)
+                .unwrap_or_else(|| ctx.materialize_operand_at(source));
+            let op_result = ctx
+                .get_box_replacement_operand_opt(result_opref)
+                .unwrap_or_else(|| ctx.materialize_operand_at(result_opref));
+            ctx.make_equal_to(&op_source, &op_result);
         }
         // `result_opref` is a typed synthetic alias minted by
         // `add_op_to_short` via `ctx.alloc_op_position_typed(arg_type)`
@@ -1780,18 +1775,13 @@ impl ProducedShortOp {
         // Cat-2.2 alignment: forward `source -> result_opref` after the
         // PtrInfo / const-info side tables have been seeded (so the seeds
         // see the unforwarded source key consistent with `pop.op = source`).
-        let b_source = match ctx.get_box_replacement_box(source) {
-            Some(b) => b,
-            None => ctx.mint_box_at(source),
-        };
-        let b_result = match ctx.get_box_replacement_box(result_opref) {
-            Some(b) => b,
-            None => ctx.mint_box_at(result_opref),
-        };
-        ctx.make_equal_to(
-            &Operand::from_boxref(&b_source),
-            &Operand::from_boxref(&b_result),
-        );
+        let op_source = ctx
+            .get_box_replacement_operand_opt(source)
+            .unwrap_or_else(|| ctx.materialize_operand_at(source));
+        let op_result = ctx
+            .get_box_replacement_operand_opt(result_opref)
+            .unwrap_or_else(|| ctx.materialize_operand_at(result_opref));
+        ctx.make_equal_to(&op_source, &op_result);
         // see produce_pure: extra_same_as collected lazily by
         // imported_short_preamble_builder; eager push would be a dual-write.
         Some(source)
@@ -1929,18 +1919,13 @@ impl ProducedShortOp {
         }
         // Cat-2.2 alignment: forward `source -> result_opref` after the
         // const-info / ArrayPtrInfo side tables have been seeded.
-        let b_source = match ctx.get_box_replacement_box(source) {
-            Some(b) => b,
-            None => ctx.mint_box_at(source),
-        };
-        let b_result = match ctx.get_box_replacement_box(result_opref) {
-            Some(b) => b,
-            None => ctx.mint_box_at(result_opref),
-        };
-        ctx.make_equal_to(
-            &Operand::from_boxref(&b_source),
-            &Operand::from_boxref(&b_result),
-        );
+        let op_source = ctx
+            .get_box_replacement_operand_opt(source)
+            .unwrap_or_else(|| ctx.materialize_operand_at(source));
+        let op_result = ctx
+            .get_box_replacement_operand_opt(result_opref)
+            .unwrap_or_else(|| ctx.materialize_operand_at(result_opref));
+        ctx.make_equal_to(&op_source, &op_result);
         // see produce_pure: extra_same_as collected lazily by
         // imported_short_preamble_builder; eager push would be a dual-write.
         Some(source)
@@ -1988,18 +1973,13 @@ impl ProducedShortOp {
         // get_box_replacement uniformly.
         let result_opref = *result_map.get(&source)?;
         let _ = result_type;
-        let b_source = match ctx.get_box_replacement_box(source) {
-            Some(b) => b,
-            None => ctx.mint_box_at(source),
-        };
-        let b_result = match ctx.get_box_replacement_box(result_opref) {
-            Some(b) => b,
-            None => ctx.mint_box_at(result_opref),
-        };
-        ctx.make_equal_to(
-            &Operand::from_boxref(&b_source),
-            &Operand::from_boxref(&b_result),
-        );
+        let op_source = ctx
+            .get_box_replacement_operand_opt(source)
+            .unwrap_or_else(|| ctx.materialize_operand_at(source));
+        let op_result = ctx
+            .get_box_replacement_operand_opt(result_opref)
+            .unwrap_or_else(|| ctx.materialize_operand_at(result_opref));
+        ctx.make_equal_to(&op_source, &op_result);
         // `rewrite.py:31` `self.opt.loop_invariant_results[key] = old_op` —
         // dict-as-map semantics; pyre's Vec-backed parity overwrites the
         // entry when `func_ptr` already exists (PyPy dict behavior),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4481,11 +4481,8 @@ impl OptUnroll {
         if let Some(bound) = exported_int_bounds.and_then(|bounds| {
             // Same Phase-1 ctx as the export producer, so the canonical box for
             // `opref` is the memoized `Rc` the bound was keyed under (ptr_eq).
-            ctx.get_box_replacement_box(opref).and_then(|b| {
-                bounds
-                    .get(&majit_ir::operand::Operand::from_boxref(&b))
-                    .cloned()
-            })
+            ctx.get_box_replacement_operand_opt(opref)
+                .and_then(|o| bounds.get(&o).cloned())
         }) {
             return Some(OpInfo::int_bound(bound));
         }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -111,7 +111,7 @@ pub fn copy_str_content(
     mode: u8,
     need_next_offset: bool,
 ) -> Option<Operand> {
-    let srcbox = ctx.resolve_box_operand(&srcbox.to_boxref());
+    let srcbox = ctx.resolve_operand_operand(&srcbox);
     let (set_opcode, copy_opcode) = if mode != 0 {
         (OpCode::Unicodesetitem, OpCode::Copyunicodecontent)
     } else {
@@ -170,9 +170,9 @@ pub fn copy_str_content(
                     ctx.materialize_operand_at(ch)
                 };
                 src_offset = _int_add(&src_offset, &one, ctx);
-                let arg_target = ctx.resolve_box_operand(&targetbox.to_boxref());
-                let arg_dst_off = ctx.resolve_box_operand(&dst_offset.to_boxref());
-                let arg_char = ctx.resolve_box_operand(&charbox.to_boxref());
+                let arg_target = ctx.resolve_operand_operand(&targetbox);
+                let arg_dst_off = ctx.resolve_operand_operand(&dst_offset);
+                let arg_char = ctx.resolve_operand_operand(&charbox);
                 let setitem_op = Op::new(
                     set_opcode,
                     &[arg_target.clone(), arg_dst_off.clone(), arg_char.clone()],
@@ -195,11 +195,11 @@ pub fn copy_str_content(
     } else {
         None
     };
-    let arg_src = ctx.resolve_box_operand(&srcbox.to_boxref());
-    let arg_target = ctx.resolve_box_operand(&targetbox.to_boxref());
-    let arg_srcoff = ctx.resolve_box_operand(&srcoffsetbox.to_boxref());
-    let arg_off = ctx.resolve_box_operand(&offsetbox.to_boxref());
-    let arg_len = ctx.resolve_box_operand(&lengthbox.to_boxref());
+    let arg_src = ctx.resolve_operand_operand(&srcbox);
+    let arg_target = ctx.resolve_operand_operand(&targetbox);
+    let arg_srcoff = ctx.resolve_operand_operand(&srcoffsetbox);
+    let arg_off = ctx.resolve_operand_operand(&offsetbox);
+    let arg_len = ctx.resolve_operand_operand(&lengthbox);
     let copy_op = Op::new(
         copy_opcode,
         &[
@@ -285,8 +285,8 @@ pub fn string_copy_parts(
             for ch in &chars {
                 if let Some(ch_ref) = ch {
                     let arg_char = ctx.resolve_operand_operand(ch_ref);
-                    let arg_target = ctx.resolve_box_operand(&targetbox.to_boxref());
-                    let arg_offset = ctx.resolve_box_operand(&offset.to_boxref());
+                    let arg_target = ctx.resolve_operand_operand(&targetbox);
+                    let arg_offset = ctx.resolve_operand_operand(&offset);
                     let setitem_op = Op::new(
                         set_opcode,
                         &[arg_target.clone(), arg_offset.clone(), arg_char.clone()],
@@ -339,7 +339,7 @@ fn force_child_for_string(opref: &Operand, ctx: &mut OptContext) -> Operand {
         let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
         let forced = info.force_box(&resolved_box, ctx);
         let forced_box = ctx.materialize_operand_at(forced);
-        return ctx.resolve_box_operand(&forced_box.to_boxref());
+        return ctx.resolve_operand_operand(&forced_box);
     }
     resolved
 }
@@ -611,8 +611,8 @@ impl OptString {
         } else {
             OpCode::Strgetitem
         };
-        let arg_str = ctx.resolve_box_operand(&strbox.to_boxref());
-        let arg_index = ctx.resolve_box_operand(&index_box.to_boxref());
+        let arg_str = ctx.resolve_operand_operand(&strbox);
+        let arg_index = ctx.resolve_operand_operand(&index_box);
         // vstring.py:411-415 emit_extra(resbox). emit_for_force routes to
         // emit() during forcing (in_final_emission, the copy_str_content path)
         // and to emit_extra(current_pass_idx) during the pass — identical to
@@ -787,8 +787,8 @@ impl OptString {
             // materialized here, ahead of upstream's timing. Convergence needs
             // force_box to run over an emitted op's args at emission time.
             self.force_if_virtual(&target, ctx);
-            let arg_s = ctx.resolve_box_operand(&target.to_boxref());
-            let arg_i = ctx.resolve_box_operand(&index_box.to_boxref());
+            let arg_s = ctx.resolve_operand_operand(&target);
+            let arg_i = ctx.resolve_operand_operand(&index_box);
             let get_opcode = if mode == mode_unicode {
                 OpCode::Unicodegetitem
             } else {
@@ -1041,8 +1041,8 @@ impl OptString {
                 return ctx.materialize_operand_at(__c);
             }
         }
-        let arg_a = ctx.resolve_box_operand(&a.to_boxref());
-        let arg_b = ctx.resolve_box_operand(&b.to_boxref());
+        let arg_a = ctx.resolve_operand_operand(&a);
+        let arg_b = ctx.resolve_operand_operand(&b);
         let op = Op::new(OpCode::IntSub, &[arg_a.clone(), arg_b.clone()]);
         let __r = ctx.emit_for_force(op);
         ctx.materialize_operand_at(__r)

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -607,7 +607,7 @@ fn clone_bridge_ops_preserving_value(bridge_ops: &[majit_ir::Op]) -> Vec<majit_i
         .collect()
 }
 
-fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<majit_ir::box_ref::BoxRef>]) -> OpRef {
+fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<majit_ir::operand::Operand>]) -> OpRef {
     if opref.is_none() || opref.is_constant() {
         return opref;
     }
@@ -631,7 +631,7 @@ fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<majit_ir::box_ref::B
 
 fn translate_trace_iter_box_map(
     mut box_map: SnapshotBoxes,
-    cache: &[Option<majit_ir::box_ref::BoxRef>],
+    cache: &[Option<majit_ir::operand::Operand>],
 ) -> SnapshotBoxes {
     for boxes in box_map.iter_mut().flatten() {
         for boxref in boxes.iter_mut() {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1543,10 +1543,12 @@ impl<M: Clone> MetaInterp<M> {
         // Python object graph automatically; pyre's `Vec<Option<OpRef>>`
         // storage needs an explicit walker. Independent of `self.tracing`:
         // frames are pushed for both recording and recursive-portal calls.
-        for frame in self.framestack.frames.iter() {
-            for slot in frame.ref_regs.iter() {
-                if let Some(b) = slot.as_ref() {
-                    b.walk_const_ptr_refs(&mut visitor);
+        for frame in self.framestack.frames.iter_mut() {
+            for slot in frame.ref_regs.iter_mut() {
+                // Forward the inline `ConstPtr` gcref in place; non-Const
+                // positions (ResOp / InputArg refs) carry no inline ref.
+                if let Some(majit_ir::OpRef::ConstPtr(gcref)) = slot.as_mut() {
+                    visitor(gcref);
                 }
             }
         }
@@ -15483,10 +15485,7 @@ mod metainterp_static_data_tests {
         assert_eq!(f.int_values[0], Some(100));
         assert_eq!(f.int_regs[1], Some(OpRef::int_op(11)));
         assert_eq!(f.int_values[1], Some(101));
-        assert_eq!(
-            f.ref_regs[0].as_ref().map(|b| b.to_opref()),
-            Some(OpRef::ref_op(20))
-        );
+        assert_eq!(f.ref_regs[0], Some(OpRef::ref_op(20)));
         assert_eq!(f.ref_values[0], Some(200));
         assert_eq!(f.float_regs[0], Some(OpRef::float_op(30)));
         assert_eq!(f.float_values[0], Some(300));

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1226,7 +1226,7 @@ where
                 .iter()
                 .zip(frame.ref_values.iter())
                 .find_map(|(slot, concrete)| {
-                    (slot.as_ref().map(|b| b.to_opref()) == Some(vable_opref))
+                    (*slot == Some(vable_opref))
                         .then_some(*concrete)
                         .flatten()
                         .map(|value| value as usize as *mut u8)
@@ -1386,10 +1386,7 @@ where
             let rn = sym
                 .ref_identity_slots_end()
                 .min(self.frames.frames[0].ref_regs.len());
-            // main migrated the ref register bank to `BoxRef`; infer the
-            // saved-bank element type from `ref_regs` so the save/restore
-            // tracks that bank's box representation.
-            let saved_ref_regs = self.frames.frames[0].ref_regs[..rn].to_vec();
+            let saved_ref_regs: Vec<Option<OpRef>> = self.frames.frames[0].ref_regs[..rn].to_vec();
             let saved_ref_values: Vec<Option<i64>> =
                 self.frames.frames[0].ref_values[..rn].to_vec();
             let root_inflight_int_result =
@@ -1446,7 +1443,7 @@ where
             }
             for idx in 0..rn {
                 if Some(idx) != root_inflight_ref_result {
-                    self.frames.frames[0].ref_regs[idx] = saved_ref_regs[idx].clone();
+                    self.frames.frames[0].ref_regs[idx] = saved_ref_regs[idx];
                     self.frames.frames[0].ref_values[idx] = saved_ref_values[idx];
                 }
             }
@@ -2421,8 +2418,7 @@ where
                 }
                 JitArgKind::Ref => {
                     let (value, concrete) = self.read_ref_reg(caller_src);
-                    portal_frame.ref_regs[callee_dst] =
-                        Some(majit_ir::box_ref::BoxRef::from_opref(value));
+                    portal_frame.ref_regs[callee_dst] = Some(value);
                     portal_frame.ref_values[callee_dst] = Some(concrete);
                 }
                 JitArgKind::Float => {
@@ -3964,11 +3960,7 @@ where
                             // bug.
                             let opref_opt = match slot {
                                 0 => frame.int_regs.get(reg_idx).copied().flatten(),
-                                1 => frame
-                                    .ref_regs
-                                    .get(reg_idx)
-                                    .and_then(|o| o.as_ref())
-                                    .map(|b| b.to_opref()),
+                                1 => frame.ref_regs.get(reg_idx).copied().flatten(),
                                 2 => frame.float_regs.get(reg_idx).copied().flatten(),
                                 _ => unreachable!(),
                             };
@@ -4215,8 +4207,7 @@ where
                         }
                         JitArgKind::Ref => {
                             let (value, concrete) = self.read_ref_reg(caller_src);
-                            sub_frame.ref_regs[callee_dst] =
-                                Some(majit_ir::box_ref::BoxRef::from_opref(value));
+                            sub_frame.ref_regs[callee_dst] = Some(value);
                             sub_frame.ref_values[callee_dst] = Some(concrete);
                         }
                         JitArgKind::Float => {
@@ -6238,17 +6229,14 @@ where
 
     fn set_ref_reg(&mut self, reg: usize, opref: Option<OpRef>, value: Option<i64>) {
         let frame = self.frames.current_mut();
-        frame.ref_regs[reg] = opref.map(majit_ir::box_ref::BoxRef::from_opref);
+        frame.ref_regs[reg] = opref;
         frame.ref_values[reg] = value;
     }
 
     fn read_ref_reg(&mut self, reg: usize) -> (OpRef, i64) {
         let frame = self.frames.current_mut();
         (
-            frame.ref_regs[reg]
-                .as_ref()
-                .expect("jitcode ref register was uninitialized")
-                .to_opref(),
+            frame.ref_regs[reg].expect("jitcode ref register was uninitialized"),
             frame.ref_values[reg].expect("jitcode concrete ref register was uninitialized"),
         )
     }
@@ -8996,9 +8984,7 @@ mod tests {
         sub.parent_descr_idx = 3;
         sub.int_regs[0] = Some(majit_ir::OpRef::int_op(11));
         sub.int_values[0] = Some(110);
-        sub.ref_regs[0] = Some(majit_ir::box_ref::BoxRef::from_opref(
-            majit_ir::OpRef::ref_op(22),
-        ));
+        sub.ref_regs[0] = Some(majit_ir::OpRef::ref_op(22));
         sub.ref_values[0] = Some(220);
         sub.float_regs[0] = Some(majit_ir::OpRef::float_op(33));
         sub.float_values[0] = Some(330);

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -13,7 +13,6 @@ use majit_ir::{OpRef, Type};
 use crate::jitcode::{JitArgKind, JitCode, read_u8, read_u16};
 use crate::opencoder::{Box as OpBox, TraceRecordBuffer};
 use crate::recorder::SnapshotTagged;
-use majit_ir::box_ref::BoxRef;
 
 /// Map an int register (OpRef, concrete value) to an `OpBox`.
 /// Constant OpRefs materialize as `ConstInt(value)`; real trace slots
@@ -37,8 +36,8 @@ fn register_to_box_int(opref: OpRef, value: i64) -> OpBox {
 fn register_to_box_ref(opref: OpRef, value: i64) -> OpBox {
     if opref.is_constant() {
         // history.py:314 `ConstPtr.value` is the single object field. The
-        // forwarded gcref lives in the ConstPtr payload (the `ref_regs`
-        // BoxRef's Cell, updated in place by `walk_active_trace_refs`), so
+        // forwarded gcref lives in the inline `OpRef::ConstPtr` payload
+        // (`ref_regs[i]`, updated in place by `walk_active_trace_refs`), so
         // read it from `opref` rather than the unforwarded `ref_values`
         // mirror, which is stale after a moving collection.
         let bits = match opref {
@@ -80,7 +79,7 @@ pub struct MIFrame {
     pub code_cursor: usize,
     pub int_regs: Vec<Option<OpRef>>,
     pub int_values: Vec<Option<i64>>,
-    pub ref_regs: Vec<Option<BoxRef>>,
+    pub ref_regs: Vec<Option<OpRef>>,
     pub ref_values: Vec<Option<i64>>,
     pub float_regs: Vec<Option<OpRef>>,
     pub float_values: Vec<Option<i64>>,
@@ -446,7 +445,7 @@ impl MIFrame {
         let num_regs_r = self.jitcode.c_num_regs_r as usize;
         for (i, &value) in self.jitcode.constants_r.iter().enumerate() {
             let slot = num_regs_r + i;
-            self.ref_regs[slot] = Some(BoxRef::from_opref(ctx.const_ref(value)));
+            self.ref_regs[slot] = Some(ctx.const_ref(value));
             self.ref_values[slot] = Some(value);
         }
         let num_regs_f = self.jitcode.c_num_regs_f as usize;
@@ -541,7 +540,7 @@ impl MIFrame {
                 self.int_values[target_index] = Some(concrete);
             }
             JitArgKind::Ref => {
-                self.ref_regs[target_index] = Some(BoxRef::from_opref(opref));
+                self.ref_regs[target_index] = Some(opref);
                 self.ref_values[target_index] = Some(concrete);
             }
             JitArgKind::Float => {
@@ -637,7 +636,7 @@ impl MIFrame {
                     }
                     b'r' => {
                         let opref = OpRef::const_ptr(majit_ir::GcRef::NULL);
-                        self.ref_regs[index] = Some(BoxRef::from_opref(opref));
+                        self.ref_regs[index] = Some(opref);
                         self.ref_values[index] = Some(0);
                         (None, None, None)
                     }
@@ -735,9 +734,7 @@ impl MIFrame {
                     OpBox::ConstPtr(0)
                 } else if idx < num_regs_r {
                     let opref = self.ref_regs[idx]
-                        .as_ref()
-                        .expect("get_list_of_active_boxes: ref register uninitialized")
-                        .to_opref();
+                        .expect("get_list_of_active_boxes: ref register uninitialized");
                     let value = self.ref_values[idx]
                         .expect("get_list_of_active_boxes: ref value uninitialized");
                     register_to_box_ref(opref, value)
@@ -813,7 +810,7 @@ impl MIFrame {
                     }
                     b'r' => {
                         let opref = OpRef::const_ptr(majit_ir::GcRef::NULL);
-                        self.ref_regs[index] = Some(BoxRef::from_opref(opref));
+                        self.ref_regs[index] = Some(opref);
                         self.ref_values[index] = Some(0);
                     }
                     b'f' => {
@@ -888,14 +885,12 @@ impl MIFrame {
                     SnapshotTagged::Const(0, Type::Ref)
                 } else if idx < num_regs_r {
                     let opref = self.ref_regs[idx]
-                        .as_ref()
-                        .expect("get_list_of_active_snapshot_boxes: ref register uninitialized")
-                        .to_opref();
+                        .expect("get_list_of_active_snapshot_boxes: ref register uninitialized");
                     let value = self.ref_values[idx]
                         .expect("get_list_of_active_snapshot_boxes: ref value uninitialized");
                     if opref.is_constant() {
                         // history.py:314 `ConstPtr.value` — take the forwarded
-                        // gcref from the BoxRef-derived ConstPtr, not the
+                        // gcref from the inline `OpRef::ConstPtr`, not the
                         // unforwarded `ref_values` mirror (stale after a move).
                         let bits = match opref {
                             OpRef::ConstPtr(gcref) => gcref.0 as i64,
@@ -969,21 +964,13 @@ impl MIFrame {
     /// once via `TraceCtx::get_opref_type`. `Type::Void` panics with the
     /// upstream assertion message.
     pub fn replace_active_box_in_frame(&mut self, oldbox: OpRef, newbox: OpRef, oldbox_type: Type) {
-        // `ref_regs` stores `BoxRef`; the int/float banks stay `OpRef`. The
-        // shared replace logic compares by OpRef value (pyre's flat-OpRef
-        // adaptation of pyjitpl.py:240 `registers[i] is oldbox`), so the
-        // ref bank round-trips through `to_opref`/`from_opref`.
+        // All three banks are flat `Vec<Option<OpRef>>`; the shared replace
+        // logic compares by OpRef value (pyre's flat-OpRef adaptation of
+        // pyjitpl.py:240 `registers[i] is oldbox`).
         let registers = match oldbox_type {
             Type::Int => &mut self.int_regs,
             Type::Float => &mut self.float_regs,
-            Type::Ref => {
-                for slot in self.ref_regs.iter_mut() {
-                    if slot.as_ref().map(|b| b.to_opref()) == Some(oldbox) {
-                        *slot = Some(BoxRef::from_opref(newbox));
-                    }
-                }
-                return;
-            }
+            Type::Ref => &mut self.ref_regs,
             // pyjitpl.py:236-244 `else: assert 0, oldbox` — RPython rejects
             // any box whose `type` attribute is not 'i' / 'r' / 'f'.
             // Mirroring that assertion strength keeps the contract: the
@@ -1019,7 +1006,7 @@ impl MIFrame {
                     count_i += 1;
                 }
                 JitArgKind::Ref => {
-                    self.ref_regs[count_r] = Some(BoxRef::from_opref(*value));
+                    self.ref_regs[count_r] = Some(*value);
                     self.ref_values[count_r] = Some(*concrete);
                     count_r += 1;
                 }
@@ -1116,15 +1103,9 @@ mod tests {
         assert_eq!(frame.int_values[0], Some(100));
         assert_eq!(frame.int_regs[1], Some(OpRef::int_op(11)));
         assert_eq!(frame.int_values[1], Some(101));
-        assert_eq!(
-            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
-            Some(OpRef::ref_op(20))
-        );
+        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(20)));
         assert_eq!(frame.ref_values[0], Some(200));
-        assert_eq!(
-            frame.ref_regs[1].as_ref().map(|b| b.to_opref()),
-            Some(OpRef::ref_op(21))
-        );
+        assert_eq!(frame.ref_regs[1], Some(OpRef::ref_op(21)));
         assert_eq!(frame.ref_values[1], Some(201));
         assert_eq!(frame.float_regs[0], Some(OpRef::float_op(30)));
         assert_eq!(frame.float_values[0], Some(300));
@@ -1164,9 +1145,7 @@ mod tests {
         frame.int_regs[0] = Some(OpRef::int_op(5));
         frame.int_values[0] = Some(0);
         // ref_regs[0] constant pointer addr=0xdead_beef → Box::ConstPtr.
-        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::const_ptr(majit_ir::GcRef(
-            0xdead_beef,
-        ))));
+        frame.ref_regs[0] = Some(OpRef::const_ptr(majit_ir::GcRef(0xdead_beef)));
         frame.ref_values[0] = Some(0xdead_beef);
 
         let sd = Arc::new(crate::MetaInterpStaticData::new());
@@ -1447,7 +1426,7 @@ mod tests {
         let mut frame = MIFrame::new(jitcode.clone(), 0);
         frame.int_regs[0] = Some(OpRef::int_op(1));
         frame.int_values[0] = Some(11);
-        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::ref_op(2)));
+        frame.ref_regs[0] = Some(OpRef::ref_op(2));
         frame.ref_values[0] = Some(22);
         frame.float_regs[0] = Some(OpRef::float_op(3));
         frame.float_values[0] = Some(33);
@@ -1480,7 +1459,7 @@ mod tests {
         frame.int_regs[0] = Some(OpRef::int_op(7));
         frame.int_regs[1] = Some(OpRef::int_op(8));
         frame.int_regs[2] = Some(OpRef::int_op(7)); // duplicate — must also flip.
-        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::ref_op(7))); // same raw u32 but different bank/variant.
+        frame.ref_regs[0] = Some(OpRef::ref_op(7)); // same raw u32 but different bank/variant.
         frame.float_regs[0] = Some(OpRef::float_op(7));
 
         frame.replace_active_box_in_frame(OpRef::int_op(7), OpRef::int_op(42), Type::Int);
@@ -1489,10 +1468,7 @@ mod tests {
         assert_eq!(frame.int_regs[1], Some(OpRef::int_op(8)));
         assert_eq!(frame.int_regs[2], Some(OpRef::int_op(42)));
         // Ref / float banks untouched — bank dispatch is by oldbox.type.
-        assert_eq!(
-            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
-            Some(OpRef::ref_op(7))
-        );
+        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(7)));
         assert_eq!(frame.float_regs[0], Some(OpRef::float_op(7)));
     }
 
@@ -1501,13 +1477,10 @@ mod tests {
     fn replace_active_box_in_frame_returns_early_when_bank_empty() {
         let jitcode = make_jitcode_with_regs(0, 1, 0);
         let mut frame = MIFrame::new(jitcode, 0);
-        frame.ref_regs[0] = Some(BoxRef::from_opref(OpRef::ref_op(7)));
+        frame.ref_regs[0] = Some(OpRef::ref_op(7));
         frame.replace_active_box_in_frame(OpRef::int_op(7), OpRef::int_op(42), Type::Int);
         // Int bank empty — ref bank stays untouched.
-        assert_eq!(
-            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
-            Some(OpRef::ref_op(7))
-        );
+        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(7)));
     }
 
     /// Type::Void is not a valid box type (pyjitpl.py:246 `assert 0,
@@ -1535,10 +1508,7 @@ mod tests {
 
         frame.pc = 1;
         frame.make_result_of_lastop(JitArgKind::Ref, 0, OpRef::ref_op(8), 88);
-        assert_eq!(
-            frame.ref_regs[0].as_ref().map(|b| b.to_opref()),
-            Some(OpRef::ref_op(8))
-        );
+        assert_eq!(frame.ref_regs[0], Some(OpRef::ref_op(8)));
         assert_eq!(frame.ref_values[0], Some(88));
 
         frame.pc = 2;

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -88,13 +88,14 @@ pub const TAG_CONST_OFFSET: i32 = 0;
 /// resume.py:137/370: RPython uses `dict` keyed by the actual Box object
 /// (object `is` identity). In Python 3 that dict is insertion-ordered, and
 /// `_number_virtuals` iterates it directly. #160/S11 keys this map by the
-/// canonical [`BoxRef`](majit_ir::box_ref::BoxRef) (`Rc::ptr_eq` = PyPy `box is
-/// box`), the faithful port of the dict-by-`is`; the no-HashMap house rule
-/// keeps the `VecMap` backing (linear scan, dict-assignment semantics,
-/// preserved insertion order). Two reaches of one logical box resolve to one
-/// memoized Rc (via `from_bound_op`/`from_bound_inputarg`) and collapse to one
-/// key; distinct boxes — e.g. an `InputArg` vs a `ResOp` result — stay
-/// distinct, where a raw-position key could have aliased them.
+/// canonical [`Operand`](majit_ir::operand::Operand) (`Rc::ptr_eq` on the
+/// producer = PyPy `box is box`), the faithful port of the dict-by-`is` —
+/// `Operand` IS the box object `resume.py liveboxes` stores; the no-HashMap
+/// house rule keeps the `VecMap` backing (linear scan, dict-assignment
+/// semantics, preserved insertion order). Two reaches of one logical box
+/// resolve to one producer Rc (via `from_bound_op`/`from_bound_inputarg`) and
+/// collapse to one key; distinct boxes — e.g. an `InputArg` vs a `ResOp`
+/// result — stay distinct, where a raw-position key could have aliased them.
 ///
 /// Invariant: keys are never Const boxes. Per `resume.py:204-205`
 /// `_number_boxes`, `isinstance(box, Const)` short-circuits to
@@ -116,34 +117,30 @@ impl LiveboxMap {
     }
 
     #[inline(always)]
-    pub fn get(&self, b: &majit_ir::box_ref::BoxRef) -> Option<i16> {
-        self.entries
-            .get(&majit_ir::operand::Operand::from_boxref(b))
-            .copied()
+    pub fn get(&self, b: &majit_ir::operand::Operand) -> Option<i16> {
+        self.entries.get(b).copied()
     }
 
     #[inline(always)]
-    pub fn insert(&mut self, b: majit_ir::box_ref::BoxRef, value: i16) {
+    pub fn insert(&mut self, b: majit_ir::operand::Operand, value: i16) {
         debug_assert!(
             b.const_value().is_none(),
             "LiveboxMap::insert: Const box {b:?} violates resume.py:204-223 \
              `_number_boxes` invariant — `isinstance(box, Const)` is encoded \
              via `getconst(box)` and never enters numb_state.liveboxes",
         );
-        self.entries
-            .insert(majit_ir::operand::Operand::from_boxref(&b), value);
+        self.entries.insert(b, value);
     }
 
     #[inline(always)]
-    pub fn contains_key(&self, b: &majit_ir::box_ref::BoxRef) -> bool {
-        self.entries
-            .contains_key(&majit_ir::operand::Operand::from_boxref(b))
+    pub fn contains_key(&self, b: &majit_ir::operand::Operand) -> bool {
+        self.entries.contains_key(b)
     }
 
     /// Iterate over all (canonical box, tag) pairs in RPython dict insertion
     /// order (Rc::ptr_eq identity = PyPy `box is box`).
-    pub fn iter(&self) -> impl Iterator<Item = (majit_ir::box_ref::BoxRef, i16)> + '_ {
-        self.entries.iter().map(|(op, v)| (op.to_boxref(), *v))
+    pub fn iter(&self) -> impl Iterator<Item = (majit_ir::operand::Operand, i16)> + '_ {
+        self.entries.iter().map(|(op, v)| (op.clone(), *v))
     }
 }
 
@@ -413,10 +410,10 @@ pub struct SimpleBoxEnv {
     pub types: majit_ir::VecMap<u32, majit_ir::Type>,
     pub virtuals: majit_ir::vec_set::VecSet<u32>,
     pub virtual_fields: majit_ir::VecMap<u32, majit_ir::VirtualFieldsInfo>,
-    /// #160/S11: one canonical BoxRef per replacement-walked OpRef. This env
-    /// holds no producer Ops, so it memoizes here to give `Rc::ptr_eq` dedup
+    /// #160/S11: one canonical box `Operand` per replacement-walked OpRef. This
+    /// env holds no producer Ops, so it memoizes here to give `Rc::ptr_eq` dedup
     /// parity with production (where `from_bound_op` memoizes on the Op).
-    box_cache: std::cell::RefCell<majit_ir::VecMap<majit_ir::OpRef, majit_ir::box_ref::BoxRef>>,
+    box_cache: std::cell::RefCell<majit_ir::VecMap<majit_ir::OpRef, majit_ir::operand::Operand>>,
 }
 
 impl SimpleBoxEnv {
@@ -453,8 +450,8 @@ impl BoxEnv for SimpleBoxEnv {
         opref
     }
 
-    fn get_box_replacement_boxref(&self, opref: majit_ir::OpRef) -> majit_ir::box_ref::BoxRef {
-        // #160/S11: no producer Ops here, so memoize one BoxRef per
+    fn get_box_replacement_operand(&self, opref: majit_ir::OpRef) -> majit_ir::operand::Operand {
+        // #160/S11: no producer Ops here, so memoize one Operand per
         // replacement-walked OpRef to mirror production's from_bound_op
         // memoization — two reaches of one logical box share an Rc (ptr_eq).
         let root = self.get_box_replacement(opref);
@@ -466,9 +463,11 @@ impl BoxEnv for SimpleBoxEnv {
         // keyed liveboxes/cached maps reject a position-only box). The method
         // is never reached in non-test builds, where `from_opref` is retained.
         #[cfg(test)]
-        let b = crate::history::test_support::rooted_box_from_opref(root);
+        let b = majit_ir::operand::Operand::from_boxref(
+            &crate::history::test_support::rooted_box_from_opref(root),
+        );
         #[cfg(not(test))]
-        let b = majit_ir::box_ref::BoxRef::from_opref(root);
+        let b = majit_ir::operand::Operand::from_opref(root);
         self.box_cache.borrow_mut().insert(root, b.clone());
         b
     }
@@ -3367,13 +3366,10 @@ impl ResumeDataLoopMemo {
     /// - new: `boxes.append(box); num = -len(boxes)`
     pub fn assign_number_to_box(
         &mut self,
-        b: &majit_ir::box_ref::BoxRef,
+        b: &majit_ir::operand::Operand,
         boxes: &mut Vec<OpRef>,
     ) -> i32 {
-        if let Some(&num) = self
-            .cached_boxes
-            .get(&majit_ir::operand::Operand::from_boxref(b))
-        {
+        if let Some(&num) = self.cached_boxes.get(b) {
             // resume.py:268: boxes[-num - 1] = box
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
@@ -3384,8 +3380,7 @@ impl ResumeDataLoopMemo {
         // resume.py:270-271: boxes.append(box); num = -len(boxes)
         boxes.push(b.to_opref());
         let num = -(boxes.len() as i32);
-        self.cached_boxes
-            .insert(majit_ir::operand::Operand::from_boxref(b), num);
+        self.cached_boxes.insert(b.clone(), num);
         num
     }
 
@@ -3393,13 +3388,10 @@ impl ResumeDataLoopMemo {
     /// RPython's `new_liveboxes = [None] * memo.num_cached_boxes()`.
     pub fn assign_number_to_box_opt(
         &mut self,
-        b: &majit_ir::box_ref::BoxRef,
+        b: &majit_ir::operand::Operand,
         boxes: &mut Vec<Option<OpRef>>,
     ) -> i32 {
-        if let Some(&num) = self
-            .cached_boxes
-            .get(&majit_ir::operand::Operand::from_boxref(b))
-        {
+        if let Some(&num) = self.cached_boxes.get(b) {
             let idx = (-num - 1) as usize;
             if idx < boxes.len() {
                 boxes[idx] = Some(b.to_opref());
@@ -3408,23 +3400,18 @@ impl ResumeDataLoopMemo {
         }
         boxes.push(Some(b.to_opref()));
         let num = -(boxes.len() as i32);
-        self.cached_boxes
-            .insert(majit_ir::operand::Operand::from_boxref(b), num);
+        self.cached_boxes.insert(b.clone(), num);
         num
     }
 
     /// resume.py:278 assign_number_to_virtual — returns a negative number.
-    pub fn assign_number_to_virtual(&mut self, b: &majit_ir::box_ref::BoxRef) -> i32 {
-        if let Some(&num) = self
-            .cached_virtuals
-            .get(&majit_ir::operand::Operand::from_boxref(b))
-        {
+    pub fn assign_number_to_virtual(&mut self, b: &majit_ir::operand::Operand) -> i32 {
+        if let Some(&num) = self.cached_virtuals.get(b) {
             return num;
         }
         // resume.py:283: num = self.cached_virtuals[box] = -len(self.cached_virtuals) - 1
         let num = -(self.num_cached_virtuals() as i32) - 1;
-        self.cached_virtuals
-            .insert(majit_ir::operand::Operand::from_boxref(b), num);
+        self.cached_virtuals.insert(b.clone(), num);
         num
     }
 
@@ -3486,9 +3473,9 @@ impl ResumeDataLoopMemo {
         }
         // #160/S11: key by the canonical box (Rc::ptr_eq = PyPy `box is`).
         // `opref` is already replacement-walked by the caller, so re-walking
-        // through get_box_replacement_boxref is idempotent and yields the one
+        // through get_box_replacement_operand is idempotent and yields the one
         // memoized Rc per logical box.
-        let b = env.get_box_replacement_boxref(opref);
+        let b = env.get_box_replacement_operand(opref);
         if liveboxes_from_env.contains_key(&b) || new_liveboxes.contains_key(&b) {
             return;
         }
@@ -3512,7 +3499,7 @@ impl ResumeDataLoopMemo {
     ) {
         // #160/S11: key by the canonical box (Rc::ptr_eq). virtualbox is
         // replacement-walked by the caller; re-walking is idempotent.
-        let b = env.get_box_replacement_boxref(virtualbox);
+        let b = env.get_box_replacement_operand(virtualbox);
         let tagged = liveboxes_from_env.get(&b).unwrap_or(UNASSIGNEDVIRTUAL);
         new_liveboxes.insert(b, tagged);
     }
@@ -3548,7 +3535,7 @@ impl ResumeDataLoopMemo {
         // each entry was inserted with so virtual numbering preserves
         // `box.type` (history.py:220).
         // #160/S11: new_liveboxes.iter() yields the canonical box directly.
-        let keys: Vec<(majit_ir::box_ref::BoxRef, i16)> = new_liveboxes.iter().collect();
+        let keys: Vec<(majit_ir::operand::Operand, i16)> = new_liveboxes.iter().collect();
         for (box_id, tagged) in keys {
             let (_, tagbits) = untag(tagged);
             if tagbits == TAGBOX {
@@ -3604,7 +3591,7 @@ impl ResumeDataLoopMemo {
                 // new_liveboxes (nested virtuals discovered via worklist).
                 let opref = opref_id;
                 // #160/S11: liveboxes is box-keyed; form the canonical box.
-                let b = env.get_box_replacement_boxref(opref);
+                let b = env.get_box_replacement_operand(opref);
                 let tagged = numb_state
                     .liveboxes
                     .get(&b)
@@ -3635,24 +3622,18 @@ impl ResumeDataLoopMemo {
                                 return self.getconst(val, tp);
                             }
                             // #160/S11: livebox / cached maps are box-keyed.
-                            let b = env.get_box_replacement_boxref(opref);
+                            let b = env.get_box_replacement_operand(opref);
                             if let Some(t) = numb_state.liveboxes.get(&b) {
                                 return t;
                             }
                             if let Some(t) = new_liveboxes.get(&b) {
                                 if tagged_eq(t, UNASSIGNED) {
-                                    if let Some(&num) = self
-                                        .cached_boxes
-                                        .get(&majit_ir::operand::Operand::from_boxref(&b))
-                                    {
+                                    if let Some(&num) = self.cached_boxes.get(&b) {
                                         return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                                     }
                                 }
                                 if tagged_eq(t, UNASSIGNEDVIRTUAL) {
-                                    if let Some(&num) = self
-                                        .cached_virtuals
-                                        .get(&majit_ir::operand::Operand::from_boxref(&b))
-                                    {
+                                    if let Some(&num) = self.cached_virtuals.get(&b) {
                                         return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                                     }
                                 }
@@ -3782,7 +3763,7 @@ impl ResumeDataLoopMemo {
         }
         // #160/S11: key the livebox / cached maps by the canonical box
         // (Rc::ptr_eq). `opref` is already replacement-walked by the caller.
-        let b = env.get_box_replacement_boxref(opref);
+        let b = env.get_box_replacement_operand(opref);
         // resume.py:566-567: liveboxes_from_env → existing tag
         if let Some(tagged) = liveboxes_from_env.get(&b) {
             return tagged;
@@ -3790,18 +3771,12 @@ impl ResumeDataLoopMemo {
         if let Some(tagged) = new_liveboxes.get(&b) {
             // Resolve UNASSIGNED to real cached number
             if tagged_eq(tagged, UNASSIGNED) {
-                if let Some(&num) = self
-                    .cached_boxes
-                    .get(&majit_ir::operand::Operand::from_boxref(&b))
-                {
+                if let Some(&num) = self.cached_boxes.get(&b) {
                     return tag(num, TAGBOX).unwrap_or(UNASSIGNED);
                 }
             }
             if tagged_eq(tagged, UNASSIGNEDVIRTUAL) {
-                if let Some(&num) = self
-                    .cached_virtuals
-                    .get(&majit_ir::operand::Operand::from_boxref(&b))
-                {
+                if let Some(&num) = self.cached_virtuals.get(&b) {
                     return tag(num, TAGVIRTUAL).unwrap_or(UNASSIGNEDVIRTUAL);
                 }
             }
@@ -3849,7 +3824,7 @@ impl ResumeDataLoopMemo {
             // #160/S11: key liveboxes by the canonical box (Rc::ptr_eq =
             // PyPy `box is`). `opref` is replacement-walked above and non-const
             // here (Const short-circuited via the is_const branch).
-            let b = env.get_box_replacement_boxref(opref);
+            let b = env.get_box_replacement_operand(opref);
             // resume.py:206-208: liveboxes
             if let Some(tagged) = numb_state.liveboxes.get(&b) {
                 numb_state.append_short(tagged);
@@ -4612,17 +4587,20 @@ mod tests {
         // bound to a rooted producer so they shed to Operand::InputArg / Op.
         // Under ptr_eq keying they stay distinct keys (PyPy `box is box`),
         // never collapsed by a shared raw slot index.
-        let input =
-            crate::history::test_support::rooted_box_from_opref(majit_ir::OpRef::input_arg_int(0));
-        let op = crate::history::test_support::rooted_box_from_opref(majit_ir::OpRef::int_op(0));
+        let input = majit_ir::operand::Operand::from_boxref(
+            &crate::history::test_support::rooted_box_from_opref(majit_ir::OpRef::input_arg_int(0)),
+        );
+        let op = majit_ir::operand::Operand::from_boxref(
+            &crate::history::test_support::rooted_box_from_opref(majit_ir::OpRef::int_op(0)),
+        );
 
         liveboxes.insert(input.clone(), UNASSIGNED);
         liveboxes.insert(op.clone(), UNASSIGNEDVIRTUAL);
 
         assert_eq!(liveboxes.get(&input), Some(UNASSIGNED));
         assert_eq!(liveboxes.get(&op), Some(UNASSIGNEDVIRTUAL));
-        // iter() reconstructs each key's bound BoxRef view via to_boxref, so
-        // compare by the stable (type, position) OpRef identity + order.
+        // iter() yields each key's Operand directly, so compare by the stable
+        // (type, position) OpRef identity + order.
         assert_eq!(
             liveboxes
                 .iter()
@@ -4947,7 +4925,7 @@ mod tests {
             virtuals: majit_ir::vec_set::VecSet<u32>,
             virtual_fields: majit_ir::VecMap<u32, majit_ir::VirtualFieldsInfo>,
             box_cache:
-                std::cell::RefCell<majit_ir::VecMap<majit_ir::OpRef, majit_ir::box_ref::BoxRef>>,
+                std::cell::RefCell<majit_ir::VecMap<majit_ir::OpRef, majit_ir::operand::Operand>>,
         }
 
         impl RefOnlyVirtualEnv {
@@ -4971,18 +4949,20 @@ mod tests {
                     .unwrap_or(opref)
             }
 
-            fn get_box_replacement_boxref(
+            fn get_box_replacement_operand(
                 &self,
                 opref: majit_ir::OpRef,
-            ) -> majit_ir::box_ref::BoxRef {
-                // #160/S11: memoize one BoxRef per replacement-walked OpRef.
+            ) -> majit_ir::operand::Operand {
+                // #160/S11: memoize one Operand per replacement-walked OpRef.
                 let root = self.get_box_replacement(opref);
                 if let Some(b) = self.box_cache.borrow().get(&root) {
                     return b.clone();
                 }
                 // Synthesize a rooted bound producer so the box sheds to
                 // `Operand::Op`/`InputArg` for the Operand-keyed liveboxes map.
-                let b = crate::history::test_support::rooted_box_from_opref(root);
+                let b = majit_ir::operand::Operand::from_boxref(
+                    &crate::history::test_support::rooted_box_from_opref(root),
+                );
                 self.box_cache.borrow_mut().insert(root, b.clone());
                 b
             }

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1496,6 +1496,10 @@ impl Assembler {
                     size: spec.size,
                     type_id: spec.type_id,
                     vtable: *vtable as usize,
+                    // `bh_new_with_vtable` allocates a GC-headered object (the
+                    // result is a fresh GC ref, below), so the size descr is
+                    // GC-managed.
+                    is_gc_managed: true,
                     // `STRUCT._name` identity is left empty for the transient
                     // `bh_new_with_vtable` size descr; the gc_cache hit keys on
                     // `type_id` (`path_hash(owner)`), not this field.

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1496,10 +1496,6 @@ impl Assembler {
                     size: spec.size,
                     type_id: spec.type_id,
                     vtable: *vtable as usize,
-                    // `bh_new_with_vtable` allocates a GC-headered object (the
-                    // result is a fresh GC ref, below), so the size descr is
-                    // GC-managed.
-                    is_gc_managed: true,
                     // `STRUCT._name` identity is left empty for the transient
                     // `bh_new_with_vtable` size descr; the gc_cache hit keys on
                     // `type_id` (`path_hash(owner)`), not this field.


### PR DESCRIPTION
Continues the box-identity endgame (#47 / #9): completes the E6 prerequisite chain (box identity made memoization-independent, then the `Op`/`InputArg` `box_cache` memo deleted) and starts E7 proper — retyping the box-object channels back to the upstream PyPy shape where the channel stores the AbstractValue (`Operand`) directly, and draining `BoxRef` bridge round-trips.

### E6 — box identity made memo-independent, `box_cache` deleted
- `same_box` compares bound producers before the kind match (`ca0d15bc4c`)
- `PartialEq`/`Hash` compare bound producers, memo-independent (`84166ab4a7`)
- `position()` reads live `op.pos` for a bound ResOp box (`70c8cadd35`)
- strip the `box_cache` memo, delete the `Op`/`InputArg` `box_cache` field (`b11979e2a4`)
- `materialize_operand_at` reads the bound host natively (`374335ac99`)

### Map / heap re-keys to Operand identity
- `quasi_immut_cache` re-keyed to Operand identity (`16ec78e67b`)
- heap `cached_structs` re-keyed; drop the dead `available_boxes` param (`cbd20be47f`)
- `DictArgKey::Op` re-keyed to Operand (`74772a74d2`)

### E7 — box-object channels restored to the PyPy shape
- opencoder `_cache` holds `Operand`, drop the `_produced_roots` Weak-upgrade crutch (`e9c20e025f`)
- resume `LiveboxMap` + the box-handle env yield `Operand` (`ccb7b04e67`)
- `ref_regs` holds `OpRef`, forward the inline `ConstPtr` gcref in place during moving collection (`8050090684`)
- flip `force_child` to `Operand`, delete the now-dead `resolve_box_operand` resolver (`4d7c06cdcd`)

### Bridge drains
- drain `resolve_box_operand` `to_boxref` round-trips (`30cfd761fe`)
- drain `BoxRef` bridges via the native Operand twins, rounds 1 and 2 (`bc6ee9159b`, `dae528dc97`)

### jitcode GC-descr (rebase residuals)
- set / dedup `is_gc_managed` on the `bh_new_with_vtable` size descr (`e4c2858606`, `81b202122c`)

Gate: `majit-metainterp` dynasm-lib 1358 / cranelift-lib 1356; `pyre/check.py` 158/158 on both the dynasm and cranelift backends.

Refs #47, #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
