### PR TITLE
#268 bignum nursery/GC representation: kill the malloc_raw leak + bound within-run RSS

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -182,7 +182,7 @@ jobs:
     steps: *prepare-charon-llbc-steps
 
   cargo-test-linux:
-    name: cargo test (ubuntu-24.04, ${{ matrix.backend }})
+    name: cargo test (ubuntu-24.04)
     runs-on: ubuntu-24.04
     needs: prepare-charon-llbc-linux
     if: ${{ !cancelled() && needs.prepare-charon-llbc-linux.result == 'success' }}
@@ -191,10 +191,6 @@ jobs:
       # artifact into this workspace path.
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [dynasm, cranelift]
 
     steps: &cargo-test-steps
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -245,41 +241,43 @@ jobs:
           /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
         sudo docker image prune --all --force || true
         df -h /
-    - name: Run cargo test for ${{ matrix.backend }}
+    - name: Run cargo tests
       # Pin bash: on windows-latest the default shell is PowerShell, where
-      # "$BACKEND" does not expand the env var (it would need $env:BACKEND),
-      # so cargo test would run with an empty feature set.
+      # POSIX loop/status handling would otherwise need a separate spelling.
       shell: bash
-      env:
-        BACKEND: ${{ matrix.backend }}
-      run: cargo test --all --no-default-features --features "$BACKEND"
+      run: |
+        status=0
+        for backend in dynasm cranelift; do
+          echo "::group::cargo test ($backend)"
+          if cargo test --all --no-default-features --features "$backend"; then
+            echo "::notice title=cargo test::$backend passed"
+          else
+            code=$?
+            echo "::error title=cargo test::$backend failed with exit $code"
+            status=1
+          fi
+          echo "::endgroup::"
+        done
+        exit "$status"
 
   cargo-test-macos:
-    name: cargo test (macos-latest, ${{ matrix.backend }})
+    name: cargo test (macos-latest)
     runs-on: macos-latest
     needs: prepare-charon-llbc-macos
     if: ${{ !cancelled() && needs.prepare-charon-llbc-macos.result == 'success' }}
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [dynasm, cranelift]
     steps: *cargo-test-steps
 
   cargo-test-windows:
-    name: cargo test (windows-latest, ${{ matrix.backend }})
+    name: cargo test (windows-latest)
     runs-on: windows-latest
     needs: prepare-charon-llbc-windows
     if: ${{ !cancelled() && needs.prepare-charon-llbc-windows.result == 'success' }}
     env:
       PYRE_SHARED_BUILD: ${{ github.workspace }}/.pyre-build
       CHARON_VERSION: nightly-2026.05.29
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [dynasm, cranelift]
     steps: *cargo-test-steps
 
   pyre-check-linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1277,6 +1277,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -1599,6 +1608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2114,6 +2132,7 @@ dependencies = [
  "dirs",
  "lexopt",
  "majit-metainterp",
+ "mimalloc",
  "pyre-interpreter",
  "pyre-jit",
  "pyre-object",
@@ -2347,7 +2366,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2746,7 +2765,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2809,7 +2828,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3702,7 +3721,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1420,6 +1420,23 @@ fn alloc_nursery_typed_via_active_runtime(type_id: u32, size: usize) -> GcRef {
     with_cranelift_gc(|gc| gc.alloc_nursery_no_collect_typed(type_id, size)).unwrap_or(GcRef(0))
 }
 
+/// `majit_gc::AllocNurseryCollectingTypedFn` installed by `set_gc_allocator`.
+/// Unlike [`alloc_nursery_typed_via_active_runtime`] (no-collect), this runs a
+/// minor when the nursery is full. Only the elidable bigint payload helpers use
+/// it, from a residual call whose jitframe gcmap roots the trace's live set, so
+/// the embedded minor cycle reclaims dead bigints instead of spilling to old-gen.
+fn alloc_nursery_collecting_typed_via_active_runtime(type_id: u32, size: usize) -> GcRef {
+    with_cranelift_gc(|gc| gc.alloc_nursery_typed(type_id, size)).unwrap_or(GcRef(0))
+}
+
+/// `majit_gc::ChargeMemoryPressureFn` installed by `set_gc_allocator`. Charges a
+/// freshly-built bignum's off-heap limb-`Vec` bytes so the active GC's minor
+/// cadence reflects true footprint; may force a minor, safe from the same
+/// gcmap-rooted residual call as [`alloc_nursery_collecting_typed_via_active_runtime`].
+fn charge_memory_pressure_via_active_runtime(bytes: usize) {
+    with_cranelift_gc(|gc| gc.charge_memory_pressure(bytes));
+}
+
 /// `majit_gc::AllocOldgenTypedFn` installed by `set_gc_allocator`.
 /// Routes host-side allocations that need a stable (non-moving)
 /// pointer through the active cranelift-owned GC's old-gen. Used by
@@ -7736,6 +7753,12 @@ impl CraneliftBackend {
             supports_guard_gc_type,
         });
         majit_gc::set_active_alloc_nursery_typed(Some(alloc_nursery_typed_via_active_runtime));
+        majit_gc::set_active_alloc_nursery_collecting_typed(Some(
+            alloc_nursery_collecting_typed_via_active_runtime,
+        ));
+        majit_gc::set_active_charge_memory_pressure(Some(
+            charge_memory_pressure_via_active_runtime,
+        ));
         majit_gc::set_active_alloc_oldgen_typed(Some(alloc_oldgen_typed_via_active_runtime));
         majit_gc::set_active_collect_full(Some(collect_full_via_active_runtime));
         majit_gc::set_active_collect_oldgen(Some(collect_oldgen_nonmoving_via_active_runtime));

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1439,8 +1439,8 @@ fn charge_memory_pressure_via_active_runtime(bytes: usize) {
 
 /// Charge an old-gen object's off-heap payload against the major threshold on
 /// the active cranelift runtime's GC, without forcing a minor.
-fn charge_oldgen_external_via_active_runtime(bytes: usize) {
-    with_cranelift_gc(|gc| gc.charge_oldgen_external(bytes));
+fn charge_oldgen_external_via_active_runtime(obj_addr: usize, bytes: usize) {
+    with_cranelift_gc(|gc| gc.charge_oldgen_external(obj_addr, bytes));
 }
 
 /// `majit_gc::AllocOldgenTypedFn` installed by `set_gc_allocator`.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -1437,6 +1437,12 @@ fn charge_memory_pressure_via_active_runtime(bytes: usize) {
     with_cranelift_gc(|gc| gc.charge_memory_pressure(bytes));
 }
 
+/// Charge an old-gen object's off-heap payload against the major threshold on
+/// the active cranelift runtime's GC, without forcing a minor.
+fn charge_oldgen_external_via_active_runtime(bytes: usize) {
+    with_cranelift_gc(|gc| gc.charge_oldgen_external(bytes));
+}
+
 /// `majit_gc::AllocOldgenTypedFn` installed by `set_gc_allocator`.
 /// Routes host-side allocations that need a stable (non-moving)
 /// pointer through the active cranelift-owned GC's old-gen. Used by
@@ -7758,6 +7764,9 @@ impl CraneliftBackend {
         ));
         majit_gc::set_active_charge_memory_pressure(Some(
             charge_memory_pressure_via_active_runtime,
+        ));
+        majit_gc::set_active_charge_oldgen_external(Some(
+            charge_oldgen_external_via_active_runtime,
         ));
         majit_gc::set_active_alloc_oldgen_typed(Some(alloc_oldgen_typed_via_active_runtime));
         majit_gc::set_active_collect_full(Some(collect_full_via_active_runtime));

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -234,6 +234,35 @@ fn dynasm_alloc_nursery_typed(type_id: u32, size: usize) -> GcRef {
     })
 }
 
+/// Host-side *collecting* nursery allocation trampoline. Unlike
+/// [`dynasm_alloc_nursery_typed`], this runs a minor collection when the nursery
+/// is full (instead of spilling to old-gen). Used only by the elidable bigint
+/// payload helpers, which are invoked from a residual `CallR` whose gcmap roots
+/// the trace's live set and which hold no unrooted GC pointer across the
+/// allocation — so the embedded minor cycle is safe and dead bigints are
+/// reclaimed instead of accumulating in old-gen.
+fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
+    DYNASM_ACTIVE_GC.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        match guard.as_deref_mut() {
+            Some(gc) => gc.alloc_nursery_typed(type_id, size),
+            None => GcRef(0),
+        }
+    })
+}
+
+/// Host-side memory-pressure trampoline — charges off-heap (GC-invisible) bytes
+/// such as a freshly-built bignum's limb `Vec` on the active GC. May force a
+/// minor collection; only called from the gcmap-rooted bignum collecting-alloc
+/// site (see [`dynasm_alloc_nursery_collecting_typed`]).
+fn dynasm_charge_memory_pressure(bytes: usize) {
+    DYNASM_ACTIVE_GC.with(|cell| {
+        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
+            gc.charge_memory_pressure(bytes);
+        }
+    })
+}
+
 /// Host-side old-gen allocation trampoline. Used by
 /// pyre-object allocators (`w_int_new`, `w_float_new`) whose
 /// callers cannot register the returned pointer as a GC root before
@@ -1228,6 +1257,10 @@ impl DynasmBackend {
             supports_guard_gc_type,
         });
         majit_gc::set_active_alloc_nursery_typed(Some(dynasm_alloc_nursery_typed));
+        majit_gc::set_active_alloc_nursery_collecting_typed(Some(
+            dynasm_alloc_nursery_collecting_typed,
+        ));
+        majit_gc::set_active_charge_memory_pressure(Some(dynasm_charge_memory_pressure));
         majit_gc::set_active_alloc_oldgen_typed(Some(dynasm_alloc_oldgen_typed));
         majit_gc::set_active_collect_full(Some(dynasm_collect_full));
         majit_gc::set_active_collect_oldgen(Some(dynasm_collect_oldgen_nonmoving));

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -251,14 +251,14 @@ fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
     })
 }
 
