### PR TITLE
Reconcile majit rtyper parity surfaces and fix #274 regressions

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -1459,11 +1459,10 @@ impl<'a> IntegralForwardModification<'a> {
                 }
             }
             self.set_index_var(result, idx);
-        } else {
-            // Both non-const: track the variable.
-            let idx = self.get_or_create(a0, &b0);
-            self.set_index_var(result, idx);
         }
+        // No var/var branch: `additive_func_source` only handles const/const,
+        // const/var, and var/const (dependency.py:899-913); a non-const ±
+        // non-const result is intentionally left untracked in `index_vars`.
     }
 
     /// dependency.py:922-948: operation_INT_MUL.

--- a/majit/majit-translate/src/flowspace/argument.rs
+++ b/majit/majit-translate/src/flowspace/argument.rs
@@ -86,8 +86,7 @@ impl Signature {
     }
 
     /// RPython `Signature.__getitem__` (argument.py:51-58).
-    #[allow(dead_code)]
-    fn getitem(&self, i: usize) -> SignatureItem<'_> {
+    pub fn getitem(&self, i: usize) -> SignatureItem<'_> {
         match i {
             0 => SignatureItem::Argnames(&self.argnames),
             1 => SignatureItem::Varargname(self.varargname.as_deref()),
@@ -101,9 +100,8 @@ impl Signature {
 ///
 /// Kept for RPython `Signature.__getitem__` parity even though current Rust
 /// callers prefer [`Signature::tuple_view`].
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SignatureItem<'a> {
+pub enum SignatureItem<'a> {
     Argnames(&'a [String]),
     Varargname(Option<&'a str>),
     Kwargname(Option<&'a str>),

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3702,7 +3702,19 @@ pub fn remove_duplicate_inputargs(graph: &mut FunctionGraph) {
             }
         }
         for (dup_i, _) in removable_slots.into_iter().rev() {
+            // The dropped slot also carries a matching `OpKind::Input` op
+            // (renamed onto the surviving duplicate by the rename above), so
+            // remove one per slot — same as the phi-slot dedup path and
+            // `prune_dead_phis` Step 7.  Leaving it behind would expose an
+            // in-block parameter that no predecessor supplies to later
+            // operation-walking passes.
+            let slot = graph.blocks[block_idx].inputargs[dup_i].clone();
             graph.blocks[block_idx].inputargs.remove(dup_i);
+            if let Some(op_idx) = graph.blocks[block_idx].operations.iter().position(|op| {
+                matches!(op.kind, OpKind::Input { .. }) && op.result.as_ref() == Some(&slot)
+            }) {
+                graph.blocks[block_idx].operations.remove(op_idx);
+            }
             for pred_idx in 0..graph.blocks.len() {
                 for link in &mut graph.blocks[pred_idx].exits {
                     if link.target == block_id {

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3702,17 +3702,27 @@ pub fn remove_duplicate_inputargs(graph: &mut FunctionGraph) {
             }
         }
         for (dup_i, _) in removable_slots.into_iter().rev() {
-            // The dropped slot also carries a matching `OpKind::Input` op
-            // (renamed onto the surviving duplicate by the rename above), so
-            // remove one per slot — same as the phi-slot dedup path and
-            // `prune_dead_phis` Step 7.  Leaving it behind would expose an
-            // in-block parameter that no predecessor supplies to later
-            // operation-walking passes.
-            let slot = graph.blocks[block_idx].inputargs[dup_i].clone();
+            // Drop the `OpKind::Input` op paired with the DUPLICATE slot by its
+            // slot position — `del block.inputargs[i]` by index
+            // (simplify.py:650-653).  After the rename several Input ops can
+            // share the survivor's result, so a result match would risk
+            // dropping the survivor (first-seen) slot's own `name`/`ty`/
+            // `class_root` metadata instead of the duplicate's.  The k-th
+            // `OpKind::Input` op mirrors the k-th inputarg (paired in order at
+            // construction; earlier passes preserve that order).
+            let mut seen_inputs = 0usize;
+            let mut dup_op_idx = None;
+            for (op_idx, op) in graph.blocks[block_idx].operations.iter().enumerate() {
+                if matches!(op.kind, OpKind::Input { .. }) {
+                    if seen_inputs == dup_i {
+                        dup_op_idx = Some(op_idx);
+                        break;
+                    }
+                    seen_inputs += 1;
+                }
+            }
             graph.blocks[block_idx].inputargs.remove(dup_i);
-            if let Some(op_idx) = graph.blocks[block_idx].operations.iter().position(|op| {
-                matches!(op.kind, OpKind::Input { .. }) && op.result.as_ref() == Some(&slot)
-            }) {
+            if let Some(op_idx) = dup_op_idx {
                 graph.blocks[block_idx].operations.remove(op_idx);
             }
             for pred_idx in 0..graph.blocks.len() {

--- a/majit/majit-translate/src/tool/algo/regalloc.rs
+++ b/majit/majit-translate/src/tool/algo/regalloc.rs
@@ -95,8 +95,12 @@ impl RegAllocatorState {
         graph: &FunctionGraph,
         consider: &dyn Fn(&crate::flowspace::model::Variable) -> bool,
     ) {
-        for block in &graph.blocks {
-            self.process_block(block, consider);
+        // `for block in self.graph.iterblocks()` (regalloc.py:27): walk
+        // reachable blocks in `iterblocks()` DFS order — not raw `graph.blocks`
+        // storage order — so depgraph node insertion (and the coloring derived
+        // from it) matches, consistent with `coalesce_variables`.
+        for bid in graph.iterblocks_order() {
+            self.process_block(graph.block(bid), consider);
         }
     }
 

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/opimpl.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/opimpl.rs
@@ -56,6 +56,12 @@ pub type FoldFn = fn(&[ConstValue]) -> Option<ConstValue>;
 /// RPython `ops_returning_a_bool`.
 pub const ops_returning_a_bool: &[&str] = &["gt", "ge", "lt", "le", "eq", "ne", "bool", "is_true"];
 
+/// RPython `r_longlonglong_arg = r_longlonglong`.
+pub type r_longlonglong_arg = i128;
+
+/// RPython `r_longlonglong_result = r_longlonglong`.
+pub type r_longlonglong_result = i128;
+
 /// RPython `argtype_by_name` keys. The values are host Python type objects
 /// upstream; the Rust fold path enforces them through `ConstValue` carriers.
 pub const argtype_by_name: &[&str] = &[

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rgcref.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rgcref.rs
@@ -27,11 +27,25 @@ use crate::translator::rtyper::rtyper::{
     variable_with_lltype,
 };
 
+/// RPython `UNKNOWN = object()` (`rgcref.py:6`): sentinel marking a
+/// `_ll_eq_func` / `_ll_hash_func` slot as not-yet-computed, distinct from a
+/// computed `None` (the base repr has no eq/hash helper).
+#[derive(Debug, Clone)]
+enum LlHelperCache {
+    Unknown,
+    Computed(Option<LowLevelFunction>),
+}
+
 #[derive(Debug)]
 pub struct GCRefRepr {
     r_base: Arc<dyn Repr>,
     lltype: LowLevelType,
     state: ReprState,
+    /// `self._ll_eq_func = UNKNOWN` (`rgcref.py:21`), memoized on first
+    /// `get_ll_eq_function` call.
+    _ll_eq_func: RefCell<LlHelperCache>,
+    /// `self._ll_hash_func = UNKNOWN` (`rgcref.py:22`).
+    _ll_hash_func: RefCell<LlHelperCache>,
 }
 
 impl GCRefRepr {
@@ -48,6 +62,8 @@ impl GCRefRepr {
             r_base,
             lltype: GCREF.clone(),
             state: ReprState::new(),
+            _ll_eq_func: RefCell::new(LlHelperCache::Unknown),
+            _ll_hash_func: RefCell::new(LlHelperCache::Unknown),
         });
         cache.borrow_mut().insert(key, repr.clone());
         repr
@@ -92,60 +108,77 @@ impl Repr for GCRefRepr {
         ))
     }
 
+    /// RPython `GCRefRepr.get_ll_eq_function` (`rgcref.py:32-46`): compute the
+    /// wrapper once, caching it in `_ll_eq_func` past the `UNKNOWN` sentinel.
     fn get_ll_eq_function(
         &self,
         rtyper: &RPythonTyper,
     ) -> Result<Option<LowLevelFunction>, TyperError> {
-        let Some(base_eq) = self.r_base.get_ll_eq_function(rtyper)? else {
-            return Ok(None);
-        };
-        let name = format!("ll_gcref_eq_{}", self.r_base.lowleveltype().short_name());
-        let base_lltype = self.r_base.lowleveltype().clone();
-        rtyper
-            .lowlevel_helper_function_with_builder(
-                name.clone(),
-                vec![self.lltype.clone(), self.lltype.clone()],
-                LowLevelType::Bool,
-                move |_rtyper, args, result| {
-                    build_gcref_wrapper_graph(
-                        &name,
-                        args,
-                        result,
-                        &base_lltype,
-                        base_eq.clone(),
-                        "ptr",
-                    )
-                },
-            )
-            .map(Some)
+        if matches!(*self._ll_eq_func.borrow(), LlHelperCache::Unknown) {
+            let ll_eq_func = match self.r_base.get_ll_eq_function(rtyper)? {
+                None => None,
+                Some(base_eq) => {
+                    let name = format!("ll_gcref_eq_{}", self.r_base.lowleveltype().short_name());
+                    let base_lltype = self.r_base.lowleveltype().clone();
+                    Some(rtyper.lowlevel_helper_function_with_builder(
+                        name.clone(),
+                        vec![self.lltype.clone(), self.lltype.clone()],
+                        LowLevelType::Bool,
+                        move |_rtyper, args, result| {
+                            build_gcref_wrapper_graph(
+                                &name,
+                                args,
+                                result,
+                                &base_lltype,
+                                base_eq.clone(),
+                                "ptr",
+                            )
+                        },
+                    )?)
+                }
+            };
+            *self._ll_eq_func.borrow_mut() = LlHelperCache::Computed(ll_eq_func);
+        }
+        match &*self._ll_eq_func.borrow() {
+            LlHelperCache::Computed(func) => Ok(func.clone()),
+            LlHelperCache::Unknown => unreachable!("_ll_eq_func computed above"),
+        }
     }
 
+    /// RPython `GCRefRepr.get_ll_hash_function` (`rgcref.py:48-62`).
     fn get_ll_hash_function(
         &self,
         rtyper: &RPythonTyper,
     ) -> Result<Option<LowLevelFunction>, TyperError> {
-        let Some(base_hash) = self.r_base.get_ll_hash_function(rtyper)? else {
-            return Ok(None);
-        };
-        let name = format!("ll_gcref_hash_{}", self.r_base.lowleveltype().short_name());
-        let base_lltype = self.r_base.lowleveltype().clone();
-        rtyper
-            .lowlevel_helper_function_with_builder(
-                name.clone(),
-                vec![self.lltype.clone()],
-                LowLevelType::Signed,
-                move |_rtyper, args, result| {
-                    build_gcref_wrapper_graph(
-                        &name,
-                        args,
-                        result,
-                        &base_lltype,
-                        base_hash.clone(),
-                        "ptr",
-                    )
-                },
-            )
-            .map(Some)
+        if matches!(*self._ll_hash_func.borrow(), LlHelperCache::Unknown) {
+            let ll_hash_func = match self.r_base.get_ll_hash_function(rtyper)? {
+                None => None,
+                Some(base_hash) => {
+                    let name = format!("ll_gcref_hash_{}", self.r_base.lowleveltype().short_name());
+                    let base_lltype = self.r_base.lowleveltype().clone();
+                    Some(rtyper.lowlevel_helper_function_with_builder(
+                        name.clone(),
+                        vec![self.lltype.clone()],
+                        LowLevelType::Signed,
+                        move |_rtyper, args, result| {
+                            build_gcref_wrapper_graph(
+                                &name,
+                                args,
+                                result,
+                                &base_lltype,
+                                base_hash.clone(),
+                                "ptr",
+                            )
+                        },
+                    )?)
+                }
+            };
+            *self._ll_hash_func.borrow_mut() = LlHelperCache::Computed(ll_hash_func);
+        }
+        match &*self._ll_hash_func.borrow() {
+            LlHelperCache::Computed(func) => Ok(func.clone()),
+            LlHelperCache::Unknown => unreachable!("_ll_hash_func computed above"),
+        }
     }
 }
 

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rgcref.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rgcref.rs
@@ -5,8 +5,9 @@
 //! pointers as `llmemory.GCREF` while preserving the original external
 //! repr. The port mirrors the cache/keying, constant opaque casts, and
 //! pairtype conversions used by `externalvsinternal(..., gcref=True)`.
-//! `DummyValueBuilderGCRef` is deferred until pyre grows the matching
-//! `rtyper.cache_dummy_values` surface.
+//! `DummyValueBuilderGCRef.ll_dummy_value` and the conditional
+//! `GCRefRepr.ll_str` wrapper are deferred as latent surfaces (see their
+//! doc comments for the precise blockers).
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -49,7 +50,14 @@ pub struct GCRefRepr {
 }
 
 impl GCRefRepr {
-    /// RPython `GCRefRepr.make(r_base, cache)` (`rgcref.py:11-17`).
+    /// RPython `GCRefRepr.make(r_base, cache)` (`rgcref.py:11-17`),
+    /// folding in `__init__` (`rgcref.py:20-28`).
+    ///
+    /// The conditional `self.ll_str` wrapper (`rgcref.py:24-28`, installed
+    /// only `if hasattr(r_base, 'll_str')`) is omitted: no pyre `Repr`
+    /// exposes an `ll_str` method, so the `hasattr` guard is always false
+    /// and there is nothing to wrap. It can be ported once the
+    /// `Repr::ll_str` / `rtype_str` surface lands.
     pub fn make(
         r_base: Arc<dyn Repr>,
         cache: &RefCell<HashMap<usize, Arc<GCRefRepr>>>,
@@ -182,12 +190,15 @@ impl Repr for GCRefRepr {
     }
 }
 
-/// RPython `class DummyValueBuilderGCRef(object)` (`rgcref.py:66-104`).
+/// RPython `class DummyValueBuilderGCRef(object)` (`rgcref.py:74-104`).
 ///
-/// The `ll_dummy_value` property depends on
-/// `RPythonTyper.cache_dummy_values`, which is still deferred in this
-/// port. The identity, hash, and freeze behavior is available so callers
-/// can use the same object surface.
+/// The `ll_dummy_value` property (`rgcref.py:93-104`) is deferred along
+/// with the generic [`super::super::rmodel::DummyValueBuilder`] it
+/// delegates to: it is a latent surface (no caller reaches it) and needs
+/// the `RPythonTyper.cache_dummy_values` map plus the typer threaded in to
+/// run `getinstancerepr(None)` → `DummyValueBuilder(TYPE.TO)` →
+/// `cast_opaque_ptr(GCREF, ...)`. The identity, hash, and freeze behavior
+/// is available so callers can use the same object surface.
 #[derive(Clone, Debug)]
 pub struct DummyValueBuilderGCRef {
     rtyper_id: usize,
@@ -210,7 +221,8 @@ impl DummyValueBuilderGCRef {
 
     pub fn ll_dummy_value(&self) -> Result<Constant, TyperError> {
         Err(TyperError::missing_rtype_operation(
-            "DummyValueBuilderGCRef.ll_dummy_value - RPythonTyper.cache_dummy_values deferred",
+            "DummyValueBuilderGCRef.ll_dummy_value - latent: needs cache_dummy_values + \
+             getinstancerepr(None) → DummyValueBuilder(TYPE.TO) → cast_opaque_ptr(GCREF)",
         ))
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rrange.rs
@@ -16,6 +16,7 @@ use crate::translator::rtyper::lltypesystem::lltype::{
     _ptr, LowLevelType, LowLevelValue, MallocFlavor, Ptr, PtrTarget, Struct, malloc,
 };
 pub use crate::translator::rtyper::rrange::AbstractRangeRepr as RangeRepr;
+pub use crate::translator::rtyper::rrange::RangeIteratorRepr;
 
 /// RPython `ll_length(l)`.
 pub fn ll_length(l: &_ptr) -> Result<i64, TyperError> {
@@ -100,12 +101,6 @@ pub fn ll_newrangest(start: i64, stop: i64, step: i64) -> Result<_ptr, TyperErro
     Ok(l)
 }
 
-/// RPython `class RangeIteratorRepr(AbstractRangeIteratorRepr)`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RangeIteratorRepr {
-    pub lowleveltype: LowLevelType,
-}
-
 /// RPython `ll_rangeiter(ITERPTR, rng)`.
 pub fn ll_rangeiter(ITERPTR: &Ptr, rng: &_ptr) -> Result<_ptr, TyperError> {
     let mut iter = malloc(ITERPTR.TO.clone().into(), None, MallocFlavor::Gc, false)
@@ -181,11 +176,14 @@ mod tests {
         assert_eq!(signed_field(&iter, "stop").expect("stop"), 2);
         assert_eq!(signed_field(&iter, "step").expect("step"), -2);
 
-        let iter_repr = RangeIteratorRepr {
-            lowleveltype: lltype::LowLevelType::Ptr(Box::new(iter_type)),
-        };
+        // The concrete `RangeIteratorRepr` (re-exported from the abstract
+        // module) mints its RANGEITER lowleveltype from a constant-step
+        // `RangeRepr`; the variable-step shape exercised above for the
+        // runtime helpers is deferred at the repr level.
+        let iter_repr = RangeIteratorRepr::new(&RangeRepr::new(1).expect("step-1 RangeRepr"))
+            .expect("iter repr");
         assert!(matches!(
-            iter_repr.lowleveltype,
+            iter_repr.lowleveltype(),
             lltype::LowLevelType::Ptr(_)
         ));
     }

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rrange.rs
@@ -177,13 +177,18 @@ mod tests {
         assert_eq!(signed_field(&iter, "step").expect("step"), -2);
 
         // The concrete `RangeIteratorRepr` (re-exported from the abstract
-        // module) mints its RANGEITER lowleveltype from a constant-step
-        // `RangeRepr`; the variable-step shape exercised above for the
-        // runtime helpers is deferred at the repr level.
+        // module) mints a RANGEITER lowleveltype from a constant-step
+        // `RangeRepr` and a RANGESTITER from a variable-step one.
         let iter_repr = RangeIteratorRepr::new(&RangeRepr::new(1).expect("step-1 RangeRepr"))
             .expect("iter repr");
         assert!(matches!(
             iter_repr.lowleveltype(),
+            lltype::LowLevelType::Ptr(_)
+        ));
+        let var_iter_repr = RangeIteratorRepr::new(&RangeRepr::new(0).expect("step-0 RangeRepr"))
+            .expect("variable-step iter repr");
+        assert!(matches!(
+            var_iter_repr.lowleveltype(),
             lltype::LowLevelType::Ptr(_)
         ));
     }

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -1155,13 +1155,14 @@ fn dispatch_rtype_is_(
         // rnone.py:61-64 — `pairtype(NoneRepr, Repr).rtype_is_` calls
         // `rtype_is_None(robj2, rnone1, hop, pos=1)`.
         (NoneRepr, Repr) => super::rnone::pair_none_any_rtype_is_(r1, r2, hop),
-        // rpbc.py:713-725 — `pairtype(MultipleUnrelatedFrozenPBCRepr,
-        // MultipleUnrelatedFrozenPBCRepr).rtype_is_` emits adr_eq.
-        // The (MU, Single) / (Single, MU) arms in the same upstream
-        // block depend on a Single->MU convert_from_to that has not
-        // landed yet; those shapes still fall through to the generic
-        // (Repr, Repr) dispatcher below.
-        (MultipleUnrelatedFrozenPBCRepr, MultipleUnrelatedFrozenPBCRepr) => {
+        // rpbc.py:713-725 — the one upstream block registers
+        // `rtype_is_` on `pairtype(MU, MU)`, `pairtype(MU, Single)`,
+        // and `pairtype(Single, MU)`. All three emit adr_eq after
+        // converting both operands to the MU repr; a Single operand is
+        // a constant PBC and converts via `inputconst -> convert_const`.
+        (MultipleUnrelatedFrozenPBCRepr, MultipleUnrelatedFrozenPBCRepr)
+        | (MultipleUnrelatedFrozenPBCRepr, SingleFrozenPBCRepr)
+        | (SingleFrozenPBCRepr, MultipleUnrelatedFrozenPBCRepr) => {
             super::rpbc::pair_mu_mu_rtype_is_(r1, r2, hop).map(Some)
         }
         // rpbc.py:558-571 — `pairtype(FunctionReprBase,

--- a/majit/majit-translate/src/translator/rtyper/pairtype.rs
+++ b/majit/majit-translate/src/translator/rtyper/pairtype.rs
@@ -175,6 +175,11 @@ pub enum ReprClassId {
     /// iterator over a list/slice (`GcStruct("listiter", ("list", LIST),
     /// ("index", Signed))`).
     ListIteratorRepr,
+    /// `rrange.py:145 AbstractRangeIteratorRepr(IteratorRepr)` — the
+    /// iterator over a `range()` list (`GcStruct("range", ("next",
+    /// Signed), ("stop", Signed))`). Distinct from `RangeRepr`: an
+    /// iterator repr is its own iterator, not the container.
+    RangeIteratorRepr,
 }
 
 impl ReprClassId {
@@ -242,6 +247,7 @@ impl ReprClassId {
             // → Repr`; the abstract bases carry no pairtype entries, so
             // the resolution chain collapses to `Self → Repr`.
             ListIteratorRepr => &[ListIteratorRepr, Repr],
+            RangeIteratorRepr => &[RangeIteratorRepr, Repr],
         }
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3094,17 +3094,11 @@ pub fn rtyper_makerepr(
                 range_step.filter(|_| !mutated && !matches!(s_value, SomeValue::Impossible));
             use crate::translator::rtyper::rlist::{FixedSizeListRepr, ListRepr};
             if let Some(step) = range_repr_step {
-                if step != 0 {
-                    Ok(std::sync::Arc::new(
-                        crate::translator::rtyper::lltypesystem::rrange::RangeRepr::new(step)?,
-                    ) as std::sync::Arc<dyn Repr>)
-                } else {
-                    Err(TyperError::missing_rtype_operation(format!(
-                        "SomeList(range_step=0).rtyper_makerepr — variable-step \
-                         RANGEST RangeRepr (_getstep) deferred (listdef: {:?})",
-                        s_list.listdef
-                    )))
-                }
+                // rlist.py:45 — any non-None range_step selects RangeRepr,
+                // constant (`RANGE`) or variable (`step == 0` → `RANGEST`).
+                Ok(std::sync::Arc::new(
+                    crate::translator::rtyper::lltypesystem::rrange::RangeRepr::new(step)?,
+                ) as std::sync::Arc<dyn Repr>)
             } else {
                 let item_r = rtyper.getrepr(&s_value)?;
                 let rtyper_rc = rtyper.self_rc()?;

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -1224,10 +1224,15 @@ pub fn mangle(prefix: &str, name: &str) -> String {
 
 /// RPython `class DummyValueBuilder(object)` (`rmodel.py:432-464`).
 ///
-/// The lazy `ll_dummy_value` allocation depends on
-/// `RPythonTyper.cache_dummy_values`, which is still absent in this
-/// port. The identity, hash, and freeze surfaces are present so
-/// `Repr.get_ll_dummyval_obj` can return the same object shape.
+/// The lazy `ll_dummy_value` allocation (`rmodel.py:452-464`) is deferred:
+/// it is a latent surface — no caller reaches `Repr.get_ll_dummyval_obj`
+/// yet — and completing it needs three pieces: (1) a
+/// `RPythonTyper.cache_dummy_values` map (the `LowLevelType` key is
+/// already `Hash + Eq`), (2) this builder to receive the `&RPythonTyper`
+/// at call time (it stores only `rtyper_id` for identity, not the typer),
+/// and (3) `malloc(TYPE, immortal=True)` (`malloc(TYPE, 1, ...)` for
+/// `_is_varsize()`). The identity, hash, and freeze surfaces are present
+/// so `get_ll_dummyval_obj` can already return the same object shape.
 #[allow(non_snake_case)]
 #[derive(Clone, Debug)]
 pub struct DummyValueBuilder {
@@ -1258,7 +1263,8 @@ impl DummyValueBuilder {
 
     pub fn ll_dummy_value(&self) -> Result<lltype::LowLevelValue, TyperError> {
         Err(TyperError::missing_rtype_operation(
-            "DummyValueBuilder.ll_dummy_value - RPythonTyper.cache_dummy_values deferred",
+            "DummyValueBuilder.ll_dummy_value - latent: needs RPythonTyper.cache_dummy_values \
+             + the typer threaded in for malloc(TYPE, immortal=True)",
         ))
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3088,15 +3088,14 @@ pub fn rtyper_makerepr(
                 range_step.filter(|_| !mutated && !matches!(s_value, SomeValue::Impossible));
             use crate::translator::rtyper::rlist::{FixedSizeListRepr, ListRepr};
             if let Some(step) = range_repr_step {
-                if step == 1 {
+                if step != 0 {
                     Ok(std::sync::Arc::new(
                         crate::translator::rtyper::lltypesystem::rrange::RangeRepr::new(step)?,
                     ) as std::sync::Arc<dyn Repr>)
                 } else {
                     Err(TyperError::missing_rtype_operation(format!(
-                        "SomeList(range_step={step}).rtyper_makerepr — general \
-                         RangeRepr (const step != 1 / variable step) deferred; \
-                         ll_rangelen needs int_floordiv lowering (listdef: {:?})",
+                        "SomeList(range_step=0).rtyper_makerepr — variable-step \
+                         RANGEST RangeRepr (_getstep) deferred (listdef: {:?})",
                         s_list.listdef
                     )))
                 }

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -4478,7 +4478,10 @@ pub fn pair_mu_mu_rtype_is_(
     use crate::translator::rtyper::rtyper::{ConvertedTo, GenopResult};
     // upstream: `if isinstance(robj1, MultipleUnrelatedFrozenPBCRepr):
     //              r = robj1; else: r = robj2`.
-    let r = if matches!(r1.repr_class_id(), ReprClassId::MultipleUnrelatedFrozenPBCRepr) {
+    let r = if matches!(
+        r1.repr_class_id(),
+        ReprClassId::MultipleUnrelatedFrozenPBCRepr
+    ) {
         r1
     } else {
         r2

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -4463,21 +4463,28 @@ impl Repr for MultipleUnrelatedFrozenPBCRepr {
 ///     return hop.genop('adr_eq', vlist, resulttype=Bool)
 /// ```
 ///
-/// Both operands are already MU repr, so the receiver selection is a
-/// no-op — `r1` is used directly. The upstream block also covers
-/// `pairtype(MU, SingleFrozen)` / `pairtype(SingleFrozen, MU)` shapes,
-/// which require a `SingleFrozen -> MU` convert_from_to path (null
-/// address materialisation) that is not yet ported; those arms still
-/// fall through to the generic `(Repr, Repr)` dispatcher and surface
-/// `is of instances of the non-pointers` TyperError until the
-/// conversion helper lands.
+/// The same `rtype_is_` body backs `pairtype(MU, MU)`,
+/// `pairtype(MU, SingleFrozen)`, and `pairtype(SingleFrozen, MU)`. The
+/// receiver `r` is whichever operand is the MU repr, and BOTH operands
+/// are converted to `r` via `inputargs(r, r)`. A `SingleFrozen` operand
+/// is a single prebuilt constant, so its `inputarg` routes through
+/// `inputconst(r, value)` -> `MU.convert_const` (fakeaddress for a live
+/// frozendesc, NULL address for `None`); no `convert_from_to` is needed.
 pub fn pair_mu_mu_rtype_is_(
     r1: &dyn Repr,
     r2: &dyn Repr,
     hop: &crate::translator::rtyper::rtyper::HighLevelOp,
 ) -> Result<crate::flowspace::model::Hlvalue, TyperError> {
     use crate::translator::rtyper::rtyper::{ConvertedTo, GenopResult};
-    let v_list = hop.inputargs(vec![ConvertedTo::Repr(r1), ConvertedTo::Repr(r2)])?;
+    // upstream: `if isinstance(robj1, MultipleUnrelatedFrozenPBCRepr):
+    //              r = robj1; else: r = robj2`.
+    let r = if matches!(r1.repr_class_id(), ReprClassId::MultipleUnrelatedFrozenPBCRepr) {
+        r1
+    } else {
+        r2
+    };
+    // upstream: `vlist = hop.inputargs(r, r)`.
+    let v_list = hop.inputargs(vec![ConvertedTo::Repr(r), ConvertedTo::Repr(r)])?;
     Ok(hop
         .genop("adr_eq", v_list, GenopResult::LLType(LowLevelType::Bool))
         .expect("adr_eq with Bool result returns a value"))

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -9,11 +9,18 @@
 //! repr is NOT array-backed (`FixedSizeListRepr`) but an immutable
 //! `GcStruct("range", start, stop)` (`lltypesystem/rrange.py:51-57`).
 //!
+//! Landed: `rtype_len` (`step == 1`), `rtype_getitem` (constant-step,
+//! nonneg, `dum_nocheck`), and constant-step `RangeIteratorRepr`
+//! (`make_iterator_repr` / `newiter` / `rtype_next` via the `ll_rangeiter`
+//! + `ll_rangenext_up` / `_down` helper graphs).
+//!
 //! Deferred to follow-on slices (matching how `FixedSizeListRepr` landed
-//! `rtype_len` first): the general-step `ll_rangelen` length (needs the
-//! `int_floordiv` lowering, not yet a recognised low-level op), the
-//! `RANGEST` variable-step path, `pairtype(AbstractRangeRepr, IntegerRepr)`
-//! `rtype_getitem`, and `RangeIteratorRepr`.
+//! `rtype_len` first), all blocked on `_ll_rangelen`'s `int_floordiv`
+//! (not yet a recognised low-level op) or the variable-step `RANGEST`
+//! path: the general-step `ll_rangelen` length, the `rtype_getitem`
+//! `checkidx` (implicit-IndexError) and negative-index (`ll_rangeitem`)
+//! branches, the `RANGEST` variable-step `_getstep` getitem, and the
+//! variable-step `RANGESTITER` iterator (`ll_rangenext_updown`).
 
 #![allow(non_camel_case_types)]
 
@@ -26,8 +33,10 @@ use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, Ptr, PtrTarget, Struct};
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, constant_with_lltype, helper_pygraph_from_graph, variable_with_lltype,
+    ConvertedTo, HighLevelOp, constant_with_lltype, exception_args, helper_pygraph_from_graph,
+    variable_with_lltype,
 };
+use std::sync::Arc;
 
 fn rrange_deferred(name: &str) -> TyperError {
     TyperError::missing_rtype_operation(format!("rrange.{name} helper surface deferred"))
@@ -381,6 +390,29 @@ impl Repr for AbstractRangeRepr {
         )?;
         hop.gendirectcall(&helper, args)
     }
+
+    /// RPython `RangeRepr.make_iterator_repr(self, variant=None)`
+    /// (`lltypesystem/rrange.py:63-67`):
+    ///
+    /// ```python
+    /// def make_iterator_repr(self, variant=None):
+    ///     if variant is not None:
+    ///         raise TyperError("unsupported %r iterator over a range list" %
+    ///                          (variant,))
+    ///     return RangeIteratorRepr(self)
+    /// ```
+    ///
+    /// The constant-step (`step != 0`) iterator lands; the variable-step
+    /// `RANGESTITER` iterator (`step == 0`) is deferred inside
+    /// [`RangeIteratorRepr::new`].
+    fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
+        if !variant.is_empty() {
+            return Err(TyperError::message(format!(
+                "unsupported {variant:?} iterator over a range list"
+            )));
+        }
+        Ok(Arc::new(RangeIteratorRepr::new(self)?))
+    }
 }
 
 /// Synthesise the `ll_rangelen1` helper graph (`rrange.py:68-72`):
@@ -539,6 +571,427 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["l".to_string(), "index".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// RPython `class RangeIteratorRepr(AbstractRangeIteratorRepr)`
+/// (`rrange.py:145-156` + `lltypesystem/rrange.py:85-97`), constant-step
+/// (`step != 0`, `RANGEITER`) slice.
+///
+/// ```python
+/// class AbstractRangeIteratorRepr(IteratorRepr):
+///     def __init__(self, r_rng):
+///         self.r_rng = r_rng
+///         if r_rng.step != 0:
+///             self.lowleveltype = r_rng.RANGEITER
+///         else:
+///             self.lowleveltype = r_rng.RANGESTITER
+/// ```
+///
+/// where (`lltypesystem/rrange.py:58`) `RANGEITER = Ptr(GcStruct("range",
+/// ("next", Signed), ("stop", Signed)))`. Like
+/// [`super::rtuple::Length1TupleIteratorRepr`], pyre collapses the
+/// abstract/concrete split into one concrete repr. The variable-step
+/// `RANGESTITER` (`("next", "stop", "step")`) shape and its
+/// `ll_rangenext_updown` advance are deferred.
+#[derive(Debug)]
+pub struct RangeIteratorRepr {
+    /// `self.r_rng.step` (`rrange.py:147`) — the constant range step,
+    /// nonzero for this repr. Selects `ll_rangenext_up` / `_down` and is
+    /// baked as the advance `step` runtime arg.
+    step: i64,
+    /// `self.lowleveltype = r_rng.RANGEITER` (`lltypesystem/rrange.py:58`)
+    /// — `Ptr(GcStruct("range", ("next", Signed), ("stop", Signed)))`.
+    lowleveltype: LowLevelType,
+    state: ReprState,
+}
+
+impl RangeIteratorRepr {
+    /// RPython `AbstractRangeIteratorRepr.__init__(self, r_rng)`
+    /// (`rrange.py:146-151`) for the `step != 0` `RANGEITER` shape.
+    pub fn new(r_rng: &AbstractRangeRepr) -> Result<Self, TyperError> {
+        if r_rng.step == 0 {
+            return Err(rrange_deferred(
+                "RangeIteratorRepr (variable-step RANGESTITER / ll_rangenext_updown)",
+            ));
+        }
+        // RANGEITER = GcStruct("range", ("next", Signed), ("stop", Signed)).
+        // Mutable (no immutable hint): `ll_rangenext_*` writes `iter.next`.
+        let signed = LowLevelType::Signed;
+        let st = Struct::gc(
+            "range",
+            vec![
+                ("next".to_string(), signed.clone()),
+                ("stop".to_string(), signed),
+            ],
+        );
+        let lowleveltype = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Struct(st),
+        }));
+        Ok(RangeIteratorRepr {
+            step: r_rng.step,
+            lowleveltype,
+            state: ReprState::new(),
+        })
+    }
+}
+
+impl Repr for RangeIteratorRepr {
+    fn lowleveltype(&self) -> &LowLevelType {
+        &self.lowleveltype
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "RangeIteratorRepr"
+    }
+
+    fn repr_class_id(&self) -> super::pairtype::ReprClassId {
+        super::pairtype::ReprClassId::RangeRepr
+    }
+
+    /// RPython `AbstractRangeIteratorRepr.newiter(self, hop)`
+    /// (`rrange.py:153-156`):
+    ///
+    /// ```python
+    /// def newiter(self, hop):
+    ///     v_rng, = hop.inputargs(self.r_rng)
+    ///     citerptr = hop.inputconst(Void, self.lowleveltype)
+    ///     return hop.gendirectcall(self.ll_rangeiter, citerptr, v_rng)
+    /// ```
+    ///
+    /// As with [`super::rtuple::Length1TupleIteratorRepr::newiter`], the
+    /// iterator low-level type is baked into the helper builder rather
+    /// than threaded as a `citerptr` Void const; the source range repr
+    /// is read from `args_r[0]`.
+    fn newiter(&self, hop: &HighLevelOp) -> RTypeResult {
+        let r_rng = {
+            let args_r = hop.args_r.borrow();
+            args_r.first().and_then(|o| o.clone()).ok_or_else(|| {
+                TyperError::message("RangeIteratorRepr.newiter: arg0 repr missing")
+            })?
+        };
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(r_rng.as_ref())])?;
+        let range_lltype = r_rng.lowleveltype().clone();
+        let iter_lltype = self.lowleveltype.clone();
+        let range_for_builder = range_lltype.clone();
+        let iter_for_builder = iter_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_rangeiter".to_string(),
+            vec![range_lltype],
+            iter_lltype,
+            move |_rtyper, _args, _result| {
+                build_ll_rangeiter_helper_graph(
+                    "ll_rangeiter",
+                    range_for_builder.clone(),
+                    iter_for_builder.clone(),
+                )
+            },
+        )?;
+        hop.gendirectcall(&helper, vlist)
+    }
+
+    /// RPython `AbstractRangeIteratorRepr.rtype_next(self, hop)`
+    /// (`rrange.py:158-170`):
+    ///
+    /// ```python
+    /// def rtype_next(self, hop):
+    ///     v_iter, = hop.inputargs(self)
+    ///     args = hop.inputconst(Signed, self.r_rng.step),
+    ///     if self.r_rng.step > 0:
+    ///         llfn = ll_rangenext_up
+    ///     elif self.r_rng.step < 0:
+    ///         llfn = ll_rangenext_down
+    ///     else:
+    ///         llfn = ll_rangenext_updown
+    ///         args = ()
+    ///     hop.has_implicit_exception(StopIteration)
+    ///     hop.exception_is_here()
+    ///     return hop.gendirectcall(llfn, v_iter, *args)
+    /// ```
+    ///
+    /// `step != 0` here (the repr rejects variable step), so the
+    /// `ll_rangenext_updown` arm is unreachable; `up` (`step > 0`) and
+    /// `down` (`step < 0`) bake the constant step as the advance arg.
+    fn rtype_next(&self, hop: &HighLevelOp) -> RTypeResult {
+        let mut args = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        args.push(constant_with_lltype(
+            ConstValue::Int(self.step),
+            LowLevelType::Signed,
+        ));
+        hop.has_implicit_exception("StopIteration");
+        hop.exception_is_here()?;
+        let name = if self.step > 0 {
+            "ll_rangenext_up"
+        } else {
+            "ll_rangenext_down"
+        };
+        let up = self.step > 0;
+        let iter_lltype = self.lowleveltype.clone();
+        let iter_for_builder = iter_lltype.clone();
+        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+            name.to_string(),
+            vec![iter_lltype, LowLevelType::Signed],
+            LowLevelType::Signed,
+            move |_rtyper, _args, _result| {
+                build_ll_rangenext_helper_graph(name, iter_for_builder.clone(), up)
+            },
+        )?;
+        hop.gendirectcall(&helper, args)
+    }
+}
+
+/// Synthesise the `ll_rangeiter` helper graph
+/// (`lltypesystem/rrange.py:91-97`) for the constant-step `RANGEITER`
+/// shape:
+///
+/// ```python
+/// def ll_rangeiter(ITERPTR, rng):
+///     iter = malloc(ITERPTR.TO)
+///     iter.next = rng.start
+///     iter.stop = rng.stop
+///     return iter
+/// ```
+///
+/// Single block: `start = getfield(rng, 'start'); stop = getfield(rng,
+/// 'stop'); iter = malloc(RANGEITER, flavor=gc); setfield(iter, 'next',
+/// start); setfield(iter, 'stop', stop)`. `ITERPTR` is baked as
+/// `iter_lltype`; the `RANGESTITER` `iter.step = rng.step` write is
+/// elided (constant-step only).
+pub(crate) fn build_ll_rangeiter_helper_graph(
+    name: &str,
+    range_lltype: LowLevelType,
+    iter_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let rng_arg = variable_with_lltype("rng", range_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(rng_arg.clone())]);
+    let return_var = variable_with_lltype("result", iter_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let LowLevelType::Ptr(ptr) = &iter_lltype else {
+        return Err(TyperError::message(
+            "build_ll_rangeiter_helper_graph: iter lltype is not Ptr",
+        ));
+    };
+    let inner_struct = match &ptr.TO {
+        PtrTarget::Struct(body) => body.clone(),
+        other => {
+            return Err(TyperError::message(format!(
+                "build_ll_rangeiter_helper_graph: Ptr target must be Struct, got {other:?}"
+            )));
+        }
+    };
+
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+
+    // start = rng.start; stop = rng.stop.
+    let v_start = variable_with_lltype("start", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(rng_arg.clone()), field_const("start")],
+        Hlvalue::Variable(v_start.clone()),
+    ));
+    let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(rng_arg), field_const("stop")],
+        Hlvalue::Variable(v_stop.clone()),
+    ));
+
+    // iter = malloc(RANGEITER, flavor=gc).
+    let c_type = Constant::with_concretetype(
+        ConstValue::LowLevelType(Box::new(LowLevelType::Struct(Box::new(inner_struct)))),
+        LowLevelType::Void,
+    );
+    let c_flags =
+        Constant::with_concretetype(ConstValue::byte_str("flavor=gc"), LowLevelType::Void);
+    let v_iter = variable_with_lltype("iter", iter_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "malloc",
+        vec![Hlvalue::Constant(c_type), Hlvalue::Constant(c_flags)],
+        Hlvalue::Variable(v_iter.clone()),
+    ));
+
+    // iter.next = start; iter.stop = stop.
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(v_iter.clone()),
+            field_const("next"),
+            Hlvalue::Variable(v_start),
+        ],
+        Hlvalue::Variable(variable_with_lltype("v0", LowLevelType::Void)),
+    ));
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(v_iter.clone()),
+            field_const("stop"),
+            Hlvalue::Variable(v_stop),
+        ],
+        Hlvalue::Variable(variable_with_lltype("v1", LowLevelType::Void)),
+    ));
+
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(v_iter)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["rng".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise the `ll_rangenext_up` / `ll_rangenext_down` helper graph
+/// (`rrange.py:172-184`):
+///
+/// ```python
+/// def ll_rangenext_up(iter, step):    # `_down` flips `>=` to `<=`
+///     next = iter.next
+///     if next >= iter.stop:
+///         raise StopIteration
+///     iter.next = next + step
+///     return next
+/// ```
+///
+/// 2-block CFG. `up` selects `int_ge` (`next >= stop`) vs `int_le`
+/// (`next <= stop`) for the StopIteration guard:
+/// - **start**: `next = getfield(iter, 'next'); stop = getfield(iter,
+///   'stop'); atend = int_ge/int_le(next, stop)`. Switch on `atend`:
+///   True → exceptblock (StopIteration); False → cont, carrying `iter,
+///   next, step`.
+/// - **cont**: `newnext = int_add(next, step); setfield(iter, 'next',
+///   newnext)`; return `next`.
+pub(crate) fn build_ll_rangenext_helper_graph(
+    name: &str,
+    iter_lltype: LowLevelType,
+    up: bool,
+) -> Result<PyGraph, TyperError> {
+    let iter_arg = variable_with_lltype("iter", iter_lltype.clone());
+    let step_arg = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(iter_arg.clone()),
+        Hlvalue::Variable(step_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+    let bool_const = |b: bool| constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool);
+
+    // next = iter.next; stop = iter.stop; atend = next >=/<= stop.
+    let v_next = variable_with_lltype("next", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(iter_arg.clone()), field_const("next")],
+        Hlvalue::Variable(v_next.clone()),
+    ));
+    let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(iter_arg.clone()), field_const("stop")],
+        Hlvalue::Variable(v_stop.clone()),
+    ));
+    let v_atend = variable_with_lltype("atend", LowLevelType::Bool);
+    let cmp_op = if up { "int_ge" } else { "int_le" };
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        cmp_op,
+        vec![Hlvalue::Variable(v_next.clone()), Hlvalue::Variable(v_stop)],
+        Hlvalue::Variable(v_atend.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(v_atend));
+
+    // cont block args: (iter, next, step).
+    let c_iter = variable_with_lltype("iter", iter_lltype);
+    let c_next = variable_with_lltype("next", LowLevelType::Signed);
+    let c_step = variable_with_lltype("step", LowLevelType::Signed);
+    let cont = Block::shared(vec![
+        Hlvalue::Variable(c_iter.clone()),
+        Hlvalue::Variable(c_next.clone()),
+        Hlvalue::Variable(c_step.clone()),
+    ]);
+
+    let exc_args = exception_args("StopIteration")?;
+    startblock.closeblock(vec![
+        // atend == True: raise StopIteration.
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        // atend == False: advance and return.
+        Link::new(
+            vec![
+                Hlvalue::Variable(iter_arg),
+                Hlvalue::Variable(v_next),
+                Hlvalue::Variable(step_arg),
+            ],
+            Some(cont.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // newnext = next + step; iter.next = newnext.
+    let v_newnext = variable_with_lltype("newnext", LowLevelType::Signed);
+    {
+        let mut b = cont.borrow_mut();
+        b.operations.push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(c_next.clone()), Hlvalue::Variable(c_step)],
+            Hlvalue::Variable(v_newnext.clone()),
+        ));
+        b.operations.push(SpaceOperation::new(
+            "setfield",
+            vec![
+                Hlvalue::Variable(c_iter),
+                field_const("next"),
+                Hlvalue::Variable(v_newnext),
+            ],
+            Hlvalue::Variable(variable_with_lltype("v0", LowLevelType::Void)),
+        ));
+    }
+    cont.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(c_next)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["iter".to_string(), "step".to_string()],
         func,
     ))
 }
@@ -757,5 +1210,161 @@ mod tests {
             Some(signed_repr() as Arc<dyn Repr>),
         ]);
         assert!(range_repr.rtype_getitem(&hop).is_err());
+    }
+
+    /// `make_iterator_repr` mints a `RangeIteratorRepr` whose lowleveltype
+    /// is the `RANGEITER` struct (`next`, `stop`). A non-None variant is
+    /// rejected (`rrange.py:64-66`); the variable-step (`step == 0`)
+    /// iterator is deferred.
+    #[test]
+    fn make_iterator_repr_constant_step_yields_rangeiter_with_next_stop_struct() {
+        let r_rng = AbstractRangeRepr::new(1).unwrap();
+        let it = r_rng.make_iterator_repr(&[]).unwrap();
+        assert_eq!(it.class_name(), "RangeIteratorRepr");
+        assert_eq!(it.repr_class_id(), ReprClassId::RangeRepr);
+        match it.lowleveltype() {
+            LowLevelType::Ptr(p) => match &p.TO {
+                PtrTarget::Struct(st) => {
+                    assert_eq!(st._names_without_voids(), vec!["next", "stop"]);
+                }
+                other => panic!("RANGEITER TO not Struct: {other:?}"),
+            },
+            other => panic!("RANGEITER not Ptr: {other:?}"),
+        }
+        // unsupported variant → TyperError.
+        assert!(r_rng.make_iterator_repr(&["reversed".to_string()]).is_err());
+        // variable-step RANGESTITER iterator is deferred.
+        let rst = AbstractRangeRepr::new(0).unwrap();
+        assert!(rst.make_iterator_repr(&[]).is_err());
+    }
+
+    /// `ll_rangeiter` single block: `getfield start; getfield stop;
+    /// malloc RANGEITER; setfield next; setfield stop`.
+    #[test]
+    fn build_ll_rangeiter_helper_graph_synthesizes_getfields_malloc_setfields() {
+        let r_rng = AbstractRangeRepr::new(1).unwrap();
+        let iter_lltype = RangeIteratorRepr::new(&r_rng)
+            .unwrap()
+            .lowleveltype()
+            .clone();
+        let range_lltype = r_rng.lowleveltype().clone();
+        let g = build_ll_rangeiter_helper_graph("ll_rangeiter", range_lltype, iter_lltype).unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(
+            ops,
+            vec!["getfield", "getfield", "malloc", "setfield", "setfield"]
+        );
+        assert!(startblock.exitswitch.is_none());
+        assert_eq!(startblock.exits.len(), 1);
+        assert_eq!(startblock.inputargs.len(), 1);
+    }
+
+    /// `ll_rangenext_up` start block guards with `int_ge` and branches to
+    /// the StopIteration (exceptblock) and advance (cont) exits;
+    /// `ll_rangenext_down` flips the guard to `int_le`.
+    #[test]
+    fn build_ll_rangenext_helper_graph_guards_with_int_ge_up_int_le_down() {
+        let r_rng = AbstractRangeRepr::new(1).unwrap();
+        let iter_lltype = RangeIteratorRepr::new(&r_rng)
+            .unwrap()
+            .lowleveltype()
+            .clone();
+
+        for (up, cmp) in [(true, "int_ge"), (false, "int_le")] {
+            let name = if up {
+                "ll_rangenext_up"
+            } else {
+                "ll_rangenext_down"
+            };
+            let g = build_ll_rangenext_helper_graph(name, iter_lltype.clone(), up).unwrap();
+            let inner = g.graph.borrow();
+            let startblock = inner.startblock.borrow();
+            let ops: Vec<&str> = startblock
+                .operations
+                .iter()
+                .map(|op| op.opname.as_str())
+                .collect();
+            assert_eq!(ops, vec!["getfield", "getfield", cmp]);
+            assert!(startblock.exitswitch.is_some());
+            assert_eq!(startblock.exits.len(), 2);
+            // (iter, step) inputargs.
+            assert_eq!(startblock.inputargs.len(), 2);
+        }
+    }
+
+    /// rrange.py:158-170 constant-step `rtype_next` lowers to a
+    /// `direct_call` of `ll_rangenext_up` (`step > 0`) with the constant
+    /// step appended, preceded by `hop.exception_is_here()`.
+    #[test]
+    fn rangeiter_rtype_next_emits_direct_call_to_ll_rangenext_up() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        let r_rng = AbstractRangeRepr::new(1).unwrap();
+        let iter_repr: Arc<RangeIteratorRepr> = Arc::new(RangeIteratorRepr::new(&r_rng).unwrap());
+        let iter_lltype = iter_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_iter = Variable::new();
+        v_iter.set_concretetype(Some(iter_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "next".to_string(),
+                vec![Hlvalue::Variable(v_iter)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        // Non-constant binding so inputarg reaches convertvar (identity, no-op).
+        hop.args_s
+            .borrow_mut()
+            .push(crate::annotator::model::SomeValue::Impossible);
+        hop.args_r
+            .borrow_mut()
+            .push(Some(iter_repr.clone() as Arc<dyn Repr>));
+
+        let result = iter_repr
+            .rtype_next(&hop)
+            .unwrap_or_else(|err| panic!("range rtype_next: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        assert!(ops._called_exception_is_here_or_cannot_occur);
+        // direct_call args: funcptr, v_iter, cstep (the baked step).
+        assert_eq!(ops.ops[0].args.len(), 3);
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_rangenext_up"),
+            "expected 'll_rangenext_up' in {dbg}"
+        );
+        let Hlvalue::Constant(cstep) = &ops.ops[0].args[2] else {
+            panic!("expected Constant step as last direct_call arg");
+        };
+        assert!(matches!(cstep.value, ConstValue::Int(1)));
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -576,8 +576,9 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
 }
 
 /// RPython `class RangeIteratorRepr(AbstractRangeIteratorRepr)`
-/// (`rrange.py:145-156` + `lltypesystem/rrange.py:85-97`), constant-step
-/// (`step != 0`, `RANGEITER`) slice.
+/// (`rrange.py:145-156` + `lltypesystem/rrange.py:85-97`), covering both
+/// the constant-step (`step != 0`, `RANGEITER`) and variable-step
+/// (`step == 0`, `RANGESTITER`) shapes.
 ///
 /// ```python
 /// class AbstractRangeIteratorRepr(IteratorRepr):
@@ -592,16 +593,15 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
 /// where (`lltypesystem/rrange.py:58`) `RANGEITER = Ptr(GcStruct("range",
 /// ("next", Signed), ("stop", Signed)))`. Like
 /// [`super::rtuple::Length1TupleIteratorRepr`], pyre collapses the
-/// abstract/concrete split into one concrete repr. The variable-step
-/// `RANGESTITER` (`("next", "stop", "step")`) shape and its
-/// `ll_rangenext_updown` advance are deferred.
+/// abstract/concrete split into one concrete repr.
 #[derive(Debug)]
 pub struct RangeIteratorRepr {
-    /// `self.r_rng.step` (`rrange.py:147`) — the range step. Nonzero
-    /// selects `ll_rangenext_up` / `_down` (baked as the advance `step`
-    /// runtime arg); `0` is variable step, selecting `ll_rangenext_updown`
-    /// (which reads `iter.step` at runtime).
-    step: i64,
+    /// `self.r_rng` (`rrange.py:146`) — the source range repr. An
+    /// `AbstractRangeRepr` is fully determined by its `step`, so the
+    /// iterator carries its own self-contained copy (rebuilt from the
+    /// source step) rather than re-deriving the range repr from
+    /// `hop.args_r[0]` in `newiter`.
+    r_rng: AbstractRangeRepr,
     /// `self.lowleveltype = r_rng.RANGEITER` / `RANGESTITER`
     /// (`lltypesystem/rrange.py:41,58`) — `Ptr(GcStruct("range", ("next",
     /// Signed), ("stop", Signed)[, ("step", Signed)]))`. The `step` field
@@ -631,7 +631,7 @@ impl RangeIteratorRepr {
             TO: PtrTarget::Struct(st),
         }));
         Ok(RangeIteratorRepr {
-            step: r_rng.step,
+            r_rng: AbstractRangeRepr::new(r_rng.step)?,
             lowleveltype,
             state: ReprState::new(),
         })
@@ -640,7 +640,7 @@ impl RangeIteratorRepr {
     /// Whether this iterator's struct carries a runtime `step` field
     /// (the variable-step `RANGESTITER`).
     fn is_variable_step(&self) -> bool {
-        self.step == 0
+        self.r_rng.step == 0
     }
 }
 
@@ -693,17 +693,11 @@ impl Repr for RangeIteratorRepr {
     ///
     /// As with [`super::rtuple::Length1TupleIteratorRepr::newiter`], the
     /// iterator low-level type is baked into the helper builder rather
-    /// than threaded as a `citerptr` Void const; the source range repr
-    /// is read from `args_r[0]`.
+    /// than threaded as a `citerptr` Void const. The conversion target is
+    /// the iterator's own stored `self.r_rng` (`hop.inputargs(self.r_rng)`).
     fn newiter(&self, hop: &HighLevelOp) -> RTypeResult {
-        let r_rng = {
-            let args_r = hop.args_r.borrow();
-            args_r.first().and_then(|o| o.clone()).ok_or_else(|| {
-                TyperError::message("RangeIteratorRepr.newiter: arg0 repr missing")
-            })?
-        };
-        let vlist = hop.inputargs(vec![ConvertedTo::Repr(r_rng.as_ref())])?;
-        let range_lltype = r_rng.lowleveltype().clone();
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(&self.r_rng)])?;
+        let range_lltype = self.r_rng.lowleveltype().clone();
         let iter_lltype = self.lowleveltype.clone();
         let range_for_builder = range_lltype.clone();
         let iter_for_builder = iter_lltype.clone();
@@ -753,7 +747,7 @@ impl Repr for RangeIteratorRepr {
         // `args = ()` for variable step (updown reads iter.step).
         if !self.is_variable_step() {
             args.push(constant_with_lltype(
-                ConstValue::Int(self.step),
+                ConstValue::Int(self.r_rng.step),
                 LowLevelType::Signed,
             ));
         }
@@ -775,12 +769,12 @@ impl Repr for RangeIteratorRepr {
             )?;
             return hop.gendirectcall(&helper, args);
         }
-        let name = if self.step > 0 {
+        let name = if self.r_rng.step > 0 {
             "ll_rangenext_up"
         } else {
             "ll_rangenext_down"
         };
-        let up = self.step > 0;
+        let up = self.r_rng.step > 0;
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
             name.to_string(),
             vec![iter_lltype, LowLevelType::Signed],
@@ -1676,11 +1670,11 @@ mod tests {
         }
     }
 
-    /// rrange.py:158-170 constant-step `rtype_next` lowers to a
-    /// `direct_call` of `ll_rangenext_up` (`step > 0`) with the constant
-    /// step appended, preceded by `hop.exception_is_here()`.
-    #[test]
-    fn rangeiter_rtype_next_emits_direct_call_to_ll_rangenext_up() {
+    /// Drive constant-step `RangeIteratorRepr::rtype_next` and assert it
+    /// lowers to a single `direct_call` of `expected_name` with the baked
+    /// constant `step` appended, preceded by `hop.exception_is_here()`
+    /// (rrange.py:158-170).
+    fn assert_rtype_next_emits_direct_call(step: i64, expected_name: &str) {
         use crate::annotator::annrpython::RPythonAnnotator;
         use crate::flowspace::model::{SpaceOperation, Variable};
         use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
@@ -1691,7 +1685,7 @@ mod tests {
             .initialize_exceptiondata()
             .expect("initialize_exceptiondata in test setup");
 
-        let r_rng = AbstractRangeRepr::new(1).unwrap();
+        let r_rng = AbstractRangeRepr::new(step).unwrap();
         let iter_repr: Arc<RangeIteratorRepr> = Arc::new(RangeIteratorRepr::new(&r_rng).unwrap());
         let iter_lltype = iter_repr.lowleveltype().clone();
 
@@ -1736,14 +1730,25 @@ mod tests {
             panic!("expected Constant funcptr as direct_call arg 0");
         };
         let dbg = format!("{:?}", c.value);
-        assert!(
-            dbg.contains("ll_rangenext_up"),
-            "expected 'll_rangenext_up' in {dbg}"
-        );
+        assert!(dbg.contains(expected_name), "expected '{expected_name}' in {dbg}");
         let Hlvalue::Constant(cstep) = &ops.ops[0].args[2] else {
             panic!("expected Constant step as last direct_call arg");
         };
-        assert!(matches!(cstep.value, ConstValue::Int(1)));
+        assert!(matches!(cstep.value, ConstValue::Int(s) if s == step));
+    }
+
+    /// rrange.py:158-170 `step > 0` lowers to `ll_rangenext_up` with the
+    /// baked positive step.
+    #[test]
+    fn rangeiter_rtype_next_emits_direct_call_to_ll_rangenext_up() {
+        assert_rtype_next_emits_direct_call(1, "ll_rangenext_up");
+    }
+
+    /// rrange.py:158-170 `step < 0` lowers to `ll_rangenext_down` with the
+    /// baked negative step.
+    #[test]
+    fn rangeiter_rtype_next_emits_direct_call_to_ll_rangenext_down() {
+        assert_rtype_next_emits_direct_call(-1, "ll_rangenext_down");
     }
 
     /// rmodel.py:266-268 `IteratorRepr.rtype_iter` — `iter()` on a range

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -10,23 +10,23 @@
 //! `GcStruct("range", start, stop)` (`lltypesystem/rrange.py:51-57`).
 //!
 //! Landed: `rtype_len` (`step == 1`), `rtype_getitem` (constant-step,
-//! nonneg, `dum_nocheck`), and constant-step `RangeIteratorRepr`
-//! (`make_iterator_repr` / `newiter` / `rtype_next` via the `ll_rangeiter`
-//! + `ll_rangenext_up` / `_down` helper graphs).
+//! nonneg, `dum_nocheck`), and the `RangeIteratorRepr`
+//! (`make_iterator_repr` / `newiter` / `rtype_next`) for both the
+//! constant-step `RANGEITER` (`ll_rangenext_up` / `_down`) and the
+//! variable-step `RANGESTITER` (`ll_rangeiter` step-field copy +
+//! `ll_rangenext_updown`).
 //!
 //! Deferred to follow-on slices (matching how `FixedSizeListRepr` landed
-//! `rtype_len` first), all blocked on `_ll_rangelen`'s `int_floordiv`
-//! (not yet a recognised low-level op) or the variable-step `RANGEST`
-//! path: the general-step `ll_rangelen` length, the `rtype_getitem`
-//! `checkidx` (implicit-IndexError) and negative-index (`ll_rangeitem`)
-//! branches, the `RANGEST` variable-step `_getstep` getitem, and the
-//! variable-step `RANGESTITER` iterator (`ll_rangenext_updown`).
+//! `rtype_len` first): the general-step `ll_rangelen` length, the
+//! `rtype_getitem` `checkidx` (implicit-IndexError) and negative-index
+//! (`ll_rangeitem`) branches, and the `RANGEST` variable-step `_getstep`
+//! getitem.
 
 #![allow(non_camel_case_types)]
 
 use crate::flowspace::model::{
-    Block, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
-    SpaceOperation,
+    Block, BlockRef, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
+    SpaceOperation, Variable,
 };
 use crate::flowspace::pygraph::PyGraph;
 use crate::translator::rtyper::error::TyperError;
@@ -402,8 +402,8 @@ impl Repr for AbstractRangeRepr {
     ///     return RangeIteratorRepr(self)
     /// ```
     ///
-    /// The constant-step (`step != 0`) iterator lands; the variable-step
-    /// `RANGESTITER` iterator (`step == 0`) is deferred inside
+    /// Both the constant-step (`step != 0` → `RANGEITER`) and the
+    /// variable-step (`step == 0` → `RANGESTITER`) iterators are built by
     /// [`RangeIteratorRepr::new`].
     fn make_iterator_repr(&self, variant: &[String]) -> Result<Arc<dyn Repr>, TyperError> {
         if !variant.is_empty() {
@@ -597,35 +597,36 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
 /// `ll_rangenext_updown` advance are deferred.
 #[derive(Debug)]
 pub struct RangeIteratorRepr {
-    /// `self.r_rng.step` (`rrange.py:147`) — the constant range step,
-    /// nonzero for this repr. Selects `ll_rangenext_up` / `_down` and is
-    /// baked as the advance `step` runtime arg.
+    /// `self.r_rng.step` (`rrange.py:147`) — the range step. Nonzero
+    /// selects `ll_rangenext_up` / `_down` (baked as the advance `step`
+    /// runtime arg); `0` is variable step, selecting `ll_rangenext_updown`
+    /// (which reads `iter.step` at runtime).
     step: i64,
-    /// `self.lowleveltype = r_rng.RANGEITER` (`lltypesystem/rrange.py:58`)
-    /// — `Ptr(GcStruct("range", ("next", Signed), ("stop", Signed)))`.
+    /// `self.lowleveltype = r_rng.RANGEITER` / `RANGESTITER`
+    /// (`lltypesystem/rrange.py:41,58`) — `Ptr(GcStruct("range", ("next",
+    /// Signed), ("stop", Signed)[, ("step", Signed)]))`. The `step` field
+    /// is present only for the variable-step `RANGESTITER`.
     lowleveltype: LowLevelType,
     state: ReprState,
 }
 
 impl RangeIteratorRepr {
     /// RPython `AbstractRangeIteratorRepr.__init__(self, r_rng)`
-    /// (`rrange.py:146-151`) for the `step != 0` `RANGEITER` shape.
+    /// (`rrange.py:146-151`): `RANGEITER` (`step != 0`) or `RANGESTITER`
+    /// (`step == 0`, with the extra runtime `step` field).
     pub fn new(r_rng: &AbstractRangeRepr) -> Result<Self, TyperError> {
-        if r_rng.step == 0 {
-            return Err(rrange_deferred(
-                "RangeIteratorRepr (variable-step RANGESTITER / ll_rangenext_updown)",
-            ));
-        }
-        // RANGEITER = GcStruct("range", ("next", Signed), ("stop", Signed)).
-        // Mutable (no immutable hint): `ll_rangenext_*` writes `iter.next`.
+        // RANGEITER = GcStruct("range", ("next", Signed), ("stop", Signed));
+        // RANGESTITER adds ("step", Signed). Mutable (no immutable hint):
+        // `ll_rangenext_*` writes `iter.next`.
         let signed = LowLevelType::Signed;
-        let st = Struct::gc(
-            "range",
-            vec![
-                ("next".to_string(), signed.clone()),
-                ("stop".to_string(), signed),
-            ],
-        );
+        let mut fields = vec![
+            ("next".to_string(), signed.clone()),
+            ("stop".to_string(), signed.clone()),
+        ];
+        if r_rng.step == 0 {
+            fields.push(("step".to_string(), signed));
+        }
+        let st = Struct::gc("range", fields);
         let lowleveltype = LowLevelType::Ptr(Box::new(Ptr {
             TO: PtrTarget::Struct(st),
         }));
@@ -634,6 +635,12 @@ impl RangeIteratorRepr {
             lowleveltype,
             state: ReprState::new(),
         })
+    }
+
+    /// Whether this iterator's struct carries a runtime `step` field
+    /// (the variable-step `RANGESTITER`).
+    fn is_variable_step(&self) -> bool {
+        self.step == 0
     }
 }
 
@@ -700,6 +707,7 @@ impl Repr for RangeIteratorRepr {
         let iter_lltype = self.lowleveltype.clone();
         let range_for_builder = range_lltype.clone();
         let iter_for_builder = iter_lltype.clone();
+        let variable_step = self.is_variable_step();
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
             "ll_rangeiter".to_string(),
             vec![range_lltype],
@@ -709,6 +717,7 @@ impl Repr for RangeIteratorRepr {
                     "ll_rangeiter",
                     range_for_builder.clone(),
                     iter_for_builder.clone(),
+                    variable_step,
                 )
             },
         )?;
@@ -734,25 +743,44 @@ impl Repr for RangeIteratorRepr {
     ///     return hop.gendirectcall(llfn, v_iter, *args)
     /// ```
     ///
-    /// `step != 0` here (the repr rejects variable step), so the
-    /// `ll_rangenext_updown` arm is unreachable; `up` (`step > 0`) and
-    /// `down` (`step < 0`) bake the constant step as the advance arg.
+    /// `step > 0` → `ll_rangenext_up`, `step < 0` → `ll_rangenext_down`
+    /// (both bake the constant step as the advance arg); `step == 0`
+    /// (variable) → `ll_rangenext_updown`, which reads `iter.step` and
+    /// takes no extra arg.
     fn rtype_next(&self, hop: &HighLevelOp) -> RTypeResult {
         let mut args = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
-        args.push(constant_with_lltype(
-            ConstValue::Int(self.step),
-            LowLevelType::Signed,
-        ));
+        // upstream: `args = inputconst(Signed, step),` for nonzero step,
+        // `args = ()` for variable step (updown reads iter.step).
+        if !self.is_variable_step() {
+            args.push(constant_with_lltype(
+                ConstValue::Int(self.step),
+                LowLevelType::Signed,
+            ));
+        }
         hop.has_implicit_exception("StopIteration");
         hop.exception_is_here()?;
+        let iter_lltype = self.lowleveltype.clone();
+        let iter_for_builder = iter_lltype.clone();
+        if self.is_variable_step() {
+            let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+                "ll_rangenext_updown".to_string(),
+                vec![iter_lltype],
+                LowLevelType::Signed,
+                move |_rtyper, _args, _result| {
+                    build_ll_rangenext_updown_helper_graph(
+                        "ll_rangenext_updown",
+                        iter_for_builder.clone(),
+                    )
+                },
+            )?;
+            return hop.gendirectcall(&helper, args);
+        }
         let name = if self.step > 0 {
             "ll_rangenext_up"
         } else {
             "ll_rangenext_down"
         };
         let up = self.step > 0;
-        let iter_lltype = self.lowleveltype.clone();
-        let iter_for_builder = iter_lltype.clone();
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
             name.to_string(),
             vec![iter_lltype, LowLevelType::Signed],
@@ -766,26 +794,28 @@ impl Repr for RangeIteratorRepr {
 }
 
 /// Synthesise the `ll_rangeiter` helper graph
-/// (`lltypesystem/rrange.py:91-97`) for the constant-step `RANGEITER`
-/// shape:
+/// (`lltypesystem/rrange.py:91-97`):
 ///
 /// ```python
 /// def ll_rangeiter(ITERPTR, rng):
 ///     iter = malloc(ITERPTR.TO)
 ///     iter.next = rng.start
 ///     iter.stop = rng.stop
+///     if ITERPTR.TO is RANGESTITER:
+///         iter.step = rng.step
 ///     return iter
 /// ```
 ///
 /// Single block: `start = getfield(rng, 'start'); stop = getfield(rng,
 /// 'stop'); iter = malloc(RANGEITER, flavor=gc); setfield(iter, 'next',
 /// start); setfield(iter, 'stop', stop)`. `ITERPTR` is baked as
-/// `iter_lltype`; the `RANGESTITER` `iter.step = rng.step` write is
-/// elided (constant-step only).
+/// `iter_lltype`; for the variable-step `RANGESTITER` (`variable_step`)
+/// the `iter.step = rng.step` copy is also emitted.
 pub(crate) fn build_ll_rangeiter_helper_graph(
     name: &str,
     range_lltype: LowLevelType,
     iter_lltype: LowLevelType,
+    variable_step: bool,
 ) -> Result<PyGraph, TyperError> {
     let rng_arg = variable_with_lltype("rng", range_lltype);
     let startblock = Block::shared(vec![Hlvalue::Variable(rng_arg.clone())]);
@@ -822,7 +852,7 @@ pub(crate) fn build_ll_rangeiter_helper_graph(
     let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "getfield",
-        vec![Hlvalue::Variable(rng_arg), field_const("stop")],
+        vec![Hlvalue::Variable(rng_arg.clone()), field_const("stop")],
         Hlvalue::Variable(v_stop.clone()),
     ));
 
@@ -859,6 +889,27 @@ pub(crate) fn build_ll_rangeiter_helper_graph(
         ],
         Hlvalue::Variable(variable_with_lltype("v1", LowLevelType::Void)),
     ));
+
+    // if ITERPTR.TO is RANGESTITER: iter.step = rng.step.
+    if variable_step {
+        let v_step = variable_with_lltype("step", LowLevelType::Signed);
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(rng_arg), field_const("step")],
+            Hlvalue::Variable(v_step.clone()),
+        ));
+        startblock.borrow_mut().operations.push(SpaceOperation::new(
+            "setfield",
+            vec![
+                Hlvalue::Variable(v_iter.clone()),
+                field_const("step"),
+                Hlvalue::Variable(v_step),
+            ],
+            Hlvalue::Variable(variable_with_lltype("v2", LowLevelType::Void)),
+        ));
+    } else {
+        let _ = rng_arg;
+    }
 
     startblock.closeblock(vec![
         Link::new(
@@ -1012,6 +1063,227 @@ pub(crate) fn build_ll_rangenext_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["iter".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// Build one ascending/descending guard block for
+/// [`build_ll_rangenext_updown_helper_graph`]. `cmp_op` selects `int_ge`
+/// (ascending, `next >= stop`) vs `int_le` (descending, `next <= stop`):
+/// on the at-end branch the guard raises `StopIteration`; otherwise it
+/// advances by passing `(iter, next, step)` to `advance`.
+fn build_rangenext_guard_block(
+    guard: &BlockRef,
+    b_iter: Variable,
+    b_step: Variable,
+    cmp_op: &str,
+    advance: &BlockRef,
+    exceptblock: &BlockRef,
+) -> Result<(), TyperError> {
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+    let bool_const = |b: bool| constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool);
+
+    let v_next = variable_with_lltype("next", LowLevelType::Signed);
+    let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    let v_atend = variable_with_lltype("atend", LowLevelType::Bool);
+    {
+        let mut g = guard.borrow_mut();
+        g.operations.push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(b_iter.clone()), field_const("next")],
+            Hlvalue::Variable(v_next.clone()),
+        ));
+        g.operations.push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(b_iter.clone()), field_const("stop")],
+            Hlvalue::Variable(v_stop.clone()),
+        ));
+        g.operations.push(SpaceOperation::new(
+            cmp_op,
+            vec![Hlvalue::Variable(v_next.clone()), Hlvalue::Variable(v_stop)],
+            Hlvalue::Variable(v_atend.clone()),
+        ));
+        g.exitswitch = Some(Hlvalue::Variable(v_atend));
+    }
+
+    let exc_args = exception_args("StopIteration")?;
+    guard.closeblock(vec![
+        // atend == True: raise StopIteration.
+        Link::new(exc_args, Some(exceptblock.clone()), Some(bool_const(true))).into_ref(),
+        // atend == False: advance and return.
+        Link::new(
+            vec![
+                Hlvalue::Variable(b_iter),
+                Hlvalue::Variable(v_next),
+                Hlvalue::Variable(b_step),
+            ],
+            Some(advance.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+    Ok(())
+}
+
+/// Synthesise the `ll_rangenext_updown` helper graph
+/// (`rrange.py:186-191`):
+///
+/// ```python
+/// def ll_rangenext_updown(iter):
+///     step = iter.step
+///     if step > 0:
+///         return ll_rangenext_up(iter, step)
+///     else:
+///         return ll_rangenext_down(iter, step)
+/// ```
+///
+/// 4-block CFG. The variable-step iterator carries `step` in its struct,
+/// so it is read at runtime and its sign selects the advance direction.
+/// The `ll_rangenext_up` / `ll_rangenext_down` bodies are inlined behind
+/// the sign branch (mirroring how [`build_ll_rangenext_helper_graph`]
+/// inlines the constant-step body) rather than re-dispatched as direct
+/// calls:
+/// - **start** `(iter)`: `step = getfield(iter, 'step'); pos =
+///   int_gt(step, 0)`. Switch on `pos`: True → up_guard, False →
+///   down_guard; both carry `iter, step`.
+/// - **up_guard** / **down_guard** `(iter, step)`: built by
+///   [`build_rangenext_guard_block`] with `int_ge` / `int_le`.
+/// - **advance** `(iter, next, step)`: `newnext = int_add(next, step);
+///   setfield(iter, 'next', newnext)`; return `next`.
+pub(crate) fn build_ll_rangenext_updown_helper_graph(
+    name: &str,
+    iter_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let iter_arg = variable_with_lltype("iter", iter_lltype.clone());
+    let startblock = Block::shared(vec![Hlvalue::Variable(iter_arg.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+    let bool_const = |b: bool| constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool);
+
+    // step = iter.step; pos = step > 0.
+    let v_step = variable_with_lltype("step", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(iter_arg.clone()), field_const("step")],
+        Hlvalue::Variable(v_step.clone()),
+    ));
+    let v_pos = variable_with_lltype("pos", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_gt",
+        vec![
+            Hlvalue::Variable(v_step.clone()),
+            constant_with_lltype(ConstValue::Int(0), LowLevelType::Signed),
+        ],
+        Hlvalue::Variable(v_pos.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(v_pos));
+
+    // up_guard / down_guard block params: (iter, step).
+    let up_iter = variable_with_lltype("iter", iter_lltype.clone());
+    let up_step = variable_with_lltype("step", LowLevelType::Signed);
+    let up_guard = Block::shared(vec![
+        Hlvalue::Variable(up_iter.clone()),
+        Hlvalue::Variable(up_step.clone()),
+    ]);
+    let down_iter = variable_with_lltype("iter", iter_lltype.clone());
+    let down_step = variable_with_lltype("step", LowLevelType::Signed);
+    let down_guard = Block::shared(vec![
+        Hlvalue::Variable(down_iter.clone()),
+        Hlvalue::Variable(down_step.clone()),
+    ]);
+
+    // advance block params: (iter, next, step).
+    let adv_iter = variable_with_lltype("iter", iter_lltype);
+    let adv_next = variable_with_lltype("next", LowLevelType::Signed);
+    let adv_step = variable_with_lltype("step", LowLevelType::Signed);
+    let advance = Block::shared(vec![
+        Hlvalue::Variable(adv_iter.clone()),
+        Hlvalue::Variable(adv_next.clone()),
+        Hlvalue::Variable(adv_step.clone()),
+    ]);
+
+    startblock.closeblock(vec![
+        // step > 0: ascending guard.
+        Link::new(
+            vec![
+                Hlvalue::Variable(iter_arg.clone()),
+                Hlvalue::Variable(v_step.clone()),
+            ],
+            Some(up_guard.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        // step <= 0: descending guard.
+        Link::new(
+            vec![Hlvalue::Variable(iter_arg), Hlvalue::Variable(v_step)],
+            Some(down_guard.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    build_rangenext_guard_block(
+        &up_guard,
+        up_iter,
+        up_step,
+        "int_ge",
+        &advance,
+        &graph.exceptblock,
+    )?;
+    build_rangenext_guard_block(
+        &down_guard,
+        down_iter,
+        down_step,
+        "int_le",
+        &advance,
+        &graph.exceptblock,
+    )?;
+
+    // newnext = next + step; iter.next = newnext; return next.
+    let v_newnext = variable_with_lltype("newnext", LowLevelType::Signed);
+    {
+        let mut b = advance.borrow_mut();
+        b.operations.push(SpaceOperation::new(
+            "int_add",
+            vec![
+                Hlvalue::Variable(adv_next.clone()),
+                Hlvalue::Variable(adv_step),
+            ],
+            Hlvalue::Variable(v_newnext.clone()),
+        ));
+        b.operations.push(SpaceOperation::new(
+            "setfield",
+            vec![
+                Hlvalue::Variable(adv_iter),
+                field_const("next"),
+                Hlvalue::Variable(v_newnext),
+            ],
+            Hlvalue::Variable(variable_with_lltype("v0", LowLevelType::Void)),
+        ));
+    }
+    advance.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(adv_next)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["iter".to_string()],
         func,
     ))
 }
@@ -1233,11 +1505,11 @@ mod tests {
     }
 
     /// `make_iterator_repr` mints a `RangeIteratorRepr` whose lowleveltype
-    /// is the `RANGEITER` struct (`next`, `stop`). A non-None variant is
-    /// rejected (`rrange.py:64-66`); the variable-step (`step == 0`)
-    /// iterator is deferred.
+    /// is the `RANGEITER` struct (`next`, `stop`) for constant step and the
+    /// `RANGESTITER` struct (`next`, `stop`, `step`) for variable step. A
+    /// non-None variant is rejected (`rrange.py:64-66`).
     #[test]
-    fn make_iterator_repr_constant_step_yields_rangeiter_with_next_stop_struct() {
+    fn make_iterator_repr_yields_rangeiter_and_rangestiter_structs() {
         let r_rng = AbstractRangeRepr::new(1).unwrap();
         let it = r_rng.make_iterator_repr(&[]).unwrap();
         assert_eq!(it.class_name(), "RangeIteratorRepr");
@@ -1253,9 +1525,19 @@ mod tests {
         }
         // unsupported variant → TyperError.
         assert!(r_rng.make_iterator_repr(&["reversed".to_string()]).is_err());
-        // variable-step RANGESTITER iterator is deferred.
+
+        // variable-step (step == 0) → RANGESTITER with the extra `step` field.
         let rst = AbstractRangeRepr::new(0).unwrap();
-        assert!(rst.make_iterator_repr(&[]).is_err());
+        let it = rst.make_iterator_repr(&[]).unwrap();
+        match it.lowleveltype() {
+            LowLevelType::Ptr(p) => match &p.TO {
+                PtrTarget::Struct(st) => {
+                    assert_eq!(st._names_without_voids(), vec!["next", "stop", "step"]);
+                }
+                other => panic!("RANGESTITER TO not Struct: {other:?}"),
+            },
+            other => panic!("RANGESTITER not Ptr: {other:?}"),
+        }
     }
 
     /// `ll_rangeiter` single block: `getfield start; getfield stop;
@@ -1268,7 +1550,8 @@ mod tests {
             .lowleveltype()
             .clone();
         let range_lltype = r_rng.lowleveltype().clone();
-        let g = build_ll_rangeiter_helper_graph("ll_rangeiter", range_lltype, iter_lltype).unwrap();
+        let g = build_ll_rangeiter_helper_graph("ll_rangeiter", range_lltype, iter_lltype, false)
+            .unwrap();
         let inner = g.graph.borrow();
         let startblock = inner.startblock.borrow();
         let ops: Vec<&str> = startblock
@@ -1283,6 +1566,81 @@ mod tests {
         assert!(startblock.exitswitch.is_none());
         assert_eq!(startblock.exits.len(), 1);
         assert_eq!(startblock.inputargs.len(), 1);
+    }
+
+    /// Variable-step `ll_rangeiter` additionally copies `iter.step =
+    /// rng.step` (the `if ITERPTR.TO is RANGESTITER` branch,
+    /// lltypesystem/rrange.py:95-96), so the block carries a third
+    /// `getfield` + `setfield` pair.
+    #[test]
+    fn build_ll_rangeiter_helper_graph_variable_step_copies_step_field() {
+        let r_rng = AbstractRangeRepr::new(0).unwrap();
+        let iter_lltype = RangeIteratorRepr::new(&r_rng)
+            .unwrap()
+            .lowleveltype()
+            .clone();
+        let range_lltype = r_rng.lowleveltype().clone();
+        let g = build_ll_rangeiter_helper_graph("ll_rangeiter", range_lltype, iter_lltype, true)
+            .unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(
+            ops,
+            vec![
+                "getfield", "getfield", "malloc", "setfield", "setfield", "getfield", "setfield"
+            ]
+        );
+        assert!(startblock.exitswitch.is_none());
+        assert_eq!(startblock.exits.len(), 1);
+    }
+
+    /// `ll_rangenext_updown` reads `iter.step`, branches on `int_gt(step,
+    /// 0)`, and inlines the ascending (`int_ge`) / descending (`int_le`)
+    /// guards into a shared advance block (rrange.py:186-191).
+    #[test]
+    fn build_ll_rangenext_updown_helper_graph_branches_on_step_sign() {
+        let r_rng = AbstractRangeRepr::new(0).unwrap();
+        let iter_lltype = RangeIteratorRepr::new(&r_rng)
+            .unwrap()
+            .lowleveltype()
+            .clone();
+        let g = build_ll_rangenext_updown_helper_graph("ll_rangenext_updown", iter_lltype).unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        // step = iter.step; pos = step > 0.
+        assert_eq!(ops, vec!["getfield", "int_gt"]);
+        assert!(startblock.exitswitch.is_some());
+        // True → up_guard, False → down_guard.
+        assert_eq!(startblock.exits.len(), 2);
+        // single `iter` inputarg.
+        assert_eq!(startblock.inputargs.len(), 1);
+
+        // The two guard targets compare with int_ge / int_le.
+        let mut cmps: Vec<String> = startblock
+            .exits
+            .iter()
+            .map(|link| {
+                let target = link.borrow().target.clone().unwrap();
+                let body = target.borrow();
+                body.operations
+                    .iter()
+                    .map(|op| op.opname.clone())
+                    .find(|name| name == "int_ge" || name == "int_le")
+                    .unwrap()
+            })
+            .collect();
+        cmps.sort();
+        assert_eq!(cmps, vec!["int_ge".to_string(), "int_le".to_string()]);
     }
 
     /// `ll_rangenext_up` start block guards with `int_ge` and branches to

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -33,8 +33,8 @@ use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, Ptr, PtrTarget, Struct};
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, constant_with_lltype, exception_args, helper_pygraph_from_graph,
-    variable_with_lltype,
+    ConvertedTo, GenopResult, HighLevelOp, constant_with_lltype, exception_args,
+    helper_pygraph_from_graph, variable_with_lltype,
 };
 use std::sync::Arc;
 
@@ -246,6 +246,31 @@ impl AbstractRangeRepr {
             step,
         })
     }
+
+    /// RPython `AbstractRangeRepr._getstep(self, v_rng, hop)`
+    /// (`rrange.py:18-20`):
+    ///
+    /// ```python
+    /// def _getstep(self, v_rng, hop):
+    ///     return hop.genop(self.getfield_opname,
+    ///             [v_rng, hop.inputconst(Void, 'step')], resulttype=Signed)
+    /// ```
+    ///
+    /// `getfield_opname` is `"getfield"` (`lltypesystem/rrange.py:48`),
+    /// reading the runtime `step` field of a variable-step `RANGEST`.
+    fn _getstep(&self, v_rng: Hlvalue, hop: &HighLevelOp) -> Result<Hlvalue, TyperError> {
+        hop.genop(
+            "getfield",
+            vec![
+                v_rng,
+                constant_with_lltype(ConstValue::byte_str("step"), LowLevelType::Void),
+            ],
+            GenopResult::LLType(LowLevelType::Signed),
+        )
+        .ok_or_else(|| {
+            TyperError::message("AbstractRangeRepr._getstep: genop returned no result")
+        })
+    }
 }
 
 impl Repr for AbstractRangeRepr {
@@ -282,9 +307,9 @@ impl Repr for AbstractRangeRepr {
     ///
     /// `step == 1` → `ll_rangelen1`; any other constant `step != 0` →
     /// `ll_rangelen` with the step baked as the `inputconst(Signed,
-    /// self.step)` arg (`_ll_rangelen`'s floor-division via
-    /// `int_floordiv`). The variable-step `RANGEST` (`step == 0`, needs
-    /// `_getstep`) path is deferred.
+    /// self.step)` arg; the variable-step `RANGEST` (`step == 0`) reads its
+    /// runtime `step` via `_getstep` and feeds it to the same `ll_rangelen`
+    /// (`_ll_rangelen`'s floor-division via `int_floordiv`).
     fn rtype_len(&self, hop: &HighLevelOp) -> RTypeResult {
         let mut args = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
         let ptr_lltype = self.lltype.clone();
@@ -300,17 +325,13 @@ impl Repr for AbstractRangeRepr {
             )?;
             return hop.gendirectcall(&helper, args);
         }
-        if self.step == 0 {
-            return Err(TyperError::missing_rtype_operation(
-                "AbstractRangeRepr.rtype_len(step=0) — variable-step RANGEST \
-                 _getstep path deferred",
-            ));
-        }
-        // step != 0 (constant): v_step = inputconst(Signed, self.step).
-        args.push(constant_with_lltype(
-            ConstValue::Int(self.step),
-            LowLevelType::Signed,
-        ));
+        // v_step: inputconst for a constant step, `_getstep` for variable.
+        let v_step = if self.step != 0 {
+            constant_with_lltype(ConstValue::Int(self.step), LowLevelType::Signed)
+        } else {
+            self._getstep(args[0].clone(), hop)?
+        };
+        args.push(v_step);
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
             "ll_rangelen".to_string(),
             vec![ptr_lltype, LowLevelType::Signed],
@@ -345,26 +366,21 @@ impl Repr for AbstractRangeRepr {
     ///     return hop.gendirectcall(llfn, v_func, v_lst, v_index, cstep)
     /// ```
     ///
-    /// The constant-step (`step != 0`) + nonneg + `dum_nocheck` fast path:
+    /// The nonneg + `dum_nocheck` fast path:
     /// `ll_rangeitem_nonneg(dum_nocheck, l, index, step)` collapses (no
     /// IndexError branch) to `l.start + index * step` (`rrange.py:74-77`).
     /// Unlike `rtype_len`, the formula is `int_mul` + `int_add` with no
-    /// floor-division, so any constant step lowers here. `step` is baked
-    /// as the `inputconst(Signed, self.step)` runtime arg. The `checkidx`
-    /// (implicit-IndexError, needs `_ll_rangelen` floor-division), the
-    /// negative-index (`ll_rangeitem`), and the variable-step `RANGEST`
-    /// (`step == 0`, needs `_getstep`) branches surface a `TyperError`
-    /// until those land.
+    /// floor-division, so any step lowers here: a constant step is baked as
+    /// `inputconst(Signed, self.step)`, a variable-step `RANGEST`
+    /// (`step == 0`) reads its runtime `step` via `_getstep`. The `checkidx`
+    /// (implicit-IndexError) and negative-index (`ll_rangeitem`) branches —
+    /// both needing the `_ll_rangelen` floor-division inline — surface a
+    /// `TyperError` until they land.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::annotator::model::SomeValue;
         if hop.has_implicit_exception("IndexError") {
             return Err(TyperError::message(
                 "AbstractRangeRepr.rtype_getitem: checkidx IndexError branch not yet ported",
-            ));
-        }
-        if self.step == 0 {
-            return Err(TyperError::message(
-                "AbstractRangeRepr.rtype_getitem: variable-step RANGEST (_getstep) not yet ported",
             ));
         }
         let s1 = hop.args_s.borrow().get(1).cloned().ok_or_else(|| {
@@ -387,10 +403,13 @@ impl Repr for AbstractRangeRepr {
             ConvertedTo::Repr(self),
             ConvertedTo::LowLevelType(&LowLevelType::Signed),
         ])?;
-        args.push(constant_with_lltype(
-            ConstValue::Int(self.step),
-            LowLevelType::Signed,
-        ));
+        // cstep: inputconst for a constant step, `_getstep` for variable.
+        let cstep = if self.step != 0 {
+            constant_with_lltype(ConstValue::Int(self.step), LowLevelType::Signed)
+        } else {
+            self._getstep(args[0].clone(), hop)?
+        };
+        args.push(cstep);
         hop.exception_is_here()?;
         let ptr_lltype = self.lltype.clone();
         let ptr_for_builder = ptr_lltype.clone();
@@ -1819,9 +1838,78 @@ mod tests {
         );
     }
 
+    /// rrange.py:25-29 — `len()` on a variable-step `RANGEST` reads the
+    /// runtime `step` via `_getstep` (a `getfield`) and passes it to
+    /// `ll_rangelen`, so the trailing direct_call arg is the getfield
+    /// result variable, not a baked constant.
+    #[test]
+    fn rangerepr_len_variable_step_reads_getstep_then_ll_rangelen() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        // step == 0 (variable) → RANGEST; _getstep reads iter.step.
+        let range_repr: Arc<AbstractRangeRepr> =
+            Arc::new(AbstractRangeRepr::new(0).expect("AbstractRangeRepr::new(0)"));
+        let range_lltype = range_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_rng = Variable::new();
+        v_rng.set_concretetype(Some(range_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "len".to_string(),
+                vec![Hlvalue::Variable(v_rng)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .push(crate::annotator::model::SomeValue::Impossible);
+        hop.args_r
+            .borrow_mut()
+            .push(Some(range_repr.clone() as Arc<dyn Repr>));
+
+        let result = range_repr
+            .rtype_len(&hop)
+            .unwrap_or_else(|err| panic!("range rtype_len(step=0): {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        // _getstep getfield, then the ll_rangelen direct_call.
+        assert_eq!(ops.ops.len(), 2);
+        assert_eq!(ops.ops[0].opname, "getfield");
+        assert_eq!(ops.ops[1].opname, "direct_call");
+        // direct_call args: funcptr, v_rng, v_step (the getfield result).
+        assert_eq!(ops.ops[1].args.len(), 3);
+        assert!(matches!(ops.ops[1].args[2], Hlvalue::Variable(_)));
+        let Hlvalue::Constant(c) = &ops.ops[1].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(
+            dbg.contains("ll_rangelen"),
+            "expected 'll_rangelen' in {dbg}"
+        );
+    }
+
     /// Negative-index (`args_s[1].nonneg == false`) needs the `ll_rangeitem`
     /// length normalisation (`_ll_rangelen` floor-division), deferred; like
-    /// the checkidx and variable-step branches it surfaces a `TyperError`.
+    /// the checkidx branch it surfaces a `TyperError`.
     #[test]
     fn rangerepr_getitem_negative_index_is_deferred() {
         use crate::annotator::annrpython::RPythonAnnotator;

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -10,17 +10,20 @@
 //! repr is NOT array-backed (`FixedSizeListRepr`) but an immutable
 //! `GcStruct("range", start, stop)` (`lltypesystem/rrange.py:51-57`).
 //!
-//! Landed: `rtype_len` for any constant step (`ll_rangelen1` for `step ==
-//! 1`, the general `ll_rangelen` / `_ll_rangelen` floor-division
-//! otherwise), `rtype_getitem` (constant-step, nonneg, `dum_nocheck`),
-//! and the `RangeIteratorRepr` (`make_iterator_repr` / `newiter` /
-//! `rtype_next`) for both the constant-step `RANGEITER` (`ll_rangenext_up`
-//! / `_down`) and the variable-step `RANGESTITER` (`ll_rangeiter`
-//! step-field copy + `ll_rangenext_updown`).
+//! Landed: `rtype_len` for any step (`ll_rangelen1` for `step == 1`, the
+//! general `ll_rangelen` / `_ll_rangelen` floor-division otherwise),
+//! `rtype_getitem` for all four `(checkidx, nonneg)` combinations
+//! (`ll_rangeitem_nonneg` / `ll_rangeitem` and their `_checked` variants,
+//! sharing the `_ll_rangelen` length core), the `RANGEST` variable-step
+//! `_getstep` (`rtype_len` / `rtype_getitem`), and the `RangeIteratorRepr`
+//! (`make_iterator_repr` / `newiter` / `rtype_next`) for both the
+//! constant-step `RANGEITER` (`ll_rangenext_up` / `_down`) and the
+//! variable-step `RANGESTITER` (`ll_rangeiter` step-field copy +
+//! `ll_rangenext_updown`).
 //!
-//! Deferred to follow-on slices: the `rtype_getitem` `checkidx`
-//! (implicit-IndexError) and negative-index (`ll_rangeitem`) branches,
-//! and the `RANGEST` variable-step `_getstep` (`rtype_len` / `rtype_getitem`).
+//! Deferred to follow-on slices: `rtype_builtin_range` (the `range(...)`
+//! constructor lowering, which needs `ll_newrange` / `ll_newrangest` and the
+//! list-repr-backed `ll_range2list`).
 
 #![allow(non_camel_case_types)]
 
@@ -31,15 +34,28 @@ use crate::flowspace::model::{
 use crate::flowspace::pygraph::PyGraph;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, Ptr, PtrTarget, Struct};
+use crate::translator::rtyper::lltypesystem::rstr::sub_helper_funcptr_constant;
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, GenopResult, HighLevelOp, constant_with_lltype, exception_args,
-    helper_pygraph_from_graph, variable_with_lltype,
+    ConvertedTo, GenopResult, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype,
+    exception_args, helper_pygraph_from_graph, variable_with_lltype,
 };
 use std::sync::Arc;
 
 fn rrange_deferred(name: &str) -> TyperError {
     TyperError::missing_rtype_operation(format!("rrange.{name} helper surface deferred"))
+}
+
+fn signed_const(n: i64) -> Hlvalue {
+    constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed)
+}
+
+fn bool_const(b: bool) -> Hlvalue {
+    constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool)
+}
+
+fn void_field(f: &str) -> Hlvalue {
+    constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void)
 }
 
 /// RPython `_ll_rangelen(start, stop, step)`.
@@ -102,7 +118,14 @@ pub fn ll_rangeitem(
     Ok(start + index * step)
 }
 
-/// RPython `rtype_builtin_range(hop)`.
+/// RPython `rtype_builtin_range(hop)` (`rrange.py:96-126`) — lowers
+/// `range(...)`. Deferred: the `AbstractRangeRepr` result arm needs
+/// `ll_newrange` / `ll_newrangest` helper graphs (malloc + setfield
+/// start/stop[/step], `lltypesystem/rrange.py:77-102`), and the
+/// non-range (real-list) arm needs `ll_range2list`, which builds a list
+/// via the list repr's `ll_newlist` + `ll_setitem_fast` (not yet a
+/// graph-buildable surface here). It is also not yet wired into the
+/// rtyper's builtin dispatch.
 pub fn rtype_builtin_range(_hop: &HighLevelOp) -> RTypeResult {
     Err(rrange_deferred("rtype_builtin_range"))
 }
@@ -267,9 +290,7 @@ impl AbstractRangeRepr {
             ],
             GenopResult::LLType(LowLevelType::Signed),
         )
-        .ok_or_else(|| {
-            TyperError::message("AbstractRangeRepr._getstep: genop returned no result")
-        })
+        .ok_or_else(|| TyperError::message("AbstractRangeRepr._getstep: genop returned no result"))
     }
 }
 
@@ -366,23 +387,18 @@ impl Repr for AbstractRangeRepr {
     ///     return hop.gendirectcall(llfn, v_func, v_lst, v_index, cstep)
     /// ```
     ///
-    /// The nonneg + `dum_nocheck` fast path:
-    /// `ll_rangeitem_nonneg(dum_nocheck, l, index, step)` collapses (no
-    /// IndexError branch) to `l.start + index * step` (`rrange.py:74-77`).
-    /// Unlike `rtype_len`, the formula is `int_mul` + `int_add` with no
-    /// floor-division, so any step lowers here: a constant step is baked as
-    /// `inputconst(Signed, self.step)`, a variable-step `RANGEST`
-    /// (`step == 0`) reads its runtime `step` via `_getstep`. The `checkidx`
-    /// (implicit-IndexError) and negative-index (`ll_rangeitem`) branches —
-    /// both needing the `_ll_rangelen` floor-division inline — surface a
-    /// `TyperError` until they land.
+    /// `spec` (`dum_checkidx` / `dum_nocheck`) and `hop.args_s[1].nonneg`
+    /// select one of four `func`-folded helpers via [`rangeitem_helper`]: the
+    /// nonneg `dum_nocheck` fast path `ll_rangeitem_nonneg`
+    /// (`l.start + index * step`, `rrange.py:74-77`), the negative-index
+    /// `ll_rangeitem` (`rrange.py:88-90`), the bound-checked nonneg
+    /// `ll_rangeitem_nonneg` (`rrange.py:75-76`), or the full checked
+    /// `ll_rangeitem` (`rrange.py:80-87`). A constant step is baked as
+    /// `inputconst(Signed, self.step)`; a variable-step `RANGEST`
+    /// (`step == 0`) reads its runtime `step` via `_getstep`.
     fn rtype_getitem(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::annotator::model::SomeValue;
-        if hop.has_implicit_exception("IndexError") {
-            return Err(TyperError::message(
-                "AbstractRangeRepr.rtype_getitem: checkidx IndexError branch not yet ported",
-            ));
-        }
+        let checkidx = hop.has_implicit_exception("IndexError");
         let s1 = hop.args_s.borrow().get(1).cloned().ok_or_else(|| {
             TyperError::message("AbstractRangeRepr.rtype_getitem: args_s[1] missing")
         })?;
@@ -394,11 +410,6 @@ impl Repr for AbstractRangeRepr {
                 )));
             }
         };
-        if !nonneg {
-            return Err(TyperError::message(
-                "AbstractRangeRepr.rtype_getitem: negative-index ll_rangeitem branch not yet ported",
-            ));
-        }
         let mut args = hop.inputargs(vec![
             ConvertedTo::Repr(self),
             ConvertedTo::LowLevelType(&LowLevelType::Signed),
@@ -411,19 +422,7 @@ impl Repr for AbstractRangeRepr {
         };
         args.push(cstep);
         hop.exception_is_here()?;
-        let ptr_lltype = self.lltype.clone();
-        let ptr_for_builder = ptr_lltype.clone();
-        let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_rangeitem_nonneg".to_string(),
-            vec![ptr_lltype, LowLevelType::Signed, LowLevelType::Signed],
-            LowLevelType::Signed,
-            move |_rtyper, _args, _result| {
-                build_ll_rangeitem_nonneg_helper_graph(
-                    "ll_rangeitem_nonneg",
-                    ptr_for_builder.clone(),
-                )
-            },
-        )?;
+        let helper = rangeitem_helper(&hop.rtyper, checkidx, nonneg, self.lltype.clone())?;
         hop.gendirectcall(&helper, args)
     }
 
@@ -586,27 +585,100 @@ pub(crate) fn build_ll_rangelen_helper_graph(
         Hlvalue::Variable(return_var),
     );
 
-    let signed_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
-    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
-    let bool_const = |b: bool| constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool);
-
-    // start = l.start; stop = l.stop; pos = step > 0.
+    // start = l.start; stop = l.stop.
     let v_start = variable_with_lltype("start", LowLevelType::Signed);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "getfield",
-        vec![Hlvalue::Variable(l_arg.clone()), field_const("start")],
+        vec![Hlvalue::Variable(l_arg.clone()), void_field("start")],
         Hlvalue::Variable(v_start.clone()),
     ));
     let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "getfield",
-        vec![Hlvalue::Variable(l_arg), field_const("stop")],
+        vec![Hlvalue::Variable(l_arg), void_field("stop")],
         Hlvalue::Variable(v_stop.clone()),
     ));
