### PR TITLE
Tagged-int representation scaffolding + value-based int is/id; rtyper classdef-less narrowing

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1910,9 +1910,19 @@ impl Bookkeeper {
     /// Project one struct's registry rows into its `ClassDef.attrs`
     /// — the pass-2 body of [`Self::getuniqueclassdef_for_struct_root`].
     fn project_struct_rows(self: &Rc<Self>, n: &str) -> Result<(), AnnotatorError> {
+        // A monomorphised generic spelling (`Option<*mut PyObject>`,
+        // `Result<Tuple>`) shares the bare template's rows; the registry
+        // only carries the un-suffixed key (`Option`/`option::Option`).
+        // Strip the `<…>` argument span so the lookup resolves under the
+        // template key — matching `StructFieldRegistry::lookup_fields`,
+        // which the bare-`reg.fields.get` here bypasses.
         let fields: Option<Vec<(String, String)>> = {
             let guard = self.pyre_struct_fields.borrow();
-            guard.as_ref().and_then(|r| r.fields.get(n).cloned())
+            guard.as_ref().and_then(|r| {
+                r.fields
+                    .get(majit_ir::descr::strip_generic_args(n).as_ref())
+                    .cloned()
+            })
         };
         let Some(fields) = fields else {
             return Ok(());

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -4172,19 +4172,20 @@ mod tests {
             .enum_variant_narrowing_knowntypedata("Opt<i64>::A", &receiver)
             .expect("an already-narrowed receiver still resolves the base table");
 
-        let classdef_of = |ktd: &crate::annotator::model::KnownTypeData, discr: i64| {
-            match ktd
-                .get(&ExitCaseKey::Int(discr))
-                .and_then(|c| c.get(&receiver))
-                .expect("case present")
-            {
-                SomeValue::Instance(si) => si.classdef.clone().expect("variant carries a classdef"),
-                other => panic!("expected SomeInstance, got {other:?}"),
-            }
+        let classdef_of = |ktd: &crate::annotator::model::KnownTypeData, discr: i64| match ktd
+            .get(&ExitCaseKey::Int(discr))
+            .and_then(|c| c.get(&receiver))
+            .expect("case present")
+        {
+            SomeValue::Instance(si) => si.classdef.clone().expect("variant carries a classdef"),
+            other => panic!("expected SomeInstance, got {other:?}"),
         };
         for discr in [0i64, 1i64] {
             assert!(
-                Rc::ptr_eq(&classdef_of(&from_base, discr), &classdef_of(&from_variant, discr)),
+                Rc::ptr_eq(
+                    &classdef_of(&from_base, discr),
+                    &classdef_of(&from_variant, discr)
+                ),
                 "Int({discr}): narrowing an already-narrowed receiver must reuse \
                  the base variant classdef, not deepen it (::A::A)"
             );

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1869,10 +1869,28 @@ impl Bookkeeper {
                 })
                 .cloned()?
         };
+        // A receiver already narrowed to a variant subclass
+        // (`Option<T>::None`) reaches this read with `enum_root` carrying
+        // the `::variant` tail; appending another variant
+        // (`Option<T>::None::None`) deepens the per-instantiation classdef
+        // every pass, so the lattice never reaches a fixpoint.  Re-narrow
+        // against the base enum — strip a trailing `::<variant>` segment so
+        // the discriminant maps back to the SAME variant subclasses
+        // (idempotent on re-read).
+        let base_enum_root: &str = {
+            let mut base = enum_root;
+            for (_discr, variant_name) in &by_discr {
+                if let Some(stripped) = base.strip_suffix(&format!("::{variant_name}")) {
+                    base = stripped;
+                    break;
+                }
+            }
+            base
+        };
         let mut ktd = super::model::KnownTypeData::new();
         for (discr, variant_name) in &by_discr {
             let variant_cd = self
-                .getuniqueclassdef_for_enum_variant(enum_root, variant_name)
+                .getuniqueclassdef_for_enum_variant(base_enum_root, variant_name)
                 .ok()?;
             let s_variant = SomeValue::Instance(super::model::SomeInstance::new(
                 Some(variant_cd),
@@ -4100,6 +4118,67 @@ mod tests {
                 .is_none(),
             "non-enum class yields no knowntypedata"
         );
+    }
+
+    #[test]
+    fn enum_variant_narrowing_is_idempotent_on_already_narrowed_receiver() {
+        // A `__discriminant` re-read on a receiver already narrowed to a
+        // variant subclass reaches the narrowing with `enum_root` carrying
+        // the `::variant` tail (`Opt<i64>::A`).  It must re-derive the base
+        // enum's variant subclasses (idempotent), NOT append another variant
+        // (`Opt<i64>::A::A`) — otherwise the per-instantiation classdef
+        // deepens every annotation pass and never reaches a fixpoint.  The
+        // generic `<…>` instantiation is required to reproduce: the table
+        // lookup strips it (`strip_instantiation_suffix`), so the narrowed
+        // root resolves the same variant table while the variant-build sees
+        // the full narrowed name.
+        use crate::annotator::model::{ExitCaseKey, SomeValue};
+        use crate::flowspace::model::Variable;
+        use crate::front::StructFieldRegistry;
+        use std::collections::HashMap;
+
+        let bk = bk();
+        let mut reg = StructFieldRegistry::default();
+        reg.fields.insert(
+            "Opt<i64>".to_string(),
+            vec![("__discriminant".to_string(), "i64".to_string())],
+        );
+        bk.set_pyre_struct_fields(Rc::new(reg));
+
+        // Table keyed by the bare template root (`strip_instantiation_suffix`
+        // reduces both `Opt<i64>` and `Opt<i64>::A` to `Opt`).
+        let mut by_discr: HashMap<i64, String> = HashMap::new();
+        by_discr.insert(0, "A".to_string());
+        by_discr.insert(1, "B".to_string());
+        let mut map: HashMap<String, HashMap<i64, String>> = HashMap::new();
+        map.insert("Opt".to_string(), by_discr);
+        bk.set_pyre_enum_variant_by_discriminant(Rc::new(map));
+
+        let receiver = Rc::new(Variable::new());
+        let from_base = bk
+            .enum_variant_narrowing_knowntypedata("Opt<i64>", &receiver)
+            .expect("base enum resolves the variant table");
+        let from_variant = bk
+            .enum_variant_narrowing_knowntypedata("Opt<i64>::A", &receiver)
+            .expect("an already-narrowed receiver still resolves the base table");
+
+        let classdef_of = |ktd: &crate::annotator::model::KnownTypeData, discr: i64| {
+            match ktd
+                .get(&ExitCaseKey::Int(discr))
+                .and_then(|c| c.get(&receiver))
+                .expect("case present")
+            {
+                SomeValue::Instance(si) => si.classdef.clone().expect("variant carries a classdef"),
+                other => panic!("expected SomeInstance, got {other:?}"),
+            }
+        };
+        for discr in [0i64, 1i64] {
+            assert!(
+                Rc::ptr_eq(&classdef_of(&from_base, discr), &classdef_of(&from_variant, discr)),
+                "Int({discr}): narrowing an already-narrowed receiver must reuse \
+                 the base variant classdef, not deepen it (::A::A)"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2818,10 +2818,18 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
                     });
                 }
             };
-            Ok(SomeValue::Integer(SomeInteger::new_with_knowntype(
-                int1.nonneg && int2.nonneg,
-                knowntype,
-            )))
+            // `knowntypedata` on `SomeInteger` is a pyre-only refinement
+            // (upstream carries it only on `SomeBool`). Intersect it when
+            // both sides carry it — the same invariant the `SomeBool` arm
+            // below protects: dropping the merged refinement makes
+            // `union(new, old) != new`, which breaks `contains` (and hence
+            // `setbinding`) for a discriminant integer that generalises its
+            // prior binding.
+            let mut si = SomeInteger::new_with_knowntype(int1.nonneg && int2.nonneg, knowntype);
+            if let (Some(k1), Some(k2)) = (&int1.knowntypedata, &int2.knowntypedata) {
+                si.set_knowntypedata(merge_knowntypedata(k1, k2));
+            }
+            Ok(SomeValue::Integer(si))
         }
 
         // pairtype(SomeBool, SomeBool).union() (binaryop.py:298-306):

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4825,6 +4825,22 @@ impl<'a> Lowering<'a> {
         } else {
             tyref_to_value_type(&call.dest.ty, self.llbc)
         };
+        // A call returning `*mut <registered ADT>` (a `PyObjectRef`) collapses
+        // to a classdef-less `Ref(None)` — `tyref_to_value_type` erases the
+        // pointee class root.  Capture the pointee root now so the result can be
+        // narrowed to `SomeInstance(root)` after the call op: the call-result
+        // twin of the FieldRead-base and ptr-identity-cast `__pyre_cast_instance`
+        // narrows, letting a downstream getattr / method dispatch on the result
+        // resolve instead of blocking the annotator on a classdef-less instance.
+        // Gated on the raw-pointer pointee (not a bare ADT) so foreign value
+        // types (`BigInt` / `Wtf8Buf` — no registered struct) are excluded.
+        let result_narrow_root: Option<String> = if matches!(result_ty, ValueType::Ref(None)) {
+            tyref_node(&call.dest.ty, self.llbc)
+                .and_then(|n| strip_ty_wrappers(n, self.llbc))
+                .and_then(|n| raw_ptr_pointee_class_root(n, self.llbc))
+        } else {
+            None
+        };
 
         // Resolve arguments before deciding the call shape so receiver
         // resolution and `dyn` operand handling share the same path.
@@ -5690,9 +5706,30 @@ impl<'a> Lowering<'a> {
             self.checked_arith_call_results.push(result_var.clone());
         }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
-            result: Some(result_var),
+            result: Some(result_var.clone()),
             kind: op_kind,
         });
+        // Narrow a classdef-less registered-ADT call result to
+        // `SomeInstance(root)` (see `result_narrow_root` above).  Identity at
+        // jitcode (`__pyre_cast_instance` → cast_pointer → `same_as`), so
+        // already-resolved results and production codegen are unaffected; only
+        // a `Ref(None)` raw-`PyObjectRef` result gains its pointee class.
+        if let Some(root) = result_narrow_root {
+            let narrowed = self
+                .graph
+                .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(narrowed.clone()),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+                    },
+                    args: vec![result_var.clone()],
+                    result_ty: ValueType::Ref(Some(root)),
+                },
+            });
+            self.local_var[dest_local] = Some(narrowed);
+        }
 
         // Close the block: forward to the success target. The call's
         // `on_unwind` successor is a Rust panic-cleanup path (destructor

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3823,8 +3823,49 @@ impl<'a> Lowering<'a> {
                     && let Some((owner_root, field_name, field_ty, owner_id)) =
                         self.resolve_adt_field(field_payload)
                 {
+                    // Narrow a classdef-less raw-pointer-deref base to
+                    // `SomeInstance(<pointee root>)` before the field read.
+                    // A `(*p).field` where `p: *mut/*const <Struct>` deref's to
+                    // a value whose pointee class root `tyref_to_value_type`
+                    // erases to `Ref(None)`; when such a value arrives as a
+                    // callee-propagated argument (a non-parameter `PyObjectRef`
+                    // bound through `recursivecall`), the downstream getattr
+                    // blocks the annotator on a classdef-less instance. The
+                    // field's declaring struct is authoritative, so this is a
+                    // sound downcast — identity when the base already carries
+                    // the class — the same `__pyre_cast_instance` narrow the
+                    // ptr-identity-cast arm applies before its own field reads.
+                    let narrow_root: Option<String> = match &inner.kind {
+                        PlaceKind::Projection(pre, ProjectionElem::Atom(s)) if s == "Deref" => {
+                            tyref_node(&pre.ty, self.llbc)
+                                .and_then(|n| strip_ty_wrappers(n, self.llbc))
+                                .and_then(|n| raw_ptr_pointee_class_root(n, self.llbc))
+                        }
+                        _ => None,
+                    };
                     let base = self.resolve_place(mir_bb, *inner)?;
                     let bb_id = self.block_id[mir_bb];
+                    let base = if let Some(root) = narrow_root {
+                        let narrowed = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                            result: Some(narrowed.clone()),
+                            kind: OpKind::Call {
+                                target: CallTarget::FunctionPath {
+                                    segments: vec![
+                                        "__pyre_cast_instance".to_string(),
+                                        root.clone(),
+                                    ],
+                                },
+                                args: vec![base],
+                                result_ty: ValueType::Ref(Some(root)),
+                            },
+                        });
+                        narrowed
+                    } else {
+                        base
+                    };
                     // The field's DECLARED ty is the polymorphic decl's
                     // (monomorphize=false): for a generic container
                     // (`ControlFlow<B, C>`, `Result<T, E>`) it is a bare

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2058,11 +2058,29 @@ fn classify_unported_reason(reason: &str) -> &'static str {
         "RPBC-CALLFAMILY (seeded-method registration)"
     } else if reason.contains("InstanceRepr.convert_const") {
         "FIELD-PROJECTION (typed-Ref field rows)"
-    } else if reason.contains("MissingRTypeAttribute")
-        || reason.contains("Cannot find attribute ")
-        || reason.contains("classdef-less instance")
-    {
-        "CLASSDEF-LESS-INSTANCE (typed-Ref ClassDef)"
+    } else if reason.contains("Cannot find attribute ") {
+        // find_method has no arm for this method on a TYPED builtin repr
+        // (`next` on SomeIterator, `len`/`swap`/`as_slice` on SomeList,
+        // `get` on SomeInteger, …). A method-resolution gap on a typed
+        // repr — NOT a classdef-less typed-Ref. (`next` on Iterator is the
+        // iter_next vertical; the List/Integer/Dict/String rows are
+        // find_method method-table gaps.)
+        "METHOD-RESOLUTION-GAP (find_method on builtin repr)"
+    } else if reason.contains("classdef-less instance") {
+        // getattr/method on a SomeInstance seeded with classdef=None — the
+        // receiver is a FOREIGN pointee (BigInt `to_f64`/`clone`, Wtf8Buf
+        // `as_str`, Vec/slice `deref`/`len`/`iter`). Resolved by
+        // residualizing/seeding the foreign type, NOT by ClassDef
+        // projection: the real pyre structs are already registry-known, so
+        // there is no missing struct to register here.
+        "CLASSDEF-LESS-FOREIGN (foreign-type getattr)"
+    } else if reason.contains("MissingRTypeAttribute") {
+        // rtyper getclsfield walked rbase to the root class without finding
+        // the attr (e.g. the `ob_type`-on-`PyType` wrong-resolution: PyType
+        // has no ob_type field, so this is a mis-resolution, not a real
+        // projectable field). A class-field walk miss, distinct from an
+        // annotation-stage classdef-less instance.
+        "GETCLSFIELD-MISS (rtyper class-field walk)"
     } else if reason.contains("KeyError: no binding for arg")
         || reason.contains("inputarg lacks annotation")
         || (reason.contains("variable ") && reason.contains(" used before definition"))

