### PR TITLE
#171: post-#271 review fixes + seq-iter/iter() parity + rtyper foldable getitem

### DIFF
--- a/majit/majit-translate/src/translator/backendopt/writeanalyze.rs
+++ b/majit/majit-translate/src/translator/backendopt/writeanalyze.rs
@@ -638,9 +638,13 @@ impl<'t> GraphAnalyzer<WriteEffects, Option<FreshMallocs>> for ReadWriteAnalyzer
             }])),
             // `elif op.opname == "getarrayitem":`
             // `frozenset([("readarray", op.args[0].concretetype)])`.
-            "getarrayitem" => WriteEffects::Set(HashSet::from([Effect::ReadArray {
-                TYPE: arg_concretetype(op, 0),
-            }])),
+            // The foldable `getarrayitem_pure` (rlist.py:721-724) reads the
+            // same array, so it records the identical `("readarray", T)`.
+            "getarrayitem" | "getarrayitem_pure" => {
+                WriteEffects::Set(HashSet::from([Effect::ReadArray {
+                    TYPE: arg_concretetype(op, 0),
+                }]))
+            }
             // `elif op.opname == "getinteriorfield":`.
             "getinteriorfield" => {
                 let name = self.getinteriorname(op);

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/lloperation.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/lloperation.rs
@@ -1001,6 +1001,19 @@ pub fn ll_operations() -> &'static HashMap<&'static str, LLOp> {
             "getarrayitem",
             LLOp::new(false, false, &[], false, true, false, false),
         );
+        // The foldable element load `ll_getitem_foldable_nonneg`
+        // (rlist.py:721-724, `oopspec = 'list.getitem_foldable(l,
+        // index)'`) selected by `rtype_getitem` when `not
+        // listdef.listitem.mutated` (rlist.py:255-258). `lloperation.py:89`
+        // `is_pure` returns True for a `getarrayitem` off an immutable
+        // field; pyre marks the foldable selection with the distinct
+        // `canfold=True` opname so the backendopt passes treat it as the
+        // pure read RPython's `is_pure` reports.
+        insert_llop(
+            &mut ops,
+            "getarrayitem_pure",
+            LLOp::new(false, true, &[], false, true, false, false),
+        );
         insert_llop(
             &mut ops,
             "getarraysize",

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -303,7 +303,11 @@ impl Repr for FixedSizeListRepr {
     /// `AbstractBaseListRepr`: the no-variant case mints
     /// `ListIteratorRepr(self)`; the `("reversed",)` variant
     /// (`ReversedListIteratorRepr`) is deferred.
-    fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+    fn make_iterator_repr(
+        &self,
+        variant: &[String],
+        foldable: bool,
+    ) -> Result<Arc<dyn Repr>, TyperError> {
         if !variant.is_empty() {
             return Err(TyperError::missing_rtype_operation(
                 "FixedSizeListRepr.make_iterator_repr: non-default variant \
@@ -315,6 +319,7 @@ impl Repr for FixedSizeListRepr {
             self.item_repr.clone(),
             self.external_item_repr.clone(),
             true,
+            foldable,
         )?))
     }
 }
@@ -775,17 +780,24 @@ impl Repr for ListRepr {
     /// `ListIteratorRepr(self)`; the `("reversed",)` variant
     /// (`ReversedListIteratorRepr`) is deferred. The resized receiver is
     /// flagged so `ll_listnext` reads `length` via the struct header.
-    fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+    fn make_iterator_repr(
+        &self,
+        variant: &[String],
+        foldable: bool,
+    ) -> Result<Arc<dyn Repr>, TyperError> {
         if !variant.is_empty() {
             return Err(TyperError::missing_rtype_operation(
                 "ListRepr.make_iterator_repr: non-default variant (reversed) deferred",
             ));
         }
+        // A resized list is always `mutated`, so `foldable` is false here; it is
+        // threaded for signature parity and gated again by `list_is_fixed`.
         Ok(Arc::new(ListIteratorRepr::new(
             self.lltype.clone(),
             self.item_repr.clone(),
             self.external_item_repr.clone(),
             false,
+            foldable,
         )?))
     }
 }
@@ -3005,15 +3017,19 @@ pub struct ListIteratorRepr {
     /// The `ll_length` read-out SHAPE only: `true` for `FixedSizeListRepr`
     /// (length via `getarraysize` on the bare `Ptr(GcArray)`), `false` for
     /// the resized `ListRepr` (length via `getfield(l, "length")` on the
-    /// header struct). This does NOT capture the `ll_listnext` vs
-    /// `ll_listnext_foldable` selection, which upstream gates on
-    /// `isinstance(FixedSizeListRepr) AND not r_list.listitem.mutated`
-    /// (`lltypesystem/rlist.py:462-466`): a `FixedSizeListRepr` can still
-    /// be `mutated` (in-place setitem without resize), and that list takes
-    /// the non-foldable `ll_listnext`. The deferred `ll_listnext` slice
-    /// must thread `listitem.mutated` separately — selecting foldable from
-    /// `list_is_fixed` alone would fold a mutable load and miscompile.
+    /// header struct). Distinct from [`Self::foldable`]: the length read-out is
+    /// the same `getarraysize`/`length` op whether or not the element load
+    /// folds.
     list_is_fixed: bool,
+    /// `not r_list.listitem.mutated` (`lltypesystem/rlist.py:462-466`): selects
+    /// `ll_listnext_foldable` over `ll_listnext`, so an unmutated
+    /// `FixedSizeListRepr`'s element load lowers to the PURE `getarrayitem_pure`
+    /// the optimizer can fold / CSE across iterations. Only meaningful together
+    /// with `list_is_fixed` — a `FixedSizeListRepr` can still be `mutated`
+    /// (in-place setitem without resize) and a resized `ListRepr` is always
+    /// `mutated`, so `rtype_next` gates the foldable read on
+    /// `list_is_fixed && foldable`.
+    foldable: bool,
 }
 
 impl ListIteratorRepr {
@@ -3022,6 +3038,7 @@ impl ListIteratorRepr {
         item_repr: Arc<dyn Repr>,
         external_item_repr: Arc<dyn Repr>,
         list_is_fixed: bool,
+        foldable: bool,
     ) -> Result<Self, TyperError> {
         // upstream `Ptr(GcStruct('listiter', ('list', r_list.lowleveltype),
         // ('index', Signed)))`.
@@ -3042,6 +3059,7 @@ impl ListIteratorRepr {
             item_repr,
             external_item_repr,
             list_is_fixed,
+            foldable,
         })
     }
 }
@@ -3133,18 +3151,15 @@ impl Repr for ListIteratorRepr {
     /// ```
     ///
     /// `ll_listnext` (the `index >= ll_length()` bounds-check that raises
-    /// `StopIteration`) lowers to [`build_ll_listnext_helper_graph`], whose
-    /// element read is a plain `getarrayitem` (non-pure). The
-    /// `ll_listnext_foldable` selection (`lltypesystem/rlist.py:462-466`,
-    /// gated on `FixedSizeListRepr AND not listitem.mutated`) routes the read
-    /// through the `list.getitem_foldable` oopspec, which upstream lowers to a
-    /// PURE `getarrayitem` the optimizer can fold/CSE across iterations. pyre
-    /// does NOT yet produce that pure list load — the list-getitem oopspec
-    /// lowering hardcodes `pure: false` and there is no `ArraylenGcPure` /
-    /// pure-getarrayitem on the list path — so the foldable optimization is
-    /// uniformly absent for BOTH `ll_len_foldable` (a non-pure `ArraylenGc`)
-    /// and iteration. Restoring it is a cross-cutting codewriter feature, not
-    /// a `listitem.mutated`-threading slice; see the `list_is_fixed` field doc.
+    /// `StopIteration`) lowers to [`build_ll_listnext_helper_graph`]. For an
+    /// unmutated `FixedSizeListRepr` (`self.foldable && self.list_is_fixed`) the
+    /// helper is `ll_listnext_foldable` (`lltypesystem/rlist.py:462-466,
+    /// 484-491`), whose element read is the PURE `getarrayitem_pure`
+    /// (`ll_getitem_foldable_nonneg`, the `list.getitem_foldable` oopspec) the
+    /// optimizer can fold / CSE across iterations; every other list keeps the
+    /// plain `getarrayitem`. The two helpers carry distinct names so the
+    /// per-signature helper cache never serves a folded body for a mutated list
+    /// of the same element type.
     /// The upstream result `recast` (`rlist.py:449` `self.r_list.recast`,
     /// `rlist.py:67`) converts the `ll_listnext` result back to
     /// `external_item_repr` via [`list_recast`] — identity for primitive
@@ -3158,20 +3173,32 @@ impl Repr for ListIteratorRepr {
         let iter_lltype = self.lltype.clone();
         let list_lltype = self.list_lltype.clone();
         let list_is_fixed = self.list_is_fixed;
+        // lltypesystem/rlist.py:462-466 — an unmutated FixedSizeListRepr reads
+        // each element through the PURE `getarrayitem_pure`
+        // (`ll_getitem_foldable_nonneg`); every other list takes the plain
+        // getarrayitem. A resized list is always mutated, so `list_is_fixed`
+        // also gates it.
+        let foldable = self.foldable && list_is_fixed;
+        let helper_name = if foldable {
+            "ll_listnext_foldable"
+        } else {
+            "ll_listnext"
+        };
         let iter_for_builder = iter_lltype.clone();
         let list_for_builder = list_lltype.clone();
         let item_for_builder = item_lltype.clone();
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_listnext".to_string(),
+            helper_name.to_string(),
             vec![iter_lltype],
             item_lltype,
             move |_rtyper, _args, _result| {
                 build_ll_listnext_helper_graph(
-                    "ll_listnext",
+                    helper_name,
                     iter_for_builder.clone(),
                     list_for_builder.clone(),
                     item_for_builder.clone(),
                     list_is_fixed,
+                    foldable,
                 )
             },
         )?;
@@ -3318,6 +3345,7 @@ pub(crate) fn build_ll_listnext_helper_graph(
     list_lltype: LowLevelType,
     item_lltype: LowLevelType,
     list_is_fixed: bool,
+    foldable: bool,
 ) -> Result<PyGraph, TyperError> {
     // The resized list keeps its element array in the "items" field; the
     // fixed list IS the bare `Ptr(GcArray)`.
@@ -3471,8 +3499,17 @@ pub(crate) fn build_ll_listnext_helper_graph(
                 Hlvalue::Variable(v_res.clone()),
             ));
         } else {
+            // `ll_listnext_foldable` (rlist.py:484-491) reads the element via
+            // `ll_getitem_foldable_nonneg` = the PURE `getarrayitem_pure`; the
+            // plain `ll_listnext` uses the non-pure `getarrayitem`. Only the
+            // fixed list folds (a resized list is always mutated).
+            let read_op = if foldable {
+                "getarrayitem_pure"
+            } else {
+                "getarrayitem"
+            };
             b.operations.push(SpaceOperation::new(
-                "getarrayitem",
+                read_op,
                 vec![Hlvalue::Variable(c_l), Hlvalue::Variable(c_index)],
                 Hlvalue::Variable(v_res.clone()),
             ));
@@ -4738,6 +4775,7 @@ mod tests {
             signed_repr() as Arc<dyn Repr>,
             signed_repr() as Arc<dyn Repr>,
             true,
+            false,
         )
         .expect("ListIteratorRepr::new");
         assert_eq!(r_iter.class_name(), "ListIteratorRepr");
@@ -4787,6 +4825,7 @@ mod tests {
             signed_repr() as Arc<dyn Repr>,
             signed_repr() as Arc<dyn Repr>,
             true,
+            false,
         )
         .expect("ListIteratorRepr::new");
         let pygraph = build_ll_listiter_helper_graph(
@@ -4827,6 +4866,7 @@ mod tests {
             signed_repr() as Arc<dyn Repr>,
             signed_repr() as Arc<dyn Repr>,
             true,
+            false,
         )
         .expect("ListIteratorRepr::new")
         .lowleveltype()
@@ -4894,6 +4934,7 @@ mod tests {
             signed_repr() as Arc<dyn Repr>,
             signed_repr() as Arc<dyn Repr>,
             true,
+            false,
         )
         .expect("ListIteratorRepr::new");
         let pygraph = build_ll_listnext_helper_graph(
@@ -4902,6 +4943,7 @@ mod tests {
             r_list.lowleveltype().clone(),
             LowLevelType::Signed,
             true,
+            false,
         )
         .expect("build_ll_listnext_helper_graph");
         let graph = pygraph.graph.borrow();
@@ -4954,6 +4996,55 @@ mod tests {
         );
     }
 
+    /// `ll_listnext_foldable` over an unmutated fixed list reads the element via
+    /// the PURE `getarrayitem_pure` (`lltypesystem/rlist.py:484-491` →
+    /// `ll_getitem_foldable_nonneg`), so the trace optimizer can fold / CSE the
+    /// load across iterations.
+    #[test]
+    fn build_ll_listnext_foldable_helper_emits_getarrayitem_pure() {
+        let rtyper = fresh_rtyper_live();
+        let r_list = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let r_iter = ListIteratorRepr::new(
+            r_list.lowleveltype().clone(),
+            signed_repr() as Arc<dyn Repr>,
+            signed_repr() as Arc<dyn Repr>,
+            true,
+            true,
+        )
+        .expect("ListIteratorRepr::new");
+        let pygraph = build_ll_listnext_helper_graph(
+            "ll_listnext_foldable",
+            r_iter.lowleveltype().clone(),
+            r_list.lowleveltype().clone(),
+            LowLevelType::Signed,
+            true,
+            true,
+        )
+        .expect("build_ll_listnext_helper_graph");
+        let graph = pygraph.graph.borrow();
+        let cont_ops: Vec<Vec<String>> = graph
+            .iterblocks()
+            .iter()
+            .map(|b| {
+                b.borrow()
+                    .operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .collect()
+            })
+            .collect();
+        assert!(
+            cont_ops.iter().any(|seq| seq
+                == &vec![
+                    "int_add".to_string(),
+                    "setfield".to_string(),
+                    "getarrayitem_pure".to_string()
+                ]),
+            "foldable continue block must emit getarrayitem_pure, got {cont_ops:?}"
+        );
+    }
+
     /// `ll_listnext` over a resized list reads `length` from the header and
     /// `items` array before `getarrayitem` (`lltypesystem/rlist.py` ADTIList).
     #[test]
@@ -4965,6 +5056,7 @@ mod tests {
             signed_repr() as Arc<dyn Repr>,
             signed_repr() as Arc<dyn Repr>,
             false,
+            false,
         )
         .expect("ListIteratorRepr::new");
         let pygraph = build_ll_listnext_helper_graph(
@@ -4972,6 +5064,7 @@ mod tests {
             r_iter.lowleveltype().clone(),
             r_list.lowleveltype().clone(),
             LowLevelType::Signed,
+            false,
             false,
         )
         .expect("build_ll_listnext_helper_graph");
@@ -5030,6 +5123,7 @@ mod tests {
                 signed_repr() as Arc<dyn Repr>,
                 signed_repr() as Arc<dyn Repr>,
                 true,
+                false,
             )
             .expect("ListIteratorRepr::new"),
         );

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -898,6 +898,67 @@ pub(crate) fn build_ll_fixed_getitem_fast_helper_graph(
     ))
 }
 
+/// Synthesise `ll_getitem_foldable_nonneg` (`rlist.py:721-724`):
+///
+/// ```python
+/// def ll_getitem_foldable_nonneg(l, index):
+///     ll_assert(index >= 0, "unexpectedly negative list getitem index")
+///     return l.ll_getitem_fast(index)
+/// ll_getitem_foldable_nonneg.oopspec = 'list.getitem_foldable(l, index)'
+/// ```
+///
+/// Identical body to [`build_ll_fixed_getitem_fast_helper_graph`] (the
+/// `ll_assert` is a debug-only bound check), except the element read is the
+/// FOLDABLE `getarrayitem_pure`. `rtype_getitem` (rlist.py:255-258) selects
+/// this helper instead of `ll_fixed_getitem_fast` when `not
+/// listitem.mutated`, so the immutable element load can be folded / CSE'd;
+/// the `oopspec = 'list.getitem_foldable'` is realised here by the distinct
+/// `getarrayitem_pure` opname, which `lloperation` marks `canfold=True`.
+pub(crate) fn build_ll_fixed_getitem_fast_foldable_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let index_arg = variable_with_lltype("index", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(index_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", item_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let v_item = variable_with_lltype("item", item_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarrayitem_pure",
+        vec![Hlvalue::Variable(l_arg), Hlvalue::Variable(index_arg)],
+        Hlvalue::Variable(v_item.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_item)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string()],
+        func,
+    ))
+}
+
 /// Synthesise `ll_fixed_setitem_fast` (`lltypesystem/rlist.py:407-410`):
 ///
 /// ```python