+
+    emit_rangelen_body(
+        &graph.returnblock,
+        &startblock,
+        Hlvalue::Variable(v_start),
+        Hlvalue::Variable(v_stop),
+        Hlvalue::Variable(step_arg),
+    );
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise the `_ll_rangelen(start, stop, step)` helper graph
+/// (`rrange.py:56-63`) — the shared length core that `ll_rangelen`
+/// (`rrange.py:65-66`) and the checked / negative-index `ll_rangeitem`
+/// variants `direct_call`. `start`/`stop`/`step` are runtime args; the body is
+/// [`emit_rangelen_body`].
+pub(crate) fn build_underscore_ll_rangelen_helper_graph(name: &str) -> Result<PyGraph, TyperError> {
+    let start_arg = variable_with_lltype("start", LowLevelType::Signed);
+    let stop_arg = variable_with_lltype("stop", LowLevelType::Signed);
+    let step_arg = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(start_arg.clone()),
+        Hlvalue::Variable(stop_arg.clone()),
+        Hlvalue::Variable(step_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    emit_rangelen_body(
+        &graph.returnblock,
+        &startblock,
+        Hlvalue::Variable(start_arg),
+        Hlvalue::Variable(stop_arg),
+        Hlvalue::Variable(step_arg),
+    );
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["start".to_string(), "stop".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// Append the `_ll_rangelen(start, stop, step)` body (`rrange.py:56-63`) onto
+/// `startblock`, whose `start`/`stop`/`step` operands are already available.
+/// Branches on `int_gt(step, 0)`, runs the matching floor-division arm
+/// `(stop - start + (step - 1)) // step` or `(start - stop - (step + 1)) //
+/// (-step)`, then clamps a negative result to `0`, linking the length into
+/// `returnblock`. The floor-divisions run on non-negative operands, so
+/// `int_floordiv` (truncating) matches Python's `//`.
+fn emit_rangelen_body(
+    returnblock: &BlockRef,
+    startblock: &BlockRef,
+    start: Hlvalue,
+    stop: Hlvalue,
+    step: Hlvalue,
+) {
+    // pos = step > 0.
     let v_pos = variable_with_lltype("pos", LowLevelType::Bool);
     startblock.borrow_mut().operations.push(SpaceOperation::new(
         "int_gt",
-        vec![Hlvalue::Variable(step_arg.clone()), signed_const(0)],
+        vec![step.clone(), signed_const(0)],
         Hlvalue::Variable(v_pos.clone()),
     ));
     startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(v_pos));
@@ -635,21 +707,13 @@ pub(crate) fn build_ll_rangelen_helper_graph(
 
     startblock.closeblock(vec![
         Link::new(
-            vec![
-                Hlvalue::Variable(v_start.clone()),
-                Hlvalue::Variable(v_stop.clone()),
-                Hlvalue::Variable(step_arg.clone()),
-            ],
+            vec![start.clone(), stop.clone(), step.clone()],
             Some(pos_arm.clone()),
             Some(bool_const(true)),
         )
         .into_ref(),
         Link::new(
-            vec![
-                Hlvalue::Variable(v_start),
-                Hlvalue::Variable(v_stop),
-                Hlvalue::Variable(step_arg),
-            ],
+            vec![start, stop, step],
             Some(neg_arm.clone()),
             Some(bool_const(false)),
         )
@@ -753,28 +817,17 @@ pub(crate) fn build_ll_rangelen_helper_graph(
     clamp.closeblock(vec![
         Link::new(
             vec![signed_const(0)],
-            Some(graph.returnblock.clone()),
+            Some(returnblock.clone()),
             Some(bool_const(true)),
         )
         .into_ref(),
         Link::new(
             vec![Hlvalue::Variable(c_result)],
-            Some(graph.returnblock.clone()),
+            Some(returnblock.clone()),
             Some(bool_const(false)),
         )
         .into_ref(),
     ]);
-
-    let func = GraphFunc::new(
-        name.to_string(),
-        Constant::new(ConstValue::Dict(Default::default())),
-    );
-    graph.func = Some(func.clone());
-    Ok(helper_pygraph_from_graph(
-        graph,
-        vec!["l".to_string(), "step".to_string()],
-        func,
-    ))
 }
 
 /// Synthesise the `ll_rangeitem_nonneg` helper graph (`rrange.py:74-77`)
@@ -809,26 +862,12 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
         Hlvalue::Variable(return_var),
     );
 
-    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
-
-    let v_start = variable_with_lltype("start", LowLevelType::Signed);
-    startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "getfield",
-        vec![Hlvalue::Variable(l_arg), field_const("start")],
-        Hlvalue::Variable(v_start.clone()),
-    ));
-    let v_prod = variable_with_lltype("prod", LowLevelType::Signed);
-    startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "int_mul",
-        vec![Hlvalue::Variable(index_arg), Hlvalue::Variable(step_arg)],
-        Hlvalue::Variable(v_prod.clone()),
-    ));
-    let v_result = variable_with_lltype("result", LowLevelType::Signed);
-    startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "int_add",
-        vec![Hlvalue::Variable(v_start), Hlvalue::Variable(v_prod)],
-        Hlvalue::Variable(v_result.clone()),
-    ));
+    let v_result = emit_range_formula(
+        &startblock,
+        &l_arg,
+        Hlvalue::Variable(index_arg),
+        Hlvalue::Variable(step_arg),
+    );
     startblock.closeblock(vec![
         Link::new(
             vec![Hlvalue::Variable(v_result)],
@@ -848,6 +887,576 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
         vec!["l".to_string(), "index".to_string(), "step".to_string()],
         func,
     ))
+}
+
+/// Push the `l.start + index * step` tail (`rrange.py:77`) onto `block` and
+/// return the Signed result var: `start = getfield(l, 'start'); prod =
+/// int_mul(index, step); result = int_add(start, prod)`.
+fn emit_range_formula(block: &BlockRef, l: &Variable, index: Hlvalue, step: Hlvalue) -> Variable {
+    let v_start = variable_with_lltype("start", LowLevelType::Signed);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l.clone()), void_field("start")],
+        Hlvalue::Variable(v_start.clone()),
+    ));
+    let v_prod = variable_with_lltype("prod", LowLevelType::Signed);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "int_mul",
+        vec![index, step],
+        Hlvalue::Variable(v_prod.clone()),
+    ));
+    let v_result = variable_with_lltype("result", LowLevelType::Signed);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(v_start), Hlvalue::Variable(v_prod)],
+        Hlvalue::Variable(v_result.clone()),
+    ));
+    v_result
+}
+
+/// Build (or retrieve cached) the `_ll_rangelen` sub-helper and return a
+/// funcptr `Constant` to `direct_call` it from the checked / negative-index
+/// `ll_rangeitem` variants (`rrange.py:81,88,131`).
+fn underscore_rangelen_funcptr(rtyper: &RPythonTyper) -> Result<Constant, TyperError> {
+    let inner = rtyper.lowlevel_helper_function_with_builder(
+        "_ll_rangelen".to_string(),
+        vec![
+            LowLevelType::Signed,
+            LowLevelType::Signed,
+            LowLevelType::Signed,
+        ],
+        LowLevelType::Signed,
+        move |_rtyper, _args, _result| build_underscore_ll_rangelen_helper_graph("_ll_rangelen"),
+    )?;
+    sub_helper_funcptr_constant(rtyper, &inner)
+}
+
+/// Push `length = _ll_rangelen(l.start, l.stop, step)` onto `block` and return
+/// the Signed length var: `start = getfield(l, 'start'); stop = getfield(l,
+/// 'stop'); length = direct_call(_ll_rangelen, start, stop, step)`.
+fn emit_range_length(
+    block: &BlockRef,
+    l: &Variable,
+    step: Hlvalue,
+    rangelen: &Constant,
+) -> Variable {
+    let v_start = variable_with_lltype("start", LowLevelType::Signed);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l.clone()), void_field("start")],
+        Hlvalue::Variable(v_start.clone()),
+    ));
+    let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l.clone()), void_field("stop")],
+        Hlvalue::Variable(v_stop.clone()),
+    ));
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(rangelen.clone()),
+            Hlvalue::Variable(v_start),
+            Hlvalue::Variable(v_stop),
+            step,
+        ],
+        Hlvalue::Variable(length.clone()),
+    ));
+    length
+}
+
+/// `ll_rangeitem(func, l, index, step)` with `func is dum_nocheck`
+/// (`rrange.py:79-90`, else arm): negative index, no bound check —
+/// `if index < 0: index += _ll_rangelen(l.start, l.stop, step); return l.start
+/// + index * step`. 3-block CFG (start → block_neg_fix → block_dispatch)
+/// forwarding the possibly-fixed index to the inline `l.start + index*step`.
+fn build_ll_rangeitem_neg_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let rangelen = underscore_rangelen_funcptr(rtyper)?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let step = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+        Hlvalue::Variable(step.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_fix = variable_with_lltype("l", ptr_lltype.clone());
+    let i_fix = variable_with_lltype("index", LowLevelType::Signed);
+    let step_fix = variable_with_lltype("step", LowLevelType::Signed);
+    let block_neg_fix = Block::shared(vec![
+        Hlvalue::Variable(l_fix.clone()),
+        Hlvalue::Variable(i_fix.clone()),
+        Hlvalue::Variable(step_fix.clone()),
+    ]);
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let step_disp = variable_with_lltype("step", LowLevelType::Signed);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+        Hlvalue::Variable(step_disp.clone()),
+    ]);
+
+    // ---- start: is_neg = int_lt(index, 0); branch.
+    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
+        Hlvalue::Variable(is_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l.clone()),
+                Hlvalue::Variable(i.clone()),
+                Hlvalue::Variable(step.clone()),
+            ],
+            Some(block_neg_fix.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(i),
+                Hlvalue::Variable(step),
+            ],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_neg_fix: length = _ll_rangelen(...); i_fixed = index + length.
+    let length = emit_range_length(
+        &block_neg_fix,
+        &l_fix,
+        Hlvalue::Variable(step_fix.clone()),
+        &rangelen,
+    );
+    let i_fixed = variable_with_lltype("index", LowLevelType::Signed);
+    block_neg_fix
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(i_fix), Hlvalue::Variable(length)],
+            Hlvalue::Variable(i_fixed.clone()),
+        ));
+    block_neg_fix.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_fix),
+                Hlvalue::Variable(i_fixed),
+                Hlvalue::Variable(step_fix),
+            ],
+            Some(block_dispatch.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: result = l.start + index*step.
+    let result = emit_range_formula(
+        &block_dispatch,
+        &l_disp,
+        Hlvalue::Variable(i_disp),
+        Hlvalue::Variable(step_disp),
+    );
+    block_dispatch.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// `ll_rangeitem_nonneg(func, l, index, step)` with `func is dum_checkidx`
+/// (`rrange.py:74-77`): nonneg index, bound check — `if index >=
+/// _ll_rangelen(l.start, l.stop, step): raise IndexError; return l.start +
+/// index * step`. 2-block CFG plus `graph.exceptblock`.
+fn build_ll_rangeitem_nonneg_checked_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let rangelen = underscore_rangelen_funcptr(rtyper)?;
+    let exc_args = exception_args("IndexError")?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let step = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+        Hlvalue::Variable(step.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let step_disp = variable_with_lltype("step", LowLevelType::Signed);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+        Hlvalue::Variable(step_disp.clone()),
+    ]);
+
+    // ---- start: length = _ll_rangelen(...); oob = int_ge(index, length); branch.
+    let length = emit_range_length(&startblock, &l, Hlvalue::Variable(step.clone()), &rangelen);
+    let oob = variable_with_lltype("oob", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_ge",
+        vec![Hlvalue::Variable(i.clone()), Hlvalue::Variable(length)],
+        Hlvalue::Variable(oob.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(oob));
+    startblock.closeblock(vec![
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(i),
+                Hlvalue::Variable(step),
+            ],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: result = l.start + index*step.
+    let result = emit_range_formula(
+        &block_dispatch,
+        &l_disp,
+        Hlvalue::Variable(i_disp),
+        Hlvalue::Variable(step_disp),
+    );
+    block_dispatch.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// `ll_rangeitem(func, l, index, step)` with `func is dum_checkidx`
+/// (`rrange.py:79-90`, then arm): `length = _ll_rangelen(l.start, l.stop,
+/// step); if index < 0: index += length; if index < 0 or index >= length:
+/// raise IndexError; return l.start + index * step`. 5-block CFG (start →
+/// block_add → block_check_low → block_check_high → block_dispatch) plus
+/// `graph.exceptblock`.
+fn build_ll_rangeitem_checked_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let rangelen = underscore_rangelen_funcptr(rtyper)?;
+    let exc_low = exception_args("IndexError")?;
+    let exc_high = exception_args("IndexError")?;
+
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    let i = variable_with_lltype("index", LowLevelType::Signed);
+    let step = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l.clone()),
+        Hlvalue::Variable(i.clone()),
+        Hlvalue::Variable(step.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // block_add params: (l, index, step, length).
+    let l_add = variable_with_lltype("l", ptr_lltype.clone());
+    let i_add = variable_with_lltype("index", LowLevelType::Signed);
+    let step_add = variable_with_lltype("step", LowLevelType::Signed);
+    let len_add = variable_with_lltype("length", LowLevelType::Signed);
+    let block_add = Block::shared(vec![
+        Hlvalue::Variable(l_add.clone()),
+        Hlvalue::Variable(i_add.clone()),
+        Hlvalue::Variable(step_add.clone()),
+        Hlvalue::Variable(len_add.clone()),
+    ]);
+
+    // block_check_low params: (l, index, step, length).
+    let l_lo = variable_with_lltype("l", ptr_lltype.clone());
+    let i_lo = variable_with_lltype("index", LowLevelType::Signed);
+    let step_lo = variable_with_lltype("step", LowLevelType::Signed);
+    let len_lo = variable_with_lltype("length", LowLevelType::Signed);
+    let block_check_low = Block::shared(vec![
+        Hlvalue::Variable(l_lo.clone()),
+        Hlvalue::Variable(i_lo.clone()),
+        Hlvalue::Variable(step_lo.clone()),
+        Hlvalue::Variable(len_lo.clone()),
+    ]);
+
+    // block_check_high params: (l, index, step, length).
+    let l_hi = variable_with_lltype("l", ptr_lltype.clone());
+    let i_hi = variable_with_lltype("index", LowLevelType::Signed);
+    let step_hi = variable_with_lltype("step", LowLevelType::Signed);
+    let len_hi = variable_with_lltype("length", LowLevelType::Signed);
+    let block_check_high = Block::shared(vec![
+        Hlvalue::Variable(l_hi.clone()),
+        Hlvalue::Variable(i_hi.clone()),
+        Hlvalue::Variable(step_hi.clone()),
+        Hlvalue::Variable(len_hi.clone()),
+    ]);
+
+    // block_dispatch params: (l, index, step).
+    let l_disp = variable_with_lltype("l", ptr_lltype);
+    let i_disp = variable_with_lltype("index", LowLevelType::Signed);
+    let step_disp = variable_with_lltype("step", LowLevelType::Signed);
+    let block_dispatch = Block::shared(vec![
+        Hlvalue::Variable(l_disp.clone()),
+        Hlvalue::Variable(i_disp.clone()),
+        Hlvalue::Variable(step_disp.clone()),
+    ]);
+
+    // ---- start: length = _ll_rangelen(...); is_neg = int_lt(index, 0); branch.
+    let length = emit_range_length(&startblock, &l, Hlvalue::Variable(step.clone()), &rangelen);
+    let is_neg = variable_with_lltype("is_neg", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(i.clone()), signed_const(0)],
+        Hlvalue::Variable(is_neg.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_neg));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l.clone()),
+                Hlvalue::Variable(i.clone()),
+                Hlvalue::Variable(step.clone()),
+                Hlvalue::Variable(length.clone()),
+            ],
+            Some(block_add.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(i),
+                Hlvalue::Variable(step),
+                Hlvalue::Variable(length),
+            ],
+            Some(block_check_low.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_add: index += length. -> block_check_low.
+    let i_added = variable_with_lltype("index", LowLevelType::Signed);
+    block_add.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(i_add), Hlvalue::Variable(len_add.clone())],
+        Hlvalue::Variable(i_added.clone()),
+    ));
+    block_add.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_add),
+                Hlvalue::Variable(i_added),
+                Hlvalue::Variable(step_add),
+                Hlvalue::Variable(len_add),
+            ],
+            Some(block_check_low.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_check_low: if index < 0: raise IndexError; else check_high.
+    let lo = variable_with_lltype("lo", LowLevelType::Bool);
+    block_check_low
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_lt",
+            vec![Hlvalue::Variable(i_lo.clone()), signed_const(0)],
+            Hlvalue::Variable(lo.clone()),
+        ));
+    block_check_low.borrow_mut().exitswitch = Some(Hlvalue::Variable(lo));
+    block_check_low.closeblock(vec![
+        Link::new(
+            exc_low,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_lo),
+                Hlvalue::Variable(i_lo),
+                Hlvalue::Variable(step_lo),
+                Hlvalue::Variable(len_lo),
+            ],
+            Some(block_check_high.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_check_high: if index >= length: raise IndexError; else dispatch.
+    let hi = variable_with_lltype("hi", LowLevelType::Bool);
+    block_check_high
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "int_ge",
+            vec![Hlvalue::Variable(i_hi.clone()), Hlvalue::Variable(len_hi)],
+            Hlvalue::Variable(hi.clone()),
+        ));
+    block_check_high.borrow_mut().exitswitch = Some(Hlvalue::Variable(hi));
+    block_check_high.closeblock(vec![
+        Link::new(
+            exc_high,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_hi),
+                Hlvalue::Variable(i_hi),
+                Hlvalue::Variable(step_hi),
+            ],
+            Some(block_dispatch.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_dispatch: result = l.start + index*step.
+    let result = emit_range_formula(
+        &block_dispatch,
+        &l_disp,
+        Hlvalue::Variable(i_disp),
+        Hlvalue::Variable(step_disp),
+    );
+    block_dispatch.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "index".to_string(), "step".to_string()],
+        func,
+    ))
+}
+
+/// Build (or retrieve cached) the range-getitem helper for the `(checkidx,
+/// nonneg)` combination (`rrange.py:34-50`), selecting the `dum_nocheck`
+/// nonneg fast path (`ll_rangeitem_nonneg`), the `dum_nocheck` negative-index
+/// `ll_rangeitem`, the `dum_checkidx` nonneg `ll_rangeitem_nonneg`, or the full
+/// checked `ll_rangeitem`. `func` is folded at build time, so each combination
+/// gets its own helper name to keep the `(name, args, result)` cache keys
+/// distinct.
+fn rangeitem_helper(
+    rtyper: &RPythonTyper,
+    checkidx: bool,
+    nonneg: bool,
+    ptr_lltype: LowLevelType,
+) -> Result<LowLevelFunction, TyperError> {
+    let name = match (checkidx, nonneg) {
+        (false, true) => "ll_rangeitem_nonneg",
+        (false, false) => "ll_rangeitem",
+        (true, true) => "ll_rangeitem_nonneg_checked",
+        (true, false) => "ll_rangeitem_checked",
+    };
+    let name_owned = name.to_string();
+    let ptr_for_builder = ptr_lltype.clone();
+    rtyper.lowlevel_helper_function_with_builder(
+        name.to_string(),
+        vec![ptr_lltype, LowLevelType::Signed, LowLevelType::Signed],
+        LowLevelType::Signed,
+        move |rtyper_inner, _args, _result| match (checkidx, nonneg) {
+            (false, true) => {
+                build_ll_rangeitem_nonneg_helper_graph(&name_owned, ptr_for_builder.clone())
+            }
+            (false, false) => build_ll_rangeitem_neg_helper_graph(
+                rtyper_inner,
+                &name_owned,
+                ptr_for_builder.clone(),
+            ),
+            (true, true) => build_ll_rangeitem_nonneg_checked_helper_graph(
+                rtyper_inner,
+                &name_owned,
+                ptr_for_builder.clone(),
+            ),
+            (true, false) => build_ll_rangeitem_checked_helper_graph(
+                rtyper_inner,
+                &name_owned,
+                ptr_for_builder.clone(),
+            ),
+        },
+    )
 }
 
 /// RPython `class RangeIteratorRepr(AbstractRangeIteratorRepr)`