-/// Host-side memory-pressure trampoline — charges off-heap (GC-invisible) bytes
-/// such as a freshly-built bignum's limb `Vec` on the active GC. May force a
-/// minor collection; only called from the gcmap-rooted bignum collecting-alloc
-/// site (see [`dynasm_alloc_nursery_collecting_typed`]).
-fn dynasm_charge_oldgen_external(bytes: usize) {
+/// Host-side old-gen external-byte trampoline — charges off-heap
+/// (GC-invisible) bytes such as a freshly-built bignum's limb `Vec` on the
+/// active GC when the initialized object landed in old-gen. Never forces a
+/// minor collection.
+fn dynasm_charge_oldgen_external(obj_addr: usize, bytes: usize) {
     DYNASM_ACTIVE_GC.with(|cell| {
         if let Some(gc) = cell.borrow_mut().as_deref_mut() {
-            gc.charge_oldgen_external(bytes);
+            gc.charge_oldgen_external(obj_addr, bytes);
         }
     })
 }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -255,6 +255,14 @@ fn dynasm_alloc_nursery_collecting_typed(type_id: u32, size: usize) -> GcRef {
 /// such as a freshly-built bignum's limb `Vec` on the active GC. May force a
 /// minor collection; only called from the gcmap-rooted bignum collecting-alloc
 /// site (see [`dynasm_alloc_nursery_collecting_typed`]).
+fn dynasm_charge_oldgen_external(bytes: usize) {
+    DYNASM_ACTIVE_GC.with(|cell| {
+        if let Some(gc) = cell.borrow_mut().as_deref_mut() {
+            gc.charge_oldgen_external(bytes);
+        }
+    })
+}
+
 fn dynasm_charge_memory_pressure(bytes: usize) {
     DYNASM_ACTIVE_GC.with(|cell| {
         if let Some(gc) = cell.borrow_mut().as_deref_mut() {
@@ -1261,6 +1269,7 @@ impl DynasmBackend {
             dynasm_alloc_nursery_collecting_typed,
         ));
         majit_gc::set_active_charge_memory_pressure(Some(dynasm_charge_memory_pressure));
+        majit_gc::set_active_charge_oldgen_external(Some(dynasm_charge_oldgen_external));
         majit_gc::set_active_alloc_oldgen_typed(Some(dynasm_alloc_oldgen_typed));
         majit_gc::set_active_collect_full(Some(dynasm_collect_full));
         majit_gc::set_active_collect_oldgen(Some(dynasm_collect_oldgen_nonmoving));

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2591,17 +2591,18 @@ impl GcAllocator for MiniMarkGC {
         }
     }
 
-    /// Add a directly-old-gen-allocated object's off-heap `bytes` to the running
+    /// Add an old-gen object's off-heap `bytes` to the running
     /// `oldgen_external_bytes`, so a bignum allocated straight into old-gen via
-    /// the stable hook enters `get_total_memory_used` (and thus the major
-    /// threshold) at allocation time, not only at the next major's
-    /// `recompute_oldgen_external_bytes`. No minor is forced — old-gen is
-    /// non-moving — so this is safe on the unrooted host/interpreter path. The
-    /// end-of-major recompute corrects any drift, so the charge only needs to be
-    /// approximately right; it mirrors the promotion-path charge in
-    /// `deal_with_young_objects_with_destructors`.
-    fn charge_oldgen_external(&mut self, bytes: usize) {
-        self.oldgen_external_bytes = self.oldgen_external_bytes.saturating_add(bytes);
+    /// a stable or fallback allocation enters `get_total_memory_used` (and thus
+    /// the major threshold) at allocation time, not only at the next major's
+    /// `recompute_oldgen_external_bytes`. Nursery objects are ignored here
+    /// because their external bytes are charged when they promote. No minor is
+    /// forced — old-gen is non-moving — so this is safe on unrooted
+    /// host/interpreter paths. The end-of-major recompute corrects any drift.
+    fn charge_oldgen_external(&mut self, obj_addr: usize, bytes: usize) {
+        if self.oldgen.contains(obj_addr) {
+            self.oldgen_external_bytes = self.oldgen_external_bytes.saturating_add(bytes);
+        }
     }
 
     fn alloc_nursery_no_collect(&mut self, size: usize) -> GcRef {
@@ -3198,6 +3199,25 @@ mod tests {
         gc.alloc_with_type(tid, 16);
         assert!(gc.young_objects_with_destructors.is_empty());
         assert!(gc.old_objects_with_destructors.is_empty());
+    }
+
+    #[test]
+    fn oldgen_external_charge_ignores_nursery_counts_oldgen() {
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+
+        let young = gc.alloc_with_type(tid, 16);
+        assert!(gc.is_in_nursery(young.0));
+        <MiniMarkGC as crate::GcAllocator>::charge_oldgen_external(&mut gc, young.0, 128);
+        assert_eq!(gc.oldgen_external_bytes, 0);
+
+        let old = gc.alloc_in_oldgen(tid, GcHeader::SIZE + 16);
+        assert!(!gc.is_in_nursery(old.0));
+        <MiniMarkGC as crate::GcAllocator>::charge_oldgen_external(&mut gc, old.0, 128);
+        assert_eq!(gc.oldgen_external_bytes, 128);
+
+        <MiniMarkGC as crate::GcAllocator>::charge_oldgen_external(&mut gc, 0, 64);
+        assert_eq!(gc.oldgen_external_bytes, 128);
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -402,6 +402,15 @@ pub struct MiniMarkGC {
     /// major threshold onto the minor trigger because the charged objects (young
     /// bignums) are reclaimed at minors.
     pressure_since_minor: usize,
+    /// Sum of the off-heap (GC-invisible) byte footprint of old-gen objects
+    /// whose type carries an `external_size` fn — currently promoted `BigInt`
+    /// payloads whose limb `Vec` lives in the system heap. Folded into
+    /// `get_total_memory_used` so the major-collection threshold reflects the
+    /// true footprint, not just the tracked struct, and majors fire to reclaim
+    /// the limb memory of dead promoted bignums. Incremented when such an object
+    /// is promoted (its value is valid post-copy) and recomputed exactly from
+    /// the surviving destructor list at the end of each major cycle.
+    oldgen_external_bytes: usize,
     /// Pinned nursery objects that must not be moved during minor collection.
     pinned_objects: VecSet<usize>,
     /// minimark.py:338 `nursery_objects_shadows = AddressDict()`.
@@ -510,6 +519,7 @@ impl MiniMarkGC {
             bytes_made_old_since_cycle: 0,
             threshold_bytes_made_old: 0,
             pressure_since_minor: 0,
+            oldgen_external_bytes: 0,
             pinned_objects: VecSet::new(),
             nursery_objects_shadows: std::collections::HashMap::new(),
             compiled_code_registry: CompiledCodeRegistry::new(),
@@ -1150,6 +1160,15 @@ impl MiniMarkGC {
                 // Surviving: track the promoted copy for the major cycle.
                 let new_obj = unsafe { GcHeader::forwarding_address(hdr_ptr) };
                 self.old_objects_with_destructors.push(new_obj);
+                // The payload is now in old-gen with a valid value; fold its
+                // off-heap footprint into the major threshold so the dead
+                // promoted bigints' limb memory is reclaimed by a major.
+                let tid = unsafe { (*header_of(new_obj)).type_id() };
+                if let Some(external_size) = self.types.get(tid).external_size {
+                    self.oldgen_external_bytes = self
+                        .oldgen_external_bytes
+                        .saturating_add(unsafe { external_size(new_obj) });
+                }
             }
         }
     }
@@ -1416,7 +1435,7 @@ impl MiniMarkGC {
     /// aggregates promoted objects and large/raw objects allocated straight
     /// into the old generation.
     fn get_total_memory_used(&self) -> usize {
-        self.oldgen.total_bytes()
+        self.oldgen.total_bytes() + self.oldgen_external_bytes
     }
 
     /// incminimark.py:1288-1290 `threshold_reached`. True once the old-gen
@@ -1713,6 +1732,11 @@ impl MiniMarkGC {
         if !self.old_objects_with_destructors.is_empty() {
             self.deal_with_old_objects_with_destructors();
         }
+        // Reset the live off-heap footprint exactly from the survivors (the
+        // dying objects' destructors just ran, freeing their limb Vecs), so the
+        // promotion-time running total cannot drift and the next-major threshold
+        // taken from get_total_memory_used below reflects the post-sweep truth.
+        self.recompute_oldgen_external_bytes();
         self.oldgen.sweep();
         // incminimark.py:2566-2577 — set the threshold for the next major
         // collection to `major_collection_threshold` times the surviving
@@ -1797,6 +1821,22 @@ impl MiniMarkGC {
             }
         }
         self.old_objects_with_destructors = new_objects;
+    }
+
+    /// Recompute `oldgen_external_bytes` exactly from the surviving
+    /// destructor-bearing old-gen objects. Called at the end of a major cycle
+    /// so the running promotion-time increment cannot drift (an object may
+    /// reach old-gen without passing through the promotion increment, e.g. a
+    /// large object allocated straight into old-gen).
+    fn recompute_oldgen_external_bytes(&mut self) {
+        let mut total = 0usize;
+        for &addr in &self.old_objects_with_destructors {
+            let tid = unsafe { (*header_of(addr)).type_id() };
+            if let Some(external_size) = self.types.get(tid).external_size {
+                total = total.saturating_add(unsafe { external_size(addr) });
+            }
+        }
+        self.oldgen_external_bytes = total;
     }
 
     /// Whether an incremental marking cycle is currently in progress.

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2585,10 +2585,23 @@ impl GcAllocator for MiniMarkGC {
     /// forced minor holds no unrooted nursery pointer, the same invariant
     /// `alloc_with_type` relies on for its own nursery-full `do_collect_nursery`.
     fn charge_memory_pressure(&mut self, bytes: usize) {
-        self.pressure_since_minor += bytes;
+        self.pressure_since_minor = self.pressure_since_minor.saturating_add(bytes);
         if self.nursery.used() + self.pressure_since_minor >= self.nursery.size() {
             self.do_collect_nursery();
         }
+    }
+
+    /// Add a directly-old-gen-allocated object's off-heap `bytes` to the running
+    /// `oldgen_external_bytes`, so a bignum allocated straight into old-gen via
+    /// the stable hook enters `get_total_memory_used` (and thus the major
+    /// threshold) at allocation time, not only at the next major's
+    /// `recompute_oldgen_external_bytes`. No minor is forced — old-gen is
+    /// non-moving — so this is safe on the unrooted host/interpreter path. The
+    /// end-of-major recompute corrects any drift, so the charge only needs to be
+    /// approximately right; it mirrors the promotion-path charge in
+    /// `deal_with_young_objects_with_destructors`.
+    fn charge_oldgen_external(&mut self, bytes: usize) {
+        self.oldgen_external_bytes = self.oldgen_external_bytes.saturating_add(bytes);
     }
 
     fn alloc_nursery_no_collect(&mut self, size: usize) -> GcRef {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -314,6 +314,22 @@ pub struct MiniMarkGC {
     /// collection (incminimark.py:3107-3133); the major-side
     /// consumer lands in the major-collection sweep phase.
     old_objects_with_weakrefs: Vec<usize>,
+    /// incminimark.py:407 `self.young_objects_with_destructors =
+    /// self.AddressStack()`. Nursery-resident objects whose type carries
+    /// a lightweight `TypeInfo.destructor`. Populated by
+    /// `register_destructor_if_needed` at allocation (incminimark.py:689
+    /// `if needs_finalizer:`). Drained at end of minor cycle by
+    /// `deal_with_young_objects_with_destructors` (incminimark.py:1868,
+    /// :2884-2895): a dead object's destructor runs, a survivor moves to
+    /// `old_objects_with_destructors`.
+    young_objects_with_destructors: Vec<usize>,
+    /// incminimark.py:408 `self.old_objects_with_destructors =
+    /// self.AddressStack()`. Old-gen objects with a destructor, populated
+    /// by promotion from the young list and by direct old-gen allocation.
+    /// Drained by `deal_with_old_objects_with_destructors`
+    /// (incminimark.py:2510-2511, :2897-2912) before the major sweep:
+    /// a VISITED object survives, a dying one's destructor runs.
+    old_objects_with_destructors: Vec<usize>,
     /// True while [`do_collect_oldgen_nonmoving`](MiniMarkGC::do_collect_oldgen_nonmoving)
     /// is running. A non-moving major skips the leading minor, so unlike
     /// `do_collect_full` it marks through a *populated* nursery: `mark_object`
@@ -462,6 +478,8 @@ impl MiniMarkGC {
             old_objects_with_cards_set: Vec::new(),
             young_objects_with_weakrefs: Vec::new(),
             old_objects_with_weakrefs: Vec::new(),
+            young_objects_with_destructors: Vec::new(),
+            old_objects_with_destructors: Vec::new(),
             oldgen_nonmoving_active: false,
             oldgen_nonmoving_nursery_marks: Vec::new(),
             config,
@@ -671,12 +689,14 @@ impl MiniMarkGC {
             Self::init_nursery_object(ptr, type_id);
             let obj = GcRef((ptr as usize) + GcHeader::SIZE);
             self.register_weakref_if_needed(type_id, obj.0);
+            self.register_destructor_if_needed(type_id, obj.0);
             return obj;
         }
 
         Self::init_nursery_object(ptr, type_id);
         let obj = GcRef((ptr as usize) + GcHeader::SIZE);
         self.register_weakref_if_needed(type_id, obj.0);
+        self.register_destructor_if_needed(type_id, obj.0);
         obj
     }
 
@@ -700,6 +720,7 @@ impl MiniMarkGC {
         Self::init_nursery_object(ptr, type_id);
         let obj = GcRef((ptr as usize) + GcHeader::SIZE);
         self.register_weakref_if_needed(type_id, obj.0);
+        self.register_destructor_if_needed(type_id, obj.0);
         obj
     }
 
@@ -720,6 +741,41 @@ impl MiniMarkGC {
         }
     }
 
+    /// incminimark.py:689-690 parity. When a freshly nursery-allocated
+    /// object's type carries a lightweight `TypeInfo.destructor`, push it
+    /// onto the young-destructor list so the next minor collection runs
+    /// the destructor if the object dies (or promotes it to the
+    /// old-destructor list if it survives).
+    ///
+    /// `obj_addr` is the payload base (post-header).
+    fn register_destructor_if_needed(&mut self, type_id: u32, obj_addr: usize) {
+        if (type_id as usize) >= self.types.len() {
+            return;
+        }
+        if self.types.get(type_id).destructor.is_some() {
+            self.young_objects_with_destructors.push(obj_addr);
+        }
+    }
+
+    /// Run the lightweight destructor registered for `obj_addr`'s type,
+    /// if any. incminimark.py `call_destructor` analog: looks up the
+    /// type's `TypeInfo.destructor` and calls it on the payload base.
+    ///
+    /// # Safety
+    /// `obj_addr` must point at a live (not-yet-freed) object payload
+    /// whose header still names a registered type id — true for a dead
+    /// nursery object before `nursery.reset()` and a dying old-gen object
+    /// before `oldgen.sweep()`.
+    fn run_destructor(&self, obj_addr: usize) {
+        let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        if (type_id as usize) >= self.types.len() {
+            return;
+        }
+        if let Some(destructor) = self.types.get(type_id).destructor {
+            unsafe { destructor(obj_addr) };
+        }
+    }
+
     /// Initialize a nursery object's header.
     fn init_nursery_object(header_ptr: *mut u8, type_id: u32) {
         let hdr = unsafe { &mut *(header_ptr as *mut GcHeader) };
@@ -736,7 +792,17 @@ impl MiniMarkGC {
         *hdr = GcHeader::with_flags(type_id, flags::TRACK_YOUNG_PTRS);
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
-        GcRef((ptr as usize) + GcHeader::SIZE)
+        let obj_addr = (ptr as usize) + GcHeader::SIZE;
+        // A destructor-bearing object that never passes through the
+        // nursery (large object, or nursery-full fallback) is recorded
+        // straight onto the old-destructor list so a later major
+        // collection runs its destructor when it dies.
+        if (type_id as usize) < self.types.len()
+            && self.types.get(type_id).destructor.is_some()
+        {
+            self.old_objects_with_destructors.push(obj_addr);
+        }
+        GcRef(obj_addr)
     }
 
     /// Perform a minor (nursery) collection.
@@ -922,6 +988,15 @@ impl MiniMarkGC {
             self.invalidate_young_weakrefs();
         }
 
+        // incminimark.py:1868-1869 — then run the destructor of each
+        // dead nursery object (and promote survivors to the
+        // old-destructor list). Must happen after every live nursery
+        // object is forwarded (so survival is detectable) and before the
+        // nursery reset below reclaims the backing bytes.
+        if !self.young_objects_with_destructors.is_empty() {
+            self.deal_with_young_objects_with_destructors();
+        }
+
         // incminimark.py:1876-1882: clear the shadow map now that all
         // nursery objects have been forwarded (or died).  Without pinned
         // objects every nursery object was dragged out (into its shadow
@@ -1036,6 +1111,29 @@ impl MiniMarkGC {
             // the chance to invalidate it later.
             if self.oldgen.contains(pointing_to) {
                 self.old_objects_with_weakrefs.push(new_obj);
+            }
+        }
+    }
+
+    /// incminimark.py:2884-2895 `deal_with_young_objects_with_destructors`.
+    ///
+    /// "We can reasonably assume that destructors don't do anything fancy
+    /// and *just* call them. Among other things they won't resurrect
+    /// objects." For each recorded young object: if it was not forwarded
+    /// out it died — run its destructor; otherwise it survived — move it
+    /// (translated to its new old-gen address) to the old-destructor list
+    /// so the next major collection can reclaim it.
+    fn deal_with_young_objects_with_destructors(&mut self) {
+        while let Some(obj_addr) = self.young_objects_with_destructors.pop() {
+            let hdr_ptr = (obj_addr - GcHeader::SIZE) as *const GcHeader;
+            if !unsafe { (*hdr_ptr).is_forwarded() } {
+                // Dead: run the destructor before the nursery reset frees
+                // the bytes.
+                self.run_destructor(obj_addr);
+            } else {
+                // Surviving: track the promoted copy for the major cycle.
+                let new_obj = unsafe { GcHeader::forwarding_address(hdr_ptr) };
+                self.old_objects_with_destructors.push(new_obj);
             }
         }
     }
@@ -1593,6 +1691,12 @@ impl MiniMarkGC {
             .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::VISITED) });
         self.old_objects_with_cards_set
             .retain(|&addr| unsafe { (*header_of(addr)).has_flag(flags::VISITED) });
+        // incminimark.py:2510-2511 — run destructors of dying old objects
+        // before the sweep frees them (VISITED still distinguishes
+        // survivors from the dying at this point).
+        if !self.old_objects_with_destructors.is_empty() {
+            self.deal_with_old_objects_with_destructors();
+        }
         self.oldgen.sweep();
         // incminimark.py:2566-2577 — set the threshold for the next major
         // collection to `major_collection_threshold` times the surviving
@@ -1654,6 +1758,29 @@ impl MiniMarkGC {
             }
         }
         self.old_objects_with_weakrefs = new_with_weakref;
+    }
+
+    /// incminimark.py:2897-2912 `deal_with_old_objects_with_destructors`.
+    ///
+    /// Walk the old-destructor list: a VISITED (surviving) object is kept
+    /// in a fresh list; a dying (not-VISITED) object's destructor runs
+    /// before the imminent sweep frees its memory. Must run while VISITED
+    /// bits are still meaningful — i.e. before `oldgen.sweep()` clears
+    /// them.
+    fn deal_with_old_objects_with_destructors(&mut self) {
+        let entries = std::mem::take(&mut self.old_objects_with_destructors);
+        let mut new_objects = Vec::with_capacity(entries.len());
+        for obj_addr in entries {
+            let hdr_ptr = (obj_addr - GcHeader::SIZE) as *const GcHeader;
+            if unsafe { (*hdr_ptr).has_flag(flags::VISITED) } {
+                // surviving
+                new_objects.push(obj_addr);
+            } else {
+                // dying
+                self.run_destructor(obj_addr);
+            }
+        }
+        self.old_objects_with_destructors = new_objects;
     }
 
     /// Whether an incremental marking cycle is currently in progress.
@@ -2853,6 +2980,141 @@ mod tests {
             gc.alloc_with_type(0, 16);
         }
         assert!(gc.minor_collections > 0);
+    }
+
+    // --- Lightweight destructor tests (incminimark.py:2884-2912 parity) ---
+    //
+    // The counting destructor below deliberately does NOT `drop_in_place`
+    // the dummy payload (the test allocations are raw bytes, not a real
+    // `Drop` type); it only records that the collector dispatched it on
+    // the right object at the right time. A serializing lock keeps the
+    // shared counter races-free under cargo's parallel test runner.
+
+    static DESTRUCTOR_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    static DESTRUCTOR_RUNS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    static DESTRUCTOR_LAST_ADDR: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    unsafe fn counting_destructor(obj_addr: usize) {
+        DESTRUCTOR_RUNS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        DESTRUCTOR_LAST_ADDR.store(obj_addr, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn destructor_runs() -> usize {
+        DESTRUCTOR_RUNS.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    #[test]
+    fn destructor_runs_on_nursery_death() {
+        let _guard = DESTRUCTOR_TEST_LOCK.lock().unwrap();
+        DESTRUCTOR_RUNS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_destructor(16, counting_destructor));
+
+        let obj = gc.alloc_with_type(tid, 16);
+        // Recorded on the young-destructor list at allocation.
+        assert_eq!(gc.young_objects_with_destructors, vec![obj.0]);
+
+        // Not rooted → dies on the next minor collection.
+        gc.collect_nursery();
+
+        assert_eq!(destructor_runs(), 1);
+        assert_eq!(
+            DESTRUCTOR_LAST_ADDR.load(std::sync::atomic::Ordering::SeqCst),
+            obj.0
+        );
+        // Both lists drained: dead object never reaches the old list.
+        assert!(gc.young_objects_with_destructors.is_empty());
+        assert!(gc.old_objects_with_destructors.is_empty());
+    }
+
+    #[test]
+    fn destructor_not_run_on_survival_then_run_on_oldgen_death() {
+        let _guard = DESTRUCTOR_TEST_LOCK.lock().unwrap();
+        DESTRUCTOR_RUNS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_destructor(16, counting_destructor));
+
+        let obj = gc.alloc_with_type(tid, 16);
+        let mut root = obj;
+        unsafe {
+            gc.roots.add(&mut root);
+        }
+
+        // Survives the minor → promoted, NOT destructed; moves young→old list.
+        gc.collect_nursery();
+        assert_eq!(destructor_runs(), 0);
+        assert!(!gc.is_in_nursery(root.0));
+        assert!(gc.young_objects_with_destructors.is_empty());
+        assert_eq!(gc.old_objects_with_destructors, vec![root.0]);
+
+        // Unroot → dies at the next major collection.
+        gc.roots.clear();
+        gc.collect_full();
+        assert_eq!(destructor_runs(), 1);
+        assert!(gc.old_objects_with_destructors.is_empty());
+    }
+
+    #[test]
+    fn destructor_survives_multiple_minors_no_double_count() {
+        let _guard = DESTRUCTOR_TEST_LOCK.lock().unwrap();
+        DESTRUCTOR_RUNS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::with_destructor(16, counting_destructor));
+
+        let obj = gc.alloc_with_type(tid, 16);
+        let mut root = obj;
+        unsafe {
+            gc.roots.add(&mut root);
+        }
+
+        // Multiple minors while rooted: promoted once, never re-destructed,
+        // and the old list does not accumulate duplicates.
+        gc.collect_nursery();
+        gc.collect_nursery();
+        gc.collect_nursery();
+        assert_eq!(destructor_runs(), 0);
+        assert_eq!(gc.old_objects_with_destructors, vec![root.0]);
+
+        gc.roots.clear();
+        gc.collect_full();
+        assert_eq!(destructor_runs(), 1);
+    }
+
+    #[test]
+    fn destructor_on_direct_oldgen_alloc_runs_on_major_death() {
+        let _guard = DESTRUCTOR_TEST_LOCK.lock().unwrap();
+        DESTRUCTOR_RUNS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        // large_object_threshold = nursery/2 = 512; a 1024-byte payload
+        // bypasses the nursery and is registered straight onto the old list.
+        let mut gc = test_gc(1024);
+        let tid = gc.register_type(TypeInfo::with_destructor(1024, counting_destructor));
+
+        let obj = gc.alloc_with_type(tid, 1024);
+        assert!(!gc.is_in_nursery(obj.0));
+        assert!(gc.young_objects_with_destructors.is_empty());
+        assert_eq!(gc.old_objects_with_destructors, vec![obj.0]);
+
+        // Unrooted → reclaimed by the major collection.
+        gc.collect_full();
+        assert_eq!(destructor_runs(), 1);
+        assert!(gc.old_objects_with_destructors.is_empty());
+    }
+
+    #[test]
+    fn no_destructor_means_no_list_entry() {
+        let _guard = DESTRUCTOR_TEST_LOCK.lock().unwrap();
+        let mut gc = test_gc(4096);
+        // A plain type (no destructor) is never recorded on either list.
+        let tid = gc.register_type(TypeInfo::simple(16));
+        gc.alloc_with_type(tid, 16);
+        assert!(gc.young_objects_with_destructors.is_empty());
+        assert!(gc.old_objects_with_destructors.is_empty());
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -390,6 +390,18 @@ pub struct MiniMarkGC {
     ///
     /// Mirrors incminimark's `threshold_objects_made_old`.
     threshold_bytes_made_old: usize,
+    /// Off-heap memory pressure (external, GC-invisible payload bytes — e.g. a
+    /// bignum's limb `Vec`) charged since the last minor collection. Added to the
+    /// nursery struct-fill when deciding whether to force a minor in
+    /// [`charge_memory_pressure`](MiniMarkGC::charge_memory_pressure), so the
+    /// collection cadence reflects true footprint rather than only the 8+payload
+    /// struct bytes the nursery bump pointer tracks. Reset to 0 at the start of
+    /// each minor (the previous generation's external bytes were freed by the
+    /// dead young objects' destructors), mirroring how `nursery.reset()` zeroes
+    /// struct fill. RPython `rgc.add_memory_pressure` analog, retargeted from the
+    /// major threshold onto the minor trigger because the charged objects (young
+    /// bignums) are reclaimed at minors.
+    pressure_since_minor: usize,
     /// Pinned nursery objects that must not be moved during minor collection.
     pinned_objects: VecSet<usize>,
     /// minimark.py:338 `nursery_objects_shadows = AddressDict()`.
@@ -497,6 +509,7 @@ impl MiniMarkGC {
             next_major_collection_threshold: min_heap_size,
             bytes_made_old_since_cycle: 0,
             threshold_bytes_made_old: 0,
+            pressure_since_minor: 0,
             pinned_objects: VecSet::new(),
             nursery_objects_shadows: std::collections::HashMap::new(),
             compiled_code_registry: CompiledCodeRegistry::new(),
@@ -797,9 +810,7 @@ impl MiniMarkGC {
         // nursery (large object, or nursery-full fallback) is recorded
         // straight onto the old-destructor list so a later major
         // collection runs its destructor when it dies.
-        if (type_id as usize) < self.types.len()
-            && self.types.get(type_id).destructor.is_some()
-        {
+        if (type_id as usize) < self.types.len() && self.types.get(type_id).destructor.is_some() {
             self.old_objects_with_destructors.push(obj_addr);
         }
         GcRef(obj_addr)
@@ -821,6 +832,11 @@ impl MiniMarkGC {
             );
         }
         self.minor_collections += 1;
+        // The previous generation's external (off-heap) bytes have been freed by
+        // the dead young objects' destructors during this cycle; restart the
+        // since-last-minor pressure budget, mirroring nursery.reset() zeroing
+        // struct fill.
+        self.pressure_since_minor = 0;
 
         // Phase 1: Process roots — copy nursery objects they point to.
         // We use raw pointers to avoid borrow checker issues since
@@ -2520,6 +2536,21 @@ impl GcAllocator for MiniMarkGC {
         self.alloc_with_type(type_id, size)
     }
 
+    /// Charge `bytes` of off-heap pressure and force a minor when the combined
+    /// nursery footprint (struct fill + charged external bytes) reaches the
+    /// nursery size. Called from the bignum collecting-alloc site BEFORE the
+    /// struct is carved and BEFORE the fresh value is written into the nursery,
+    /// while the operand bignums are already boxed and gcmap-rooted at the
+    /// residual call and the fresh value lives only on the Rust stack — so the
+    /// forced minor holds no unrooted nursery pointer, the same invariant
+    /// `alloc_with_type` relies on for its own nursery-full `do_collect_nursery`.
+    fn charge_memory_pressure(&mut self, bytes: usize) {
+        self.pressure_since_minor += bytes;
+        if self.nursery.used() + self.pressure_since_minor >= self.nursery.size() {
+            self.do_collect_nursery();
+        }
+    }
+
     fn alloc_nursery_no_collect(&mut self, size: usize) -> GcRef {
         self.alloc_with_type_no_collect(0, size)
     }
@@ -2991,8 +3022,7 @@ mod tests {
     // shared counter races-free under cargo's parallel test runner.
 
     static DESTRUCTOR_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    static DESTRUCTOR_RUNS: std::sync::atomic::AtomicUsize =
-        std::sync::atomic::AtomicUsize::new(0);
+    static DESTRUCTOR_RUNS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     static DESTRUCTOR_LAST_ADDR: std::sync::atomic::AtomicUsize =
         std::sync::atomic::AtomicUsize::new(0);
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -209,6 +209,15 @@ pub trait GcAllocator: Send {
         let _ = bytes;
     }
 
+    /// Add `bytes` of a directly-old-gen-allocated object's off-heap payload to
+    /// the major-collection threshold's external total, WITHOUT forcing a minor
+    /// (unlike [`charge_memory_pressure`](GcAllocator::charge_memory_pressure)).
+    /// Default is a no-op so backends without a generational collector compile
+    /// unchanged.
+    fn charge_oldgen_external(&mut self, bytes: usize) {
+        let _ = bytes;
+    }
+
     /// incminimark.py:1569: jit_remember_young_pointer(obj)
     /// Perform a write barrier check on `obj`.
     /// Must be called before storing a GC reference into `obj`.
@@ -927,6 +936,33 @@ pub fn set_active_charge_memory_pressure(hook: Option<ChargeMemoryPressureFn>) {
 /// when no backend is installed on this thread.
 pub fn charge_memory_pressure(bytes: usize) {
     ACTIVE_CHARGE_MEMORY_PRESSURE.with(|c| {
+        if let Some(f) = c.get() {
+            f(bytes);
+        }
+    })
+}
+
+/// Thread-local callback that charges an old-gen object's off-heap payload
+/// against the active backend's major threshold (`GcAllocator::charge_oldgen_external`),
+/// without forcing a minor. Used by host-side stable allocators of GC objects
+/// whose payload includes external, GC-invisible memory (the bignum limb `Vec`).
+/// Returns silently when no backend is installed.
+pub type ChargeOldgenExternalFn = fn(bytes: usize);
+
+thread_local! {
+    static ACTIVE_CHARGE_OLDGEN_EXTERNAL: Cell<Option<ChargeOldgenExternalFn>> =
+        const { Cell::new(None) };
+}
+
+/// Install the active backend's old-gen external-byte callback. Pass `None` to clear.
+pub fn set_active_charge_oldgen_external(hook: Option<ChargeOldgenExternalFn>) {
+    ACTIVE_CHARGE_OLDGEN_EXTERNAL.with(|c| c.set(hook));
+}
+
+/// Charge `bytes` of an old-gen object's off-heap payload on the active backend's
+/// GC. No-op when no backend is installed on this thread.
+pub fn charge_oldgen_external(bytes: usize) {
+    ACTIVE_CHARGE_OLDGEN_EXTERNAL.with(|c| {
         if let Some(f) = c.get() {
             f(bytes);
         }

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -200,6 +200,15 @@ pub trait GcAllocator: Send {
         self.alloc_nursery_no_collect_typed(type_id, size)
     }
 
+    /// Charge `bytes` of off-heap memory pressure (e.g. a nursery object's
+    /// external, GC-invisible payload such as a bignum's limb `Vec`). Mirrors
+    /// RPython `rgc.add_memory_pressure`: the GC accounts memory it cannot see so
+    /// collection cadence reflects true footprint. Default is a no-op so backends
+    /// without a generational collector compile unchanged.
+    fn charge_memory_pressure(&mut self, bytes: usize) {
+        let _ = bytes;
+    }
+
     /// incminimark.py:1569: jit_remember_young_pointer(obj)
     /// Perform a write barrier check on `obj`.
     /// Must be called before storing a GC reference into `obj`.
@@ -864,6 +873,63 @@ pub fn alloc_oldgen_typed(type_id: u32, payload_size: usize) -> GcRef {
     ACTIVE_ALLOC_OLDGEN_TYPED.with(|c| match c.get() {
         Some(f) => f(type_id, payload_size),
         None => GcRef(0),
+    })
+}
+
+/// Thread-local callback for a *collecting* nursery allocation — unlike
+/// [`alloc_nursery_typed`] (which the backends install as the no-collect
+/// variant), this one runs a minor collection when the nursery is full instead
+/// of spilling to old-gen. Only safe for callers that hold no unrooted GC
+/// pointer across the allocation AND run at a JIT safepoint whose gcmap roots
+/// the live set (e.g. the elidable bigint payload helpers, invoked from a
+/// gcmap-carrying residual CallR). Returns `GcRef(0)` when no backend installed.
+pub type AllocNurseryCollectingTypedFn = fn(type_id: u32, payload_size: usize) -> GcRef;
+
+thread_local! {
+    static ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED: Cell<Option<AllocNurseryCollectingTypedFn>> =
+        const { Cell::new(None) };
+}
+
+/// Install the active backend's collecting-nursery allocator callback. Pass
+/// `None` to clear. Backends that do not install one leave callers to fall back
+/// to the no-collect path.
+pub fn set_active_alloc_nursery_collecting_typed(hook: Option<AllocNurseryCollectingTypedFn>) {
+    ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED.with(|c| c.set(hook));
+}
+
+/// Allocate through the active backend's collecting nursery allocator. Returns
+/// `GcRef(0)` when no backend (or no collecting hook) is installed on this
+/// thread (callers treat this as null and fall back to the no-collect path).
+pub fn alloc_nursery_collecting_typed(type_id: u32, payload_size: usize) -> GcRef {
+    ACTIVE_ALLOC_NURSERY_COLLECTING_TYPED.with(|c| match c.get() {
+        Some(f) => f(type_id, payload_size),
+        None => GcRef(0),
+    })
+}
+
+/// Thread-local callback that charges off-heap memory pressure on the active
+/// backend's GC (`GcAllocator::charge_memory_pressure`). Used by host-side
+/// allocators of GC objects whose payload includes external, GC-invisible memory
+/// (the bignum limb `Vec`). Returns silently when no backend is installed.
+pub type ChargeMemoryPressureFn = fn(bytes: usize);
+
+thread_local! {
+    static ACTIVE_CHARGE_MEMORY_PRESSURE: Cell<Option<ChargeMemoryPressureFn>> =
+        const { Cell::new(None) };
+}
+
+/// Install the active backend's memory-pressure callback. Pass `None` to clear.
+pub fn set_active_charge_memory_pressure(hook: Option<ChargeMemoryPressureFn>) {
+    ACTIVE_CHARGE_MEMORY_PRESSURE.with(|c| c.set(hook));
+}
+
+/// Charge `bytes` of off-heap memory pressure on the active backend's GC. No-op
+/// when no backend is installed on this thread.
+pub fn charge_memory_pressure(bytes: usize) {
+    ACTIVE_CHARGE_MEMORY_PRESSURE.with(|c| {
+        if let Some(f) = c.get() {
+            f(bytes);
+        }
     })
 }
 

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -209,13 +209,15 @@ pub trait GcAllocator: Send {
         let _ = bytes;
     }
 
-    /// Add `bytes` of a directly-old-gen-allocated object's off-heap payload to
-    /// the major-collection threshold's external total, WITHOUT forcing a minor
-    /// (unlike [`charge_memory_pressure`](GcAllocator::charge_memory_pressure)).
-    /// Default is a no-op so backends without a generational collector compile
-    /// unchanged.
-    fn charge_oldgen_external(&mut self, bytes: usize) {
-        let _ = bytes;
+    /// Add `bytes` of `obj_addr`'s off-heap payload to the major-collection
+    /// threshold's external total if the object is already old-gen, WITHOUT
+    /// forcing a minor (unlike
+    /// [`charge_memory_pressure`](GcAllocator::charge_memory_pressure)).
+    /// Callers may pass a nursery object; generational collectors ignore it
+    /// because promotion accounting will charge it later. Default is a no-op so
+    /// backends without a generational collector compile unchanged.
+    fn charge_oldgen_external(&mut self, obj_addr: usize, bytes: usize) {
+        let _ = (obj_addr, bytes);
     }
 
     /// incminimark.py:1569: jit_remember_young_pointer(obj)
@@ -942,12 +944,12 @@ pub fn charge_memory_pressure(bytes: usize) {
     })
 }
 
-/// Thread-local callback that charges an old-gen object's off-heap payload
-/// against the active backend's major threshold (`GcAllocator::charge_oldgen_external`),
-/// without forcing a minor. Used by host-side stable allocators of GC objects
-/// whose payload includes external, GC-invisible memory (the bignum limb `Vec`).
-/// Returns silently when no backend is installed.
-pub type ChargeOldgenExternalFn = fn(bytes: usize);
+/// Thread-local callback that charges an object's off-heap payload against the
+/// active backend's major threshold (`GcAllocator::charge_oldgen_external`) when
+/// the object is old-gen, without forcing a minor. Used after initializing GC
+/// objects whose payload includes external, GC-invisible memory (the bignum limb
+/// `Vec`). Returns silently when no backend is installed.
+pub type ChargeOldgenExternalFn = fn(obj_addr: usize, bytes: usize);
 
 thread_local! {
     static ACTIVE_CHARGE_OLDGEN_EXTERNAL: Cell<Option<ChargeOldgenExternalFn>> =
@@ -959,12 +961,12 @@ pub fn set_active_charge_oldgen_external(hook: Option<ChargeOldgenExternalFn>) {
     ACTIVE_CHARGE_OLDGEN_EXTERNAL.with(|c| c.set(hook));
 }
 
-/// Charge `bytes` of an old-gen object's off-heap payload on the active backend's
-/// GC. No-op when no backend is installed on this thread.
-pub fn charge_oldgen_external(bytes: usize) {
+/// Charge `bytes` of `obj_addr`'s off-heap payload on the active backend's GC
+/// when the object is old-gen. No-op when no backend is installed on this thread.
+pub fn charge_oldgen_external(obj_addr: usize, bytes: usize) {
     ACTIVE_CHARGE_OLDGEN_EXTERNAL.with(|c| {
         if let Some(f) = c.get() {
-            f(bytes);
+            f(obj_addr, bytes);
         }
     })
 }

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -343,6 +343,13 @@ pub type CustomTraceFn = unsafe fn(obj_addr: usize, f: &mut dyn FnMut(*mut GcRef
 /// convention as [`CustomTraceFn`].
 pub type DestructorFn = unsafe fn(obj_addr: usize);
 
+/// Returns the off-heap (GC-invisible) byte footprint owned by the object at
+/// `obj_addr` — e.g. a foreign `BigInt`'s limb `Vec`, which lives in the system
+/// heap and is not counted by `oldgen.total_bytes()`. The collector folds a
+/// promoted instance's result into `get_total_memory_used` so the major
+/// threshold reflects the true footprint, not just the tracked struct.
+pub type ExternalSizeFn = unsafe fn(obj_addr: usize) -> usize;
+
 /// Information about a GC-managed type.
 pub struct TypeInfo {
     /// Fixed size of the object (excluding header), or base size for varsize objects.
@@ -406,6 +413,13 @@ pub struct TypeInfo {
     /// payloads owning non-GC heap memory get their drop glue run. See
     /// [`DestructorFn`].
     pub destructor: Option<DestructorFn>,
+    /// When set, returns the off-heap byte footprint of an instance (see
+    /// [`ExternalSizeFn`]). A promoted instance's result is added to
+    /// `oldgen_external_bytes` so the major-collection threshold accounts for
+    /// memory the GC cannot see (a foreign `BigInt`'s limb `Vec`). Only
+    /// meaningful alongside a `destructor` (the type whose external memory the
+    /// destructor frees).
+    pub external_size: Option<ExternalSizeFn>,
 }
 
 impl TypeInfo {
@@ -425,6 +439,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -448,7 +463,15 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: Some(destructor),
+            external_size: None,
         }
+    }
+
+    /// Builder: attach an [`ExternalSizeFn`] so the collector folds a promoted
+    /// instance's off-heap footprint into the major-collection threshold.
+    pub fn with_external_size(mut self, external_size: ExternalSizeFn) -> Self {
+        self.external_size = Some(external_size);
+        self
     }
 
     /// `gctypelayout.is_weakref_type(WEAKREF)` parity — TypeInfo for
@@ -471,6 +494,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: true,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -499,6 +523,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -524,6 +549,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -558,6 +584,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -582,6 +609,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -603,6 +631,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -628,6 +657,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -649,6 +679,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 
@@ -676,6 +707,7 @@ impl TypeInfo {
             subclassrange_max: 0,
             is_weakref: false,
             destructor: None,
+            external_size: None,
         }
     }
 

--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -93,6 +93,13 @@ impl TypeInfoLayout {
     pub const T_HAS_CUSTOM_TRACE: u64 = 0x200000;
     /// `T_HAS_OLDSTYLE_FINALIZER` (gctypelayout.py:198).
     pub const T_HAS_OLDSTYLE_FINALIZER: u64 = 0x400000;
+    /// Lightweight-destructor marker (bit 23, the otherwise-unused slot
+    /// between `T_HAS_OLDSTYLE_FINALIZER` and `T_HAS_GCPTR`). RPython
+    /// folds the lightweight-destructor case into its `q_finalizer`
+    /// machinery rather than a distinct infobit; majit models the
+    /// `TypeInfo.destructor` half with its own bit so the materialized
+    /// table reflects which types carry a destructor.
+    pub const T_HAS_DESTRUCTOR: u64 = 0x800000;
     /// `T_HAS_GCPTR` (gctypelayout.py:199).
     pub const T_HAS_GCPTR: u64 = 0x1000000;
     /// `T_HAS_MEMORY_PRESSURE` (gctypelayout.py:200) — first field is
@@ -170,6 +177,7 @@ impl TypeEntry {
 ///   bit   20    : T_IS_RPYTHON_INSTANCE
 ///   bit   21    : T_HAS_CUSTOM_TRACE
 ///   bit   22    : T_HAS_OLDSTYLE_FINALIZER
+///   bit   23    : T_HAS_DESTRUCTOR (majit lightweight-destructor bit)
 ///   bit   24    : T_HAS_GCPTR
 ///   bit   25    : T_HAS_MEMORY_PRESSURE
 ///   bits 26..31 : T_KEY_VALUE  (T_KEY_MASK sanity check)
@@ -233,6 +241,11 @@ pub fn encode_type_shape(info: &TypeInfo, index: u32) -> u64 {
     // gctypelayout.py:294-295 `is_subclass_of_object`.
     if info.is_object {
         infobits |= TypeInfoLayout::T_IS_RPYTHON_INSTANCE;
+    }
+    // Lightweight-destructor marker (majit's half of the
+    // gctypelayout.py:245-257 destructor surface).
+    if info.destructor.is_some() {
+        infobits |= TypeInfoLayout::T_HAS_DESTRUCTOR;
     }
     // gctypelayout.py:296 — T_KEY_VALUE sanity tag.
     infobits | TypeInfoLayout::T_KEY_VALUE
@@ -313,6 +326,23 @@ impl TypeRegistry {
 /// called for each GC reference slot address.
 pub type CustomTraceFn = unsafe fn(obj_addr: usize, f: &mut dyn FnMut(*mut GcRef));
 
+/// Lightweight destructor function type.
+///
+/// RPython parity: the `destructor` half of
+/// `gctypelayout.py:245-257` (the `q_finalizer` / lightweight
+/// destructor path). When set, the collector calls this on an object
+/// that is about to be reclaimed — at minor collection for a dead
+/// nursery object and at major collection for a dead old-gen object —
+/// so a payload owning non-GC heap memory (e.g. a foreign `BigInt`'s
+/// limb `Vec`) gets its drop glue run instead of leaking. As in
+/// incminimark's `deal_with_young/old_objects_with_destructors`
+/// (incminimark.py:2884-2912), a destructor "just" runs and does not
+/// resurrect the object.
+///
+/// `obj_addr` is the object payload start (post-header), the same
+/// convention as [`CustomTraceFn`].
+pub type DestructorFn = unsafe fn(obj_addr: usize);
+
 /// Information about a GC-managed type.
 pub struct TypeInfo {
     /// Fixed size of the object (excluding header), or base size for varsize objects.
@@ -368,6 +398,14 @@ pub struct TypeInfo {
     /// so the collector's minor / major cycles can locate weakref
     /// objects when scanning the type-info group.
     pub is_weakref: bool,
+    /// `gctypelayout.py:245-257` lightweight-destructor parity. When
+    /// `Some`, an instance of this type is recorded on the GC's
+    /// `young_objects_with_destructors` list at allocation, and the
+    /// collector runs this hook when the instance dies (minor cycle for
+    /// a dead nursery object, major cycle for a dead old-gen object) so
+    /// payloads owning non-GC heap memory get their drop glue run. See
+    /// [`DestructorFn`].
+    pub destructor: Option<DestructorFn>,
 }
 
 impl TypeInfo {
@@ -386,6 +424,30 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
+        }
+    }
+
+    /// Create a type info for a fixed-size object with no GC pointers
+    /// that owns non-GC heap memory reclaimed by a lightweight
+    /// `destructor`. The collector runs `destructor` when an instance
+    /// dies (see [`DestructorFn`]). Used for the foreign `BigInt`
+    /// payload, whose limb `Vec` must be dropped rather than leaked.
+    pub fn with_destructor(size: usize, destructor: DestructorFn) -> Self {
+        TypeInfo {
+            size,
+            has_gc_ptrs: false,
+            gc_ptr_offsets: Vec::new(),
+            item_size: 0,
+            length_offset: 0,
+            items_have_gc_ptrs: false,
+            custom_trace: None,
+            is_object: false,
+            parent: None,
+            subclassrange_min: 0,
+            subclassrange_max: 0,
+            is_weakref: false,
+            destructor: Some(destructor),
         }
     }
 
@@ -408,6 +470,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: true,
+            destructor: None,
         }
     }
 
@@ -435,6 +498,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -459,6 +523,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -492,6 +557,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -515,6 +581,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -535,6 +602,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -559,6 +627,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -579,6 +648,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 
@@ -605,6 +675,7 @@ impl TypeInfo {
             subclassrange_min: 0,
             subclassrange_max: 0,
             is_weakref: false,
+            destructor: None,
         }
     }
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1130,7 +1130,7 @@ def main():
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    2)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
-        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       2,       2,       2)
+        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       3,       2,       3)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       13,      2,       13)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1130,7 +1130,7 @@ def main():
         #             name              script                          timeout  d_vs_cp  d_vs_py  c_vs_cp  c_vs_py
         chk.run_bench("int_loop",       f"{B}/int_loop.py",             5,       None,    2,       None,    2)
         chk.run_bench("float_loop",     f"{B}/float_loop.py",           5,       None,    1.5,     None,    1.5)
-        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       4,       2,       4)
+        chk.run_bench("fib_loop",       f"{B}/fib_loop.py",             5,       2,       2,       2,       2)
         chk.run_bench("inline_helper",  f"{B}/inline_helper.py",        5,       None,    1.2,     None,    1.2)
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       13,      2,       13)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -357,49 +357,144 @@ unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// and returns 0 so the trailing `GUARD_NO_EXCEPTION` deopts.
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_floordiv_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
-    jit_bigint_floordiv(a, b)
+    let (a, b) = unsafe {
+        (
+            w_long_get_value(a as PyObjectRef),
+            w_long_get_value(b as PyObjectRef),
+        )
+    };
+    bigint_floordiv_core(a, b, false)
 }
 
-/// `rbigint.mod` payload half (`longobject.py:426 _mod` → `rbigint.mod` →
-/// `divmod`). Same `EF_ELIDABLE_CAN_RAISE` contract as
-/// [`jit_w_long_floordiv_raw`].
+/// `rbigint.mod` over `W_LongObject` operands (no-collect, record-time). Same
+/// `EF_ELIDABLE_CAN_RAISE` contract as [`jit_w_long_floordiv_raw`].
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_mod_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
-    jit_bigint_mod(a, b)
+    let (a, b) = unsafe {
+        (
+            w_long_get_value(a as PyObjectRef),
+            w_long_get_value(b as PyObjectRef),
+        )
+    };
+    bigint_mod_core(a, b, false)
 }
 
-/// `rbigint.lshift` payload half (`longobject.py:372-380 _lshift`). Elidable
-/// but CAN raise ValueError (negative shift) / OverflowError (shift too large
-/// and base nonzero) → `EF_ELIDABLE_CAN_RAISE`: `CALL_PURE` + `GUARD_NO_EXCEPTION`.
-/// Returns a bare `*mut BigInt` (Int) on success; on a raising input publishes
-/// the exception and returns 0 so the trailing guard deopts. Walker-only (the
-/// trait path defers shift to the generic residual), so the concrete invocation
-/// only runs after the walker proved the op authentic.
+/// `rbigint.lshift` over `W_LongObject` operands (no-collect, record-time).
+/// Elidable but CAN raise ValueError (negative shift) / OverflowError (shift too
+/// large and base nonzero) → `EF_ELIDABLE_CAN_RAISE`. Walker-only (the trait
+/// path defers shift to the generic residual).
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_lshift_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
-    jit_bigint_lshift(a, b)
+    let (a, b) = unsafe {
+        (
+            w_long_get_value(a as PyObjectRef),
+            w_long_get_value(b as PyObjectRef),
+        )
+    };
+    bigint_lshift_core(a, b, false)
 }
 
-/// `rbigint.rshift` payload half (`longobject.py:390-398 _rshift`). Like
+/// `rbigint.rshift` over `W_LongObject` operands (no-collect, record-time). Like
 /// [`jit_w_long_lshift_raw`] but a shift too large yields 0 / -1 (all bits
 /// shifted out) instead of OverflowError; only a negative shift raises.
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
-    jit_bigint_rshift(a, b)
+    let (a, b) = unsafe {
+        (
+            w_long_get_value(a as PyObjectRef),
+            w_long_get_value(b as PyObjectRef),
+        )
+    };
+    bigint_rshift_core(a, b, false)
 }
 
-/// The bare `*mut BigInt` payload of a known `W_LongObject`, as the i64 the
-/// payload-helper ABI uses — the runtime value of `GetfieldGcPure(value)`.
-///
-/// # Safety
-/// `obj` (an i64-encoded `PyObjectRef`) must point to a valid `W_LongObject`.
+/// Allocate a result bigint, choosing the COLLECTING nursery (runtime payload
+/// helpers, invoked from a gcmap-rooted residual call) or the NO-COLLECT nursery
+/// (record-time wrappers, which hold the operands natively so a collection would
+/// move them). See `longobject::alloc_bigint_nursery_collecting`.
 #[inline]
-unsafe fn w_long_payload_i64(obj: i64) -> i64 {
-    unsafe { w_long_get_value(obj as PyObjectRef) as *const BigInt as i64 }
+fn alloc_result_bigint(value: BigInt, collecting: bool) -> i64 {
+    if collecting {
+        pyre_object::longobject::alloc_bigint_nursery_collecting(value) as i64
+    } else {
+        pyre_object::longobject::alloc_bigint_nursery(value) as i64
+    }
+}
+
+/// `rbigint.floordiv`/`mod`/`lshift`/`rshift` cores over `&BigInt` operands,
+/// shared by the collecting runtime payload helpers (`jit_bigint_*`) and the
+/// no-collect record-time wrappers (`jit_w_long_*_raw`). Each returns a bare
+/// `*mut BigInt` (Int, as i64) on success; a zero divisor / out-of-range shift
+/// publishes the exception and returns 0 so the trailing `GUARD_NO_EXCEPTION`
+/// deopts.
+fn bigint_floordiv_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
+    if b.sign() == malachite_bigint::Sign::NoSign {
+        crate::runtime_ops::jit_publish_exception(
+            PyError::zero_division("integer division or modulo by zero").to_exc_object(),
+        );
+        return 0;
+    }
+    // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
+    alloc_result_bigint(a.div_mod_floor(b).0, collecting)
+}
+
+fn bigint_mod_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
+    if b.sign() == malachite_bigint::Sign::NoSign {
+        // `%` alone reports "integer modulo by zero".
+        crate::runtime_ops::jit_publish_exception(
+            PyError::zero_division("integer modulo by zero").to_exc_object(),
+        );
+        return 0;
+    }
+    // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
+    alloc_result_bigint(a.div_mod_floor(b).1, collecting)
+}
+
+fn bigint_lshift_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
+    if b.sign() == malachite_bigint::Sign::Minus {
+        crate::runtime_ops::jit_publish_exception(
+            PyError::value_error("negative shift count").to_exc_object(),
+        );
+        return 0;
+    }
+    // `rbigint.toint()` is a *signed* machine int (i64), so a count above
+    // i64::MAX overflows here — not at usize::MAX — matching `_lshift`.
+    let shift = match b.to_i64() {
+        Some(v) => v as usize,
+        None => {
+            if a.sign() == malachite_bigint::Sign::NoSign {
+                return alloc_result_bigint(BigInt::from(0), collecting);
+            }
+            crate::runtime_ops::jit_publish_exception(
+                PyError::overflow_error("shift count too large").to_exc_object(),
+            );
+            return 0;
+        }
+    };
+    alloc_result_bigint(bigint_lshift(a.clone(), shift), collecting)
+}
+
+fn bigint_rshift_core(a: &BigInt, b: &BigInt, collecting: bool) -> i64 {
+    if b.sign() == malachite_bigint::Sign::Minus {
+        crate::runtime_ops::jit_publish_exception(
+            PyError::value_error("negative shift count").to_exc_object(),
+        );
+        return 0;
+    }
+    // `toint()` overflow (count > i64::MAX) takes this branch like `_rshift`;
+    // for rshift the result (0 / -1) is the same as an actual huge shift.
+    let shift = match b.to_i64() {
+        Some(v) => v as usize,
+        None => {
+            let val = if a.sign() == malachite_bigint::Sign::Minus {
+                -1
+            } else {
+                0
+            };
+            return alloc_result_bigint(BigInt::from(val), collecting);
+        }
+    };
+    alloc_result_bigint(bigint_rshift(a.clone(), shift), collecting)
 }
 
 /// `rbigint.floordiv`/`mod`/`lshift`/`rshift` payload halves on bare
@@ -407,105 +502,37 @@ unsafe fn w_long_payload_i64(obj: i64) -> i64 {
 /// each `W_LongObject` operand's immutable `value` via `GetfieldGcPure`. Taking
 /// the payloads (not the wrappers) keeps these elidable calls pure on the
 /// immutable bigints so the optimizer never reorders them ahead of the boxing
-/// `setfield_gc`. Each returns a bare `*mut BigInt` (Int) on success; a zero
-/// divisor / out-of-range shift publishes the exception and returns 0 so the
-/// trailing `GUARD_NO_EXCEPTION` deopts. `EF_ELIDABLE_CAN_RAISE`.
+/// `setfield_gc`. Allocates the result via the COLLECTING nursery (the call is a
+/// gcmap-rooted residual `CallR` holding no unrooted pointer across the alloc).
+/// `EF_ELIDABLE_CAN_RAISE`.
 ///
 /// # Safety note: `extern "C"` over `i64`-encoded `*const BigInt` operands, live
 /// for the duration of the call.
 #[majit_macros::elidable]
 pub extern "C" fn jit_bigint_floordiv(a: i64, b: i64) -> i64 {
-    let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe {
-        let vb = &*b;
-        if vb.sign() == malachite_bigint::Sign::NoSign {
-            crate::runtime_ops::jit_publish_exception(
-                PyError::zero_division("integer division or modulo by zero").to_exc_object(),
-            );
-            return 0;
-        }
-        // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
-        pyre_object::longobject::alloc_bigint_nursery((&*a).div_mod_floor(vb).0) as i64
-    }
+    let (a, b) = unsafe { (&*(a as *const BigInt), &*(b as *const BigInt)) };
+    bigint_floordiv_core(a, b, true)
 }
 
-/// `rbigint.mod` on bare payloads. See [`jit_bigint_floordiv`].
+/// `rbigint.mod` on bare payloads (collecting). See [`jit_bigint_floordiv`].
 #[majit_macros::elidable]
 pub extern "C" fn jit_bigint_mod(a: i64, b: i64) -> i64 {
-    let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe {
-        let vb = &*b;
-        if vb.sign() == malachite_bigint::Sign::NoSign {
-            // `%` alone reports "integer modulo by zero".
-            crate::runtime_ops::jit_publish_exception(
-                PyError::zero_division("integer modulo by zero").to_exc_object(),
-            );
-            return 0;
-        }
-        // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
-        pyre_object::longobject::alloc_bigint_nursery((&*a).div_mod_floor(vb).1) as i64
-    }
+    let (a, b) = unsafe { (&*(a as *const BigInt), &*(b as *const BigInt)) };
+    bigint_mod_core(a, b, true)
 }
 
-/// `rbigint.lshift` on bare payloads. See [`jit_bigint_floordiv`].
+/// `rbigint.lshift` on bare payloads (collecting). See [`jit_bigint_floordiv`].
 #[majit_macros::elidable]
 pub extern "C" fn jit_bigint_lshift(a: i64, b: i64) -> i64 {
-    let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe {
-        let vb = &*b;
-        if vb.sign() == malachite_bigint::Sign::Minus {
-            crate::runtime_ops::jit_publish_exception(
-                PyError::value_error("negative shift count").to_exc_object(),
-            );
-            return 0;
-        }
-        // `rbigint.toint()` is a *signed* machine int (i64), so a count above
-        // i64::MAX overflows here — not at usize::MAX — matching `_lshift`.
-        let shift = match vb.to_i64() {
-            Some(v) => v as usize,
-            None => {
-                if (&*a).sign() == malachite_bigint::Sign::NoSign {
-                    return pyre_object::longobject::alloc_bigint_nursery(BigInt::from(0)) as i64;
-                }
-                crate::runtime_ops::jit_publish_exception(
-                    PyError::overflow_error("shift count too large").to_exc_object(),
-                );
-                return 0;
-            }
-        };
-        pyre_object::longobject::alloc_bigint_nursery(bigint_lshift((&*a).clone(), shift)) as i64
-    }
+    let (a, b) = unsafe { (&*(a as *const BigInt), &*(b as *const BigInt)) };
+    bigint_lshift_core(a, b, true)
 }
 
-/// `rbigint.rshift` on bare payloads. Like [`jit_bigint_lshift`] but a shift too
-/// large yields 0 / -1 (all bits shifted out) instead of OverflowError; only a
-/// negative shift raises.
+/// `rbigint.rshift` on bare payloads (collecting). See [`jit_bigint_floordiv`].
 #[majit_macros::elidable]
 pub extern "C" fn jit_bigint_rshift(a: i64, b: i64) -> i64 {
-    let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe {
-        let vb = &*b;
-        if vb.sign() == malachite_bigint::Sign::Minus {
-            crate::runtime_ops::jit_publish_exception(
-                PyError::value_error("negative shift count").to_exc_object(),
-            );
-            return 0;
-        }
-        // `toint()` overflow (count > i64::MAX) takes this branch like `_rshift`;
-        // for rshift the result (0 / -1) is the same as an actual huge shift.
-        let shift = match vb.to_i64() {
-            Some(v) => v as usize,
-            None => {
-                let val = if (&*a).sign() == malachite_bigint::Sign::Minus {
-                    -1
-                } else {
-                    0
-                };
-                return pyre_object::longobject::alloc_bigint_nursery(BigInt::from(val)) as i64;
-            }
-        };
-        pyre_object::longobject::alloc_bigint_nursery(bigint_rshift((&*a).clone(), shift)) as i64
-    }
+    let (a, b) = unsafe { (&*(a as *const BigInt), &*(b as *const BigInt)) };
+    bigint_rshift_core(a, b, true)
 }
 
 /// `rbigint.truediv` payload half (`longobject.py:62-70 _truediv` →

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -357,19 +357,8 @@ unsafe fn long_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// and returns 0 so the trailing `GUARD_NO_EXCEPTION` deopts.
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_floordiv_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe {
-        let vb = w_long_get_value(b);
-        if vb.sign() == malachite_bigint::Sign::NoSign {
-            crate::runtime_ops::jit_publish_exception(
-                PyError::zero_division("integer division or modulo by zero").to_exc_object(),
-            );
-            return 0;
-        }
-        // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
-        pyre_object::lltype::malloc_raw(w_long_get_value(a).div_mod_floor(vb).0) as i64
-    }
+    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
+    jit_bigint_floordiv(a, b)
 }
 
 /// `rbigint.mod` payload half (`longobject.py:426 _mod` → `rbigint.mod` →
@@ -377,20 +366,8 @@ pub extern "C" fn jit_w_long_floordiv_raw(a: i64, b: i64) -> i64 {
 /// [`jit_w_long_floordiv_raw`].
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_mod_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe {
-        let vb = w_long_get_value(b);
-        if vb.sign() == malachite_bigint::Sign::NoSign {
-            // `%` alone reports "integer modulo by zero".
-            crate::runtime_ops::jit_publish_exception(
-                PyError::zero_division("integer modulo by zero").to_exc_object(),
-            );
-            return 0;
-        }
-        // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
-        pyre_object::lltype::malloc_raw(w_long_get_value(a).div_mod_floor(vb).1) as i64
-    }
+    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
+    jit_bigint_mod(a, b)
 }
 
 /// `rbigint.lshift` payload half (`longobject.py:372-380 _lshift`). Elidable
@@ -402,10 +379,80 @@ pub extern "C" fn jit_w_long_mod_raw(a: i64, b: i64) -> i64 {
 /// only runs after the walker proved the op authentic.
 #[majit_macros::elidable]
 pub extern "C" fn jit_w_long_lshift_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
+    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
+    jit_bigint_lshift(a, b)
+}
+
+/// `rbigint.rshift` payload half (`longobject.py:390-398 _rshift`). Like
+/// [`jit_w_long_lshift_raw`] but a shift too large yields 0 / -1 (all bits
+/// shifted out) instead of OverflowError; only a negative shift raises.
+#[majit_macros::elidable]
+pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
+    let (a, b) = unsafe { (w_long_payload_i64(a), w_long_payload_i64(b)) };
+    jit_bigint_rshift(a, b)
+}
+
+/// The bare `*mut BigInt` payload of a known `W_LongObject`, as the i64 the
+/// payload-helper ABI uses — the runtime value of `GetfieldGcPure(value)`.
+///
+/// # Safety
+/// `obj` (an i64-encoded `PyObjectRef`) must point to a valid `W_LongObject`.
+#[inline]
+unsafe fn w_long_payload_i64(obj: i64) -> i64 {
+    unsafe { w_long_get_value(obj as PyObjectRef) as *const BigInt as i64 }
+}
+
+/// `rbigint.floordiv`/`mod`/`lshift`/`rshift` payload halves on bare
+/// `*const BigInt` operands — the divmod/shift the walker emits after reading
+/// each `W_LongObject` operand's immutable `value` via `GetfieldGcPure`. Taking
+/// the payloads (not the wrappers) keeps these elidable calls pure on the
+/// immutable bigints so the optimizer never reorders them ahead of the boxing
+/// `setfield_gc`. Each returns a bare `*mut BigInt` (Int) on success; a zero
+/// divisor / out-of-range shift publishes the exception and returns 0 so the
+/// trailing `GUARD_NO_EXCEPTION` deopts. `EF_ELIDABLE_CAN_RAISE`.
+///
+/// # Safety note: `extern "C"` over `i64`-encoded `*const BigInt` operands, live
+/// for the duration of the call.
+#[majit_macros::elidable]
+pub extern "C" fn jit_bigint_floordiv(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
-        let vb = w_long_get_value(b);
+        let vb = &*b;
+        if vb.sign() == malachite_bigint::Sign::NoSign {
+            crate::runtime_ops::jit_publish_exception(
+                PyError::zero_division("integer division or modulo by zero").to_exc_object(),
+            );
+            return 0;
+        }
+        // rbigint.floordiv → _divmod, returning the quotient half (rbigint.py:1001).
+        pyre_object::longobject::alloc_bigint_nursery((&*a).div_mod_floor(vb).0) as i64
+    }
+}
+
+/// `rbigint.mod` on bare payloads. See [`jit_bigint_floordiv`].
+#[majit_macros::elidable]
+pub extern "C" fn jit_bigint_mod(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe {
+        let vb = &*b;
+        if vb.sign() == malachite_bigint::Sign::NoSign {
+            // `%` alone reports "integer modulo by zero".
+            crate::runtime_ops::jit_publish_exception(
+                PyError::zero_division("integer modulo by zero").to_exc_object(),
+            );
+            return 0;
+        }
+        // rbigint.mod → _divmod, returning the remainder half (rbigint.py:1001).
+        pyre_object::longobject::alloc_bigint_nursery((&*a).div_mod_floor(vb).1) as i64
+    }
+}
+
+/// `rbigint.lshift` on bare payloads. See [`jit_bigint_floordiv`].
+#[majit_macros::elidable]
+pub extern "C" fn jit_bigint_lshift(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe {
+        let vb = &*b;
         if vb.sign() == malachite_bigint::Sign::Minus {
             crate::runtime_ops::jit_publish_exception(
                 PyError::value_error("negative shift count").to_exc_object(),
@@ -417,8 +464,8 @@ pub extern "C" fn jit_w_long_lshift_raw(a: i64, b: i64) -> i64 {
         let shift = match vb.to_i64() {
             Some(v) => v as usize,
             None => {
-                if w_long_get_value(a).sign() == malachite_bigint::Sign::NoSign {
-                    return pyre_object::lltype::malloc_raw(BigInt::from(0)) as i64;
+                if (&*a).sign() == malachite_bigint::Sign::NoSign {
+                    return pyre_object::longobject::alloc_bigint_nursery(BigInt::from(0)) as i64;
                 }
                 crate::runtime_ops::jit_publish_exception(
                     PyError::overflow_error("shift count too large").to_exc_object(),
@@ -426,19 +473,18 @@ pub extern "C" fn jit_w_long_lshift_raw(a: i64, b: i64) -> i64 {
                 return 0;
             }
         };
-        pyre_object::lltype::malloc_raw(bigint_lshift(w_long_get_value(a).clone(), shift)) as i64
+        pyre_object::longobject::alloc_bigint_nursery(bigint_lshift((&*a).clone(), shift)) as i64
     }
 }
 
-/// `rbigint.rshift` payload half (`longobject.py:390-398 _rshift`). Like
-/// [`jit_w_long_lshift_raw`] but a shift too large yields 0 / -1 (all bits
-/// shifted out) instead of OverflowError; only a negative shift raises.
+/// `rbigint.rshift` on bare payloads. Like [`jit_bigint_lshift`] but a shift too
+/// large yields 0 / -1 (all bits shifted out) instead of OverflowError; only a
+/// negative shift raises.
 #[majit_macros::elidable]
-pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
+pub extern "C" fn jit_bigint_rshift(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
     unsafe {
-        let vb = w_long_get_value(b);
+        let vb = &*b;
         if vb.sign() == malachite_bigint::Sign::Minus {
             crate::runtime_ops::jit_publish_exception(
                 PyError::value_error("negative shift count").to_exc_object(),
@@ -450,15 +496,15 @@ pub extern "C" fn jit_w_long_rshift_raw(a: i64, b: i64) -> i64 {
         let shift = match vb.to_i64() {
             Some(v) => v as usize,
             None => {
-                let val = if w_long_get_value(a).sign() == malachite_bigint::Sign::Minus {
+                let val = if (&*a).sign() == malachite_bigint::Sign::Minus {
                     -1
                 } else {
                     0
                 };
-                return pyre_object::lltype::malloc_raw(BigInt::from(val)) as i64;
+                return pyre_object::longobject::alloc_bigint_nursery(BigInt::from(val)) as i64;
             }
         };
-        pyre_object::lltype::malloc_raw(bigint_rshift(w_long_get_value(a).clone(), shift)) as i64
+        pyre_object::longobject::alloc_bigint_nursery(bigint_rshift((&*a).clone(), shift)) as i64
     }
 }
 

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -788,6 +788,28 @@ static W_FLOAT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
+static W_LONG_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        std::mem::size_of::<pyre_object::longobject::W_LongObject>(),
+        pyre_object::longobject::W_LONG_GC_TYPE_ID,
+        &pyre_object::pyobject::LONG_TYPE as *const _ as usize,
+        &[(
+            "W_LongObject.value",
+            pyre_object::longobject::LONG_VALUE_OFFSET,
+            8,
+            // The `value` slot is a gc-pointer to the BigInt payload, so it
+            // enters `gc_fielddescrs` (the boxing SetfieldGc emits the write
+            // barrier). Immutable: a long's payload is set once at creation.
+            Type::Ref,
+            false,
+            true,
+            false,
+        )],
+        "W_LongObject",
+        "longobject::W_LongObject",
+    )
+});
+
 static W_BOOL_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_object::boolobject::W_BoolObject>(),
@@ -1940,6 +1962,12 @@ pub fn float_floatval_descr() -> DescrRef {
     field_descr_from_group(&W_FLOAT_DESCR_GROUP, 0)
 }
 
+/// FieldDescr for `W_LongObject.value` (the `*mut BigInt` gc-pointer), for the
+/// inline-NEW boxing of a `jit_w_long_*_raw` result.
+pub fn long_value_descr() -> DescrRef {
+    field_descr_from_group(&W_LONG_DESCR_GROUP, 0)
+}
+
 pub fn str_len_descr() -> DescrRef {
     // Python len(str) returns codepoint count.
     // unicodeobject.py:165 W_UnicodeObject._len() → _length field.
@@ -2003,6 +2031,12 @@ pub fn w_range_iter_size_descr() -> DescrRef {
 /// vtable = &FLOAT_TYPE (ob_type for virtual materialization).
 pub fn w_float_size_descr() -> DescrRef {
     W_FLOAT_DESCR_GROUP.size_descr.clone()
+}
+
+/// Size descriptor for W_LongObject allocation via NewWithVtable (the inline
+/// boxing of a bigint result). vtable = &LONG_TYPE (ob_type).
+pub fn w_long_size_descr() -> DescrRef {
+    W_LONG_DESCR_GROUP.size_descr.clone()
 }
 
 /// Size descriptor for canonical `W_TupleObject`.

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -808,6 +808,30 @@ pub fn emit_box_int_inline(
     new_op
 }
 
+/// Emit inline W_LongObject creation (NewWithVtable + SetfieldGc) for the
+/// boxing of a bigint result — the PyPy `W_LongObject(rbigint)` shape
+/// (`new_with_vtable` + `setfield_gc('num', z)`). `bigint_ref` is the
+/// (Ref-typed) `jit_w_long_*_raw` result; the collecting `NewWithVtable`
+/// gcmap-roots it, and the SetfieldGc into the registered `value`
+/// gc-pointer field carries the write barrier.
+///
+/// Like [`emit_box_int_inline`], `w_class` is left zero-filled — the JIT int
+/// box does the same; `type(x)`/`isinstance` resolve through `ob_type` (the
+/// vtable the NewWithVtable writes).
+pub fn emit_box_long_inline(
+    ctx: &mut TraceCtx,
+    bigint_ref: OpRef,
+    size_descr: majit_ir::DescrRef,
+    value_descr: majit_ir::DescrRef,
+) -> OpRef {
+    let new_op = ctx.record_op_with_descr(OpCode::NewWithVtable, &[], size_descr);
+    ctx.heap_cache_mut().new_object(new_op);
+    let value_idx = value_descr.index();
+    ctx.record_op_with_descr(OpCode::SetfieldGc, &[new_op, bigint_ref], value_descr);
+    ctx.heapcache_setfield_cached(new_op, value_idx, bigint_ref);
+    new_op
+}
+
 /// Emit inline `W_BaseException` creation (NewWithVtable + SetfieldGc
 /// for `kind` / `w_class` / `args_w`), so a builtin exception built by a
 /// Python `raise Type(args)` becomes traced New+SetField ops the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12578,10 +12578,11 @@ fn walker_guard_class(
 /// Walker-native W_LongObject (bigint) arithmetic specialization for the
 /// `BINARY_OP` helper residual_call (oopspec `BinaryOp`).  When both
 /// operands are concrete `W_LongObject`, emit `GUARD_CLASS(LONG_TYPE)` per
-/// operand + a `CALL_PURE_I` to the elidable `rbigint` payload helper
-/// (`long_binop_raw_helper`, `rbigint.py @jit.elidable`) producing a bare
-/// bigint, then a residual `CALL_R` to `jit_bigint_result_box` (the
-/// `W_LongObject(...)` NEW / `bigint_result` demote).  Neither is the opaque
+/// operand + `GETFIELD_GC_PURE_R(value)` + a `CALL_PURE_R` to the elidable
+/// `rbigint` payload helper (`long_binop_raw_helper`, `rbigint.py
+/// @jit.elidable`) producing a bare Ref-typed bigint, then inline
+/// `W_LongObject(...)` boxing via `new_with_vtable` + `setfield_gc('value')`.
+/// Neither is the opaque
 /// `CALL_MAY_FORCE` the generic leg records, so this sheds the per-iteration
 /// force-token store + `GUARD_NOT_FORCED` + `GUARD_NO_EXCEPTION` from
 /// bigint-heavy loops (e.g. `fib_loop`).
@@ -12632,13 +12633,14 @@ fn try_walker_specialize_binary_op_long(
     let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
         return Ok(None);
     };
-    // `newlong` demote: when the bigint result fits i64 it becomes a
-    // W_IntObject upstream, which the inline-NEW long box cannot represent — so
-    // decline the spec here (before emitting any op) and let the generic record
-    // handle the demote. The op already executed authentically above, so for
-    // the division helpers the divisor is nonzero and `raw_concrete` neither
-    // raises nor publishes. In fib_loop this never fires: long+long operands
-    // are already past i64 range, so the sum never fits again.
+    // Pyre representation demote: when the bigint result fits i64 it becomes a
+    // W_IntObject in pyre's two-class int model, which the inline-NEW long box
+    // cannot represent — so decline the spec here (before emitting any op) and
+    // let the generic record handle the demote. The op already executed
+    // authentically above, so for the division helpers the divisor is nonzero
+    // and `raw_concrete` neither raises nor publishes. In fib_loop this never
+    // fires: long+long operands are already past i64 range, so the sum never
+    // fits again.
     let raw_concrete = (spec.raw_fn)(lhs_obj as i64, rhs_obj as i64);
     let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
     if fits_concrete != 0 {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12637,15 +12637,19 @@ fn try_walker_specialize_binary_op_long(
         &[lhs],
         crate::descr::long_value_descr(),
     );
-    ctx.trace_ctx
-        .set_opref_concrete(lhs_pl, majit_ir::Value::Ref(majit_ir::GcRef(lhs_payload as usize)));
+    ctx.trace_ctx.set_opref_concrete(
+        lhs_pl,
+        majit_ir::Value::Ref(majit_ir::GcRef(lhs_payload as usize)),
+    );
     let rhs_pl = ctx.trace_ctx.record_op_with_descr(
         OpCode::GetfieldGcPureR,
         &[rhs],
         crate::descr::long_value_descr(),
     );
-    ctx.trace_ctx
-        .set_opref_concrete(rhs_pl, majit_ir::Value::Ref(majit_ir::GcRef(rhs_payload as usize)));
+    ctx.trace_ctx.set_opref_concrete(
+        rhs_pl,
+        majit_ir::Value::Ref(majit_ir::GcRef(rhs_payload as usize)),
+    );
     let add_fn = spec.payload_fn as *const ();
     let concrete_args = [
         majit_ir::Value::Int(add_fn as usize as i64),
@@ -12662,8 +12666,10 @@ fn try_walker_specialize_binary_op_long(
         &concrete_args,
         majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
     );
-    ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)));
+    ctx.trace_ctx.set_opref_concrete(
+        raw,
+        majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
+    );
     if raw.inline_const_to_value().is_none() {
         walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12294,6 +12294,25 @@ fn walker_int_eq_const(
     r
 }
 
+/// Record `uint_lt(raw, const k)` and stamp its already-known concrete truth.
+/// Used to guard a machine shift count into `[0, k)`: the x86 SHL/SAR encoding
+/// masks the count mod 64, so a reused trace whose shift count leaves the range
+/// must bail to the generic (bignum-capable) leg rather than shift by `count &
+/// 63`. `uint_lt` folds the negative case in (a negative count reads as a huge
+/// unsigned value `>= k`).
+fn walker_uint_lt_const(
+    ctx: &mut WalkContext<'_, '_>,
+    raw: OpRef,
+    k: i64,
+    concrete_truth: i64,
+) -> OpRef {
+    let k_const = ctx.trace_ctx.const_int(k);
+    let r = ctx.trace_ctx.record_op(OpCode::UintLt, &[raw, k_const]);
+    ctx.trace_ctx
+        .set_opref_concrete(r, majit_ir::Value::Int(concrete_truth));
+    r
+}
+
 /// Record `float_eq(raw, const k)` and stamp its already-known concrete
 /// truth.  Used to build the float-div zero-divisor precondition guard
 /// walker-native (the JIT representation of `floatobject.py:519 _floatdiv`'s
@@ -12408,33 +12427,31 @@ fn try_walker_specialize_binary_op_int(
                 }
             }
             OpCode::IntLshift => {
-                let Ok(shift) = u32::try_from(rb) else {
-                    return Ok(None);
-                };
-                if shift >= i64::BITS {
-                    return Ok(None);
-                }
-                // intobject.py:207 ovfcheck(a << b)
-                let result = la.wrapping_shl(shift);
-                if result.wrapping_shr(shift) != la {
-                    return Ok(None);
-                }
+                // Don't specialize int `<<`: route to the generic (residual
+                // BINARY_OP) leg, which carries the full intobject.py
+                // descr_lshift semantics (promote to bignum on overflow, raise
+                // ValueError on a negative count). A bare walker-native IntLshift
+                // would be wrong — the trace is reused for any operands and x86
+                // SHL masks the count mod 64 — and a *guarded* specialization
+                // (range + round-trip guards, bail to bignum) crashes the
+                // cranelift backend: when the lshift result is the loop variable
+                // its box alternates small-int / bignum across the guard's
+                // bridge boundary, and that trips a cranelift bridge bug (works
+                // on dynasm). The generic leg handles the alternation correctly
+                // on both backends.
+                return Ok(None);
             }
             OpCode::IntRshift => {
+                // A count >= LONG_BIT (or negative) folds to 0/-1 in
+                // intobject.py:229-231, but that fold would be baked into the
+                // reused trace and be wrong for an in-range count; route it to
+                // the generic leg instead. An in-range recorded count is
+                // specialized below behind a runtime range guard.
                 let Ok(shift) = u32::try_from(rb) else {
                     return Ok(None);
                 };
                 if shift >= i64::BITS {
-                    // intobject.py:229-231 large shift → 0 or -1, no IR op.
-                    let result = if la < 0 { -1i64 } else { 0i64 };
-                    let raw = ctx.trace_ctx.const_int(result);
-                    let boxed = crate::state::wrapint(ctx.trace_ctx, raw);
-                    ctx.trace_ctx.set_opref_concrete(
-                        boxed,
-                        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
-                    );
-                    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
-                    return Ok(Some(()));
+                    return Ok(None);
                 }
             }
             _ => {}
@@ -12497,6 +12514,18 @@ fn try_walker_specialize_binary_op_int(
                 majit_ir::Value::Int(concrete_result),
             );
             (r, concrete_result)
+        }
+        OpCode::IntRshift => {
+            // The machine SAR masks the count mod 64, so guard the count into
+            // [0, LONG_BIT) — a reused trace bails rather than shifting by
+            // `count & 63`. (The recorded count is < LONG_BIT here: a count
+            // >= LONG_BIT const-folds to 0/-1 in the needs_check block above.)
+            let in_range = walker_uint_lt_const(ctx, rhs_raw, i64::BITS as i64, 1);
+            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[in_range])?;
+            let r = ctx
+                .trace_ctx
+                .record_op(OpCode::IntRshift, &[lhs_raw, rhs_raw]);
+            (r, majit_metainterp::eval_binop_i(OpCode::IntRshift, la, rb))
         }
         _ => {
             let r = ctx.trace_ctx.record_op(op_code, &[lhs_raw, rhs_raw]);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12603,59 +12603,95 @@ fn try_walker_specialize_binary_op_long(
     let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
         return Ok(None);
     };
+    // `newlong` demote: when the bigint result fits i64 it becomes a
+    // W_IntObject upstream, which the inline-NEW long box cannot represent — so
+    // decline the spec here (before emitting any op) and let the generic record
+    // handle the demote. The op already executed authentically above, so for
+    // the division helpers the divisor is nonzero and `raw_concrete` neither
+    // raises nor publishes. In fib_loop this never fires: long+long operands
+    // are already past i64 range, so the sum never fits again.
+    let raw_concrete = (spec.raw_fn)(lhs_obj as i64, rhs_obj as i64);
+    let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
+    if fits_concrete != 0 {
+        return Ok(None);
+    }
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;
-    // Pure `rbigint` payload op: read both W_LongObject payloads and return a
-    // bare `*mut BigInt` (Int). The raw pointer is consumed only by the
-    // residual box below — it is dead after it and never spans a guard, so it
-    // needs no blackhole reconstruction. Every op allocates
-    // (`EF_ELIDABLE_OR_MEMORYERROR`) or divides (`EF_ELIDABLE_CAN_RAISE`), so a
-    // trailing `GuardNoException` follows (`pyjitpl.py:2110-2112`).
-    // `walker_execute_may_force_boxed` above already executed the op
-    // authentically, so for the division helpers the divisor is guaranteed
-    // nonzero here (a zero divisor would have raised → `None` → generic defer);
-    // the guard still covers a divide-by-zero / OOM on a later replay.
-    let raw_concrete = (spec.raw_fn)(lhs_obj as i64, rhs_obj as i64);
-    let add_fn = spec.raw_fn as *const ();
-    let concrete_args = [
-        majit_ir::Value::Int(add_fn as usize as i64),
-        majit_ir::Value::Ref(majit_ir::GcRef(lhs_obj as usize)),
-        majit_ir::Value::Ref(majit_ir::GcRef(rhs_obj as usize)),
-    ];
-    let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
-        OpCode::CallI,
-        add_fn,
-        &[lhs, rhs],
-        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
-        majit_ir::Type::Int,
-        spec.effect,
-        &concrete_args,
-        majit_ir::Value::Int(raw_concrete),
+    // Read each operand's immutable `value` payload (`GetfieldGcPure`), then call
+    // the elidable `rbigint` op on the bare `*const BigInt` payloads. Passing the
+    // payloads (not the wrappers) keeps the call pure on the immutable bigints, so
+    // the optimizer forwards the field read and never reorders this elidable call
+    // ahead of the boxing `setfield_gc` below — which would otherwise read the
+    // freshly-allocated result wrapper's uninitialized `value` (the function-loop
+    // unroll exposed exactly that reorder). The result is a GC-managed
+    // `*mut BigInt`, Ref-typed so the JIT gcmap roots it across the collecting
+    // boxing NEW. Every op allocates (`EF_ELIDABLE_OR_MEMORYERROR`) or divides
+    // (`EF_ELIDABLE_CAN_RAISE`), so a trailing `GuardNoException` follows
+    // (`pyjitpl.py:2110-2112`).
+    let off = pyre_object::longobject::LONG_VALUE_OFFSET;
+    let lhs_payload = unsafe { *((lhs_obj as *const u8).add(off) as *const i64) };
+    let rhs_payload = unsafe { *((rhs_obj as *const u8).add(off) as *const i64) };
+    let lhs_pl = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcPureR,
+        &[lhs],
+        crate::descr::long_value_descr(),
     );
     ctx.trace_ctx
-        .set_opref_concrete(raw, majit_ir::Value::Int(raw_concrete));
-    // pyjitpl.py:1946: no GuardNoException when the pure call folded to a Const.
+        .set_opref_concrete(lhs_pl, majit_ir::Value::Ref(majit_ir::GcRef(lhs_payload as usize)));
+    let rhs_pl = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcPureR,
+        &[rhs],
+        crate::descr::long_value_descr(),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(rhs_pl, majit_ir::Value::Ref(majit_ir::GcRef(rhs_payload as usize)));
+    let add_fn = spec.payload_fn as *const ();
+    let concrete_args = [
+        majit_ir::Value::Int(add_fn as usize as i64),
+        majit_ir::Value::Ref(majit_ir::GcRef(lhs_payload as usize)),
+        majit_ir::Value::Ref(majit_ir::GcRef(rhs_payload as usize)),
+    ];
+    let raw = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+        OpCode::CallR,
+        add_fn,
+        &[lhs_pl, rhs_pl],
+        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+        majit_ir::Type::Ref,
+        spec.effect,
+        &concrete_args,
+        majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)),
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(raw, majit_ir::Value::Ref(majit_ir::GcRef(raw_concrete as usize)));
     if raw.inline_const_to_value().is_none() {
         walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
     }
-    // Residual `bigint_result` box: wrap the bigint in a Python int, demoting to
-    // W_IntObject when it fits. Non-elidable (`dont_look_inside`), so the wrapper
-    // object is never pure-CSE'd — a distinct result per op, matching upstream's
-    // separate `NEW`; `EF_CANNOT_RAISE` ⇒ no GuardNoException and non-forcing.
-    let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
-    let result = ctx.trace_ctx.call_typed_with_effect(
-        OpCode::CallR,
-        box_fn,
+    // `newlong` demote guard: `GuardFalse(fits_int(raw))`. Passes at record time
+    // (checked above), deopts to the interpreter if a future replay yields an
+    // i64-fitting result. Resumes at op_pc (the BINARY_OP), like the GuardClass
+    // guards.
+    let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
+    let fits = ctx.trace_ctx.call_typed_with_effect(
+        OpCode::CallI,
+        fits_fn,
         &[raw],
-        &[majit_ir::Type::Int],
-        majit_ir::Type::Ref,
+        &[majit_ir::Type::Ref],
+        majit_ir::Type::Int,
         majit_metainterp::cannot_raise_effect_info(),
     );
-    // Stamp the result's concrete shadow so `write_residual_call_result_to_dst`
-    // (via `concrete_from_recorded_opref`) propagates the authentic sum object
-    // into the dst slot; the subsequent STORE_FAST then carries it. Without
-    // this the dst shadow is Null and the local materializes unbound.
+    ctx.trace_ctx
+        .set_opref_concrete(fits, majit_ir::Value::Int(fits_concrete));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
+    // Inline `W_LongObject(raw)` NEW (`new_with_vtable` + `setfield_gc('value')`).
+    // NewWithVtable lowers to the collecting `CallMallocNursery` — the GC
+    // safepoint that lets bigint-heavy loops reclaim dead bigints.
+    let result = crate::helpers::emit_box_long_inline(
+        ctx.trace_ctx,
+        raw,
+        crate::descr::w_long_size_descr(),
+        crate::descr::long_value_descr(),
+    );
     ctx.trace_ctx.set_opref_concrete(
         result,
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12636,16 +12636,23 @@ fn try_walker_specialize_binary_op_long(
     // Pyre representation demote: when the bigint result fits i64 it becomes a
     // W_IntObject in pyre's two-class int model, which the inline-NEW long box
     // cannot represent — so decline the spec here (before emitting any op) and
-    // let the generic record handle the demote. The op already executed
-    // authentically above, so for the division helpers the divisor is nonzero
-    // and `raw_concrete` neither raises nor publishes. In fib_loop this never
-    // fires: long+long operands are already past i64 range, so the sum never
-    // fits again.
-    let raw_concrete = (spec.raw_fn)(lhs_obj as i64, rhs_obj as i64);
-    let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
-    if fits_concrete != 0 {
+    // let the generic record handle the demote. Reuse the authentic boxed
+    // result's payload instead of running `spec.raw_fn` a second time; the raw
+    // helpers allocate/publish exception state and must not be used as a
+    // trace-time probe.
+    let boxed_result_obj = boxed_result_i64 as usize as pyre_object::PyObjectRef;
+    if boxed_result_obj == pyre_object::PY_NULL || unsafe { pyre_object::is_int(boxed_result_obj) }
+    {
         return Ok(None);
     }
+    if !unsafe { pyre_object::is_long(boxed_result_obj) } {
+        return Ok(None);
+    }
+    let raw_concrete = unsafe {
+        *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
+            as *const i64)
+    };
+    let fits_concrete = 0_i64;
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
     walker_guard_class(ctx, op_pc, rhs, long_type_addr)?;

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -265,19 +265,22 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
 
 /// The elidable `rbigint` payload helper + effect for a specialised
 /// W_LongObject binary op (see [`long_binop_raw_helper`]). The bigint result is
-/// boxed by the caller via `jit_bigint_result_box` (→ Python int, demoting).
+/// boxed by the caller as a `W_LongObject` after the pyre-specific fits-int
+/// demotion guard.
 /// True-divide is NOT here — it returns a float (`CallPureF` + `wrapfloat`), so
 /// it has its own specialisation ([`try_walker_specialize_truediv_op_long`]).
 pub(crate) struct LongBinopSpec {
     /// Pure `rbigint` payload op over the two `W_LongObject` *wrappers*
-    /// `[Ref, Ref] → Int`, returning a bare `*mut BigInt` (arithmetic / divmod /
-    /// shift). Used for record-time concrete evaluation and the trait path.
+    /// `[Ref, Ref] -> Ref`, returning a bare `*mut BigInt` (arithmetic / divmod /
+    /// shift). Used only for record-time concrete evaluation, where the
+    /// operands are native tracer values and the helper must not collect.
     pub raw_fn: extern "C" fn(i64, i64) -> i64,
     /// The same `rbigint` op over the two bare `*const BigInt` *payloads*
-    /// `[Ref, Ref] → Int`. The walker emits this after a `GetfieldGcPure(value)`
-    /// on each operand, so the elidable call is pure on the immutable bigints
-    /// (not the wrappers) and the optimizer never reorders it ahead of the
-    /// boxing `setfield_gc` that initializes a fresh result wrapper.
+    /// `[Ref, Ref] -> Ref`. The trace emits this after a
+    /// `GetfieldGcPure(value)` on each operand, so the elidable call is pure on
+    /// the immutable bigints (not the wrappers) and the optimizer never
+    /// reorders it ahead of the boxing `setfield_gc` that initializes a fresh
+    /// result wrapper.
     pub payload_fn: extern "C" fn(i64, i64) -> i64,
     pub effect: majit_ir::EffectInfo,
     /// True for the divmod ops, whose helper publishes ZeroDivisionError on a
@@ -6066,20 +6069,23 @@ impl MIFrame {
 
     /// W_LongObject (bigint) arithmetic fast path. Mirrors PyPy's
     /// `W_LongObject._add` trace shape: `GuardClass(LONG_TYPE)` on each
-    /// operand, then a `CALL_PURE_I` to the elidable `rbigint` payload helper
-    /// ([`long_binop_raw_helper`]) producing a bare bigint, then a residual
-    /// `CALL_R` to `jit_bigint_result_box` (the `W_LongObject(...)` NEW /
-    /// `bigint_result` demote). Unlike the generic `binary_value` residual
-    /// neither is a `CALL_MAY_FORCE`, so the loop body sheds the
-    /// per-iteration force-token store + `GUARD_NOT_FORCED`. Each op keeps a
-    /// trailing `GUARD_NO_EXCEPTION`: the arithmetic ops (add/sub/mul/and/or/
-    /// xor) allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the divmod / shift
-    /// ops are `EF_ELIDABLE_CAN_RAISE`; both have `check_can_raise()` true
+    /// operand, `GetfieldGcPureR(value)` to read the immutable bigint payload,
+    /// then a `CALL_PURE_R` to the elidable `rbigint` payload helper
+    /// ([`long_binop_raw_helper`]) producing a bare GC bigint. The result is
+    /// boxed with `new_with_vtable` + `setfield_gc('value')`; pyre's two-class
+    /// int representation adds a fits-int guard before the long box so future
+    /// replay deopts to the interpreter when the result should be a W_IntObject.
+    /// Unlike the generic `binary_value` residual this is not a
+    /// `CALL_MAY_FORCE`, so the loop body sheds the per-iteration force-token
+    /// store + `GUARD_NOT_FORCED`. Each op keeps a trailing
+    /// `GUARD_NO_EXCEPTION`: the arithmetic ops (add/sub/mul/and/or/xor)
+    /// allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the divmod / shift ops
+    /// are `EF_ELIDABLE_CAN_RAISE`; both have `check_can_raise()` true
     /// (`pyjitpl.py:2110-2112`). The trait path only specialises the ops it can
-    /// pre-screen for raising inputs (arithmetic + divmod); shift is walker-only
-    /// (`trait_safe == false`). True-divide (float result) and pow fall through
-    /// to the generic residual here — true-divide has its own walker fast path
-    /// (`try_walker_specialize_truediv_op_long`).
+    /// pre-screen for raising inputs (arithmetic + divmod); shift is
+    /// walker-only (`trait_safe == false`). True-divide (float result) and pow
+    /// fall through to the generic residual here — true-divide has its own
+    /// walker fast path (`try_walker_specialize_truediv_op_long`).
     pub(crate) fn binary_long_value(
         &mut self,
         a: OpRef,
@@ -6107,52 +6113,83 @@ impl MIFrame {
         if spec.is_division && unsafe { pyre_object::longobject::w_long_is_zero(concrete_rhs) } {
             return self.trace_binary_value(a, b, op);
         }
+        let raw_concrete = (spec.raw_fn)(concrete_lhs as i64, concrete_rhs as i64);
+        let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
+        if fits_concrete != 0 {
+            return self.trace_binary_value(a, b, op);
+        }
+        let lhs_payload =
+            unsafe { pyre_object::longobject::w_long_get_value(concrete_lhs) as *const _ };
+        let rhs_payload =
+            unsafe { pyre_object::longobject::w_long_get_value(concrete_rhs) as *const _ };
         self.with_ctx(|this, ctx| {
             this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
             this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
-            // Pure `rbigint` payload op → bare `*mut BigInt` (Int), recorded as
-            // CALL_PURE_I via `record_result_of_call_pure` (patches CALL_I and
-            // populates `call_pure_results`), mirroring the walker fast path.
+            // Read each operand's immutable `value` payload (`GetfieldGcPure`),
+            // then call the elidable `rbigint` op on the bare payloads. The
+            // result is Ref-typed so the JIT gcmap roots it across the
+            // collecting `NewWithVtable` used for boxing.
+            let lhs_pl = ctx.record_op_with_descr(
+                OpCode::GetfieldGcPureR,
+                &[a],
+                crate::descr::long_value_descr(),
+            );
+            ctx.set_opref_concrete(lhs_pl, Value::Ref(GcRef(lhs_payload as usize)));
+            let rhs_pl = ctx.record_op_with_descr(
+                OpCode::GetfieldGcPureR,
+                &[b],
+                crate::descr::long_value_descr(),
+            );
+            ctx.set_opref_concrete(rhs_pl, Value::Ref(GcRef(rhs_payload as usize)));
             // Every op allocates (`EF_ELIDABLE_OR_MEMORYERROR`) or divides
             // (`EF_ELIDABLE_CAN_RAISE`), so `check_can_raise()` is true and a
             // trailing `GuardNoException` follows (`pyjitpl.py:2110-2112`).
-            let fn_ptr = spec.raw_fn as *const ();
-            let raw_concrete = (spec.raw_fn)(concrete_lhs as i64, concrete_rhs as i64);
+            let fn_ptr = spec.payload_fn as *const ();
             let concrete_args = [
                 Value::Int(fn_ptr as usize as i64),
-                Value::Ref(GcRef(concrete_lhs as usize)),
-                Value::Ref(GcRef(concrete_rhs as usize)),
+                Value::Ref(GcRef(lhs_payload as usize)),
+                Value::Ref(GcRef(rhs_payload as usize)),
             ];
             let raw = ctx.call_typed_with_effect_pure_can_raise(
-                OpCode::CallI,
+                OpCode::CallR,
                 fn_ptr,
-                &[a, b],
+                &[lhs_pl, rhs_pl],
                 &[Type::Ref, Type::Ref],
-                Type::Int,
+                Type::Ref,
                 spec.effect,
                 &concrete_args,
-                Value::Int(raw_concrete),
+                Value::Ref(GcRef(raw_concrete as usize)),
             );
+            ctx.set_opref_concrete(raw, Value::Ref(GcRef(raw_concrete as usize)));
             // pyjitpl.py:1946: exc = exc and not isinstance(op, Const). When all
             // args were constant the pure call folds to a Const, so no
             // GuardNoException is recorded.
             if raw.inline_const_to_value().is_none() {
                 this.generate_guard(ctx, OpCode::GuardNoException, &[]);
             }
-            // …then the residual `bigint_result` box/demote → Python int (Ref).
-            // Models the `W_LongObject(...)` NEW: `EF_CANNOT_RAISE` and
-            // non-elidable (`dont_look_inside`), so it is never pure-CSE'd and,
-            // like upstream's NEW, carries no `GuardNoException` (a MemoryError
-            // from the allocation is the GC slowpath's concern, not a guard).
-            let box_fn = pyre_object::longobject::jit_bigint_result_box as *const ();
-            Ok::<_, PyError>(ctx.call_typed_with_effect(
-                OpCode::CallR,
-                box_fn,
+            // Pyre representation demotion guard: future replay that yields an
+            // i64-fitting bigint must deopt so the interpreter can return the
+            // W_IntObject representation.
+            let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
+            let fits = ctx.call_typed_with_effect(
+                OpCode::CallI,
+                fits_fn,
                 &[raw],
-                &[Type::Int],
-                Type::Ref,
+                &[Type::Ref],
+                Type::Int,
                 majit_metainterp::cannot_raise_effect_info(),
-            ))
+            );
+            ctx.set_opref_concrete(fits, Value::Int(fits_concrete));
+            this.generate_guard(ctx, OpCode::GuardFalse, &[fits]);
+            // Inline `W_LongObject(raw)` NEW (`new_with_vtable` +
+            // `setfield_gc('value')`), matching the RPython allocation shape.
+            let result = crate::helpers::emit_box_long_inline(
+                ctx,
+                raw,
+                crate::descr::w_long_size_descr(),
+                crate::descr::long_value_descr(),
+            );
+            Ok::<_, PyError>(result)
         })
     }
 

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -269,9 +269,16 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
 /// True-divide is NOT here — it returns a float (`CallPureF` + `wrapfloat`), so
 /// it has its own specialisation ([`try_walker_specialize_truediv_op_long`]).
 pub(crate) struct LongBinopSpec {
-    /// Pure `rbigint` payload op `[Ref, Ref] → Int`, returning a bare
-    /// `*mut BigInt` (arithmetic / divmod / shift).
+    /// Pure `rbigint` payload op over the two `W_LongObject` *wrappers*
+    /// `[Ref, Ref] → Int`, returning a bare `*mut BigInt` (arithmetic / divmod /
+    /// shift). Used for record-time concrete evaluation and the trait path.
     pub raw_fn: extern "C" fn(i64, i64) -> i64,
+    /// The same `rbigint` op over the two bare `*const BigInt` *payloads*
+    /// `[Ref, Ref] → Int`. The walker emits this after a `GetfieldGcPure(value)`
+    /// on each operand, so the elidable call is pure on the immutable bigints
+    /// (not the wrappers) and the optimizer never reorders it ahead of the
+    /// boxing `setfield_gc` that initializes a fresh result wrapper.
+    pub payload_fn: extern "C" fn(i64, i64) -> i64,
     pub effect: majit_ir::EffectInfo,
     /// True for the divmod ops, whose helper publishes ZeroDivisionError on a
     /// zero divisor. The trait path pre-checks the divisor with `w_long_is_zero`
@@ -300,70 +307,84 @@ pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<LongBinopSpec>
     use majit_metainterp::{ELIDABLE_EFFECT_INFO, ELIDABLE_OR_MEMERROR_EFFECT_INFO};
     use pyre_interpreter::objspace::descroperation as desc;
     use pyre_object::longobject as lo;
-    // (raw_fn, effect, is_division, trait_safe)
-    let (raw_fn, effect, is_division, trait_safe): (extern "C" fn(i64, i64) -> i64, _, _, _) =
-        match op {
-            BinaryOperator::Add | BinaryOperator::InplaceAdd => (
-                lo::jit_w_long_add_raw,
-                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-                false,
-                true,
-            ),
-            BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (
-                lo::jit_w_long_sub_raw,
-                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-                false,
-                true,
-            ),
-            BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (
-                lo::jit_w_long_mul_raw,
-                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-                false,
-                true,
-            ),
-            BinaryOperator::And | BinaryOperator::InplaceAnd => (
-                lo::jit_w_long_and_raw,
-                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-                false,
-                true,
-            ),
-            BinaryOperator::Or | BinaryOperator::InplaceOr => (
-                lo::jit_w_long_or_raw,
-                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-                false,
-                true,
-            ),
-            BinaryOperator::Xor | BinaryOperator::InplaceXor => (
-                lo::jit_w_long_xor_raw,
-                ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-                false,
-                true,
-            ),
-            BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => (
-                desc::jit_w_long_floordiv_raw,
-                ELIDABLE_EFFECT_INFO,
-                true,
-                true,
-            ),
-            BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
-                (desc::jit_w_long_mod_raw, ELIDABLE_EFFECT_INFO, true, true)
-            }
-            BinaryOperator::Lshift | BinaryOperator::InplaceLshift => (
-                desc::jit_w_long_lshift_raw,
-                ELIDABLE_EFFECT_INFO,
-                false,
-                false,
-            ),
-            BinaryOperator::Rshift | BinaryOperator::InplaceRshift => (
-                desc::jit_w_long_rshift_raw,
-                ELIDABLE_EFFECT_INFO,
-                false,
-                false,
-            ),
-            _ => return None,
-        };
+    // (raw_fn, payload_fn, effect, is_division, trait_safe)
+    type RawFn = extern "C" fn(i64, i64) -> i64;
+    let (raw_fn, payload_fn, effect, is_division, trait_safe): (RawFn, RawFn, _, _, _) = match op {
+        BinaryOperator::Add | BinaryOperator::InplaceAdd => (
+            lo::jit_w_long_add_raw,
+            lo::jit_bigint_add,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (
+            lo::jit_w_long_sub_raw,
+            lo::jit_bigint_sub,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (
+            lo::jit_w_long_mul_raw,
+            lo::jit_bigint_mul,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::And | BinaryOperator::InplaceAnd => (
+            lo::jit_w_long_and_raw,
+            lo::jit_bigint_and,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Or | BinaryOperator::InplaceOr => (
+            lo::jit_w_long_or_raw,
+            lo::jit_bigint_or,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::Xor | BinaryOperator::InplaceXor => (
+            lo::jit_w_long_xor_raw,
+            lo::jit_bigint_xor,
+            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+            false,
+            true,
+        ),
+        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => (
+            desc::jit_w_long_floordiv_raw,
+            desc::jit_bigint_floordiv,
+            ELIDABLE_EFFECT_INFO,
+            true,
+            true,
+        ),
+        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => (
+            desc::jit_w_long_mod_raw,
+            desc::jit_bigint_mod,
+            ELIDABLE_EFFECT_INFO,
+            true,
+            true,
+        ),
+        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => (
+            desc::jit_w_long_lshift_raw,
+            desc::jit_bigint_lshift,
+            ELIDABLE_EFFECT_INFO,
+            false,
+            false,
+        ),
+        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => (
+            desc::jit_w_long_rshift_raw,
+            desc::jit_bigint_rshift,
+            ELIDABLE_EFFECT_INFO,
+            false,
+            false,
+        ),
+        _ => return None,
+    };
     Some(LongBinopSpec {
         raw_fn,
+        payload_fn,
         effect,
         is_division,
         trait_safe,

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -263,37 +263,21 @@ fn trace_set_tuple_w_class(ctx: &mut TraceCtx, tuple: OpRef, descr: DescrRef) {
     ctx.heapcache_setfield_cached(tuple, descr.index(), w_class);
 }
 
-/// The elidable `rbigint` payload helper + effect for a specialised
+/// The elidable `rbigint` payload helper + effect for a walker-specialised
 /// W_LongObject binary op (see [`long_binop_raw_helper`]). The bigint result is
 /// boxed by the caller as a `W_LongObject` after the pyre-specific fits-int
 /// demotion guard.
 /// True-divide is NOT here — it returns a float (`CallPureF` + `wrapfloat`), so
 /// it has its own specialisation ([`try_walker_specialize_truediv_op_long`]).
 pub(crate) struct LongBinopSpec {
-    /// Pure `rbigint` payload op over the two `W_LongObject` *wrappers*
-    /// `[Ref, Ref] -> Ref`, returning a bare `*mut BigInt` (arithmetic / divmod /
-    /// shift). Used only for record-time concrete evaluation, where the
-    /// operands are native tracer values and the helper must not collect.
-    pub raw_fn: extern "C" fn(i64, i64) -> i64,
-    /// The same `rbigint` op over the two bare `*const BigInt` *payloads*
-    /// `[Ref, Ref] -> Ref`. The trace emits this after a
+    /// Pure `rbigint` op over the two bare `*const BigInt` *payloads*
+    /// `[Ref, Ref] -> Ref`. The walker emits this after a
     /// `GetfieldGcPure(value)` on each operand, so the elidable call is pure on
     /// the immutable bigints (not the wrappers) and the optimizer never
     /// reorders it ahead of the boxing `setfield_gc` that initializes a fresh
     /// result wrapper.
     pub payload_fn: extern "C" fn(i64, i64) -> i64,
     pub effect: majit_ir::EffectInfo,
-    /// True for the divmod ops, whose helper publishes ZeroDivisionError on a
-    /// zero divisor. The trait path pre-checks the divisor with `w_long_is_zero`
-    /// before invoking the helper for `call_pure_results`.
-    pub is_division: bool,
-    /// False for the shift ops, whose raising inputs (negative / over-large
-    /// count) are not a simple divisor check. The trait path defers these to the
-    /// generic residual rather than risk publishing an exception mid-trace; the
-    /// walker still specialises them (it executes the authentic op first and
-    /// bails on a raise, so the concrete helper call here only runs on a
-    /// non-raising op).
-    pub trait_safe: bool,
 }
 
 /// Map a `BinaryOperator` to its `rbigint` payload helper, or `None` when the
@@ -304,94 +288,47 @@ pub(crate) struct LongBinopSpec {
 /// `cr == "mem"`); the divmod / shift ops also raise (ZeroDivision /
 /// ValueError·Overflow) so they are `EF_ELIDABLE_CAN_RAISE` (`call.py:296`).
 /// Both classes have `check_can_raise()` true, so `pyjitpl.py:2110-2112` emits
-/// the guard. Shared by the trait path ([`binary_long_value`]) and the walker
-/// (`try_walker_specialize_binary_op_long`).
+/// the guard. The legacy trait path delegates to the generic residual because
+/// it cannot reuse the authentic boxed result's payload.
 pub(crate) fn long_binop_raw_helper(op: BinaryOperator) -> Option<LongBinopSpec> {
     use majit_metainterp::{ELIDABLE_EFFECT_INFO, ELIDABLE_OR_MEMERROR_EFFECT_INFO};
     use pyre_interpreter::objspace::descroperation as desc;
     use pyre_object::longobject as lo;
-    // (raw_fn, payload_fn, effect, is_division, trait_safe)
-    type RawFn = extern "C" fn(i64, i64) -> i64;
-    let (raw_fn, payload_fn, effect, is_division, trait_safe): (RawFn, RawFn, _, _, _) = match op {
-        BinaryOperator::Add | BinaryOperator::InplaceAdd => (
-            lo::jit_w_long_add_raw,
-            lo::jit_bigint_add,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => (
-            lo::jit_w_long_sub_raw,
-            lo::jit_bigint_sub,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => (
-            lo::jit_w_long_mul_raw,
-            lo::jit_bigint_mul,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::And | BinaryOperator::InplaceAnd => (
-            lo::jit_w_long_and_raw,
-            lo::jit_bigint_and,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Or | BinaryOperator::InplaceOr => (
-            lo::jit_w_long_or_raw,
-            lo::jit_bigint_or,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::Xor | BinaryOperator::InplaceXor => (
-            lo::jit_w_long_xor_raw,
-            lo::jit_bigint_xor,
-            ELIDABLE_OR_MEMERROR_EFFECT_INFO,
-            false,
-            true,
-        ),
-        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => (
-            desc::jit_w_long_floordiv_raw,
-            desc::jit_bigint_floordiv,
-            ELIDABLE_EFFECT_INFO,
-            true,
-            true,
-        ),
-        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => (
-            desc::jit_w_long_mod_raw,
-            desc::jit_bigint_mod,
-            ELIDABLE_EFFECT_INFO,
-            true,
-            true,
-        ),
-        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => (
-            desc::jit_w_long_lshift_raw,
-            desc::jit_bigint_lshift,
-            ELIDABLE_EFFECT_INFO,
-            false,
-            false,
-        ),
-        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => (
-            desc::jit_w_long_rshift_raw,
-            desc::jit_bigint_rshift,
-            ELIDABLE_EFFECT_INFO,
-            false,
-            false,
-        ),
+    type PayloadFn = extern "C" fn(i64, i64) -> i64;
+    let (payload_fn, effect): (PayloadFn, _) = match op {
+        BinaryOperator::Add | BinaryOperator::InplaceAdd => {
+            (lo::jit_bigint_add, ELIDABLE_OR_MEMERROR_EFFECT_INFO)
+        }
+        BinaryOperator::Subtract | BinaryOperator::InplaceSubtract => {
+            (lo::jit_bigint_sub, ELIDABLE_OR_MEMERROR_EFFECT_INFO)
+        }
+        BinaryOperator::Multiply | BinaryOperator::InplaceMultiply => {
+            (lo::jit_bigint_mul, ELIDABLE_OR_MEMERROR_EFFECT_INFO)
+        }
+        BinaryOperator::And | BinaryOperator::InplaceAnd => {
+            (lo::jit_bigint_and, ELIDABLE_OR_MEMERROR_EFFECT_INFO)
+        }
+        BinaryOperator::Or | BinaryOperator::InplaceOr => {
+            (lo::jit_bigint_or, ELIDABLE_OR_MEMERROR_EFFECT_INFO)
+        }
+        BinaryOperator::Xor | BinaryOperator::InplaceXor => {
+            (lo::jit_bigint_xor, ELIDABLE_OR_MEMERROR_EFFECT_INFO)
+        }
+        BinaryOperator::FloorDivide | BinaryOperator::InplaceFloorDivide => {
+            (desc::jit_bigint_floordiv, ELIDABLE_EFFECT_INFO)
+        }
+        BinaryOperator::Remainder | BinaryOperator::InplaceRemainder => {
+            (desc::jit_bigint_mod, ELIDABLE_EFFECT_INFO)
+        }
+        BinaryOperator::Lshift | BinaryOperator::InplaceLshift => {
+            (desc::jit_bigint_lshift, ELIDABLE_EFFECT_INFO)
+        }
+        BinaryOperator::Rshift | BinaryOperator::InplaceRshift => {
+            (desc::jit_bigint_rshift, ELIDABLE_EFFECT_INFO)
+        }
         _ => return None,
     };
-    Some(LongBinopSpec {
-        raw_fn,
-        payload_fn,
-        effect,
-        is_division,
-        trait_safe,
-    })
+    Some(LongBinopSpec { payload_fn, effect })
 }
 
 /// Emit `GetfieldGcR(w_class) → PtrEq(expected) → GuardTrue` so the trace
@@ -6067,130 +6004,21 @@ impl MIFrame {
         self.trace_binary_value(a, b, op)
     }
 
-    /// W_LongObject (bigint) arithmetic fast path. Mirrors PyPy's
-    /// `W_LongObject._add` trace shape: `GuardClass(LONG_TYPE)` on each
-    /// operand, `GetfieldGcPureR(value)` to read the immutable bigint payload,
-    /// then a `CALL_PURE_R` to the elidable `rbigint` payload helper
-    /// ([`long_binop_raw_helper`]) producing a bare GC bigint. The result is
-    /// boxed with `new_with_vtable` + `setfield_gc('value')`; pyre's two-class
-    /// int representation adds a fits-int guard before the long box so future
-    /// replay deopts to the interpreter when the result should be a W_IntObject.
-    /// Unlike the generic `binary_value` residual this is not a
-    /// `CALL_MAY_FORCE`, so the loop body sheds the per-iteration force-token
-    /// store + `GUARD_NOT_FORCED`. Each op keeps a trailing
-    /// `GUARD_NO_EXCEPTION`: the arithmetic ops (add/sub/mul/and/or/xor)
-    /// allocate so they are `EF_ELIDABLE_OR_MEMORYERROR`, the divmod / shift ops
-    /// are `EF_ELIDABLE_CAN_RAISE`; both have `check_can_raise()` true
-    /// (`pyjitpl.py:2110-2112`). The trait path only specialises the ops it can
-    /// pre-screen for raising inputs (arithmetic + divmod); shift is
-    /// walker-only (`trait_safe == false`). True-divide (float result) and pow
-    /// fall through to the generic residual here — true-divide has its own
-    /// walker fast path (`try_walker_specialize_truediv_op_long`).
+    /// Long-object BINARY_OP trait path. The production tracer is the jitcode
+    /// walker; this legacy path cannot observe the authentic boxed result before
+    /// recording, so it must not call raw bigint helpers as a trace-time probe.
+    /// Delegate to the generic residual here and keep the raw-payload
+    /// specialization in the walker, which reuses the already-executed boxed
+    /// result's payload.
     pub(crate) fn binary_long_value(
         &mut self,
         a: OpRef,
         b: OpRef,
         op: BinaryOperator,
-        concrete_lhs: PyObjectRef,
-        concrete_rhs: PyObjectRef,
+        _concrete_lhs: PyObjectRef,
+        _concrete_rhs: PyObjectRef,
     ) -> Result<OpRef, PyError> {
-        let Some(spec) = long_binop_raw_helper(op) else {
-            return self.trace_binary_value(a, b, op);
-        };
-        // Shift raises on inputs the trait path cannot cheaply pre-screen
-        // (negative or over-large shift count), so it defers to the generic
-        // residual here — the walker still specialises it, executing the
-        // authentic op first. (True-divide is not in `long_binop_raw_helper`
-        // at all, so it already took the early return above.)
-        if !spec.trait_safe {
-            return self.trace_binary_value(a, b, op);
-        }
-        // The division helpers publish ZeroDivisionError on a zero divisor;
-        // that path is handled by the generic residual, so fast-path only
-        // nonzero divisors (the helper is otherwise side-effect-free when
-        // invoked for `call_pure_results` below). The arithmetic helpers only
-        // ever fail with MemoryError, which cannot fire during tracing.
-        if spec.is_division && unsafe { pyre_object::longobject::w_long_is_zero(concrete_rhs) } {
-            return self.trace_binary_value(a, b, op);
-        }
-        let raw_concrete = (spec.raw_fn)(concrete_lhs as i64, concrete_rhs as i64);
-        let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
-        if fits_concrete != 0 {
-            return self.trace_binary_value(a, b, op);
-        }
-        let lhs_payload =
-            unsafe { pyre_object::longobject::w_long_get_value(concrete_lhs) as *const _ };
-        let rhs_payload =
-            unsafe { pyre_object::longobject::w_long_get_value(concrete_rhs) as *const _ };
-        self.with_ctx(|this, ctx| {
-            this.guard_class(ctx, a, &LONG_TYPE as *const PyType);
-            this.guard_class(ctx, b, &LONG_TYPE as *const PyType);
-            // Read each operand's immutable `value` payload (`GetfieldGcPure`),
-            // then call the elidable `rbigint` op on the bare payloads. The
-            // result is Ref-typed so the JIT gcmap roots it across the
-            // collecting `NewWithVtable` used for boxing.
-            let lhs_pl = ctx.record_op_with_descr(
-                OpCode::GetfieldGcPureR,
-                &[a],
-                crate::descr::long_value_descr(),
-            );
-            ctx.set_opref_concrete(lhs_pl, Value::Ref(GcRef(lhs_payload as usize)));
-            let rhs_pl = ctx.record_op_with_descr(
-                OpCode::GetfieldGcPureR,
-                &[b],
-                crate::descr::long_value_descr(),
-            );
-            ctx.set_opref_concrete(rhs_pl, Value::Ref(GcRef(rhs_payload as usize)));
-            // Every op allocates (`EF_ELIDABLE_OR_MEMORYERROR`) or divides
-            // (`EF_ELIDABLE_CAN_RAISE`), so `check_can_raise()` is true and a
-            // trailing `GuardNoException` follows (`pyjitpl.py:2110-2112`).
-            let fn_ptr = spec.payload_fn as *const ();
-            let concrete_args = [
-                Value::Int(fn_ptr as usize as i64),
-                Value::Ref(GcRef(lhs_payload as usize)),
-                Value::Ref(GcRef(rhs_payload as usize)),
-            ];
-            let raw = ctx.call_typed_with_effect_pure_can_raise(
-                OpCode::CallR,
-                fn_ptr,
-                &[lhs_pl, rhs_pl],
-                &[Type::Ref, Type::Ref],
-                Type::Ref,
-                spec.effect,
-                &concrete_args,
-                Value::Ref(GcRef(raw_concrete as usize)),
-            );
-            ctx.set_opref_concrete(raw, Value::Ref(GcRef(raw_concrete as usize)));
-            // pyjitpl.py:1946: exc = exc and not isinstance(op, Const). When all
-            // args were constant the pure call folds to a Const, so no
-            // GuardNoException is recorded.
-            if raw.inline_const_to_value().is_none() {
-                this.generate_guard(ctx, OpCode::GuardNoException, &[]);
-            }
-            // Pyre representation demotion guard: future replay that yields an
-            // i64-fitting bigint must deopt so the interpreter can return the
-            // W_IntObject representation.
-            let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
-            let fits = ctx.call_typed_with_effect(
-                OpCode::CallI,
-                fits_fn,
-                &[raw],
-                &[Type::Ref],
-                Type::Int,
-                majit_metainterp::cannot_raise_effect_info(),
-            );
-            ctx.set_opref_concrete(fits, Value::Int(fits_concrete));
-            this.generate_guard(ctx, OpCode::GuardFalse, &[fits]);
-            // Inline `W_LongObject(raw)` NEW (`new_with_vtable` +
-            // `setfield_gc('value')`), matching the RPython allocation shape.
-            let result = crate::helpers::emit_box_long_inline(
-                ctx,
-                raw,
-                crate::descr::w_long_size_descr(),
-                crate::descr::long_value_descr(),
-            );
-            Ok::<_, PyError>(result)
-        })
+        self.trace_binary_value(a, b, op)
     }
 
     pub(crate) fn binary_float_value(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1244,11 +1244,14 @@ thread_local! {
             w_str_tid,
         );
         pytype_to_tid.insert(&pyre_object::STR_TYPE as *const _ as usize, w_str_tid);
-        // W_LongObject carries a `*mut BigInt` (raw heap) only. Same
-        // size-only registration shape as W_UnicodeObject.
-        let w_long_tid = gc.register_type(TypeInfo::object_subclass(
+        // W_LongObject carries a `value: *mut BigInt` that now points at a
+        // GC-managed bigint payload (BIGINT_GC_TYPE_ID, registered below), so
+        // the collector must trace/forward it — register the `value` offset as
+        // a gc-pointer rather than the old size-only shape.
+        let w_long_tid = gc.register_type(TypeInfo::object_subclass_with_gc_ptrs(
             std::mem::size_of::<pyre_object::longobject::W_LongObject>(),
             object_tid,
+            vec![pyre_object::longobject::LONG_VALUE_OFFSET],
         ));
         debug_assert_eq!(w_long_tid, W_LONG_GC_TYPE_ID);
         majit_gc::GcAllocator::register_vtable_for_type(
@@ -1916,6 +1919,19 @@ thread_local! {
             <pyre_object::memoryview::W_MemoryView
                 as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
         );
+        // Raw `BigInt` payload backing every `W_LongObject.value` (and the JIT
+        // `jit_w_long_*_raw` results). Not an `rclass.OBJECT` instance — a bare
+        // payload with no gc-pointer fields (malachite's limb `Vec` is off-GC),
+        // carrying a lightweight destructor that runs `BigInt`'s drop glue so
+        // the limbs are freed instead of leaked when the collector reclaims a
+        // dead bigint. Registered at runtime id (no fixed const) and published
+        // to pyre-object via `set_bigint_gc_type_id`; the id is never embedded
+        // in a JIT descr (bigints are host-allocated, never `NewWithVtable`'d).
+        let bigint_tid = gc.register_type(TypeInfo::with_destructor(
+            pyre_object::longobject::BIGINT_PAYLOAD_SIZE,
+            pyre_object::longobject::bigint_destructor,
+        ));
+        pyre_object::longobject::set_bigint_gc_type_id(bigint_tid);
         // rclass.py:340-346 — assign subclassrange_{min,max} to each
         // vtable entry. freeze_types() runs assign_inheritance_ids
         // (normalizecalls.py:373-389), then we write the computed ranges

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1945,10 +1945,13 @@ thread_local! {
         // dead bigint. Registered at runtime id (no fixed const) and published
         // to pyre-object via `set_bigint_gc_type_id`; the id is never embedded
         // in a JIT descr (bigints are host-allocated, never `NewWithVtable`'d).
-        let bigint_tid = gc.register_type(TypeInfo::with_destructor(
-            pyre_object::longobject::BIGINT_PAYLOAD_SIZE,
-            pyre_object::longobject::bigint_destructor,
-        ));
+        let bigint_tid = gc.register_type(
+            TypeInfo::with_destructor(
+                pyre_object::longobject::BIGINT_PAYLOAD_SIZE,
+                pyre_object::longobject::bigint_destructor,
+            )
+            .with_external_size(pyre_object::longobject::bigint_external_size),
+        );
         pyre_object::longobject::set_bigint_gc_type_id(bigint_tid);
         // rclass.py:340-346 — assign subclassrange_{min,max} to each
         // vtable entry. freeze_types() runs assign_inheritance_ids

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -78,6 +78,13 @@ fn pyre_object_gc_charge_memory_pressure_trampoline(bytes: usize) {
     majit_gc::charge_memory_pressure(bytes);
 }
 
+/// Old-gen external-byte charge trampoline. Bridges a host stable bignum alloc
+/// (`alloc_bigint_stable`) to the active backend's major threshold without
+/// forcing a minor.
+fn pyre_object_gc_charge_oldgen_external_trampoline(bytes: usize) {
+    majit_gc::charge_oldgen_external(bytes);
+}
+
 /// `gc.collect()` (interp_gc.py:7-26) trampoline. Bridges
 /// pyre-object's `try_gc_collect` to `majit_gc::collect_full`, which
 /// fans out to the active backend's `dynasm_collect_full` /
@@ -2057,6 +2064,9 @@ thread_local! {
         );
         pyre_object::gc_hook::register_gc_charge_memory_pressure_hook(
             pyre_object_gc_charge_memory_pressure_trampoline,
+        );
+        pyre_object::gc_hook::register_gc_charge_oldgen_external_hook(
+            pyre_object_gc_charge_oldgen_external_trampoline,
         );
         pyre_object::register_gc_collect_hook(pyre_object_gc_collect_trampoline);
         pyre_object::gc_hook::register_gc_collect_oldgen_hook(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -81,8 +81,8 @@ fn pyre_object_gc_charge_memory_pressure_trampoline(bytes: usize) {
 /// Old-gen external-byte charge trampoline. Bridges a host stable bignum alloc
 /// (`alloc_bigint_stable`) to the active backend's major threshold without
 /// forcing a minor.
-fn pyre_object_gc_charge_oldgen_external_trampoline(bytes: usize) {
-    majit_gc::charge_oldgen_external(bytes);
+fn pyre_object_gc_charge_oldgen_external_trampoline(obj_addr: usize, bytes: usize) {
+    majit_gc::charge_oldgen_external(obj_addr, bytes);
 }
 
 /// `gc.collect()` (interp_gc.py:7-26) trampoline. Bridges

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -60,6 +60,24 @@ fn pyre_object_gc_alloc_stable_trampoline(type_id: u32, size: usize) -> *mut u8 
     majit_gc::alloc_oldgen_typed(type_id, size).0 as *mut u8
 }
 
+/// Trampoline for *collecting* nursery host-side allocations — routes
+/// pyre-object's collecting-allocation hook to the backend's collecting nursery
+/// allocator (minor-on-full). Only the elidable bigint payload helpers use it,
+/// from a gcmap-carrying residual call holding no unrooted pointer across the
+/// allocation, so the embedded minor cycle is safe.
+fn pyre_object_gc_alloc_collecting_trampoline(type_id: u32, size: usize) -> *mut u8 {
+    majit_gc::alloc_nursery_collecting_typed(type_id, size).0 as *mut u8
+}
+
+/// Trampoline for off-heap memory-pressure charges — routes pyre-object's
+/// memory-pressure hook to the backend's GC. The bignum collecting-alloc site
+/// charges its limb-`Vec` bytes here so minor cadence reflects true footprint;
+/// the charge may force a minor, safe because the caller is the same gcmap-rooted
+/// residual call as [`pyre_object_gc_alloc_collecting_trampoline`].
+fn pyre_object_gc_charge_memory_pressure_trampoline(bytes: usize) {
+    majit_gc::charge_memory_pressure(bytes);
+}
+
 /// `gc.collect()` (interp_gc.py:7-26) trampoline. Bridges
 /// pyre-object's `try_gc_collect` to `majit_gc::collect_full`, which
 /// fans out to the active backend's `dynasm_collect_full` /
@@ -2031,6 +2049,12 @@ thread_local! {
         // lives here.
         pyre_object::register_gc_alloc_hook(pyre_object_gc_alloc_trampoline);
         pyre_object::register_gc_alloc_stable_hook(pyre_object_gc_alloc_stable_trampoline);
+        pyre_object::gc_hook::register_gc_alloc_collecting_hook(
+            pyre_object_gc_alloc_collecting_trampoline,
+        );
+        pyre_object::gc_hook::register_gc_charge_memory_pressure_hook(
+            pyre_object_gc_charge_memory_pressure_trampoline,
+        );
         pyre_object::register_gc_collect_hook(pyre_object_gc_collect_trampoline);
         pyre_object::gc_hook::register_gc_collect_oldgen_hook(
             pyre_object_gc_collect_oldgen_trampoline,

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -137,10 +137,10 @@ pub fn try_gc_charge_memory_pressure(bytes: usize) {
     })
 }
 
-/// Signature of the host-side old-gen external-byte callback: add `bytes` of a
-/// directly-old-gen-allocated object's off-heap payload to the major-collection
-/// threshold's external total.
-pub type GcChargeOldgenExternalFn = fn(bytes: usize);
+/// Signature of the host-side old-gen external-byte callback: add `bytes` of
+/// `obj_addr`'s off-heap payload to the major-collection threshold's external
+/// total when the object is old-gen.
+pub type GcChargeOldgenExternalFn = fn(obj_addr: usize, bytes: usize);
 
 thread_local! {
     static GC_CHARGE_OLDGEN_EXTERNAL_HOOK: Cell<Option<GcChargeOldgenExternalFn>> =
@@ -157,17 +157,17 @@ pub fn clear_gc_charge_oldgen_external_hook() {
     GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| cell.set(None));
 }
 
-/// Charge `bytes` of an old-gen object's off-heap payload against the major
-/// threshold via the installed hook (no-op when none is installed). Unlike
-/// [`try_gc_charge_memory_pressure`] this never forces a minor, so it is safe on
-/// the unrooted host/interpreter stable-alloc path (`alloc_bigint_stable`): a
-/// directly-old-gen bignum's limb `Vec` would otherwise stay invisible to the
-/// threshold until the next major's `recompute_oldgen_external_bytes`.
+/// Charge `bytes` of `obj_addr`'s off-heap payload against the major threshold
+/// via the installed hook when the object is old-gen (no-op when none is
+/// installed). Unlike [`try_gc_charge_memory_pressure`] this never forces a
+/// minor, so it is safe after allocating an unrooted payload: a directly-old-gen
+/// bignum's limb `Vec` would otherwise stay invisible to the threshold until
+/// the next major's `recompute_oldgen_external_bytes`.
 #[inline]
-pub fn try_gc_charge_oldgen_external(bytes: usize) {
+pub fn try_gc_charge_oldgen_external(obj_addr: usize, bytes: usize) {
     GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| {
         if let Some(f) = cell.get() {
-            f(bytes);
+            f(obj_addr, bytes);
         }
     })
 }

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -78,6 +78,65 @@ pub fn try_gc_alloc_stable(type_id: u32, payload_size: usize) -> Option<*mut u8>
     GC_ALLOC_STABLE_HOOK.with(|cell| cell.get().map(|f| f(type_id, payload_size)))
 }
 
+thread_local! {
+    static GC_ALLOC_COLLECTING_HOOK: Cell<Option<GcAllocHookFn>> = const { Cell::new(None) };
+}
+
+/// Install the *collecting* nursery allocation callback for this thread.
+///
+/// Unlike [`register_gc_alloc_hook`] (no-collect), the backend routes this to a
+/// nursery allocator that runs a minor collection when the nursery is full. Only
+/// for callers that hold no unrooted GC pointer across the allocation and run at
+/// a JIT safepoint (gcmap-rooted) — i.e. the elidable bigint payload helpers.
+pub fn register_gc_alloc_collecting_hook(hook: GcAllocHookFn) {
+    GC_ALLOC_COLLECTING_HOOK.with(|cell| cell.set(Some(hook)));
+}
+
+/// Remove the collecting-allocation callback on this thread.
+pub fn clear_gc_alloc_collecting_hook() {
+    GC_ALLOC_COLLECTING_HOOK.with(|cell| cell.set(None));
+}
+
+/// Attempt a collecting GC nursery allocation via the installed hook. Returns
+/// `None` when no collecting hook is installed (callers fall back to the
+/// no-collect [`try_gc_alloc`]).
+#[inline]
+pub fn try_gc_alloc_collecting(type_id: u32, payload_size: usize) -> Option<*mut u8> {
+    GC_ALLOC_COLLECTING_HOOK.with(|cell| cell.get().map(|f| f(type_id, payload_size)))
+}
+
+/// Signature of the host-side memory-pressure callback: charge `bytes` of
+/// off-heap, GC-invisible payload (a bignum's external limb `Vec`).
+pub type GcChargeMemoryPressureFn = fn(bytes: usize);
+
+thread_local! {
+    static GC_CHARGE_MEMORY_PRESSURE_HOOK: Cell<Option<GcChargeMemoryPressureFn>> =
+        const { Cell::new(None) };
+}
+
+/// Install the memory-pressure callback for this thread.
+pub fn register_gc_charge_memory_pressure_hook(hook: GcChargeMemoryPressureFn) {
+    GC_CHARGE_MEMORY_PRESSURE_HOOK.with(|cell| cell.set(Some(hook)));
+}
+
+/// Remove the memory-pressure callback on this thread.
+pub fn clear_gc_charge_memory_pressure_hook() {
+    GC_CHARGE_MEMORY_PRESSURE_HOOK.with(|cell| cell.set(None));
+}
+
+/// Charge `bytes` of off-heap memory pressure via the installed hook (no-op when
+/// none is installed, e.g. bare unit tests or backends without a generational GC).
+/// Only the bignum collecting-alloc site calls this, from a gcmap-rooted residual
+/// call where a forced minor is safe.
+#[inline]
+pub fn try_gc_charge_memory_pressure(bytes: usize) {
+    GC_CHARGE_MEMORY_PRESSURE_HOOK.with(|cell| {
+        if let Some(f) = cell.get() {
+            f(bytes);
+        }
+    })
+}
+
 /// Signature of the host-side full-collection callback. Used by
 /// `pypy/module/gc/interp_gc.py:7-26 collect` ports — i.e. user-level
 /// `gc.collect()` reaches the live GC through this hook.

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -137,6 +137,41 @@ pub fn try_gc_charge_memory_pressure(bytes: usize) {
     })
 }
 
+/// Signature of the host-side old-gen external-byte callback: add `bytes` of a
+/// directly-old-gen-allocated object's off-heap payload to the major-collection
+/// threshold's external total.
+pub type GcChargeOldgenExternalFn = fn(bytes: usize);
+
+thread_local! {
+    static GC_CHARGE_OLDGEN_EXTERNAL_HOOK: Cell<Option<GcChargeOldgenExternalFn>> =
+        const { Cell::new(None) };
+}
+
+/// Install the old-gen external-byte callback for this thread.
+pub fn register_gc_charge_oldgen_external_hook(hook: GcChargeOldgenExternalFn) {
+    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| cell.set(Some(hook)));
+}
+
+/// Remove the old-gen external-byte callback on this thread.
+pub fn clear_gc_charge_oldgen_external_hook() {
+    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| cell.set(None));
+}
+
+/// Charge `bytes` of an old-gen object's off-heap payload against the major
+/// threshold via the installed hook (no-op when none is installed). Unlike
+/// [`try_gc_charge_memory_pressure`] this never forces a minor, so it is safe on
+/// the unrooted host/interpreter stable-alloc path (`alloc_bigint_stable`): a
+/// directly-old-gen bignum's limb `Vec` would otherwise stay invisible to the
+/// threshold until the next major's `recompute_oldgen_external_bytes`.
+#[inline]
+pub fn try_gc_charge_oldgen_external(bytes: usize) {
+    GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| {
+        if let Some(f) = cell.get() {
+            f(bytes);
+        }
+    })
+}
+
 /// Signature of the host-side full-collection callback. Used by
 /// `pypy/module/gc/interp_gc.py:7-26 collect` ports — i.e. user-level
 /// `gc.collect()` reaches the live GC through this hook.

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -1,8 +1,9 @@
 //! W_LongObject -- arbitrary-precision integer backed by `BigInt`.
 //!
 //! Used when i64 overflow is detected in `W_IntObject` arithmetic.
-//! The JIT never inlines bigint operations; `GuardClass(INT_TYPE)` rejects
-//! `W_LongObject` and deoptimizes back to the interpreter.
+//! The JIT may specialize bigint operations by reading immutable `value`
+//! payloads, calling pure raw-payload helpers, and boxing the resulting payload
+//! with the same `W_LongObject` layout.
 
 use malachite_bigint::BigInt;
 
@@ -11,7 +12,8 @@ use crate::pyobject::*;
 /// Arbitrary-precision integer object.
 ///
 /// Layout: `[ob_type: *const PyType | value: *mut BigInt]`
-/// The `value` pointer owns a heap-allocated `BigInt` (via `Box::into_raw`).
+/// The `value` pointer references an immutable `BigInt` payload, usually
+/// GC-managed and occasionally leaked via `malloc_raw` before GC init.
 #[repr(C)]
 pub struct W_LongObject {
     pub ob_header: PyObject,
@@ -91,10 +93,12 @@ pub fn alloc_bigint_nursery(value: BigInt) -> *mut BigInt {
         if let Some(raw) =
             crate::gc_hook::try_gc_alloc(tid, BIGINT_PAYLOAD_SIZE).filter(|p| !p.is_null())
         {
+            let external = bigint_external_bytes(&value);
             unsafe {
                 std::ptr::write(raw as *mut BigInt, value);
-                return raw as *mut BigInt;
             }
+            crate::gc_hook::try_gc_charge_oldgen_external(raw as usize, external);
+            return raw as *mut BigInt;
         }
     }
     crate::lltype::malloc_raw(value)
@@ -147,14 +151,16 @@ pub unsafe fn bigint_external_size(addr: usize) -> usize {
 pub fn alloc_bigint_nursery_collecting(value: BigInt) -> *mut BigInt {
     let tid = bigint_gc_type_id();
     if tid != 0 {
-        crate::gc_hook::try_gc_charge_memory_pressure(bigint_external_bytes(&value));
+        let external = bigint_external_bytes(&value);
+        crate::gc_hook::try_gc_charge_memory_pressure(external);
         if let Some(raw) = crate::gc_hook::try_gc_alloc_collecting(tid, BIGINT_PAYLOAD_SIZE)
             .filter(|p| !p.is_null())
         {
             unsafe {
                 std::ptr::write(raw as *mut BigInt, value);
-                return raw as *mut BigInt;
             }
+            crate::gc_hook::try_gc_charge_oldgen_external(raw as usize, external);
+            return raw as *mut BigInt;
         }
     }
     alloc_bigint_nursery(value)
@@ -180,7 +186,7 @@ pub fn alloc_bigint_stable(value: BigInt) -> *mut BigInt {
             unsafe {
                 std::ptr::write(raw as *mut BigInt, value);
             }
-            crate::gc_hook::try_gc_charge_oldgen_external(external);
+            crate::gc_hook::try_gc_charge_oldgen_external(raw as usize, external);
             return raw as *mut BigInt;
         }
     }
@@ -191,8 +197,8 @@ pub fn alloc_bigint_stable(value: BigInt) -> *mut BigInt {
 /// without copying the payload — the wrapper just stores `value`, it does not
 /// take exclusive ownership. Pure-call CSE of the elidable `rbigint` helpers
 /// can fold two ops to the same `*mut BigInt`, so one payload may back more
-/// than one wrapper; that is sound only because payloads are never freed
-/// (`malloc_raw` / `Box::leak`).
+/// than one wrapper; that is sound because payloads are immutable after
+/// initialization and every wrapper/trace op treats the payload as a GC ref.
 pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
     // W_LongObject shares the `int` type with W_IntObject — the two only
     // differ in their storage layout, not their Python-level identity

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -171,10 +171,17 @@ pub fn alloc_bigint_stable(value: BigInt) -> *mut BigInt {
         if let Some(raw) =
             crate::gc_hook::try_gc_alloc_stable(tid, BIGINT_PAYLOAD_SIZE).filter(|p| !p.is_null())
         {
+            // Charge the limb-`Vec` bytes against the old-gen external total so a
+            // directly-old-gen bignum's footprint enters the major threshold now,
+            // not only at the next major's recompute. No minor is forced, so this
+            // is safe on the unrooted host/interpreter path (a memory-pressure
+            // charge here could force an unsafe moving minor).
+            let external = bigint_external_bytes(&value);
             unsafe {
                 std::ptr::write(raw as *mut BigInt, value);
-                return raw as *mut BigInt;
             }
+            crate::gc_hook::try_gc_charge_oldgen_external(external);
+            return raw as *mut BigInt;
         }
     }
     crate::lltype::malloc_raw(value)
@@ -211,6 +218,11 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
             crate::gc_hook::try_gc_remove_root(&mut slot as *mut *mut u8);
         }
         if let Some(raw) = raw {
+            // Advance the dispatch-loop safepoint counter, as w_int_new /
+            // w_float_new do for their stable allocs — otherwise a long-dominated
+            // interpreter workload never reaches the safepoint threshold and the
+            // dead old-gen long wrappers + their bigint payloads accumulate.
+            crate::gc_interp::note_alloc();
             unsafe {
                 std::ptr::write(
                     raw as *mut W_LongObject,

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -100,6 +100,54 @@ pub fn alloc_bigint_nursery(value: BigInt) -> *mut BigInt {
     crate::lltype::malloc_raw(value)
 }
 
+/// The external (off-heap, GC-invisible) byte footprint of a `BigInt`'s limb
+/// `Vec` — `ceil(bits/64)` limbs of 8 bytes each. `bits()` is constant-time
+/// (reads only the top limb, no allocation). Values that fit one machine word
+/// (`bits <= 64`) are stored inline with no `Vec`, so they carry 0 external bytes.
+#[inline]
+fn bigint_external_bytes(value: &BigInt) -> usize {
+    let bits = value.bits();
+    if bits <= 64 {
+        0
+    } else {
+        ((bits + 63) / 64) as usize * 8
+    }
+}
+
+/// Allocate `value` as a GC-managed `BigInt` through the *collecting* nursery —
+/// a minor collection fires when the nursery is full (reclaiming dead bigints)
+/// instead of spilling to old-gen unbounded. Only for the elidable bigint
+/// payload helpers (`jit_bigint_*`), which the walker emits as a residual
+/// `CallR` whose gcmap roots the trace's live set, and which read both operand
+/// payloads into a local sum before allocating — so nothing unrooted is held
+/// across the embedded minor cycle. Falls back to the no-collect path when no
+/// collecting hook is installed (other backends), then to `malloc_raw`.
+///
+/// Before allocating, the result's limb-`Vec` bytes are charged as off-heap
+/// memory pressure so the nursery's minor cadence reflects the bignum's true
+/// footprint, not just the 48-byte struct the bump pointer tracks (otherwise the
+/// last nursery generation of large bigints accumulates uncollected). The charge
+/// may itself force a minor; that is safe here because it runs before the fresh
+/// `value` is written into the nursery (it still lives only on the Rust stack and
+/// holds no nursery GC pointer) while the operand bigints are already boxed and
+/// gcmap-rooted at the residual call.
+#[inline]
+pub fn alloc_bigint_nursery_collecting(value: BigInt) -> *mut BigInt {
+    let tid = bigint_gc_type_id();
+    if tid != 0 {
+        crate::gc_hook::try_gc_charge_memory_pressure(bigint_external_bytes(&value));
+        if let Some(raw) = crate::gc_hook::try_gc_alloc_collecting(tid, BIGINT_PAYLOAD_SIZE)
+            .filter(|p| !p.is_null())
+        {
+            unsafe {
+                std::ptr::write(raw as *mut BigInt, value);
+                return raw as *mut BigInt;
+            }
+        }
+    }
+    alloc_bigint_nursery(value)
+}
+
 /// Allocate `value` as a GC-managed `BigInt` at a stable (old-gen, non-moving)
 /// address, for host/interpreter callers (`w_long_new`) that hold the pointer
 /// on the Rust stack without rooting it. Mirrors `w_float_new`'s
@@ -152,7 +200,13 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
         }
         if let Some(raw) = raw {
             unsafe {
-                std::ptr::write(raw as *mut W_LongObject, W_LongObject { ob_header: header, value });
+                std::ptr::write(
+                    raw as *mut W_LongObject,
+                    W_LongObject {
+                        ob_header: header,
+                        value,
+                    },
+                );
             }
             // Creation write barrier: the old-gen wrapper may reference a young
             // bigint, so remember it for the next minor collection's tracer.
@@ -160,7 +214,10 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
             return raw as PyObjectRef;
         }
     }
-    crate::lltype::malloc_typed(W_LongObject { ob_header: header, value }) as PyObjectRef
+    crate::lltype::malloc_typed(W_LongObject {
+        ob_header: header,
+        value,
+    }) as PyObjectRef
 }
 
 /// Allocate a new W_LongObject on the heap from a `BigInt` value. The bigint
@@ -277,57 +334,50 @@ pub extern "C" fn jit_w_long_toint(obj: i64) -> i64 {
 /// `GuardNoException` covers the allocation. The result is an internal bigint
 /// never exposed to Python `is`, so sharing one payload for two equal-input
 /// adds is unobservable.
+/// Wrapper-level (`W_LongObject` operands) variants used for record-time
+/// concrete evaluation and the trait path, which run OUTSIDE a JIT safepoint and
+/// hold the operand wrappers natively — so they allocate via the NO-COLLECT
+/// `alloc_bigint_nursery` (a collection here would move the tracer's operands).
+/// The walker-emitted runtime call uses the collecting payload variants below.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
-    jit_bigint_add(a, b)
+    let (a, b) = (a as PyObjectRef, b as PyObjectRef);
+    unsafe { alloc_bigint_nursery(w_long_get_value(a) + w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.sub` — the payload half of `W_LongObject._sub`
-/// (`pypy/objspace/std/longobject.py`). Like [`jit_w_long_add_raw`] but
-/// subtracts; allocates, so `EF_ELIDABLE_OR_MEMORYERROR`.
+/// `rbigint.sub` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_sub_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
-    jit_bigint_sub(a, b)
+    let (a, b) = (a as PyObjectRef, b as PyObjectRef);
+    unsafe { alloc_bigint_nursery(w_long_get_value(a) - w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.mul` payload half of `W_LongObject._mul`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+/// `rbigint.mul` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_mul_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
-    jit_bigint_mul(a, b)
+    let (a, b) = (a as PyObjectRef, b as PyObjectRef);
+    unsafe { alloc_bigint_nursery(w_long_get_value(a) * w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.and_` payload half of `W_LongObject._and`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+/// `rbigint.and_` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_and_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
-    jit_bigint_and(a, b)
+    let (a, b) = (a as PyObjectRef, b as PyObjectRef);
+    unsafe { alloc_bigint_nursery(w_long_get_value(a) & w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.or_` payload half of `W_LongObject._or`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+/// `rbigint.or_` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_or_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
-    jit_bigint_or(a, b)
+    let (a, b) = (a as PyObjectRef, b as PyObjectRef);
+    unsafe { alloc_bigint_nursery(w_long_get_value(a) | w_long_get_value(b)) as i64 }
 }
 
-/// `rbigint.xor_` payload half of `W_LongObject._xor`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+/// `rbigint.xor_` over `W_LongObject` operands (no-collect). See [`jit_w_long_add_raw`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
-    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
-    jit_bigint_xor(a, b)
-}
-
-/// The bare `*mut BigInt` payload of a known `W_LongObject`, as the i64 the
-/// payload-helper ABI uses — the runtime value of `GetfieldGcPure(value)`.
-///
-/// # Safety
-/// `obj` must point to a valid `W_LongObject`.
-#[inline]
-unsafe fn w_long_payload_i64(obj: PyObjectRef) -> i64 {
-    unsafe { w_long_get_value(obj) as *const BigInt as i64 }
+    let (a, b) = (a as PyObjectRef, b as PyObjectRef);
+    unsafe { alloc_bigint_nursery(w_long_get_value(a) ^ w_long_get_value(b)) as i64 }
 }
 
 /// `rbigint.add`/`sub`/`mul`/`and_`/`or_`/`xor_` (`rpython/rlib/rbigint.py`,
@@ -336,7 +386,10 @@ unsafe fn w_long_payload_i64(obj: PyObjectRef) -> i64 {
 /// via `GetfieldGcPure`. Taking the payloads (not the `W_LongObject` wrappers)
 /// keeps the call's inputs the immutable bigints, so the optimizer forwards the
 /// field read and never reorders this elidable call ahead of the boxing
-/// `setfield_gc` that initializes the fresh result wrapper. Returns a freshly
+/// `setfield_gc` that initializes the fresh result wrapper. Allocates the result
+/// via the COLLECTING nursery (the call is a gcmap-rooted residual `CallR`
+/// holding no unrooted pointer across the alloc), so dead bigints are reclaimed
+/// by minor collections instead of accumulating in old-gen. Returns a freshly
 /// heap-allocated `*mut BigInt` (as i64). Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
 ///
 /// # Safety note: `extern "C"` over `i64`-encoded `*const BigInt`. The pointers
@@ -344,42 +397,42 @@ unsafe fn w_long_payload_i64(obj: PyObjectRef) -> i64 {
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { alloc_bigint_nursery(&*a + &*b) as i64 }
+    unsafe { alloc_bigint_nursery_collecting(&*a + &*b) as i64 }
 }
 
-/// `rbigint.sub` on bare payloads. See [`jit_bigint_add`].
+/// `rbigint.sub` on bare payloads (collecting). See [`jit_bigint_add`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { alloc_bigint_nursery(&*a - &*b) as i64 }
+    unsafe { alloc_bigint_nursery_collecting(&*a - &*b) as i64 }
 }
 
-/// `rbigint.mul` on bare payloads. See [`jit_bigint_add`].
+/// `rbigint.mul` on bare payloads (collecting). See [`jit_bigint_add`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_mul(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { alloc_bigint_nursery(&*a * &*b) as i64 }
+    unsafe { alloc_bigint_nursery_collecting(&*a * &*b) as i64 }
 }
 
-/// `rbigint.and_` on bare payloads. See [`jit_bigint_add`].
+/// `rbigint.and_` on bare payloads (collecting). See [`jit_bigint_add`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_and(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { alloc_bigint_nursery(&*a & &*b) as i64 }
+    unsafe { alloc_bigint_nursery_collecting(&*a & &*b) as i64 }
 }
 
-/// `rbigint.or_` on bare payloads. See [`jit_bigint_add`].
+/// `rbigint.or_` on bare payloads (collecting). See [`jit_bigint_add`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_or(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { alloc_bigint_nursery(&*a | &*b) as i64 }
+    unsafe { alloc_bigint_nursery_collecting(&*a | &*b) as i64 }
 }
 
-/// `rbigint.xor_` on bare payloads. See [`jit_bigint_add`].
+/// `rbigint.xor_` on bare payloads (collecting). See [`jit_bigint_add`].
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_xor(a: i64, b: i64) -> i64 {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { alloc_bigint_nursery(&*a ^ &*b) as i64 }
+    unsafe { alloc_bigint_nursery_collecting(&*a ^ &*b) as i64 }
 }
 
 /// `rbigint` comparison payload for `W_LongObject` — returns the sign of

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -114,6 +114,18 @@ fn bigint_external_bytes(value: &BigInt) -> usize {
     }
 }
 
+/// External (off-heap) byte footprint of a GC `BigInt` payload at `addr` — the
+/// payload base is the `BigInt` itself (see [`bigint_destructor`]). Registered
+/// as the type's `external_size` so the collector folds a promoted bigint's
+/// limb `Vec` into the major-collection threshold.
+///
+/// # Safety
+/// `addr` must point at a live, initialized `BigInt` payload (true for a
+/// promoted or surviving old-gen bigint the collector is accounting for).
+pub unsafe fn bigint_external_size(addr: usize) -> usize {
+    bigint_external_bytes(unsafe { &*(addr as *const BigInt) })
+}
+
 /// Allocate `value` as a GC-managed `BigInt` through the *collecting* nursery —
 /// a minor collection fires when the nursery is full (reclaiming dead bigints)
 /// instead of spilling to old-gen unbounded. Only for the elidable bigint

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -39,6 +39,87 @@ impl crate::lltype::GcType for W_LongObject {
     const SIZE: usize = W_LONG_OBJECT_SIZE;
 }
 
+/// Payload size of a raw `BigInt` GC object (the malachite struct only; its
+/// limb `Vec` lives in malachite's own heap and is freed by [`bigint_destructor`]).
+pub const BIGINT_PAYLOAD_SIZE: usize = std::mem::size_of::<BigInt>();
+
+/// GC type id for the raw `BigInt` payload, published at JitDriver init by
+/// `set_bigint_gc_type_id`. `0` until then, in which case the alloc helpers
+/// fall back to the leaked `malloc_raw` (bare unit tests / pre-init bootstrap).
+///
+/// Unlike the `W_*` object ids this is set at runtime rather than a fixed
+/// const: the `BigInt` payload is never embedded in a JIT descr (it is only
+/// ever allocated by the host `try_gc_alloc` path, never `NewWithVtable`'d in a
+/// trace), so it needs no compile-time-stable value.
+static BIGINT_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Record the GC type id registered for the `BigInt` payload (called once from
+/// `pyre-jit::eval` after `gc.register_type`).
+pub fn set_bigint_gc_type_id(id: u32) {
+    BIGINT_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[inline]
+fn bigint_gc_type_id() -> u32 {
+    BIGINT_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Lightweight GC destructor for the `BigInt` payload: run its drop glue so
+/// malachite's limb `Vec` is freed when the collector reclaims a dead bigint.
+/// Registered on [`BIGINT_GC_TYPE_ID`] via `TypeInfo::with_destructor`; the
+/// copying nursery would otherwise abandon the payload without dropping it,
+/// leaking the limbs (the `malloc_raw` leak this whole path replaces).
+///
+/// # Safety
+/// `addr` must point at a live, initialized `BigInt` payload the GC is
+/// reclaiming. The collector calls it exactly once, on the final dead copy
+/// (a survived/forwarded object is re-listed, never destructed).
+pub unsafe fn bigint_destructor(addr: usize) {
+    unsafe { std::ptr::drop_in_place(addr as *mut BigInt) }
+}
+
+/// Allocate `value` as a GC-managed `BigInt` in the nursery (no-collect host
+/// path). For the JIT `*_raw` arithmetic helpers, whose result flows straight
+/// into the boxing `NewWithVtable` in the same trace — that collecting NEW
+/// gcmap-roots the returned pointer, so a young payload is forwarded/promoted
+/// rather than dangling. Falls back to the leaked `malloc_raw` when no GC hook
+/// is installed (bare unit tests, where the result is never traced).
+#[inline]
+pub fn alloc_bigint_nursery(value: BigInt) -> *mut BigInt {
+    let tid = bigint_gc_type_id();
+    if tid != 0 {
+        if let Some(raw) =
+            crate::gc_hook::try_gc_alloc(tid, BIGINT_PAYLOAD_SIZE).filter(|p| !p.is_null())
+        {
+            unsafe {
+                std::ptr::write(raw as *mut BigInt, value);
+                return raw as *mut BigInt;
+            }
+        }
+    }
+    crate::lltype::malloc_raw(value)
+}
+
+/// Allocate `value` as a GC-managed `BigInt` at a stable (old-gen, non-moving)
+/// address, for host/interpreter callers (`w_long_new`) that hold the pointer
+/// on the Rust stack without rooting it. Mirrors `w_float_new`'s
+/// `try_gc_alloc_stable`. Falls back to the leaked `malloc_raw` pre-init.
+#[inline]
+pub fn alloc_bigint_stable(value: BigInt) -> *mut BigInt {
+    let tid = bigint_gc_type_id();
+    if tid != 0 {
+        if let Some(raw) =
+            crate::gc_hook::try_gc_alloc_stable(tid, BIGINT_PAYLOAD_SIZE).filter(|p| !p.is_null())
+        {
+            unsafe {
+                std::ptr::write(raw as *mut BigInt, value);
+                return raw as *mut BigInt;
+            }
+        }
+    }
+    crate::lltype::malloc_raw(value)
+}
+
 /// Wrap an already heap-allocated `*mut BigInt` in a fresh W_LongObject
 /// without copying the payload — the wrapper just stores `value`, it does not
 /// take exclusive ownership. Pure-call CSE of the elidable `rbigint` helpers
@@ -51,18 +132,43 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
     // (PyPy does the same via W_AbstractIntObject's typedef). Wire
     // `w_class` to INT_TYPE.instantiate so `type(x) is int` and
     // `isinstance(x, int)` both hold for long integers.
-    crate::lltype::malloc_typed(W_LongObject {
-        ob_header: PyObject {
-            ob_type: &LONG_TYPE as *const PyType,
-            w_class: get_instantiate(&INT_TYPE),
-        },
-        value,
-    }) as PyObjectRef
+    let header = PyObject {
+        ob_type: &LONG_TYPE as *const PyType,
+        w_class: get_instantiate(&INT_TYPE),
+    };
+    if crate::gc_interp::enabled() {
+        // Pin the (possibly young) `value` payload across the wrapper malloc:
+        // a minor collection inside `try_gc_alloc_stable` can move a young
+        // bigint, so re-read its address afterwards. The proxy/dictproxy
+        // `gct_fv_gc_malloc` bracket pattern, but for a raw `*mut BigInt`
+        // rooted as a GcRef slot rather than a PyObjectRef.
+        let mut slot = value as *mut u8;
+        let pinned = unsafe { crate::gc_hook::try_gc_add_root(&mut slot as *mut *mut u8) };
+        let raw = crate::gc_hook::try_gc_alloc_stable(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE)
+            .filter(|p| !p.is_null());
+        let value = slot as *mut BigInt;
+        if pinned {
+            crate::gc_hook::try_gc_remove_root(&mut slot as *mut *mut u8);
+        }
+        if let Some(raw) = raw {
+            unsafe {
+                std::ptr::write(raw as *mut W_LongObject, W_LongObject { ob_header: header, value });
+            }
+            // Creation write barrier: the old-gen wrapper may reference a young
+            // bigint, so remember it for the next minor collection's tracer.
+            crate::gc_hook::try_gc_write_barrier(raw);
+            return raw as PyObjectRef;
+        }
+    }
+    crate::lltype::malloc_typed(W_LongObject { ob_header: header, value }) as PyObjectRef
 }
 
-/// Allocate a new W_LongObject on the heap from a `BigInt` value.
+/// Allocate a new W_LongObject on the heap from a `BigInt` value. The bigint
+/// payload is GC-managed at a stable address (held on the Rust stack by host
+/// callers without rooting), and the wrapper traces it via the registered
+/// `LONG_VALUE_OFFSET` gc-pointer.
 pub fn w_long_new(value: BigInt) -> PyObjectRef {
-    w_long_from_raw(crate::lltype::malloc_raw(value))
+    w_long_from_raw(alloc_bigint_stable(value))
 }
 
 /// Create a W_LongObject from an i64 value.
@@ -123,6 +229,22 @@ pub extern "C" fn jit_w_long_fits_int(obj: i64) -> i64 {
     unsafe { w_long_fits_int(obj) as i64 }
 }
 
+/// `rbigint.fits_int()` on a bare `*mut BigInt` — the demote guard for the
+/// inline-NEW boxing of a `jit_w_long_*_raw` result. Returns 1 when the bigint
+/// fits i64 (i.e. should demote to `W_IntObject`), 0 otherwise. The walker/trait
+/// emit `GuardFalse(fits)` after the raw op so a result that does fit deopts to
+/// the interpreter (which performs the demote); the common bigint case (does
+/// not fit) passes the guard and falls through to `NewWithVtable(W_LONG)`.
+/// Non-elidable, cannot-raise (mirrors [`jit_w_long_fits_int`]).
+///
+/// # Safety note: `extern "C"` over an `i64`-encoded `*mut BigInt`, matching the
+/// raw-helper ABI. The pointer is a live GC bigint produced by a preceding
+/// raw op in the same trace.
+pub extern "C" fn jit_bigint_fits_int(num: i64) -> i64 {
+    let num = num as *const BigInt;
+    unsafe { i64::try_from(&*num).is_ok() as i64 }
+}
+
 /// `W_LongObject.toint()` (`pypy/objspace/std/longobject.py:138`) →
 /// `rbigint.toint()` (`rpython/rlib/rbigint.py:465`, `@jit.elidable`).
 /// Extract an i64 from a W_LongObject. RPython `toint` raises
@@ -157,12 +279,8 @@ pub extern "C" fn jit_w_long_toint(obj: i64) -> i64 {
 /// adds is unobservable.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe {
-        let sum = w_long_get_value(a) + w_long_get_value(b);
-        crate::lltype::malloc_raw(sum) as i64
-    }
+    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
+    jit_bigint_add(a, b)
 }
 
 /// `rbigint.sub` — the payload half of `W_LongObject._sub`
@@ -170,41 +288,98 @@ pub extern "C" fn jit_w_long_add_raw(a: i64, b: i64) -> i64 {
 /// subtracts; allocates, so `EF_ELIDABLE_OR_MEMORYERROR`.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_sub_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) - w_long_get_value(b)) as i64 }
+    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
+    jit_bigint_sub(a, b)
 }
 
 /// `rbigint.mul` payload half of `W_LongObject._mul`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_mul_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) * w_long_get_value(b)) as i64 }
+    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
+    jit_bigint_mul(a, b)
 }
 
 /// `rbigint.and_` payload half of `W_LongObject._and`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_and_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) & w_long_get_value(b)) as i64 }
+    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
+    jit_bigint_and(a, b)
 }
 
 /// `rbigint.or_` payload half of `W_LongObject._or`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_or_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) | w_long_get_value(b)) as i64 }
+    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
+    jit_bigint_or(a, b)
 }
 
 /// `rbigint.xor_` payload half of `W_LongObject._xor`. Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_w_long_xor_raw(a: i64, b: i64) -> i64 {
-    let a = a as PyObjectRef;
-    let b = b as PyObjectRef;
-    unsafe { crate::lltype::malloc_raw(w_long_get_value(a) ^ w_long_get_value(b)) as i64 }
+    let (a, b) = unsafe { (w_long_payload_i64(a as PyObjectRef), w_long_payload_i64(b as PyObjectRef)) };
+    jit_bigint_xor(a, b)
+}
+
+/// The bare `*mut BigInt` payload of a known `W_LongObject`, as the i64 the
+/// payload-helper ABI uses — the runtime value of `GetfieldGcPure(value)`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_LongObject`.
+#[inline]
+unsafe fn w_long_payload_i64(obj: PyObjectRef) -> i64 {
+    unsafe { w_long_get_value(obj) as *const BigInt as i64 }
+}
+
+/// `rbigint.add`/`sub`/`mul`/`and_`/`or_`/`xor_` (`rpython/rlib/rbigint.py`,
+/// each `@jit.elidable`) on bare `*const BigInt` payloads — the elidable
+/// arithmetic the walker emits after reading each operand's immutable `value`
+/// via `GetfieldGcPure`. Taking the payloads (not the `W_LongObject` wrappers)
+/// keeps the call's inputs the immutable bigints, so the optimizer forwards the
+/// field read and never reorders this elidable call ahead of the boxing
+/// `setfield_gc` that initializes the fresh result wrapper. Returns a freshly
+/// heap-allocated `*mut BigInt` (as i64). Allocates → `EF_ELIDABLE_OR_MEMORYERROR`.
+///
+/// # Safety note: `extern "C"` over `i64`-encoded `*const BigInt`. The pointers
+/// are live GC bigints (the operands' value fields) for the duration of the call.
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { alloc_bigint_nursery(&*a + &*b) as i64 }
+}
+
+/// `rbigint.sub` on bare payloads. See [`jit_bigint_add`].
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { alloc_bigint_nursery(&*a - &*b) as i64 }
+}
+
+/// `rbigint.mul` on bare payloads. See [`jit_bigint_add`].
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_mul(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { alloc_bigint_nursery(&*a * &*b) as i64 }
+}
+
+/// `rbigint.and_` on bare payloads. See [`jit_bigint_add`].
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_and(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { alloc_bigint_nursery(&*a & &*b) as i64 }
+}
+
+/// `rbigint.or_` on bare payloads. See [`jit_bigint_add`].
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_or(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { alloc_bigint_nursery(&*a | &*b) as i64 }
+}
+
+/// `rbigint.xor_` on bare payloads. See [`jit_bigint_add`].
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_xor(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { alloc_bigint_nursery(&*a ^ &*b) as i64 }
 }
 
 /// `rbigint` comparison payload for `W_LongObject` — returns the sign of

--- a/pyre/pyrex/Cargo.toml
+++ b/pyre/pyrex/Cargo.toml
@@ -27,6 +27,12 @@ default = ["dynasm"]
 jit = []  # meta feature: enabled by cranelift or dynasm
 cranelift = ["jit", "pyre-jit/cranelift"]
 dynasm = ["jit", "pyre-jit/dynasm"]
+# Opt-in: use mimalloc as the global allocator. OFF by default. The bignum path
+# allocates a fresh limb Vec per rbigint op through the global allocator; the
+# platform default (notably the Windows system heap) dominates the per-op cost,
+# so mimalloc roughly halves bignum-heavy workloads (fib_loop beats PyPy).
+# Enable with e.g. `--features dynasm,mimalloc`.
+mimalloc = ["dep:mimalloc"]
 
 [dependencies]
 pyre-object = { workspace = true }
@@ -37,3 +43,4 @@ lexopt = { workspace = true }
 rustpython-compiler = { workspace = true }
 dirs = { workspace = true }
 rustyline = { workspace = true }
+mimalloc = { version = "0.1", optional = true }

--- a/pyre/pyrex/src/bin/pyre-cranelift.rs
+++ b/pyre/pyrex/src/bin/pyre-cranelift.rs
@@ -1,3 +1,8 @@
+// Opt-in (`--features mimalloc`); see `pyre-dynasm.rs`. OFF by default.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     pyrex::main_entry("pyre-cranelift");
 }

--- a/pyre/pyrex/src/bin/pyre-dynasm.rs
+++ b/pyre/pyrex/src/bin/pyre-dynasm.rs
@@ -1,3 +1,10 @@
+// Opt-in (`--features mimalloc`): mimalloc roughly halves bignum-heavy
+// workloads by replacing the platform default heap on the per-rbigint-op limb
+// Vec allocation. OFF by default.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     pyrex::main_entry("pyre-dynasm");
 }

--- a/pyre/pyrex/src/main.rs
+++ b/pyre/pyrex/src/main.rs
@@ -1,3 +1,8 @@
+// Opt-in (`--features mimalloc`); see `bin/pyre-dynasm.rs`. OFF by default.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     pyrex::main_entry("pyre");
 }


### PR DESCRIPTION
fix #268

## Summary

`W_LongObject.value` (the rbigint payload) was `malloc_raw`'d (`Box::into_raw` — no GC
header, never freed), so every bignum result leaked. `fib_loop` accumulated ~300k growing
bignums → allocator/cache/TLB collapse (the root of the bignum-path slowdown vs PyPy). This
routes the BigInt payload through the GC so dead bignums are reclaimed.

Two parts (the issue's chosen single combined change):

### Part 1 — majit-gc lightweight destructors (`9cbdbed1a3`)
`TypeInfo.destructor` + young/old object-with-destructor lists +
`deal_with_*_objects_with_destructors` (incminimark.py:2884-2912 parity, `T_HAS_DESTRUCTOR`
bit). Runs `drop_in_place::<BigInt>` on dead bignums so malachite's external limb `Vec` is
freed.

### Part 2/3 — bignum GC/nursery representation (`0ceef909cf`)
- BigInt payload alloc'd via the GC hooks (nursery / old-gen stable), `malloc_raw` only as a
  no-hook fallback; `W_LONG` registered with its `value` field as a gc-pointer offset; a
  `BIGINT` GC type carrying the `drop_in_place` destructor.
- Boxing = inline `NewWithVtable(W_LONG)` + `setfield_gc(value)` behind a
  `GuardFalse(fits_int)` demote guard. The `NewWithVtable` lowers to the collecting
  `CallMallocNursery` — the per-iteration safepoint bigint loops previously lacked.
- The walker reads each operand's immutable `value` via `GetfieldGcPure` and calls the
  elidable rbigint op on the bare `*const BigInt` payloads (`W_LongObject(self.num.add(
  other.num))` parity). Passing the payloads, not the wrappers, keeps the elidable call pure
  on the immutable bigints so the optimizer never reorders it ahead of the boxing setfield.

## Root-caused crash (fixed here)
A JIT-compiled long loop *inside a function* segfaulted on BOTH backends (top-level loops and
no-loop functions were fine → logic/IR bug, not codegen). The elidable op took the
`W_LongObject` *wrappers* and read `.value` opaquely; after the function-loop unroll the
optimizer reordered the elidable `CallR` ahead of the boxing `setfield_gc` that initializes
the fresh result wrapper → it read an uninitialized BigInt pointer. The payload-based
emission above is the fix.

## Verification
- Function-loop crash gone; `fib_loop` + all 8 benchmarks correct on dynasm AND cranelift.
- `majit-gc` 165 / `pyre-object` 194 tests green (4 `jitcode_runtime` failures are
  pre-existing and unrelated — `PopTop#23` arm-numbering, fail on a clean tree).
- Collections now occur (fn `fib(200000)` → 3 minors vs 0 before).
- Leak proof: `fib(100000)`×5 RSS ≈ `fib(100000)`×1 (5× the dead bignums, +14% RSS) →
  reclaimed, no cumulative leak.
- Perf: the machine-independent `fib_loop / int_loop` ratio drops 7.90 → 3.54, i.e. ~2.2×
  faster on the bignum path.

### Part 4 — within-run RSS: collecting alloc + memory pressure (`0af65788ff`)
Part 2/3's bignum alloc was no-collect → a long bignum loop filled the nursery once and
spilled the rest to old-gen unbounded (`fib(100000)` peaked ~316MB, `fib(300000)` ~1.3GB).

- Route the runtime payload helpers (`jit_bigint_*`) through a **collecting** nursery alloc
  (new host-hook chain mirroring the no-collect one, both backends). The wrapper helpers
  (`jit_w_long_*_raw`, record-time / trait path) stay no-collect since the tracer holds their
  operands natively; the shared div/mod/shift logic is extracted into
  `bigint_*_core(a, b, collecting)`.
- **Memory pressure** (RPython `rgc.add_memory_pressure` analog): `charge_memory_pressure`
  adds a `pressure_since_minor` counter and forces a minor when nursery struct-fill + charged
  external bytes reach the nursery size (reset at each minor). The bignum site charges
  `ceil(bits/64)*8` external limb-`Vec` bytes before allocating — so minor cadence reflects
  true footprint, not just the 48-byte struct. Collecting alone did nothing (the nursery only
  counts the struct); the pressure charge is the load-bearing fix.

Results (release, peak working set), both dynasm and cranelift:

| case | minors | peak RSS | vs Part 2/3 |
|---|---|---|---|
| `fib(100000)` | 1 → 105 | 316 → **~59 MB** | **5.4×** |
| `fib(300000)` | 5 → 934 | 1308 → **~157 MB** | **8.3×** |

Also **faster**: the small working set wins cache/TLB locality (`fib_loop / int_loop` ratio
3.54 → 2.46), outweighing the extra memzero. The residual-call gcmap-under-forced-collection
is proven safe on both backends (1000+ forced minors, all benches + function-loops correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bigint handling in the JIT and interpreter, including better support for shifts and division, plus more consistent allocation behavior.
  * Added support for tracking off-heap memory use, which can help the runtime make better GC decisions.
  * Added an optional allocator feature for improved performance on bigint-heavy workloads.

* **Bug Fixes**
  * Improved garbage collection behavior for objects with custom cleanup needs.
  * Reduced unnecessary test job duplication across operating systems in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->