@@ -1623,6 +1684,16 @@ impl ListLayout {
             ListLayout::Resized => "ll_getitem_fast",
         }
     }
+    /// rlist.py:721-724 `ll_getitem_foldable_nonneg` — the foldable
+    /// counterpart of `getitem_fast_name`, a DISTINCT function so the
+    /// helper cache never serves a foldable graph to a mutated list (or
+    /// vice-versa). Only the Fixed layout reaches it (Resized ⟹ mutated).
+    fn getitem_fast_foldable_name(self) -> &'static str {
+        match self {
+            ListLayout::Fixed => "ll_fixed_getitem_fast_foldable",
+            ListLayout::Resized => "ll_getitem_fast_foldable",
+        }
+    }
     fn setitem_fast_name(self) -> &'static str {
         match self {
             ListLayout::Fixed => "ll_fixed_setitem_fast",
@@ -2137,10 +2208,21 @@ fn list_getitem_helper(
     layout: ListLayout,
     checkidx: bool,
     nonneg: bool,
+    foldable: bool,
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<LowLevelFunction, TyperError> {
+    // rlist.py:255-258 `basegetitem` selection: the `(false, true)` nonneg +
+    // `dum_nocheck` fast path is the only one whose element load `rtype_getitem`
+    // can route through the foldable `ll_getitem_foldable_nonneg` (rlist.py:721-
+    // 724) when `not listitem.mutated`. The foldable variant is a DISTINCT
+    // function from `ll_*_getitem_fast` (mirroring RPython's two helpers), so it
+    // gets a distinct cache name — without it the `lowlevel_helper_function_with_
+    // builder` `name` cache would reuse one list's foldable graph for another
+    // mutated list of the same item_lltype.
+    let fast_foldable = foldable && !checkidx && nonneg;
     let name = match (checkidx, nonneg) {
+        (false, true) if fast_foldable => layout.getitem_fast_foldable_name(),
         (false, true) => layout.getitem_fast_name(),
         (false, false) => layout.getitem_neg_name(),
         (true, true) => layout.getitem_nonneg_checked_name(),
@@ -2156,6 +2238,17 @@ fn list_getitem_helper(
         item_lltype,
         move |rtyper_inner, _args, _result| match (checkidx, nonneg) {
             (false, true) => match layout {
+                // rlist.py:721-724 `ll_getitem_foldable_nonneg` — the Fixed
+                // fast load, but foldable (`oopspec = 'list.getitem_foldable'`).
+                // The Resized layout is always mutated (resize ⟹ mutate, rlist.py
+                // `ListDef.resize`) so `fast_foldable` can only fire on Fixed.
+                ListLayout::Fixed if fast_foldable => {
+                    build_ll_fixed_getitem_fast_foldable_helper_graph(
+                        &name_owned,
+                        ptr_for_builder.clone(),
+                        item_for_builder.clone(),
+                    )
+                }
                 ListLayout::Fixed => build_ll_fixed_getitem_fast_helper_graph(
                     &name_owned,
                     ptr_for_builder.clone(),
@@ -2207,6 +2300,27 @@ fn list_rtype_getitem(
 ) -> Result<Hlvalue, TyperError> {
     use crate::annotator::model::SomeValue;
     let checkidx = hop.has_implicit_exception("IndexError");
+    // rlist.py:255-258 `basegetitem` selection by the listdef's mutated
+    // flag: `ll_getitem_fast` (non-foldable) when `listdef.listitem.mutated`,
+    // else `ll_getitem_foldable_nonneg` (foldable, `oopspec =
+    // 'list.getitem_foldable(l, index)'`, rlist.py:721-724). `mutated` is the
+    // gate, NOT the layout — a non-resized FixedSizeListRepr that is still
+    // mutated (setitem without resize) is non-foldable; `ListDef.resize()`
+    // calls `mutate()` so a Resized list is always mutated ⟹ never foldable.
+    let s0 = hop
+        .args_s
+        .borrow()
+        .first()
+        .cloned()
+        .ok_or_else(|| TyperError::message("list rtype_getitem: args_s[0] missing"))?;
+    let foldable = match &s0 {
+        SomeValue::List(lst) => !lst.listdef.listitem_rc().borrow().mutated,
+        other => {
+            return Err(TyperError::message(format!(
+                "list rtype_getitem: args_s[0] must be SomeList, got {other:?}"
+            )));
+        }
+    };
     let s1 = hop
         .args_s
         .borrow()
@@ -2235,6 +2349,7 @@ fn list_rtype_getitem(
         layout,
         checkidx,
         nonneg,
+        foldable,
         ptr_lltype.clone(),
         item_lltype.clone(),
     )?;
@@ -3431,12 +3546,13 @@ mod tests {
         assert_eq!(repr.repr_class_id(), ReprClassId::FixedSizeListRepr);
     }
 
-    /// rlist.py:247-267 nonneg + checkidx=False branch — `getitem` on a
-    /// `FixedSizeListRepr` lowers to a `direct_call` of
-    /// `ll_fixed_getitem_fast` (a single `getarrayitem` on the
+    /// rlist.py:247-267 nonneg + checkidx=False branch on an UNMUTATED
+    /// `FixedSizeListRepr` — `basegetitem = ll_getitem_foldable_nonneg`
+    /// (rlist.py:258), so `getitem` lowers to a `direct_call` of the foldable
+    /// `ll_fixed_getitem_fast_foldable` (a single `getarrayitem_pure` on the
     /// `Ptr(GcArray)` receiver), preceded by `hop.exception_cannot_occur()`.
     #[test]
-    fn fixed_size_list_getitem_nonneg_emits_direct_call_to_ll_fixed_getitem_fast() {
+    fn fixed_size_list_getitem_nonneg_unmutated_emits_foldable_helper() {
         let ann = RPythonAnnotator::new(None, None, None, false);
         let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
         rtyper
@@ -3489,7 +3605,7 @@ mod tests {
 
         let result = list_repr
             .rtype_getitem(&hop)
-            .unwrap_or_else(|err| panic!("list getitem nonneg: {err:?}"));
+            .unwrap_or_else(|err| panic!("list getitem nonneg unmutated: {err:?}"));
         assert!(matches!(result, Some(Hlvalue::Variable(_))));
         let ops = llops.borrow();
         assert_eq!(ops.ops.len(), 1);
@@ -3503,8 +3619,119 @@ mod tests {
         };
         let dbg = format!("{:?}", c.value);
         assert!(
-            dbg.contains("ll_fixed_getitem_fast"),
-            "expected 'll_fixed_getitem_fast' in {dbg}"
+            dbg.contains("ll_fixed_getitem_fast_foldable"),
+            "unmutated list must select the foldable helper, got {dbg}"
+        );
+    }
+
+    /// rlist.py:255-256 — a MUTATED `FixedSizeListRepr` (in-place setitem
+    /// without resize) keeps `basegetitem = ll_getitem_fast`, so `getitem`
+    /// lowers to the NON-foldable `ll_fixed_getitem_fast` (plain
+    /// `getarrayitem`), proving the foldable selection is gated on
+    /// `listitem.mutated`, not on the Fixed layout.
+    #[test]
+    fn fixed_size_list_getitem_nonneg_mutated_emits_nonfoldable_helper() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let list_repr: Arc<FixedSizeListRepr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+                .expect("FixedSizeListRepr::new"),
+        );
+        let list_lltype = list_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_list = Variable::new();
+        v_list.set_concretetype(Some(list_lltype));
+        let v_idx = Variable::new();
+        v_idx.set_concretetype(Some(LowLevelType::Signed));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "getitem".to_string(),
+                vec![Hlvalue::Variable(v_list), Hlvalue::Variable(v_idx)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().extend([
+            SomeValue::List(SomeList::new(ListDef::new(
+                None,
+                SomeValue::Integer(SomeInteger::new(false, false)),
+                /* mutated */ true,
+                /* resized */ false,
+            ))),
+            SomeValue::Integer(SomeInteger::new(/* nonneg */ true, false)),
+        ]);
+        hop.args_r.borrow_mut().extend([
+            Some(list_repr.clone() as Arc<dyn Repr>),
+            Some(signed_repr() as Arc<dyn Repr>),
+        ]);
+
+        let result = list_repr
+            .rtype_getitem(&hop)
+            .unwrap_or_else(|err| panic!("list getitem nonneg mutated: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_fixed_getitem_fast") && !dbg.contains("_foldable"),
+            "mutated list must select the non-foldable helper, got {dbg}"
+        );
+    }
+
+    /// The foldable helper body [`build_ll_fixed_getitem_fast_foldable_helper_graph`]
+    /// emits the PURE `getarrayitem_pure` element load (rlist.py:721-724
+    /// `oopspec = 'list.getitem_foldable'`), while the non-foldable
+    /// [`build_ll_fixed_getitem_fast_helper_graph`] emits a plain
+    /// `getarrayitem`.
+    #[test]
+    fn fixed_getitem_fast_foldable_body_emits_getarrayitem_pure() {
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let repr = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new");
+        let ptr = repr.lowleveltype().clone();
+        let item = LowLevelType::Signed;
+
+        let foldable = build_ll_fixed_getitem_fast_foldable_helper_graph(
+            "ll_fixed_getitem_fast_foldable",
+            ptr.clone(),
+            item.clone(),
+        )
+        .expect("build foldable helper");
+        let nonfoldable =
+            build_ll_fixed_getitem_fast_helper_graph("ll_fixed_getitem_fast", ptr, item)
+                .expect("build non-foldable helper");
+
+        // `block_op_sequences` also visits the (op-less) returnblock.
+        assert_eq!(
+            block_op_sequences(&foldable),
+            vec![vec!["getarrayitem_pure".to_string()], vec![]],
+            "foldable helper body must be the pure element load"
+        );
+        assert_eq!(
+            block_op_sequences(&nonfoldable),
+            vec![vec!["getarrayitem".to_string()], vec![]],
+            "non-foldable helper body must be the plain element load"
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -1779,10 +1779,20 @@ fn emit_list_length_read(block: &BlockRef, layout: ListLayout, l: &Variable) -> 
 fn list_getitem_fast_funcptr(
     rtyper: &RPythonTyper,
     layout: ListLayout,
+    foldable: bool,
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<Constant, TyperError> {
-    let name = layout.getitem_fast_name().to_string();
+    // rlist.py:264-266 — the `basegetitem` passed into every (nonneg×checkidx)
+    // wrapper is the foldable `ll_getitem_foldable_nonneg` (rlist.py:721-724)
+    // when the list item is not mutated.  Only Fixed has a foldable element
+    // load; Resized is always mutated, so `foldable` is never set for it.
+    let foldable_fixed = foldable && matches!(layout, ListLayout::Fixed);
+    let name = if foldable_fixed {
+        layout.getitem_fast_foldable_name().to_string()
+    } else {
+        layout.getitem_fast_name().to_string()
+    };
     let name_owned = name.clone();
     let ptr_for_builder = ptr_lltype.clone();
     let item_for_builder = item_lltype.clone();
@@ -1791,6 +1801,13 @@ fn list_getitem_fast_funcptr(
         vec![ptr_lltype, LowLevelType::Signed],
         item_lltype,
         move |_rtyper, _args, _result| match layout {
+            ListLayout::Fixed if foldable_fixed => {
+                build_ll_fixed_getitem_fast_foldable_helper_graph(
+                    &name_owned,
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                )
+            }
             ListLayout::Fixed => build_ll_fixed_getitem_fast_helper_graph(
                 &name_owned,
                 ptr_for_builder.clone(),
@@ -1815,11 +1832,17 @@ fn build_ll_list_getitem_neg_helper_graph(
     rtyper: &RPythonTyper,
     layout: ListLayout,
     name: &str,
+    foldable: bool,
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<PyGraph, TyperError> {
-    let c_fast =
-        list_getitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let c_fast = list_getitem_fast_funcptr(
+        rtyper,
+        layout,
+        foldable,
+        ptr_lltype.clone(),
+        item_lltype.clone(),
+    )?;
 
     let l = variable_with_lltype("l", ptr_lltype.clone());
     let i = variable_with_lltype("index", LowLevelType::Signed);
@@ -1933,11 +1956,17 @@ fn build_ll_list_getitem_nonneg_checked_helper_graph(
     rtyper: &RPythonTyper,
     layout: ListLayout,
     name: &str,
+    foldable: bool,
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<PyGraph, TyperError> {
-    let c_fast =
-        list_getitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let c_fast = list_getitem_fast_funcptr(
+        rtyper,
+        layout,
+        foldable,
+        ptr_lltype.clone(),
+        item_lltype.clone(),
+    )?;
     let exc_args = exception_args("IndexError")?;
 
     let l = variable_with_lltype("l", ptr_lltype.clone());
@@ -2030,11 +2059,17 @@ fn build_ll_list_getitem_checked_helper_graph(
     rtyper: &RPythonTyper,
     layout: ListLayout,
     name: &str,
+    foldable: bool,
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<PyGraph, TyperError> {
-    let c_fast =
-        list_getitem_fast_funcptr(rtyper, layout, ptr_lltype.clone(), item_lltype.clone())?;
+    let c_fast = list_getitem_fast_funcptr(
+        rtyper,
+        layout,
+        foldable,
+        ptr_lltype.clone(),
+        item_lltype.clone(),
+    )?;
     let exc_args = exception_args("IndexError")?;
 
     let l = variable_with_lltype("l", ptr_lltype.clone());
@@ -2212,23 +2247,25 @@ fn list_getitem_helper(
     ptr_lltype: LowLevelType,
     item_lltype: LowLevelType,
 ) -> Result<LowLevelFunction, TyperError> {
-    // rlist.py:255-258 `basegetitem` selection: the `(false, true)` nonneg +
-    // `dum_nocheck` fast path is the only one whose element load `rtype_getitem`
-    // can route through the foldable `ll_getitem_foldable_nonneg` (rlist.py:721-
-    // 724) when `not listitem.mutated`. The foldable variant is a DISTINCT
-    // function from `ll_*_getitem_fast` (mirroring RPython's two helpers), so it
-    // gets a distinct cache name — without it the `lowlevel_helper_function_with_
-    // builder` `name` cache would reuse one list's foldable graph for another
-    // mutated list of the same item_lltype.
-    let fast_foldable = foldable && !checkidx && nonneg;
-    let name = match (checkidx, nonneg) {
-        (false, true) if fast_foldable => layout.getitem_fast_foldable_name(),
+    // rlist.py:255-266 `basegetitem` selection by the listdef's `mutated` flag,
+    // passed into ALL four (nonneg×checkidx) wrappers: the foldable
+    // `ll_getitem_foldable_nonneg` (rlist.py:721-724) when not mutated, else
+    // `ll_getitem_fast`.  Each foldable wrapper gets a distinct `_foldable`
+    // cache name so `lowlevel_helper_function_with_builder` never serves a
+    // foldable graph to a mutated list of the same item_lltype.  Only Fixed has
+    // a foldable element load; Resized is always mutated (the `mutated | resized`
+    // invariant in ListDef construction) so `foldable` is never set for it.
+    let base = match (checkidx, nonneg) {
         (false, true) => layout.getitem_fast_name(),
         (false, false) => layout.getitem_neg_name(),
         (true, true) => layout.getitem_nonneg_checked_name(),
         (true, false) => layout.getitem_checked_name(),
-    }
-    .to_string();
+    };
+    let name = if foldable {
+        format!("{base}_foldable")
+    } else {
+        base.to_string()
+    };
     let name_owned = name.clone();
     let ptr_for_builder = ptr_lltype.clone();
     let item_for_builder = item_lltype.clone();
@@ -2240,15 +2277,13 @@ fn list_getitem_helper(
             (false, true) => match layout {
                 // rlist.py:721-724 `ll_getitem_foldable_nonneg` — the Fixed
                 // fast load, but foldable (`oopspec = 'list.getitem_foldable'`).
-                // The Resized layout is always mutated (resize ⟹ mutate, rlist.py
-                // `ListDef.resize`) so `fast_foldable` can only fire on Fixed.
-                ListLayout::Fixed if fast_foldable => {
-                    build_ll_fixed_getitem_fast_foldable_helper_graph(
-                        &name_owned,
-                        ptr_for_builder.clone(),
-                        item_for_builder.clone(),
-                    )
-                }
+                // The Resized layout is always mutated so `foldable` can only
+                // fire on Fixed.
+                ListLayout::Fixed if foldable => build_ll_fixed_getitem_fast_foldable_helper_graph(
+                    &name_owned,
+                    ptr_for_builder.clone(),
+                    item_for_builder.clone(),
+                ),
                 ListLayout::Fixed => build_ll_fixed_getitem_fast_helper_graph(
                     &name_owned,
                     ptr_for_builder.clone(),
@@ -2264,6 +2299,7 @@ fn list_getitem_helper(
                 rtyper_inner,
                 layout,
                 &name_owned,
+                foldable,
                 ptr_for_builder.clone(),
                 item_for_builder.clone(),
             ),
@@ -2271,6 +2307,7 @@ fn list_getitem_helper(
                 rtyper_inner,
                 layout,
                 &name_owned,
+                foldable,
                 ptr_for_builder.clone(),
                 item_for_builder.clone(),
             ),
@@ -2278,6 +2315,7 @@ fn list_getitem_helper(
                 rtyper_inner,
                 layout,
                 &name_owned,
+                foldable,
                 ptr_for_builder.clone(),
                 item_for_builder.clone(),
             ),
@@ -2305,8 +2343,9 @@ fn list_rtype_getitem(
     // else `ll_getitem_foldable_nonneg` (foldable, `oopspec =
     // 'list.getitem_foldable(l, index)'`, rlist.py:721-724). `mutated` is the
     // gate, NOT the layout — a non-resized FixedSizeListRepr that is still
-    // mutated (setitem without resize) is non-foldable; `ListDef.resize()`
-    // calls `mutate()` so a Resized list is always mutated ⟹ never foldable.
+    // mutated (setitem without resize) is non-foldable; a Resized list carries
+    // the `mutated | resized` construction invariant (listdef.py:128 /
+    // listdef.rs) so it is always mutated ⟹ never foldable.
     let s0 = hop
         .args_s
         .borrow()
@@ -4601,6 +4640,7 @@ mod tests {
             &rtyper,
             ListLayout::Fixed,
             "ll_fixed_getitem_checked",
+            /* foldable */ false,
             repr.lowleveltype().clone(),
             LowLevelType::Signed,
         )

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -354,6 +354,16 @@ impl Default for ReprState {
 /// .convert_from_to` reads both sides' `methodname` + `self_repr`).
 /// All concrete `Repr` impls are `'static` today so the bound is
 /// satisfied implicitly.
+
+/// `not r_list.listitem.mutated` for the foldable iterator-next selection
+/// (`lltypesystem/rlist.py:462-466`): an unmutated list reads each element
+/// through the PURE `getarrayitem_pure` (`ll_getitem_foldable_nonneg`). Any
+/// non-list container is non-foldable. Mirrors the `rtype_getitem` `basegetitem`
+/// gate (`rlist.py:255-258`).
+fn list_container_foldable(s: &SomeValue) -> bool {
+    matches!(s, SomeValue::List(lst) if !lst.listdef.listitem_rc().borrow().mutated)
+}
+
 pub trait Repr: Debug + std::any::Any {
     /// RPython `Repr.lowleveltype` (`rmodel.py:26` + each subclass).
     fn lowleveltype(&self) -> &LowLevelType;
@@ -1027,15 +1037,31 @@ pub trait Repr: Debug + std::any::Any {
     ///     r_iter = self.make_iterator_repr()
     ///     return r_iter.newiter(hop)
     /// ```
+    ///
+    /// `foldable` (`not r_list.listitem.mutated`) is read off the container
+    /// annotation so an unmutated list's iterator can fold the element load
+    /// (`lltypesystem/rlist.py:462-466`); it is irrelevant on this path (only
+    /// `newiter` runs) but kept consistent with the `next`-op repr.
     fn rtype_iter(&self, hop: &HighLevelOp) -> RTypeResult {
-        let r_iter = self.make_iterator_repr(&[])?;
+        let foldable = hop
+            .args_s
+            .borrow()
+            .first()
+            .map(list_container_foldable)
+            .unwrap_or(false);
+        let r_iter = self.make_iterator_repr(&[], foldable)?;
         r_iter.newiter(hop)
     }
 
     /// RPython `Repr.make_iterator_repr(self, *variant)` (rmodel.py:233-235):
     /// the base raises a `TyperError`; container reprs (list, range, dict,
-    /// str) override to mint their iterator repr.
-    fn make_iterator_repr(&self, _variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+    /// str) override to mint their iterator repr. `foldable` selects the
+    /// foldable element-load helper for an unmutated list iterator.
+    fn make_iterator_repr(
+        &self,
+        _variant: &[String],
+        _foldable: bool,
+    ) -> Result<Arc<dyn Repr>, TyperError> {
         Err(self.missing_rtype_operation("make_iterator_repr"))
     }
 
@@ -3130,7 +3156,8 @@ pub fn rtyper_makerepr(
                 ))
             } else {
                 let r_container = rtyper.getrepr(s_iter.s_container.as_ref())?;
-                r_container.make_iterator_repr(&s_iter.variant)
+                let foldable = list_container_foldable(s_iter.s_container.as_ref());
+                r_container.make_iterator_repr(&s_iter.variant, foldable)
             }
         }
         // rpbc.py:35-62 — SomePBC.rtyper_makerepr. Only the degenerate

--- a/majit/majit-translate/src/translator/rtyper/rtuple.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtuple.rs
@@ -2153,8 +2153,13 @@ impl Repr for TupleRepr {
     }
 
     /// RPython `TupleRepr.make_iterator_repr(self, variant=None)`
-    /// (rtuple.py:214-222).
-    fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+    /// (rtuple.py:214-222).  A tuple is immutable, so the list foldable
+    /// flag is irrelevant here.
+    fn make_iterator_repr(
+        &self,
+        variant: &[String],
+        _foldable: bool,
+    ) -> Result<Arc<dyn Repr>, TyperError> {
         if !variant.is_empty() {
             return Err(TyperError::message(format!(
                 "unsupported {:?} iterator over a tuple",

--- a/pyre/bench/synth/generator_pep479.py
+++ b/pyre/bench/synth/generator_pep479.py
@@ -1,0 +1,58 @@
+# PEP 479: a StopIteration that escapes a generator body is replaced by
+# RuntimeError("generator raised StopIteration") chained from it, across every
+# drive path (list / for / tuple / next / send) and whether the StopIteration
+# was raised explicitly or leaked from a `next()` in the body.  A normal
+# generator return is unaffected.  3.14 and PyPy agree, so check.py (PyPy
+# oracle) can assert this.
+
+
+def g_raise():
+    yield 1
+    raise StopIteration
+
+
+def g_nextleak():
+    yield 1
+    next(iter([]))
+
+
+def g_return():
+    yield 1
+    return 7
+
+
+def drive():
+    out = []
+
+    def check(label, fn):
+        try:
+            out.append((label, "ok", fn()))
+        except RuntimeError as e:
+            cause = type(e.__cause__).__name__ if e.__cause__ is not None else None
+            out.append((label, "runtimeerror", str(e), cause))
+        except Exception as e:  # noqa: BLE001
+            out.append((label, "other", type(e).__name__))
+
+    check("list", lambda: list(g_raise()))
+    check("for", lambda: [x for x in g_raise()])
+    check("tuple", lambda: tuple(g_raise()))
+    check("next", lambda: (lambda it: [next(it), next(it)])(g_raise()))
+    check("send", lambda: (lambda it: (next(it), it.send(None)))(g_raise()))
+    check("nextleak", lambda: list(g_nextleak()))
+    check("normal_return", lambda: list(g_return()))
+
+    # Drive the conversion hot so a compiled trace exercises the leak path.
+    hot = 0
+    n = 0
+    while n < 20000:
+        try:
+            list(g_raise())
+        except RuntimeError:
+            hot += 1
+        n += 1
+    out.append(("hot", hot))
+    return out
+
+
+for row in drive():
+    print(row)

--- a/pyre/bench/synth/generator_pep479.py
+++ b/pyre/bench/synth/generator_pep479.py
@@ -24,7 +24,7 @@ def g_return():
 def drive():
     out = []
 
-    def check(label, fn):
+    def check(label, fn) -> None:
         try:
             out.append((label, "ok", fn()))
         except RuntimeError as e:
@@ -34,7 +34,7 @@ def drive():
             out.append((label, "other", type(e).__name__))
 
     check("list", lambda: list(g_raise()))
-    check("for", lambda: [x for x in g_raise()])
+    check("for", lambda: [x for x in g_raise()])  # noqa: C416 - exercises the for-loop iteration path distinctly from the list() case
     check("tuple", lambda: tuple(g_raise()))
     check("next", lambda: (lambda it: [next(it), next(it)])(g_raise()))
     check("send", lambda: (lambda it: (next(it), it.send(None)))(g_raise()))

--- a/pyre/bench/synth/list_error_parity.py
+++ b/pyre/bench/synth/list_error_parity.py
@@ -1,0 +1,34 @@
+# list error-message parity where 3.14 and PyPy agree (check.py oracle is
+# PyPy).  list.index uses "%R is not in list" (the value's repr); list.pop
+# distinguishes empty vs out-of-range.  list.remove is intentionally omitted:
+# 3.14 says "list.remove(x): x not in list" but PyPy says "... (): N is ...",
+# a divergence that cannot be asserted against the PyPy oracle.
+def cap(fn):
+    try:
+        return ("ok", fn())
+    except (ValueError, IndexError, TypeError) as e:
+        return (type(e).__name__, str(e))
+
+
+def drive():
+    out = []
+    out.append(("index_missing", cap(lambda: [1, 2, 3].index(9))))
+    out.append(("index_str", cap(lambda: [1, 2].index("z"))))
+    out.append(("index_missing_range", cap(lambda: [1, 2, 1].index(1, 2))))
+    out.append(("pop_empty", cap(lambda: [].pop())))
+    out.append(("pop_oob", cap(lambda: [1, 2].pop(9))))
+    # hot index-miss so a compiled trace exercises the raise path
+    hits = 0
+    n = 0
+    while n < 20000:
+        try:
+            [1, 2, 3].index(9)
+        except ValueError:
+            hits += 1
+        n += 1
+    out.append(("hot_index_miss", hits))
+    return out
+
+
+for row in drive():
+    print(row)

--- a/pyre/bench/synth/list_error_parity.py
+++ b/pyre/bench/synth/list_error_parity.py
@@ -1,8 +1,11 @@
-# list error-message parity where 3.14 and PyPy agree (check.py oracle is
-# PyPy).  list.index uses "%R is not in list" (the value's repr); list.pop
-# distinguishes empty vs out-of-range.  list.remove is intentionally omitted:
-# 3.14 says "list.remove(x): x not in list" but PyPy says "... (): N is ...",
-# a divergence that cannot be asserted against the PyPy oracle.
+# list error-message parity where 3.14 and PyPy AGREE (check.py oracle is
+# PyPy).  list.index's missing-value message DIVERGES — 3.14 says
+# "list.index(x): x not in list" (gh-100242 dropped the repr) while PyPy keeps
+# the older "%R is not in list" form — so the index message itself is not
+# asserted here; only the raise PATH is exercised (hot_index_miss, comparing
+# the ValueError count) plus list.pop's empty/out-of-range IndexError
+# messages, which agree.  list.remove is likewise omitted (3.14
+# "list.remove(x): x not in list" vs PyPy "%R is not in list").
 def cap(fn):
     try:
         return ("ok", fn())
@@ -12,12 +15,12 @@ def cap(fn):
 
 def drive():
     out = []
-    out.append(("index_missing", cap(lambda: [1, 2, 3].index(9))))
-    out.append(("index_str", cap(lambda: [1, 2].index("z"))))
-    out.append(("index_missing_range", cap(lambda: [1, 2, 1].index(1, 2))))
+    # list.index honouring start: 1 reappears at index 2, so this succeeds.
+    out.append(("index_found_range", cap(lambda: [1, 2, 1].index(1, 2))))
     out.append(("pop_empty", cap(lambda: [].pop())))
     out.append(("pop_oob", cap(lambda: [1, 2].pop(9))))
-    # hot index-miss so a compiled trace exercises the raise path
+    # hot index-miss so a compiled trace exercises the raise path; only the
+    # ValueError count is compared (the message diverges 3.14 vs PyPy).
     hits = 0
     n = 0
     while n < 20000:

--- a/pyre/bench/synth/list_inplace_mul_parity.py
+++ b/pyre/bench/synth/list_inplace_mul_parity.py
@@ -40,6 +40,16 @@ def drive():
     # `__imul__` is exposed on the list type.
     out.append(("has_imul", hasattr([1], "__imul__")))
 
+    # `*= n` accepts any object with __index__, not just int/long.
+    class Count:
+        def __index__(self):
+            return 3
+
+    ix = [7]
+    ix_id = ix
+    ix *= Count()
+    out.append(("index_obj", ix, ix is ix_id))
+
     # Drive a hot loop so a compiled trace exercises the in-place repeat.
     total = 0
     k = 0

--- a/pyre/bench/synth/list_inplace_mul_parity.py
+++ b/pyre/bench/synth/list_inplace_mul_parity.py
@@ -1,0 +1,57 @@
+# In-place list repeat (`list *= n`) parity.  CPython and PyPy both mutate the
+# list in place (listobject descr_inplace_mul), so the list object identity is
+# preserved across `*=`; only `*` produces a fresh list.  check.py's oracle is
+# PyPy, which agrees with CPython here.
+
+
+def drive():
+    out = []
+
+    # `*=` repeats in place: same object, repeated contents.
+    x = [1, 2]
+    y = x
+    x *= 3
+    out.append(("repeat", x, x is y))
+
+    # `*= 0` empties in place.
+    z = [9, 8, 7]
+    zid = z
+    z *= 0
+    out.append(("zero", z, z is zid))
+
+    # A negative count empties in place too.
+    n = [1, 2, 3]
+    nid = n
+    n *= -4
+    out.append(("negative", n, n is nid))
+
+    # `*= 1` is a no-op that keeps identity and contents.
+    o = [5, 6]
+    oid = o
+    o *= 1
+    out.append(("one", o, o is oid))
+
+    # The repeat is observable through an alias.
+    a = [0]
+    b = a
+    a *= 4
+    out.append(("alias", b))
+
+    # `__imul__` is exposed on the list type.
+    out.append(("has_imul", hasattr([1], "__imul__")))
+
+    # Drive a hot loop so a compiled trace exercises the in-place repeat.
+    total = 0
+    k = 0
+    while k < 20000:
+        h = [k, k + 1]
+        h *= 3
+        total += len(h)
+        k += 1
+    out.append(("hot", total))
+
+    return out
+
+
+for row in drive():
+    print(row)

--- a/pyre/bench/synth/seqiter_pickle_parity.py
+++ b/pyre/bench/synth/seqiter_pickle_parity.py
@@ -1,0 +1,64 @@
+# Sequence-iterator pickle protocol parity.  check.py's correctness oracle is
+# PyPy, so this bench asserts only behaviour where 3.14 and PyPy AGREE.
+#
+# `iter(list)` yields the generic sequence iterator (W_AbstractSeqIterObject),
+# whose `__reduce__` / `__setstate__` recreate the cursor (iterobject.py:32-45):
+#   * a live cursor reduces to `(iter, (seq,), index)`;
+#   * an exhausted cursor (`w_seq is None`) reduces to `_empty_iterable` =
+#     `(iter, ((),))` (iterobject.py:251-253), so it restores empty;
+#   * `__setstate__` clamps a negative index to 0 with no upper clamp, and only
+#     while the sequence is still live.
+# The 3.14 list_iterator clamps the restored index up to the length, but PyPy's
+# W_FastListIterObject inherits the abstract (no upper clamp) form and pyre
+# routes list iteration through the same generic cursor, so the no-upper-clamp
+# shape is the PyPy-oracle behaviour asserted here.
+
+
+def drive():
+    out = []
+
+    # Live cursor: __reduce__ carries the index; replaying it resumes mid-list.
+    it = iter([10, 20, 30, 40, 50])
+    next(it)
+    next(it)
+    r = it.__reduce__()
+    it2 = r[0](*r[1])
+    if len(r) > 2 and r[2] is not None:
+        it2.__setstate__(r[2])
+    out.append(("partial", list(it2), len(r)))
+
+    # Exhausted cursor reduces to the empty-iterable shape (no index element).
+    ex = iter([1, 2])
+    list(ex)
+    r2 = ex.__reduce__()
+    it3 = r2[0](*r2[1])
+    out.append(("exhausted", list(it3), len(r2)))
+
+    # A negative restored index clamps to 0 (the whole list is reproduced).
+    n = iter([1, 2, 3])
+    n.__setstate__(-5)
+    out.append(("negative", list(n)))
+
+    # __setstate__ on an already-exhausted cursor is a no-op (seq is None).
+    g = iter([1, 2, 3])
+    list(g)
+    g.__setstate__(0)
+    out.append(("exhausted_setstate", list(g)))
+
+    # Drive a reduce/replay hot so a compiled trace exercises the cursor path.
+    total = 0
+    k = 0
+    while k < 20000:
+        h = iter([1, 2, 3, 4])
+        next(h)
+        rr = h.__reduce__()
+        h2 = rr[0](*rr[1])
+        h2.__setstate__(rr[2])
+        total += sum(h2)
+        k += 1
+    out.append(("hot", total))
+    return out
+
+
+for row in drive():
+    print(row)

--- a/pyre/bench/synth/seqiter_pickle_parity.py
+++ b/pyre/bench/synth/seqiter_pickle_parity.py
@@ -6,12 +6,10 @@
 #   * a live cursor reduces to `(iter, (seq,), index)`;
 #   * an exhausted cursor (`w_seq is None`) reduces to `_empty_iterable` =
 #     `(iter, ((),))` (iterobject.py:251-253), so it restores empty;
-#   * `__setstate__` clamps a negative index to 0 with no upper clamp, and only
-#     while the sequence is still live.
-# The 3.14 list_iterator clamps the restored index up to the length, but PyPy's
-# W_FastListIterObject inherits the abstract (no upper clamp) form and pyre
-# routes list iteration through the same generic cursor, so the no-upper-clamp
-# shape is the PyPy-oracle behaviour asserted here.
+#   * `__setstate__` restores the index only while the sequence is still live.
+# A negative restored index DIVERGES (3.14 leaves the iterator exhausted; PyPy
+# clamps the index to 0) so it is exercised only in the implementation, not
+# asserted here; every case below agrees between 3.14 and PyPy.
 
 
 def drive():
@@ -33,11 +31,6 @@ def drive():
     r2 = ex.__reduce__()
     it3 = r2[0](*r2[1])
     out.append(("exhausted", list(it3), len(r2)))
-
-    # A negative restored index clamps to 0 (the whole list is reproduced).
-    n = iter([1, 2, 3])
-    n.__setstate__(-5)
-    out.append(("negative", list(n)))
 
     # __setstate__ on an already-exhausted cursor is a no-op (seq is None).
     g = iter([1, 2, 3])

--- a/pyre/bench/synth/seqiter_tuple_error_parity.py
+++ b/pyre/bench/synth/seqiter_tuple_error_parity.py
@@ -10,24 +10,24 @@ import operator
 
 
 class LenSeq:
-    def __len__(self):
+    def __len__(self) -> int:
         return 7
 
-    def __getitem__(self, i):
+    def __getitem__(self, i) -> int:
         if i >= 7:
             raise IndexError
         return i
 
 
 class NoLenSeq:
-    def __getitem__(self, i):
+    def __getitem__(self, i) -> int:
         if i >= 4:
             raise IndexError
         return i
 
 
 class TupOverride(tuple):
-    def __getitem__(self, i):
+    def __getitem__(self, i) -> int:
         return 1000 + tuple.__getitem__(self, i)
 
 
@@ -36,33 +36,33 @@ class InstanceGetitem:
 
 
 class BadIter:
-    def __iter__(self):
+    def __iter__(self) -> int:
         return 42
 
 
 class BadListIter(list):
-    def __iter__(self):
+    def __iter__(self) -> int:
         return 99
 
 
 class LhViaGetattr:
     # __length_hint__ synthesised through __getattr__ — a type-MRO special
     # lookup must NOT see it, so operator.length_hint falls to the default.
-    def __getattr__(self, name):
+    def __getattr__(self, name) -> object:
         if name == "__length_hint__":
             return lambda: 5
         raise AttributeError(name)
 
 
 class NextViaGetattr:
-    def __getattr__(self, name):
+    def __getattr__(self, name) -> object:
         if name == "__next__":
             return lambda: 1
         raise AttributeError(name)
 
 
 class IterReturnsGetattrNext:
-    def __iter__(self):
+    def __iter__(self) -> object:
         return NextViaGetattr()
 
 
@@ -74,7 +74,7 @@ class TupleIterNone(tuple):
     __iter__ = None
 
 
-def drive():
+def drive() -> list:  # noqa: PLR0915 - parity oracle kept intentionally linear
     out = []
 
     # A generic `__getitem__` cursor iterates lazily to the IndexError (it

--- a/pyre/bench/synth/seqiter_tuple_error_parity.py
+++ b/pyre/bench/synth/seqiter_tuple_error_parity.py
@@ -35,6 +35,16 @@ class InstanceGetitem:
     pass
 
 
+class BadIter:
+    def __iter__(self):
+        return 42
+
+
+class BadListIter(list):
+    def __iter__(self):
+        return 99
+
+
 def drive():
     out = []
 
@@ -76,6 +86,21 @@ def drive():
         out.append(("instance_getitem", "iterable"))
     except TypeError:
         out.append(("instance_getitem", "not_iterable"))
+
+    # (3a) iter() validates that a dispatched `__iter__` returns an iterator;
+    # a non-iterator result raises TypeError (the message text differs between
+    # 3.14 and PyPy, so only the raise itself is asserted).  Both the generic
+    # instance and the list-subclass override path are checked.
+    try:
+        iter(BadIter())
+        out.append(("bad_iter", "no_error"))
+    except TypeError:
+        out.append(("bad_iter", "typeerror"))
+    try:
+        iter(BadListIter())
+        out.append(("bad_list_iter", "no_error"))
+    except TypeError:
+        out.append(("bad_list_iter", "typeerror"))
 
     return out
 

--- a/pyre/bench/synth/seqiter_tuple_error_parity.py
+++ b/pyre/bench/synth/seqiter_tuple_error_parity.py
@@ -45,6 +45,35 @@ class BadListIter(list):
         return 99
 
 
+class LhViaGetattr:
+    # __length_hint__ synthesised through __getattr__ — a type-MRO special
+    # lookup must NOT see it, so operator.length_hint falls to the default.
+    def __getattr__(self, name):
+        if name == "__length_hint__":
+            return lambda: 5
+        raise AttributeError(name)
+
+
+class NextViaGetattr:
+    def __getattr__(self, name):
+        if name == "__next__":
+            return lambda: 1
+        raise AttributeError(name)
+
+
+class IterReturnsGetattrNext:
+    def __iter__(self):
+        return NextViaGetattr()
+
+
+class ListIterNone(list):
+    __iter__ = None
+
+
+class TupleIterNone(tuple):
+    __iter__ = None
+
+
 def drive():
     out = []
 
@@ -101,6 +130,37 @@ def drive():
         out.append(("bad_list_iter", "no_error"))
     except TypeError:
         out.append(("bad_list_iter", "typeerror"))
+
+    # length_hint is a type-MRO special lookup: a __getattr__- or
+    # instance-synthesised __length_hint__ is ignored (→ default), while a
+    # builtin iterator's hint is still found.
+    out.append(("lh_via_getattr", operator.length_hint(LhViaGetattr(), 0)))
+    y = InstanceGetitem()
+    y.__length_hint__ = lambda: 9
+    out.append(("lh_via_instance", operator.length_hint(y, 0)))
+    out.append(("lh_listiter", operator.length_hint(iter([1, 2, 3, 4]), 0)))
+
+    # iter() validates __next__ with a type-MRO lookup too: a __next__ reachable
+    # only via __getattr__ does not make the result an iterator (message text
+    # differs across 3.14/PyPy, so only the raise is asserted).
+    try:
+        iter(IterReturnsGetattrNext())
+        out.append(("getattr_next", "no_error"))
+    except TypeError:
+        out.append(("getattr_next", "typeerror"))
+
+    # An explicit `__iter__ = None` on a list/tuple subclass marks it
+    # non-iterable; the message (subclass name) agrees across 3.14 and PyPy.
+    try:
+        list(ListIterNone([1, 2, 3]))
+        out.append(("list_iter_none", "iterable"))
+    except TypeError as e:
+        out.append(("list_iter_none", str(e)))
+    try:
+        list(TupleIterNone([1, 2, 3]))
+        out.append(("tuple_iter_none", "iterable"))
+    except TypeError as e:
+        out.append(("tuple_iter_none", str(e)))
 
     return out
 

--- a/pyre/bench/synth/seqiter_tuple_error_parity.py
+++ b/pyre/bench/synth/seqiter_tuple_error_parity.py
@@ -1,0 +1,84 @@
+# PR271 review parity guard.  check.py's correctness oracle is PyPy, so this
+# bench only asserts behaviour where 3.14 and PyPy AGREE; it guards the
+# tuple-subclass override (P1), the live `__length_hint__` (P2) and the
+# type-slot `__getitem__` iteration check (3b).  The 3.14-specific seq-iter
+# `next` behaviour (StopIteration treated as exhaustion, retryable after a
+# non-IndexError) diverges from PyPy and is documented at baseobjspace.rs
+# `next` / `iter_iternext`, so it cannot be asserted against the PyPy oracle
+# here.
+import operator
+
+
+class LenSeq:
+    def __len__(self):
+        return 7
+
+    def __getitem__(self, i):
+        if i >= 7:
+            raise IndexError
+        return i
+
+
+class NoLenSeq:
+    def __getitem__(self, i):
+        if i >= 4:
+            raise IndexError
+        return i
+
+
+class TupOverride(tuple):
+    def __getitem__(self, i):
+        return 1000 + tuple.__getitem__(self, i)
+
+
+class InstanceGetitem:
+    pass
+
+
+def drive():
+    out = []
+
+    # A generic `__getitem__` cursor iterates lazily to the IndexError (it
+    # ignores `__len__`).  Driven hot so the FOR_ITER over the cursor compiles.
+    total = 0
+    n = 0
+    while n < 20000:
+        for x in LenSeq():
+            total += x
+        n += 1
+    out.append(("lazy_iter", total))
+
+    # (P2) `__length_hint__` recomputed from the live sequence (len - index),
+    # reachable through operator.length_hint as well as the direct call.
+    it = iter(LenSeq())
+    lh0 = operator.length_hint(it)
+    next(it)
+    lh1 = operator.length_hint(it)
+    out.append(("len_hint", lh0, lh1, it.__length_hint__()))
+    out.append(("len_hint_nolen", operator.length_hint(iter(NoLenSeq()))))
+
+    # (P1) tuple-subclass `__getitem__` override honoured in a hot trace (the
+    # JIT must not read the raw `wrappeditems` block).
+    t = TupOverride([10, 20, 30])
+    acc = 0
+    n = 0
+    while n < 20000:
+        acc = t[1]
+        n += 1
+    out.append(("tuple_override", acc))
+
+    # (3b) an instance-dict `__getitem__` does not enable iteration (special
+    # methods resolve on the type, not the instance).
+    c = InstanceGetitem()
+    c.__getitem__ = lambda i: i
+    try:
+        list(c)
+        out.append(("instance_getitem", "iterable"))
+    except TypeError:
+        out.append(("instance_getitem", "not_iterable"))
+
+    return out
+
+
+for row in drive():
+    print(row)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1685,27 +1685,24 @@ fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
 
 /// `sequenceiterator.__length_hint__()` — elements not yet produced.
 /// `sequenceiterator.__length_hint__()` — `iterobject.c iter_len`: when the
-/// underlying sequence is live and exposes `__len__`, `len(seq) - index`,
+/// underlying sequence is live and exposes `__len__`, `len(seq) - index`
 /// recomputed from the LIVE sequence (so a sequence mutated mid-iteration
-/// reports its current length).  A cleared sequence, a missing `__len__`, or
-/// a negative remainder all report `NotImplemented`, which [`length_hint`]
-/// resolves to its default.  This dynamic `len(seq)` differs from PyPy's
-/// `W_AbstractSeqIterObject.getlength` (iterobject.py:16-24), which clamps to
-/// 0 and propagates a missing `__len__`; the behaviour target is 3.14.
+/// reports its current length), clamped to 0.  A cleared sequence (exhausted)
+/// or a negative remainder reports 0; only a sequence WITHOUT `__len__`
+/// reports `NotImplemented` (iter_len's sole NotImplemented path), which
+/// [`length_hint`] resolves to its default.  The dynamic `len(seq)` differs
+/// from PyPy's `W_AbstractSeqIterObject.getlength` (iterobject.py:16-24),
+/// which propagates a missing `__len__`; the behaviour target is 3.14.
 fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let seq = pyre_object::w_seq_iter_seq(args[0]);
         if seq.is_null() {
-            return Ok(pyre_object::special::w_not_implemented());
+            return Ok(w_int_new(0));
         }
         match len_w(seq) {
             Ok(length) => {
                 let remaining = length - pyre_object::w_seq_iter_index(args[0]);
-                if remaining >= 0 {
-                    Ok(w_int_new(remaining))
-                } else {
-                    Ok(pyre_object::special::w_not_implemented())
-                }
+                Ok(w_int_new(remaining.max(0)))
             }
             // A sequence without `__len__` reports NotImplemented, not an error.
             Err(e) if e.kind == crate::PyErrorKind::TypeError => {
@@ -9066,7 +9063,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             // without `__iter__` are reported as non-iterable.  Read off
             // the user `W_TypeObject` (typeobject.py:169) so heap-type
             // dict/list/tuple subclasses inherit the marker — see
-            // `is_iterable` at baseobjspace.rs:5343 for the same pattern.
+            // `is_iterable` (this file) for the same pattern.
             let w_user_type = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
             let is_mapping =
                 pyre_object::typeobject::w_type_get_flag_map_or_seq(w_user_type) == b'M';

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8842,6 +8842,25 @@ pub fn fixedview(
     unpackiterable(w_iterable, expected_length)
 }
 
+/// descroperation.py:343-345 — `iter()` requires the object returned by a
+/// dispatched `__iter__` to itself be an iterator (`space.lookup(w_iterator,
+/// '__next__') is not None`), raising TypeError otherwise.  Builtin-iterator
+/// `__next__` is exposed through the attribute protocol (not the type dict),
+/// so the presence test goes through `getattr_str` (cf. `length_hint`); a
+/// non-AttributeError from a `__getattribute__` hook propagates unchanged.
+unsafe fn iter_check_is_iterator(w_iterator: PyObjectRef) -> PyResult {
+    match getattr_str(w_iterator, "__next__") {
+        Ok(_) => Ok(w_iterator),
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+            Err(PyError::type_error(format!(
+                "iter() returned non-iterator of type '{}'",
+                (*(*w_iterator).ob_type).name
+            )))
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// `iter(obj)` — PyPy: space.iter(w_obj)
 /// Calls __iter__ on the object if available.
 pub fn iter(obj: PyObjectRef) -> PyResult {
@@ -8892,7 +8911,8 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                     if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::LIST_TYPE))
                         && !is_none(method)
                     {
-                        return crate::call::call_function_impl_result(method, &[obj]);
+                        let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                        return iter_check_is_iterator(w_iter);
                     }
                 }
             }
@@ -8904,7 +8924,8 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                     if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE))
                         && !is_none(method)
                     {
-                        return crate::call::call_function_impl_result(method, &[obj]);
+                        let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                        return iter_check_is_iterator(w_iter);
                     }
                 }
             }
@@ -9056,7 +9077,8 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                         (*(*obj).ob_type).name
                     )));
                 }
-                return crate::call::call_function_impl_result(method, &[obj]);
+                let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                return iter_check_is_iterator(w_iter);
             }
             // descroperation.py:333-334 — `__getitem__` fallback only when
             // `space.type(w_obj).flag_map_or_seq != 'M'`.  Mapping types

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7844,8 +7844,14 @@ fn generator_unpack_into(
                 // finished.  Pyre's inline `frame.execute_frame` path
                 // skips that finally block, so mirror it explicitly.
                 Err(e) if e.kind == crate::PyErrorKind::StopIteration => {
+                    // generator.py:131-138 — `_invoke_execute_frame` applies
+                    // `_leak_stopiteration` (PEP 479) BEFORE unpack_into's
+                    // `if e.match(StopIteration): break`, so a StopIteration
+                    // leaked from the body becomes RuntimeError and propagates;
+                    // it is not the normal-exhaustion path (which is the
+                    // `Ok`/`frame_finished_execution` arm below).
                     w_generator_set_exhausted(gen_obj);
-                    break;
+                    return Err(leak_stopiteration(e));
                 }
                 Err(e) => {
                     w_generator_set_exhausted(gen_obj);
@@ -9971,7 +9977,16 @@ fn generator_send_ex(gen_obj: PyObjectRef, w_arg: PyObjectRef, operr: Option<PyE
             }
             Err(e) => {
                 w_generator_set_exhausted(gen_obj);
-                Err(e)
+                // generator.py `_leak_stopiteration` (PEP 479) — a
+                // StopIteration that escaped the body becomes RuntimeError;
+                // any other error propagates unchanged.  The normal-return
+                // StopIteration is built in the `Ok`/`frame_finished_execution`
+                // arm above and never reaches here.
+                if e.kind == crate::PyErrorKind::StopIteration {
+                    Err(leak_stopiteration(e))
+                } else {
+                    Err(e)
+                }
             }
         }
     }
@@ -9994,6 +10009,26 @@ fn stop_iteration_with_value(value: PyObjectRef) -> PyError {
         }
     }
     unsafe { PyError::from_exc_object(exc) }
+}
+
+/// generator.py:131-138 `_invoke_execute_frame` / `_leak_stopiteration`
+/// (PEP 479): a `StopIteration` that escapes the generator body — whether
+/// raised explicitly or leaked from a `next()` inside the body — is replaced
+/// by `RuntimeError("generator raised StopIteration")` chained from it
+/// (`__cause__` and `__context__` both point at the leaked exception, and the
+/// cause suppresses the context in display, mirroring
+/// `chain_exceptions_from_cause`).  This is distinct from a normal generator
+/// return, which surfaces through the `Ok`/`frame_finished_execution` path.
+unsafe fn leak_stopiteration(e: PyError) -> PyError {
+    use pyre_object::interp_exceptions::*;
+    let w_stopiter = e.to_exc_object();
+    let rt = w_exception_new(ExcKind::RuntimeError, "generator raised StopIteration");
+    if pyre_object::is_exception(rt) && !w_stopiter.is_null() {
+        w_exception_set_context(rt, w_stopiter);
+        w_exception_set_cause(rt, w_stopiter);
+        w_exception_set_suppress_context(rt, true);
+    }
+    PyError::from_exc_object(rt)
 }
 
 /// PyPy: GeneratorIterator.next() — equivalent to __next__

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7939,23 +7939,38 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
                 || e.kind == crate::PyErrorKind::AttributeError => {}
         Err(e) => return Err(e),
     }
-    // baseobjspace.py:1093 `w_descr = space.lookup(w_obj, '__length_hint__')`.
-    // pyre exposes builtin-iterator special methods (the seq-iter / range-iter
-    // `__length_hint__`) through the attribute protocol rather than the type
-    // dict, so a type-only `lookup` misses them; resolve the bound method via
-    // getattr_str — the same fallback `len` uses for `__len__` — so the hint
-    // works for both user classes and builtin iterators.  A missing attribute
-    // yields the default.
-    let w_bound = match getattr_str(w_obj, "__length_hint__") {
-        Ok(m) => m,
-        Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(default),
-        Err(e) => return Err(e),
+    // baseobjspace.py:1093 `w_descr = space.lookup(w_obj, '__length_hint__')`
+    // — a type-MRO special-method lookup, NOT full attribute access: an
+    // instance-dict or `__getattr__`-synthesized `__length_hint__` is not
+    // consulted.  pyre's builtin iterators carry `__length_hint__` in the
+    // getattr_str method tables rather than the type dict, so a type miss on a
+    // non-user object falls back to getattr_str (a builtin cannot reach a
+    // `__getattr__`/instance attribute there); a user-class instance with a
+    // type miss takes the default.
+    let w_type = crate::typedef::r#type(w_obj).unwrap_or(std::ptr::null_mut());
+    let w_descr = if w_type.is_null() {
+        None
+    } else {
+        unsafe { lookup_in_type_where(w_type, "__length_hint__") }
     };
-    // baseobjspace.py:1095 `space.get_and_call_function(w_descr, w_obj)` — the
-    // getattr_str result is already bound, so it is called with no extra args;
-    // `call_function_impl_result` returns a Result directly, matching the
-    // upstream raise/return discipline.
-    let w_hint = match crate::call::call_function_impl_result(w_bound, &[]) {
+    let self_args = [w_obj];
+    // baseobjspace.py:1095 `space.get_and_call_function(w_descr, w_obj)` — a
+    // type-MRO descriptor is called with the object as self; the builtin
+    // method-table result is already bound and called with no extra args.
+    let (callable, args): (PyObjectRef, &[PyObjectRef]) = match w_descr {
+        Some(descr) => (descr, &self_args),
+        None => {
+            if unsafe { is_instance(w_obj) } {
+                return Ok(default);
+            }
+            match getattr_str(w_obj, "__length_hint__") {
+                Ok(m) => (m, &[]),
+                Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(default),
+                Err(e) => return Err(e),
+            }
+        }
+    };
+    let w_hint = match crate::call::call_function_impl_result(callable, args) {
         Ok(v) => v,
         Err(err) => {
             if err.kind == crate::PyErrorKind::TypeError
@@ -8850,20 +8865,39 @@ pub fn fixedview(
 
 /// descroperation.py:343-345 — `iter()` requires the object returned by a
 /// dispatched `__iter__` to itself be an iterator (`space.lookup(w_iterator,
-/// '__next__') is not None`), raising TypeError otherwise.  Builtin-iterator
-/// `__next__` is exposed through the attribute protocol (not the type dict),
-/// so the presence test goes through `getattr_str` (cf. `length_hint`); a
-/// non-AttributeError from a `__getattribute__` hook propagates unchanged.
+/// '__next__') is not None`), raising TypeError otherwise.  `space.lookup` is
+/// a type-MRO lookup: a `__next__` reachable only via `__getattr__` or the
+/// instance dict does NOT qualify.  pyre's builtin iterators carry `__next__`
+/// in the getattr_str method tables rather than the type dict, so a type miss
+/// on a non-user object falls back to getattr_str (a builtin reaches no
+/// `__getattr__`/instance attribute there); a user-class instance with a type
+/// miss is not an iterator.
+/// The user-visible Python type name (`type(obj).__name__`) for error
+/// messages — the `w_class` name rather than the shared builtin vtable name,
+/// so a heap subclass reports its own name.
+unsafe fn obj_type_name(obj: PyObjectRef) -> &'static str {
+    match crate::typedef::r#type(obj) {
+        Some(tp) => pyre_object::typeobject::w_type_get_name(tp),
+        None => (*(*obj).ob_type).name,
+    }
+}
+
 unsafe fn iter_check_is_iterator(w_iterator: PyObjectRef) -> PyResult {
-    match getattr_str(w_iterator, "__next__") {
-        Ok(_) => Ok(w_iterator),
-        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-            Err(PyError::type_error(format!(
-                "iter() returned non-iterator of type '{}'",
-                (*(*w_iterator).ob_type).name
-            )))
-        }
-        Err(e) => Err(e),
+    let w_type = crate::typedef::r#type(w_iterator).unwrap_or(std::ptr::null_mut());
+    let has_next = if !w_type.is_null() && lookup_in_type_where(w_type, "__next__").is_some() {
+        true
+    } else if is_instance(w_iterator) {
+        false
+    } else {
+        getattr_str(w_iterator, "__next__").is_ok()
+    };
+    if has_next {
+        Ok(w_iterator)
+    } else {
+        Err(PyError::type_error(format!(
+            "iter() returned non-iterator of type '{}'",
+            obj_type_name(w_iterator)
+        )))
     }
 }
 
@@ -8914,9 +8948,16 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         if is_list(obj) {
             if !pyre_object::is_exact_list(obj) {
                 if let Some((src, method)) = lookup_where((*obj).w_class, "__iter__") {
-                    if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::LIST_TYPE))
-                        && !is_none(method)
-                    {
+                    if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::LIST_TYPE)) {
+                        // descroperation.py:339-341 — an explicit
+                        // `__iter__ = None` override marks the subclass
+                        // non-iterable even though the lookup succeeds.
+                        if is_none(method) {
+                            return Err(PyError::type_error(format!(
+                                "'{}' object is not iterable",
+                                obj_type_name(obj)
+                            )));
+                        }
                         let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
                         return iter_check_is_iterator(w_iter);
                     }
@@ -8927,9 +8968,16 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         if is_tuple(obj) {
             if !pyre_object::is_exact_tuple(obj) {
                 if let Some((src, method)) = lookup_where((*obj).w_class, "__iter__") {
-                    if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE))
-                        && !is_none(method)
-                    {
+                    if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE)) {
+                        // descroperation.py:339-341 — an explicit
+                        // `__iter__ = None` override marks the subclass
+                        // non-iterable even though the lookup succeeds.
+                        if is_none(method) {
+                            return Err(PyError::type_error(format!(
+                                "'{}' object is not iterable",
+                                obj_type_name(obj)
+                            )));
+                        }
                         let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
                         return iter_check_is_iterator(w_iter);
                     }
@@ -9127,14 +9175,16 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             };
             if let Some(w_metaclass) = w_metaclass {
                 if let Some(method) = lookup_in_type_where(w_metaclass, "__iter__") {
-                    return Ok(crate::call_function(method, &[obj]));
+                    let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                    return iter_check_is_iterator(w_iter);
                 }
             }
             // Fallback: check type type's MRO
             if let Some(w_type_type) = crate::typedef::gettypefor(&pyre_object::pyobject::TYPE_TYPE)
             {
                 if let Some(method) = lookup_in_type_where(w_type_type, "__iter__") {
-                    return Ok(crate::call_function(method, &[obj]));
+                    let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                    return iter_check_is_iterator(w_iter);
                 }
             }
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1653,10 +1653,16 @@ fn builtin_callable(name: &str) -> PyObjectRef {
 }
 
 /// `sequenceiterator.__reduce__()` — `iterobject.py
-/// W_AbstractSeqIterObject.descr_reduce`: `(iter, (seq,), index)`.
+/// W_AbstractSeqIterObject.descr_reduce`: `(iter, (seq,), index)` for a live
+/// sequence; an exhausted iterator (`w_seq is None`) pickles to `_empty_iterable`
+/// (`iterobject.py:251-253`) = `(iter, ((),))` so it restores empty.
 fn seq_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let seq = pyre_object::w_seq_iter_seq(args[0]);
+        if seq.is_null() {
+            let empty_state = w_tuple_new(vec![w_tuple_new(vec![])]);
+            return Ok(w_tuple_new(vec![builtin_callable("iter"), empty_state]));
+        }
         let index = pyre_object::w_seq_iter_index(args[0]);
         let state = w_tuple_new(vec![seq]);
         Ok(w_tuple_new(vec![
@@ -1667,16 +1673,19 @@ fn seq_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     }
 }
 
-/// `sequenceiterator.__setstate__(index)` — clamp the cursor into
-/// `[0, length]` (`iterobject.py descr_setstate`).
+/// `sequenceiterator.__setstate__(index)` — `iterobject.py:40-45
+/// W_AbstractSeqIterObject.descr_setstate`: restore the cursor only while the
+/// sequence is live, clamping a negative index to 0.  There is no upper clamp —
+/// an out-of-range cursor is absorbed by `next` raising StopIteration on the
+/// IndexError.
 fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let mut index = int_w(args[1])?;
     unsafe {
-        let length = pyre_object::w_seq_iter_length(args[0]);
+        if pyre_object::w_seq_iter_seq(args[0]).is_null() {
+            return Ok(w_none());
+        }
         if index < 0 {
             index = 0;
-        } else if index > length {
-            index = length;
         }
         pyre_object::w_seq_iter_set_index(args[0], index);
     }
@@ -7944,9 +7953,12 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
     // instance-dict or `__getattr__`-synthesized `__length_hint__` is not
     // consulted.  pyre's builtin iterators carry `__length_hint__` in the
     // getattr_str method tables rather than the type dict, so a type miss on a
-    // non-user object falls back to getattr_str (a builtin cannot reach a
-    // `__getattr__`/instance attribute there); a user-class instance with a
-    // type miss takes the default.
+    // non-user object falls back to the bare `__getattribute__` form of
+    // getattr_str (`call_getattr = false`): it still reaches the builtin
+    // method-table `__length_hint__`, but never fires a module/metaclass
+    // `__getattr__` hook, so the lookup stays type-MRO-faithful.  A user-class
+    // instance (is_instance) is excluded entirely so its instance dict is
+    // never consulted; a type miss there takes the default.
     let w_type = crate::typedef::r#type(w_obj).unwrap_or(std::ptr::null_mut());
     let w_descr = if w_type.is_null() {
         None
@@ -7963,7 +7975,7 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
             if unsafe { is_instance(w_obj) } {
                 return Ok(default);
             }
-            match getattr_str(w_obj, "__length_hint__") {
+            match getattr_str_impl(w_obj, "__length_hint__", false) {
                 Ok(m) => (m, &[]),
                 Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(default),
                 Err(e) => return Err(e),
@@ -8869,9 +8881,11 @@ pub fn fixedview(
 /// a type-MRO lookup: a `__next__` reachable only via `__getattr__` or the
 /// instance dict does NOT qualify.  pyre's builtin iterators carry `__next__`
 /// in the getattr_str method tables rather than the type dict, so a type miss
-/// on a non-user object falls back to getattr_str (a builtin reaches no
-/// `__getattr__`/instance attribute there); a user-class instance with a type
-/// miss is not an iterator.
+/// on a non-user object falls back to the bare `__getattribute__` form of
+/// getattr_str (`call_getattr = false`): it reaches the builtin method-table
+/// `__next__` but fires no `__getattr__` hook.  A user-class instance
+/// (is_instance) is excluded so its instance dict is never consulted; a type
+/// miss there is not an iterator.
 /// The user-visible Python type name (`type(obj).__name__`) for error
 /// messages — the `w_class` name rather than the shared builtin vtable name,
 /// so a heap subclass reports its own name.
@@ -8889,7 +8903,7 @@ unsafe fn iter_check_is_iterator(w_iterator: PyObjectRef) -> PyResult {
     } else if is_instance(w_iterator) {
         false
     } else {
-        getattr_str(w_iterator, "__next__").is_ok()
+        getattr_str_impl(w_iterator, "__next__", false).is_ok()
     };
     if has_next {
         Ok(w_iterator)
@@ -9266,6 +9280,10 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 iter.index += 1;
                 return Ok(v);
             }
+            // iterobject.py:90-98 — an exhausted cursor clears its sequence ref
+            // (the generic arm above already did so on IndexError); the builtin
+            // arms clear it here so a held iterator reports as exhausted.
+            iter.seq = std::ptr::null_mut();
             return Err(PyError::stop_iteration());
         }
         // Range iterator

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1692,33 +1692,22 @@ fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
     Ok(w_none())
 }
 
-/// `sequenceiterator.__length_hint__()` — elements not yet produced.
-/// `sequenceiterator.__length_hint__()` — `iterobject.c iter_len`: when the
-/// underlying sequence is live and exposes `__len__`, `len(seq) - index`
-/// recomputed from the LIVE sequence (so a sequence mutated mid-iteration
-/// reports its current length), clamped to 0.  A cleared sequence (exhausted)
-/// or a negative remainder reports 0; only a sequence WITHOUT `__len__`
-/// reports `NotImplemented` (iter_len's sole NotImplemented path), which
-/// [`length_hint`] resolves to its default.  The dynamic `len(seq)` differs
-/// from PyPy's `W_AbstractSeqIterObject.getlength` (iterobject.py:16-24),
-/// which propagates a missing `__len__`; the behaviour target is 3.14.
+/// `sequenceiterator.__length_hint__()` — `W_AbstractSeqIterObject.getlength`
+/// (iterobject.py:16-24): `len(seq) - index` recomputed from the LIVE sequence
+/// — `space.len(w_seq)`, so a subclass `__len__` override or a mutation made
+/// mid-iteration is reflected — clamped to 0.  An exhausted (cleared) sequence
+/// reports 0.  A missing or raising `__len__` propagates as a real error;
+/// `operator.length_hint` then maps a TypeError to its default, exactly as a
+/// direct `space.len` would.
 fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let seq = pyre_object::w_seq_iter_seq(args[0]);
         if seq.is_null() {
             return Ok(w_int_new(0));
         }
-        match len_w(seq) {
-            Ok(length) => {
-                let remaining = length - pyre_object::w_seq_iter_index(args[0]);
-                Ok(w_int_new(remaining.max(0)))
-            }
-            // A sequence without `__len__` reports NotImplemented, not an error.
-            Err(e) if e.kind == crate::PyErrorKind::TypeError => {
-                Ok(pyre_object::special::w_not_implemented())
-            }
-            Err(e) => Err(e),
-        }
+        let length = len_w(seq)?;
+        let remaining = length - pyre_object::w_seq_iter_index(args[0]);
+        Ok(w_int_new(remaining.max(0)))
     }
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1684,11 +1684,35 @@ fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
 }
 
 /// `sequenceiterator.__length_hint__()` — elements not yet produced.
+/// `sequenceiterator.__length_hint__()` — `iterobject.c iter_len`: when the
+/// underlying sequence is live and exposes `__len__`, `len(seq) - index`,
+/// recomputed from the LIVE sequence (so a sequence mutated mid-iteration
+/// reports its current length).  A cleared sequence, a missing `__len__`, or
+/// a negative remainder all report `NotImplemented`, which [`length_hint`]
+/// resolves to its default.  This dynamic `len(seq)` differs from PyPy's
+/// `W_AbstractSeqIterObject.getlength` (iterobject.py:16-24), which clamps to
+/// 0 and propagates a missing `__len__`; the behaviour target is 3.14.
 fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
-        let remaining =
-            pyre_object::w_seq_iter_length(args[0]) - pyre_object::w_seq_iter_index(args[0]);
-        Ok(w_int_new(remaining.max(0)))
+        let seq = pyre_object::w_seq_iter_seq(args[0]);
+        if seq.is_null() {
+            return Ok(pyre_object::special::w_not_implemented());
+        }
+        match len_w(seq) {
+            Ok(length) => {
+                let remaining = length - pyre_object::w_seq_iter_index(args[0]);
+                if remaining >= 0 {
+                    Ok(w_int_new(remaining))
+                } else {
+                    Ok(pyre_object::special::w_not_implemented())
+                }
+            }
+            // A sequence without `__len__` reports NotImplemented, not an error.
+            Err(e) if e.kind == crate::PyErrorKind::TypeError => {
+                Ok(pyre_object::special::w_not_implemented())
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -7912,17 +7936,23 @@ pub fn length_hint(w_obj: PyObjectRef, default: i64) -> Result<i64, crate::PyErr
                 || e.kind == crate::PyErrorKind::AttributeError => {}
         Err(e) => return Err(e),
     }
-    // baseobjspace.py:1093 `w_descr = space.lookup(w_obj, '__length_hint__')`
-    // — generic class-MRO lookup, not instance-restricted.
-    let w_descr = match unsafe { lookup(w_obj, "__length_hint__") } {
-        Some(descr) => descr,
-        None => return Ok(default),
+    // baseobjspace.py:1093 `w_descr = space.lookup(w_obj, '__length_hint__')`.
+    // pyre exposes builtin-iterator special methods (the seq-iter / range-iter
+    // `__length_hint__`) through the attribute protocol rather than the type
+    // dict, so a type-only `lookup` misses them; resolve the bound method via
+    // getattr_str — the same fallback `len` uses for `__len__` — so the hint
+    // works for both user classes and builtin iterators.  A missing attribute
+    // yields the default.
+    let w_bound = match getattr_str(w_obj, "__length_hint__") {
+        Ok(m) => m,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => return Ok(default),
+        Err(e) => return Err(e),
     };
-    // baseobjspace.py:1095 `space.get_and_call_function(w_descr, w_obj)` —
-    // pyre's `call_function_impl_result` returns a Result directly,
-    // matching the upstream raise/return discipline without going through
-    // the legacy `take_call_error` pending-error stash.
-    let w_hint = match crate::call::call_function_impl_result(w_descr, &[w_obj]) {
+    // baseobjspace.py:1095 `space.get_and_call_function(w_descr, w_obj)` — the
+    // getattr_str result is already bound, so it is called with no extra args;
+    // `call_function_impl_result` returns a Result directly, matching the
+    // upstream raise/return discipline.
+    let w_hint = match crate::call::call_function_impl_result(w_bound, &[]) {
         Ok(v) => v,
         Err(err) => {
             if err.kind == crate::PyErrorKind::TypeError
@@ -9040,10 +9070,11 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             let w_user_type = crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut());
             let is_mapping =
                 pyre_object::typeobject::w_type_get_flag_map_or_seq(w_user_type) == b'M';
-            if !is_mapping
-                && (lookup_in_type_where(w_type, "__getitem__").is_some()
-                    || getattr_str(obj, "__getitem__").is_ok())
-            {
+            // descroperation.py:333-334 — `space.lookup(w_obj, '__getitem__')`
+            // is a type-MRO lookup; special-method resolution never consults
+            // the instance dict, so an `obj.__getitem__ = f` instance attribute
+            // does not enable sequence iteration.
+            if !is_mapping && lookup_in_type_where(w_type, "__getitem__").is_some() {
                 // descroperation.py:334 — `space.newseqiter(w_obj)` wraps the
                 // live object in an index cursor (iterobject.py
                 // W_SeqIterObject) that fetches each item lazily through
@@ -9135,11 +9166,15 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 }
             } else {
                 // Generic sequence-protocol object: fetch lazily through
-                // `space.getitem`.  The sequence iterator's `iter_iternext`
-                // treats IndexError or StopIteration as exhaustion (clearing
-                // w_seq so a later next() short-circuits without re-invoking
-                // __getitem__) and propagates every other error with w_seq
-                // left intact.
+                // `space.getitem`.  `iterobject.c iter_iternext` treats BOTH
+                // IndexError and StopIteration as exhaustion (clearing the
+                // sequence so a later next() short-circuits without
+                // re-invoking __getitem__), and propagates any OTHER error
+                // WITHOUT clearing the sequence, leaving the iterator
+                // retryable.  This intentionally differs from PyPy's
+                // `W_SeqIterObject.descr_next` (iterobject.py:75-79), which
+                // catches only IndexError and clears `w_seq` on every error;
+                // the observable behaviour target is 3.14.
                 match getitem(seq, w_int_new(idx)) {
                     Ok(v) => Some(v),
                     Err(e)

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -887,6 +887,34 @@ pub(crate) unsafe fn list_repeat(list: PyObjectRef, n: PyObjectRef) -> PyResult 
     Ok(w_list_new(items))
 }
 
+/// listobject.py:645-648 descr_inplace_mul — repeat the list in place; the
+/// list object identity is preserved.  Count and overflow handling mirror
+/// `list_repeat`, but the extra copies are appended into the existing
+/// storage instead of building a fresh list.
+pub(crate) unsafe fn list_inplace_repeat(list: PyObjectRef, n: PyObjectRef) -> Result<(), PyError> {
+    let count = repeat_count(n, "list is too large")?;
+    if count == 0 {
+        w_list_clear(list);
+        return Ok(());
+    }
+    let len = w_list_len(list);
+    if count == 1 || len == 0 {
+        return Ok(());
+    }
+    len.checked_mul(count)
+        .ok_or_else(|| PyError::new(PyErrorKind::OverflowError, "list is too large"))?;
+    // Snapshot the original items so the growing list is not re-read while
+    // the copies are appended.  Holding the refs across `w_list_append` is
+    // the same idiom `list_method_extend` uses for its iterable branch.
+    let snapshot = w_list_items_copy_as_vec(list);
+    for _ in 1..count {
+        for &item in &snapshot {
+            w_list_append(list, item);
+        }
+    }
+    Ok(())
+}
+
 // ── Comparison operations ─────────────────────────────────────────────
 
 unsafe fn int_lt(a: PyObjectRef, b: PyObjectRef) -> PyResult {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1235,6 +1235,12 @@ pub fn range_iter_continues(iter: PyObjectRef) -> Result<bool, PyError> {
         }
         if is_seq_iter(iter) {
             let si = &*(iter as *const W_SeqIterObject);
+            // A cleared sequence (exhausted cursor, iterobject.py:90-98) has no
+            // more items — a re-iteration of an exhausted iterator stops here
+            // without dereferencing the freed sequence.
+            if si.seq.is_null() {
+                return Ok(false);
+            }
             // sequenceiterator re-reads the live sequence length and PyPy's
             // W_FastListIterObject.descr_next ends on a getitem IndexError;
             // neither snapshots a length. Read the CURRENT sequence length so
@@ -1258,6 +1264,12 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
         }
         if is_seq_iter(iter) {
             let si = &mut *(iter as *mut W_SeqIterObject);
+            // An exhausted cursor cleared its sequence (iterobject.py:90-98
+            // `self.w_seq = None`); a re-entry stays exhausted without
+            // dereferencing the freed sequence.
+            if si.seq.is_null() {
+                return Ok(PY_NULL);
+            }
             let idx = si.index;
             // Bounds come from the sequence's CURRENT state (see
             // range_iter_continues): getitem returns None past the live
@@ -1304,6 +1316,11 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
                 si.index += 1;
                 return Ok(v);
             }
+            // iterobject.py:96-98 — clear the sequence ref on exhaustion so a
+            // held iterator's `__reduce__`/`__length_hint__` report it as an
+            // exhausted cursor (matches the generic-`__getitem__` arm of
+            // `baseobjspace::next`).
+            si.seq = PY_NULL;
             return Ok(PY_NULL);
         }
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -161,11 +161,15 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     match crate::listobject::w_list_find_or_count(list, value, start, stop, false)? {
         crate::listobject::FindOrCountResult::Index(i) => Ok(w_int_new(i)),
         crate::listobject::FindOrCountResult::NotFound => {
-            // listobject.py:809 `oefmt(space.w_ValueError, "%R is not in list", w_value)`.
-            let r = unsafe { crate::py_repr(value)? };
+            // listobject.c list_index_impl (3.14): a fixed
+            // "list.index(x): x not in list" message that does NOT format the
+            // value.  gh-100242 dropped the older "%R is not in list" form
+            // (which called `repr` on the missing value); PyPy still uses that
+            // older form, so this message is the 3.14 target and cannot be
+            // asserted against the PyPy check.py oracle.
             Err(crate::PyError::new(
                 crate::PyErrorKind::ValueError,
-                format!("{r} is not in list"),
+                "list.index(x): x not in list".to_string(),
             ))
         }
         crate::listobject::FindOrCountResult::Count(_) => {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -160,10 +160,14 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let (start, stop) = crate::sliceobject::unwrap_start_stop(size, w_start, w_stop)?;
     match crate::listobject::w_list_find_or_count(list, value, start, stop, false)? {
         crate::listobject::FindOrCountResult::Index(i) => Ok(w_int_new(i)),
-        crate::listobject::FindOrCountResult::NotFound => Err(crate::PyError::new(
-            crate::PyErrorKind::ValueError,
-            "list.index(x): x not in list".to_string(),
-        )),
+        crate::listobject::FindOrCountResult::NotFound => {
+            // listobject.py:809 `oefmt(space.w_ValueError, "%R is not in list", w_value)`.
+            let r = unsafe { crate::py_repr(value)? };
+            Err(crate::PyError::new(
+                crate::PyErrorKind::ValueError,
+                format!("{r} is not in list"),
+            ))
+        }
         crate::listobject::FindOrCountResult::Count(_) => {
             unreachable!("find_or_count with count=false never returns Count")
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2164,17 +2164,13 @@ fn init_list_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "__imul__",
             |args| {
-                if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
-                    unsafe {
-                        crate::objspace::descroperation::list_inplace_repeat(args[0], args[1])?
-                    };
-                    Ok(args[0])
-                } else {
-                    // NotImplemented lets `*=` fall through to `list * n`,
-                    // which emits the "can't multiply sequence by non-int"
-                    // message.
-                    Ok(pyre_object::w_not_implemented())
-                }
+                // listobject.py descr_inplace_mul: the count goes through
+                // `__index__`; a non-index operand becomes NotImplemented.
+                let Some(w_count) = list_repeat_index(args[1])? else {
+                    return Ok(pyre_object::w_not_implemented());
+                };
+                unsafe { crate::objspace::descroperation::list_inplace_repeat(args[0], w_count)? };
+                Ok(args[0])
             },
             2,
         ),
@@ -2191,17 +2187,26 @@ fn init_list_type(ns: &mut DictStorage) {
     }
 }
 
-/// `listobject.c:list_repeat` — `list * n` / `n * list`.  A non-integer
-/// count raises the `__index__` TypeError.
-fn list_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
-        unsafe { crate::objspace::descroperation::list_repeat(args[0], args[1]) }
-    } else {
-        // NotImplemented lets the `*` operator try a reflected `__rmul__`
-        // and otherwise emit the "can't multiply sequence by non-int"
-        // message, instead of this method's own slot error.
-        Ok(pyre_object::w_not_implemented())
+/// Coerce a `list * n` / `list *= n` repeat count through `__index__`
+/// (`space.getindex_w`).  An operand without `__index__` yields `None`, which
+/// the caller maps to NotImplemented so the `*`/`*=` operator can try a
+/// reflected `__rmul__` and otherwise emit the "can't multiply sequence by
+/// non-int" message; any other coercion error propagates.
+fn list_repeat_index(w_obj: PyObjectRef) -> Result<Option<PyObjectRef>, crate::PyError> {
+    match crate::baseobjspace::space_index(w_obj) {
+        Ok(w_count) => Ok(Some(w_count)),
+        Err(e) if e.kind == crate::PyErrorKind::TypeError => Ok(None),
+        Err(e) => Err(e),
     }
+}
+
+/// `listobject.c:list_repeat` — `list * n` / `n * list`.  The count goes
+/// through `__index__`, so any object implementing it repeats the list.
+fn list_descr_mul(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_count) = list_repeat_index(args[1])? else {
+        return Ok(pyre_object::w_not_implemented());
+    };
+    unsafe { crate::objspace::descroperation::list_repeat(args[0], w_count) }
 }
 
 // ── Str TypeDef ──────────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2158,6 +2158,27 @@ fn init_list_type(ns: &mut DictStorage) {
             2,
         ),
     );
+    dict_storage_store(
+        ns,
+        "__imul__",
+        make_builtin_function_with_arity(
+            "__imul__",
+            |args| {
+                if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
+                    unsafe {
+                        crate::objspace::descroperation::list_inplace_repeat(args[0], args[1])?
+                    };
+                    Ok(args[0])
+                } else {
+                    // NotImplemented lets `*=` fall through to `list * n`,
+                    // which emits the "can't multiply sequence by non-int"
+                    // message.
+                    Ok(pyre_object::w_not_implemented())
+                }
+            },
+            2,
+        ),
+    );
     for (name, func) in [
         ("__eq__", list_dunder_eq as DunderFn),
         ("__ne__", list_dunder_ne),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13660,17 +13660,29 @@ fn try_walker_specialize_subscr(
         return Ok(None);
     };
 
-    // #171/#11 Approach C: canonical array-backed `W_TupleObject[i]`.  A
-    // canonical tuple is gated on `ob_type == &TUPLE_TYPE` (tupleobject.py
-    // / tupleobject.rs:222) — NOT `is_tuple()` (which accepts the three
-    // SPECIALISED_TUPLE_{II,FF,OO} variants) and NOT a `w_class` compare
-    // (specialised tuples carry the canonical tuple `w_class`).  Specialised
-    // tuples store `value0`/`value1` inline with no `wrappeditems` block, so
-    // a `getfield(wrappeditems)` on one yields garbage — they MUST fall to
-    // the generic residual.  The runtime `guard_class(&TUPLE_TYPE)` deopts
-    // any later non-canonical tuple flowing in.
-    let tuple_canonical =
-        unsafe { std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::TUPLE_TYPE) };
+    // #171/#11 Approach C: canonical array-backed `W_TupleObject[i]`.  Two
+    // gates, both required:
+    //   * `ob_type == &TUPLE_TYPE` (tupleobject.py / tupleobject.rs:222) —
+    //     NOT `is_tuple()` (which also accepts the three
+    //     SPECIALISED_TUPLE_{II,FF,OO} variants).  Specialised tuples store
+    //     `value0`/`value1` inline with no `wrappeditems` block, so a
+    //     `getfield(wrappeditems)` on one yields garbage.
+    //   * `w_class == canonical tuple` — a tuple SUBCLASS instance shares the
+    //     payload `ob_type == &TUPLE_TYPE` but retags `w_class` and may
+    //     override `__getitem__`; `baseobjspace::getitem` honours that
+    //     override (subclass_special_override) so the pure `wrappeditems[i]`
+    //     load must NOT be taken for it.
+    // A failing gate falls to the generic residual.  The paired runtime
+    // `guard_class(&TUPLE_TYPE)` + exact `w_class` guard (in
+    // `try_walker_specialize_subscr_tuple`) deopt any later non-canonical
+    // tuple or subclass instance flowing in.
+    let tuple_canonical = unsafe {
+        std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::TUPLE_TYPE)
+            && std::ptr::eq(
+                (*list_obj).w_class,
+                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
+            )
+    };
     if tuple_canonical {
         return try_walker_specialize_subscr_tuple(
             ctx, op_pc, list_op, key_op, list_obj, key_obj, allboxes, call_descr, dst, dst_bank,
@@ -13883,6 +13895,18 @@ fn try_walker_specialize_subscr_tuple(
     ctx.trace_ctx
         .heap_cache_mut()
         .class_now_known(list_op, tuple_type_addr);
+
+    // A tuple SUBCLASS instance shares `ob_type == &TUPLE_TYPE` (so it passes
+    // the GuardClass above) but retags `w_class` and may override
+    // `__getitem__`; guard the exact canonical `w_class` so such an instance
+    // side-exits to the generic residual (which honours the override) rather
+    // than taking this pure `wrappeditems[i]` load.
+    walker_guard_exact_w_class(
+        ctx,
+        op_pc,
+        list_op,
+        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
+    )?;
 
     // Unbox the index operand (guard_class + getfield intval).  bool shares
     // int's `intval`, so a bool index guards its own &BOOL_TYPE.


### PR DESCRIPTION
Follow-up work on the #171 list-JIT branch after #271 merged: the PR271 code-review dispositions plus adjacent iterator-protocol and rtyper foldable-getitem parity.

## Commits
- **rtyper: select foldable getitem for unmutated `FixedSizeListRepr`** — `rtype_getitem` reads `args_s[0].listdef.listitem.mutated` and routes the unmutated case to a foldable `basegetitem` (`ll_fixed_getitem_fast_foldable` emitting `getarrayitem_pure`), per rlist.py:255-258. New `getarrayitem_pure` lloperation (canfold) + writeanalyze `ReadArray` effect.
- **jit/interp: PR271 review fixes** — P1: tuple-subscript walker pure-load now gates on the canonical `w_class` (trace-time) + a runtime `walker_guard_exact_w_class`, so a tuple subclass overriding `__getitem__` deopts instead of reading the raw `wrappeditems` block. seq-iter `next` kept faithful to `iter_iternext` (StopIteration is exhaustion; non-IndexError is retryable); `length_hint` resolves `__length_hint__` via `getattr_str`; the `__getitem__` iteration fallback uses a type-slot lookup.
- **rtyper: apply foldable getitem across all four getitem shapes** — the `foldable` flag is threaded through the negative-index and the two checked getitem wrappers, so an unmutated list folds its element load in all four (nonneg×checkidx) combinations (rlist.py:264-266), each with a distinct `_foldable` cache name.
- **interp: seq-iter `length_hint` returns 0 for cleared/negative remainder** — matches `iter_len` (cleared seq → 0, negative remainder → 0, no `__len__` → NotImplemented).
- **interp: `iter()` rejects a `__iter__` that returns a non-iterator** — descroperation.py:343-345; validates the list-subclass / tuple-subclass / generic-instance `__iter__`-override result via `getattr_str`, raising TypeError otherwise.

## Verification
- `pyre/check.py --backend dynasm,cranelift`: 159/159 ×2.
- Unit: pyre-interpreter 374, majit-translate 2799 — 0 failures.
- New parity bench `seqiter_tuple_error_parity.py` (asserts only cases where 3.14 and PyPy agree, since check.py's oracle is PyPy): tuple-subclass override, live `length_hint`, type-slot `__getitem__`, and the §3a non-iterator raise — 4-way CPython/PyPy/dynasm/cranelift agreement.

Refs #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new benchmark scripts covering generator `StopIteration` behavior, iterator pickle/replay parity, and list error-message parity.
* **Bug Fixes**
  * Improved iterator/generator semantics to better match Python, including correct handling of leaked `StopIteration` and more accurate `len_hint`/`iter` resolution.
  * Fixed iterator exhaustion so repeated `next()`/re-iteration behaves consistently.
  * Aligned `list.index` error text and prevented tuple-subclass optimizations from bypassing overridden item access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->