@@ -1907,11 +2516,9 @@ mod tests {
         );
     }
 
-    /// Negative-index (`args_s[1].nonneg == false`) needs the `ll_rangeitem`
-    /// length normalisation (`_ll_rangelen` floor-division), deferred; like
-    /// the checkidx branch it surfaces a `TyperError`.
-    #[test]
-    fn rangerepr_getitem_negative_index_is_deferred() {
+    /// Drive `rtype_getitem` for a given `(implicit IndexError, nonneg)` and
+    /// return the funcptr-`Constant` debug string of the emitted `direct_call`.
+    fn getitem_helper_name_for(checkidx: bool, nonneg: bool) -> String {
         use crate::annotator::annrpython::RPythonAnnotator;
         use crate::annotator::listdef::ListDef;
         use crate::annotator::model::{SomeInteger, SomeList, SomeValue};
@@ -1937,6 +2544,23 @@ mod tests {
         v_idx.set_concretetype(Some(LowLevelType::Signed));
         let v_result = Variable::new();
         v_result.set_concretetype(Some(LowLevelType::Signed));
+        // An IndexError exceptionlink makes `has_implicit_exception("IndexError")`
+        // (the `dum_checkidx` selector) return true.
+        let exc_links = if checkidx {
+            let exitblock = std::rc::Rc::new(std::cell::RefCell::new(Block::new(vec![])));
+            let cls_index = crate::flowspace::model::HOST_ENV
+                .lookup_exception_class("IndexError")
+                .unwrap();
+            vec![std::rc::Rc::new(std::cell::RefCell::new(Link::new(
+                vec![],
+                Some(exitblock),
+                Some(Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                    cls_index,
+                )))),
+            )))]
+        } else {
+            Vec::new()
+        };
         let hop = HighLevelOp::new(
             rtyper.clone(),
             SpaceOperation::new(
@@ -1944,7 +2568,7 @@ mod tests {
                 vec![Hlvalue::Variable(v_rng), Hlvalue::Variable(v_idx)],
                 Hlvalue::Variable(v_result),
             ),
-            Vec::new(),
+            exc_links,
             llops.clone(),
         );
         hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
@@ -1955,13 +2579,118 @@ mod tests {
                 /* mutated */ false,
                 /* resized */ false,
             ))),