--- a/pyre/bench/synth/list_insert.py
+++ b/pyre/bench/synth/list_insert.py
@@ -4,16 +4,18 @@
 # On main, first insert() called items_to_vec() → Object strategy;
 # on this branch, stays Integer throughout (no boxing overhead).
 # insert(0, x) is O(n) per call → total O(n^2); small N is intentional.
-#
-# NOTE: kept at module level intentionally — wrapping in def main() lets the
-# JIT fire and exposes a dynasm-side wrong-output bug. Re-wrap once that's
-# fixed.
+# Runs under `def main()` so the JIT compiles the insert loop.
 
-N = 50000
 
-lst = []
-i = 0
-while i < N:
-    lst.insert(0, i)
-    i = i + 1
-print(lst[0], lst[-1], len(lst))
+def main():
+    N = 50000
+
+    lst = []
+    i = 0
+    while i < N:
+        lst.insert(0, i)
+        i = i + 1
+    print(lst[0], lst[-1], len(lst))
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2318,7 +2318,23 @@ pub fn finditem_str(obj: PyObjectRef, key: &str) -> Result<Option<PyObjectRef>, 
 
 /// PyPy-compatible identity check returning a raw boolean value.
 pub fn is_w(w_one: PyObjectRef, w_two: PyObjectRef) -> bool {
-    std::ptr::eq(w_one, w_two)
+    if std::ptr::eq(w_one, w_two) {
+        return true;
+    }
+    // `W_IntObject.is_w` (intobject.py:44-53): two plain `int`s are
+    // identical when their values are equal.  `bool` and `int`
+    // subclasses (`user_overridden_class`) keep pointer identity — the
+    // exact-type gate excludes both (a `bool`'s exact type is `bool`,
+    // a subclass instance's exact type is the subclass).
+    unsafe {
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::INT_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::INT_TYPE)
+        {
+            return pyre_object::intobject::w_int_get_value(w_one)
+                == pyre_object::intobject::w_int_get_value(w_two);
+        }
+    }
+    false
 }
 
 /// PyPy-compatible identity check returning a Python bool object.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2321,17 +2321,23 @@ pub fn is_w(w_one: PyObjectRef, w_two: PyObjectRef) -> bool {
     if std::ptr::eq(w_one, w_two) {
         return true;
     }
