### PR TITLE
JIT: make the vstack operand-stack mirror the default kept-stack resume source (#73)

### DIFF
--- a/pyre/bench/synth/kept_stack_aliased_swap_boxed.py
+++ b/pyre/bench/synth/kept_stack_aliased_swap_boxed.py
@@ -1,0 +1,30 @@
+# Two operand-stack temps holding heap ints (>= 256) are swapped across a
+# `goto_if_not` branch guard, a shape a per-jitcode merge-color map is prone
+# to COLLAPSE (alias both slots onto one color).  The flat-free boxed-int
+# kept-slot check (`kept_stack_has_boxed_int_hazard`) inspects each kept slot
+# through its per-PC `pcdep_color_slots` color (or `const_ref_slots_at_pc`
+# raw), so it must not be fooled by a collapsed/stale merge color the way the
+# flat `stack_slot_color_map` read was.
+#
+# Regression guard for the kept_boxed_int flat-map migration: a wrong/stale
+# color would either miss the boxed-int hazard (miscompile) or recover the
+# wrong slot.  Pure arithmetic -> deterministic checksum.
+N = 400000
+
+
+def main():
+    a = 100000
+    b = 200000
+    i = 0
+    while i < N:
+        if i % 6 == 0:
+            a, b = 900000, a
+        else:
+            a, b = b, 800000
+        a = a % 999983
+        b = b % 999983
+        i += 1
+    print(a, b)
+
+
+main()

--- a/pyre/bench/synth/kept_stack_boxed_in_handler.py
+++ b/pyre/bench/synth/kept_stack_boxed_in_handler.py
@@ -1,0 +1,31 @@
+# A boxed-int conditional-expression keeps a heap int (>= 256) live on the
+# operand stack across a `goto_if_not` branch guard INSIDE an exception
+# handler body.  The kept-stack guard's not-taken arm resumes at a PC the
+# exception table protects, where the partial walker snapshot cannot
+# reconstruct the kept handler-state operand — so the guard must decline to
+# the interpreter (`branch_resume_inside_exc_region`, the flat-free
+# replacement for the accidental `stack_slot_color_map` boxed-int decline).
+#
+# Regression guard: with the decline missing, the bridge / blackhole resume
+# rebuilds the kept boxed int (or the re-raised exception) as NULL / a wrong
+# value and the handler arithmetic diverges from the interpreter.  Pure
+# arithmetic -> deterministic checksum.
+N = 300000
+
+
+def main():
+    acc = 9
+    i = 0
+    while i < N:
+        try:
+            if i % 3 == 0:
+                raise ValueError("x")
+            acc = (acc + 2) % 999983
+        except ValueError:
+            acc = 777777 if (i % 2 == 0) else acc
+            acc = (acc + 5) % 999983
+        i += 1
+    print(acc)
+
+
+main()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7371,7 +7371,7 @@ enum VstackOpClass {
     /// new TOS with `vstack_last_ref`.  Covers value producers whose
     /// result is the topmost stack slot: LOAD_FAST / LOAD_CONST /
     /// LOAD_GLOBAL(result) / LOAD_NAME / LOAD_ATTR / BINARY_OP /
-    /// BINARY_SUBSCR / COMPARE_OP / unary ops / TO_BOOL / CALL / COPY /
+    /// BINARY_SUBSCR / COMPARE_OP / unary ops / TO_BOOL / CALL /
     /// IS_OP / CONTAINS_OP / single-result BUILD_*.
     ResultToTos,
     /// The opcode only pops (and/or stores to a local/global/attr/subscr,
@@ -7390,6 +7390,15 @@ enum VstackOpClass {
     /// short-circuit guard) lands on the right slot instead of latching the
     /// mirror invalid.
     Swap(usize),
+    /// `COPY(i)` duplicates the box `i` positions from the top onto the new
+    /// TOS (`opcode_copy_value` = `push(peek_at(i-1))`).  Net depth +1; the
+    /// new TOS box is `vstack_boxes[depth-1-i]` (the COPIED slot), NOT the
+    /// last Ref written — only `COPY 1` (dup of TOS, the and/or/condexpr and
+    /// chained-comparison truthiness dup) coincides with `vstack_last_ref`.
+    /// Reconcile sources the duplicated slot directly so `COPY i>1`
+    /// (duplicating a deeper operand) is faithful.  The carried `usize` is
+    /// the decoded `i`.
+    Copy(usize),
     /// Anything that does not fit the shapes above —
     /// UNPACK_SEQUENCE / UNPACK_EX (net push > 1), LOAD_GLOBAL pushing a
     /// NULL sentinel beneath the result, STORE_FAST__STORE_FAST (net pop
@@ -7431,7 +7440,6 @@ fn classify_vstack_opcode(
         | Instruction::LoadName { .. }
         | Instruction::LoadDeref { .. }
         | Instruction::LoadLocals
-        | Instruction::Copy { .. }
         | Instruction::UnaryNegative
         | Instruction::UnaryNot
         | Instruction::UnaryInvert
@@ -7509,6 +7517,12 @@ fn classify_vstack_opcode(
         // permutation (net depth 0); the decoded `i` drives the
         // `vstack_boxes` exchange in `reconcile_vstack_at_boundary`.
         Instruction::Swap { i } => VstackOpClass::Swap(i.get(op_arg) as usize),
+
+        // COPY(i): duplicate the box `i` positions from the top onto the new
+        // TOS (net +1).  The decoded `i` drives the duplicate-from-slot copy
+        // in `reconcile_vstack_at_boundary` (sources `vstack_boxes[depth-1-i]`,
+        // not `vstack_last_ref`, so `COPY i>1` is faithful).
+        Instruction::Copy { i } => VstackOpClass::Copy(i.get(op_arg) as usize),
 
         // Everything else (UNPACK_*, FOR_ITER, STORE_FAST__STORE_FAST,
         // TO_BOOL if present as a distinct variant, exception machinery,
@@ -7591,6 +7605,26 @@ fn reconcile_vstack_at_boundary(
                 ctx.vstack_boxes.swap(top, other);
             } else {
                 ctx.vstack_valid = false;
+            }
+        }
+        VstackOpClass::Copy(i) => {
+            // COPY(i): duplicate the box `i` positions from the top onto the
+            // new TOS (net +1).  The duplicated box is the COPIED slot
+            // `vstack_boxes[new_depth-1-i]` (`opcode_copy_value` =
+            // `push(peek_at(i-1))`), sourced directly rather than from
+            // `vstack_last_ref` so `COPY i>1` (duplicating a deeper operand)
+            // is faithful; `COPY 1` reduces to dup-of-TOS.  A missing source
+            // slot or out-of-range arg declines (latch invalid).
+            match new_depth.checked_sub(1 + i) {
+                Some(src_idx) if i >= 1 && src_idx < ctx.vstack_boxes.len() => {
+                    let src = ctx.vstack_boxes[src_idx];
+                    ctx.vstack_boxes.truncate(new_depth);
+                    if ctx.vstack_boxes.len() < new_depth {
+                        ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+                    }
+                    ctx.vstack_boxes[new_depth - 1] = src;
+                }
+                _ => ctx.vstack_valid = false,
             }
         }
         VstackOpClass::Unmodeled => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2626,6 +2626,7 @@ pub fn dispatch_via_miframe_at_opcode_entry<'a>(
         entry_py_pc,
         None,
         majit_ir::resumedata::NO_JITCODE_PC,
+        None,
     );
 
     // pyjitpl.py:82-90 `setup` per-bank allocation: each bank gets
@@ -5827,6 +5828,7 @@ fn collect_outer_active_boxes(
     entry_py_pc: u32,
     guard_py_pc: Option<u32>,
     carried_jitcode_pc: i32,
+    vstack: Option<&[OpRef]>,
 ) -> Vec<OpRef> {
     // `#124` Approach B: resolve the base live-box set through the carried
     // JitCode coordinate so the encoder's color set matches the decoder's
@@ -6118,8 +6120,44 @@ fn collect_outer_active_boxes(
             .position(|&c| c as u32 == merge_color)?;
         kept_slot_source_local_box(sym, trace_ctx, regs_r, &local_color_map, guard_py_pc, slot)
     };
+    // #73 mirror-sourced kept operand-stack slots: at a branch guard the
+    // not-taken arm preserves the operand-stack bottom, so the live walk-level
+    // box mirror (`ctx.vstack_boxes`, indexed by absolute operand-stack depth)
+    // holds the exact kept value for resume operand slot `s`.  This replaces
+    // the stale `registers_r[merge_color]` / edge-recovery color heuristics
+    // below, which read a color the regalloc reused between the guard pc and
+    // the resume pc (the #424 merge-color-staleness corruption).  Gated
+    // (`PYRE_VSTACK_USE`, the same gate as the `stack_sync` vable overlay) and
+    // scoped to the branch-guard reconstruction (`guard_py_pc`); INERT
+    // otherwise (byte-identical to the legacy color read).
+    let vstack_mirror: Option<&[OpRef]> = vstack
+        .filter(|_| guard_py_pc.is_some() && std::env::var_os("PYRE_VSTACK_USE").is_some());
     for &idx in &banks.ref_ {
         let color = idx as usize;
+        if let Some(mirror) = vstack_mirror {
+            // Resume operand-stack slot for this live Ref color; the mirror
+            // box for that slot is the kept value (bottom-anchored: resume
+            // slot `s` == `vstack_boxes[s]`, the same mapping `mirror_covers_
+            // kept` validates).
+            if let Some(sem) = crate::state::semantic_ref_slot_for_reg_color(
+                nlocals,
+                valid_stack_only,
+                &local_color_map,
+                &stack_color_map,
+                &live_locals,
+                pcdep_opt,
+                color,
+            ) {
+                if sem >= nlocals {
+                    if let Some(&m) = mirror.get(sem - nlocals) {
+                        if m != OpRef::NONE && !opref_is_null_const_ptr(m) {
+                            active.push(m);
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
         if let Some(&rv) = kept_recovered.get(&idx) {
             // Edge-move-resolved kept operand; overrides the unwritten
             // merge-color read for this not-taken-arm operand-stack slot.
@@ -9137,6 +9175,7 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 liveness_py_pc,
                 guard_py_pc,
                 guard_jitcode_pc,
+                ctx.vstack_valid.then_some(ctx.vstack_boxes.as_slice()),
             );
             ctx.trace_ctx
                 .capture_snapshot_for_last_guard_with_vable_vref(
@@ -9260,6 +9299,7 @@ fn compute_inline_caller_frame(
         fallthrough_py_pc,
         None,
         majit_ir::resumedata::NO_JITCODE_PC,
+        None,
     );
     if let (Some(saved), true) = (saved, result_color < ctx.registers_r.len()) {
         ctx.registers_r[result_color] = saved;
@@ -14263,6 +14303,7 @@ fn try_walker_orthodox_list_append(
         call_site_py_pc,
         None,
         majit_ir::resumedata::NO_JITCODE_PC,
+        None,
     );
 
     // Swap in the call-site resume context + the callee's GLOBAL descr pool

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5724,100 +5724,6 @@ fn opref_is_null_const_ptr(op: OpRef) -> bool {
     op.as_const_ptr().is_some_and(|g| g.is_null())
 }
 
-/// #124 provenance recovery: the live box of operand-stack `slot`'s source
-/// local at a branch guard, or `None` when the slot is not a `LOAD_FAST`
-/// local carried unchanged (the conservative source analysis reports
-/// `Other`), `guard_py_pc` is absent, or the local's register is empty.
-///
-/// A short-circuit `and`/`or` keeps the tested value on the not-taken arm,
-/// but the walk executed the taken arm and folded a constant into the kept
-/// slot's reused operand-stack register — so reading that register (the
-/// `#420` edge-move recovery / the merge-color read) yields the stale fold.
-/// The local's OWN register is not reused for the fold, so it still holds
-/// the live box; read it via the forward source analysis + local color map.
-fn kept_slot_source_local_box(
-    sym: &crate::state::PyreSym,
-    trace_ctx: &TraceCtx,
-    regs_r: &[OpRef],
-    local_color_map: &[u16],
-    guard_py_pc: Option<u32>,
-    slot: usize,
-) -> Option<OpRef> {
-    if std::env::var_os("PYRE_KEPT_OVERRIDE").is_none() {
-        return None;
-    }
-    let gpc = guard_py_pc? as usize;
-    if sym.jitcode.is_null() {
-        return None;
-    }
-    let lv = unsafe {
-        let jc = &*sym.jitcode;
-        if jc.payload.code_ptr.is_null() {
-            return None;
-        }
-        crate::liveness::liveness_for(jc.payload.code_ptr)
-    };
-    let local_idx = lv.stack_slot_source_local(gpc, slot)? as usize;
-    // For a portal-owner frame the local box lives in the vable shadow
-    // (`write_stack_slot` retires the `registers_r` local/stack colors to
-    // `NONE`); for a non-owner frame it sits in the register bank.  Mirror
-    // the encoder's local-slot resolution (`collect_outer_active_boxes`):
-    // prefer the shadow when real, else the register.
-    let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
-    let shadow = trace_ctx.virtualizable_box_at(nvs + local_idx);
-    let v = match shadow {
-        Some(b) if b != OpRef::NONE && !opref_is_null_const_ptr(b) => b,
-        _ => {
-            let lcolor = *local_color_map.get(local_idx)? as usize;
-            regs_r.get(lcolor).copied().unwrap_or(OpRef::NONE)
-        }
-    };
-    let ok = v != OpRef::NONE && !opref_is_null_const_ptr(v);
-    ok.then_some(v)
-}
-
-/// #124 depth > 1 gate: `true` when kept operand-stack `slot` (at the guard
-/// jitcode pc `jitcode_pc`) sources from a `LOAD_FAST` local whose value is
-/// live in the vable shadow.  Such a slot is recoverable by the snapshot's
-/// `stack_sync` provenance override even though its retired register color
-/// reads `NONE` on a portal-owner frame — so it need not force the
-/// conservative `BranchGuardKeptStackUnsupported` decline.  Scoped to the
-/// shadow path (the portal-frame case the existing gate cannot cover);
-/// gated behind `PYRE_KEPT_OVERRIDE`.
-fn kept_slot_local_shadow_recoverable(
-    jitcode_pc: usize,
-    trace_ctx: &TraceCtx,
-    slot: usize,
-) -> bool {
-    if std::env::var_os("PYRE_KEPT_OVERRIDE").is_none() {
-        return false;
-    }
-    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
-    if full_body_sym.is_null() {
-        return false;
-    }
-    let sym = unsafe { &*full_body_sym };
-    if sym.jitcode.is_null() {
-        return false;
-    }
-    let (lv, guard_py_pc) = unsafe {
-        let jc = &*sym.jitcode;
-        if jc.payload.code_ptr.is_null() {
-            return false;
-        }
-        let gpc = python_pc_for_jitcode_pc(&jc.payload.metadata, jitcode_pc) as usize;
-        (crate::liveness::liveness_for(jc.payload.code_ptr), gpc)
-    };
-    let Some(local_idx) = lv.stack_slot_source_local(guard_py_pc, slot) else {
-        return false;
-    };
-    let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
-    matches!(
-        trace_ctx.virtualizable_box_at(nvs + local_idx as usize),
-        Some(b) if b != OpRef::NONE && !opref_is_null_const_ptr(b)
-    )
-}
-
 fn collect_outer_active_boxes(
     sym: &crate::state::PyreSym,
     trace_ctx: &TraceCtx,
@@ -6111,15 +6017,6 @@ fn collect_outer_active_boxes(
     // guard-pc source value directly, exact for any kept-stack depth.
     let kept_recovered: std::collections::HashMap<u32, OpRef> = BRANCH_GUARD_KEPT_RECOVERED
         .with(|c| c.borrow().iter().map(|&(dst, v)| (dst as u32, v)).collect());
-    // #124 provenance override (see `kept_slot_source_local_box`): the kept
-    // slot for a Ref color is the operand-stack slot whose resume merge color
-    // it is; its source local is read at the GUARD pc (pre-pop, unambiguous).
-    let kept_local_box = |merge_color: u32| -> Option<OpRef> {
-        let slot = stack_color_map
-            .iter()
-            .position(|&c| c as u32 == merge_color)?;
-        kept_slot_source_local_box(sym, trace_ctx, regs_r, &local_color_map, guard_py_pc, slot)
-    };
     // #73 mirror-sourced kept operand-stack slots: at a branch guard the
     // not-taken arm preserves the operand-stack bottom, so the live walk-level
     // box mirror (`ctx.vstack_boxes`, indexed by absolute operand-stack depth)
@@ -6161,10 +6058,7 @@ fn collect_outer_active_boxes(
         if let Some(&rv) = kept_recovered.get(&idx) {
             // Edge-move-resolved kept operand; overrides the unwritten
             // merge-color read for this not-taken-arm operand-stack slot.
-            // Prefer the live-local provenance when the kept slot is a
-            // short-circuit-kept local whose register the taken-arm fold
-            // clobbered.
-            active.push(kept_local_box(idx).unwrap_or(rv));
+            active.push(rv);
             continue;
         }
         if let Some(&subst) = kept_stack_subst.get(&idx) {
@@ -7800,8 +7694,7 @@ pub(crate) fn fbw_abort_resume_py_pc(
         return None;
     }
     // SAFETY: read-only access to the sym's immutable jitcode layout, live
-    // for the walk that produced `abort_jit_pc` (same access pattern as
-    // `kept_slot_source_local_box`).
+    // for the walk that produced `abort_jit_pc`.
     let jc = unsafe { &*sym.jitcode };
     if jc.payload.code_ptr.is_null() {
         return None;
@@ -8964,7 +8857,6 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     ))
                 }
             };
-            let kept_local_color_map = crate::state::local_slot_color_map_at(jitcode_index as i32);
             let stack_sync: Vec<(usize, OpRef)> = if sym.owns_virtualizable_shadow() {
                 let (depth, stack_color_map) = unsafe {
                     let jc = &*sym.jitcode;
@@ -9063,18 +8955,6 @@ fn walker_capture_snapshot_for_last_guard_impl(
                             Some(m) if m != OpRef::NONE => m,
                             _ => legacy,
                         };
-                        // #124 provenance override: a short-circuit-kept local
-                        // whose register the taken-arm fold clobbered — source
-                        // the live local box instead of the stale read.
-                        let v = kept_slot_source_local_box(
-                            sym,
-                            ctx.trace_ctx,
-                            ctx.registers_r,
-                            &kept_local_color_map,
-                            guard_py_pc,
-                            s,
-                        )
-                        .unwrap_or(v);
                         if v != OpRef::NONE && !opref_is_null_const_ptr(v) {
                             Some((nvs + nlocals + s, v))
                         } else {
@@ -14755,8 +14635,7 @@ fn try_walker_lower_exc_info_residual(
     // resolves to NULL or a non-exception, recover the authoritative exception
     // from the tracked channel, matching the graph-side producer.
     if is_push_set
-        && (store_concrete.is_null()
-            || !unsafe { pyre_object::is_exception(store_concrete) })
+        && (store_concrete.is_null() || !unsafe { pyre_object::is_exception(store_concrete) })
     {
         if let (Some(tracked_op), ConcreteValue::Ref(tracked_obj)) =
             (ctx.last_exc_value, ctx.last_exc_value_concrete)
@@ -16963,17 +16842,8 @@ fn handle(
                             // reads its (unwritten/stale) merge color — it is NOT
                             // live-across, since the edge renamed siblings — so
                             // keep the conservative decline.
-                            cols.iter().enumerate().all(|(i, c)| {
-                                resolved.iter().any(|&(dst, _)| dst == *c)
-                                    // #124: an unrenamed sibling slot retired to
-                                    // the vable shadow is recovered by the
-                                    // snapshot's local-provenance override.
-                                    || kept_slot_local_shadow_recoverable(
-                                        op.pc,
-                                        ctx.trace_ctx,
-                                        i,
-                                    )
-                            })
+                            cols.iter()
+                                .all(|c| resolved.iter().any(|&(dst, _)| dst == *c))
                         } else {
                             // Empty trampoline: the not-taken edge does NO
                             // renaming (an exception-handler / non-merge resume).
@@ -16986,20 +16856,11 @@ fn handle(
                             // `registers_r[color]` is in range and non-`NONE` (the
                             // same file the snapshot reads; `record_guard` below
                             // does not mutate it).
-                            cols.iter().enumerate().all(|(i, c)| {
+                            cols.iter().all(|c| {
                                 ctx.registers_r
                                     .get(*c as usize)
                                     .copied()
                                     .is_some_and(|v| v != OpRef::NONE)
-                                    // #124: a kept slot retired to the vable
-                                    // shadow on a portal-owner frame reads
-                                    // `NONE` here but is recovered by the
-                                    // snapshot's local-provenance override.
-                                    || kept_slot_local_shadow_recoverable(
-                                        op.pc,
-                                        ctx.trace_ctx,
-                                        i,
-                                    )
                             })
                         };
                         distinct && all_recoverable

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8168,6 +8168,123 @@ fn branch_resume_stack_colors(frame: &ActiveResumeFrame, target: usize) -> Optio
     }
 }
 
+/// Flat-free (#267) boxed-int kept-slot hazard: a kept operand-stack slot
+/// holding a heap int outside `[0, 256)` is reconstructed with a WRONG / NULL
+/// value on a kept-stack branch-guard resume (the conditional-expression /
+/// short-circuit boxed-int crash), so its presence forces the conservative
+/// decline.  This replaces the dense `stack_slot_color_map` read the gate used
+/// to inspect: every kept-slot kind has a per-PC source — a live Variable
+/// through `pcdep_color_slots` (inspect its concrete register), a Ref constant
+/// (the hoisted boxed int `pcdep_color_slots` omits) through
+/// `const_ref_slots_at_pc` (inspect the raw value).  A kept slot in NEITHER map
+/// is unrestorable / a non-Ref constant the per-PC sources cannot prove safe,
+/// so it forces the decline too — strictly no less conservative than the flat
+/// read.
+fn kept_stack_has_boxed_int_hazard(
+    frame: &ActiveResumeFrame,
+    target: usize,
+    concrete_registers_r: &[ConcreteValue],
+) -> bool {
+    let pjc = &frame.0;
+    if pjc.code_ptr.is_null() {
+        // No FBW frame layout — the trait-leg `reads_null_ref` gate already
+        // declines; report no hazard so this predicate adds nothing there.
+        return false;
+    }
+    // SAFETY: `code_ptr` / `metadata` are immutable payload layout fields kept
+    // alive by the frame's `Arc<PyJitCode>`; const raws are runtime PyObject
+    // pointers captured at codewrite time and read-only here.
+    unsafe {
+        let code = &*pjc.code_ptr;
+        let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
+        let py = skip_python_trivia_forward(code, py);
+        let Some(depth) = crate::liveness::liveness_for(pjc.code_ptr)
+            .depth_at_py_pc()
+            .get(py)
+            .copied()
+            .map(|d| d as usize)
+        else {
+            // Unknown resume depth — cannot prove safe.
+            return true;
+        };
+        if depth == 0 {
+            return false;
+        }
+        let nlocals = code.varnames.len();
+        let pcdep = pjc.metadata.pcdep_color_slots.get(py);
+        let consts = pjc.metadata.const_ref_slots_at_pc.get(py);
+        // The concrete shadow unboxes exact ints, so a kept slot that holds a
+        // heap int surfaces either already-unboxed as `Int(v)` or still-boxed
+        // as `Ref(W_IntObject)`; a value `< 0` or `>= 256` is the unrestorable
+        // boxed-int hazard in either shape.
+        let raw_is_boxed_int = |p: pyre_object::PyObjectRef| {
+            !p.is_null()
+                && pyre_object::is_int(p)
+                && !(0..256).contains(&pyre_object::w_int_get_value(p))
+        };
+        for s in 0..depth {
+            let slot = (nlocals + s) as u16;
+            // Live Variable slot: inspect its concrete register value.
+            if let Some(color) =
+                pcdep.and_then(|e| e.iter().find_map(|&(c, sl)| (sl == slot).then_some(c)))
+            {
+                let boxed = match concrete_registers_r.get(color as usize) {
+                    Some(ConcreteValue::Int(v)) => !(0..256).contains(v),
+                    Some(ConcreteValue::Ref(p)) => raw_is_boxed_int(*p),
+                    _ => false,
+                };
+                if boxed {
+                    return true;
+                }
+                continue;
+            }
+            // Ref constant slot (the hoisted boxed int): inspect the raw value.
+            if let Some(raw) =
+                consts.and_then(|e| e.iter().find_map(|&(sl, raw)| (sl == slot).then_some(raw)))
+            {
+                if raw_is_boxed_int(raw as pyre_object::PyObjectRef) {
+                    return true;
+                }
+                continue;
+            }
+            // Neither: an unrestorable / non-Ref-constant kept slot the per-PC
+            // sources cannot prove safe — decline (conservative).
+            return true;
+        }
+        false
+    }
+}
+
+/// Flat-free (#267) hazard: a kept-stack branch guard whose not-taken arm
+/// resumes at a PC protected by an exception handler.  The kept operand stack
+/// there can hold exception-handler state (the value `PUSH_EXC_INFO` pushed and
+/// the bare `raise` re-reads) that the partial walker snapshot does not
+/// reconstruct on a blackhole resume: the re-raise then reads NULL and the
+/// outer `CHECK_EXC_MATCH` dereferences it.  This is the principled decline the
+/// flat `stack_slot_color_map` boxed-int read used to trigger only by accident
+/// (a stale merge color aliasing a boxed int at the same slot).  Conservative —
+/// any kept-stack arm under an active handler declines to the interpreter;
+/// subsumed once the #73 symbolic-valuestack capture reconstructs the kept
+/// exception operand directly.
+fn branch_resume_inside_exc_region(frame: &ActiveResumeFrame, target: usize) -> bool {
+    let pjc = &frame.0;
+    if pjc.code_ptr.is_null() {
+        return false;
+    }
+    // SAFETY: `code_ptr` is an immutable payload field kept alive by the
+    // frame's `Arc<PyJitCode>`; `exceptiontable` is read-only.
+    unsafe {
+        let code = &*pjc.code_ptr;
+        let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
+        let py = skip_python_trivia_forward(code, py);
+        // `lookup_exceptiontable` takes byte offsets; pyre tracks `py` as an
+        // instruction index (2 bytes / instruction), so scale (`trace_opcode.rs`
+        // parity).
+        pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, (py * 2) as u32)
+            .is_some()
+    }
+}
+
 /// The resume snapshot's live Ref register colors at a kept-stack branch
 /// guard's not-taken arm, plus the jitcode `num_regs_r` (the const-window
 /// boundary `n()`).  These are exactly the registers the blackhole restores
@@ -16853,29 +16970,17 @@ fn handle(
                     // succeed depends on optimizer guard-folding the record does
                     // not see, so decline whenever a kept slot is a boxed int —
                     // correct (interpreter), matching the pre-#416 decline.
-                    let kept_boxed_int = gate_frame
+                    let kept_boxed_int = gate_frame.as_ref().is_some_and(|f| {
+                        kept_stack_has_boxed_int_hazard(f, other_target, ctx.concrete_registers_r)
+                    });
+                    // Hazard (4): the not-taken arm resumes at an
+                    // exception-handler-protected PC whose kept operand stack
+                    // holds exception state the partial snapshot cannot
+                    // reconstruct (the bare-`raise` re-raise reads NULL).
+                    let inside_exc_region = gate_frame
                         .as_ref()
-                        .and_then(|f| branch_resume_stack_colors(f, other_target))
-                        .as_deref()
-                        .unwrap_or(&[])
-                        .iter()
-                        .any(|&c| match ctx.concrete_registers_r.get(c as usize) {
-                            // The concrete shadow unboxes exact ints
-                            // (`ConcreteValue::from_pyobj`), so a kept slot that
-                            // holds a heap int can surface either already-unboxed
-                            // as `Int(v)` or still-boxed as `Ref(W_IntObject)`.
-                            // Match both shapes: a large (`< 0` or `>= 256`) value
-                            // is the unrestorable boxed-int hazard either way, and
-                            // matching only `Ref` would let an unboxed large int
-                            // bypass the decline.
-                            Some(ConcreteValue::Int(v)) => !(0..256).contains(v),
-                            Some(ConcreteValue::Ref(p)) if !p.is_null() => unsafe {
-                                pyre_object::is_int(*p)
-                                    && !(0..256).contains(&pyre_object::w_int_get_value(*p))
-                            },
-                            _ => false,
-                        });
-                    if reads_null_ref || uses_edge_recovery || kept_boxed_int {
+                        .is_some_and(|f| branch_resume_inside_exc_region(f, other_target));
+                    if reads_null_ref || uses_edge_recovery || kept_boxed_int || inside_exc_region {
                         return Err(DispatchError::BranchGuardUnrestorableKeptStackPermanent {
                             pc: op.pc,
                         });

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14533,12 +14533,16 @@ fn try_walker_lower_exc_info_residual(
     // exception there.  At a bridge resume into a handler the slot's per-PC
     // resume reconstruction can alias a non-exception constant (e.g. the vable
     // `f_code` scalar when the catch-landing exception slot shares its color),
-    // so the published current exception would become a code object.  When the
-    // PUSH store's operand resolves to a non-exception, recover the authoritative
-    // exception from the tracked channel, matching the graph-side producer.
+    // so the published current exception would become a code object.  The
+    // reconstruction can also leave the slot NULL (a bare handler entry whose
+    // caught-exception slot was filled with a null sentinel), which would
+    // publish `set_current_exception(NULL)` and lose the active exception for a
+    // following bare `raise` / `sys.exc_info()`.  When the PUSH store's operand
+    // resolves to NULL or a non-exception, recover the authoritative exception
+    // from the tracked channel, matching the graph-side producer.
     if is_push_set
-        && !store_concrete.is_null()
-        && !unsafe { pyre_object::is_exception(store_concrete) }
+        && (store_concrete.is_null()
+            || !unsafe { pyre_object::is_exception(store_concrete) })
     {
         if let (Some(tracked_op), ConcreteValue::Ref(tracked_obj)) =
             (ctx.last_exc_value, ctx.last_exc_value_concrete)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7381,7 +7381,16 @@ enum VstackOpClass {
     /// STORE_FAST / STORE_GLOBAL / STORE_NAME / STORE_ATTR /
     /// STORE_SUBSCR / STORE_SLICE / JUMP_* / RETURN_* / DELETE_*.
     PopOnlyOrSideStore,
-    /// Anything that does not fit the two simple shapes above — SWAP,
+    /// `SWAP(i)` permutes the operand stack: it exchanges the TOS box with
+    /// the box `i` positions below it (the `localsplus[depth-1]` /
+    /// `localsplus[depth-i]` exchange in `swap_values`).  Net depth is
+    /// unchanged; the carried `usize` is the decoded `i`.  Reconcile applies
+    /// the same exchange to `vstack_boxes`, so a value kept across a SWAP
+    /// (e.g. `a + ((i & 1) or 5)` reorders its operands with SWAP before the
+    /// short-circuit guard) lands on the right slot instead of latching the
+    /// mirror invalid.
+    Swap(usize),
+    /// Anything that does not fit the shapes above —
     /// UNPACK_SEQUENCE / UNPACK_EX (net push > 1), LOAD_GLOBAL pushing a
     /// NULL sentinel beneath the result, STORE_FAST__STORE_FAST (net pop
     /// 2), FOR_ITER, or any opcode this classifier does not recognise.
@@ -7496,7 +7505,12 @@ fn classify_vstack_opcode(
             }
         }
 
-        // Everything else (SWAP, UNPACK_*, FOR_ITER, STORE_FAST__STORE_FAST,
+        // SWAP(i): exchange TOS with the box `i` positions below.  A pure
+        // permutation (net depth 0); the decoded `i` drives the
+        // `vstack_boxes` exchange in `reconcile_vstack_at_boundary`.
+        Instruction::Swap { i } => VstackOpClass::Swap(i.get(op_arg) as usize),
+
+        // Everything else (UNPACK_*, FOR_ITER, STORE_FAST__STORE_FAST,
         // TO_BOOL if present as a distinct variant, exception machinery,
         // …) is not modeled — decline and fall back to the legacy read.
         _ => VstackOpClass::Unmodeled,
@@ -7559,6 +7573,25 @@ fn reconcile_vstack_at_boundary(
         }
         VstackOpClass::PopOnlyOrSideStore => {
             ctx.vstack_boxes.truncate(new_depth);
+        }
+        VstackOpClass::Swap(i) => {
+            // SWAP is net-depth-0 (prev_depth == new_depth).  Exchange the
+            // TOS box with the box `i` positions below it, matching
+            // `swap_values` (`localsplus[depth-1] <-> localsplus[depth-i]`).
+            // A NONE in either slot is just permuted (the later hole-fill /
+            // legacy-defer handles it); a malformed / out-of-range arg
+            // declines (latch invalid).
+            ctx.vstack_boxes.truncate(new_depth);
+            if ctx.vstack_boxes.len() < new_depth {
+                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            }
+            if new_depth >= 1 && i >= 1 && i <= new_depth {
+                let top = new_depth - 1;
+                let other = new_depth - i;
+                ctx.vstack_boxes.swap(top, other);
+            } else {
+                ctx.vstack_valid = false;
+            }
         }
         VstackOpClass::Unmodeled => {
             ctx.vstack_valid = false;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -16800,6 +16800,31 @@ fn handle(
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
                 let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
+                // #73 vstack correctness ORACLE (default OFF, measurement only).
+                // `PYRE_VSTACK_COMPILE` (requires `PYRE_VSTACK_USE` so the
+                // snapshot actually sources the mirror, not the stale legacy
+                // read) lets a kept-stack guard COMPILE whenever the walk-level
+                // operand-stack mirror (`ctx.vstack_boxes`) covers EVERY kept
+                // resume slot `0..resume_depth` with a non-NONE, non-NULL box —
+                // i.e. the snapshot is 100% mirror-sourced with no legacy
+                // fallback.  This bypasses the kept-stack declines (whose
+                // purpose is precisely the unreliable legacy resume the mirror
+                // replaces) so a depth > 1 / boxed-int / edge-recovery shape can
+                // be exercised end-to-end and byte-compared vs the interpreter.
+                // With either env var unset `mirror_covers_kept` is `false`, so
+                // every decline below is byte-identical to today (zero change).
+                let vstack_compile = std::env::var_os("PYRE_VSTACK_USE").is_some()
+                    && std::env::var_os("PYRE_VSTACK_COMPILE").is_some();
+                let mirror_covers_kept = vstack_compile
+                    && ctx.vstack_valid
+                    && resume_depth.is_some_and(|d| {
+                        (0..d).all(|s| {
+                            ctx.vstack_boxes
+                                .get(s as usize)
+                                .copied()
+                                .is_some_and(|b| b != OpRef::NONE && !opref_is_null_const_ptr(b))
+                        })
+                    });
                 // `branch_resume_target_stack_depth` reads the full-body-walk-
                 // only `FULL_BODY_SNAPSHOT_SYM`, so `kept_stack` is always
                 // false in the trait leg — yet the trait leg re-executes the
@@ -16983,7 +17008,7 @@ fn handle(
                 // wrong depth, so a kept-stack arm in a later function would skip
                 // the decline and silently miscompile.  `kept_stack` reads the
                 // correct per-function depth and closes that gap.
-                if (kept_stack || kept_stack_any_leg) && !relax_124 {
+                if (kept_stack || kept_stack_any_leg) && !relax_124 && !mirror_covers_kept {
                     let liveness =
                         branch_arm_resume_ref_liveness(other_target, ctx.outer_jitcode_index);
                     // Hazard (1): the not-taken arm reads a regular Ref register
@@ -17053,7 +17078,7 @@ fn handle(
                         });
                     }
                 }
-                if depth_gt_1 && !recovery_complete && !relax_124 {
+                if depth_gt_1 && !recovery_complete && !relax_124 && !mirror_covers_kept {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6126,12 +6126,12 @@ fn collect_outer_active_boxes(
     // holds the exact kept value for resume operand slot `s`.  This replaces
     // the stale `registers_r[merge_color]` / edge-recovery color heuristics
     // below, which read a color the regalloc reused between the guard pc and
-    // the resume pc (the #424 merge-color-staleness corruption).  Gated
-    // (`PYRE_VSTACK_USE`, the same gate as the `stack_sync` vable overlay) and
-    // scoped to the branch-guard reconstruction (`guard_py_pc`); INERT
-    // otherwise (byte-identical to the legacy color read).
-    let vstack_mirror: Option<&[OpRef]> = vstack
-        .filter(|_| guard_py_pc.is_some() && std::env::var_os("PYRE_VSTACK_USE").is_some());
+    // the resume pc (the #424 merge-color-staleness corruption).  Scoped to
+    // the branch-guard reconstruction (`guard_py_pc`); the merge-color
+    // heuristics below remain only as the fallback for slots the mirror does
+    // not cover (mirror invalid, or an Int-bank temp the Ref-only mirror does
+    // not hold).
+    let vstack_mirror: Option<&[OpRef]> = vstack.filter(|_| guard_py_pc.is_some());
     for &idx in &banks.ref_ {
         let color = idx as usize;
         if let Some(mirror) = vstack_mirror {
@@ -9000,25 +9000,20 @@ fn walker_capture_snapshot_for_last_guard_impl(
                 // `step_vstack_mirror`) is the analog of PyPy
                 // `MIFrame.registers_r` valuestack array.
                 //
-                // Default (both env vars UNSET): keep the legacy read EXACTLY
-                // — byte-identical to the prior `(0..depth.min(len))` loop (a
-                // slot with no color contributes a NONE legacy value, filtered
-                // out below, same as the old min-bound).  `PYRE_VSTACK_DIAG`:
-                // log every slot where the mirror disagrees with the legacy
+                // The mirror is the primary source for every slot `0..depth`;
+                // a slot the mirror does not cover (invalid mirror, slot beyond
+                // the mirror, or an Int-bank temp the Ref-only mirror leaves
+                // NONE) falls back to the legacy `registers_r[stack_color_map]`
+                // read, gated behind `ctx.vstack_valid`.  `PYRE_VSTACK_DIAG`
+                // logs every slot where the mirror disagrees with the legacy
                 // read (read-only — never changes the value used).
-                // `PYRE_VSTACK_USE`: flip to the mirror as the actual source
-                // (a LATER slice may lift this; out of scope for Slice 1).
-                // Both gated behind `ctx.vstack_valid` so an undermodeled walk
-                // falls back.
                 let vstack_diag = std::env::var_os("PYRE_VSTACK_DIAG").is_some();
-                let vstack_use = std::env::var_os("PYRE_VSTACK_USE").is_some();
                 // Iterate the FULL resume depth, not just
-                // `depth.min(stack_color_map.len())`.  Under `PYRE_VSTACK_USE`
-                // the mirror is the primary source for every slot `0..depth`,
-                // so a slot beyond the (possibly shorter) static color map is
-                // still covered.  Default / non-USE keeps the legacy bound
-                // semantics: a slot with no color reads NONE (legacy) → it is
-                // filtered out, identical to the old min-bounded loop.
+                // `depth.min(stack_color_map.len())`.  The mirror is the
+                // primary source for every slot `0..depth`, so a slot beyond
+                // the (possibly shorter) static color map is still covered; a
+                // slot with no mirror box and no color reads NONE and is
+                // filtered out below.
                 (0..depth)
                     .filter_map(|s| {
                         // Legacy read: only defined for slots the static color
@@ -9059,20 +9054,14 @@ fn walker_capture_snapshot_for_last_guard_impl(
                                 ),
                             }
                         }
-                        let v = if vstack_use {
-                            // PRIMARY: the mirror for every slot `0..depth`.
-                            // Fall back to legacy only when the mirror lacks a
-                            // box for this slot (mirror invalid, slot beyond
-                            // the mirror, or a slot the mirror left NONE — e.g.
-                            // an Int-bank stack temp the Ref-only mirror does
-                            // not hold).  Never worse than the default read.
-                            match mirror {
-                                Some(m) if m != OpRef::NONE => m,
-                                _ => legacy,
-                            }
-                        } else {
-                            // INERT DEFAULT (Slice 1): legacy source only.
-                            legacy
+                        // PRIMARY: the mirror for every slot `0..depth`.  Fall
+                        // back to legacy only when the mirror lacks a box for
+                        // this slot (mirror invalid, slot beyond the mirror, or
+                        // a slot the mirror left NONE — e.g. an Int-bank stack
+                        // temp the Ref-only mirror does not hold).
+                        let v = match mirror {
+                            Some(m) if m != OpRef::NONE => m,
+                            _ => legacy,
                         };
                         // #124 provenance override: a short-circuit-kept local
                         // whose register the taken-arm fold clobbered — source
@@ -16841,23 +16830,17 @@ fn handle(
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
                 let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
-                // #73 vstack correctness ORACLE (default OFF, measurement only).
-                // `PYRE_VSTACK_COMPILE` (requires `PYRE_VSTACK_USE` so the
-                // snapshot actually sources the mirror, not the stale legacy
-                // read) lets a kept-stack guard COMPILE whenever the walk-level
-                // operand-stack mirror (`ctx.vstack_boxes`) covers EVERY kept
-                // resume slot `0..resume_depth` with a non-NONE, non-NULL box —
-                // i.e. the snapshot is 100% mirror-sourced with no legacy
-                // fallback.  This bypasses the kept-stack declines (whose
-                // purpose is precisely the unreliable legacy resume the mirror
-                // replaces) so a depth > 1 / boxed-int / edge-recovery shape can
-                // be exercised end-to-end and byte-compared vs the interpreter.
-                // With either env var unset `mirror_covers_kept` is `false`, so
-                // every decline below is byte-identical to today (zero change).
-                let vstack_compile = std::env::var_os("PYRE_VSTACK_USE").is_some()
-                    && std::env::var_os("PYRE_VSTACK_COMPILE").is_some();
-                let mirror_covers_kept = vstack_compile
-                    && ctx.vstack_valid
+                // #73 mirror-sourced kept-stack compile: a kept-stack guard
+                // COMPILES whenever the walk-level operand-stack mirror
+                // (`ctx.vstack_boxes`) covers EVERY kept resume slot
+                // `0..resume_depth` with a non-NONE, non-NULL box — i.e. the
+                // snapshot is 100% mirror-sourced with no legacy fallback.  This
+                // bypasses the kept-stack declines below (whose purpose is
+                // precisely the unreliable legacy resume the mirror replaces).
+                // When the mirror does NOT cover a kept slot (invalid mirror,
+                // Int-bank temp, inline sub-walk) `mirror_covers_kept` is
+                // `false` and the conservative declines below still fire.
+                let mirror_covers_kept = ctx.vstack_valid
                     && resume_depth.is_some_and(|d| {
                         (0..d).all(|s| {
                             ctx.vstack_boxes

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -753,6 +753,25 @@ fn source_stack_effects(
             }
             same(s)
         }
+        Instruction::PopTop
+        | Instruction::PopJumpIfTrue { .. }
+        | Instruction::PopJumpIfFalse { .. }
+        | Instruction::PopJumpIfNone { .. }
+        | Instruction::PopJumpIfNotNone { .. } => {
+            // POP_TOP and POP_JUMP_IF_* pop exactly the top value (the latter
+            // on BOTH the fall-through and the branch arm); every operand-stack
+            // slot below is untouched and keeps its source.  Modeling this
+            // precisely — instead of the conservative `rebuild_other` net-pop
+            // wipe — keeps a short-circuit `and`/`or`'s operand BELOW the
+            // popped condition/value (e.g. `acc` kept on the stack across the
+            // guard in `acc = acc + (a or b)`, where the not-taken arm's
+            // `POP_TOP` would otherwise drop `acc`'s provenance) `Local`-sourced
+            // through the merge, so the bridge/blackhole can recover it from the
+            // live local instead of a reused (stale-fold) merge color.
+            let mut s = before.to_vec();
+            s.pop();
+            same(s)
+        }
         _ => {
             let (ft_d, br_d) = stack_effects(instr, op_arg, d);
             (rebuild_other(before, ft_d), rebuild_other(before, br_d))

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7876,7 +7876,7 @@ impl JitState for PyreJitState {
                 }
             }
         };
-        let semantic_mirror: Vec<OpRef> = if maps.is_portal_bridge
+        let mut semantic_mirror: Vec<OpRef> = if maps.is_portal_bridge
             || (maps.local_color_map.is_empty()
                 && maps.stack_color_map.is_empty()
                 && maps.pcdep_entries.is_empty())
@@ -7965,6 +7965,38 @@ impl JitState for PyreJitState {
             }
             mirror
         };
+        // #124/#73 Blocker A: a kept operand-stack slot whose per-PC liveness
+        // source is a live local reads a STALE merge color through the
+        // color→slot inversion above.  Regalloc reuses a color for different
+        // values between the guard pc (where the resume register file was
+        // captured) and the resume pc (whose `stack_color_map`/`pcdep` the
+        // inversion uses), so `bridge_registers_r[color]` holds a sibling
+        // value, not the kept local (e.g. `acc=acc+(a or b)` resumes with
+        // operand-stack slot 0 = `acc` but the slot-0 color holds `b` at the
+        // guard).  The semantic local mirror `[0,nlocals)` is already correct
+        // (vable-overlaid from the live frame), and `StackSource::Local`
+        // guarantees the slot still equals that local's current value, so
+        // source such a stack slot from its source local.  This is the bridge
+        // analog of the guard-side local-provenance override
+        // (jitcode_dispatch.rs `kept_slot_local_shadow_recoverable`).
+        if let Some(code_ptr) = METAINTERP_SD.with(|r| {
+            r.borrow()
+                .jitcodes
+                .get(frame0.jitcode_index as usize)
+                .map(|jc| jc.payload.code_ptr)
+        }) {
+            if !code_ptr.is_null() {
+                let lv = crate::liveness::liveness_for(code_ptr);
+                for d in 0..stack_only {
+                    if let Some(local_idx) = lv.stack_slot_source_local(frame0.pc as usize, d) {
+                        let li = local_idx as usize;
+                        if li < nlocals && nlocals + d < semantic_mirror.len() {
+                            semantic_mirror[nlocals + d] = semantic_mirror[li];
+                        }
+                    }
+                }
+            }
+        }
         let bridge_locals: Vec<OpRef> = semantic_mirror.iter().take(nlocals).copied().collect();
         // #124 kept operand-stack temps: the stack tail of the same
         // slot-indexed mirror (`[nlocals, nlocals + stack_only)`), so a

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2385,12 +2385,25 @@ pub fn trace_and_compile_from_bridge(
     // to the handler is the orthodox follow-up, gated on the in-try
     // residual-call resume-PC epic; declining is correctness-first.)
     let caught_in_frame = pending_exc && last_bridge_is_exception_guard && {
-        let off = if frame.last_instr < 0 {
-            0u32
+        if is_multiframe_resume {
+            // `resume_pc` (and thus `frame.last_instr`, set above) addresses the
+            // INNERMOST inlined frame, but `code` is the live OUTER frame, so an
+            // exception-table lookup would consult the wrong code object — it can
+            // miss a try/except local to the inlined callee and let the bridge
+            // walk record the callee's NULL raised-call result. The multi-frame
+            // resume already routes through the blackhole below (`resume_via_blackhole`);
+            // decline up-front so no possibly-wrong bridge is traced/attached and
+            // the blackhole rebuilds the inlined framestack and routes the
+            // exception to the correct handler.
+            true
         } else {
-            (frame.last_instr as u32) * 2
-        };
-        pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
+            let off = if frame.last_instr < 0 {
+                0u32
+            } else {
+                (frame.last_instr as u32) * 2
+            };
+            pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, off).is_some()
+        }
     };
     if pending_exc && (!last_bridge_is_exception_guard || caught_in_frame) {
         if majit_metainterp::majit_log_enabled() {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4276,21 +4276,32 @@ fn filter_liveness_in_place(
         // trace, so the inversion is a no-op the overlay then fills — keeps the
         // map non-empty and the runtime on the correct (overlay) path.
         if let Some(pcdep) = pcdep_color_slots {
-            let mut group_entries: Vec<(u16, u16)> = Vec::new();
+            // #367: publish each member PC's OWN per-PC color→slot entry, NOT
+            // the cross-PC union. The folded `-live-` marker's `union_r` makes
+            // the conservative-superset live SET correct (preserving extra
+            // registers never harms), but UNIONing the (color, slot) inversion
+            // across member PCs is unsound: two member PCs can color the same
+            // operand-stack slots differently (a merge resume vs a sibling
+            // compare arm), so the union maps one color to two slots holding
+            // DIFFERENT values and `semantic_ref_slot_for_reg_color` inverts to
+            // the wrong slot. The runtime resumes at a PRECISE py_pc, so each PC
+            // reads its own injective coloring (a within-PC repeated color is a
+            // legitimate same-value COPY, which inverts soundly either way).
+            // Restrict to the marker's live colors so every shipped color
+            // inverts to a marker-alive register.
             for &py_pc in &py_pcs {
+                let mut pc_entries: Vec<(u16, u16)> = Vec::new();
                 if let Some(entries) = pcdep.get(py_pc) {
                     for &(color, slot) in entries {
                         if union_r.contains(&color) || (slot as usize) < nlocals {
-                            group_entries.push((color, slot));
+                            pc_entries.push((color, slot));
                         }
                     }
                 }
-            }
-            group_entries.sort_unstable();
-            group_entries.dedup();
-            for &py_pc in &py_pcs {
+                pc_entries.sort_unstable();
+                pc_entries.dedup();
                 if let Some(slot_out) = marker_pcdep.get_mut(py_pc) {
-                    *slot_out = group_entries.clone();
+                    *slot_out = pc_entries;
                 }
             }
         }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4474,66 +4474,35 @@ fn resolve_const_ref_slot(c: &super::flow::Constant) -> Option<i64> {
 fn build_pcdep_color_slots(
     pcdep_slot_var: &[Vec<(u16, u32)>],
     pcdep_slot_var_resume: &[Vec<(u16, u32)>],
-    use_resume_only: bool,
     coloring: &std::collections::HashMap<super::flow::VariableId, u16>,
     live_oracle: &std::collections::HashMap<super::flow::VariableId, u16>,
     rename: &[Vec<u16>; 3],
     code: &CodeObject,
     depth_at_pc: &[u16],
-    local_color_map: &[u16],
-    stack_color_map: &[u16],
 ) -> Vec<Vec<(u16, u16)>> {
     let lv = pyre_jit_trace::state::liveness_for(code as *const _);
     let nlocals = code.varnames.len();
     let mut out: Vec<Vec<(u16, u16)>> = vec![Vec::new(); pcdep_slot_var.len()];
-    for (py_pc, snap) in pcdep_slot_var.iter().enumerate() {
+    for py_pc in 0..pcdep_slot_var.len() {
         if !lv.is_reachable(py_pc) {
             continue;
         }
         let depth = depth_at_pc.get(py_pc).copied().unwrap_or(0) as usize;
         // Per-slot color, keyed by semantic slot.
         //
-        // `use_resume_only` (#355 B2-proper): build the map from the PRE-dispatch
-        // resume-depth Variable snapshot ALONE. B1 proved that snapshot fully
-        // subsumes the flat base (every flat-base survivor is either a resume-
-        // depth Variable here, or a deep-stack Constant the value-stack
-        // resumedata rematerializes from the const pool); B2 proved those
-        // constants are redundant. So the resume-depth Variables, joined through
-        // the splice coloring, are the sole live source — no flat base, no
-        // constant entries.
-        //
-        // Flat path (gate off, escape hatch): seed from the flat maps (one color
-        // per slot, PC-independent) for every LIVE frame slot — the post-opcode
-        // FrameState snapshot can UNDER-capture the operand stack at a kept-stack
-        // / mid-opcode resume — then OVERRIDE with the post-opcode snapshot's
-        // true per-PC SSA color wherever it has the slot. The marker-consistent
-        // union filter (`filter_liveness_in_place`) later drops any flat base
-        // color not SSA-live at the marker, so the override is the sole survivor
-        // for every normally-captured slot; the flat base only survives for the
-        // kept-stack slots the snapshot missed.
+        // #355 B2-proper: build the map from the PRE-dispatch resume-depth
+        // Variable snapshot ALONE. B1 proved that snapshot fully subsumes the
+        // flat base (every flat-base survivor is either a resume-depth Variable
+        // here, or a deep-stack Constant the value-stack resumedata
+        // rematerializes from the const pool); B2 proved those constants are
+        // redundant. So the resume-depth Variables, joined through the splice
+        // coloring, are the sole live source — no flat base, no constant
+        // entries.
         let mut slot_color: std::collections::BTreeMap<u16, u16> =
             std::collections::BTreeMap::new();
-        if !use_resume_only {
-            for i in 0..nlocals {
-                if lv.is_local_live(py_pc, i) {
-                    if let Some(&c) = local_color_map.get(i) {
-                        slot_color.insert(i as u16, c);
-                    }
-                }
-            }
-            for d in 0..depth {
-                if let Some(&c) = stack_color_map.get(d) {
-                    slot_color.insert((nlocals + d) as u16, c);
-                }
-            }
-        }
-        let src: &[(u16, u32)] = if use_resume_only {
-            pcdep_slot_var_resume
-                .get(py_pc)
-                .map_or(&[][..], |v| v.as_slice())
-        } else {
-            snap
-        };
+        let src: &[(u16, u32)] = pcdep_slot_var_resume
+            .get(py_pc)
+            .map_or(&[][..], |v| v.as_slice());
         for &(slot, var_id) in src {
             let slot_us = slot as usize;
             if slot_us < nlocals {
@@ -11329,14 +11298,11 @@ impl CodeWriter {
         let pcdep_color_slots: Vec<Vec<(u16, u16)>> = build_pcdep_color_slots(
             &pcdep_slot_var,
             &pcdep_slot_var_resume,
-            true,
             &splice_regallocs[Kind::Ref.index()].coloring,
             &graph_regallocs[Kind::Ref.index()].coloring,
             &alloc_result.rename,
             code,
             &depth_at_pc,
-            &pyre_color_for_semantic_local,
-            &stack_slot_color_map,
         );
         // #348 (gated, no runtime effect): self-check that the production
         // splice coloring — now built with the co-live interference — gives

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4262,12 +4262,25 @@ fn filter_liveness_in_place(
         // Collect the group's `(color, slot)` entries (union of member PCs'
         // per-PC maps) restricted to those colors, then publish to every
         // member PC so the runtime inversion covers the full folded marker.
+        //
+        // LOCAL slots bypass the `union_r` restriction. A frame whose locals
+        // are all live as UNBOXED Int/Float in the trace (e.g. an integer
+        // loop's back-edge) carries only the portal reds in the marker's Ref
+        // `union_r`, so every local's per-PC Ref color is filtered out and the
+        // group's entries go empty. An empty per-PC map then drives
+        // `setup_bridge_sym` into its all-empty identity branch (color==slot),
+        // which mis-restores a freely-colored frame; the per-CodeObject branch
+        // it should take instead refills every local from the virtualizable
+        // image (`overlay_local`). Keeping the local entries — whose colors are
+        // out of `registers_r` range or decode to NONE under the int-typed
+        // trace, so the inversion is a no-op the overlay then fills — keeps the
+        // map non-empty and the runtime on the correct (overlay) path.
         if let Some(pcdep) = pcdep_color_slots {
             let mut group_entries: Vec<(u16, u16)> = Vec::new();
             for &py_pc in &py_pcs {
                 if let Some(entries) = pcdep.get(py_pc) {
                     for &(color, slot) in entries {
-                        if union_r.contains(&color) {
+                        if union_r.contains(&color) || (slot as usize) < nlocals {
                             group_entries.push((color, slot));
                         }
                     }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11317,40 +11317,27 @@ impl CodeWriter {
         }
         // #348: per-PC color↔slot resume map — the production resume path.
         // Built from the same per-PC snapshot + splice coloring the injectivity
-        // check validated. When populated, `filter_liveness_in_place` derives
-        // the `-live-` colors from this map (not the flat maps) and the runtime
-        // encode/decode invert color→slot through it, so all three sites share
-        // one per-program-point color space. The flat maps remain only as the
-        // kept-stack fallback base inside `build_pcdep_color_slots` (the
-        // post-opcode snapshot under-captures mid-opcode operand-stack temps;
-        // retiring same-slot coalescing miscompiles those — symstack-gated).
-        // `PYRE_PCDEP_RESUME_OFF` restores the pure flat-map path (byte-
-        // identical to the pre-per-PC production resume) as an escape hatch.
-        let pcdep_resume = std::env::var_os("PYRE_PCDEP_RESUME_OFF").is_none();
+        // check validated. `filter_liveness_in_place` derives the `-live-`
+        // colors from this map (not the flat maps) and the runtime encode/decode
+        // invert color→slot through it, so all three sites share one
+        // per-program-point color space.
         // #355 B2-proper: build the per-PC map from the resume-depth Variable
-        // snapshot alone (no flat base, no constant entries) — the production
-        // default. Proven byte-identical to the flat-base path on both backends
-        // (corpus gate_changed=0 + resume-critical kept-stack repros). The flat-
-        // base + post-opcode build is kept as the `PYRE_B2_RESUME_MAP_OFF`
-        // escape hatch (`PYRE_PCDEP_RESUME_OFF` still disables the per-PC map
-        // entirely, restoring the pure flat-map decode).
-        let b2_resume_map = std::env::var_os("PYRE_B2_RESUME_MAP_OFF").is_none();
-        let pcdep_color_slots: Vec<Vec<(u16, u16)>> = if pcdep_resume {
-            build_pcdep_color_slots(
-                &pcdep_slot_var,
-                &pcdep_slot_var_resume,
-                b2_resume_map,
-                &splice_regallocs[Kind::Ref.index()].coloring,
-                &graph_regallocs[Kind::Ref.index()].coloring,
-                &alloc_result.rename,
-                code,
-                &depth_at_pc,
-                &pyre_color_for_semantic_local,
-                &stack_slot_color_map,
-            )
-        } else {
-            Vec::new()
-        };
+        // snapshot alone (no flat base, no constant entries) — the sole
+        // production resume source. Proven byte-identical to the flat-base
+        // path on both backends (corpus gate_changed=0 + resume-critical
+        // kept-stack repros).
+        let pcdep_color_slots: Vec<Vec<(u16, u16)>> = build_pcdep_color_slots(
+            &pcdep_slot_var,
+            &pcdep_slot_var_resume,
+            true,
+            &splice_regallocs[Kind::Ref.index()].coloring,
+            &graph_regallocs[Kind::Ref.index()].coloring,
+            &alloc_result.rename,
+            code,
+            &depth_at_pc,
+            &pyre_color_for_semantic_local,
+            &stack_slot_color_map,
+        );
         // #348 (gated, no runtime effect): self-check that the production
         // splice coloring — now built with the co-live interference — gives
         // an injective per-PC color map. `splice_value_parent` is the same
@@ -11402,11 +11389,7 @@ impl CodeWriter {
             &depth_at_pc,
             &pyre_color_for_semantic_local,
             &stack_slot_color_map,
-            if pcdep_resume {
-                Some(pcdep_color_slots.as_slice())
-            } else {
-                None
-            },
+            Some(pcdep_color_slots.as_slice()),
             portal_frame_reg,
             portal_ec_reg,
             walker_tracked_pc_live_indices_out.as_deref(),
@@ -11415,13 +11398,8 @@ impl CodeWriter {
         );
         // #348 Part (2): ship the marker-consistent per-PC map (the fold-group
         // union) so the runtime inversion covers every color the (possibly
-        // folded) `-live-` marker carries. Falls back to the raw per-PC map
-        // when the gate built no marker map (it is empty iff gate off).
-        let pcdep_color_slots = if pcdep_resume {
-            marker_pcdep_color_slots
-        } else {
-            pcdep_color_slots
-        };
+        // folded) `-live-` marker carries.
+        let pcdep_color_slots = marker_pcdep_color_slots;
         // Runtime entry/liveness lookups expect the byte offset of the
         // surviving `-live-` marker for each Python PC
         // (`jitcode.get_live_vars_info` first checks `code[pc] ==

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -1140,57 +1140,6 @@ fn collect_cfg_coalesce_pairs(
     pairs
 }
 
-/// Coalesce pairs that force every Variable the walker pinned to
-/// one frame slot onto a single canonical color.
-///
-/// `walker_slot_for_variable[v.id]` records the frame slot the walker
-/// assigned each Ref Variable.  The canonical graph regalloc colors by
-/// SSA graph-lifetime Variable, so distinct Variables that share a slot
-/// (successive LOAD_FAST/STORE_FAST scratch, stack-slot reuse across a
-/// loop) receive distinct colors.  The dense per-slot resume map
-/// (`stack_slot_color_map` / `pyre_color_for_semantic_local`) holds only
-/// ONE color per slot, so a multi-color slot yields an ambiguous
-/// `slot → color` inverse — the slot-to-color conflict the splice
-/// would otherwise surface.
-///
-/// Emitting `(first, other)` pairs per slot group requests the regalloc
-/// pre-merge them in `perform_register_allocation_with_pairs`, so each
-/// slot's Variables land on one color and the inverse is unambiguous.
-/// The merge is coalesce-safe: the walker's own slot-numbered coloring
-/// proves a frame slot holds exactly one live value at a time
-/// (STORE_FAST / pop kills the prior occupant), so the per-slot live
-/// ranges are disjoint and never interfere.
-///
-/// Restricted to Ref Variables via the Ref-coloring membership test —
-/// `walker_slot_for_variable` only tracks Ref slots, and
-/// `perform_register_allocation_all_kinds_with_pairs` applies pairs to
-/// the Ref kind only.
-fn collect_same_slot_coalesce_pairs(
-    walker_slot_for_variable: &[Option<u16>],
-    ref_coloring: &HashMap<super::flow::VariableId, u16>,
-) -> Vec<(super::flow::VariableId, super::flow::VariableId)> {
-    let Some(max_slot) = walker_slot_for_variable.iter().flatten().copied().max() else {
-        return Vec::new();
-    };
-    let mut first_for_slot: Vec<Option<super::flow::VariableId>> =
-        vec![None; max_slot as usize + 1];
-    let mut pairs = Vec::new();
-    for (vid, slot) in walker_slot_for_variable.iter().enumerate() {
-        let Some(slot) = *slot else { continue };
-        let vid = super::flow::VariableId(vid as u32);
-        // Ref-kind only: a Variable appears in the Ref coloring iff
-        // `perform_register_allocation` colored it as Ref.
-        if !ref_coloring.contains_key(&vid) {
-            continue;
-        }
-        match first_for_slot[slot as usize] {
-            None => first_for_slot[slot as usize] = Some(vid),
-            Some(first) => pairs.push((first, vid)),
-        }
-    }
-    pairs
-}
-
 /// Drop coalesce pairs that would TRANSITIVELY merge a
 /// frame-local slot with another DISTINCT frame-local slot, or with any
 /// stack slot, into one regalloc group.
@@ -11012,8 +10961,8 @@ impl CodeWriter {
         // slot and decline the splice (set_membership / tuple_unpacking).
         // A Variable is live iff the graph regalloc — the gate-off coloring,
         // which never sees the leaked Refs — colored it; mask the rest out
-        // of the resume-color consumers below. This is the same membership
-        // oracle `collect_same_slot_coalesce_pairs` already filters on.
+        // of the resume-color consumers below (the same Ref-coloring
+        // membership test used throughout the splice).
         let walker_slot_for_variable_live: Vec<Option<u16>> = walker_slot_for_variable
             .iter()
             .enumerate()
@@ -11046,19 +10995,19 @@ impl CodeWriter {
         // two distinct frame-local slots into one regalloc group —
         // otherwise the slots share a union-find rep and the co-live
         // interference between them is a self-edge no-op.
-        let splice_pairs = {
-            let same_slot_pairs = collect_same_slot_coalesce_pairs(
-                &walker_slot_for_variable,
-                &graph_regallocs[Kind::Ref.index()].coloring,
-            );
-            let mut splice_pairs = same_slot_pairs;
-            splice_pairs.extend_from_slice(&cfg_variable_pairs);
-            filter_cross_slot_coalesce_pairs(
-                &splice_pairs,
-                &walker_slot_for_variable,
-                code.varnames.len(),
-            )
-        };
+        // Same-slot coalescing retired (#267): RPython's flatten has no
+        // walker-slot coalescing. Body locals are colored freely by the chordal
+        // coloring; a guard resume reconstructs each live local/stack value via
+        // the per-PC color→slot map plus the virtualizable-frame overlay
+        // (`overlay_local` in `setup_bridge_sym`), so a frame slot no longer
+        // needs one canonical color across its re-read Variables. Only the CFG
+        // value-equivalence pairs (the walker's COPY/SWAP lineage) remain, to
+        // merge provably-equal Variables.
+        let splice_pairs = filter_cross_slot_coalesce_pairs(
+            &cfg_variable_pairs,
+            &walker_slot_for_variable,
+            code.varnames.len(),
+        );
         // Liveness-correct CPython-co-live interference: each resume PC's
         // simultaneously-CPython-live, non-value-equivalent locals/stack
         // Variables interfere, so the chordal coloring keeps them on


### PR DESCRIPTION
#267 

## Summary

This batch builds the **walk-level operand-stack box mirror** (`ctx.vstack_boxes`, the analog of PyPy's `MIFrame.registers_r` valuestack) and promotes it to the **production default** source for reconstructing kept operand-stack values at a branch-guard resume — replacing the static merge-color read (`registers_r[stack_slot_color_map[s]]`) that the regalloc renames/reuses across the guard→resume gap (the #424 merge-color-staleness corruption).

This is the keystone step of the #73 symbolic-valuestack epic (retire the flat `stack_slot_color_map` merge-color resume model in favour of PyPy-style per-bytecode liveness).

## Arc of the change

- **pcdep cleanup** — retire same-slot coalescing (#267); drop the `PYRE_PCDEP_RESUME_OFF` / `PYRE_B2_RESUME_MAP_OFF` escape hatches and the dead flat-base arm; keep local-slot entries in `marker_pcdep` past the `union_r` filter.
- **principled flat-free kept-stack decline** — boxed-int + exception-region hazards, with regression benches.
- **build the mirror** — model `SWAP{i}` and `COPY{i}` operand-stack effects; add the `PYRE_VSTACK_COMPILE` correctness oracle (compile a normally-declined kept-stack guard from the mirror and byte-compare vs the interpreter).
- **mirror-source the resume** — failarg list and the bridge loop-carried-local slot both source from the mirror.
- **fix the chcmp blocker** — the codewriter marker-fold shipped the cross-PC *union* of `(color,slot)` pcdep entries to every PC sharing a `-live-` marker; folded chained-compare arms colour the same slots differently, so the union mapped one colour to two slots and `semantic_ref_slot_for_reg_color` restored the wrong slot. Now each member PC ships its own per-PC injective entry (the runtime resumes at a precise `py_pc`); the union is kept only for the live-register set.
- **flip to default** — remove the `PYRE_VSTACK_USE` / `PYRE_VSTACK_COMPILE` env gates from the three mirror consumers (failarg source, `stack_sync` vable overlay, `mirror_covers_kept` decline bypass). The legacy merge-color read remains only as the fallback for slots the Ref-only mirror leaves NONE; the kept-stack declines still fire when the mirror does not cover a slot (invalid mirror / Int-bank temp / inline sub-walk).
- **retire the mirror-superseded KEPT_OVERRIDE guard-half** — delete `kept_slot_source_local_box` / `kept_slot_local_shadow_recoverable` / `kept_local_box` / `kept_local_color_map` (all `PYRE_KEPT_OVERRIDE` early-returns, byte-identical by default). The bridge-half (`setup_bridge_sym` + `liveness::stack_slot_source_local`) is a distinct mechanism and is left intact.

## Verification

- `check.py` **dynasm 160/160** and **cranelift 160/160** as the default (no env vars).
- **364 adversarial kept-stack programs** byte-exact `oracle == dynasm == cranelift`: chained comparisons (arity 2–6, mixed relations), short-circuit chains, heap-int kept results outside `[0,256)`, nested ternaries/loops, list-index and call operands.
- `pyre-jit-trace` lib: 270 pass (4 pre-existing `pop_top` arm-id failures are an unrelated rebase arm-shift, tracked separately).

## Deferred

The remaining merge-color deletion cascade (the kept-stack declines, the `kept_recovered`/`kept_stack_subst` failarg fallbacks, `branch_resume_stack_colors`, and the `stack_slot_color_map` field + readers) stays load-bearing until the mirror covers the currently-declined shapes (FOR_ITER / UNPACK / inline sub-walk / Int-bank / exception-region) and pcdep is total. That is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)