-            SomeValue::Integer(SomeInteger::new(/* nonneg */ false, false)),
+            SomeValue::Integer(SomeInteger::new(nonneg, false)),
         ]);
         hop.args_r.borrow_mut().extend([
             Some(range_repr.clone() as Arc<dyn Repr>),
             Some(signed_repr() as Arc<dyn Repr>),
         ]);
-        assert!(range_repr.rtype_getitem(&hop).is_err());
+        let result = range_repr
+            .rtype_getitem(&hop)
+            .unwrap_or_else(|err| panic!("range getitem ({checkidx}, {nonneg}): {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        let last = ops.ops.last().expect("expected at least one op");
+        assert_eq!(last.opname, "direct_call");
+        let Hlvalue::Constant(c) = &last.args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        format!("{:?}", c.value)
+    }
+
+    /// All four `(checkidx, nonneg)` combinations lower to a `direct_call` of
+    /// the matching `func`-folded helper (`rrange.py:34-50`).
+    #[test]
+    fn rangerepr_getitem_selects_func_folded_helper_per_combination() {
+        let nocheck_nonneg = getitem_helper_name_for(false, true);
+        assert!(
+            nocheck_nonneg.contains("ll_rangeitem_nonneg") && !nocheck_nonneg.contains("checked"),
+            "expected 'll_rangeitem_nonneg' in {nocheck_nonneg}"
+        );
+        let nocheck_neg = getitem_helper_name_for(false, false);
+        assert!(
+            nocheck_neg.contains("ll_rangeitem") && !nocheck_neg.contains("nonneg"),
+            "expected 'll_rangeitem' in {nocheck_neg}"
+        );
+        let checked_nonneg = getitem_helper_name_for(true, true);
+        assert!(
+            checked_nonneg.contains("ll_rangeitem_nonneg_checked"),
+            "expected 'll_rangeitem_nonneg_checked' in {checked_nonneg}"
+        );
+        let checked_neg = getitem_helper_name_for(true, false);
+        assert!(
+            checked_neg.contains("ll_rangeitem_checked") && !checked_neg.contains("nonneg"),
+            "expected 'll_rangeitem_checked' in {checked_neg}"
+        );
+    }
+
+    /// `_ll_rangelen(start, stop, step)` takes the three Signed operands
+    /// directly (no `getfield`) and runs the sign-branch floor-division core:
+    /// the startblock switches on `int_gt(step, 0)` into two arms each ending
+    /// in `int_floordiv`.
+    #[test]
+    fn build_underscore_ll_rangelen_helper_graph_has_signed_params_and_floordiv() {
+        let g = build_underscore_ll_rangelen_helper_graph("_ll_rangelen").unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        // (start, stop, step) inputargs; no getfield — the first op is the
+        // sign test int_gt.
+        assert_eq!(startblock.inputargs.len(), 3);
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(ops, vec!["int_gt"]);
+        assert_eq!(startblock.exits.len(), 2);
+        for link in startblock.exits.iter() {
+            let arm = link.borrow().target.clone().unwrap();
+            let body = arm.borrow();
+            let last = body.operations.last().map(|op| op.opname.as_str());
+            assert_eq!(last, Some("int_floordiv"));
+        }
+    }
+
+    /// The full checked `ll_rangeitem` (`dum_checkidx`, negative-index) reads
+    /// the length once via `direct_call(_ll_rangelen, ...)` and raises
+    /// `IndexError` from both the `index < 0` and `index >= length` guards
+    /// (two links into the graph's exceptblock).
+    #[test]
+    fn build_ll_rangeitem_checked_helper_graph_raises_indexerror_from_both_guards() {
+        let ann = crate::annotator::annrpython::RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let ptr = AbstractRangeRepr::new(1).unwrap().lowleveltype().clone();
+        let g =
+            build_ll_rangeitem_checked_helper_graph(&rtyper, "ll_rangeitem_checked", ptr).unwrap();
+        let inner = g.graph.borrow();
+
+        // Exactly one `direct_call` to `_ll_rangelen` across the whole graph.
+        let mut rangelen_calls = 0usize;
+        // Exactly two links target the exceptblock (the two IndexError guards).
+        let mut raise_links = 0usize;
+        for block in inner.iterblocks() {
+            for op in block.borrow().operations.iter() {
+                if op.opname == "direct_call" {
+                    if let Some(Hlvalue::Constant(c)) = op.args.first() {
+                        if format!("{:?}", c.value).contains("_ll_rangelen") {
+                            rangelen_calls += 1;
+                        }
+                    }
+                }
+            }
+            for link in block.borrow().exits.iter() {
+                if let Some(target) = link.borrow().target.as_ref() {
+                    if std::rc::Rc::ptr_eq(target, &inner.exceptblock) {
+                        raise_links += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(rangelen_calls, 1, "expected a single _ll_rangelen call");
+        assert_eq!(raise_links, 2, "expected two IndexError-raising links");
     }
 
     /// `make_iterator_repr` mints a `RangeIteratorRepr` whose lowleveltype

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -1,7 +1,8 @@
 //! RPython `rpython/rtyper/rrange.py` + `lltypesystem/rrange.py` —
-//! minimal `AbstractRangeRepr` slice covering the `len(range(...))` lowering for
-//! the step-1 case (`range(n)` / `range(a, b)`), which is the form
-//! `builtin_range` mints for the overwhelmingly common call shapes
+//! `AbstractRangeRepr` slice covering the `len(range(...))` / indexing /
+//! iteration lowering for constant-step ranges (`range(n)` / `range(a,
+//! b)` / `range(a, b, k)` for constant `k != 0`), the forms
+//! `builtin_range` mints for the common call shapes
 //! (`annotator/builtin.rs:523-528`).
 //!
 //! A `range()` result that is never mutated annotates as a `SomeList`
@@ -9,18 +10,17 @@
 //! repr is NOT array-backed (`FixedSizeListRepr`) but an immutable
 //! `GcStruct("range", start, stop)` (`lltypesystem/rrange.py:51-57`).
 //!
-//! Landed: `rtype_len` (`step == 1`), `rtype_getitem` (constant-step,
-//! nonneg, `dum_nocheck`), and the `RangeIteratorRepr`
-//! (`make_iterator_repr` / `newiter` / `rtype_next`) for both the
-//! constant-step `RANGEITER` (`ll_rangenext_up` / `_down`) and the
-//! variable-step `RANGESTITER` (`ll_rangeiter` step-field copy +
-//! `ll_rangenext_updown`).
+//! Landed: `rtype_len` for any constant step (`ll_rangelen1` for `step ==
+//! 1`, the general `ll_rangelen` / `_ll_rangelen` floor-division
+//! otherwise), `rtype_getitem` (constant-step, nonneg, `dum_nocheck`),
+//! and the `RangeIteratorRepr` (`make_iterator_repr` / `newiter` /
+//! `rtype_next`) for both the constant-step `RANGEITER` (`ll_rangenext_up`
+//! / `_down`) and the variable-step `RANGESTITER` (`ll_rangeiter`
+//! step-field copy + `ll_rangenext_updown`).
 //!
-//! Deferred to follow-on slices (matching how `FixedSizeListRepr` landed
-//! `rtype_len` first): the general-step `ll_rangelen` length, the
-//! `rtype_getitem` `checkidx` (implicit-IndexError) and negative-index
-//! (`ll_rangeitem`) branches, and the `RANGEST` variable-step `_getstep`
-//! getitem.
+//! Deferred to follow-on slices: the `rtype_getitem` `checkidx`
+//! (implicit-IndexError) and negative-index (`ll_rangeitem`) branches,
+//! and the `RANGEST` variable-step `_getstep` (`rtype_len` / `rtype_getitem`).
 
 #![allow(non_camel_case_types)]
 
@@ -280,29 +280,46 @@ impl Repr for AbstractRangeRepr {
     ///     return hop.gendirectcall(ll_rangelen, v_rng, v_step)
     /// ```
     ///
-    /// Only the `step == 1` (`ll_rangelen1`) path lands today; the
-    /// general `ll_rangelen` (`_ll_rangelen`'s floor-division) is
-    /// deferred until `int_floordiv` is a recognised low-level op.
+    /// `step == 1` → `ll_rangelen1`; any other constant `step != 0` →
+    /// `ll_rangelen` with the step baked as the `inputconst(Signed,
+    /// self.step)` arg (`_ll_rangelen`'s floor-division via
+    /// `int_floordiv`). The variable-step `RANGEST` (`step == 0`, needs
+    /// `_getstep`) path is deferred.
     fn rtype_len(&self, hop: &HighLevelOp) -> RTypeResult {
-        if self.step != 1 {
-            return Err(TyperError::missing_rtype_operation(format!(
-                "AbstractRangeRepr.rtype_len(step={}) — general ll_rangelen path \
-                 deferred (needs int_floordiv lowering)",
-                self.step
-            )));
-        }
-        let v_rng = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        let mut args = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
         let ptr_lltype = self.lltype.clone();
         let ptr_for_builder = ptr_lltype.clone();
+        if self.step == 1 {
+            let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+                "ll_rangelen1".to_string(),
+                vec![ptr_lltype],
+                LowLevelType::Signed,
+                move |_rtyper, _args, _result| {
+                    build_ll_rangelen1_helper_graph("ll_rangelen1", ptr_for_builder.clone())
+                },
+            )?;
+            return hop.gendirectcall(&helper, args);
+        }
+        if self.step == 0 {
+            return Err(TyperError::missing_rtype_operation(
+                "AbstractRangeRepr.rtype_len(step=0) — variable-step RANGEST \
+                 _getstep path deferred",
+            ));
+        }
+        // step != 0 (constant): v_step = inputconst(Signed, self.step).
+        args.push(constant_with_lltype(
+            ConstValue::Int(self.step),
+            LowLevelType::Signed,
+        ));
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
-            "ll_rangelen1".to_string(),
-            vec![ptr_lltype],
+            "ll_rangelen".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed],
             LowLevelType::Signed,
             move |_rtyper, _args, _result| {
-                build_ll_rangelen1_helper_graph("ll_rangelen1", ptr_for_builder.clone())
+                build_ll_rangelen_helper_graph("ll_rangelen", ptr_for_builder.clone())
             },
         )?;
-        hop.gendirectcall(&helper, v_rng)
+        hop.gendirectcall(&helper, args)
     }
 
     /// RPython `pair(AbstractRangeRepr, IntegerRepr).rtype_getitem`
@@ -498,6 +515,235 @@ pub(crate) fn build_ll_rangelen1_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["l".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise the general `ll_rangelen` helper graph (`rrange.py:64-65`
+/// delegating to `_ll_rangelen`, `rrange.py:56-63`):
+///
+/// ```python
+/// def ll_rangelen(l, step):
+///     return _ll_rangelen(l.start, l.stop, step)
+///
+/// def _ll_rangelen(start, stop, step):
+///     if step > 0:
+///         result = (stop - start + (step - 1)) // step
+///     else:
+///         result = (start - stop - (step + 1)) // (-step)
+///     if result < 0:
+///         result = 0
+///     return result
+/// ```
+///
+/// 4-block CFG. `step` is a runtime arg (the `inputconst(Signed,
+/// self.step)` the caller appends), so both sign arms are emitted and the
+/// branch folds once the constant step is inlined. The floor-divisions
+/// run on non-negative operands, so `int_floordiv` (truncating) matches
+/// Python's `//`:
+/// - **start** `(l, step)`: `start = getfield(l, 'start'); stop =
+///   getfield(l, 'stop'); pos = int_gt(step, 0)`. Switch on `pos`: True →
+///   pos_arm, False → neg_arm; both carry `start, stop, step`.
+/// - **pos_arm** `(start, stop, step)`: `result = int_floordiv(int_add(
+///   int_sub(stop, start), int_sub(step, 1)), step)` → clamp.
+/// - **neg_arm** `(start, stop, step)`: `result = int_floordiv(int_sub(
+///   int_sub(start, stop), int_add(step, 1)), int_neg(step))` → clamp.
+/// - **clamp** `(result)`: `neg = int_lt(result, 0)`; True →
+///   returnblock(`0`), False → returnblock(`result`).
+pub(crate) fn build_ll_rangelen_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let l_arg = variable_with_lltype("l", ptr_lltype);
+    let step_arg = variable_with_lltype("step", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(l_arg.clone()),
+        Hlvalue::Variable(step_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let signed_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let field_const = |f: &str| constant_with_lltype(ConstValue::byte_str(f), LowLevelType::Void);
+    let bool_const = |b: bool| constant_with_lltype(ConstValue::Bool(b), LowLevelType::Bool);
+
+    // start = l.start; stop = l.stop; pos = step > 0.
+    let v_start = variable_with_lltype("start", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l_arg.clone()), field_const("start")],
+        Hlvalue::Variable(v_start.clone()),
+    ));
+    let v_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(l_arg), field_const("stop")],
+        Hlvalue::Variable(v_stop.clone()),
+    ));
+    let v_pos = variable_with_lltype("pos", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_gt",
+        vec![Hlvalue::Variable(step_arg.clone()), signed_const(0)],
+        Hlvalue::Variable(v_pos.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(v_pos));
+
+    // pos_arm / neg_arm params: (start, stop, step).
+    let p_start = variable_with_lltype("start", LowLevelType::Signed);
+    let p_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    let p_step = variable_with_lltype("step", LowLevelType::Signed);
+    let pos_arm = Block::shared(vec![
+        Hlvalue::Variable(p_start.clone()),
+        Hlvalue::Variable(p_stop.clone()),
+        Hlvalue::Variable(p_step.clone()),
+    ]);
+    let n_start = variable_with_lltype("start", LowLevelType::Signed);
+    let n_stop = variable_with_lltype("stop", LowLevelType::Signed);
+    let n_step = variable_with_lltype("step", LowLevelType::Signed);
+    let neg_arm = Block::shared(vec![
+        Hlvalue::Variable(n_start.clone()),
+        Hlvalue::Variable(n_stop.clone()),
+        Hlvalue::Variable(n_step.clone()),
+    ]);
+
+    // clamp param: (result).
+    let c_result = variable_with_lltype("result", LowLevelType::Signed);
+    let clamp = Block::shared(vec![Hlvalue::Variable(c_result.clone())]);
+
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(v_start.clone()),
+                Hlvalue::Variable(v_stop.clone()),
+                Hlvalue::Variable(step_arg.clone()),
+            ],
+            Some(pos_arm.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(v_start),
+                Hlvalue::Variable(v_stop),
+                Hlvalue::Variable(step_arg),
+            ],
+            Some(neg_arm.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // pos_arm: result = (stop - start + (step - 1)) // step.
+    let pos_result = variable_with_lltype("result", LowLevelType::Signed);
+    {
+        let mut b = pos_arm.borrow_mut();
+        let diff = variable_with_lltype("diff", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_sub",
+            vec![
+                Hlvalue::Variable(p_stop.clone()),
+                Hlvalue::Variable(p_start.clone()),
+            ],
+            Hlvalue::Variable(diff.clone()),
+        ));
+        let sm1 = variable_with_lltype("sm1", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_sub",
+            vec![Hlvalue::Variable(p_step.clone()), signed_const(1)],
+            Hlvalue::Variable(sm1.clone()),
+        ));
+        let num = variable_with_lltype("num", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(diff), Hlvalue::Variable(sm1)],
+            Hlvalue::Variable(num.clone()),
+        ));
+        b.operations.push(SpaceOperation::new(
+            "int_floordiv",
+            vec![Hlvalue::Variable(num), Hlvalue::Variable(p_step)],
+            Hlvalue::Variable(pos_result.clone()),
+        ));
+    }
+    pos_arm.closeblock(vec![
+        Link::new(vec![Hlvalue::Variable(pos_result)], Some(clamp.clone()), None).into_ref(),
+    ]);
+
+    // neg_arm: result = (start - stop - (step + 1)) // (-step).
+    let neg_result = variable_with_lltype("result", LowLevelType::Signed);
+    {
+        let mut b = neg_arm.borrow_mut();
+        let diff = variable_with_lltype("diff", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_sub",
+            vec![
+                Hlvalue::Variable(n_start.clone()),
+                Hlvalue::Variable(n_stop.clone()),
+            ],
+            Hlvalue::Variable(diff.clone()),
+        ));
+        let sp1 = variable_with_lltype("sp1", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_add",
+            vec![Hlvalue::Variable(n_step.clone()), signed_const(1)],
+            Hlvalue::Variable(sp1.clone()),
+        ));
+        let num = variable_with_lltype("num", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_sub",
+            vec![Hlvalue::Variable(diff), Hlvalue::Variable(sp1)],
+            Hlvalue::Variable(num.clone()),
+        ));
+        let nstep = variable_with_lltype("nstep", LowLevelType::Signed);
+        b.operations.push(SpaceOperation::new(
+            "int_neg",
+            vec![Hlvalue::Variable(n_step)],
+            Hlvalue::Variable(nstep.clone()),
+        ));
+        b.operations.push(SpaceOperation::new(
+            "int_floordiv",
+            vec![Hlvalue::Variable(num), Hlvalue::Variable(nstep)],
+            Hlvalue::Variable(neg_result.clone()),
+        ));
+    }
+    neg_arm.closeblock(vec![
+        Link::new(vec![Hlvalue::Variable(neg_result)], Some(clamp.clone()), None).into_ref(),
+    ]);
+
+    // clamp: if result < 0: result = 0.
+    let v_neg = variable_with_lltype("neg", LowLevelType::Bool);
+    clamp.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![Hlvalue::Variable(c_result.clone()), signed_const(0)],
+        Hlvalue::Variable(v_neg.clone()),
+    ));
+    clamp.borrow_mut().exitswitch = Some(Hlvalue::Variable(v_neg));
+    clamp.closeblock(vec![
+        Link::new(
+            vec![signed_const(0)],
+            Some(graph.returnblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(c_result)],
+            Some(graph.returnblock.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string(), "step".to_string()],
         func,
     ))
 }