-    // `W_IntObject.is_w` (intobject.py:44-53): two plain `int`s are
-    // identical when their values are equal.  `bool` and `int`
-    // subclasses (`user_overridden_class`) keep pointer identity — the
-    // exact-type gate excludes both (a `bool`'s exact type is `bool`,
-    // a subclass instance's exact type is the subclass).
+    // `W_AbstractIntObject.is_w` (intobject.py:44-53): two plain `int`s
+    // — `W_IntObject` or the BigInt-backed `W_LongObject` — are
+    // identical when their values are equal.  `bool`
+    // (`W_BoolObject.is_w` is pure pointer identity, boolobject.py:25)
+    // and `int` subclasses (`user_overridden_class`) keep pointer
+    // identity — the exact-type gate excludes both (a `bool`'s
+    // `w_class` is `bool`, a subclass instance's is the subclass), so
+    // they fall through to the `ptr::eq` above.
     unsafe {
         if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::INT_TYPE)
             && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::INT_TYPE)
         {
-            return pyre_object::intobject::w_int_get_value(w_one)
-                == pyre_object::intobject::w_int_get_value(w_two);
+            // `space.bigint_w(self).eq(space.bigint_w(w_other))`
+            // (intobject.py:51-53). A `W_LongObject` stores a `BigInt`
+            // pointer, so it must be read as a bigint, not as an i64.
+            return pyre_object::functional::range_obj_to_bigint(w_one)
+                == pyre_object::functional::range_obj_to_bigint(w_two);
         }
     }
     false

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4855,7 +4855,10 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// `id(obj)` — PyPy: baseobjspace.py id → object identity as int
 fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     assert!(!args.is_empty(), "id() takes exactly one argument");
-    Ok(w_int_new(args[0] as i64))
+    // `space.id` (baseobjspace.py:843) routes through
+    // `w_obj.immutable_unique_id`: a plain `int` yields a value-derived
+    // id, every other object its address.
+    Ok(w_int_new(crate::function::immutable_unique_id(args[0]) as i64))
 }
 
 /// `hash(obj)` — PyPy: `descroperation.py:1006 hash`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4855,10 +4855,14 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// `id(obj)` — PyPy: baseobjspace.py id → object identity as int
 fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     assert!(!args.is_empty(), "id() takes exactly one argument");
