### PR TITLE
#289 review follow-ups: gap-9 barrier guard + gap-7 jitcode skeleton invariant

### DIFF
--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2249,9 +2249,24 @@ fn run_two_phase_prepass_inner(
     // once a subclassrange has been baked into the immutable jitcode const pool
     // during Phase B (#203 gap 9). The pass is idempotent without new
     // classdefs, so Phase B's per-subject numbering is then a no-op.
-    if let Ok((annotator, _rtyper)) = call_registry.ensure_session() {
-        crate::translator::rtyper::normalizecalls::assign_inheritance_ids(&annotator);
-    }
+    // A failed session init must NOT fall through to Phase B: that would let
+    // `run_phase_b_rtype_isolated` materialize vtables without the global
+    // `assign_inheritance_ids` pass and reopen the stale minid/maxid contract
+    // this barrier exists to hold. Surface and skip — Phase B is incremental,
+    // so the next call retries with a live session.
+    let (annotator, _rtyper) = match call_registry.ensure_session() {
+        Ok(session) => session,
+        Err(err) => {
+            if rtyper_verbose_enabled() {
+                eprintln!(
+                    "[PREPASS inheritance-id barrier] ensure_session failed, \
+                     skipping Phase B: {err:?}"
+                );
+            }
+            return;
+        }
+    };
+    crate::translator::rtyper::normalizecalls::assign_inheritance_ids(&annotator);
 
     // ── Phase B — rtype-all with per-graph isolation ─────────────────
     // Writes its rtype_skipped set into the cache incrementally so partial

--- a/pyre/pyre-jit/src/jit/call.rs
+++ b/pyre/pyre-jit/src/jit/call.rs
@@ -481,12 +481,20 @@ impl CallControl {
     /// the drain, but this entry point only runs when the key is absent
     /// (`get_jitcode`'s `call.py:155` guard), so there is no populated
     /// holder to clobber.
-    pub fn reset_jitcode_skeleton(
+    fn reset_jitcode_skeleton(
         &mut self,
         key: usize,
         code_ptr: *const CodeObject,
         w_code: *const (),
     ) {
+        // Only the absent-key path (`get_jitcode`'s `needs_rebuild`) installs a
+        // skeleton. Enforce it so a stray call cannot roll a populated jitcode
+        // back to a skeleton and break the runtime-reader publication invariant
+        // documented above.
+        debug_assert!(
+            !self.jitcodes.contains_key(&key),
+            "reset_jitcode_skeleton must only create fresh skeleton entries"
+        );
         self.jitcodes.insert(
             key,
             std::sync::Arc::new(PyJitCode::skeleton(code_ptr, w_code)),


### PR DESCRIPTION
close #203 

Follow-up to the merged #289, addressing two CodeRabbit `Major` review findings on that PR's commits.

## Fixes
- **rtyper / gap-9 barrier (`cutover.rs`):** a failed `ensure_session()` no longer falls through to Phase B without the global `assign_inheritance_ids` pass. It now surfaces via `rtyper_verbose_enabled` and returns, so `run_phase_b_rtype_isolated` never materializes vtables under a stale `minid`/`maxid` contract. Phase B is incremental, so the next call retries with a live session.
- **jit / gap-7 skeleton (`call.rs`):** `reset_jitcode_skeleton` is now private and `debug_assert!`s the key is absent, so it cannot roll a populated jitcode back to a skeleton and break the runtime-reader publication invariant its own doc-comment states. (No external caller; build confirms.)

## Triaged, no action (the two #289 Codex `P2`s)
- **typed-warmup lifecycle threading** (`pyjitpl.rs:3578`): the typed trace-start selection vs hash-only abort/attach/finish only diverges on a full 64-bit `get_uhash` collision between two hot green keys (~10⁻¹¹). Deliberately deferred and documented (`warmstate.rs:598-604`); the typed `*_for_key` variants exist + are unit-tested for when the full GreenKey threading lands.
- **`deliver_blackhole_exception` override** (`jitdriver.rs:2497`): this is the majit-metainterp *framework* driver's hook. Production pyre uses its own `eval.rs` blackhole path, and no `#[jit_interp]` example raises, so it is the documented not-positively-exercisable structural-parity scaffold (`jit_state.rs:361-363`).

Verified: majit-translate tests pass; check.py dynasm 158/158.

Refs #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