@@ -1337,6 +1583,36 @@ mod tests {
         assert_eq!(startblock.exits.len(), 2);
     }
 
+    /// The general `ll_rangelen` branches on `int_gt(step, 0)` into the
+    /// ascending / descending floor-division arms (each ending in
+    /// `int_floordiv`), then clamps the negative result to zero.
+    #[test]
+    fn build_ll_rangelen_helper_graph_branches_on_step_sign_with_floordiv() {
+        let ptr = AbstractRangeRepr::new(2).unwrap().lowleveltype().clone();
+        let g = build_ll_rangelen_helper_graph("ll_rangelen", ptr).unwrap();
+        let inner = g.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        // start = l.start; stop = l.stop; pos = step > 0.
+        assert_eq!(ops, vec!["getfield", "getfield", "int_gt"]);
+        assert!(startblock.exitswitch.is_some());
+        assert_eq!(startblock.exits.len(), 2);
+        // (l, step) inputargs.
+        assert_eq!(startblock.inputargs.len(), 2);
+
+        // Both sign arms end in int_floordiv.
+        for link in startblock.exits.iter() {
+            let arm = link.borrow().target.clone().unwrap();
+            let body = arm.borrow();
+            let last = body.operations.last().map(|op| op.opname.as_str());
+            assert_eq!(last, Some("int_floordiv"));
+        }
+    }
+
     #[test]
     fn build_ll_rangeitem_nonneg_helper_graph_synthesizes_getfield_mul_add() {
         let ptr = AbstractRangeRepr::new(1).unwrap().lowleveltype().clone();
@@ -1439,6 +1715,72 @@ mod tests {
             dbg.contains("ll_rangeitem_nonneg"),
             "expected 'll_rangeitem_nonneg' in {dbg}"
         );
+    }
+
+    /// rrange.py:22-30 — `len()` on a constant-step `range` with `step !=
+    /// 1` lowers to a `direct_call` of the general `ll_rangelen` with the
+    /// constant step baked as the trailing arg.
+    #[test]
+    fn rangerepr_len_const_step_emits_direct_call_to_ll_rangelen() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+
+        // step == 2 (constant step != 1) → general ll_rangelen.
+        let range_repr: Arc<AbstractRangeRepr> =
+            Arc::new(AbstractRangeRepr::new(2).expect("AbstractRangeRepr::new(2)"));
+        let range_lltype = range_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_rng = Variable::new();
+        v_rng.set_concretetype(Some(range_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(LowLevelType::Signed));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "len".to_string(),
+                vec![Hlvalue::Variable(v_rng)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .push(crate::annotator::model::SomeValue::Impossible);
+        hop.args_r
+            .borrow_mut()
+            .push(Some(range_repr.clone() as Arc<dyn Repr>));
+
+        let result = range_repr
+            .rtype_len(&hop)
+            .unwrap_or_else(|err| panic!("range rtype_len(step=2): {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1);
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        // direct_call args: funcptr, v_rng, cstep (the baked step).
+        assert_eq!(ops.ops[0].args.len(), 3);
+        let Hlvalue::Constant(cstep) = &ops.ops[0].args[2] else {
+            panic!("expected Constant step as last direct_call arg");
+        };
+        assert!(matches!(cstep.value, ConstValue::Int(2)));
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr as direct_call arg 0");
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(dbg.contains("ll_rangelen"), "expected 'll_rangelen' in {dbg}");
     }
 
     /// Negative-index (`args_s[1].nonneg == false`) needs the `ll_rangeitem`

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -669,7 +669,12 @@ pub(crate) fn build_ll_rangelen_helper_graph(
         ));
     }
     pos_arm.closeblock(vec![
-        Link::new(vec![Hlvalue::Variable(pos_result)], Some(clamp.clone()), None).into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(pos_result)],
+            Some(clamp.clone()),
+            None,
+        )
+        .into_ref(),
     ]);
 
     // neg_arm: result = (start - stop - (step + 1)) // (-step).