-    // `space.id` (baseobjspace.py:843) routes through
-    // `w_obj.immutable_unique_id`: a plain `int` yields a value-derived
-    // id, every other object its address.
-    Ok(w_int_new(crate::function::immutable_unique_id(args[0]) as i64))
+    // `space.id` (baseobjspace.py:843-854): a plain `int` yields its
+    // value-derived `immutable_unique_id`; every other object falls back
+    // to `compute_unique_id` — its address.
+    let obj = args[0];
+    Ok(match crate::function::immutable_unique_id(obj) {
+        Some(w_id) => w_id,
+        None => w_int_new(obj as usize as i64),
+    })
 }
 
 /// `hash(obj)` — PyPy: `descroperation.py:1006 hash`.

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -355,6 +355,12 @@ unsafe fn exc_user_dunder_obj(obj: PyObjectRef, name: &str) -> Option<PyObjectRe
 }
 
 pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
+    // A tagged immediate must be formatted before `unwrap_cell` /
+    // `ob_type` touch it as a pointer; `repr` of a plain `int` is its
+    // decimal value. Gated on `CAN_BE_TAGGED` (default false).
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return Ok(format!("{}", pyre_object::tagged_int::untag_int(obj)));
+    }
     let obj = crate::baseobjspace::unwrap_cell(obj);
     if obj.is_null() {
         return Ok("NULL".to_string());
@@ -708,6 +714,12 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
 /// Format for str() — tries __str__ first, then __repr__.
 pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
     unsafe {
+        // `str` of a tagged `int` immediate is its decimal value; format
+        // it before `unwrap_cell` / `ob_type` deref. Gated on
+        // `CAN_BE_TAGGED` (default false).
+        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+            return Ok(format!("{}", pyre_object::tagged_int::untag_int(obj)));
+        }
         let obj = crate::baseobjspace::unwrap_cell(obj);
         if obj.is_null() {
             return Ok("NULL".to_string());
@@ -898,6 +910,15 @@ pub unsafe fn py_str(obj: PyObjectRef) -> Result<String, crate::PyError> {
 /// `obj` must point to a valid `PyObject`.
 pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     unsafe {
+        // A tagged `int` immediate stringifies to its decimal value
+        // (plain ASCII); format it before `unwrap_cell` / `ob_type`
+        // touch it as a pointer. Gated on `CAN_BE_TAGGED` (default false).
+        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+            return Ok(Wtf8Buf::from_string(format!(
+                "{}",
+                pyre_object::tagged_int::untag_int(obj)
+            )));
+        }
         let obj = crate::baseobjspace::unwrap_cell(obj);
         if !obj.is_null() {
             let tp = (*obj).ob_type;

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -238,10 +238,7 @@ pub unsafe fn dict_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
 unsafe fn builtin_leaf_repr_string(obj: PyObjectRef, tp: *const PyType) -> Option<String> {
     unsafe {
         if std::ptr::eq(tp, &INT_TYPE as *const PyType) {
-            Some(format!(
-                "{}",
-                pyre_object::intobject::w_int_get_value(obj)
-            ))
+            Some(format!("{}", pyre_object::intobject::w_int_get_value(obj)))
         } else if std::ptr::eq(tp, &FLOAT_TYPE as *const PyType) {
             let float_obj = obj as *const pyre_object::floatobject::W_FloatObject;
             Some(format_float_repr((*float_obj).floatval))

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -238,8 +238,10 @@ pub unsafe fn dict_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
 unsafe fn builtin_leaf_repr_string(obj: PyObjectRef, tp: *const PyType) -> Option<String> {
     unsafe {
         if std::ptr::eq(tp, &INT_TYPE as *const PyType) {
-            let int_obj = obj as *const pyre_object::intobject::W_IntObject;
-            Some(format!("{}", (*int_obj).intval))
+            Some(format!(
+                "{}",
+                pyre_object::intobject::w_int_get_value(obj)
+            ))
         } else if std::ptr::eq(tp, &FLOAT_TYPE as *const PyType) {
             let float_obj = obj as *const pyre_object::floatobject::W_FloatObject;
             Some(format_float_repr((*float_obj).floatval))

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2777,7 +2777,10 @@ impl OpcodeStepExecutor for PyFrame {
     fn is_op(&mut self, invert: crate::bytecode::Invert) -> Result<(), PyError> {
         let b = self.pop();
         let a = self.pop();
-        let same = std::ptr::eq(a, b); // pointer identity
+        // `COMPARE_OP 'is'` → `space.is_w` (descroperation.py): plain
+        // `int`s are identical by value (`W_IntObject.is_w`), everything
+        // else by pointer.
+        let same = crate::baseobjspace::is_w(a, b);
         let result = match invert {
             crate::bytecode::Invert::No => same,
             crate::bytecode::Invert::Yes => !same,

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1644,17 +1644,24 @@ const IDTAG_SHIFT: i64 = 4;
 const IDTAG_INT: i64 = 1;
 
 #[inline]
-pub fn immutable_unique_id(obj: PyObjectRef) -> usize {
-    // `W_IntObject.immutable_unique_id` (intobject.py:55-60): a plain
-    // `int` has a value-derived id; `int` subclasses
-    // (`user_overridden_class`) fall through to the pointer id.
+pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
+    // `W_AbstractIntObject.immutable_unique_id` (intobject.py:55-60): a
+    // plain `int` — `W_IntObject` or the BigInt-backed `W_LongObject` —
+    // has a value-derived id `(bigint_w << IDTAG_SHIFT) | IDTAG_INT`,
+    // wrapped as an `int` (a `long` when it overflows i64). `bool`
+    // (`W_BoolObject.immutable_unique_id` returns None, boolobject.py:28)
+    // and `int` subclasses (`user_overridden_class`) return `None`, so
+    // `space.id` falls back to the address-based uid.
     unsafe {
         if is_exact_type(obj, &INT_TYPE) {
-            let v = pyre_object::intobject::w_int_get_value(obj);
-            return ((v << IDTAG_SHIFT) | IDTAG_INT) as usize;
+            // `b.lshift(IDTAG_SHIFT).int_or_(IDTAG_INT)`; the shifted
+            // value is even, so `| IDTAG_INT` equals `+ IDTAG_INT`.
+            let b = (pyre_object::functional::range_obj_to_bigint(obj) << IDTAG_SHIFT as usize)
+                + malachite_bigint::BigInt::from(IDTAG_INT);
+            return Some(pyre_object::functional::range_bigint_to_obj(b));
         }
     }
-    obj as usize
+    None
 }
 
 /// PyPy-compatible `find` helper.

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1638,9 +1638,23 @@ pub unsafe fn fdel_func_doc(obj: PyObjectRef) -> Result<(), crate::PyError> {
     unsafe { function_del_doc(obj) }
 }
 
+/// `pypy/objspace/std/util.py:6,9` — `id()` of a plain `int` is its
+/// value tagged `(value << IDTAG_SHIFT) | IDTAG_INT`.
+const IDTAG_SHIFT: i64 = 4;
+const IDTAG_INT: i64 = 1;
+
 #[inline]
-pub fn immutable_unique_id(_obj: PyObjectRef) -> usize {
-    _obj as usize
+pub fn immutable_unique_id(obj: PyObjectRef) -> usize {
+    // `W_IntObject.immutable_unique_id` (intobject.py:55-60): a plain
+    // `int` has a value-derived id; `int` subclasses
+    // (`user_overridden_class`) fall through to the pointer id.
+    unsafe {
+        if is_exact_type(obj, &INT_TYPE) {
+            let v = pyre_object::intobject::w_int_get_value(obj);
+            return ((v << IDTAG_SHIFT) | IDTAG_INT) as usize;
+        }
+    }
+    obj as usize
 }
 
 /// PyPy-compatible `find` helper.

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -139,6 +139,13 @@ pub fn w_int_type_id() -> usize {
 /// `obj` must point to a valid `W_IntObject`.
 #[inline]
 pub unsafe fn w_int_get_value(obj: PyObjectRef) -> i64 {
+    // `ll_unboxed_to_int`: a tagged immediate carries its value in the
+    // pointer bits (`>> 1`). The `crate::tagged_int::CAN_BE_TAGGED`
+    // static (default `false`) short-circuits the check away, so the
+    // heap-box read below is the only live path until enablement.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return crate::tagged_int::untag_int(obj);
+    }
     unsafe { (*(obj as *const W_IntObject)).intval }
 }
 

--- a/pyre/pyre-object/src/lib.rs
+++ b/pyre/pyre-object/src/lib.rs
@@ -49,6 +49,7 @@ pub mod setobject;
 pub mod sliceobject;
 pub mod special;
 pub mod specialisedtupleobject;
+pub mod tagged_int;
 pub mod tupleobject;
 pub mod typedef;
 pub mod typeobject;

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -246,6 +246,13 @@ pub fn ll_cast_to_object(obj: PyObjectRef) -> PyObjectRef {
 /// `obj` must be a valid non-null `PyObject`.
 #[inline]
 pub unsafe fn ll_type(obj: PyObjectRef) -> *const PyType {
+    // `ll_unboxed_getclass`: a tagged immediate's class is the `int`
+    // vtable, synthesized before the `ob_type` deref. Gated on the
+    // `CAN_BE_TAGGED` static (default false), so the deref is the only
+    // live path until enablement.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return &INT_TYPE as *const PyType;
+    }
     unsafe { (*obj).ob_type }
 }
 
@@ -303,6 +310,12 @@ pub unsafe fn ll_isinstance(obj: PyObjectRef, cls: &PyType) -> bool {
 /// If non-null, `obj` must be a valid `PyObject`.
 #[inline]
 pub unsafe fn ll_inst_type(obj: PyObjectRef) -> *const PyType {
+    // `ll_unboxed_getclass_canbenone`: a tagged immediate has the low
+    // bit set and is therefore non-null, so the `int`-vtable synth
+    // precedes the null check. Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return &INT_TYPE as *const PyType;
+    }
     unsafe {
         if !obj.is_null() {
             (*obj).ob_type
@@ -633,6 +646,15 @@ pub unsafe fn py_type_check(obj: PyObjectRef, tp: &PyType) -> bool {
 
 #[inline]
 pub unsafe fn is_int(obj: PyObjectRef) -> bool {
+    // A tagged immediate is a plain `int` (never a `bool`: bools are
+    // even-aligned singletons). `is_int` reaches `ob_type` via
+    // `py_type_check`, which derefs directly — so it carries its own
+    // tag short-circuit rather than routing through `ll_type`. Gated on
+    // the `CAN_BE_TAGGED` static (default false), inspecting only the
+    // pointer bits, so the deref path below is the only live one.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return true;
+    }
     unsafe { py_type_check(obj, &INT_TYPE) || py_type_check(obj, &BOOL_TYPE) }
 }
 

--- a/pyre/pyre-object/src/tagged_int.rs
+++ b/pyre/pyre-object/src/tagged_int.rs
@@ -1,0 +1,115 @@
+//! Tagged-int primitive — `rpython/rlib/rerased.py` /
+//! `rpython/rtyper/lltypesystem/rtagged.py` applied to the runtime
+//! `int` representation.
+//!
+//! A small `int` can be stored as an *immediate* inside a `PyObjectRef`
+//! slot — the odd bit pattern `(value << 1) | 1` — instead of a heap
+//! `W_IntObject`. Heap pointers are 8-byte aligned (`W_IntObject`
+//! carries an `i64`), so the low bit distinguishes an immediate from a
+//! real pointer; `None`/`True`/`False` are even-aligned statics and are
+//! never tagged.
+//!
+//! This module is the structural primitive only: it has **zero call
+//! sites** and is inert behind [`CAN_BE_TAGGED`]. The maker
+//! (`intobject::w_int_new`), the readers/dispatch chokepoints, the GC
+//! collector skip, and the enablement flip land in later slices; the
+//! enablement itself is gated on the symbolic-valuestack work (#73).
+//!
+//! The bit layout mirrors the already-ported rtyper helper
+//! `majit/majit-translate/src/translator/rtyper/lltypesystem/rtagged.rs`
+//! (`ll_int_to_unboxed` = `value * 2 + 1`, `ll_unboxed_to_int` =
+//! `n >> 1`, `is_unboxed_instance` = `(n & 1) != 0`).
+
+use crate::pyobject::PyObjectRef;
+
+/// `rpython/rtyper/lltypesystem/rtagged.py:64-96` static `can_be_tagged`
+/// gate, collapsed to the single runtime `int` class. Defaults `false`,
+/// mirroring `rpython/config/translationoption.py:185 taggedpointers`
+/// (off by default), so every consumer chokepoint short-circuits to the
+/// untagged path and this primitive stays inert until the enablement
+/// slice. `rerased.py:1-3`: the point is to avoid putting `& 1` tag
+/// checks on every object — they are gated on this static.
+pub const CAN_BE_TAGGED: bool = false;
+
+/// `value` fits the tagged immediate range, i.e. `value << 1` does not
+/// overflow `i64`. Callers range-check with this before [`tag_int`];
+/// it mirrors the `checked_mul`/`checked_add` overflow guard in
+/// `rtagged.rs::ll_int_to_unboxed`.
+#[inline]
+pub fn fits_tagged(value: i64) -> bool {
+    value >= (i64::MIN >> 1) && value <= (i64::MAX >> 1)
+}
+
+/// `ll_int_to_unboxed` — reinterpret `(value << 1) | 1` as a pointer.
+///
+/// The caller must have checked [`fits_tagged`]; the tagging arithmetic
+/// lives here, never at the `Signed<->Ptr` cast boundaries (those stay
+/// identity reinterpret-casts).
+#[inline]
+pub fn tag_int(value: i64) -> PyObjectRef {
+    debug_assert!(fits_tagged(value), "tag_int: value out of taggable range");
+    (((value << 1) | 1) as usize) as PyObjectRef
+}
+
+/// `ll_unboxed_to_int` — recover the payload with an arithmetic (sign
+/// preserving) `>> 1`. Caller must have established [`is_tagged_int`].
+#[inline]
+pub fn untag_int(p: PyObjectRef) -> i64 {
+    (p as usize as i64) >> 1
+}
+
+/// `is_unboxed_instance` — the low bit distinguishes a tagged immediate
+/// from a real (even-aligned) heap pointer.
+#[inline]
+pub fn is_tagged_int(p: PyObjectRef) -> bool {
+    (p as usize) & 1 == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_untagged() {
+        // The enablement gate is off, matching the `taggedpointers`
+        // default; consumers must short-circuit to the heap-box path.
+        assert!(!CAN_BE_TAGGED);
+    }
+
+    #[test]
+    fn tag_round_trips_signed_payload() {
+        for v in [-1_000_000i64, -42, -1, 0, 1, 21, 1_000_000] {
+            let p = tag_int(v);
+            assert!(is_tagged_int(p));
+            assert_eq!(untag_int(p), v);
+        }
+    }
+
+    #[test]
+    fn tag_round_trips_range_boundaries() {
+        let lo = i64::MIN >> 1;
+        let hi = i64::MAX >> 1;
+        assert!(fits_tagged(lo) && fits_tagged(hi));
+        assert_eq!(untag_int(tag_int(lo)), lo);
+        assert_eq!(untag_int(tag_int(hi)), hi);
+    }
+
+    #[test]
+    fn fits_tagged_rejects_top_bit_values() {
+        assert!(!fits_tagged(i64::MAX));
+        assert!(!fits_tagged(i64::MIN));
+        assert!(fits_tagged(i64::MAX >> 1));
+        assert!(fits_tagged(i64::MIN >> 1));
+    }
+
+    #[test]
+    fn even_aligned_and_null_pointers_are_not_tagged() {
+        // A null pointer (address 0) and any 8-byte-aligned heap pointer
+        // have a clear low bit, so a real `PyObjectRef` never reads as
+        // tagged.
+        assert!(!is_tagged_int(std::ptr::null_mut()));
+        let raw = Box::into_raw(Box::new(0u64)) as PyObjectRef;
+        assert!(!is_tagged_int(raw));
+        unsafe { drop(Box::from_raw(raw as *mut u64)) };
+    }
+}

--- a/tagged-int.plan.md
+++ b/tagged-int.plan.md
@@ -1,0 +1,248 @@
+# Tagged-int representation — design, disposition, and roadmap
+
+Status: **design / not started.** This is the "Phase F tagged-int" referenced
+by the four cast-boundary comments. The document below is the authoritative
+plan; it supersedes the loose framing in those comments (notably the idea that
+the casts themselves should perform the tag arithmetic — they must not; see §2).
+
+The "tagged-int" representation stores a small Python `int` as an *immediate*
+inside a `PyObjectRef` slot — an odd bit pattern `(value << 1) | 1` — instead of
+a heap-allocated `W_IntObject`. Heap pointers are even-aligned, so the low bit
+distinguishes an immediate from a real pointer. It is RPython's `UnboxedValue` /
+`rerased` mechanism applied to `W_IntObject`.
+
+---
+
+## TL;DR / disposition
+
+1. **The four cast boundaries stay identity reinterpret-casts forever.** They do
+   **not** perform `<< 1 | 1` / `>> 1`. The `(i & 1) == 1` in their comments is
+   an *assertion* that the operand is already an odd (tagged) value, not a
+   tagging step. Tagging arithmetic lives **only** at the box/erase site. The
+   earlier "flip the four casts to tagged semantics" framing is a deviation
+   from upstream and must not be implemented (§2, evidence).
+
+2. **Tagged-int is an OPTIONAL RPython feature, off by default in PyPy.**
+   `translationoption.py:185 BoolOption("taggedpointers")` defaults false;
+   `W_IntObject` is a plain heap box (`intobject.py:540-542 __slots__='intval'`);
+   there are **zero** production `UnboxedValue` subclasses. pyre's current
+   heap-boxed `W_IntObject` + `withprebuiltint` cache (`intobject.rs`) already
+   mirrors the PyPy **default** line-for-line. So "tagged-int not implemented"
+   is faithful to the default, **not** a parity gap. Pursue it only as a
+   deliberate, optional optimization — not as a correctness obligation.
+
+3. **The runtime *enablement* (making `w_int_new` return a tagged immediate) is
+   genuinely gated on #73** (symbolic-valuestack / pc-map). A tagged immediate
+   reaching a deopt slot typed `Type::Ref` is dereferenced as a pointer by the
+   blackhole and crashes (§4, evidence). This half cannot land green today.
+
+4. **The structural, ungated half is landable** behind a compile-const flag
+   defaulting OFF: the primitive (`tag/untag/is_tagged`), the tag-aware reader
+   and dispatch chokepoints, and (carefully) the cast assertions. All inert
+   until enablement. See the slice roadmap (§6).
+
+5. **The genuinely faithful, ungated, behavior-improving work hiding adjacent to
+   this epic is NOT tagging at all** — it is porting `int.__eq__`-by-value for
+   `is_w` and the `IDTAG`-based `immutable_unique_id` (§7). pyre is currently
+   missing both. These are independent of tagging and of #73. They carry a real
+   behavioral change (`big is big` → True, PyPy semantics) and so need check.py
+   adjudication, but they are the actual int-identity parity gap.
+
+---
+
+## 1. Representation (the bit layout, if pursued)
+
+Authoritative spec is the already-ported rtyper helper
+`majit/majit-translate/src/translator/rtyper/lltypesystem/rtagged.rs`
+(`ll_int_to_unboxed` = `value * 2 + 1` with `checked_mul`/`checked_add`;
+`ll_unboxed_to_int` = `n >> 1`; `is_unboxed_instance` = `(n & 1) != 0`),
+itself a port of `rpython/rtyper/lltypesystem/rtagged.py` /
+`rpython/rlib/rerased.py`.
+
+A new runtime module `pyre/pyre-object/src/tagged_int.rs` would mirror it:
+
+```rust
+fn tag_int(v: i64) -> PyObjectRef     // ((v << 1) | 1) as *mut PyObject; caller range-checks
+fn untag_int(p: PyObjectRef) -> i64   // (p as i64) >> 1   (arithmetic, sign-preserving)
+fn is_tagged_int(p: PyObjectRef) -> bool  // (p as i64) & 1 == 1
+fn fits_tagged(v: i64) -> bool        // v >= (i64::MIN >> 1) && v <= (i64::MAX >> 1)
+```
+
+Soundness of the tag bit: every real `PyObjectRef` comes from
+`Box::into_raw(Box::new(W_IntObject))` (`lltype.rs`) or
+`gc_hook::try_gc_alloc_stable`, both 8-byte aligned (`W_IntObject` carries an
+`i64`), so the low 3 bits are always zero on a genuine heap pointer. The odd
+tag therefore never collides with a real pointer. `None`/`True`/`False` are
+8-byte-aligned statics (even) and are **not** tagged (PyPy tags `int` only).
+
+---
+
+## 2. The casts stay identity (do NOT flip them) — decisive
+
+`rpython/jit/metainterp/blackhole.py:603-610`:
+
+```python
+def bhimpl_cast_ptr_to_int(a):
+    i = lltype.cast_ptr_to_int(a)
+    ll_assert((i & 1) == 1, "bhimpl_cast_ptr_to_int: not an odd int")
+    return i                       # NO >> 1
+def bhimpl_cast_int_to_ptr(i):
+    ll_assert((i & 1) == 1, "bhimpl_cast_int_to_ptr: not an odd int")
+    return lltype.cast_int_to_ptr(llmemory.GCREF, i)   # NO << 1 | 1
+```
+
+The cast is a pure bit reinterpretation; the value is *already* `v*2+1`
+(tagged earlier, at erase/box time). The backend agrees: x86
+`genop_cast_*` = `_genop_same_as` (identity); `runner_test.py:1957` round-trips
+`cast_int_to_ptr(-17) -> cast_ptr_to_int == -17` (an even value) through the
+casts *identically*. pyre's cranelift backend already documents and enforces
+this (`majit/majit-backend-cranelift/src/compiler.rs:9210-9222`: casts wired to
+`_genop_same_as`; "OR-tagging here would fold a fake odd pointer ... could
+collide with a real GC pointer").
+
+Consequence for the four boundaries (all currently identity):
+- `majit/majit-metainterp/src/executor.rs:758-759` — const-fold: **keep identity**.
+- `majit/majit-metainterp/src/blackhole.rs:8131-8144` — bhimpl: **keep identity**;
+  the only change ever is adding the `(i & 1) == 1` *assertion*.
+- `pyre/pyre-jit-trace/src/jitcode_dispatch.rs:17082/17096` — recorder: **keep identity**.
+
+Why the JIT needs no runtime tag check at the casts: each `OpCode` has a static
+result `Type` (`CastPtrToInt ∈ int!`, `CastIntToPtr ∈ ref_!`), and the blackhole
+keeps three physically separate register banks (`registers_i/r/f`); the cast
+handlers move bits by argcode alone. Int-vs-ref is compile-time at the JIT layer.
+
+**Boundary #5 (do not forget):** the optimizer registers `CastPtrToInt` /
+`CastIntToPtr` as mutual pure inverses for CSE
+(`majit/majit-metainterp/src/optimizeopt/rewrite.rs:1926-1941`). This is sound
+*only because the casts are identity*. It is another reason never to put
+arithmetic in the casts.
+
+---
+
+## 3. Runtime consumer chokepoints (tag-aware sites, if enabled)
+
+The runtime funnels through very few sites:
+
+- **Box (maker):** `pyre/pyre-object/src/intobject.rs:90 w_int_new` — the single
+  tag site (`if fits_tagged(v) return tag_int(v)` before the malloc/gc block).
+  `w_int_new_unique` (subclass identity) must **never** tag.
+- **Unbox (reader):** `intobject.rs:141 w_int_get_value` (branch on
+  `is_tagged_int`); the one direct-deref reader
+  `pyre/pyre-interpreter/src/display.rs:242` must route through it.
+  (`display.rs:257` is the **bool** branch — leave it.)
+- **Type dispatch:** `pyre/pyre-object/src/pyobject.rs` `is_int` must
+  short-circuit true on `is_tagged` *before* the `ob_type` deref;
+  `ll_type`/`ll_inst_type` synthesize `&INT_TYPE` for a tagged value. Mirror
+  `rtagged` `ll_unboxed_getclass`. Note `is_int` today already includes
+  `BOOL_TYPE` — reconcile. Per upstream (`rtagged.py:64-96 gettype_from_unboxed`)
+  the `& 1` check is gated on a static `can_be_tagged`; do not sprinkle an
+  unconditional runtime `& 1` into the shared dispatch for every object
+  (`rerased.py:1-3`: the point is to avoid "tag checks everywhere").
+- **repr/str:** `display.rs py_repr/py_str` must format the immediate before the
+  `ob_type` deref.
+- **Arithmetic fast paths** (`descroperation.rs` int_add/...): no per-op change;
+  they ride free once read+make are tag-aware. Verify-only.
+
+---
+
+## 4. The #73 gate on enablement — decisive
+
+At deopt, every reconstructed value-stack slot is routed to the int-bank or
+ref-bank by `slot_types: Vec<Type>` (`majit/majit-metainterp/src/resume.rs`),
+which is keyed off the Python pc / pc-map kept-stack — the #73
+symbolic-valuestack layer. `resume.rs` already calls `box_int` for a `Type::Ref`
+slot that the optimizer unboxed to `Int`. The instant `w_int_new` can return a
+tagged immediate that flows into a `Type::Ref` slot, deopt pushes a tagged value
+into `registers_r` and the blackhole dereferences it as a pointer → crash.
+
+So the enablement flip (`w_int_new` tagging live; Slice 6) cannot land green
+until #73 lets `slot_types` / symbolic-valuestack carry "this Ref-slot may hold a
+tagged immediate." This confirms the 2026-06-24 verdict as **PARTIAL**: the
+structural half is ungated; the enablement half is #73-gated.
+
+Orthogonal to #424: that bug is the `W_IntObject*`-in-a-kept-slot
+Python-object layer (heap box); tagging is the `Signed<->Ptr` lltype layer.
+Tagging does not fix #424's depth>1 reconstruction.
+
+---
+
+## 5. The GC consumer-side requirement (missed by the naive design)
+
+Guarding the *producer* (`w_int_new`) is not enough. Once a tagged immediate is
+stored into any traced container (list/tuple item, dict value, instance dict,
+closure cell), the collector reads it back out of a `GcRef` field and would
+dereference it as a header. Every collector consumer site in
+`majit/majit-gc/src/collector.rs` (the fixed-field and varsize trace loops,
+`mark_object`, `copy_nursery_object`, weakref target reads) filters only on
+`is_null` + an address-range test (`is_in_nursery` / `is_managed_heap_object`);
+**none** checks the low bit. Because `fits_tagged` admits the full 63-bit value
+range, a tagged immediate's bit pattern can land inside the live heap range,
+pass the range check, and have `header_of(addr) = addr - 8` read garbage — a
+value/ASLR-dependent SIGSEGV.
+
+Therefore enablement (Slice 6) must be preceded by a collector slice that adds an
+`is_tagged`-skip (`field & 1 == 1`) at every collector consumer site (mirror
+gctransform: odd pointers are not traced). This is a hard prerequisite, not an
+optimization.
+
+---
+
+## 6. Slice roadmap
+
+Each slice is independently gate-green (census neutral-or-shrink AND check.py
+both backends) and inert (behind `PYRE_TAGGED_INT=false`) until Slice 6.
+
+| # | Title | blocked_by | Notes |
+|---|-------|-----------|-------|
+| 0 | Design doc (this file) + inert `tagged_int.rs` primitive + unit tests | none | zero call sites; census neutral by construction |
+| 1 | Tag-aware `w_int_get_value` + route `display.rs:242` through it | #0 | dead branch (no tagged value exists yet) |
+| 2 | `is_int` short-circuit + `ll_type`/`ll_inst_type` synth (gated on static can_be_tagged) | #1 | dead branch |
+| 3 | repr/str tag-guard | #2 | dead branch |
+| 4 | GC collector consumer `is_tagged`-skip (collector.rs) | #0 | hard prerequisite for #6; inert until a tagged value exists |
+| 5 | Add `(i & 1) == 1` *assertions* to the cast bhimpls (casts stay identity) + CSE inverse audit | #0 | assertions only; backend untouched |
+| 6 | **ENABLE** tagging in `w_int_new` | **#73**, #1-5 | live flip; reds on every polymorphic-int-slot deopt until #73 |
+
+The "first slice" for *starting* PART 1 is **Slice 0 (this doc)**. The inert
+primitive itself is deliberately **deferred**, not landed with the doc, because
+(a) the epic is an optional feature whose enablement is #73-gated, and (b) the
+GC-consumer requirement (§5) and the assertion-only cast change (§5/§2) should be
+designed before committing infra. Land code only when the user elects to pursue
+the optional epic.
+
+---
+
+## 7. The real ungated int-identity parity gap (separate from tagging)
+
+PyPy implements int `is` and `id()` at the objspace layer, independent of any
+pointer tagging:
+
+- `intobject.py:553-567 W_IntObject.is_w` compares **by value** (with a
+  `user_overridden_class` guard) — so in PyPy `big is big` is **True**.
+- `intobject.py:55-60 immutable_unique_id` = `bigint << IDTAG_SHIFT | IDTAG_INT`
+  (`util.py` `IDTAG_SHIFT=4`, `IDTAG_INT=1`) — a value-derived id, so equal ints
+  share `id()`.
+
+pyre is missing both: `baseobjspace.rs:2239 is_w` is bare `std::ptr::eq`, and
+`function.rs:1642 immutable_unique_id` is `_obj as usize` (raw pointer). So
+pyre's `big is big` is False and `id(big)` is the malloc address — a real
+deviation from PyPy.
+
+Porting these is faithful, ungated, and touches neither the cast layer nor #73.
+The caveat is behavioral: `big is big → True` and value-shaped `id()` may flip
+check.py tests that pin CPython-style int identity. This makes it a deliberate
+slice needing check.py adjudication, but it is the actual int-identity parity
+work — and a more valuable, more faithful target than the optional tagged-int
+enablement, which is blocked on #73 regardless.
+
+---
+
+## 8. False-start traps (NOT tagged-int infra — exclude)
+
+- **Register-class** `blackhole.rs:7429-7461` `/id>X` / `/iXd` handler variants
+  ("pyre tagged-int base in an int register"): a regalloc bank selector for an
+  already-real even-aligned base pointer. Not live value tagging.
+- **Resume byte-stream** `resume.rs` `tag(value, tagbits) = (value << 2) | tagbits`
+  with `TAGCONST/TAGINT/TAGBOX/TAGVIRTUAL`: a 2-bit serialization tag in the
+  resume metadata, decoded to a typed `Const::Int`. Different layout (`<< 2`),
+  different purpose. Do not reuse `TAGINT` or the `<< 2` encoder for the runtime
+  representation.


### PR DESCRIPTION
Current `ec-wiring` batch (origin/main..ec-wiring). Two themes.

## Tagged-int representation scaffolding (#122 PART 1)

Inert groundwork for storing a small `int` as an immediate `(value << 1) | 1`
in a `PyObjectRef` slot (`rerased.py` / `rtagged.py`). Everything is gated
behind `tagged_int::CAN_BE_TAGGED` (`const false`, mirroring the
`taggedpointers` default), so each consumer short-circuits to the heap-box
path and the behaviour is byte-identical until the enablement slice
(gated on #73).

- Add the tagged-int primitive module (`tag_int`/`untag_int`/`is_tagged_int`/
  `fits_tagged`) with zero call sites.
- Make `w_int_get_value` tag-aware and route the int repr reader through it.
- Make `is_int`, `ll_type`, `ll_inst_type` tag-aware (`is_int` carries its own
  guard since it reaches `ob_type` via `py_type_check`, not `ll_type`).
- Guard int repr/str rendering (`py_repr`/`py_str`/`py_str_wtf8`) for a tagged
  immediate.
- Design plan: `tagged-int.plan.md`.

## Value-based int `is` / `id()`

- `W_AbstractIntObject.is_w` (intobject.py:44-53): two plain `int`s are
  identical when their values are equal; `bool` and `int` subclasses keep
  pointer identity. `IS_OP` routes through `is_w`.
- `id()` of a plain `int` is `(value << IDTAG_SHIFT) | IDTAG_INT`.
- A follow-up commit makes both compare/compute in bigint space so a
  `W_LongObject` (which shares `int`'s `w_class`) is not misread as an i64 and
  large-int ids no longer overflow.

## rtyper classdef-less narrowing (#122 type-narrowing)

- Narrow classdef-less registered-ADT call results and raw-pointer-deref field
  bases via `__pyre_cast_instance`.
- Strip the `::variant` tail in enum discriminant narrowing to avoid deepening
  without a fixpoint.
- Strip generic args in `project_struct_rows` registry lookup.
- Merge `knowntypedata` in the `SomeInteger` union arm.
- Split the CLASSDEF-LESS census bucket by failure kind; `list_insert`.

Gate: `pyre/check.py` dynasm 158/158 + cranelift 158/158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
