### PR TITLE
#203 post-#237: close gaps 7 (marker-path), 1 (blackhole exc), 9 (rtyper barrier), 3+8 (virtualizable)

### DIFF
--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -45,7 +45,7 @@ pub use resoperation::{
 pub use value::{
     Const, FAILARGS_LIMIT, GcRef, GreenAsI64, GreenKey, GreenType, InputArg, InputArgRc,
     JitDriverVar, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir, make_str_slot,
-    set_str_resolver, set_unicode_resolver,
+    pypyjit_greenkey_uhash, set_str_resolver, set_unicode_resolver,
 };
 pub use vec_map::{VecMap, VecMapExt};
 pub use vec_set::VecSet;

--- a/majit/majit-ir/src/value.rs
+++ b/majit/majit-ir/src/value.rs
@@ -967,6 +967,21 @@ impl GreenKey {
     }
 }
 
+/// Allocation-free `get_uhash` for the pypyjit portal green tuple
+/// `[next_instr:Int, is_being_profiled:Int, pycode:Ref]`
+/// (interp_jit.py:67-70). Equals
+/// `GreenKey::with_types(vec![pc, profiled, code], vec![Int, Int, Ref]).get_uhash()`
+/// without allocating the key's `values`/`types` vectors — the portal
+/// merge-point hook hashes this per back-edge, so the hot path must not
+/// allocate (warmstate.py:584-593 `JitCell.get_uhash`).
+pub fn pypyjit_greenkey_uhash(pc: usize, is_being_profiled: bool, code_ptr: u64) -> u64 {
+    let mut x: u64 = (-1888132534_i64) as u64;
+    x = (x ^ hash_whatever(GreenType::Int, pc as i64)).wrapping_mul(1405695061);
+    x = (x ^ hash_whatever(GreenType::Int, is_being_profiled as i64)).wrapping_mul(1405695061);
+    x = (x ^ hash_whatever(GreenType::Ref, code_ptr as i64)).wrapping_mul(1405695061);
+    x
+}
+
 /// Macro-emitted bridge used by `#[jit_interp]` to build a typed
 /// `GreenKey` from heterogeneous green expressions.
 ///
@@ -1135,5 +1150,33 @@ mod tests {
         assert_eq!(GreenType::from(Type::Ref), GreenType::Ref);
         assert_eq!(GreenType::from(Type::Float), GreenType::Float);
         assert_eq!(GreenType::from(Type::Void), GreenType::Void);
+    }
+
+    /// The allocation-free portal hash must be byte-identical to building
+    /// the typed `GreenKey([pc, profiled, code], [Int, Int, Ref])` and
+    /// calling `get_uhash` — that equivalence is what lets the legacy
+    /// `make_green_key` u64 flow and the typed marker path agree on the
+    /// same cell (issue #203 gap-7 hash unification).
+    #[test]
+    fn test_pypyjit_greenkey_uhash_matches_get_uhash() {
+        let cases: &[(usize, bool, u64)] = &[
+            (0, false, 0),
+            (0, false, 0x1000),
+            (7, false, 0xdead_beef),
+            (7, true, 0xdead_beef),
+            (123456, false, 0x7fff_ffff_ffff_fff0),
+            (1, true, 1),
+        ];
+        for &(pc, profiled, code) in cases {
+            let key = GreenKey::with_types(
+                vec![pc as i64, profiled as i64, code as i64],
+                vec![GreenType::Int, GreenType::Int, GreenType::Ref],
+            );
+            assert_eq!(
+                pypyjit_greenkey_uhash(pc, profiled, code),
+                key.get_uhash(),
+                "uhash mismatch for (pc={pc}, profiled={profiled}, code={code:#x})"
+            );
+        }
     }
 }

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -345,6 +345,26 @@ pub trait JitState: Sized {
 
     fn recover_after_compiled_run(&mut self) {}
 
+    /// blackhole.py:1679 `_exit_frame_with_exception` → warmspot.py:998-1005.
+    ///
+    /// The resumed blackhole frame chain raised an exception (`exc`, a GC ref
+    /// to the exception object) that escaped every reconstructed frame. The
+    /// blackhole resume has *finished* — the chain is fully consumed — so this
+    /// hands the exception to the interpreter's own exception machinery instead
+    /// of re-executing from the guard pc, mirroring how the Python-bytecode JIT
+    /// re-raises the stored Ref into the outer interpreter (`eval.rs`
+    /// `is_exit_frame_with_exception` → `PyError::from_exc_object`). Returns the
+    /// pc to resume at (the interpreter's unwind/handler entry).
+    ///
+    /// The default returns `None`: an interpreter with no exception machinery
+    /// never raises and so can never produce `ExitFrameWithExceptionRef` from a
+    /// blackhole resume, leaving this unreachable for it; the caller then falls
+    /// back to crude state recovery. An interpreter that *can* raise overrides
+    /// this to deliver `exc` and return its handler pc.
+    fn deliver_blackhole_exception(&mut self, _exc: GcRef) -> Option<usize> {
+        None
+    }
+
     /// State-field JIT register layout: the per-instance scalar count,
     /// flattened fixed `[int]` array lengths, and virt-array count, mirroring
     /// `live_slots_for_state_field_jit`.  The blackhole resume path threads

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2480,9 +2480,22 @@ impl<S: JitState> JitDriver<S> {
                             );
                             Some(usize::MAX)
                         }
-                        // Exception exit / multi-frame continuation / anything
-                        // else: defer to the crude recovery below.
-                        _ => None,
+                        // blackhole.py:1679 `_exit_frame_with_exception` →
+                        // warmspot.py:998-1005: the resumed chain raised an
+                        // exception that escaped every reconstructed frame
+                        // (the hand-rolled loop above drove the multi-frame
+                        // descent, propagating the exc to the bottommost frame
+                        // just like `_run_forever`). resume_in_blackhole has
+                        // finished; hand the exception to the interpreter's own
+                        // machinery (parity: `eval.rs` re-raises the stored Ref
+                        // via `PyError::from_exc_object`) instead of dropping
+                        // back to re-execute from the guard pc. Returns the
+                        // interpreter's handler pc, or `None` when it has no
+                        // exception machinery — then the crude fallback runs,
+                        // but an exception-less interpreter never reaches here.
+                        crate::jitexc::JitException::ExitFrameWithExceptionRef(exc_ref) => {
+                            state.deliver_blackhole_exception(exc_ref)
+                        }
                     };
                     bh_builder.release_interp(bh);
                     if let Some(pc) = resume_pc {
@@ -2491,10 +2504,12 @@ impl<S: JitState> JitDriver<S> {
                 }
             }
 
-            // resume_in_blackhole could not build a frame, or returned an
-            // outcome the forward-resume does not yet handle (exception exit /
-            // multi-frame chain): fall back to crude state recovery and resume
-            // the interpreter at the guard pc.
+            // resume_in_blackhole could not build a frame (no guard storage, or
+            // `blackhole_from_resumedata` declined), or the chain raised an
+            // exception and `deliver_blackhole_exception` returned `None` (the
+            // interpreter has no exception machinery — unreachable for an
+            // exception-less interpreter): fall back to crude state recovery and
+            // resume the interpreter at the guard pc.
             state.recover_after_compiled_run();
             self.meta.invalidate_loop(green_key);
             self.meta.remove_compiled_loop(green_key);

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -131,9 +131,11 @@ pub use trace_ctx::ReconstructRecipe;
 pub use trace_ctx::TraceCtx;
 
 /// Compute green key from code pointer and PC.
-/// Must use the same hash as the front-end's make_green_key.
+/// Must use the same hash as the front-end's make_green_key — the full
+/// `JitCell.get_uhash` over the pypyjit green tuple, `is_being_profiled`
+/// folded to 0 (warmstate.py:584-593).
 pub fn green_key_from_code_ptr(code_ptr: usize, pc: usize) -> u64 {
-    (code_ptr as u64).wrapping_mul(1000003) ^ (pc as u64)
+    majit_ir::pypyjit_greenkey_uhash(pc, false, code_ptr as u64)
 }
 
 /// Whether `MAJIT_LOG` is set, cached at first access.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2650,13 +2650,14 @@ impl<M: Clone> MetaInterp<M> {
     /// the `read_boxes(...) ; append(virtualizable_box)` shape from
     /// pyjitpl.py:3302-3306).
     ///