@@ -710,7 +715,12 @@ pub(crate) fn build_ll_rangelen_helper_graph(
         ));
     }
     neg_arm.closeblock(vec![
-        Link::new(vec![Hlvalue::Variable(neg_result)], Some(clamp.clone()), None).into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(neg_result)],
+            Some(clamp.clone()),
+            None,
+        )
+        .into_ref(),
     ]);
 
     // clamp: if result < 0: result = 0.
@@ -840,14 +850,26 @@ pub(crate) fn build_ll_rangeitem_nonneg_helper_graph(
 /// ("next", Signed), ("stop", Signed)))`. Like
 /// [`super::rtuple::Length1TupleIteratorRepr`], pyre collapses the
 /// abstract/concrete split into one concrete repr.
+///
+/// Following [`super::rlist::ListIteratorRepr`], the iterator stores the
+/// *data* its `ll_rangeiter` helper consumes (`range_lltype` + `step`)
+/// rather than the source `r_rng` repr object: `make_iterator_repr` is a
+/// `&self` method on the range repr and cannot reproduce the `Arc<dyn
+/// Repr>` upstream's `self.r_rng` field holds. The `newiter` conversion
+/// target is therefore `hop.args_r[0]` (the operand's own range repr), so
+/// `convertvar`'s repr-identity short-circuit (`rtyper.py:810`) fires —
+/// there is no `RangeRepr -> RangeRepr` conversion, so a rebuilt /
+/// non-identical range repr would fail to convert.
 #[derive(Debug)]
 pub struct RangeIteratorRepr {
-    /// `self.r_rng` (`rrange.py:146`) — the source range repr. An
-    /// `AbstractRangeRepr` is fully determined by its `step`, so the
-    /// iterator carries its own self-contained copy (rebuilt from the
-    /// source step) rather than re-deriving the range repr from
-    /// `hop.args_r[0]` in `newiter`.
-    r_rng: AbstractRangeRepr,
+    /// `self.r_rng.lowleveltype` — the source `RANGE` / `RANGEST` struct
+    /// the `ll_rangeiter` helper reads `start` / `stop` (/ `step`) from.
+    range_lltype: LowLevelType,
+    /// `self.r_rng.step` (`rrange.py:147`) — the range step. Nonzero
+    /// selects `ll_rangenext_up` / `_down` (baked as the advance arg); `0`
+    /// is variable step, selecting `ll_rangenext_updown` (reads
+    /// `iter.step`) and the `RANGESTITER` iter struct shape.
+    step: i64,
     /// `self.lowleveltype = r_rng.RANGEITER` / `RANGESTITER`
     /// (`lltypesystem/rrange.py:41,58`) — `Ptr(GcStruct("range", ("next",
     /// Signed), ("stop", Signed)[, ("step", Signed)]))`. The `step` field
@@ -877,7 +899,8 @@ impl RangeIteratorRepr {
             TO: PtrTarget::Struct(st),
         }));
         Ok(RangeIteratorRepr {
-            r_rng: AbstractRangeRepr::new(r_rng.step)?,
+            range_lltype: r_rng.lowleveltype().clone(),
+            step: r_rng.step,
             lowleveltype,
             state: ReprState::new(),
         })