-    /// `live_values` is the pyre analog of RPython's `original_boxes`,
-    /// with one structural difference: pyre carries greens in the
-    /// `green_key` side channel, so `live_values` holds only the red
-    /// inputargs. The absolute index inside `live_values` therefore
-    /// collapses to `index_of_virtualizable` (and `num_green_args`
-    /// contributes zero for all currently registered drivers, mirroring
-    /// pyre's single-portal discipline).
+    /// `live_values` is reds-only (greens fold to consts in the `green_key`
+    /// side channel, matching the compiled loop's reds-only entry contract), so
+    /// by default the absolute index collapses to `index_of_virtualizable`.
+    /// `PYRE_ORIGINAL_BOXES` restores RPython's `original_boxes = greens ++ reds`
+    /// shape locally (greens prepended as positional placeholders) so the read
+    /// uses the literal `num_green_args + index_of_virtualizable` index; the
+    /// resolved virtualizable pointer and its ref-bank index are unchanged
+    /// either way (the gate is a structural-parity no-op).
     fn initialize_virtualizable(&self, ctx: &mut TraceCtx, live_values: &[Value]) {
         // pyjitpl.py:3291: vinfo = self.jitdriver_sd.virtualizable_info
         // Prefer the trace-bound `active_jitdriver_sd` (RPython
@@ -2682,9 +2683,30 @@ impl<M: Clone> MetaInterp<M> {
         // driver (empty reds + named virtualizable), matching the
         // portal convention, so the strict RPython read works for
         // every driver.
-        let num_green_args = jd_sd.num_greens();
-        debug_assert_eq!(
-            num_green_args, 0,
+        // pyjitpl.py:3293 reads `original_boxes[num_green_args +
+        // index_of_virtualizable]`. pyre keeps `live_values` reds-only — the
+        // compiled loop's reds-only entry contract (`live_values_match_descriptor`,
+        // warmstate.py:387 execute_assembler), so greens normally contribute 0 and
+        // `index` collapses to `index_of_virtualizable`. `PYRE_ORIGINAL_BOXES`
+        // restores RPython's `original_boxes = greens ++ reds` shape LOCALLY: greens
+        // are prepended below as positional placeholders (their const values live in
+        // the `green_key`, so they only offset `index` to the virtualizable red) and
+        // `num_green_args` comes from the active driver descriptor. The trace
+        // inputargs / entry stay reds-only, so the virtualizable's ref-bank index
+        // (`box_ref_index`) decouples from the flat `index`.
+        let descriptor_num_greens = ctx
+            .driver_descriptor()
+            .map(|driver| driver.num_greens())
+            .unwrap_or(0);
+        let use_original_boxes = descriptor_num_greens > 0
+            && std::env::var_os("PYRE_ORIGINAL_BOXES").map_or(false, |v| v != "0");
+        let num_green_args = if use_original_boxes {
+            descriptor_num_greens
+        } else {
+            jd_sd.num_greens()
+        };
+        debug_assert!(
+            use_original_boxes || num_green_args == 0,
             "pyre green args live in green_key, not in live_values (pyjitpl.py:3293)"
         );
         assert!(
@@ -2695,6 +2717,18 @@ impl<M: Clone> MetaInterp<M> {
         );
         let index_of_virtualizable = jd_sd.index_of_virtualizable as usize;
         let index = num_green_args + index_of_virtualizable;
+        // original_boxes = [green placeholders ++ live_values]; identical to
+        // `live_values` when the gate is off (num_green_args == 0). Read by `index`
+        // for the virtualizable pointer; the reds-only `live_values` still drives the
+        // expanded-tail and inputarg-minting paths below.
+        let original_boxes: std::borrow::Cow<[Value]> = if num_green_args > 0 {
+            let mut boxes = Vec::with_capacity(num_green_args + live_values.len());
+            boxes.resize(num_green_args, Value::Void);
+            boxes.extend_from_slice(live_values);
+            std::borrow::Cow::Owned(boxes)
+        } else {
+            std::borrow::Cow::Borrowed(live_values)
+        };
 
         let num_static = info.num_static_extra_boxes;
         // virtualizable.py:86-99 `read_boxes` iterates `for i in range(len(lst))`
@@ -2708,7 +2742,7 @@ impl<M: Clone> MetaInterp<M> {
             if !reported.is_empty() {
                 reported
             } else if info.can_read_all_array_lengths_from_heap() {
-                let vable_ptr = match live_values.get(index) {
+                let vable_ptr = match original_boxes.get(index) {
                     Some(Value::Ref(r)) => r.as_usize() as *const u8,
                     Some(Value::Int(v)) => *v as *const u8,
                     _ => std::ptr::null(),
@@ -2776,26 +2810,27 @@ impl<M: Clone> MetaInterp<M> {
         // path and the regular JitDriver registry agree. The virtualizable
         // is a Ref-typed inputarg (resoperation.py:739 InputArgRef).
         //
-        // `index` is a flat arg ordinal; `OpRef::input_arg_ref` wants a
-        // ref-register-bank index. They coincide only when no ref arg precedes
-        // the virtualizable in the ref bank (PyFrame strips its green refs, so
-        // its frame is ref-bank 0 == ordinal 0). A host whose lowering keeps a
-        // green ref ahead of the identity (the state-field JIT's `program` at
-        // ref reg 0) publishes the true ref-bank index via
-        // `identity_ref_bank_index`; honor it so the minted box matches the
-        // traced vable base. `index` still drives the flat `live_values` reads.
-        let box_ref_index = info.identity_ref_bank_index.unwrap_or(index);
+        // `OpRef::input_arg_ref` wants a ref-register-bank index into the trace
+        // inputargs, which are reds-only (greens fold to consts in the green_key,
+        // never recorded as inputargs). So the virtualizable's box index is its
+        // reds-bank position (`index_of_virtualizable` — PyFrame's frame is reds[0]),
+        // NOT the greens-shifted flat `index` that reads `original_boxes`. A host
+        // whose lowering keeps a green ref ahead of the identity (the state-field
+        // JIT's `program` at ref reg 0) publishes the true ref-bank index via
+        // `identity_ref_bank_index`; honor it so the minted box matches the traced
+        // vable base.
+        let box_ref_index = info.identity_ref_bank_index.unwrap_or(index_of_virtualizable);
         let virtualizable_box = OpRef::input_arg_ref(box_ref_index as u32);
         // The identity's concrete VALUE is the live virtualizable pointer.
-        // For PyFrame `live_values[index]` already IS the frame pointer
+        // For PyFrame `original_boxes[index]` already IS the frame pointer
         // (== `vable_ptr`), so this is a no-op there. For the state-field
-        // JIT `live_values[index]` is the first scalar (stackpos), NOT the
+        // JIT `original_boxes[index]` is the first scalar (stackpos), NOT the
         // `&state` identity, so prefer `vable_ptr` when it is set
         // (`virtualizable_heap_ptr` cached it in `sync_before`).
         let virtualizable_value = if !self.vable_ptr.is_null() {
             majit_ir::Value::Ref(majit_ir::GcRef(self.vable_ptr as usize))
         } else {
-            live_values[index]
+            original_boxes[index]
         };
         let has_expanded_tail = live_values.len() >= num_reds + total_vable;
         // pyjitpl.py:3302: virtualizable_boxes = vinfo.read_boxes(...)

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3394,7 +3394,16 @@ impl<M: Clone> MetaInterp<M> {
             return BackEdgeAction::AlreadyTracing;
         }
 
-        match self.warm_state.force_start_tracing(green_key) {
+        // Force-start via the typed greenkey when the raw (code, pc) is
+        // present so the function-entry cell carries a `comparekey`;
+        // synthetic (0, 0) call sites keep the legacy u64 path.
+        let hot = match Self::with_typed_decision_key(green_key, green_key_raw, |key| {
+            self.warm_state.force_start_tracing_for_key(key)
+        }) {
+            Some(h) => h,
+            None => self.warm_state.force_start_tracing(green_key),
+        };
+        match hot {
             HotResult::NotHot => BackEdgeAction::Interpret,
             HotResult::StartTracing => {
                 self.prepare_trace_start_runtime();
@@ -3519,7 +3528,16 @@ impl<M: Clone> MetaInterp<M> {
             return BackEdgeAction::AlreadyTracing;
         }
 
-        match self.warm_state.force_start_tracing(green_key) {
+        // Force-start via the typed greenkey when the raw (code, pc) is
+        // present so the cell carries a `comparekey` like the back-edge
+        // path; synthetic (0, 0) call sites keep the legacy u64 path.
+        let hot = match Self::with_typed_decision_key(green_key, green_key_raw, |key| {
+            self.warm_state.force_start_tracing_for_key(key)
+        }) {
+            Some(h) => h,
+            None => self.warm_state.force_start_tracing(green_key),
+        };
+        match hot {
             HotResult::NotHot => BackEdgeAction::Interpret,
             HotResult::StartTracing => {
                 self.prepare_trace_start_runtime();
@@ -3548,7 +3566,19 @@ impl<M: Clone> MetaInterp<M> {
             return BackEdgeAction::AlreadyTracing;
         }
 
-        match self.warm_state.maybe_compile(green_key) {
+        // warmstate.py:446-511 — decide via the typed greenkey when the
+        // raw (code, pc) is available so the installed cell carries a
+        // `comparekey` (`maybe_compile_with_key` → `ensure_cell_for_key`),
+        // matching `JitCell.get_jitcell_for_args`. The cell bucket is
+        // `key.get_uhash()` == `make_green_key`, so the legacy u64 hash
+        // flow still resolves to the same cell.
+        let hot = match Self::with_typed_decision_key(green_key, green_key_raw, |key| {
+            self.warm_state.maybe_compile_with_key(key)
+        }) {
+            Some(h) => h,
+            None => self.warm_state.maybe_compile(green_key),
+        };
+        match hot {
             HotResult::NotHot => BackEdgeAction::Interpret,
             HotResult::StartTracing => {
                 self.prepare_trace_start_runtime();
@@ -3563,6 +3593,45 @@ impl<M: Clone> MetaInterp<M> {
             HotResult::AlreadyTracing => BackEdgeAction::AlreadyTracing,
             HotResult::RunCompiled => BackEdgeAction::RunCompiled,
         }
+    }
+
+    /// Run `f` with the typed greenkey `[next_instr, is_being_profiled=0,
+    /// pycode]` that matches `make_green_key` (warmstate.py:584-593),
+    /// reusing a thread-local `GreenKey` so the warmup-hot decision path
+    /// does not allocate the key's value/type vectors per back-edge.
+    /// `is_being_profiled` folds to 0 (the JIT path is not profiled;
+    /// trace-side keys have no frame). Returns `None` for synthetic call
+    /// sites with no raw `(code, pc)` (e.g. [`Self::on_back_edge`]), which
+    /// keep the legacy u64 hash path. On install, `ensure_cell_for_key`
+    /// clones the key into the cell's `comparekey`, so reuse is safe.
+    fn with_typed_decision_key<R>(
+        green_key: u64,
+        green_key_raw: (usize, usize),
+        f: impl FnOnce(&majit_ir::GreenKey) -> R,
+    ) -> Option<R> {
+        let (code_ptr, pc) = green_key_raw;
+        if code_ptr == 0 {
+            return None;
+        }
+        thread_local! {
+            static DECISION_KEY: std::cell::RefCell<majit_ir::GreenKey> =
+                std::cell::RefCell::new(majit_ir::GreenKey::with_types(
+                    vec![0_i64, 0, 0],
+                    vec![Type::Int, Type::Int, Type::Ref],
+                ));
+        }
+        Some(DECISION_KEY.with(|cell| {
+            let mut key = cell.borrow_mut();
+            key.values[0] = pc as i64;
+            key.values[1] = 0;
+            key.values[2] = code_ptr as i64;
+            debug_assert_eq!(
+                key.get_uhash(),
+                green_key,
+                "typed decision key must bucket to make_green_key(green_key_raw)"
+            );
+            f(&key)
+        }))
     }
 
     #[allow(dead_code)]
@@ -20207,6 +20276,66 @@ mod tests {
         assert_eq!(events[0].0, green_key, "green_key should match");
         assert!(events[0].1 > 0, "num_ops_before should be positive");
         assert!(events[0].2 > 0, "num_ops_after should be positive");
+    }
+
+    #[test]
+    fn on_back_edge_typed_installs_cell_with_typed_comparekey() {
+        // #203 gap-7 step-a cutover: a hot back-edge carrying a real
+        // (code, pc) must install a warm-state cell with a typed
+        // `comparekey`, so the marker-path lookup (`lookup_chain_with_key`)
+        // resolves to the same cell as the legacy u64 hash flow. The cell
+        // bucket is `key.get_uhash()`, which equals `make_green_key`.
+        let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let code: usize = 0x4000;
+        let pc: usize = 11;
+        let green_key = crate::green_key_from_code_ptr(code, pc);
+        let live = [Value::Int(0)];
+        for _ in 0..2 {
+            meta.on_back_edge_typed(green_key, (code, pc), None, None, &live);
+        }
+        assert!(meta.tracing.is_some(), "expected tracing to start");
+
+        let key = majit_ir::GreenKey::with_types(
+            vec![pc as i64, 0, code as i64],
+            vec![Type::Int, Type::Int, Type::Ref],
+        );
+        assert_eq!(
+            key.get_uhash(),
+            green_key,
+            "typed key must bucket to make_green_key(code, pc)"
+        );
+        assert!(
+            meta.warm_state.lookup_chain_with_key(&key).is_some(),
+            "production back-edge cell must carry a typed comparekey"
+        );
+    }
+
+    #[test]
+    fn bound_reached_force_starts_cell_with_typed_comparekey() {
+        // #203 gap-7 step-a: the can_enter_jit force-start path
+        // (`bound_reached` → `force_start_tracing_for_key`) must also
+        // install a cell with a typed comparekey, bypassing the counter.
+        let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let code: usize = 0x5000;
+        let pc: usize = 13;
+        let green_key = crate::green_key_from_code_ptr(code, pc);
+        let live = [Value::Int(0)];
+        meta.bound_reached(green_key, (code, pc), None, None, &live);
+        assert!(
+            meta.tracing.is_some(),
+            "bound_reached must force-start tracing"
+        );
+
+        let key = majit_ir::GreenKey::with_types(
+            vec![pc as i64, 0, code as i64],
+            vec![Type::Int, Type::Int, Type::Ref],
+        );
+        assert!(
+            meta.warm_state.lookup_chain_with_key(&key).is_some(),
+            "force-started cell must carry a typed comparekey"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -2819,7 +2819,9 @@ impl<M: Clone> MetaInterp<M> {
         // JIT's `program` at ref reg 0) publishes the true ref-bank index via
         // `identity_ref_bank_index`; honor it so the minted box matches the traced
         // vable base.
-        let box_ref_index = info.identity_ref_bank_index.unwrap_or(index_of_virtualizable);
+        let box_ref_index = info
+            .identity_ref_bank_index
+            .unwrap_or(index_of_virtualizable);
         let virtualizable_box = OpRef::input_arg_ref(box_ref_index as u32);
         // The identity's concrete VALUE is the live virtualizable pointer.
         // For PyFrame `original_boxes[index]` already IS the frame pointer

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -758,6 +758,30 @@ impl WarmEnterState {
         self.start_tracing_cell(green_key_hash)
     }
 
+    /// Typed-key variant of [`Self::force_start_tracing`]: reads the
+    /// matching cell by comparekey and force-starts tracing on it via
+    /// [`Self::start_tracing_cell_for_key`], so a force-started cell
+    /// (function-entry / can_enter_jit) carries a `comparekey` like the
+    /// [`Self::maybe_compile_with_key`] path.
+    pub fn force_start_tracing_for_key(&mut self, key: &GreenKey) -> HotResult {
+        if let Some(cell) = self.lookup_chain_with_key(key) {
+            if cell.is_compiled() {
+                return HotResult::RunCompiled;
+            }
+            if cell.is_tracing() {
+                return HotResult::AlreadyTracing;
+            }
+            if cell.flags & jc_flags::DONT_TRACE_HERE != 0 && cell.has_seen_a_procedure_token() {
+                return HotResult::NotHot;
+            }
+            if cell.abort_count >= MAX_TRACE_ABORT_COUNT {
+                return HotResult::NotHot;
+            }
+        }
+
+        self.start_tracing_cell_for_key(key)
+    }
+
     /// Signal that a retrace is starting from a guard failure point.
     ///
     /// `input_types` is accepted for API shape parity with

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2233,7 +2233,25 @@ fn run_two_phase_prepass_inner(
     // ── compute_at_fixpoint runs per-subject inside drive_subject's
     // annotate-half (cutover compute_at_fixpoint call); it is monotonic so
     // per-subject invocation reaches the same fixpoint (R2: the once-at-end
-    // upstream shape — annotator.complete() — is a deferred optimisation).
+    // upstream shape — annotator.complete() — is otherwise a deferred
+    // optimisation).
+
+    // ── Inheritance-id barrier — number every classdef ONCE now, with the
+    // complete Phase-A annotate-all classdef set and BEFORE Phase B rtypes
+    // and materializes any vtable. Upstream runs this in
+    // `RPythonTyper.specialize` via `perform_normalizations` before any vtable
+    // materialisation (annrpython complete: `if block_subset is None:
+    // perform_normalizations`); pyre's per-subject annotate defers
+    // `annotator.complete()`, so do the inheritance-id half explicitly here.
+    // With nothing yet baked, `assign_inheritance_ids`' global sort applies
+    // unconditionally (`shifts_baked_id` is false), so a later subclass nests
+    // into its parent bracket instead of dropping to the append-only fallback
+    // once a subclassrange has been baked into the immutable jitcode const pool
+    // during Phase B (#203 gap 9). The pass is idempotent without new
+    // classdefs, so Phase B's per-subject numbering is then a no-op.
+    if let Ok((annotator, _rtyper)) = call_registry.ensure_session() {
+        crate::translator::rtyper::normalizecalls::assign_inheritance_ids(&annotator);
+    }
 
     // ── Phase B — rtype-all with per-graph isolation ─────────────────
     // Writes its rtype_skipped set into the cache incrementally so partial

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1283,12 +1283,12 @@ impl PyFrame {
     pub fn snapshot_for_tracing(&self) -> FrameBox {
         // Frame-LOCAL state (locals_cells_stack_w / valuestackdepth / last_instr)
         // is COPIED, so snapshot mutations to locals/stack are discarded — that
-        // is the abort-safety the snapshot exists for.  But `w_globals`
-        // (below) is the SAME dict ptr: SHARED-heap mutations during recording
-        // (inline-frame STORE_GLOBAL via `concrete_execute_step`) leak to the
-        // real heap and are re-applied by the compiled loop's re-run.  This is
-        // the live miscompile the executor-into-walker cutover removes (memory
-        // `cf-executor-into-walker-epic-2026-06-08`).
+        // is the abort-safety the snapshot exists for.  `w_globals` (below) is
+        // the SAME dict ptr, so a concrete shared-heap write during recording
+        // would leak to the real heap and double-apply on the compiled loop's
+        // re-run.  Gap 10 removed that path: the concrete executor is retired,
+        // so inline-frame STORE_GLOBAL is recorded as deferred IR (no concrete
+        // write during the walk) and the compiled loop applies it exactly once.
         let mut frame = FrameBox::new(PyFrame {
             execution_context: self.execution_context,
             pycode: self.pycode,

--- a/pyre/pyre-jit-trace/src/canonical_bridge.rs
+++ b/pyre/pyre-jit-trace/src/canonical_bridge.rs
@@ -233,7 +233,6 @@ pub fn install_portal_for(
         code_ptr,
         w_code,
         false,
-        None,
     ))
 }
 
@@ -286,7 +285,6 @@ mod tests {
         // non-null wrapper, so stack_base = nlocals + ncells).
         assert_eq!(pyjit.metadata.stack_base, 0);
         assert!(!pyjit.has_abort);
-        assert!(pyjit.merge_point_pc.is_none());
         assert!(
             !pyjit.is_populated(),
             "is_populated() must report false for portal-bridged jitcode \
@@ -390,7 +388,7 @@ def f(x, y):
             "install_portal_for product must report is_portal_bridge() == true"
         );
 
-        let skeleton = PyJitCode::skeleton(std::ptr::null(), std::ptr::null(), None);
+        let skeleton = PyJitCode::skeleton(std::ptr::null(), std::ptr::null());
         assert!(
             !skeleton.is_portal_bridge(),
             "skeleton has empty jitcode.code — must NOT report portal-bridge"
@@ -428,7 +426,6 @@ def f(x, y):
             std::ptr::null(),
             std::ptr::null(),
             false,
-            None,
         );
         assert!(
             !drained.is_portal_bridge(),

--- a/pyre/pyre-jit-trace/src/driver.rs
+++ b/pyre/pyre-jit-trace/src/driver.rs
@@ -6,19 +6,17 @@
 use crate::callbacks;
 use crate::state::PyreJitState;
 
-/// RPython green_key = (pycode, next_instr).
-/// Each (code, pc) pair has independent warmup counter and compiled loop.
-///
-/// TODO: pyre's green-key is fixed `(PyCode*, pc)`
-/// and reduced to a single `u64` identityhash + Signed cast over the
-/// two-tuple. RPython's `hash_whatever(TYPE, x)` (`warmstate.py:115`)
-/// hashes individual primitives from a structural tuple of green boxes
-/// keyed by tuple identity in the JitCell dict. Pyre's two-component
-/// hash is a faithful Rust simplification — pyre's portal greens are
-/// always exactly `(PyCode, next_instr)`.
+/// RPython green_key = pypyjit greens `[next_instr, is_being_profiled,
+/// pycode]` (interp_jit.py:67-70). pyre's portal greens are always exactly
+/// `(PyCode*, next_instr)`, and the JIT path never runs under a profiler,
+/// so `is_being_profiled` folds to 0 — the trace-side call sites have no
+/// frame to read it from. The returned u64 is the full
+/// `JitCell.get_uhash` over the typed green tuple (warmstate.py:584-593),
+/// so this legacy hash flow and the typed marker-path lookup
+/// (`lookup_chain_with_key`) agree on the same cell.
 #[inline(always)]
 pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
-    (code_ptr as u64).wrapping_mul(1000003) ^ (pc as u64)
+    majit_ir::pypyjit_greenkey_uhash(pc, false, code_ptr as u64)
 }
 
 /// Type alias for the JIT driver pair. Must match pyre-jit/eval.rs JitDriverPair.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6359,6 +6359,24 @@ thread_local! {
     /// Empty outside the gated kept-stack path (cleared after each capture).
     static BRANCH_GUARD_KEPT_RECOVERED: std::cell::RefCell<Vec<(u16, OpRef)>> =
         const { std::cell::RefCell::new(Vec::new()) };
+
+    /// FBW abort-flush guard: captures whether the `abort_permanent` marker
+    /// that aborted the walk fired inside an inline sub-walk
+    /// ([`INLINE_SUBWALK_CAPTURE_BOUNDARY`]).  When set, the abort's jitcode
+    /// `op.pc` is a CALLEE coordinate with no meaning in the outer
+    /// (`FULL_BODY_SNAPSHOT_SYM`) `pc_map`, so the abort-point flush must
+    /// decline and fall back to the legacy replay.  Captured at the marker
+    /// (before the sub-walk's RAII guard restores the boundary flag) so the
+    /// top-level walk driver reads the abort-time value, not the unwound one.
+    static FBW_ABORT_IN_SUBWALK: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// Whether the walk's terminating `abort_permanent` marker fired inside an
+/// inline sub-walk (callee coordinate).  Read by the full-body walk driver
+/// to decline the abort-point flush.  See [`FBW_ABORT_IN_SUBWALK`].
+pub(crate) fn fbw_abort_in_subwalk() -> bool {
+    FBW_ABORT_IN_SUBWALK.with(|c| c.get())
 }
 
 /// RAII guard: mark the current scope as an inline sub-walk (see
@@ -7661,6 +7679,29 @@ fn vstack_containing_py_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -
         }
     }
     best_py
+}
+
+/// Map an `abort_permanent` marker's jitcode pc back to the Python opcode
+/// the interpreter must resume at.  `emit_abort_permanent` (codewriter)
+/// anchors that resume coordinate (`last_instr = py_pc - 1`); the full-body
+/// walk reads it here to flush the abort-point frame instead of replaying
+/// the walked region.  Returns None when the sym's jitcode / `code_ptr` is
+/// unavailable (no resume coordinate derivable → legacy replay).
+pub(crate) fn fbw_abort_resume_py_pc(
+    sym: &crate::state::PyreSym,
+    abort_jit_pc: usize,
+) -> Option<usize> {
+    if sym.jitcode.is_null() {
+        return None;
+    }
+    // SAFETY: read-only access to the sym's immutable jitcode layout, live
+    // for the walk that produced `abort_jit_pc` (same access pattern as
+    // `kept_slot_source_local_box`).
+    let jc = unsafe { &*sym.jitcode };
+    if jc.payload.code_ptr.is_null() {
+        return None;
+    }
+    Some(python_pc_for_jitcode_pc(&jc.payload.metadata, abort_jit_pc) as usize)
 }
 
 /// #73 (SLICE 1, INERT): step the walk-level operand-stack box mirror at
@@ -17111,6 +17152,13 @@ fn handle(
             // / unported-op fallbacks). Surface a permanent abort
             // (production driver → `TraceAction::AbortPermanent`) so the
             // location is never traced again.
+            //
+            // Capture the inline-sub-walk state here: an `op.pc` reached
+            // inside an inlined callee is a callee coordinate the outer
+            // walk's `pc_map` cannot resolve, so the abort-point flush must
+            // decline (the sub-walk's RAII guard restores the boundary flag
+            // on unwind, so the value must be latched at the marker).
+            FBW_ABORT_IN_SUBWALK.with(|c| c.set(INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|b| b.get())));
             Err(DispatchError::AbortPermanentMarkerReached { pc: op.pc })
         }
         // Heapcache-aware getfield reads. RPython

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5,10 +5,11 @@
 //! blackhole loop *executes* each `bhimpl_*` in turn; the tracing-side
 //! analogue lives in `pyjitpl.py:opimpl_*` where each opcode becomes
 //! a `MetaInterp.execute_and_record` call (RPython
-//! `pyjitpl.py:1640-1660`). Pyre is mid-migration: the production
-//! tracing path is the trait-driven `MIFrame::execute_opcode_step`
-//! (trace_opcode.rs); this module is the orthodox path that consumes
-//! the codewriter-emitted jitcode bytes directly.
+//! `pyjitpl.py:1640-1660`). This module is the sole production tracer:
+//! it consumes the codewriter-emitted jitcode bytes directly, executing
+//! as it records (`is_authoritative_executor`). The trait-driven
+//! `MIFrame::execute_opcode_step` interpret loop is retired
+//! (#203 gap 10 / #73 Phase 6).
 //!
 //! Opcode coverage:
 //!
@@ -52,11 +53,10 @@
 //! arity / shape / no-active-exception errors, production
 //! `PyreJitCodeDescr` adapter.
 //!
-//! Convergence path: when every opname has a recording handler this
-//! module replaces the trait dispatch in `MIFrame::execute_opcode_step`.
-//! The free-standing module shape stays —
-//! the entry point becomes `MIFrame::dispatch_jitcode` calling [`walk`]
-//! with the appropriate context.
+//! This module replaced the trait dispatch in
+//! `MIFrame::execute_opcode_step` (now retired). The entry point is
+//! [`walk`], driven from `trace_bytecode` (`trace.rs`) with the
+//! appropriate context.
 //!
 //! Production fidelity gaps (ranked by priority for follow-on work):
 //!

--- a/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
+++ b/pyre/pyre-jit-trace/src/opcode_handler_impls.rs
@@ -204,9 +204,10 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
         key: Self::Value,
         value: Self::Value,
     ) -> Result<(), pyre_interpreter::PyError> {
-        // MIFrame parity: trace-only, no concrete mutation.
-        // Root frame: interpreter executes the real STORE_SUBSCR.
-        // Inline frame: MetaInterp.concrete_execute_step handles it.
+        // MIFrame parity: trace-only, no concrete mutation during the walk.
+        // The emitted IR performs the STORE_SUBSCR in the compiled loop
+        // (exactly once), for both root and inline frames; see
+        // `store_subscr_value`.
         self.store_subscr_value(
             obj.opref,
             key.opref,
@@ -224,8 +225,8 @@ impl pyre_interpreter::SharedOpcodeHandler for crate::state::MIFrame {
     ) -> Result<(), pyre_interpreter::PyError> {
         // MIFrame parity: the hook itself is trace-only — the concrete
         // LIST_APPEND mutation is performed by the eval loop
-        // (`execute_opcode_step` / inline-frame `concrete_execute_step`),
-        // which is why this path marks the heap mutation.
+        // (`execute_opcode_step`), which is why this path marks the heap
+        // mutation.
         self.dm143_mark_heap_mutated();
         self.list_append_value(
             list.opref,

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -11,9 +11,8 @@
 //!     codewriter `majit_translate::jitcode::JitCode`.
 //!   * `PyJitCode` (this struct) wraps that JitCode together with
 //!     pyre-only translation metadata — `pc_map` (Python PC → byte
-//!     offset), `merge_point_pc`, the runtime `w_code` wrapper, and
-//!     register layout — that RPython
-//!     does not need because RPython's bytecode PCs are already
+//!     offset), the runtime `w_code` wrapper, and register layout — that
+//!     RPython does not need because RPython's bytecode PCs are already
 //!     JitCode PCs.
 //!
 //! The struct lives in `pyre-jit-trace` (the lower crate) so that
@@ -243,8 +242,6 @@ pub struct PyJitCodePayload {
     /// (unsupported bytecodes / emission-time bail-outs). Precomputed at
     /// compile time to avoid repeated bytecode scanning.
     pub has_abort: bool,
-    /// Python PC of the jit_merge_point opcode (trace entry header).
-    pub merge_point_pc: Option<usize>,
     /// Lazily-built per-fn walker descr pool
     /// (`state::sub_jitcode_descr_pool_for_code`): adapted `descr_refs`,
     /// raw `RuntimeBhDescr` slice, sub-jitcode lookup. Carried on the
@@ -371,7 +368,6 @@ impl PyJitCode {
         code_ptr: *const pyre_interpreter::CodeObject,
         w_code: *const (),
         has_abort: bool,
-        merge_point_pc: Option<usize>,
     ) -> Self {
         Self::new(PyJitCodePayload {
             jitcode,
@@ -379,7 +375,6 @@ impl PyJitCode {
             code_ptr,
             w_code,
             has_abort,
-            merge_point_pc,
             sub_descr_pool: std::cell::OnceCell::new(),
         })
     }
@@ -417,7 +412,6 @@ impl PyJitCode {
             code_ptr,
             w_code,
             has_abort,
-            merge_point_pc,
             sub_descr_pool,
         } = next.payload.into_inner();
         let next_jitcode = std::sync::Arc::try_unwrap(next_jitcode)
@@ -441,7 +435,6 @@ impl PyJitCode {
             current.code_ptr = code_ptr;
             current.w_code = w_code;
             current.has_abort = has_abort;
-            current.merge_point_pc = merge_point_pc;
         }
     }
 
@@ -601,17 +594,9 @@ impl PyJitCode {
     /// `assembler.assemble(...)` populates them later in
     /// `make_jitcodes`'s drain loop (codewriter.py:80).  The skeleton
     /// gives the dict an entry with a stable identity so re-entrant
-    /// `get_jitcode` calls (or pyre's `merge_point_pc` refinement
-    /// shortcut) can find an existing key without recompiling.
-    ///
-    /// Until the drain replaces the slot, the only field with meaningful
-    /// content is `merge_point_pc` (the refinement hint passed in by
-    /// `get_jitcode`).
-    pub fn skeleton(
-        code_ptr: *const pyre_interpreter::CodeObject,
-        w_code: *const (),
-        merge_point_pc: Option<usize>,
-    ) -> Self {
+    /// `get_jitcode` calls can find an existing key without recompiling
+    /// (call.py:155 `if graph in self.jitcodes: return`).
+    pub fn skeleton(code_ptr: *const pyre_interpreter::CodeObject, w_code: *const ()) -> Self {
         Self::from_parts(
             std::sync::Arc::new(RuntimeJitCode::default()),
             PyJitCodeMetadata {
@@ -638,7 +623,6 @@ impl PyJitCode {
             code_ptr,
             w_code,
             false,
-            merge_point_pc,
         )
     }
 }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7697,10 +7697,10 @@ impl JitState for PyreJitState {
         // and DROP the concrete — so a bridge resume leaves loop-carried
         // locals symbolic and a data-dependent branch derived from one
         // (`(i%7) and ...` → TO_BOOL → goto_if_not) can't fold its
-        // direction, declining to the trait leg.  Stamp each decoded
+        // direction, aborting the walk.  Stamp each decoded
         // concrete onto its OpRef so the symbolic walk folds the branch
-        // per the actual failing-iteration path (the same path the trait
-        // tracer's owned_concrete_frame would execute), emitting a real
+        // per the actual failing-iteration path (the iteration the
+        // compiled trace re-runs), emitting a real
         // GuardTrue/GuardFalse — orthodox meta-tracing ("trace the
         // concrete path, guard it"; the IR keeps the symbolic InputArg,
         // the concrete is a trace-time shadow only, so the optimizer does
@@ -12134,10 +12134,10 @@ pub fn execute_inline_residual_call(
     Ok(())
 }
 
-// inline_trace_and_execute removed — replaced by PyreMetaInterp.interpret()
-// which uses a single framestack for both root and inline frames.
-// trace_through_callee removed — replaced by build_pending_inline_frame +
-// MetaInterp.push_inline_frame (RPython perform_call parity).
+// inline_trace_and_execute / trace_through_callee removed — the trait
+// meta-interpreter that replaced them (PyreMetaInterp.interpret() +
+// push_inline_frame) is itself retired (#203 gap 10); the FBW walker
+// handles both root and inline frames.
 
 /// `pypy/objspace/std/listobject.py:2390 is_plain_int1` parity.
 ///

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -45,9 +45,10 @@ pub(crate) struct JitCode {
     /// codewriter.py:68: jitcode.index = len(all_jitcodes).
     pub index: i32,
     /// Shared `PyJitCode` payload. Same `Arc` instance also lives in
-    /// `CallControl.jitcodes`. Refinements (e.g. a `merge_point_pc`
-    /// rebuild) replace this `Arc` in place so cached `*const JitCode`
-    /// pointers see the refreshed payload on the next field access.
+    /// `CallControl.jitcodes`. A rebuild (a later primary compile
+    /// re-queuing an inlined callee graph) replaces this `Arc` so cached
+    /// `*const JitCode` pointers see the refreshed payload on the next
+    /// field access.
     pub payload: std::sync::Arc<crate::PyJitCode>,
 }
 
@@ -350,8 +351,8 @@ impl MetaInterpStaticData {
     /// count from that index's pc_map + liveness tables, so a populated
     /// entry must never change shape under an index that live resume
     /// data already references. Pyre's runtime codewriter can re-splice
-    /// a graph (e.g. on a `merge_point_pc` refinement, or when a later
-    /// primary compile re-queues an inlined callee's graph at the drain
+    /// a graph (when a later primary compile re-queues an inlined
+    /// callee's graph at the drain
     /// boundary); such a rebuild must take a FRESH index, leaving the
     /// old entry intact for old resume data. Only not-yet-populated placeholders (skeletons and
     /// portal-bridge installs, both `pc_map`-empty — no liveness any
@@ -451,7 +452,7 @@ impl MetaInterpStaticData {
             } else {
                 raw_key as *const CodeObject
             };
-            std::sync::Arc::new(crate::PyJitCode::skeleton(raw_code, code, None))
+            std::sync::Arc::new(crate::PyJitCode::skeleton(raw_code, code))
         });
         let index = self.jitcodes.len() as i32;
         Self::stamp_payload_index(index, &payload);
@@ -636,7 +637,6 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
         std::ptr::null(),
         std::ptr::null(),
         false,
-        None,
     ))
 }
 
@@ -1865,7 +1865,6 @@ fn null_jitcode() -> &'static JitCode {
             payload: std::sync::Arc::new(crate::PyJitCode::skeleton(
                 std::ptr::null(),
                 std::ptr::null(),
-                None,
             )),
         });
         // SAFETY: per-thread `OnceCell` initialises once; the
@@ -9170,7 +9169,7 @@ mod tests {
             majit_metainterp::jitcode::insns::BC_LIVE,
         );
         crate::assembler::publish_state(&insns, all_liveness, all_liveness.len(), num_liveness_ops);
-        let mut pyjit = crate::PyJitCode::skeleton(raw_code, code_ref, None);
+        let mut pyjit = crate::PyJitCode::skeleton(raw_code, code_ref);
         pyjit.jitcode = std::sync::Arc::new(builder.finish());
         pyjit.metadata.pc_map.resize(code.instructions.len(), 0);
         METAINTERP_SD.with(|r| {
@@ -9236,7 +9235,7 @@ mod tests {
             });
             inner
         };
-        let mut pyjit = crate::PyJitCode::skeleton(raw_code, w_code, None);
+        let mut pyjit = crate::PyJitCode::skeleton(raw_code, w_code);
         pyjit.jitcode = std::sync::Arc::new(runtime_jc);
         pyjit.metadata.pc_map.push(0);
         let inner_jc = JitCode {
@@ -10120,7 +10119,7 @@ mod tests {
             majit_metainterp::jitcode::insns::BC_LIVE,
         );
         crate::assembler::publish_state(&insns, &[0, 0, 0], 3, 1);
-        let mut pyjit = crate::PyJitCode::skeleton(raw_code, code_ref, None);
+        let mut pyjit = crate::PyJitCode::skeleton(raw_code, code_ref);
         pyjit.jitcode = std::sync::Arc::new(builder.finish());
         pyjit.metadata.pc_map.resize(code.instructions.len(), 0);
         METAINTERP_SD.with(|r| {
@@ -11410,7 +11409,7 @@ mod tests {
         runtime_jc.body_mut().constants_r = vec![0xAABB_CCDD_u64 as i64];
         runtime_jc.body_mut().constants_f = vec![3.14_f64.to_bits() as i64];
 
-        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null(), None);
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null());
         pyjit.jitcode = std::sync::Arc::new(runtime_jc);
         let inner_jc = super::JitCode {
             code: std::ptr::null(),
@@ -11576,7 +11575,6 @@ mod tests {
             std::ptr::null(),
             code_ref,
             false,
-            None,
         ));
         let jitcode_index = METAINTERP_SD.with(|r| unsafe {
             let ptr = r.borrow_mut().jitcode_for(code_ref, Some(pyjit));
@@ -12261,7 +12259,7 @@ mod indirectcalltargets_tests {
     }
 
     fn populated_pyjit(raw_code: *const CodeObject, code: *const ()) -> Arc<crate::PyJitCode> {
-        let mut pyjit = crate::PyJitCode::skeleton(raw_code, code, None);
+        let mut pyjit = crate::PyJitCode::skeleton(raw_code, code);
         pyjit.metadata.pc_map.push(0);
         Arc::new(pyjit)
     }
@@ -12271,7 +12269,7 @@ mod indirectcalltargets_tests {
     fn install_jitcodes_rejects_skeleton_payload() {
         let mut sd = MetaInterpStaticData::new();
         let (code, raw_code) = make_code("x = 1\n");
-        let skeleton = Arc::new(crate::PyJitCode::skeleton(raw_code, code, None));
+        let skeleton = Arc::new(crate::PyJitCode::skeleton(raw_code, code));
         sd.set_jitcodes_from_make_result(vec![skeleton]);
     }
 
@@ -12375,7 +12373,6 @@ mod indirectcalltargets_tests {
             std::ptr::null(),
             std::ptr::null(),
             false,
-            None,
         ));
 
         let mut sd = MetaInterpStaticData::new();

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -104,17 +104,19 @@ pub fn trace_bytecode(
     } else {
         start_pc
     };
-    // RPython MetaInterp._interpret() parity: root frame owns a concrete
-    // PyFrame snapshot. MetaInterp drives both symbolic tracing AND
-    // concrete execution — the interpreter does not run during tracing.
+    // RPython MetaInterp._interpret() parity: the walker (sole tracer)
+    // executes as it records over a concrete `PyFrame` snapshot
+    // (`snapshot_for_tracing`); the interpreter does not run during tracing.
+    // The snapshot copies frame-LOCAL state (abort-safety) while sharing
+    // `w_globals`; vable-statics capture reads pointer-valued fields from the
+    // live frame (`live_vable_frame_addr` below), not the snapshot copy.
     //
-    // KNOWN DIVERGENCE (live miscompile, memory
-    // `cf-executor-into-walker-epic-2026-06-08`): tracing runs on a SNAPSHOT
-    // (`snapshot_for_tracing`), not the real frame, and the compiled loop
-    // re-runs the traced iteration from the loop header.  RPython's `_interpret`
-    // advances the SINGLE real frame so the compiled loop resumes AFTER the
-    // traced iterations.  For inline-frame SHARED-heap STOREs this re-run
-    // double-applies (see `metainterp::concrete_execute_step`).
+    // The former snapshot double-apply (inline-frame SHARED-heap STOREs
+    // leaking during tracing and re-applying on the compiled loop's re-run)
+    // is resolved by gap 10: the concrete executor is deleted so STOREs are
+    // record-only, and `flush_walk_end_state_to_frame`
+    // (`raise_continue_running_normally` parity) advances the real frame so
+    // the interpreter resumes AFTER the walked region, not from its start.
     concrete_frame.set_last_instr_from_next_instr(start_pc);
     let w_code = concrete_frame.pycode;
     // Issue #73 walker-as-tracer foundation probe (read-only).

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1049,7 +1049,7 @@ fn dump_perfn_jitcode_for_trace(w_code: *const (), start_pc: usize) {
     eprintln!(
         "[perfn-jitcode] code_len={} pc_map_len={} start_pc={} entry_jitcode_pc={:?} \
          num_regs_r={} num_regs_i={} num_regs_f={} portal_frame_reg={} portal_ec_reg={} \
-         built_as_portal={} merge_point_pc={:?}",
+         built_as_portal={}",
         code.len(),
         pjc.metadata.pc_map.len(),
         start_pc,
@@ -1060,7 +1060,6 @@ fn dump_perfn_jitcode_for_trace(w_code: *const (), start_pc: usize) {
         pjc.metadata.portal_frame_reg,
         pjc.metadata.portal_ec_reg,
         pjc.metadata.built_as_portal,
-        pjc.merge_point_pc,
     );
     let mut count = 0usize;
     let mut last_next = 0usize;

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -672,6 +672,54 @@ fn run_perfn_walk(
                 }
             }
         }
+
+        // `abort_permanent` marker abort (DELETE_FAST and the other
+        // emit_abort_permanent opcodes): the marker's contract is "resume
+        // the interpreter AT this unsupported opcode and run it" — codewriter
+        // stores `last_instr = py_pc - 1` for the blackhole.  On the
+        // full-body walk that recorded write is discarded with the aborted
+        // trace, while the walk already executed the region's residual side
+        // effects concretely, so the legacy `ContinueRunningNormally` replays
+        // them from entry → double-execution (e.g. a `del`-bearing method
+        // whose prior STORE_ATTR ran once during the walk, then again on
+        // replay).  Flush the abort-point frame (locals + last_instr) so the
+        // portal resumes at the unsupported opcode instead of replaying —
+        // same mechanism and same no-unjournaled-effect predicate as the
+        // CloseLoop end-flush above.  `PYRE_FBW_ABORT_FLUSH=0` opts out.
+        if std::env::var_os("PYRE_FBW_ABORT_FLUSH").as_deref() != Some(std::ffi::OsStr::new("0")) {
+            if let Err(crate::jitcode_dispatch::DispatchError::AbortPermanentMarkerReached { pc }) =
+                &walk_result
+            {
+                let abort_jit_pc = *pc;
+                if crate::jitcode_dispatch::fbw_has_unjournaled_effect()
+                    || crate::jitcode_dispatch::fbw_abort_in_subwalk()
+                {
+                    if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] declined at abort_jit_pc={abort_jit_pc} \
+                             (unjournaled effect or inline sub-walk) — legacy replay kept"
+                        );
+                    }
+                } else if let Some(resume_py_pc) =
+                    crate::jitcode_dispatch::fbw_abort_resume_py_pc(sym, abort_jit_pc)
+                {
+                    if crate::state::flush_walk_end_state_to_frame(ctx, cf_addr, resume_py_pc) {
+                        if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                            eprintln!(
+                                "[fbw-abort-flush] COMMIT abort_jit_pc={abort_jit_pc} \
+                                 resume_py_pc={resume_py_pc}"
+                            );
+                        }
+                        WALK_END_FLUSH_COMMITTED.with(|c| c.set(true));
+                    } else if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                        eprintln!(
+                            "[fbw-abort-flush] declined at resume_py_pc={resume_py_pc} \
+                             (shadow slot without concrete / depth / lastblock) — legacy replay kept"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     // No-replay portal exit for a loop-free function trace: a `Terminate`

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -11996,7 +11996,7 @@ mod tests {
             });
             inner
         };
-        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null(), None);
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null());
         pyjit.jitcode = Arc::new(runtime_jc);
         pyjit.metadata.pc_map.push(0);
         let inner_jc = crate::state::JitCode {
@@ -12073,7 +12073,7 @@ mod tests {
             });
             inner
         };
-        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null(), None);
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null());
         pyjit.jitcode = Arc::new(runtime_jc);
         pyjit.metadata.pc_map.push(0);
         pyjit.metadata.depth_at_py_pc.push(1);
@@ -12167,7 +12167,7 @@ mod tests {
             });
             inner
         };
-        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null(), None);
+        let mut pyjit = crate::PyJitCode::skeleton(std::ptr::null(), std::ptr::null());
         pyjit.jitcode = Arc::new(runtime_jc);
         pyjit.metadata.pc_map = (0..6).collect();
         const OUTER_INDEX: i32 = 4;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -1281,15 +1281,14 @@ impl MIFrame {
     /// #143 frame-advance gate: mark this trace as having performed a concrete
     /// heap mutation during tracing. Called exactly where the concrete
     /// mutation is a certainty: the BUILTIN-form list dispatch arms
-    /// (append/pop/pop-at/reverse — the trait impl's `call_callable` executed
-    /// the builtin concretely before dispatch) and the LIST_APPEND opcode hook
-    /// (the eval loop's `execute_opcode_step` / inline-frame
-    /// `concrete_execute_step` performs the write).
+    /// (append/pop/pop-at/reverse — the walker executes the builtin
+    /// concretely before dispatch) and the LIST_APPEND opcode hook
+    /// (`execute_opcode_step` performs the write).
     ///
     /// Deliberately NOT marked: deferred stores (`STORE_SUBSCR` — the compiled
     /// loop performs the write exactly once, nbody/fannkuch), non-mutating
     /// calls, and the Method method-form arms (`m = xs.pop; m(0)`) —
-    /// the trait impl only executes `is_function` callables concretely, so no
+    /// the walker only executes `is_function` callables concretely, so no
     /// during-trace mutation happens on that path and marking it would
     /// wrongly advance past an iteration whose mutation only exists as
     /// deferred IR. (Those traces currently always abort before CloseLoop;
@@ -9866,8 +9865,7 @@ impl MIFrame {
                 // metainterp's Abort handler skips its in-trace
                 // `finishframe_exception` (which would otherwise dispatch
                 // a handler-entry push with `reraise_lasti=-1`,
-                // synthesizing the WRONG lasti and mutating
-                // `owned_concrete_frame` in a way the interpreter would
+                // synthesizing the WRONG lasti the interpreter would
                 // then resume with).  `executor.reraise()` only mutated
                 // the symbolic stack and emitted IR — both abandoned on
                 // abort.  The concrete PyFrame is untouched, so the

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3908,7 +3908,7 @@ fn jit_merge_point_hook(
             // starts, populating all_liveness. In pyre, JitCode compilation is
             // lazy — ensure the code's JitCode (with liveness) exists before
             // tracing so get_list_of_active_boxes can use it.
-            crate::jit::codewriter::register_portal_jitdriver(code, frame.pycode, Some(pc));
+            crate::jit::codewriter::register_portal_jitdriver(code, frame.pycode);
             let snapshot = frame.snapshot_for_tracing();
             let _ = concrete_frame;
             let live_frame_addr = &*frame as *const PyFrame as usize;
@@ -4624,11 +4624,7 @@ fn bound_reached(
                 || {},
                 |meta, sym| {
                     use pyre_jit_trace::trace::trace_bytecode;
-                    crate::jit::codewriter::register_portal_jitdriver(
-                        code,
-                        frame.pycode,
-                        Some(loop_header_pc),
-                    );
+                    crate::jit::codewriter::register_portal_jitdriver(code, frame.pycode);
                     let concrete_frame = frame.snapshot_for_tracing();
                     let live_frame_addr = &*frame as *const PyFrame as usize;
                     let (action, executed_frame) = trace_bytecode(
@@ -7641,7 +7637,7 @@ mod tests {
                 as *const pyre_interpreter::CodeObject
         };
         let canonical_code = unsafe { &*raw_code };
-        crate::jit::codewriter::register_portal_jitdriver(canonical_code, w_code, None);
+        crate::jit::codewriter::register_portal_jitdriver(canonical_code, w_code);
     }
 
     /// Translate Python-stack depths into the post-regalloc Ref-bank

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2858,7 +2858,12 @@ pub(crate) fn call_depth() -> u32 {
 /// Each (code, pc) pair has independent warmup counter and compiled loop.
 #[inline(always)]
 pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
-    (code_ptr as u64).wrapping_mul(1000003) ^ (pc as u64)
+    // Full `JitCell.get_uhash` over the pypyjit green tuple
+    // `[next_instr, is_being_profiled, pycode]` (warmstate.py:584-593),
+    // computed allocation-free. `is_being_profiled` folds to 0 (the JIT
+    // path is never profiled), so this matches the typed marker-path key
+    // and both lookups resolve to the same cell.
+    majit_ir::pypyjit_greenkey_uhash(pc, false, code_ptr as u64)
 }
 
 // JIT_CALL_DEPTH removed — pyre-interpreter::call::CALL_DEPTH is the single
@@ -3828,9 +3833,12 @@ fn jit_merge_point_hook(
     // exercises `WarmEnterState::lookup_chain_with_key` so the typed-key
     // surface stays warm for the cutover; the result is intentionally
     // discarded so the legacy hash-only flow below still owns the
-    // decision (incremental hash unification
-    // is blocked by a fannkuch perf regression, so the soak gate is the
-    // S3.1 prereq instead).
+    // decision. The hash-unification prereq is now done: `make_green_key`
+    // computes the full `get_uhash` allocation-free
+    // (`majit_ir::pypyjit_greenkey_uhash`, so no fannkuch regression), so
+    // the typed-key hash and the production hash agree. The remaining S3.1
+    // prereq is populating each cell's `comparekey` on the install path
+    // (legacy cells carry `None`).
     static PYRE_JIT_MARKER_PARITY_SOAK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     if *PYRE_JIT_MARKER_PARITY_SOAK
         .get_or_init(|| std::env::var_os("PYRE_JIT_MARKER_PARITY_SOAK").is_some())
@@ -3860,10 +3868,14 @@ fn jit_merge_point_hook(
             key.values[1] = if frame.get_is_being_profiled() { 1 } else { 0 };
             key.values[2] = frame.pycode as i64;
             // Shadow lookup — read-only, no install. Discarded result.
-            // Pre-S3.1 the typed `get_uhash` and the legacy
-            // `make_green_key` hash differ, so this lookup
-            // intentionally misses. The soak's value is exercising the
-            // typed-API call site so a regression in
+            // The typed `get_uhash` and the production `make_green_key`
+            // hash now agree (both are `pypyjit_greenkey_uhash`, with
+            // `is_being_profiled` 0 on the JIT path), so this lookup lands
+            // in the right bucket; it still misses only because
+            // legacy-installed cells carry `comparekey = None`
+            // (`comparekey_matches` → false). Populating `comparekey` on
+            // the install path is the remaining S3.1 step. The soak keeps
+            // the typed-API call site warm so a regression in
             // `lookup_chain_with_key` surfaces under
             // `PYRE_JIT_MARKER_PARITY_SOAK=1` before S3.1 cutover.
             let _shadow = driver

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3836,9 +3836,10 @@ fn jit_merge_point_hook(
     // decision. The hash-unification prereq is now done: `make_green_key`
     // computes the full `get_uhash` allocation-free
     // (`majit_ir::pypyjit_greenkey_uhash`, so no fannkuch regression), so
-    // the typed-key hash and the production hash agree. The remaining S3.1
-    // prereq is populating each cell's `comparekey` on the install path
-    // (legacy cells carry `None`).
+    // the typed-key hash and the production hash agree, and the production
+    // decision path now installs each cell's `comparekey`
+    // (`maybe_compile_with_key` / `force_start_tracing_for_key`), so the
+    // shadow lookup below resolves to those cells once a merge point is hot.
     static PYRE_JIT_MARKER_PARITY_SOAK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     if *PYRE_JIT_MARKER_PARITY_SOAK
         .get_or_init(|| std::env::var_os("PYRE_JIT_MARKER_PARITY_SOAK").is_some())
@@ -3867,14 +3868,15 @@ fn jit_merge_point_hook(
             key.values[0] = pc as i64;
             key.values[1] = if frame.get_is_being_profiled() { 1 } else { 0 };
             key.values[2] = frame.pycode as i64;
-            // Shadow lookup — read-only, no install. Discarded result.
-            // The typed `get_uhash` and the production `make_green_key`
-            // hash now agree (both are `pypyjit_greenkey_uhash`, with
-            // `is_being_profiled` 0 on the JIT path), so this lookup lands
-            // in the right bucket; it still misses only because
-            // legacy-installed cells carry `comparekey = None`
-            // (`comparekey_matches` → false). Populating `comparekey` on
-            // the install path is the remaining S3.1 step. The soak keeps
+            // Shadow lookup — read-only, no install. Discarded for the
+            // decision. The typed `get_uhash` and the production
+            // `make_green_key` hash agree (both `pypyjit_greenkey_uhash`,
+            // `is_being_profiled` 0 on the JIT path), so this lands in the
+            // right bucket, and the production decision path now installs
+            // each cell's `comparekey` (`maybe_compile_with_key` /
+            // `force_start_tracing_for_key`), so once a merge point is hot
+            // this lookup hits (`comparekey_matches` → true); only the
+            // early ticks before the cell is installed miss. The soak keeps
             // the typed-API call site warm so a regression in
             // `lookup_chain_with_key` surfaces under
             // `PYRE_JIT_MARKER_PARITY_SOAK=1` before S3.1 cutover.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3816,76 +3816,14 @@ fn jit_merge_point_hook(
     let concrete_frame = frame as *mut PyFrame as usize;
     let green_key = make_green_key(frame.pycode, pc);
 
-    // S2.5 (wiggly-barto plan, Stage 2 — dual verification mode).
-    //
-    // TODO(delete in S3.2): the env var and this whole soak block ship
-    // out alongside the direct-hook deletion. Upstream has no eval-side
-    // marker gate (rlib/jit.py:881-1006 + warmspot.py:874-1075 run
-    // unconditionally). The gate exists only as scaffolding for the
-    // S3.1 cutover so we can bring up the marker/static-data path
-    // alongside the legacy `make_green_key` hash flow without flipping
-    // production default in one commit.
-    //
-    // While `PYRE_JIT_MARKER_PARITY_SOAK=1` is set, this block runs
-    // shadow-style next to the production decision: it constructs the
-    // typed `GreenKey` mirroring `pypyjitdriver.greens` (rlib/jit.py:649,
-    // interp_jit.py:69 — `[next_instr, is_being_profiled, pycode]`) and
-    // exercises `WarmEnterState::lookup_chain_with_key` so the typed-key
-    // surface stays warm for the cutover; the result is intentionally
-    // discarded so the legacy hash-only flow below still owns the
-    // decision. The hash-unification prereq is now done: `make_green_key`
-    // computes the full `get_uhash` allocation-free
-    // (`majit_ir::pypyjit_greenkey_uhash`, so no fannkuch regression), so
-    // the typed-key hash and the production hash agree, and the production
-    // decision path now installs each cell's `comparekey`
-    // (`maybe_compile_with_key` / `force_start_tracing_for_key`), so the
-    // shadow lookup below resolves to those cells once a merge point is hot.
-    static PYRE_JIT_MARKER_PARITY_SOAK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    if *PYRE_JIT_MARKER_PARITY_SOAK
-        .get_or_init(|| std::env::var_os("PYRE_JIT_MARKER_PARITY_SOAK").is_some())
-    {
-        // pypyjitdriver greens declaration order
-        // (interp_jit.py:69 / rlib/jit.py:649): pc first, then
-        // is_being_profiled, then pycode — verify_green_args upstream
-        // walks the same prefix (pyjitpl.py:1532-1535).
-        //
-        // The hot-path overhead would dominate variance if we allocated
-        // three Vecs per tick; reuse a thread-local GreenKey with
-        // pre-built `types` so each call only mutates `values[0..3]`.
-        thread_local! {
-            static SOAK_KEY: std::cell::RefCell<majit_ir::GreenKey> =
-                std::cell::RefCell::new(majit_ir::GreenKey::with_types(
-                    vec![0_i64, 0, 0],
-                    vec![
-                        majit_ir::Type::Int,
-                        majit_ir::Type::Int,
-                        majit_ir::Type::Ref,
-                    ],
-                ));
-        }
-        SOAK_KEY.with(|cell| {
-            let mut key = cell.borrow_mut();
-            key.values[0] = pc as i64;
-            key.values[1] = if frame.get_is_being_profiled() { 1 } else { 0 };
-            key.values[2] = frame.pycode as i64;
-            // Shadow lookup — read-only, no install. Discarded for the
-            // decision. The typed `get_uhash` and the production
-            // `make_green_key` hash agree (both `pypyjit_greenkey_uhash`,
-            // `is_being_profiled` 0 on the JIT path), so this lands in the
-            // right bucket, and the production decision path now installs
-            // each cell's `comparekey` (`maybe_compile_with_key` /
-            // `force_start_tracing_for_key`), so once a merge point is hot
-            // this lookup hits (`comparekey_matches` → true); only the
-            // early ticks before the cell is installed miss. The soak keeps
-            // the typed-API call site warm so a regression in
-            // `lookup_chain_with_key` surfaces under
-            // `PYRE_JIT_MARKER_PARITY_SOAK=1` before S3.1 cutover.
-            let _shadow = driver
-                .meta_interp()
-                .warm_state_ref()
-                .lookup_chain_with_key(&key);
-        });
-    }
+    // The trace-START decision (counter / threshold / start-tracing) lives
+    // in the warmstate marker path — `maybe_compile_with_key` (back-edge)
+    // and `force_start_tracing_for_key` (function-entry/recursion) walk the
+    // cell chain by `comparekey_matches` and own the decision. This hook is
+    // only the trace FEED: it runs once tracing is already active and hands
+    // each merge-point opcode to `jit_merge_point_keyed`. `make_green_key`
+    // and the warmstate cell key are the same allocation-free
+    // `pypyjit_greenkey_uhash`, so the feed key and the decision key agree.
 
     let mut jit_state = build_jit_state(frame, info);
     let current_depth = call_depth();

--- a/pyre/pyre-jit/src/jit/call.rs
+++ b/pyre/pyre-jit/src/jit/call.rs
@@ -65,14 +65,10 @@ impl CallInfoCollection {
 /// `mainjitcode`, `_green_args_spec`, …); pyre adds only the fields
 /// the lazy portal-discovery path actually consumes today.
 ///
-/// Note: pyre carries `w_code` and `merge_point_pc`
-/// alongside `portal_graph` because pyre's "graph" is a Python
-/// CodeObject with no flow-graph identity. `w_code` is the wrapping
-/// `PyObjectRef`, threaded through so the runtime side keys its
-/// per-CodeObject lookups by the same identity; `merge_point_pc` is
-/// the Python PC of the `MERGE_POINT` opcode the first trace through
-/// the portal reveals (RPython has no analog because portal PCs are
-/// statically known at flow-graph time).
+/// Note: pyre carries `w_code` alongside `portal_graph` because
+/// pyre's "graph" is a Python CodeObject with no flow-graph identity.
+/// `w_code` is the wrapping `PyObjectRef`, threaded through so the
+/// runtime side keys its per-CodeObject lookups by the same identity.
 ///
 /// `Copy` was previously derived because every field was `Copy` /
 /// `Option<Copy>`; restoring `mainjitcode` (`Option<Arc<PyJitCode>>`
@@ -98,20 +94,6 @@ pub struct JitDriverStaticData {
     /// truth that bridges the two identities — see the wiggly-barto
     /// epic plan, "Risk Assessment" row 4.
     pub w_code: *const (),
-    /// pyre-only refinement hint forwarded to `get_jitcode`.
-    /// `Some(pc)` rebuilds the cached `PyJitCode` if the recorded
-    /// merge-point PC changes from a previous registration. RPython
-    /// has no analog because its portal PCs are statically known.
-    ///
-    /// **Deletion criterion (S3.2)**: removable once the per-Python-bytecode
-    /// `orgpc` is carried explicitly by `MIFrame`'s
-    /// `BC_JIT_MERGE_POINT` payload (mirroring upstream `pyjitpl.py:
-    /// 1536-1538` `orgpc` operand) and the JitCode PC ↔ Python PC map
-    /// is the single source of truth. Until then this slot keeps the
-    /// existing trace-side `make_green_key(code, pc)` lookup keyed on
-    /// the same merge-point PC the runtime registered — see plan
-    /// "Risk Assessment" row 3.
-    pub merge_point_pc: Option<usize>,
     /// RPython: `JitDriverStaticData.mainjitcode`
     /// (`call.py:147` `jd.mainjitcode = self.get_jitcode(jd.portal_graph)`
     /// left-hand side, plus `call.py:148`
@@ -126,8 +108,8 @@ pub struct JitDriverStaticData {
     /// Note (type-only): RPython types this as
     /// `JitCode`; pyre stores `Arc<PyJitCode>`, where `PyJitCode` is a
     /// thin wrapper around `Arc<RuntimeJitCode>` plus pyre-only
-    /// metadata (`PyJitCodeMetadata`, `code_ptr`, `w_code`, `has_abort`,
-    /// `merge_point_pc`).  The wrapper exists because pyre's codewriter
+    /// metadata (`PyJitCodeMetadata`, `code_ptr`, `w_code`, `has_abort`).
+    /// The wrapper exists because pyre's codewriter
     /// publication path needs interior mutability to fill an empty
     /// skeleton in place (so that the same Arc identity sits in both
     /// `cc.jitcodes[graph]` and `jd.mainjitcode` while the assembler
@@ -224,8 +206,8 @@ pub struct CallControl {
     /// `make_jitcodes()` (codewriter.py:79).
     ///
     /// pyre now mirrors RPython's bare-graph queue directly. The
-    /// pyre-only `w_code` / `merge_point_pc` adapter state lives on the
-    /// cached `PyJitCode` shell instead of in the queue tuple so
+    /// pyre-only `w_code` adapter state lives on the cached `PyJitCode`
+    /// shell instead of in the queue tuple so
     /// `enum_pending_graphs()` can match `call.py:150-153` again.
     pub unfinished_graphs: Vec<*const CodeObject>,
 
@@ -272,19 +254,18 @@ impl CallControl {
         // Index loop because get_jitcode borrows `self.jitcodes`
         // mutably, which would conflict with an immutable borrow over
         // `self.jitdrivers_sd`. The fields snapshotted below
-        // (`portal_graph`, `w_code`, `merge_point_pc`) are all `Copy`,
-        // so the per-iteration field reads stay cheap.
+        // (`portal_graph`, `w_code`) are all `Copy`, so the per-iteration
+        // field reads stay cheap.
         for i in 0..self.jitdrivers_sd.len() {
             let portal_graph = self.jitdrivers_sd[i].portal_graph;
             let w_code = self.jitdrivers_sd[i].w_code;
-            let merge_point_pc = self.jitdrivers_sd[i].merge_point_pc;
             let code = unsafe { &*portal_graph };
             // call.py:147 `jd.mainjitcode = self.get_jitcode(jd.portal_graph)`.
             // Inserts an empty PyJitCode skeleton into `jitcodes`, pushes
             // the graph onto `unfinished_graphs`. Drop the returned
             // clone immediately so the cached slot is uniquely owned for
             // the call.py:148 stamp below.
-            drop(self.get_jitcode(code, w_code, merge_point_pc));
+            drop(self.get_jitcode(code, w_code));
             // call.py:148 `jd.mainjitcode.jitdriver_sd = jd` — stamp the
             // skeleton's `jitdriver_sd` while the outer `Arc<PyJitCode>`
             // and inner `Arc<JitCode>` still have refcount 1 (only the
@@ -348,13 +329,10 @@ impl CallControl {
 
     /// Recover the pyre-only inputs the drain needs for a queued graph.
     /// The queue itself keeps RPython's bare `graph` shape; the extra
-    /// runtime identity/refinement data lives on the cached skeleton.
-    pub fn queued_graph_inputs(
-        &self,
-        code: *const CodeObject,
-    ) -> Option<(*const (), Option<usize>)> {
+    /// runtime identity (the `w_code` wrapper) lives on the cached skeleton.
+    pub fn queued_graph_inputs(&self, code: *const CodeObject) -> Option<*const ()> {
         let arc = self.jitcodes.get(&(code as usize))?;
-        Some((arc.w_code, arc.merge_point_pc))
+        Some(arc.w_code)
     }
 
     /// Reverse lookup: find the `PyJitCode` whose inner `JitCode` matches
@@ -461,18 +439,10 @@ impl CallControl {
     /// re-runs `transform_graph_to_jitcode` and replaces the slot with
     /// the populated entry (codewriter.py:80
     /// `transform_graph_to_jitcode(graph, jitcode, ...)`).
-    ///
-    /// Note: `merge_point_pc` is a pyre-only refinement
-    /// — the first trace reveals the `MERGE_POINT` opcode's PC, which
-    /// must be re-recorded on the cache entry. When it changes the
-    /// entry is reset to a new skeleton and re-queued so the drain
-    /// recompiles with the refined hint. RPython has no analog because
-    /// portal PCs are statically known.
     pub fn get_jitcode(
         &mut self,
         code: &CodeObject,
         w_code: *const (),
-        merge_point_pc: Option<usize>,
     ) -> std::sync::Arc<PyJitCode> {
         // RPython's `get_jitcode(graph)` receives the exact graph object
         // the dict is keyed by. Match that by requiring callers to pass
@@ -494,44 +464,32 @@ impl CallControl {
             // `CodeWriter::make_jitcodes`'s drain loop at
             // codewriter.py:80 `transform_graph_to_jitcode(graph,
             // jitcode, verbose, len(all_jitcodes))`.
-            self.reset_jitcode_skeleton(key, code_ptr, w_code, merge_point_pc);
+            self.reset_jitcode_skeleton(key, code_ptr, w_code);
             // call.py:171 `self.unfinished_graphs.append(graph)`.
             self.unfinished_graphs.push(code_ptr);
         }
         std::sync::Arc::clone(self.jitcodes.get(&key).unwrap())
     }
 
-    /// Reset the cached slot back to an empty skeleton — the state that
-    /// follows `JitCode(graph.name, fnaddr, calldescr, ...)` at
-    /// `call.py:168` before the drain re-runs `assembler.assemble`
+    /// Insert an empty skeleton for a freshly-registered graph — the state
+    /// that follows `JitCode(graph.name, fnaddr, calldescr, ...)` at
+    /// `call.py:168` before the drain runs `assembler.assemble`
     /// (codewriter.py:67) on it.
     ///
-    /// Note: this entry point exists only because
-    /// `get_jitcode` re-runs the drain when `merge_point_pc` is refined
-    /// — RPython has no analog because portal PCs are statically known
-    /// (call.py:155 `if graph in self.jitcodes: return self.jitcodes[graph]`
-    /// has no reset branch).
-    ///
-    /// This method must NOT use the in-place payload mutation that
-    /// `publish_jitcode` relies on: after the first drain, `jd.mainjitcode`
-    /// and any trace-side `MetaInterpStaticData.jitcodes` clone are
-    /// already pointing at the populated `Arc<PyJitCode>`. Replacing the
-    /// payload in place here would clobber those holders back to a
-    /// skeleton state, which RPython's "runtime reader never observes a
-    /// reset shell" invariant rules out. Instead we always insert a new
-    /// `Arc<PyJitCode>`; the previous Arc stays populated for any holder
-    /// that already cloned it, matching the pre-Slice-2 behavior that
-    /// fell back to `Arc::new(...)` on `Arc::get_mut` failure.
+    /// Inserts a fresh `Arc<PyJitCode>` rather than mutating an existing
+    /// payload in place: `publish_jitcode` fills the slot in place after
+    /// the drain, but this entry point only runs when the key is absent
+    /// (`get_jitcode`'s `call.py:155` guard), so there is no populated
+    /// holder to clobber.
     pub fn reset_jitcode_skeleton(
         &mut self,
         key: usize,
         code_ptr: *const CodeObject,
         w_code: *const (),
-        merge_point_pc: Option<usize>,
     ) {
         self.jitcodes.insert(
             key,
-            std::sync::Arc::new(PyJitCode::skeleton(code_ptr, w_code, merge_point_pc)),
+            std::sync::Arc::new(PyJitCode::skeleton(code_ptr, w_code)),
         );
     }
 

--- a/pyre/pyre-jit/src/jit/call.rs
+++ b/pyre/pyre-jit/src/jit/call.rs
@@ -481,11 +481,12 @@ impl CallControl {
         // unwraps `w_code` before calling into `CallControl`.
         let code_ptr = code as *const CodeObject;
         let key = code_ptr as usize;
-        let needs_rebuild = if let Some(existing) = self.jitcodes.get(&key) {
-            merge_point_pc.is_some() && existing.merge_point_pc != merge_point_pc
-        } else {
-            true
-        };
+        // call.py:155 `if graph in self.jitcodes: return self.jitcodes[graph]`
+        // — the skeleton is built once. An already-registered portal is not
+        // rebuilt when a later registration carries a different merge-point
+        // PC: pyre observes merge-point PCs at runtime, but the first
+        // registration's skeleton stands (no recompile-on-refine).
+        let needs_rebuild = !self.jitcodes.contains_key(&key);
         if needs_rebuild {
             // call.py:168-171 — create JitCode skeleton, insert, append
             // to unfinished_graphs. The body fill (jtransform / regalloc
@@ -494,10 +495,7 @@ impl CallControl {
             // codewriter.py:80 `transform_graph_to_jitcode(graph,
             // jitcode, verbose, len(all_jitcodes))`.
             self.reset_jitcode_skeleton(key, code_ptr, w_code, merge_point_pc);
-            // call.py:171 `self.unfinished_graphs.append(graph)`. pyre
-            // also re-pushes on a merge_point_pc refinement so the
-            // drain picks the refined entry up again for the recompile
-            // — see `make_jitcodes` at codewriter.rs.
+            // call.py:171 `self.unfinished_graphs.append(graph)`.
             self.unfinished_graphs.push(code_ptr);
         }
         std::sync::Arc::clone(self.jitcodes.get(&key).unwrap())

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4955,20 +4955,15 @@ impl CodeWriter {
     /// fires on every JIT entry, so the same `portal_graph` would be
     /// pushed repeatedly without the `find` guard below — `jitdrivers_sd`
     /// would grow linearly with JIT entries instead of staying bounded
-    /// by the number of unique portals. The dedup updates the existing
-    /// jd's `merge_point_pc` so the refinement hint propagates into
-    /// the next `grab_initial_jitcodes` pass.
+    /// by the number of unique portals.
     pub fn setup_jitdriver(&self, jitdriver_sd: super::call::JitDriverStaticData) {
         let jitdriver_sd = jitdriver_sd.canonicalized();
         let cc = self.callcontrol();
-        if let Some(existing) = cc
+        if cc
             .jitdrivers_sd
-            .iter_mut()
-            .find(|j| j.portal_graph == jitdriver_sd.portal_graph)
+            .iter()
+            .any(|j| j.portal_graph == jitdriver_sd.portal_graph)
         {
-            if jitdriver_sd.merge_point_pc.is_some() {
-                existing.merge_point_pc = jitdriver_sd.merge_point_pc;
-            }
             return;
         }
         // codewriter.py:99 `self.callcontrol.jitdrivers_sd.append(jitdriver_sd)`.
@@ -5011,12 +5006,7 @@ impl CodeWriter {
     /// Python bytecodes serve as the "graph". Since they are already linear
     /// and register-allocated, jtransform/regalloc/flatten are identity
     /// transforms. We go directly to assembly.
-    pub fn transform_graph_to_jitcode(
-        &self,
-        code: &CodeObject,
-        w_code: *const (),
-        merge_point_pc: Option<usize>,
-    ) -> PyJitCode {
+    pub fn transform_graph_to_jitcode(&self, code: &CodeObject, w_code: *const ()) -> PyJitCode {
         // jtransform.py:840 — the portal `frame` (and `ec`) red args are
         // threaded into every vable op from the start. Compute the graph
         // Variables once at function entry so all vable graph-shadow
@@ -5468,9 +5458,6 @@ impl CodeWriter {
         // path (`register_portal_jitdriver`) registers before the drain
         // runs `transform_graph_to_jitcode`, so the lookup must happen
         // before creating the shadow graph / entry FrameState below.
-        // `merge_point_pc` is only a pyre refinement hint; `None` still
-        // means "registered portal whose exact merge PC is not known yet",
-        // not "non-portal".
         let portal_jd_index = self
             .callcontrol()
             .jitdriver_sd_from_portal_graph(code as *const CodeObject);
@@ -5747,13 +5734,12 @@ impl CodeWriter {
         // it. Resolved per `flatten_constant_operand`'s Ref arms.
         let mut const_ref_slots_at_pc: Vec<Vec<(u16, i64)>> = vec![Vec::new(); num_instrs];
         // RPython parity: every backward jump goes through dispatch() →
-        // jit_merge_point(). `merge_point_pc` is still threaded in from
-        // bound_reached as the trace-entry refinement hint, but portal
-        // jitcode emission must not restrict merge-point bytecodes to that
-        // single PC: PyPy's dispatch loop reaches a portal merge point for
-        // every bytecode dispatch, and nested Python loops rely on the
-        // blackhole CRN at those inner headers to compile and target their
-        // own loops instead of growing giant bridges.
+        // jit_merge_point(). Portal jitcode emission must not restrict
+        // merge-point bytecodes to a single PC: PyPy's dispatch loop reaches
+        // a portal merge point for every bytecode dispatch, and nested
+        // Python loops rely on the blackhole CRN at those inner headers to
+        // compile and target their own loops instead of growing giant
+        // bridges.
 
         // pyframe.py:379-417 pushvalue/popvalue_maybe_none parity:
         // Each push/pop writes self.valuestackdepth = depth ± 1.
@@ -11517,7 +11503,6 @@ impl CodeWriter {
             portal_ec_reg,
             is_portal,
             has_abort,
-            merge_point_pc,
             num_regs,
             stack_slot_color_map,
             pyre_color_for_semantic_local,
@@ -11544,8 +11529,8 @@ impl CodeWriter {
     ///   - jitdriver_sd / calldescr / fnaddr are stamped onto the
     ///     `JitCode` (call.py:148, call.py:174-187, call.py:167).
     ///   - `PyJitCodeMetadata` is bundled with the ref-count-stable
-    ///     `Arc<JitCode>` plus the pyre-only `has_abort` /
-    ///     `merge_point_pc` fields into the returned `PyJitCode`.
+    ///     `Arc<JitCode>` plus the pyre-only `has_abort` field into the
+    ///     returned `PyJitCode`.
     fn finalize_jitcode(
         &self,
         mut assembler: SSAReprEmitter,
@@ -11560,7 +11545,6 @@ impl CodeWriter {
         portal_ec_reg: u16,
         is_portal: bool,
         has_abort: bool,
-        merge_point_pc: Option<usize>,
         num_regs: super::assembler::NumRegs,
         stack_slot_color_map: Vec<u16>,
         pyre_color_for_semantic_local: Vec<u16>,
@@ -11667,7 +11651,6 @@ impl CodeWriter {
             code as *const CodeObject,
             w_code,
             has_abort,
-            merge_point_pc,
         )
     }
 
@@ -11738,7 +11721,7 @@ impl CodeWriter {
             let Some(code_ptr) = popped else {
                 break;
             };
-            let (w_code, merge_point_pc) = self
+            let w_code = self
                 .callcontrol()
                 .queued_graph_inputs(code_ptr)
                 .expect("queued graph must still have a cached skeleton");
@@ -11750,8 +11733,7 @@ impl CodeWriter {
             // replaces the cached skeleton's payload in place. That
             // matches RPython's "same JitCode object is filled later"
             // identity flow even after other stores cloned the Arc.
-            let pyjitcode =
-                self.transform_graph_to_jitcode(unsafe { &*code_ptr }, w_code, merge_point_pc);
+            let pyjitcode = self.transform_graph_to_jitcode(unsafe { &*code_ptr }, w_code);
             let key = code_ptr as usize;
             let pyjitcode = self.callcontrol().publish_jitcode(key, pyjitcode);
             // codewriter.py:81 `all_jitcodes.append(jitcode)`.
@@ -11880,18 +11862,13 @@ fn skip_caches(code: &CodeObject, mut pos: usize) -> usize {
 /// whole to trace-side `MetaInterpStaticData`, matching
 /// `warmspot.py:281-282`. Runtime trace-side lookup must observe this
 /// installed result; it must not compile missing callees lazily.
-pub fn register_portal_jitdriver(
-    code: &pyre_interpreter::CodeObject,
-    w_code: *const (),
-    merge_point_pc: Option<usize>,
-) {
+pub fn register_portal_jitdriver(code: &pyre_interpreter::CodeObject, w_code: *const ()) {
     let writer = CodeWriter::instance();
     // codewriter.py:96-99 `setup_jitdriver(jd)` — register the
     // portal so `grab_initial_jitcodes` finds it.
     writer.setup_jitdriver(super::call::JitDriverStaticData {
         portal_graph: code as *const pyre_interpreter::CodeObject,
         w_code,
-        merge_point_pc,
         // call.py:147 LHS — initial `None` matches RPython's
         // `jd.mainjitcode = None` before `grab_initial_jitcodes`
         // fires; `grab_initial_jitcodes` itself stores the
@@ -12042,7 +12019,7 @@ pub fn compile_jitcode_for_callee(
     let writer = CodeWriter::instance();
     // call.py:155-172 `get_jitcode(graph)` — insert skeleton if missing and
     // queue the graph for the drain.
-    let _ = writer.callcontrol().get_jitcode(code, w_code, None);
+    let _ = writer.callcontrol().get_jitcode(code, w_code);
     // codewriter.py:79-85 — drain the queued graph(s), then assembler.finished.
     writer.drain_unfinished_graphs()
 }
@@ -13195,29 +13172,27 @@ mod tests {
 
         let _ = writer
             .callcontrol()
-            .get_jitcode(code_ref, w_code as *const (), Some(11));
+            .get_jitcode(code_ref, w_code as *const ());
 
         let queued = writer
             .callcontrol()
             .enum_pending_graphs()
             .expect("fresh jitcode must queue one graph");
-        let (queued_w_code, queued_merge_point_pc) = writer
+        let queued_w_code = writer
             .callcontrol()
             .queued_graph_inputs(raw_code)
             .expect("queued graph must still have a cached skeleton");
 
         assert_eq!(queued, raw_code);
         assert_eq!(queued_w_code, w_code as *const ());
-        assert_eq!(queued_merge_point_pc, Some(11));
     }
 
     #[test]
-    fn get_jitcode_does_not_rebuild_on_merge_point_pc_refinement() {
+    fn get_jitcode_returns_cached_arc_without_rebuild() {
         // call.py:155 `if graph in self.jitcodes: return self.jitcodes[graph]`
-        // has no rebuild branch: a portal's jitcode skeleton is built once
-        // and never reset when a later registration carries a different
-        // merge-point PC. The cached Arc identity must stay stable, and the
-        // portal must not be re-queued for the drain.
+        // has no rebuild branch: a portal's jitcode skeleton is built once.
+        // A repeat get_jitcode for the same graph returns the cached Arc
+        // identity and does not re-queue the portal for the drain.
         let writer = CodeWriter::new();
         let code = pyre_interpreter::compile_exec("x = 1\n").expect("source must compile");
         let w_code = pyre_interpreter::box_code_constant(&code);
@@ -13226,26 +13201,25 @@ mod tests {
         };
         let code_ref = unsafe { &*raw_code };
 
-        let first_ptr = Arc::as_ptr(&writer.callcontrol().get_jitcode(
-            code_ref,
-            w_code as *const (),
-            Some(11),
-        ));
-        // Re-register the SAME portal with a DIFFERENT merge-point PC.
-        let second_ptr = Arc::as_ptr(&writer.callcontrol().get_jitcode(
-            code_ref,
-            w_code as *const (),
-            Some(29),
-        ));
+        let first_ptr = Arc::as_ptr(
+            &writer
+                .callcontrol()
+                .get_jitcode(code_ref, w_code as *const ()),
+        );
+        let second_ptr = Arc::as_ptr(
+            &writer
+                .callcontrol()
+                .get_jitcode(code_ref, w_code as *const ()),
+        );
 
         assert_eq!(
             first_ptr, second_ptr,
-            "a merge-point PC refinement must not replace the cached portal jitcode Arc"
+            "a repeat get_jitcode must return the cached portal jitcode Arc"
         );
         assert_eq!(
             writer.callcontrol().unfinished_graphs.len(),
             1,
-            "refinement must not re-push the portal onto unfinished_graphs"
+            "a repeat get_jitcode must not re-push the portal onto unfinished_graphs"
         );
     }
 
@@ -13262,7 +13236,7 @@ mod tests {
 
         let _ = writer
             .callcontrol()
-            .get_jitcode(code_ref, w_code as *const (), None);
+            .get_jitcode(code_ref, w_code as *const ());
         let skeleton_ptr = {
             let slot = writer
                 .callcontrol()
@@ -13699,7 +13673,7 @@ mod tests {
 
         let _ = writer
             .callcontrol()
-            .get_jitcode(code_ref, w_code as *const (), None);
+            .get_jitcode(code_ref, w_code as *const ());
         assert!(writer.callcontrol().find_jitcode_arc(raw_code).is_some());
         assert!(
             writer
@@ -13730,7 +13704,6 @@ mod tests {
         writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
             portal_graph: code_ptr,
             w_code: w_code as *const (),
-            merge_point_pc: None,
             mainjitcode: None,
         });
 
@@ -13765,7 +13738,6 @@ mod tests {
         writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
             portal_graph: code_ptr,
             w_code: w_code as *const (),
-            merge_point_pc: None,
             mainjitcode: None,
         });
 
@@ -13833,7 +13805,6 @@ mod tests {
         writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
             portal_graph: code_ptr,
             w_code: w_code as *const (),
-            merge_point_pc: None,
             mainjitcode: None,
         });
 
@@ -14134,13 +14105,11 @@ mod tests {
         writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
             portal_graph: &code as *const _,
             w_code: w_code as *const (),
-            merge_point_pc: None,
             mainjitcode: None,
         });
         writer.setup_jitdriver(crate::jit::call::JitDriverStaticData {
             portal_graph: raw_code,
             w_code: w_code as *const (),
-            merge_point_pc: Some(7),
             mainjitcode: None,
         });
 
@@ -14148,7 +14117,6 @@ mod tests {
             let cc = writer.callcontrol();
             assert_eq!(cc.jitdrivers_sd.len(), 1);
             assert_eq!(cc.jitdrivers_sd[0].portal_graph, raw_code);
-            assert_eq!(cc.jitdrivers_sd[0].merge_point_pc, Some(7));
             assert_eq!(cc.jitdriver_sd_from_portal_graph(raw_code), Some(0));
 
             cc.grab_initial_jitcodes();

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -10454,6 +10454,17 @@ impl CodeWriter {
                         }
 
                         // Instructions that don't touch the operand stack (locals/cells only).
+                        // DELETE_FAST aborts rather than lowering a localsplus-slot
+                        // clear: making it traceable lets `del`-bearing regions compile
+                        // (notably the implicit `del e` an `except E as e:` handler
+                        // emits), which surfaces latent miscompiles there — exception
+                        // `__context__` chaining and raising LOAD_FAST_CHECK side-exits.
+                        // The abort's resume coordinate (`last_instr = py_pc - 1`,
+                        // stored below by `emit_abort_permanent`) is honored by the
+                        // full-body walk's abort-point flush (`run_perfn_walk`), so a
+                        // `del`-bearing hot method resumes AT the del instead of
+                        // replaying the walked region's already-executed residual side
+                        // effects.
                         Instruction::DeleteFast { .. }
                         | Instruction::DeleteDeref { .. }
                         | Instruction::DeleteGlobal { .. }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -13212,6 +13212,44 @@ mod tests {
     }
 
     #[test]
+    fn get_jitcode_does_not_rebuild_on_merge_point_pc_refinement() {
+        // call.py:155 `if graph in self.jitcodes: return self.jitcodes[graph]`
+        // has no rebuild branch: a portal's jitcode skeleton is built once
+        // and never reset when a later registration carries a different
+        // merge-point PC. The cached Arc identity must stay stable, and the
+        // portal must not be re-queued for the drain.
+        let writer = CodeWriter::new();
+        let code = pyre_interpreter::compile_exec("x = 1\n").expect("source must compile");
+        let w_code = pyre_interpreter::box_code_constant(&code);
+        let raw_code = unsafe {
+            pyre_interpreter::w_code_get_ptr(w_code) as *const pyre_interpreter::CodeObject
+        };
+        let code_ref = unsafe { &*raw_code };
+
+        let first_ptr = Arc::as_ptr(&writer.callcontrol().get_jitcode(
+            code_ref,
+            w_code as *const (),
+            Some(11),
+        ));
+        // Re-register the SAME portal with a DIFFERENT merge-point PC.
+        let second_ptr = Arc::as_ptr(&writer.callcontrol().get_jitcode(
+            code_ref,
+            w_code as *const (),
+            Some(29),
+        ));
+
+        assert_eq!(
+            first_ptr, second_ptr,
+            "a merge-point PC refinement must not replace the cached portal jitcode Arc"
+        );
+        assert_eq!(
+            writer.callcontrol().unfinished_graphs.len(),
+            1,
+            "refinement must not re-push the portal onto unfinished_graphs"
+        );
+    }
+
+    #[test]
     fn drain_unfinished_graphs_preserves_unique_pyjitcode_identity() {
         let writer = CodeWriter::new();
         let code = pyre_interpreter::compile_exec("x = 1\n").expect("source must compile");


### PR DESCRIPTION
Post-#237 continuation of the #203 framework-gap epic on `pyre-8`. Closes the remaining production-JIT gaps.

## Gaps closed
- **gap 7 — marker-path / decision-path convergence:** unify the three green-key hash sites on one allocation-free `get_uhash`; install the typed comparekey on the production trace-start paths; build the portal jitcode skeleton once and drop the `merge_point_pc` field + recompile and the marker-parity soak scaffolding.
- **gap 1 — blackhole exception delivery:** deliver blackhole exception exits to the interpreter (exception-exit + multi-frame forward-resume).
- **gap 9 — rtyper two-phase prepass:** number inheritance ids before Phase B (global inheritance-id barrier between Phase A and B).
- **gap 3+8 — virtualizable `original_boxes`:** `PYRE_ORIGINAL_BOXES` gate restoring the `original_boxes` (greens+reds) shape in `initialize_virtualizable`.
- comment correctness: describe the retired trait tracer accurately (gap 10 follow-up).

Verified: `pyre/check.py` green on both backends; `majit-translate` 2874/0.

Refs #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT tracing and resume behavior for more reliable execution after certain exceptions and abort points.
  * Added better handling for traced loop state so execution can continue more accurately from recorded paths.

* **Bug Fixes**
  * Fixed JIT key/hash generation to be consistent across tracing and runtime paths.
  * Improved handling of virtualizable and shared state during tracing, reducing duplicate or incorrect updates.
  * Updated JIT metadata handling to better match current constructor behavior and avoid stale fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->