@@ -886,7 +909,7 @@ impl RangeIteratorRepr {
     /// Whether this iterator's struct carries a runtime `step` field
     /// (the variable-step `RANGESTITER`).
     fn is_variable_step(&self) -> bool {
-        self.r_rng.step == 0
+        self.step == 0
     }
 }
 
@@ -937,13 +960,23 @@ impl Repr for RangeIteratorRepr {
     ///     return hop.gendirectcall(self.ll_rangeiter, citerptr, v_rng)
     /// ```
     ///
-    /// As with [`super::rtuple::Length1TupleIteratorRepr::newiter`], the
-    /// iterator low-level type is baked into the helper builder rather
-    /// than threaded as a `citerptr` Void const. The conversion target is
-    /// the iterator's own stored `self.r_rng` (`hop.inputargs(self.r_rng)`).
+    /// As with [`super::rlist::ListIteratorRepr::newiter`], the iterator
+    /// low-level type is baked into the helper builder rather than threaded
+    /// as a `citerptr` Void const, and the `hop.inputargs(self.r_rng)`
+    /// conversion target is the operand's own range repr (`hop.args_r[0]`):
+    /// `convertvar` short-circuits only on repr-object identity, and there
+    /// is no `RangeRepr -> RangeRepr` conversion, so the operand repr — not
+    /// a rebuilt copy — must be the target. The baked range struct lltype
+    /// comes from the iterator's self-contained `range_lltype`.
     fn newiter(&self, hop: &HighLevelOp) -> RTypeResult {
-        let vlist = hop.inputargs(vec![ConvertedTo::Repr(&self.r_rng)])?;
-        let range_lltype = self.r_rng.lowleveltype().clone();
+        let r_rng = {
+            let args_r = hop.args_r.borrow();
+            args_r.first().and_then(|o| o.clone()).ok_or_else(|| {
+                TyperError::message("RangeIteratorRepr.newiter: arg0 repr missing")
+            })?
+        };
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(r_rng.as_ref())])?;
+        let range_lltype = self.range_lltype.clone();
         let iter_lltype = self.lowleveltype.clone();
         let range_for_builder = range_lltype.clone();
         let iter_for_builder = iter_lltype.clone();
@@ -993,7 +1026,7 @@ impl Repr for RangeIteratorRepr {
         // `args = ()` for variable step (updown reads iter.step).
         if !self.is_variable_step() {
             args.push(constant_with_lltype(
-                ConstValue::Int(self.r_rng.step),
+                ConstValue::Int(self.step),
                 LowLevelType::Signed,
             ));
         }
@@ -1015,12 +1048,12 @@ impl Repr for RangeIteratorRepr {
             )?;
             return hop.gendirectcall(&helper, args);
         }
-        let name = if self.r_rng.step > 0 {
+        let name = if self.step > 0 {
             "ll_rangenext_up"
         } else {
             "ll_rangenext_down"
         };
-        let up = self.r_rng.step > 0;
+        let up = self.step > 0;
         let helper = hop.rtyper.lowlevel_helper_function_with_builder(
             name.to_string(),
             vec![iter_lltype, LowLevelType::Signed],
@@ -1780,7 +1813,10 @@ mod tests {
             panic!("expected Constant funcptr as direct_call arg 0");
         };
         let dbg = format!("{:?}", c.value);
-        assert!(dbg.contains("ll_rangelen"), "expected 'll_rangelen' in {dbg}");
+        assert!(
+            dbg.contains("ll_rangelen"),
+            "expected 'll_rangelen' in {dbg}"
+        );
     }
 
     /// Negative-index (`args_s[1].nonneg == false`) needs the `ll_rangeitem`
@@ -2072,7 +2108,10 @@ mod tests {
             panic!("expected Constant funcptr as direct_call arg 0");
         };
         let dbg = format!("{:?}", c.value);
-        assert!(dbg.contains(expected_name), "expected '{expected_name}' in {dbg}");
+        assert!(
+            dbg.contains(expected_name),
+            "expected '{expected_name}' in {dbg}"
+        );
         let Hlvalue::Constant(cstep) = &ops.ops[0].args[2] else {
             panic!("expected Constant step as last direct_call arg");
         };

--- a/majit/majit-translate/src/translator/rtyper/rrange.rs
+++ b/majit/majit-translate/src/translator/rtyper/rrange.rs
@@ -651,7 +651,27 @@ impl Repr for RangeIteratorRepr {
     }
 
     fn repr_class_id(&self) -> super::pairtype::ReprClassId {
-        super::pairtype::ReprClassId::RangeRepr
+        super::pairtype::ReprClassId::RangeIteratorRepr
+    }
+
+    /// RPython `IteratorRepr.rtype_iter(self, hop)` (rmodel.py:266-268) —
+    /// `iter(iter(x)) <==> iter(x)`: an iterator is its own iterator, so
+    /// the op is the identity on the receiver (mirroring
+    /// [`super::rlist::ListIteratorRepr::rtype_iter`]).
+    fn rtype_iter(&self, hop: &HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        Ok(Some(vlist[0].clone()))
+    }
+
+    /// RPython `IteratorRepr.rtype_method_next(self, hop)`
+    /// (rmodel.py:270-271) — `iter.next()` delegates to `rtype_next`.
+    fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
+        match method_name {
+            "next" => self.rtype_next(hop),
+            other => Err(TyperError::message(format!(
+                "missing RangeIteratorRepr.rtype_method_{other}"
+            ))),
+        }
     }
 
     /// RPython `AbstractRangeIteratorRepr.newiter(self, hop)`
@@ -1221,7 +1241,7 @@ mod tests {
         let r_rng = AbstractRangeRepr::new(1).unwrap();
         let it = r_rng.make_iterator_repr(&[]).unwrap();
         assert_eq!(it.class_name(), "RangeIteratorRepr");
-        assert_eq!(it.repr_class_id(), ReprClassId::RangeRepr);
+        assert_eq!(it.repr_class_id(), ReprClassId::RangeIteratorRepr);
         match it.lowleveltype() {
             LowLevelType::Ptr(p) => match &p.TO {
                 PtrTarget::Struct(st) => {
@@ -1366,5 +1386,60 @@ mod tests {
             panic!("expected Constant step as last direct_call arg");
         };
         assert!(matches!(cstep.value, ConstValue::Int(1)));
+    }
+
+    /// rmodel.py:266-268 `IteratorRepr.rtype_iter` — `iter()` on a range
+    /// iterator is the identity (returns the iterator unchanged, emits no
+    /// op), and the iterator carries its own `RangeIteratorRepr` class id.
+    #[test]
+    fn rangeiter_rtype_iter_returns_the_iterator_itself() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(RPythonTyper::new(&ann));
+
+        let r_rng = AbstractRangeRepr::new(1).unwrap();
+        let iter_repr: Arc<RangeIteratorRepr> = Arc::new(RangeIteratorRepr::new(&r_rng).unwrap());
+        assert_eq!(iter_repr.repr_class_id(), ReprClassId::RangeIteratorRepr);
+        let iter_lltype = iter_repr.lowleveltype().clone();
+
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(LowLevelOpList::new(
+            rtyper.clone(),
+            None,
+        )));
+        let v_iter = Variable::new();
+        v_iter.set_concretetype(Some(iter_lltype.clone()));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(iter_lltype));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "iter".to_string(),
+                vec![Hlvalue::Variable(v_iter)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .push(crate::annotator::model::SomeValue::Impossible);
+        hop.args_r
+            .borrow_mut()
+            .push(Some(iter_repr.clone() as Arc<dyn Repr>));
+
+        let result = iter_repr
+            .rtype_iter(&hop)
+            .unwrap_or_else(|err| panic!("range rtype_iter: {err:?}"));
+        // identity: the iterator is returned unchanged, no op emitted.
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_eq!(llops.borrow().ops.len(), 0);
+
+        // `it.next()` method call routes to rtype_next.
+        let method_err = iter_repr.rtype_method("unknown_method", &hop);
+        assert!(method_err.is_err());
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rtuple.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtuple.rs
@@ -1228,6 +1228,30 @@ impl Repr for Length1TupleIteratorRepr {
         "Length1TupleIteratorRepr"
     }
 
+    /// RPython `IteratorRepr.rtype_iter(self, hop)` (rmodel.py:266-268) —
+    /// `iter(iter(x)) <==> iter(x)`: an iterator is its own iterator, so
+    /// the op is the identity on the receiver (mirroring
+    /// [`super::rlist::ListIteratorRepr::rtype_iter`]).
+    fn rtype_iter(&self, hop: &crate::translator::rtyper::rtyper::HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        Ok(Some(vlist[0].clone()))
+    }
+
+    /// RPython `IteratorRepr.rtype_method_next(self, hop)`
+    /// (rmodel.py:270-271) — `iter.next()` delegates to `rtype_next`.
+    fn rtype_method(
+        &self,
+        method_name: &str,
+        hop: &crate::translator::rtyper::rtyper::HighLevelOp,
+    ) -> RTypeResult {
+        match method_name {
+            "next" => self.rtype_next(hop),
+            other => Err(TyperError::message(format!(
+                "missing Length1TupleIteratorRepr.rtype_method_{other}"
+            ))),
+        }
+    }
+
     /// RPython `AbstractTupleIteratorRepr.newiter(self, hop)` (rtuple.py:376-380).
     fn newiter(&self, hop: &crate::translator::rtyper::rtyper::HighLevelOp) -> RTypeResult {
         let r_tuple = {
@@ -2399,6 +2423,51 @@ mod tests {
         assert_eq!(body._name, "tuple1iter");
         assert_eq!(iter.ll_tupleiter, "ll_tupleiter");
         assert_eq!(iter.ll_tuplenext, "ll_tuplenext");
+    }
+
+    /// rmodel.py:266-268 `IteratorRepr.rtype_iter` — `iter()` on a tuple
+    /// iterator is the identity (returns the iterator unchanged, emits no
+    /// op); an unknown method routes to the missing-operation error.
+    #[test]
+    fn length1_tuple_iterator_rtype_iter_returns_self_identity() {
+        use crate::flowspace::model::{SpaceOperation, Variable};
+        use crate::translator::rtyper::rint::IntegerRepr;
+        use crate::translator::rtyper::rtyper::{HighLevelOp, LowLevelOpList};
+
+        let rtyper = fresh_rtyper();
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let repr = TupleRepr::new(&rtyper, vec![r_int]).unwrap();
+        let iter_repr: Arc<Length1TupleIteratorRepr> =
+            Arc::new(Length1TupleIteratorRepr::new(&repr));
+        let iter_lltype = iter_repr.lowleveltype().clone();
+
+        let llops = Rc::new(RefCell::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let v_iter = Variable::new();
+        v_iter.set_concretetype(Some(iter_lltype.clone()));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(iter_lltype));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new(
+                "iter".to_string(),
+                vec![Hlvalue::Variable(v_iter)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops.clone(),
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s
+            .borrow_mut()
+            .push(crate::annotator::model::SomeValue::Impossible);
+        hop.args_r
+            .borrow_mut()
+            .push(Some(iter_repr.clone() as Arc<dyn Repr>));
+
+        let result = iter_repr.rtype_iter(&hop).unwrap();
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_eq!(llops.borrow().ops.len(), 0);
+        assert!(iter_repr.rtype_method("bogus", &hop).is_err());
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rtuple.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtuple.rs
@@ -1434,7 +1434,19 @@ pub(crate) fn build_ll_tuplenext_helper_graph(
         .into_ref(),
     ]);
 
-    let null_tuple = Constant::with_concretetype(ConstValue::None, tuple_lltype);
+    // `iter.tuple = nullptr(typeOf(t).TO)` (rtuple.py:408): a typed null
+    // pointer, not the `None` sentinel.  The codewriter clears the ref field
+    // from a `ConstValue::LLPtr` null; a `ConstValue::None` payload carried on a
+    // `Ptr` concretetype is not accepted by `emit_const_r`.
+    let LowLevelType::Ptr(tuple_ptr_t) = tuple_lltype.clone() else {
+        return Err(TyperError::message(
+            "build_ll_tuplenext_helper_graph: tuple_lltype must be a Ptr",
+        ));
+    };
+    let null_tuple = Constant::with_concretetype(
+        ConstValue::LLPtr(Box::new(_ptr::new(*tuple_ptr_t, Ok(None)))),
+        tuple_lltype,
+    );
     let v_item = variable_with_lltype("item0", item_lltype);
     {
         let mut b = cont.borrow_mut();


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for range iterators with constant step values, including advancing forward or backward and handling end-of-iteration behavior.
  * Exposed additional signature accessors and item types for broader use in the app.

* **Bug Fixes**
  * Improved cleanup of duplicate inputs so renamed values no longer leave behind incorrect in-block definitions.
  * Made dependency and pairing behavior more consistent for certain internal value combinations, improving stability and determinism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->