### PR TITLE
#47/#9: delete the BoxRef resolver family + bind vector guard failargs to producers

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4776,7 +4776,7 @@ fn build_ref_root_slots(
     // Build the set of inputarg OpRef raw values actually used in ops.
     let mut used_inputargs: VecSet<u32> = VecSet::new();
     for op in ops.iter() {
-        for arg in op.getarglist().iter().chain(
+        for arg in op.getarglist_operand().iter().chain(
             op.getfailargs()
                 .into_iter()
                 .flatten()
@@ -5439,7 +5439,7 @@ fn ref_root_slots_with_future_regular_uses(
                     .iter()
                     .skip(position + 1)
                     .flat_map(|op| {
-                        op.getarglist_copy()
+                        op.getarglist_operand()
                             .into_iter()
                             .chain(op.getfailargs().into_iter().flatten())
                     })
@@ -8252,7 +8252,7 @@ impl CraneliftBackend {
         let longevity: VecMap<u32, usize> = {
             let mut m: VecMap<u32, usize> = VecMap::new();
             for (i, op) in ops.iter().enumerate() {
-                for arg in op.getarglist().iter().chain(
+                for arg in op.getarglist_operand().iter().chain(
                     op.getfailargs()
                         .into_iter()
                         .flatten()
@@ -8516,7 +8516,7 @@ impl CraneliftBackend {
                 var_types.insert(vi as u32, cl_type);
             }
             // Declare ALL referenced OpRefs: fail_args, op args, etc.
-            for arg in op.getarglist().iter().chain(
+            for arg in op.getarglist_operand().iter().chain(
                 op.getfailargs()
                     .into_iter()
                     .flatten()

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -16353,13 +16353,13 @@ mod tests {
     use majit_ir::operand::Operand;
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
-        let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+        let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
         let o = Op::new(opcode, &bx);
         o.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(o)
     }
 
-    use majit_ir::box_ref::bound_box_from_opref as rb;
+    use majit_ir::box_ref::bound_operand_from_opref as rb;
 
     /// llsupport/gc.py:563 GcLLDescr_framework
     ///   .get_typeid_from_classptr_if_gcremovetypeptr
@@ -16388,7 +16388,7 @@ mod tests {
         pos: u32,
         descr: majit_ir::DescrRef,
     ) -> majit_ir::OpRc {
-        let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+        let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
         let o = Op::with_descr(opcode, &bx, descr);
         o.pos.set(OpRef::op_typed(pos, opcode.result_type()));
         std::rc::Rc::new(o)
@@ -22842,7 +22842,7 @@ mod tests {
         // Ref-typed OpRef variant.
         let str0 = OpRef::ref_op(0);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22894,7 +22894,7 @@ mod tests {
         let src = OpRef::ref_op(0);
         let dst = OpRef::ref_op(3);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22948,7 +22948,7 @@ mod tests {
         // pointer use the Ref-typed OpRef variant.
         let buf = OpRef::ref_op(0);
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -22982,7 +22982,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_ref(0)];
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![
@@ -23028,7 +23028,7 @@ mod tests {
 
         let inputargs = vec![InputArg::new_ref(0)];
         let op = |oc, args: &[OpRef]| {
-            let bx: Vec<Operand> = args.iter().map(|a| Operand::from_boxref(&rb(*a))).collect();
+            let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
             std::rc::Rc::new(Op::new(oc, &bx))
         };
         let ops = vec![

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -655,7 +655,7 @@ mod tests {
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
         let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
@@ -702,7 +702,7 @@ mod tests {
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
         let mut finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
 
@@ -741,7 +741,7 @@ mod tests {
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
         let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
@@ -848,10 +848,10 @@ mod tests {
         let i0 = OpRef::int_op(0);
         let mut is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         is_object.pos.set(OpRef::int_op(1));
-        is_object.setfailargs(vec![rb(i0).to_boxref()].into());
+        is_object.setfailargs(vec![rb(i0)].into());
         let mut future = Op::new(OpCode::GuardFutureCondition, &[]);
         future.pos.set(OpRef::int_op(2));
-        future.setfailargs(vec![rb(i0).to_boxref()].into());
+        future.setfailargs(vec![rb(i0)].into());
         let plan = TracePlan::build(
             &[InputArg::from_type(Type::Ref, i0.raw())],
             &[is_object, future],

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -6047,7 +6047,7 @@ mod tests {
 
     fn make_guard(opcode: OpCode, pos: u32, args: &[OpRef], fail_args: &[OpRef]) -> Op {
         let mut op = make_op(opcode, pos, args);
-        op.setfailargs(fail_args.iter().map(|a| rb(*a).to_boxref()).collect());
+        op.setfailargs(fail_args.iter().map(|a| rb(*a)).collect());
         op
     }
 
@@ -6210,7 +6210,7 @@ mod tests {
         is_true.pos.set(i2);
         let mut guard = Op::new(OpCode::GuardTrue, &[rb(i2)]);
         guard.pos.set(OpRef::int_op(3));
-        guard.setfailargs(vec![rb(i1).to_boxref()].into());
+        guard.setfailargs(vec![rb(i1)].into());
         let mut finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
         finish.setfailargs(vec![].into());

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -4139,13 +4139,7 @@ mod tests {
         let mut token = JitCellToken::new(1603);
         backend.register_pending_target(token.number, vec![Type::Int, Type::Ref], 2, 2, -1);
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(
-            vec![
-                rb(OpRef::input_arg_int(0)),
-                rb(OpRef::input_arg_ref(1)),
-            ]
-            .into(),
-        );
+        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_ref(1))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4741,13 +4735,7 @@ mod tests {
             &[OpRef::input_arg_ref(1), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(
-            vec![
-                rb(OpRef::input_arg_ref(0)),
-                rb(OpRef::input_arg_ref(1)),
-            ]
-            .into(),
-        );
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)), rb(OpRef::input_arg_ref(1))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -4052,7 +4052,7 @@ mod tests {
         // referenced via `OpRef::input_arg_int(0)`. Variant-aware Eq/Hash
         // treats `IntOp(0)` and `InputArgInt(0)` as disjoint Box classes.
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_int(0)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_int(0))].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             mk_op(
@@ -4141,8 +4141,8 @@ mod tests {
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard.setfailargs(
             vec![
-                rb(OpRef::input_arg_int(0)).to_boxref(),
-                rb(OpRef::input_arg_ref(1)).to_boxref(),
+                rb(OpRef::input_arg_int(0)),
+                rb(OpRef::input_arg_ref(1)),
             ]
             .into(),
         );
@@ -4245,7 +4245,7 @@ mod tests {
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4430,7 +4430,7 @@ mod tests {
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(
                 OpCode::Label,
@@ -4535,7 +4535,7 @@ mod tests {
         entry_getfield.setdescr(field_descr.clone());
 
         let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let mut call1 = mk_op(
             OpCode::CallAssemblerI,
             &[OpRef::input_arg_ref(0), OpRef::int_op(4)],
@@ -4651,7 +4651,7 @@ mod tests {
             &[OpRef::input_arg_ref(0), OpRef::int_op(100)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0)).to_boxref()].into());
+        guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
             guard,
@@ -4743,8 +4743,8 @@ mod tests {
         );
         guard.setfailargs(
             vec![
-                rb(OpRef::input_arg_ref(0)).to_boxref(),
-                rb(OpRef::input_arg_ref(1)).to_boxref(),
+                rb(OpRef::input_arg_ref(0)),
+                rb(OpRef::input_arg_ref(1)),
             ]
             .into(),
         );

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -66,7 +66,7 @@ fn test_simple_int_add() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![Type::Int]);
-    finish_op.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
+    finish_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -104,7 +104,7 @@ fn test_finish_infers_int_type_when_explicit_types_are_empty() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![]);
-    finish_op.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
+    finish_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -137,7 +137,7 @@ fn test_float_add() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(1))]);
     finish_op.pos.set(OpRef::void_op(2));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![rb(OpRef::float_op(1)).to_boxref()].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(1))].into());
 
     let ops = vec![add_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -191,7 +191,7 @@ fn test_setarrayitem_raw_float_roundtrip() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(3))]);
     finish_op.pos.set(OpRef::void_op(4));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![rb(OpRef::float_op(3)).to_boxref()].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(3))].into());
 
     let ops = vec![set_op, get_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -236,7 +236,7 @@ fn test_setarrayitem_raw_float_roundtrip_with_variable_index() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(4))]);
     finish_op.pos.set(OpRef::void_op(5));
     finish_op.set_fail_arg_types(vec![Type::Float]);
-    finish_op.setfailargs(vec![rb(OpRef::float_op(4)).to_boxref()].into());
+    finish_op.setfailargs(vec![rb(OpRef::float_op(4))].into());
 
     let ops = vec![set_op, get_op, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();
@@ -291,7 +291,7 @@ fn test_guard_and_loop() {
     let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Int]);
-    guard_op.setfailargs(vec![rb(OpRef::int_op(1)).to_boxref()].into());
+    guard_op.setfailargs(vec![rb(OpRef::int_op(1))].into());
 
     let jump_op = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
     jump_op.pos.set(OpRef::void_op(4));
@@ -345,8 +345,8 @@ fn test_float_loop_carried_across_jump() {
     guard_op.set_fail_arg_types(vec![Type::Float, Type::Int]);
     guard_op.setfailargs(
         vec![
-            rb(OpRef::input_arg_float(0)).to_boxref(),
-            rb(OpRef::input_arg_int(1)).to_boxref(),
+            rb(OpRef::input_arg_float(0)),
+            rb(OpRef::input_arg_int(1)),
         ]
         .into(),
     );
@@ -477,7 +477,7 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
         let guard_gc_type = Op::new(OpCode::GuardGcType, &[rb(i0), rb(const_child_tid)]);
         guard_gc_type.pos.set(OpRef::void_op(1));
         guard_gc_type.set_fail_arg_types(vec![Type::Ref]);
-        guard_gc_type.setfailargs(vec![rb(i0).to_boxref()].into());
+        guard_gc_type.setfailargs(vec![rb(i0)].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -512,7 +512,7 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
         let guard_is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         guard_is_object.pos.set(OpRef::void_op(1));
         guard_is_object.set_fail_arg_types(vec![Type::Ref]);
-        guard_is_object.setfailargs(vec![rb(i0).to_boxref()].into());
+        guard_is_object.setfailargs(vec![rb(i0)].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -554,7 +554,7 @@ fn test_gc_typeinfo_guards_side_exit_on_mismatch() {
         let guard_subclass = Op::new(OpCode::GuardSubclass, &[rb(i0), rb(const_root_a_vtable)]);
         guard_subclass.pos.set(OpRef::void_op(1));
         guard_subclass.set_fail_arg_types(vec![Type::Ref]);
-        guard_subclass.setfailargs(vec![rb(i0).to_boxref()].into());
+        guard_subclass.setfailargs(vec![rb(i0)].into());
         let finish_op = Op::new(OpCode::Finish, &[]);
         finish_op.pos.set(OpRef::void_op(2));
         finish_op.set_fail_arg_types(vec![]);
@@ -597,7 +597,7 @@ fn test_exception_guards_use_dynasm_emit() {
     let finish_op = Op::new(OpCode::Finish, &[rb(OpRef::ref_op(0))]);
     finish_op.pos.set(OpRef::void_op(1));
     finish_op.set_fail_arg_types(vec![Type::Ref]);
-    finish_op.setfailargs(vec![rb(OpRef::ref_op(0)).to_boxref()].into());
+    finish_op.setfailargs(vec![rb(OpRef::ref_op(0))].into());
 
     let ops = vec![guard_exception, finish_op];
     let ops_rc: Vec<Rc<Op>> = ops.into_iter().map(Rc::new).collect();

--- a/majit/majit-backend-dynasm/tests/basic_loop.rs
+++ b/majit/majit-backend-dynasm/tests/basic_loop.rs
@@ -343,13 +343,7 @@ fn test_float_loop_carried_across_jump() {
     let guard_op = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
     guard_op.pos.set(OpRef::void_op(3));
     guard_op.set_fail_arg_types(vec![Type::Float, Type::Int]);
-    guard_op.setfailargs(
-        vec![
-            rb(OpRef::input_arg_float(0)),
-            rb(OpRef::input_arg_int(1)),
-        ]
-        .into(),
-    );
+    guard_op.setfailargs(vec![rb(OpRef::input_arg_float(0)), rb(OpRef::input_arg_int(1))].into());
 
     let cast_op = Op::new(OpCode::CastIntToFloat, &[rb(OpRef::input_arg_int(1))]);
     cast_op.pos.set(OpRef::float_op(4));

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -4,7 +4,6 @@
 use std::collections::HashMap;
 
 use majit_backend_wasm::codegen;
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
 use smallvec::smallvec;
@@ -25,10 +24,10 @@ use majit_ir::box_ref::bound_operand_from_opref as rb;
 fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
     let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
     let mut op = Op::new(opcode, &bx);
-    op.setfailargs(smallvec![rb(fail_args[0]).to_boxref(); 0]);
-    let mut fa: smallvec::SmallVec<[BoxRef; 3]> = smallvec::SmallVec::new();
+    op.setfailargs(smallvec![rb(fail_args[0]); 0]);
+    let mut fa: smallvec::SmallVec<[Operand; 3]> = smallvec::SmallVec::new();
     for &a in fail_args {
-        fa.push(rb(a).to_boxref());
+        fa.push(rb(a));
     }
     op.setfailargs(fa);
     op
@@ -39,7 +38,7 @@ fn test_empty_trace() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let ops = vec![{
         let mut op = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
-        op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
+        op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
         op
     }];
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
@@ -159,7 +158,7 @@ fn test_float_ops() {
         ),
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(7))]);
-            op.setfailargs(smallvec![rb(OpRef::float_op(7)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::float_op(7))]);
             op
         },
     ];
@@ -198,7 +197,7 @@ fn test_call_generates_import() {
         ),
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(1)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(1))]);
             op
         },
     ];
@@ -282,13 +281,13 @@ fn test_guard_types() {
         // GuardNoOverflow (0 args)
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         // GuardNotInvalidated (0 args, always pass)
         {
             let mut op = Op::new(OpCode::GuardNotInvalidated, &[]);
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         Op::new(
@@ -329,14 +328,14 @@ fn test_exception_guards() {
         // GuardNoException — 0 args, fails when an exception is pending.
         {
             let mut op = Op::new(OpCode::GuardNoException, &[]);
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         // GuardException(expected_type) — caught value bound to int_op(1).
         {
             let mut op = Op::new(OpCode::GuardException, &[rb(OpRef::input_arg_int(0))]);
             op.pos.set(OpRef::int_op(1));
-            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
@@ -577,7 +576,7 @@ fn test_sameas_and_conversions() {
         ),
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(9))]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(9)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(9))]);
             op
         },
     ];
@@ -615,7 +614,7 @@ fn test_overflow_ops() {
         ),
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(2)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
             op
         },
         make_op(
@@ -625,12 +624,12 @@ fn test_overflow_ops() {
         ),
         {
             let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(3)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(3))]);
             op
         },
         {
             let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]);
-            op.setfailargs(smallvec![rb(OpRef::int_op(2)).to_boxref()]);
+            op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
             op
         },
     ];

--- a/majit/majit-ir/src/op_descr.rs
+++ b/majit/majit-ir/src/op_descr.rs
@@ -168,15 +168,12 @@ impl Op {
 
     /// `resoperation.py:299/489 AbstractResOp/GuardResOp.getfailargs`
     /// parity. Returns an owned `SmallVec` clone of the fail_args slot —
-    /// None for non-guard ops.  Clone is cheap because BoxRef is an `Rc` bump and
-    /// fail_args almost always fits inline (≤3 entries).  Owned return
-    /// avoids the `Ref<[T]>` ergonomics tax for callers that chain through
-    /// `.into_iter().flatten()` or `.iter()` patterns.
-    pub fn getfailargs(&self) -> Option<smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>> {
-        self.fail_args
-            .borrow()
-            .as_ref()
-            .map(|fa| fa.iter().map(|o| o.to_boxref()).collect())
+    /// None for non-guard ops.  Clone is cheap because `Operand` is an `Rc`
+    /// bump and fail_args almost always fits inline (≤3 entries).  Owned
+    /// return avoids the `Ref<[T]>` ergonomics tax for callers that chain
+    /// through `.into_iter().flatten()` or `.iter()` patterns.
+    pub fn getfailargs(&self) -> Option<smallvec::SmallVec<[crate::operand::Operand; 3]>> {
+        self.fail_args.borrow().as_ref().map(|fa| fa.clone())
     }
 
     /// `resoperation.py:492 GuardResOp.getfailargs_copy` parity.
@@ -186,7 +183,7 @@ impl Op {
     /// `None`.  Mirror that fail-loud behaviour here so a missing-
     /// fail-args bug surfaces at the call site rather than returning
     /// a silently-empty vector.
-    pub fn getfailargs_copy(&self) -> Vec<crate::box_ref::BoxRef> {
+    pub fn getfailargs_copy(&self) -> Vec<crate::operand::Operand> {
         let borrow = self.fail_args.borrow();
         let fa = borrow.as_ref().unwrap_or_else(|| {
             panic!(
@@ -195,26 +192,21 @@ impl Op {
                  fail-loud shape (resoperation.py:492)"
             )
         });
-        fa.iter().map(|o| o.to_boxref()).collect()
+        fa.iter().cloned().collect()
     }
 
     /// `resoperation.py:495 GuardResOp.setfailargs` parity — overwrite
     /// the fail_args slot.  Takes `&self` (interior mutability) so the
     /// optimizer can stamp fail_args onto a shared `Op` reached through
     /// `Rc<Op>`.
-    pub fn setfailargs(&self, fail_args: smallvec::SmallVec<[crate::box_ref::BoxRef; 3]>) {
-        // `GuardResOp._fail_args` holds the Box objects themselves
-        // (resoperation.py:483); shed genuinely-bound boxes to their
-        // live-tracking producer operand, exactly like `Op.args`
-        // (`Operand::from_boxref`). A Const box sheds to `Operand::Const`;
-        // an unbound position-only fail-arg is a contract violation and
-        // panics (every writer binds its producer).
-        *self.fail_args.borrow_mut() = Some(
-            fail_args
-                .iter()
-                .map(crate::operand::Operand::from_boxref)
-                .collect(),
-        );
+    pub fn setfailargs(&self, fail_args: smallvec::SmallVec<[crate::operand::Operand; 3]>) {
+        // `GuardResOp._fail_args` holds the producer operands themselves
+        // (resoperation.py:483), exactly like `Op.args`: a bound fail-arg
+        // is its `Operand::Op`/`Operand::InputArg` producer, a constant is
+        // `Operand::Const`. An unbound position-only fail-arg is a contract
+        // violation (every writer binds its producer) — `Operand::from_opref`
+        // panics for it at the call site.
+        *self.fail_args.borrow_mut() = Some(fail_args);
     }
 
     /// In-place mutable view of the fail_args slot.  Lets callers iterate

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -119,6 +119,46 @@ impl Operand {
         }
     }
 
+    /// Bind `r` to a producer-carrying operand whose [`to_opref`](Self::to_opref)
+    /// equals `r` — the binding sibling of [`from_opref`](Self::from_opref). A
+    /// `None`/`Const` ref sheds inline (identical to `from_opref`); a ResOp /
+    /// InputArg position — which `from_opref` cannot represent and panics on —
+    /// binds to a freshly-minted synthetic producer (`SameAs*` / `InputArg`)
+    /// carrying the same `pos`. The returned `Operand::Op` / `Operand::InputArg`
+    /// holds a strong `Rc`, so the synthetic producer stays alive for exactly as
+    /// long as the operand is stored — no external root table (unlike the
+    /// `Weak`-backed [`bound_box_from_opref`](crate::box_ref::bound_box_from_opref)).
+    /// The vector optimizer's guard-strengthening / accumulation stitching uses
+    /// this where its producer buffers hold `Op` values (not `OpRc`), so no real
+    /// producer `Rc` is reachable to bind — `guard.py` emits fresh boxes,
+    /// `renamer.py` carries box objects.
+    pub fn bound_from_opref(r: OpRef) -> Operand {
+        use crate::resoperation::Op;
+        use crate::resoperation::OpCode;
+        use crate::value::InputArg;
+        if r.is_none() || r.is_constant() {
+            return Operand::from_opref(r);
+        }
+        let ty = r.ty().unwrap_or(Type::Void);
+        match r {
+            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
+                let ia: InputArgRc = Rc::new(InputArg::from_type(ty, r.raw()));
+                Operand::from_bound_inputarg(&ia)
+            }
+            _ => {
+                let opcode = match ty {
+                    Type::Int => OpCode::SameAsI,
+                    Type::Float => OpCode::SameAsF,
+                    Type::Ref => OpCode::SameAsR,
+                    Type::Void => OpCode::Jump,
+                };
+                let op: OpRc = Rc::new(Op::new(opcode, &[]));
+                op.pos.set(r);
+                Operand::from_bound_op(&op)
+            }
+        }
+    }
+
     /// Flat-`OpRef` view for the OpRef-keyed side tables, `op.pos`
     /// comparisons, and backend/gc encoding (`box_ref.rs:494` parity). This
     /// is the PERMANENT handoff boundary where the optimizer's operand

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -7,7 +7,6 @@
 //! / `BoxRef` from `majit-metainterp` live as extension traits in
 //! `metainterp::optimizeopt::info`.
 
-use crate::box_ref::BoxRef;
 use crate::field_entry::{FieldEntry, PreambleOp};
 use crate::intbound::IntBound;
 use crate::operand::Operand;

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1665,7 +1665,7 @@ impl std::fmt::Display for Op {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write_arg(f, arg)?;
+                    write_arg(f, &arg.to_boxref())?;
                 }
                 write!(f, "]")?;
             }
@@ -1773,7 +1773,7 @@ pub fn format_trace<V: std::fmt::Debug, T: AsRef<Op>, C: ConstLookup<V>>(
                 if i > 0 {
                     write!(out, ", ").unwrap();
                 }
-                render_arg(&mut out, arg, constants);
+                render_arg(&mut out, &arg.to_boxref(), constants);
             }
             write!(out, "]").unwrap();
         }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -23,7 +23,6 @@ use majit_backend::{
     Backend, BackendError, CompiledLoopToken, CompiledTraceInfo, ExitFrameLayout,
     ExitRecoveryLayout, FailDescrLayout, JitCellToken, TerminalExitLayout,
 };
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{
     AccumInfo, Const, DescrRef, FailDescr, GcRef, GuardPendingFieldEntry, InputArg, Op, OpCode,
@@ -450,7 +449,7 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             // class, not by per-arg inference.
             // history.py:220/261/307 — type is intrinsic on the Box; read it
             // off the OpRef variant tag (`ty()`).
-            let finish_arg_type = |b: &BoxRef| -> Type { b.to_opref().ty().unwrap_or(Type::Int) };
+            let finish_arg_type = |b: &Operand| -> Type { b.to_opref().ty().unwrap_or(Type::Int) };
             if let Some(types) = descr_types {
                 if types.len() == op.num_args() {
                     types.to_vec()
@@ -459,11 +458,11 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                     // type-shaped descr): reconstruct per-arg from the
                     // failarg variant tag (`opref.ty()`). Production FINISH
                     // always matches the descr arity.
-                    op.getarglist().iter().map(finish_arg_type).collect()
+                    op.getarglist_operand().iter().map(finish_arg_type).collect()
                 }
             } else {
                 // No descr — synthetic test FINISH only.
-                op.getarglist().iter().map(finish_arg_type).collect()
+                op.getarglist_operand().iter().map(finish_arg_type).collect()
             }
         } else if let Some(fail_args) = op.getfailargs() {
             // `store_final_boxes_in_guard` (resume.py:397) writes the
@@ -1700,7 +1699,7 @@ pub(crate) fn normalize_closing_jump_args(
         .iter()
         .rev()
         .find(|op| op.opcode == OpCode::Label)
-        .map(|op| op.getarglist_copy())
+        .map(|op| op.getarglist_operand())
     else {
         return ops;
     };
@@ -1735,7 +1734,7 @@ pub(crate) fn normalize_closing_jump_args(
         if defined.contains(&arg.to_opref()) {
             continue;
         }
-        jump.setarg(idx, Operand::from_boxref(&label_args[idx]));
+        jump.setarg(idx, label_args[idx].clone());
     }
 
     ops
@@ -1827,7 +1826,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     // discarded when the function returns; its lifetime mirrors the
     // single in-place loop rewrite that RPython's `_forwarded` model
     // accomplishes via Box mutation. No semantic divergence.
-    fn set_local_forwarded(forwarding: &mut Vec<Option<BoxRef>>, source: OpRef, target: BoxRef) {
+    fn set_local_forwarded(forwarding: &mut Vec<Option<Operand>>, source: OpRef, target: Operand) {
         if source.is_none() || source.is_constant() {
             return;
         }
@@ -1839,9 +1838,9 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     }
 
     fn get_local_box_replacement(
-        forwarding: &[Option<BoxRef>],
+        forwarding: &[Option<Operand>],
         mut opref: OpRef,
-    ) -> Option<BoxRef> {
+    ) -> Option<Operand> {
         if opref.is_none() || opref.is_constant() {
             return None;
         }
@@ -1861,7 +1860,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     fn emit_forwarded_patch_op(
         extra_ops: &mut Vec<majit_ir::OpRc>,
         op: &Op,
-        forwarding: &mut Vec<Option<BoxRef>>,
+        forwarding: &mut Vec<Option<Operand>>,
         next_opref: &mut u32,
     ) {
         let mut emitted = op.clone();
@@ -1884,7 +1883,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
                     }
                     replaced = true;
                 }
-                emitted.setarg(i, Operand::from_boxref(&bound));
+                emitted.setarg(i, bound);
             }
         }
 
@@ -1895,7 +1894,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
             if let Some(fail_args) = emitted.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
                     if let Some(bound) = get_local_box_replacement(forwarding, arg.to_opref()) {
-                        *arg = majit_ir::operand::Operand::from_boxref(&bound);
+                        *arg = bound;
                     }
                 }
             }
@@ -1903,7 +1902,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
 
         let emitted = std::rc::Rc::new(emitted);
         if let Some(source) = forwarded_source {
-            set_local_forwarded(forwarding, source, BoxRef::from_bound_op(&emitted));
+            set_local_forwarded(forwarding, source, Operand::from_bound_op(&emitted));
         }
         extra_ops.push(emitted);
     }
@@ -1923,7 +1922,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
         .collect();
 
     // compile.py:429-430 — vable_box = inputargs[index_of_virtualizable].
-    let vable_box = BoxRef::from_bound_inputarg(&expanded_inputargs[index_of_virtualizable]);
+    let vable_box = Operand::from_bound_inputarg(&expanded_inputargs[index_of_virtualizable]);
 
     // compile.py keeps Box identities disjoint automatically; in the flat
     // OpRef model we must allocate above every runtime ref already reachable
@@ -1954,7 +1953,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
         .map(|m| m + 1)
         .unwrap_or(0);
 
-    let mut forwarding: Vec<Option<BoxRef>> =
+    let mut forwarding: Vec<Option<Operand>> =
         vec![None; (max_runtime_ref as usize).saturating_add(1)];
     let mut extra_ops: Vec<majit_ir::OpRc> = Vec::new();
     let mut i = num_red_args;
@@ -1985,11 +1984,11 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
             OpRef::input_arg_typed(expanded_inputargs[i].index, expanded_inputargs[i].tp);
         let new_opref = OpRef::op_typed(next_opref, field.field_type);
         next_opref += 1;
-        let mut op = Op::new(opcode, &[Operand::from_boxref(&vable_box)]);
+        let mut op = Op::new(opcode, &[vable_box.clone()]);
         op.pos.set(new_opref);
         op.setdescr(descr);
         let op = std::rc::Rc::new(op);
-        set_local_forwarded(&mut forwarding, old_opref, BoxRef::from_bound_op(&op));
+        set_local_forwarded(&mut forwarding, old_opref, Operand::from_bound_op(&op));
         extra_ops.push(op);
         i += 1;
     }
@@ -2006,11 +2005,11 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
         // GETFIELD_GC_R(vable_box, array_field_descr) → array pointer (Ref-typed).
         let array_opref = OpRef::ref_op(next_opref);
         next_opref += 1;
-        let mut arr_load = Op::new(OpCode::GetfieldGcR, &[Operand::from_boxref(&vable_box)]);
+        let mut arr_load = Op::new(OpCode::GetfieldGcR, &[vable_box.clone()]);
         arr_load.pos.set(array_opref);
         arr_load.setdescr(array_field_descr.clone());
         let arr_load = std::rc::Rc::new(arr_load);
-        let array_box = BoxRef::from_bound_op(&arr_load);
+        let array_box = Operand::from_bound_op(&arr_load);
         extra_ops.push(arr_load);
 
         let array_descr = vinfo
@@ -2081,7 +2080,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
                 let ptr_opref = OpRef::int_op(next_opref);
                 next_opref += 1;
                 let mut ptr_load =
-                    Op::new(OpCode::GetfieldGcI, &[Operand::from_boxref(&array_box)]);
+                    Op::new(OpCode::GetfieldGcI, &[array_box.clone()]);
                 ptr_load.pos.set(ptr_opref);
                 ptr_load.setdescr(majit_ir::descr::make_field_descr(
                     ptr_offset,
@@ -2090,7 +2089,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
                     ArrayFlag::Unsigned,
                 ));
                 let ptr_load = std::rc::Rc::new(ptr_load);
-                let ptr_box = BoxRef::from_bound_op(&ptr_load);
+                let ptr_box = Operand::from_bound_op(&ptr_load);
                 extra_ops.push(ptr_load);
 
                 let raw_opcode = match array_info.item_type {
@@ -2119,14 +2118,14 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
             let mut elem_op = Op::new(
                 item_opcode,
                 &[
-                    Operand::from_boxref(&item_base),
+                    item_base.clone(),
                     Operand::from_opref(const_opref),
                 ],
             );
             elem_op.pos.set(new_opref);
             elem_op.setdescr(item_descr.clone());
             let elem_op = std::rc::Rc::new(elem_op);
-            set_local_forwarded(&mut forwarding, old_opref, BoxRef::from_bound_op(&elem_op));
+            set_local_forwarded(&mut forwarding, old_opref, Operand::from_bound_op(&elem_op));
             extra_ops.push(elem_op);
             i += 1;
         }
@@ -2495,8 +2494,8 @@ pub fn compile_tmp_callback(
     // inline, carried directly on the OpRef variant.
     let funcbox_ref = OpRef::const_int(jitdriver_sd.portal_runner_adr);
     // Green boxes follow in declaration order.
-    let mut callargs_box: Vec<BoxRef> = Vec::with_capacity(1 + greenboxes.len() + inputargs.len());
-    callargs_box.push(BoxRef::from_opref(funcbox_ref));
+    let mut callargs_box: Vec<Operand> = Vec::with_capacity(1 + greenboxes.len() + inputargs.len());
+    callargs_box.push(Operand::from_opref(funcbox_ref));
     for gb in greenboxes.iter() {
         // history.py:227/268/314 Const{Int,Float,Ptr}.value inline.
         let g_ref = match *gb {
@@ -2505,12 +2504,12 @@ pub fn compile_tmp_callback(
             Value::Float(f) => OpRef::const_float(f),
             Value::Void => panic!("compile_tmp_callback: void greenbox"),
         };
-        callargs_box.push(BoxRef::from_opref(g_ref));
+        callargs_box.push(Operand::from_opref(g_ref));
     }
     // Red args — bound to the inputarg objects themselves
     // (resoperation.py:719/727/739 InputArg{Int,Float,Ref}).
     for ia in inputargs.iter() {
-        callargs_box.push(BoxRef::from_bound_inputarg(ia));
+        callargs_box.push(Operand::from_bound_inputarg(ia));
     }
     //
     let portal_calldescr = jitdriver_sd
@@ -2536,10 +2535,7 @@ pub fn compile_tmp_callback(
     // descr=jd.portal_calldescr)`.
     let call_op = std::rc::Rc::new(Op::with_descr(
         call_opcode,
-        &callargs_box
-            .iter()
-            .map(Operand::from_boxref)
-            .collect::<Vec<_>>(),
+        &callargs_box,
         portal_calldescr,
     ));
     //
@@ -2550,7 +2546,7 @@ pub fn compile_tmp_callback(
     // `OpRef::NONE` so dynasm/cranelift backends that only emit a store
     // when `op.pos != NONE` (e.g. `x86/assembler.rs` CALL handler) don't
     // produce a bogus result slot.
-    let finishargs_box: Vec<BoxRef> = if jitdriver_sd.result_type == Type::Void {
+    let finishargs_box: Vec<Operand> = if jitdriver_sd.result_type == Type::Void {
         Vec::new()
     } else {
         // The CALL writes to the first free OpRef after inputargs.
@@ -2558,7 +2554,7 @@ pub fn compile_tmp_callback(
         // box of a typed CALL is a typed ResOp variant.
         let call_result_ref = OpRef::op_typed(num_inputs, jitdriver_sd.result_type);
         call_op.pos.set(call_result_ref);
-        vec![BoxRef::from_bound_op(&call_op)]
+        vec![Operand::from_bound_op(&call_op)]
     };
     //
     // `compile.py:1138-1144` operations = [call_op,
@@ -2569,10 +2565,7 @@ pub fn compile_tmp_callback(
     guard_op.setfailargs(smallvec![]);
     let finish_op = Op::with_descr(
         OpCode::Finish,
-        &finishargs_box
-            .iter()
-            .map(Operand::from_boxref)
-            .collect::<Vec<_>>(),
+        &finishargs_box,
         portal_finishtoken,
     );
     let operations: Vec<majit_ir::OpRc> = vec![

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -458,11 +458,17 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
                     // type-shaped descr): reconstruct per-arg from the
                     // failarg variant tag (`opref.ty()`). Production FINISH
                     // always matches the descr arity.
-                    op.getarglist_operand().iter().map(finish_arg_type).collect()
+                    op.getarglist_operand()
+                        .iter()
+                        .map(finish_arg_type)
+                        .collect()
                 }
             } else {
                 // No descr — synthetic test FINISH only.
-                op.getarglist_operand().iter().map(finish_arg_type).collect()
+                op.getarglist_operand()
+                    .iter()
+                    .map(finish_arg_type)
+                    .collect()
             }
         } else if let Some(fail_args) = op.getfailargs() {
             // `store_final_boxes_in_guard` (resume.py:397) writes the
@@ -2079,8 +2085,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
                 // RPython's flat GC-array layout — out of scope.
                 let ptr_opref = OpRef::int_op(next_opref);
                 next_opref += 1;
-                let mut ptr_load =
-                    Op::new(OpCode::GetfieldGcI, &[array_box.clone()]);
+                let mut ptr_load = Op::new(OpCode::GetfieldGcI, &[array_box.clone()]);
                 ptr_load.pos.set(ptr_opref);
                 ptr_load.setdescr(majit_ir::descr::make_field_descr(
                     ptr_offset,
@@ -2117,10 +2122,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
             next_opref += 1;
             let mut elem_op = Op::new(
                 item_opcode,
-                &[
-                    item_base.clone(),
-                    Operand::from_opref(const_opref),
-                ],
+                &[item_base.clone(), Operand::from_opref(const_opref)],
             );
             elem_op.pos.set(new_opref);
             elem_op.setdescr(item_descr.clone());
@@ -2533,11 +2535,7 @@ pub fn compile_tmp_callback(
     let call_opcode = OpCode::call_for_type(jitdriver_sd.result_type);
     // `compile.py:1132` `call_op = ResOperation(opnum, callargs,
     // descr=jd.portal_calldescr)`.
-    let call_op = std::rc::Rc::new(Op::with_descr(
-        call_opcode,
-        &callargs_box,
-        portal_calldescr,
-    ));
+    let call_op = std::rc::Rc::new(Op::with_descr(call_opcode, &callargs_box, portal_calldescr));
     //
     // `compile.py:1133-1136` `if call_op.type != 'v': finishargs = [call_op]
     // else: finishargs = []`.
@@ -2563,11 +2561,7 @@ pub fn compile_tmp_callback(
     let mut guard_op = Op::with_descr(OpCode::GuardNoException, &[], propagate_exc_descr);
     // `compile.py:1144` `operations[1].setfailargs([])` — no fail args.
     guard_op.setfailargs(smallvec![]);
-    let finish_op = Op::with_descr(
-        OpCode::Finish,
-        &finishargs_box,
-        portal_finishtoken,
-    );
+    let finish_op = Op::with_descr(OpCode::Finish, &finishargs_box, portal_finishtoken);
     let operations: Vec<majit_ir::OpRc> = vec![
         call_op,
         std::rc::Rc::new(guard_op),

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2664,8 +2664,8 @@ mod tests {
         }
         guard.setdescr(descr);
         guard.setfailargs(smallvec::smallvec![
-            rooted_inputarg_box(Type::Ref, 0),
-            rooted_inputarg_box(Type::Int, 1)
+            rooted_inputarg_operand(Type::Ref, 0),
+            rooted_inputarg_operand(Type::Int, 1)
         ]);
         guard.set_fail_arg_types(vec![Type::Ref, Type::Int]);
 
@@ -2712,10 +2712,10 @@ mod tests {
             .set_fail_arg_types(fail_arg_types.clone());
         guard.setdescr(descr);
         guard.setfailargs(smallvec::smallvec![
-            rooted_inputarg_box(Type::Ref, 0),
-            rooted_inputarg_box(Type::Ref, 1),
-            rooted_inputarg_box(Type::Ref, 2),
-            rooted_inputarg_box(Type::Ref, 3)
+            rooted_inputarg_operand(Type::Ref, 0),
+            rooted_inputarg_operand(Type::Ref, 1),
+            rooted_inputarg_operand(Type::Ref, 2),
+            rooted_inputarg_operand(Type::Ref, 3)
         ]);
         guard.set_fail_arg_types(fail_arg_types);
 

--- a/majit/majit-metainterp/src/graphpage.rs
+++ b/majit/majit-metainterp/src/graphpage.rs
@@ -18,23 +18,43 @@ struct LinkInfo {
 
 #[derive(Default)]
 struct ResOpMemo {
-    // Keyed by the box's `to_opref` (a stable position/value identity)
-    // rather than the wrapper `Rc` pointer: `from_bound_*` mints a fresh
-    // wrapper per resolution, so two reaches of one op carry distinct
-    // pointers but share one `to_opref`.
-    names: Vec<(majit_ir::OpRef, String)>,
+    names: Vec<(ResOpMemoKey, String)>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResOpMemoKey {
+    BoundOp(usize),
+    BoundInputArg(usize),
+    BoxRef(usize),
+}
+
+impl ResOpMemoKey {
+    fn from_box(box_: &BoxRef) -> Self {
+        // graphpage.py uses an object-keyed dict. A bound BoxRef is only a Rust
+        // wrapper around the real PyPy-equivalent object, so use the producer
+        // pointer there; unbound boxes and constants keep wrapper identity.
+        if let Some(op) = box_.bound_op() {
+            return ResOpMemoKey::BoundOp(std::rc::Rc::as_ptr(&op) as *const () as usize);
+        }
+        if let Some(inputarg) = box_.bound_inputarg() {
+            return ResOpMemoKey::BoundInputArg(
+                std::rc::Rc::as_ptr(&inputarg) as *const () as usize
+            );
+        }
+        ResOpMemoKey::BoxRef(box_.as_ptr() as usize)
+    }
 }
 
 impl ResOpMemo {
     pub fn get(&self, box_: &BoxRef) -> Option<&str> {
-        let key = box_.to_opref();
+        let key = ResOpMemoKey::from_box(box_);
         self.names
             .iter()
             .find_map(|(k, v)| (*k == key).then_some(v.as_str()))
     }
 
     pub fn set(&mut self, box_: &BoxRef, value: String) {
-        let key = box_.to_opref();
+        let key = ResOpMemoKey::from_box(box_);
         if let Some((_, old)) = self.names.iter_mut().find(|(k, _)| *k == key) {
             *old = value;
         } else {
@@ -647,5 +667,30 @@ mod tests {
         subgraph.get_display_text(&mut memo);
 
         assert_eq!(memo.get(&subinputarg), Some("i7"));
+    }
+
+    #[test]
+    fn memo_keeps_position_only_boxes_with_same_opref_distinct() {
+        let first = BoxRef::from_opref(OpRef::int_op(3));
+        let second = BoxRef::from_opref(OpRef::int_op(3));
+        let mut memo = ResOpMemo::default();
+
+        memo.set(&first, "first".to_string());
+        memo.set(&second, "second".to_string());
+
+        assert_eq!(memo.get(&first), Some("first"));
+        assert_eq!(memo.get(&second), Some("second"));
+    }
+
+    #[test]
+    fn memo_shares_bound_boxes_for_the_same_producer() {
+        let producer = InputArg::new_int_rc(4);
+        let first = BoxRef::from_bound_inputarg(&producer);
+        let second = BoxRef::from_bound_inputarg(&producer);
+        let mut memo = ResOpMemo::default();
+
+        memo.set(&first, "i4".to_string());
+
+        assert_eq!(memo.get(&second), Some("i4"));
     }
 }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1169,8 +1169,8 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         guard.setfailargs(smallvec::smallvec![
-            iarg_box(0).to_boxref(),
-            iarg_box(1).to_boxref()
+            iarg_box(0),
+            iarg_box(1)
         ]);
 
         let ops = vec![
@@ -1274,11 +1274,11 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
 
         let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        g0.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref()]);
+        g0.setfailargs(smallvec::smallvec![iarg_box(0)]);
         let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
         g1.setfailargs(smallvec::smallvec![
-            iarg_box(0).to_boxref(),
-            iarg_box(1).to_boxref()
+            iarg_box(0),
+            iarg_box(1)
         ]);
 
         let ops = vec![
@@ -1450,9 +1450,9 @@ mod tests {
         let mut guard_op = Op::new(OpCode::GuardTrue, &[iop_box(2)]);
         // fail_args referencing input args (0, 1) and the add result (2)
         guard_op.setfailargs(smallvec::smallvec![
-            iarg_box(0).to_boxref(),
-            iarg_box(1).to_boxref(),
-            iop_box(2).to_boxref()
+            iarg_box(0),
+            iarg_box(1),
+            iop_box(2)
         ]);
 
         let ops = vec![
@@ -1477,14 +1477,14 @@ mod tests {
         let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         g0.setfailargs(smallvec::smallvec![]);
         let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
-        g1.setfailargs(smallvec::smallvec![iarg_box(0).to_boxref()]);
+        g1.setfailargs(smallvec::smallvec![iarg_box(0)]);
         let add = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
 
         let mut g2 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         g2.setfailargs(smallvec::smallvec![
-            iarg_box(0).to_boxref(),
-            iarg_box(1).to_boxref(),
-            iop_box(2).to_boxref()
+            iarg_box(0),
+            iarg_box(1),
+            iop_box(2)
         ]);
 
         let ops = vec![
@@ -1654,7 +1654,7 @@ mod tests {
         // history.py:590: fail_args must not contain constants
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![BoxRef::from_opref(OpRef::const_int(0))]);
+        guard.setfailargs(smallvec::smallvec![Operand::from_opref(OpRef::const_int(0))]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
         let trace = TreeLoop::new(inputargs, ops);
@@ -1666,7 +1666,7 @@ mod tests {
         // history.py:591: fail_args entries must be in seen
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![iop_box(99).to_boxref()]);
+        guard.setfailargs(smallvec::smallvec![iop_box(99)]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
         let trace = TreeLoop::new(inputargs, ops);

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1168,10 +1168,7 @@ mod tests {
         // Guards in a trace carry fail_args.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![
-            iarg_box(0),
-            iarg_box(1)
-        ]);
+        guard.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1)]);
 
         let ops = vec![
             guard,
@@ -1276,10 +1273,7 @@ mod tests {
         let mut g0 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
         g0.setfailargs(smallvec::smallvec![iarg_box(0)]);
         let mut g1 = Op::new(OpCode::GuardFalse, &[iarg_box(1)]);
-        g1.setfailargs(smallvec::smallvec![
-            iarg_box(0),
-            iarg_box(1)
-        ]);
+        g1.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1)]);
 
         let ops = vec![
             g0,
@@ -1449,11 +1443,7 @@ mod tests {
         let add_op = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
         let mut guard_op = Op::new(OpCode::GuardTrue, &[iop_box(2)]);
         // fail_args referencing input args (0, 1) and the add result (2)
-        guard_op.setfailargs(smallvec::smallvec![
-            iarg_box(0),
-            iarg_box(1),
-            iop_box(2)
-        ]);
+        guard_op.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1), iop_box(2)]);
 
         let ops = vec![
             add_op,
@@ -1481,11 +1471,7 @@ mod tests {
         let add = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
 
         let mut g2 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        g2.setfailargs(smallvec::smallvec![
-            iarg_box(0),
-            iarg_box(1),
-            iop_box(2)
-        ]);
+        g2.setfailargs(smallvec::smallvec![iarg_box(0), iarg_box(1), iop_box(2)]);
 
         let ops = vec![
             g0,
@@ -1654,7 +1640,9 @@ mod tests {
         // history.py:590: fail_args must not contain constants
         let inputargs = vec![InputArg::new_int(0)];
         let mut guard = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
-        guard.setfailargs(smallvec::smallvec![Operand::from_opref(OpRef::const_int(0))]);
+        guard.setfailargs(smallvec::smallvec![Operand::from_opref(OpRef::const_int(
+            0
+        ))]);
         guard.setdescr(std::sync::Arc::new(DummyGuardDescr));
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
         let trace = TreeLoop::new(inputargs, ops);

--- a/majit/majit-metainterp/src/opencoder.rs
+++ b/majit/majit-metainterp/src/opencoder.rs
@@ -1,7 +1,6 @@
 //! Literal port of `rpython/jit/metainterp/opencoder.py` — the byte-
 //! stream trace recorder + iterator + snapshot chain reader used by
 //! the meta-interpreter.
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{InputArg, OPCODE_COUNT, Op, OpCode, OpRef, Type, Value};
 
@@ -2793,6 +2792,7 @@ impl Drop for Trace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use majit_ir::box_ref::BoxRef;
     use std::sync::Arc;
 
     /// Test fixture equivalent of RPython's `metainterp_sd` fixture used
@@ -3118,7 +3118,7 @@ mod tests {
         // opencoder.py:362-406 next() routes guard fail_args through the
         // same _untag/_get path as regular args.
         let mut guard = op_at(2, majit_ir::OpCode::GuardTrue, &[iop(1)]);
-        guard.setfailargs(vec![box_arg(iarg(0)), box_arg(iop(1))].into());
+        guard.setfailargs(vec![box_arg_operand(iarg(0)), box_arg_operand(iop(1))].into());
         let ops = vec![
             op_at(1, majit_ir::OpCode::IntEq, &[iarg(0), iarg(0)]),
             guard,

--- a/majit/majit-metainterp/src/optimizeopt/autogenintrules.rs
+++ b/majit/majit-metainterp/src/optimizeopt/autogenintrules.rs
@@ -9,7 +9,6 @@
 use crate::optimizeopt::intbounds::OptIntBounds;
 use crate::optimizeopt::intutils::IntBound;
 use crate::optimizeopt::{OptContext, OptimizationResult};
-use majit_ir::box_ref::BoxRef;
 use majit_ir::{Op, OpCode, operand::Operand};
 
 /// autogenintrules.py:14-18 `_eq(box1, bound1, box2, bound2)` helper:

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -76,10 +76,10 @@ impl Optimization for OptEarlyForce {
             // which uses ctx.current_pass_idx (== earlyforce_idx) for
             // emit_extra routing. This matches RPython's optforce=self.
             for i in 0..op.num_args() {
-                let arg_box = ctx.resolve_operand_box_opt(&op.arg(i));
-                let arg = arg_box
+                let arg_opnd = ctx.resolve_operand_operand_opt(&op.arg(i));
+                let arg = arg_opnd
                     .as_ref()
-                    .map(|b| b.to_opref())
+                    .map(|o| o.to_opref())
                     .unwrap_or_else(|| op.arg(i).to_opref());
                 // optimizer.py:354-362: force_box pops the arg's
                 // potential_extra_op and hands it to the short-preamble
@@ -90,7 +90,10 @@ impl Optimization for OptEarlyForce {
                 if let Some(tracked) = ctx.take_potential_extra_op(arg) {
                     // shortpreamble.py:434: the resolved Box is handed
                     // to the builder; fall back to the operand's own box.
-                    let arg_b = arg_box.clone().unwrap_or_else(|| op.arg(i).to_boxref());
+                    let arg_b = arg_opnd
+                        .as_ref()
+                        .map(|o| o.to_boxref())
+                        .unwrap_or_else(|| op.arg(i).to_boxref());
                     if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                         builder.add_preamble_op_from_pop(&tracked, arg_b);
                     } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -261,7 +261,12 @@ impl Guard {
         );
         guard_op.setdescr(fresh_descr);
         // guard.py:94: guard.setfailargs(loop.label.getarglist_copy())
-        guard_op.setfailargs(label_args.iter().map(|a| BoxRef::from_opref(*a)).collect());
+        guard_op.setfailargs(
+            label_args
+                .iter()
+                .map(|a| majit_ir::operand::Operand::from_opref(*a))
+                .collect(),
+        );
         // copy_all_attributes_from parity: compile.py:861-872 copies
         // rd_consts / rd_pendingfields / rd_virtuals / rd_numb.  In
         // pyre these live on the FailDescr (compile.py:855 `_attrs_`)

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -235,8 +235,8 @@ impl Guard {
         let compare = Op::new(
             opnum,
             &[
-                majit_ir::operand::Operand::from_opref(box_rhs),
-                majit_ir::operand::Operand::from_opref(other_rhs),
+                majit_ir::operand::Operand::bound_from_opref(box_rhs),
+                majit_ir::operand::Operand::bound_from_opref(other_rhs),
             ],
         );
         new_ops.push(compare.clone());
@@ -255,8 +255,8 @@ impl Guard {
         let fresh_descr = crate::compile::make_compile_loop_version_descr_from(&self.op);
         let mut guard_op = Op::new(
             self.op.opcode,
-            &[majit_ir::operand::Operand::from_boxref(
-                &BoxRef::from_opref(compare.pos.get()),
+            &[majit_ir::operand::Operand::bound_from_opref(
+                compare.pos.get(),
             )],
         );
         guard_op.setdescr(fresh_descr);
@@ -264,7 +264,7 @@ impl Guard {
         guard_op.setfailargs(
             label_args
                 .iter()
-                .map(|a| majit_ir::operand::Operand::from_opref(*a))
+                .map(|a| majit_ir::operand::Operand::bound_from_opref(*a))
                 .collect(),
         );
         // copy_all_attributes_from parity: compile.py:861-872 copies
@@ -375,16 +375,16 @@ impl Guard {
         let cmp_op = Op::new(
             self.cmp_op.opcode,
             &[
-                majit_ir::operand::Operand::from_opref(lhs),
-                majit_ir::operand::Operand::from_opref(rhs),
+                majit_ir::operand::Operand::bound_from_opref(lhs),
+                majit_ir::operand::Operand::bound_from_opref(rhs),
             ],
         );
         new_ops.push(cmp_op.clone());
         // guard.py:142-144: guard = ResOperation(opnum, [cmp_op], descr)
         let mut guard = Op::new(
             self.op.opcode,
-            &[majit_ir::operand::Operand::from_boxref(
-                &BoxRef::from_opref(cmp_op.pos.get()),
+            &[majit_ir::operand::Operand::bound_from_opref(
+                cmp_op.pos.get(),
             )],
         );
         if let Some(d) = self.op.getdescr() {

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -1566,10 +1566,9 @@ impl OptHeap {
             }
             // heap.py:525-527: make_equal_to + last_emitted_operation = REMOVED
             let b_old = Operand::from_bound_op(op_rc);
-            let b_res = {
-                let __t = ctx.get_box_replacement(res_v);
-                ctx.operand_of_box(&__t)
-            };
+            let b_res = ctx
+                .get_box_replacement_operand_opt(res_v)
+                .unwrap_or_else(|| ctx.materialize_operand_at(res_v));
             ctx.make_equal_to(&b_old, &b_res);
             self.last_emitted_removed = true;
             return true;
@@ -2656,10 +2655,9 @@ impl OptHeap {
                         // MUST_ALIAS: lazy_set targets the same array → return rhs
                         let cached = lazy_op.arg(2).to_opref();
                         let b_old = Operand::from_bound_op(op_rc);
-                        let b_cached = {
-                            let __t = ctx.get_box_replacement(cached);
-                            ctx.operand_of_box(&__t)
-                        };
+                        let b_cached = ctx
+                            .get_box_replacement_operand_opt(cached)
+                            .unwrap_or_else(|| ctx.materialize_operand_at(cached));
                         ctx.make_equal_to(&b_old, &b_cached);
                         return OptimizationResult::Remove;
                     }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3539,8 +3539,7 @@ impl Optimization for OptHeap {
                 }
                 // heap.py:844: box2 = box2.get_box_replacement() — one
                 // chain walk; the position view falls back to the source.
-                let val_box = ctx.get_box_replacement_box(val);
-                let val = val_box.as_ref().map_or(val, |b| b.to_opref());
+                let val = ctx.get_replacement_opref(val);
                 // heap.py:845 `box2 in available_boxes` is enforced later in
                 // bridgeopt; here the resolved field is exported unconditionally.
                 result.push((obj.to_opref(), descr.clone(), val));
@@ -3582,7 +3581,7 @@ impl Optimization for OptHeap {
                 .as_ref()
                 .map_or(false, |b| ctx.is_virtual(b));
             let needs_install = !ctx
-                .get_box_replacement_box(resolved)
+                .get_box_replacement_operand_opt(resolved)
                 .and_then(|cb| cb.const_value())
                 .is_some()
                 && !resolved_is_virtual;
@@ -3664,8 +3663,7 @@ impl Optimization for OptHeap {
                     }
                     // heap.py:865: box2 = box2.get_box_replacement() — one
                     // chain walk; the position view falls back to the source.
-                    let val_box = ctx.get_box_replacement_box(val);
-                    let val = val_box.as_ref().map_or(val, |b| b.to_opref());
+                    let val = ctx.get_replacement_opref(val);
                     // heap.py:866 `box2 in available_boxes` is enforced later in
                     // bridgeopt; here the resolved item is exported unconditionally.
                     result.push((obj.to_opref(), index, descr.clone(), val));
@@ -3699,7 +3697,7 @@ impl Optimization for OptHeap {
                 .as_ref()
                 .map_or(false, |b| ctx.is_virtual(b));
             let needs_install = !ctx
-                .get_box_replacement_box(resolved)
+                .get_box_replacement_operand_opt(resolved)
                 .and_then(|cb| cb.const_value())
                 .is_some()
                 && !resolved_is_virtual;

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -348,7 +348,7 @@ impl CachedField {
             .as_ref()
             .map(OptHeap::field_slot_index)
             .unwrap_or(0);
-        let arg = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+        let arg = ctx.get_replacement_opref(op.arg(1).to_opref());
         let struct_box = ctx.resolve_operand_operand(&op.arg(0));
         self.register_info(&struct_box);
         ctx.structinfo_setfield(op, descr_idx, arg);
@@ -610,7 +610,7 @@ impl ArrayCachedItem {
 
     /// heap.py:252-255 ArrayCachedItem.put_field_back_to_info
     fn put_field_back_to_info(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg = ctx.resolve_operand_box(&op.arg(2)).to_opref();
+        let arg = ctx.get_replacement_opref(op.arg(2).to_opref());
         let struct_box = ctx.resolve_operand_operand(&op.arg(0));
         self.register_info(&struct_box);
         ctx.arrayinfo_setitem(op, self.index as usize, arg);
@@ -990,7 +990,7 @@ impl OptHeap {
     /// Canonicalizes array and index through get_box_replacement.
     fn arrayitem_key(op: &Op, ctx: &mut OptContext) -> Option<ArrayItemKey> {
         let descr = op.getdescr()?;
-        let array = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let array = ctx.get_replacement_opref(op.arg(0).to_opref());
         let index_val = ctx
             .resolve_operand_operand_opt(&op.arg(1))
             .and_then(|b| ctx.get_constant_int_box(&b))?;
@@ -1668,7 +1668,7 @@ impl OptHeap {
         let mut stack: Vec<OpRef> = op
             .getarglist()
             .iter()
-            .map(|arg| ctx.resolve_box_box(&arg).to_opref())
+            .map(|arg| ctx.get_replacement_opref(arg.to_opref()))
             .collect();
         while let Some(owner) = stack.pop() {
             // heap.py:173-174 resolves the owner through `get_box_replacement`
@@ -2358,7 +2358,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.resolve_box_box(&pop.op).to_opref();
+                    let cached_seen = ctx.get_replacement_opref(pop.op.to_opref());
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2506,7 +2506,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.resolve_box_box(&pop.op).to_opref();
+                    let cached_seen = ctx.get_replacement_opref(pop.op.to_opref());
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2631,7 +2631,7 @@ impl OptHeap {
         // intermediate cache mutations can take &mut ctx without
         // tripping the borrow checker).
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let array_ref = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let array_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
 
         // Try constant-index cache first.
         if let Some(key) = Self::arrayitem_key(op, ctx) {
@@ -2846,7 +2846,7 @@ impl OptHeap {
 
             let descr_idx = descr.index();
             let arrayinfo = array_ref;
-            let indexbox = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+            let indexbox = ctx.get_replacement_opref(op.arg(1).to_opref());
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
                     let b_old = Operand::from_bound_op(op_rc);
@@ -2866,7 +2866,7 @@ impl OptHeap {
 
     fn optimize_setarrayitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         // heapcache.py:224-230 _escape_from_write parity:
-        let array_obj = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let array_obj = ctx.get_replacement_opref(op.arg(0).to_opref());
         let stored_value = op.arg(2).to_opref();
         self.escape_from_write(ctx, array_obj, stored_value);
 
@@ -2883,9 +2883,9 @@ impl OptHeap {
                         ctx.getintbound_handle(&b).borrow().clone()
                     };
                     self.force_lazy_setarrayitem(&descr, Some(&indexb), false, ctx);
-                    let arrayinfo = ctx.resolve_operand_box(&op.arg(0)).to_opref();
-                    let indexbox = ctx.resolve_operand_box(&op.arg(1)).to_opref();
-                    let resbox = ctx.resolve_operand_box(&op.arg(2)).to_opref();
+                    let arrayinfo = ctx.get_replacement_opref(op.arg(0).to_opref());
+                    let indexbox = ctx.get_replacement_opref(op.arg(1).to_opref());
+                    let resbox = ctx.get_replacement_opref(op.arg(2).to_opref());
                     self.arrayitem_submap(&descr)
                         .cache_varindex_write(arrayinfo, indexbox, resbox);
                 }
@@ -4246,7 +4246,7 @@ mod tests {
         ctx.bind_input_resops(std::slice::from_ref(&op_rc));
         let result = heap.optimize_getfield(&op, &op_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), p1);
+        assert_eq!(ctx.get_replacement_opref(pos2), p1);
     }
 
     /// After consuming an imported short field, a cache invalidation followed
@@ -4282,7 +4282,7 @@ mod tests {
         ctx.bind_input_resops(std::slice::from_ref(&op1_rc));
         let result1 = heap.optimize_getfield(&op1, &op1_rc, &mut ctx);
         assert!(matches!(result1, OptimizationResult::Remove));
-        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), p1);
+        assert_eq!(ctx.get_replacement_opref(pos2), p1);
 
         // A call invalidates all mutable field caches.
         heap.clean_caches(&mut ctx);
@@ -7055,7 +7055,7 @@ mod tests {
         let op2_rc = std::rc::Rc::new(op2.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op2_rc));
         assert!(heap._optimize_call_dict_lookup(&op2, &op2_rc, &mut ctx));
-        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
+        assert_eq!(ctx.get_replacement_opref(pos2), pos1);
         assert!(heap.last_emitted_removed);
     }
 
@@ -7120,7 +7120,7 @@ mod tests {
         let op2_rc = std::rc::Rc::new(op2.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op2_rc));
         assert!(heap._optimize_call_dict_lookup(&op2, &op2_rc, &mut ctx));
-        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
+        assert_eq!(ctx.get_replacement_opref(pos2), pos1);
     }
 
     /// heap.py:390 parity: clean_caches clears cached_dict_reads.
@@ -7248,7 +7248,7 @@ mod tests {
         let op2_rc = std::rc::Rc::new(op2.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op2_rc));
         assert!(heap._optimize_call_dict_lookup(&op2, &op2_rc, &mut ctx));
-        assert_eq!(ctx.get_box_replacement(pos2).to_opref(), pos1);
+        assert_eq!(ctx.get_replacement_opref(pos2), pos1);
     }
 
     /// optimizer.py:84-87 parity: every Optimization.emit overwrite path —

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4622,8 +4622,8 @@ mod tests {
             let mut resolved = op.clone();
             for i in 0..resolved.num_args() {
                 let arg = resolved.arg(i);
-                let rb = match ctx.resolve_box_box_opt(&arg.to_boxref()) {
-                    Some(b) => Operand::from_boxref(&b),
+                let rb = match ctx.resolve_operand_operand_opt(&arg) {
+                    Some(b) => b,
                     None => {
                         let __ar = arg.to_opref();
                         if __ar.is_none() {

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1479,10 +1479,7 @@ fn force_box_impl(
                     for ch in &info._chars {
                         if let Some(ch_ref) = ch {
                             let ch_ref = ch_ref.to_opref();
-                            let ch_resolved = ctx
-                                .get_box_replacement_box(ch_ref)
-                                .map(|b| b.to_opref())
-                                .unwrap_or(ch_ref);
+                            let ch_resolved = ctx.get_replacement_opref(ch_ref);
                             let arg_newop = ctx.materialize_operand_at(newop);
                             let arg_offset = ctx.resolve_operand_operand(&offset);
                             let arg_ch = ctx.materialize_operand_at(ch_resolved);

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -7,7 +7,6 @@ pub use crate::optimizeopt::rawbuffer::{
 /// Translated from rpython/jit/metainterp/optimizeopt/info.py.
 /// Each operation can have associated analysis info (e.g., known integer bounds,
 /// pointer info, virtual object state).
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 
@@ -1578,6 +1577,7 @@ pub use majit_ir::ptr_info::{
 mod tests {
     use super::*;
     use crate::optimizeopt::OptContext;
+    use majit_ir::box_ref::BoxRef;
     use majit_ir::{Descr, OpCode, Value};
     use std::sync::Arc;
 

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -2100,19 +2100,13 @@ mod tests {
                 match emitted.opcode {
                     OpCode::GuardTrue => {
                         let a = emitted.arg(0).to_opref();
-                        let cond = ctx
-                            .get_box_replacement_box(a)
-                            .map(|b| b.to_opref())
-                            .unwrap_or(a);
+                        let cond = ctx.get_replacement_opref(a);
                         let b = ctx.materialize_operand_at(cond);
                         ctx.make_constant_box(&b, majit_ir::Value::Int(1));
                     }
                     OpCode::GuardFalse => {
                         let a = emitted.arg(0).to_opref();
-                        let cond = ctx
-                            .get_box_replacement_box(a)
-                            .map(|b| b.to_opref())
-                            .unwrap_or(a);
+                        let cond = ctx.get_replacement_opref(a);
                         let b = ctx.materialize_operand_at(cond);
                         ctx.make_constant_box(&b, majit_ir::Value::Int(0));
                     }

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -4,7 +4,6 @@
 ///
 /// Replaces signed integer division by a constant with a sequence of
 /// UINT_MUL_HIGH + shift operations, avoiding the expensive `idiv` instruction.
-use majit_ir::operand::Operand;
 use majit_ir::{Op, OpCode, OpRef};
 
 use crate::optimizeopt::OptContext;

--- a/majit/majit-metainterp/src/optimizeopt/intutils.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intutils.rs
@@ -74,7 +74,6 @@ impl IntBoundMakeGuards for IntBound {
         ctx: &mut crate::optimizeopt::OptContext,
     ) {
         use crate::optimizeopt::Op;
-        use majit_ir::operand::Operand;
         use majit_ir::{OpCode, Type, Value};
 
         // history.py:227/268/314 Const{Int,Float,Ptr}.value inline: the

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4619,23 +4619,6 @@ impl OptContext {
         }
     }
 
-    /// Migration bridge: lower a (possibly position-only) box to its canonical
-    /// bound [`Operand`] without the `from_boxref` position-only panic. A box
-    /// already carrying a bound producer or a const wraps directly; a bare
-    /// position (a `from_opref` / `get_box_replacement` fallback mint with no
-    /// findable producer) materializes to its canonical `SameAs*` stand-in
-    /// (`resoperation.py:233-248` "the box always exists"). This mirrors the
-    /// position-only normalization [`make_equal_to`] applies to its `newop`
-    /// target. Use wherever a `resolve_*` / `get_box_replacement` result (whose
-    /// box can be position-only) feeds an `Operand` reader.
-    pub(crate) fn operand_of_box(&mut self, b: &majit_ir::box_ref::BoxRef) -> Operand {
-        if b.bound_op().is_some() || b.bound_inputarg().is_some() || b.is_constant() {
-            Operand::from_boxref(b)
-        } else {
-            self.materialize_operand_at(b.to_opref())
-        }
-    }
-
     /// S9 probe classifier for a `from_opref` fallback fire (see
     /// [`OptContext::get_box_replacement`]). `&self`-only, no mutation.
     ///

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -9099,7 +9099,10 @@ mod boxref_forwarding_tests {
     fn h3_2b_get_box_replacement_box_returns_none_when_pool_empty() {
         let ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
         // No seeded producer: no Box identity to resolve.
-        assert!(ctx.get_box_replacement_operand_opt(OpRef::int_op(0)).is_none());
+        assert!(
+            ctx.get_box_replacement_operand_opt(OpRef::int_op(0))
+                .is_none()
+        );
     }
 
     /// `OpRef::NONE` sentinel returns `None` — the BoxRef reader

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4538,42 +4538,6 @@ impl OptContext {
         source
     }
 
-    /// resoperation.py:57-68 `get_box_replacement` — walk `op._forwarded`
-    /// to the terminal box and return it. PyPy returns the box object
-    /// directly; pyre returns the `BoxRef` view. `OpRef`-keyed callers that
-    /// still need an integer handle bridge back with `.to_opref()` (the
-    /// remaining `Op.args` / fail-args boundary).
-    ///
-    /// The resolver is total (resoperation.py:57-68): a box with no
-    /// forwarding is its own replacement. bind-at-alloc (#194) binds every
-    /// value-bearing position's canonical host at allocation
-    /// (`reserve_virtual_box` / emit-time `bind_op` / `bind_input_resops`),
-    /// so the position-only `BoxRef::from_opref` fallback is unreachable in
-    /// practice (probe-verified 0 fires over the corpus); a fire signals a
-    /// bookkeeping bug. The env-gated S9 probe stays for triage, but
-    /// production returns the identity box rather than aborting the trace —
-    /// matching upstream totality and the `a-producerless` arm of
-    /// `classify_s9_fallback` ("an unforwarded box returns itself").
-    pub fn get_box_replacement(&self, opref: OpRef) -> majit_ir::box_ref::BoxRef {
-        // The sentinel `OpRef::none()` (absent operand: empty fail_arg slot,
-        // unset lazy setfield) is not a value-bearing position — its total
-        // resolution is the `none()` box itself, which `from_opref` already
-        // round-trips below. Resolve it here so the "box must exist" assert
-        // and the `s9_probe`/`from_opref` fallback apply only to value-bearing
-        // positions, matching the explicit NONE handling in `resolve_to_boxref`
-        // / `materialize_box_at` / `clear_forwarded`.
-        if opref.is_none() {
-            return majit_ir::box_ref::BoxRef::none();
-        }
-        if let Some(b) = self.get_box_replacement_box(opref) {
-            return b;
-        }
-        // S9 probe (env-gated, no-op unless `PYRE_S9_PROBE` is set): classify
-        // any fire for triage. Then return the identity box (resoperation.py:57-68).
-        self.s9_probe_fire(opref);
-        majit_ir::box_ref::BoxRef::from_opref(opref)
-    }
-
     /// [`Operand`]-yielding total mirror of [`get_box_replacement`](Self::get_box_replacement):
     /// resolve a position's `_forwarded` terminal directly as an `Operand`
     /// (canonical `Op` / `InputArg` host, or inline-`Const`) without minting a
@@ -4721,124 +4685,6 @@ impl OptContext {
         }
     }
 
-    /// `BoxRef`-addressed operand resolution. Callers holding the
-    /// operand Box (`op.arg(i)`) resolve it here instead of collapsing to
-    /// an `OpRef` and re-resolving.
-    ///
-    /// resoperation.py:57-68: a bound operand carries its producer op (or
-    /// is a Const) and walks its own `_forwarded` chain directly — the Box
-    /// object IS the reference. An unbound operand (no producer handle:
-    /// short-preamble replay / test baseline position-only box, or an
-    /// InputArg) has no producer chain to walk from the Box alone, so it
-    /// resolves through the `OpRef` position store as before.
-    ///
-    /// A bound InputArg is deliberately NOT walked box-native here: the
-    /// canonical InputArg identity lives in `inputarg_refs` (the position
-    /// store), and a consumer's operand box can wrap a non-canonical
-    /// `InputArgRc` duplicate whose `inputarg.forwarded` is stale relative
-    /// to the registered host's. Resolving such a box through its own chain
-    /// diverges from the canonical position resolution (the divergence
-    /// witness fires on `InputArgInt(0)` in the jitdriver pipeline). Routing
-    /// InputArgs through the `OpRef` store keeps resolution canonical until
-    /// InputArg identity is unified (the InputArg analog of the ResOp
-    /// emit-rebind keystone in `materialize_box_at` / `set_forwarded_op`).
-    pub fn resolve_box_box(&self, arg: &majit_ir::box_ref::BoxRef) -> majit_ir::box_ref::BoxRef {
-        self.heal_arg_to_canonical(arg);
-        if arg.bound_op().is_some() || arg.is_constant() {
-            let resolved = arg.get_box_replacement(false);
-            // A non-canonical duplicate operand box resolves to itself
-            // box-native while its position's canonical forwarding lives in
-            // the `OpRef` store (see `resolve_box_box_opt`); defer to the
-            // store, which returns the box unchanged when it holds no entry.
-            if resolved.same_box(arg) {
-                return self.get_box_replacement(arg.to_opref());
-            }
-            // The box-native walk forwarded: that chain is canonical and the
-            // `OpRef` store must agree (migration tripwire).
-            #[cfg(debug_assertions)]
-            {
-                let legacy = self.get_box_replacement(arg.to_opref());
-                debug_assert!(
-                    resolved.same_box(&legacy) || resolved.to_opref() == legacy.to_opref(),
-                    "resolve_box_box: box-native walk diverged from OpRef path for {:?}",
-                    arg.to_opref()
-                );
-            }
-            resolved
-        } else {
-            self.get_box_replacement(arg.to_opref())
-        }
-    }
-
-    /// `Option`-returning sibling of [`OptContext::resolve_box_box`], the
-    /// box-native form of `get_box_replacement_box`. resoperation.py:58
-    /// `get_box_replacement(op)` walks the box's `_forwarded` chain; a bound
-    /// operand (or Const) walks it directly here. The `None` arm is pyre's
-    /// unbound-operand adaptation (RPython has no unbound boxes): an unbound
-    /// operand resolves through the `OpRef` store and surfaces `None` when the
-    /// root does not resolve (sentinel / baseline) so callers can branch on it.
-    /// A bound InputArg stays on the `OpRef` path for the same canonical-
-    /// identity reason documented on [`OptContext::resolve_box_box`].
-    pub fn resolve_box_box_opt(
-        &self,
-        arg: &majit_ir::box_ref::BoxRef,
-    ) -> Option<majit_ir::box_ref::BoxRef> {
-        self.heal_arg_to_canonical(arg);
-        if arg.bound_op().is_some() || arg.is_constant() {
-            let resolved = arg.get_box_replacement(false);
-            // A non-canonical duplicate operand box (short-preamble replay
-            // handle / position-only export box — the bound-ResOp analog of
-            // the stale `InputArgRc` duplicate documented on `resolve_box_box`)
-            // carries no forwarding on its own `_forwarded` chain, so the
-            // box-native walk resolves it to itself even though the canonical
-            // forwarding for its position lives in the `OpRef` store. When the
-            // box resolves to itself the store is the canonical position
-            // resolution — defer to it, as the InputArg `else` arm and the
-            // "resolve positionally" short-preamble export both do.
-            if resolved.same_box(arg) {
-                return Some(
-                    self.get_box_replacement_box(arg.to_opref())
-                        .unwrap_or(resolved),
-                );
-            }
-            // The box-native walk forwarded: that chain is canonical and the
-            // `OpRef` store must agree (migration tripwire).
-            #[cfg(debug_assertions)]
-            {
-                let legacy = self.get_box_replacement_box(arg.to_opref());
-                let agrees = match &legacy {
-                    Some(l) => resolved.same_box(l) || resolved.to_opref() == l.to_opref(),
-                    None => false,
-                };
-                debug_assert!(
-                    agrees,
-                    "resolve_box_box_opt: box-native walk diverged from OpRef path for {:?}",
-                    arg.to_opref()
-                );
-            }
-            Some(resolved)
-        } else {
-            self.get_box_replacement_box(arg.to_opref())
-        }
-    }
-
-    /// Operand-input sibling of [`OptContext::resolve_box_box`]: resolves an
-    /// [`Operand`] (the op-arg carrier) to its `_forwarded` terminal `BoxRef`.
-    /// The `BoxRef` RETURN is kept — its consumers (`get_box_replacement` /
-    /// `.to_opref()` / the `&BoxRef` sinks) stay BoxRef-typed — so only the
-    /// INPUT side carries `Operand` directly, letting a caller holding
-    /// `op.arg(i)` drop the `.to_boxref()` bridge. The internal `to_boxref()`
-    /// retires when `resolve_box_box` itself flips its parameter.
-    pub fn resolve_operand_box(&self, arg: &Operand) -> majit_ir::box_ref::BoxRef {
-        self.resolve_box_box(&arg.to_boxref())
-    }
-
-    /// Operand-input sibling of [`OptContext::resolve_box_box_opt`] (`None`
-    /// when the operand is a Const / NONE / unresolved position).
-    pub fn resolve_operand_box_opt(&self, arg: &Operand) -> Option<majit_ir::box_ref::BoxRef> {
-        self.resolve_box_box_opt(&arg.to_boxref())
-    }
-
     /// Native `Operand`-in / `Operand`-out resolver: the [`Operand`] form of
     /// [`resolve_box_box`](Self::resolve_box_box). Resolves an operand to its
     /// `_forwarded` terminal WITHOUT minting a `BoxRef` — the box-native walk
@@ -4867,18 +4713,6 @@ impl OptContext {
         } else {
             self.get_box_replacement_operand(arg.to_opref())
         };
-        // Migration tripwire: the native walk must agree with the legacy
-        // resolve-then-rewrap (`Const` mints a fresh `Rc` so `same_box` fails
-        // by ptr but the resolved position `to_opref()` matches).
-        #[cfg(debug_assertions)]
-        {
-            let legacy = Operand::from_boxref(&self.resolve_operand_box(arg));
-            debug_assert!(
-                native.same_box(&legacy) || native.to_opref() == legacy.to_opref(),
-                "resolve_operand_operand: native walk diverged from legacy for {:?}",
-                arg.to_opref()
-            );
-        }
         native
     }
 
@@ -4903,24 +4737,6 @@ impl OptContext {
         } else {
             self.get_box_replacement_operand_opt(arg.to_opref())
         };
-        // Migration tripwire: the native walk must agree with the legacy
-        // resolve-then-rewrap on both presence and identity.
-        #[cfg(debug_assertions)]
-        {
-            let legacy = self
-                .resolve_operand_box_opt(arg)
-                .map(|b| Operand::from_boxref(&b));
-            let agrees = match (&native, &legacy) {
-                (Some(n), Some(l)) => n.same_box(l) || n.to_opref() == l.to_opref(),
-                (None, None) => true,
-                _ => false,
-            };
-            debug_assert!(
-                agrees,
-                "resolve_operand_operand_opt: native walk diverged from legacy for {:?}",
-                arg.to_opref()
-            );
-        }
         native
     }
 
@@ -4963,14 +4779,15 @@ impl OptContext {
         if !matches!(arg.get_forwarded(), majit_ir::box_ref::Forwarded::None) {
             return;
         }
-        let Some(canon) = self.get_box_replacement_box(arg.to_opref()) else {
+        let Some(canon) = self.get_box_replacement_operand_opt(arg.to_opref()) else {
             return;
         };
-        if arg.same_box(&canon) {
+        // `arg` is bound (checked above), so its `Operand` lowering is panic-free.
+        if Operand::from_boxref(arg).same_box(&canon) {
             return;
         }
         // Skip when `canon` wraps the same bound `Op` as `arg` under a distinct
-        // `BoxRef` — linking would be a one-node self-cycle.
+        // host — linking would be a one-node self-cycle.
         if let (Some(ao), Some(co)) = (arg.bound_op(), canon.bound_op()) {
             if std::rc::Rc::ptr_eq(&ao, &co) {
                 return;
@@ -4985,52 +4802,12 @@ impl OptContext {
         }
     }
 
-    /// Box-native `not_const=True` sibling of
-    /// [`OptContext::resolve_box_box_opt`] (resoperation.py:64-65): the
-    /// `_forwarded` walk stops before stepping into a `Const` target, so a
-    /// guard fail_arg keeps the runtime Box identity while resume numbering
-    /// carries constants as TAGCONST.
-    ///
-    /// `None` when `op` is itself a Const / NONE, or (for an unbound operand)
-    /// the position resolves to no canonical box; the caller keeps its
-    /// element unchanged then. A bound producer walks `_forwarded` directly;
-    /// an InputArg / unbound operand stays on the OpRef store path for
-    /// canonical identity (see [`OptContext::resolve_box_box`]). The
-    /// `debug_assertions` arm witnesses the box-native walk against that path.
-    pub fn get_box_replacement_not_const_box(
-        &self,
-        op: &majit_ir::box_ref::BoxRef,
-    ) -> Option<majit_ir::box_ref::BoxRef> {
-        if op.is_constant() || op.is_none() {
-            return None;
-        }
-        if op.bound_op().is_some() {
-            let resolved = op.get_box_replacement(true);
-            #[cfg(debug_assertions)]
-            {
-                if let Some(start) = self.resolve_to_boxref(op.to_opref()) {
-                    let legacy = start.get_box_replacement(true);
-                    debug_assert!(
-                        resolved.same_box(&legacy) || resolved.to_opref() == legacy.to_opref(),
-                        "get_box_replacement_not_const_box: box-native walk diverged \
-                         from OpRef path for {:?}",
-                        op.to_opref()
-                    );
-                }
-            }
-            Some(resolved)
-        } else {
-            let start = self.resolve_to_boxref(op.to_opref())?;
-            Some(start.get_box_replacement(true))
-        }
-    }
-
-    /// [`Operand`]-in / [`Operand`]-out sibling of
-    /// [`get_box_replacement_not_const_box`](Self::get_box_replacement_not_const_box):
-    /// resolve past const-folds (`get_box_replacement(true)`) directly on the
-    /// `Operand` carrier, returning `None` for a const / NONE / unresolved
-    /// operand. Lets a fail-arg consumer resolve `op.arg(i)` without the
-    /// `to_boxref()` → `from_boxref()` round-trip.
+    /// `not_const=True` operand resolver (resoperation.py:64-65): walk the
+    /// `_forwarded` chain on the `Operand` carrier but stop before stepping
+    /// into a `Const` target, so a guard fail_arg keeps the runtime identity
+    /// while resume numbering carries constants as TAGCONST. Returns `None`
+    /// for a const / NONE / unresolved operand. Lets a fail-arg consumer
+    /// resolve `op.arg(i)` directly off the `Operand`.
     pub fn get_box_replacement_not_const_operand(&self, op: &Operand) -> Option<Operand> {
         if op.is_constant() || op.is_none() {
             return None;
@@ -5064,70 +4841,25 @@ impl OptContext {
     /// returns `opref` unchanged (`from_opref(o).to_opref() == o`) — but
     /// without fabricating the intermediate position-only box.
     pub(crate) fn get_replacement_opref(&self, opref: OpRef) -> OpRef {
-        match self.get_box_replacement_box(opref) {
-            Some(b) => b.to_opref(),
+        match self.get_box_replacement_operand_opt(opref) {
+            Some(o) => o.to_opref(),
             None => opref,
         }
     }
 
-    /// `Option`-exposing sibling of [`OptContext::get_box_replacement`]:
-    /// walks the `_forwarded` chain rooted at the Box for `opref` and returns
-    /// the terminal `BoxRef`, or `None` when the root does not resolve.
-    ///
-    /// `resoperation.py:57-68 get_box_replacement(self, op)` walks
-    /// `op._forwarded` until `None | AbstractInfo`, returning the terminal
-    /// Box object. `get_box_replacement` above is total (an unresolvable root
-    /// falls back to `BoxRef::from_opref`); this variant instead surfaces the
-    /// `None` so callers that must distinguish "no bound box" — a sentinel,
-    /// or a test / retrace baseline with no upstream binding — can branch on
-    /// it rather than act on a position-only placeholder.
-    ///
-    /// `BoxRef._forwarded` (`box_ref.rs`) is the authoritative storage; both
-    /// readers walk the same chain and agree by construction.
-    pub fn get_box_replacement_box(&self, opref: OpRef) -> Option<majit_ir::box_ref::BoxRef> {
-        // Resolve the chain root through `resolve_to_boxref`, the
-        // variant-aware canonical-host resolver (producer `Op` for ResOp
-        // variants, `inputarg_refs` for InputArg, inline-Const for Const),
-        // rather than `box_pool.get` whose position-collapse merges a ResOp
-        // and an InputArg sharing a raw slot index. Production `materialize_box_at`
-        // binds every resop slot to the same producer `Op`, so reads here
-        // and writes through `materialize_box_at` agree by hitting the identical
-        // `Op.forwarded` / `InputArg.forwarded` host. A `None` resolve
-        // (sentinel, or a position with no producer / inputarg / const)
-        // leaves callers on the OpRef-returning walker fallback.
-        let start = self.resolve_to_boxref(opref)?;
-        Some(start.get_box_replacement(false))
-    }
-
-    /// [`Operand`]-yielding sibling of [`get_box_replacement_box`](Self::get_box_replacement_box):
-    /// walk the `_forwarded` chain rooted at `opref` and return the terminal as
-    /// an `Operand`, or `None` when the root does not resolve to a producer /
-    /// inputarg / const. Native form of `get_box_replacement_operand`'s body
-    /// without the position-only panic fallback.
+    /// `Option`-exposing `Operand` resolver (`resoperation.py:57-68
+    /// get_box_replacement(self, op)`): walk the `_forwarded` chain rooted at
+    /// `opref` and return the terminal as an `Operand`, or `None` when the root
+    /// does not resolve to a producer / inputarg / const. The `None` lets
+    /// callers that must distinguish "no bound box" — a sentinel, or a test /
+    /// retrace baseline with no upstream binding — branch on it rather than act
+    /// on a position-only placeholder. Native form of
+    /// `get_box_replacement_operand`'s body without the position-only panic
+    /// fallback.
     pub fn get_box_replacement_operand_opt(&self, opref: OpRef) -> Option<Operand> {
         let native = self
             .resolve_to_operand(opref)
             .map(|start| start.get_box_replacement(false));
-        // Migration tripwire: the native `Operand` walk must agree with the
-        // `BoxRef`-form `get_box_replacement_box` on both presence and identity
-        // (`Const` mints a fresh `Rc` so `same_box` fails by ptr but the
-        // resolved position `to_opref()` matches). Covers direct callers that
-        // do not flow through the `resolve_operand_operand_opt` tripwire.
-        #[cfg(debug_assertions)]
-        {
-            let legacy = self
-                .get_box_replacement_box(opref)
-                .map(|b| Operand::from_boxref(&b));
-            let agrees = match (&native, &legacy) {
-                (Some(n), Some(l)) => n.same_box(l) || n.to_opref() == l.to_opref(),
-                (None, None) => true,
-                _ => false,
-            };
-            debug_assert!(
-                agrees,
-                "get_box_replacement_operand_opt: native walk diverged from box form for {opref:?}"
-            );
-        }
         native
     }
 
@@ -8946,9 +8678,9 @@ mod boxref_forwarding_tests {
         ctx.emit(producer);
 
         // The frozen consumer arg must resolve to the emitted producer; the
-        // call also exercises resolve_box_box's witness, which would fire on
-        // the box-native-vs-OpRef divergence without the emit rebind.
-        let resolved = ctx.resolve_box_box(&consumer_arg);
+        // call also exercises resolve_operand_operand's native walk, which
+        // would diverge without the emit rebind.
+        let resolved = ctx.resolve_operand_operand(&Operand::from_boxref(&consumer_arg));
         let producer_b = ctx
             .find_producer_op(pos2)
             .expect("producer emitted at pos 2");
@@ -9165,7 +8897,7 @@ mod boxref_forwarding_tests {
         ctx.make_equal_to(&Operand::from_boxref(&b0), &Operand::from_boxref(&b_const));
 
         assert_eq!(
-            ctx.get_box_replacement(OpRef::input_arg_typed(0, Type::Int))
+            ctx.get_box_replacement_operand(OpRef::input_arg_typed(0, Type::Int))
                 .to_opref(),
             const_opref
         );
@@ -9176,7 +8908,7 @@ mod boxref_forwarding_tests {
 
         ctx.make_equal_to(&Operand::from_boxref(&b1), &Operand::from_boxref(&b0));
         assert_eq!(
-            ctx.get_box_replacement(OpRef::input_arg_typed(1, Type::Int))
+            ctx.get_box_replacement_operand(OpRef::input_arg_typed(1, Type::Int))
                 .to_opref(),
             const_opref
         );
@@ -9326,7 +9058,7 @@ mod boxref_forwarding_tests {
     fn h3_2b_get_box_replacement_box_returns_pool_entry_when_no_forward() {
         let (ctx, _b0, _b1, ia_holder) = ctx_with_two_int_boxes();
         let got = ctx
-            .get_box_replacement_box(OpRef::input_arg_typed(0, Type::Int))
+            .get_box_replacement_operand_opt(OpRef::input_arg_typed(0, Type::Int))
             .expect("canonical store resolves the slot");
         // No forwarding: the resolver materialises a fresh terminal BoxRef
         // bound to the same `InputArgRc` as the seeded slot.
@@ -9349,7 +9081,7 @@ mod boxref_forwarding_tests {
         let (mut ctx, b0, b1, ia_holder) = ctx_with_two_int_boxes();
         ctx.make_equal_to(&Operand::from_boxref(&b0), &Operand::from_boxref(&b1));
         let got = ctx
-            .get_box_replacement_box(OpRef::input_arg_typed(0, Type::Int))
+            .get_box_replacement_operand_opt(OpRef::input_arg_typed(0, Type::Int))
             .expect("bound box resolves");
         assert!(std::rc::Rc::ptr_eq(
             &got.bound_inputarg()
@@ -9357,7 +9089,7 @@ mod boxref_forwarding_tests {
             &ia_holder[1],
         ));
         // b0 itself is not the terminal.
-        assert_ne!(got, b0);
+        assert_ne!(got.to_opref(), b0.to_opref());
     }
 
     /// With no seeded canonical stores (test/retrace baseline) the
@@ -9367,7 +9099,7 @@ mod boxref_forwarding_tests {
     fn h3_2b_get_box_replacement_box_returns_none_when_pool_empty() {
         let ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
         // No seeded producer: no Box identity to resolve.
-        assert!(ctx.get_box_replacement_box(OpRef::int_op(0)).is_none());
+        assert!(ctx.get_box_replacement_operand_opt(OpRef::int_op(0)).is_none());
     }
 
     /// `OpRef::NONE` sentinel returns `None` — the BoxRef reader
@@ -9376,7 +9108,7 @@ mod boxref_forwarding_tests {
     #[test]
     fn h3_2b_get_box_replacement_box_handles_none_sentinel() {
         let (ctx, _b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
-        assert!(ctx.get_box_replacement_box(OpRef::NONE).is_none());
+        assert!(ctx.get_box_replacement_operand_opt(OpRef::NONE).is_none());
     }
 
     /// When the chain terminates at `Forwarded::Info(_)`, the
@@ -9388,7 +9120,7 @@ mod boxref_forwarding_tests {
         let (mut ctx, b0, _b1, ia_holder) = ctx_with_two_int_boxes();
         ctx.setintbound(&Operand::from_boxref(&b0), &IntBound::from_constant(7));
         let got = ctx
-            .get_box_replacement_box(OpRef::input_arg_typed(0, Type::Int))
+            .get_box_replacement_operand_opt(OpRef::input_arg_typed(0, Type::Int))
             .expect("canonical store resolves the slot");
         // Walker terminates at the slot (its `_forwarded` is Info, not a
         // chain step); the resolved BoxRef shares b0's bound InputArg.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6312,7 +6312,7 @@ impl OptContext {
     fn maybe_replace_guard_value(&self, op: &mut Op) {
         let arg0 = op.arg(0);
         // optimizer.py:755: if op.getarg(0).type == 'i'
-        let arg0_resolved = self.resolve_operand_box(&arg0).to_opref();
+        let arg0_resolved = self.get_replacement_opref(arg0.to_opref());
         if self.opref_type(arg0_resolved) != Some(majit_ir::Type::Int) {
             return;
         }
@@ -8296,7 +8296,7 @@ impl OptContext {
     /// runs `ensure_ptr_info_arg0(op).as_mut().setfield(...)`.
     pub fn structinfo_setfield(&mut self, op: &Op, field_idx: u32, value: OpRef) {
         let value = self.materialize_operand_at(value);
-        let arg0 = self.resolve_operand_box(&op.arg(0)).to_opref();
+        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
         if arg0.is_constant()
             || self
                 .get_box_replacement_box(arg0)
@@ -8437,7 +8437,7 @@ impl OptContext {
     /// `arrayinfo.getlenbound(...)` patterns.
     pub fn ensure_ptr_info_arg0(&mut self, op: &Op) -> EnsuredPtrInfo {
         // optimizer.py:464: arg0 = self.get_box_replacement(op.getarg(0))
-        let arg0 = self.resolve_operand_box(&op.arg(0)).to_opref();
+        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
         // optimizer.py:465-466: if arg0.is_constant(): return info.ConstPtrInfo(arg0)
         //
         // PyPy's `info.ConstPtrInfo(arg0)` wraps the constant box itself,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3431,10 +3431,13 @@ impl OptContext {
         // body-visible OpRef. Non-invented Pure has no forwarding installed,
         // so `get_box_replacement(source) == source` and the body references
         // source directly (RPython parity for non-invented `op = self.res`).
-        let resolved = self.resolve_box_box(&preamble_op.op);
-        let result = resolved.to_opref();
+        let resolved = self.get_box_replacement_operand_opt(preamble_op.op.to_opref());
+        let result = resolved
+            .as_ref()
+            .map(|o| o.to_opref())
+            .unwrap_or_else(|| preamble_op.op.to_opref());
         let result_type = preamble_op.preamble_op.result_type();
-        let is_constant = resolved.const_value().is_some();
+        let is_constant = resolved.and_then(|o| o.const_value()).is_some();
         let first_use = !self.imported_short_preamble_used.contains(&preamble_source);
         if first_use {
             self.imported_short_preamble_used.push(preamble_source);
@@ -6367,7 +6370,10 @@ impl OptContext {
             if let Some(preamble_op) = tracked {
                 // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
                 // — the resolved Box itself is handed to the builder.
-                let resolved_for_pop = self.resolve_box_box(&preamble_op.op);
+                let resolved_for_pop = self
+                    .get_box_replacement_operand_opt(preamble_op.op.to_opref())
+                    .map(|o| o.to_boxref())
+                    .unwrap_or_else(|| preamble_op.op.clone());
                 if let Some(builder) = self.active_short_preamble_producer_mut() {
                     builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
                 } else if let Some(builder) = self.imported_short_preamble_builder.as_mut() {
@@ -8514,11 +8520,9 @@ impl OptContext {
         // `find_producer_op` returns). The Phase-1 heal links the operand's
         // input op to that canonical even at a shared position, so the
         // box-native terminal now carries the PtrInfo `heap`/`virtualize` set.
-        let arg0_box = self.resolve_operand_box_opt(&op.arg(0));
+        let arg0_box = self.resolve_operand_operand_opt(&op.arg(0));
         if matches!(
-            arg0_box
-                .as_ref()
-                .and_then(|b| self.peek_ptr_info(&Operand::from_boxref(b))),
+            arg0_box.as_ref().and_then(|o| self.peek_ptr_info(o)),
             Some(
                 PtrInfo::Instance(_)
                     | PtrInfo::Virtual(_)
@@ -8536,12 +8540,13 @@ impl OptContext {
             // optimizer.py:469: return opinfo. The matches! above required
             // arg0_box to carry a virtual/known PtrInfo, so the terminal
             // BoxRef is already resolved — reuse it instead of re-minting.
-            let bx = arg0_box.expect("matched PtrInfo implies a resolved arg0 BoxRef");
+            let bx = arg0_box
+                .expect("matched PtrInfo implies a resolved arg0 operand")
+                .to_boxref();
             return EnsuredPtrInfo::ForwardedBox(bx);
         }
-        let last_guard_pos = if let Some(opinfo) = arg0_box
-            .as_ref()
-            .and_then(|b| self.peek_ptr_info(&Operand::from_boxref(b)))
+        let last_guard_pos = if let Some(opinfo) =
+            arg0_box.as_ref().and_then(|o| self.peek_ptr_info(o))
         {
             // optimizer.py:474:
             //     assert opinfo is None or opinfo.__class__ is info.NonNullPtrInfo

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -7653,8 +7653,8 @@ impl OptContext {
         // virtualstate.py:149-151 `opinfo = getptrinfo(box); assert
         // opinfo.is_virtual()`. Read the field box only off a virtual struct
         // ptrinfo; a concrete/instance ptrinfo falls through to the eager read.
-        let b = self.get_box_replacement_box(runtime_box)?;
-        let info = self.getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))?;
+        let op = self.get_box_replacement_operand_opt(runtime_box)?;
+        let info = self.getptrinfo(&op)?;
         let field_opref = match &info {
             crate::optimizeopt::info::PtrInfo::Virtual(_)
             | crate::optimizeopt::info::PtrInfo::VirtualStruct(_) => {
@@ -7692,8 +7692,8 @@ impl OptContext {
             .get_parent_descr()
             .map(|_| fd.index_in_parent() as u32)
             .unwrap_or_else(|| descr.index());
-        let b = self.get_box_replacement_box(runtime_box)?;
-        let info = self.getptrinfo(&majit_ir::operand::Operand::from_boxref(&b))?;
+        let op = self.get_box_replacement_operand_opt(runtime_box)?;
+        let info = self.getptrinfo(&op)?;
         if !matches!(
             info,
             crate::optimizeopt::info::PtrInfo::VirtualArrayStruct(_)
@@ -8299,7 +8299,7 @@ impl OptContext {
         let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
         if arg0.is_constant()
             || self
-                .get_box_replacement_box(arg0)
+                .get_box_replacement_operand_opt(arg0)
                 .and_then(|cb| cb.const_value())
                 .is_some()
         {
@@ -8449,7 +8449,7 @@ impl OptContext {
         // pointer Int → cast, anything else → null sentinel) and let the
         // downstream user decide whether to act on it.
         let arg0_const = self
-            .get_box_replacement_box(arg0)
+            .get_box_replacement_operand_opt(arg0)
             .and_then(|cb| cb.const_value());
         if arg0.is_constant() || arg0_const.is_some() {
             let gcref = match arg0_const {

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -18,7 +18,6 @@ use majit_ir::{DescrRef, Op, OpCode, OpRef, Type};
 use crate::optimizeopt::info::{PtrInfo, PtrInfoExt};
 use crate::optimizeopt::intutils::IntBound;
 use crate::optimizeopt::{SnapshotBoxes, SnapshotFramePcs, SnapshotFrameSizes};
-use majit_ir::box_ref::BoxRef;
 
 /// optimizer.py:47-54 OptimizationResult: result of an optimization pass.
 #[derive(Debug)]
@@ -5930,13 +5929,13 @@ mod tests {
         );
         guard_a.setfailargs(
             vec![
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 2000),
-                rooted_resop_box(Type::Int, 2001),
-                rooted_resop_box(Type::Int, 3),
-                rooted_resop_box(Type::Int, 3000),
-                rooted_resop_box(Type::Int, 3001),
-                rooted_resop_box(Type::Int, 4),
+                rooted_resop_operand(Type::Int, 0),
+                rooted_resop_operand(Type::Int, 2000),
+                rooted_resop_operand(Type::Int, 2001),
+                rooted_resop_operand(Type::Int, 3),
+                rooted_resop_operand(Type::Int, 3000),
+                rooted_resop_operand(Type::Int, 3001),
+                rooted_resop_operand(Type::Int, 4),
             ]
             .into(),
         );
@@ -5966,14 +5965,14 @@ mod tests {
         );
         guard_b.setfailargs(
             vec![
-                rooted_resop_box(Type::Int, 0),
-                rooted_resop_box(Type::Int, 2002),
-                rooted_resop_box(Type::Int, 2003),
-                rooted_resop_box(Type::Int, 3),
-                rooted_resop_box(Type::Int, 6),
-                rooted_resop_box(Type::Int, 3002),
-                rooted_resop_box(Type::Int, 3003),
-                rooted_resop_box(Type::Int, 7),
+                rooted_resop_operand(Type::Int, 0),
+                rooted_resop_operand(Type::Int, 2002),
+                rooted_resop_operand(Type::Int, 2003),
+                rooted_resop_operand(Type::Int, 3),
+                rooted_resop_operand(Type::Int, 6),
+                rooted_resop_operand(Type::Int, 3002),
+                rooted_resop_operand(Type::Int, 3003),
+                rooted_resop_operand(Type::Int, 7),
             ]
             .into(),
         );
@@ -6550,7 +6549,7 @@ mod tests {
         let field_descr = majit_ir::make_field_descr(8, 8, Type::Int, majit_ir::ArrayFlag::Signed);
 
         let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_operand(Type::Int, 10)]);
-        guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into());
+        guard.setfailargs(vec![rooted_resop_operand(Type::Int, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], size_descr),
             Op::with_descr(
@@ -6996,7 +6995,7 @@ mod tests {
         let (ops, inputs) = b.build();
         // The GuardTrue (ops[1]) keeps both header inputs as fail args; bind
         // them to the same canonical InputArg boxes the header threads.
-        ops[1].setfailargs(vec![x, y].into());
+        ops[1].setfailargs(vec![Operand::from_boxref(&x), Operand::from_boxref(&y)].into());
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_guard_snapshots_with_oprc(&ops, |_| vec![x_ref, y_ref]);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2793,7 +2793,7 @@ impl Optimizer {
             let resolved_args: Vec<OpRef> = terminal_op
                 .getarglist()
                 .iter()
-                .map(|arg| ctx.resolve_box_box(arg).to_opref())
+                .map(|arg| ctx.get_replacement_opref(arg.to_opref()))
                 .collect();
             for &resolved in &resolved_args {
                 self.force_box_for_end_of_preamble(resolved, &mut ctx);
@@ -2805,7 +2805,7 @@ impl Optimizer {
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
-                let resolved = ctx.resolve_operand_box(&arg).to_opref();
+                let resolved = ctx.get_replacement_opref(arg.to_opref());
                 let expected_ref =
                     i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
@@ -2976,7 +2976,7 @@ impl Optimizer {
                     .unwrap_or_else(|| {
                         jump.getarglist()
                             .iter()
-                            .map(|a| ctx.resolve_box_box(a).to_opref())
+                            .map(|a| ctx.get_replacement_opref(a.to_opref()))
                             .collect()
                     });
                 let mut resolved_args = original_jump_args.clone();
@@ -4952,8 +4952,8 @@ impl Optimizer {
                         majit_ir::GuardPendingFieldEntry {
                             descr: pf_op.getdescr(),
                             item_index,
-                            target: ctx.resolve_operand_box(&target).to_opref(),
-                            value: ctx.resolve_operand_box(&value).to_opref(),
+                            target: ctx.get_replacement_opref(target.to_opref()),
+                            value: ctx.get_replacement_opref(value.to_opref()),
                             target_tagged: majit_ir::resumedata::UNASSIGNED,
                             value_tagged: majit_ir::resumedata::UNASSIGNED,
                         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1794,7 +1794,10 @@ impl Optimizer {
             if let Some(preamble_op) = tracked {
                 // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
                 // — the resolved Box itself is handed to the builder.
-                let resolved_for_pop = ctx.resolve_box_box(&preamble_op.op);
+                let resolved_for_pop = ctx
+                    .get_box_replacement_operand_opt(preamble_op.op.to_opref())
+                    .map(|o| o.to_boxref())
+                    .unwrap_or_else(|| preamble_op.op.clone());
                 if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                     builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
                 } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -803,10 +803,7 @@ impl OptPure {
             let resolved_box = resolved_box.expect("recorder-populated");
             let mut info = ctx.take_ptr_info(&resolved_box).unwrap();
             let forced = info.force_box(&resolved_box, ctx);
-            return ctx
-                .get_box_replacement_box(forced)
-                .map(|b| b.to_opref())
-                .unwrap_or(forced);
+            return ctx.get_replacement_opref(forced);
         }
         resolved
     }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2696,8 +2696,8 @@ mod tests {
         let result = pass.propagate_forward(&op, &op_rc, &mut ctx);
         assert!(matches!(result, OptimizationResult::Remove));
         assert_eq!(
-            ctx.get_box_replacement_box(OpRef::int_op(2))
-                .map(|b| b.to_opref()),
+            ctx.get_box_replacement_operand_opt(OpRef::int_op(2))
+                .map(|o| o.to_opref()),
             Some(OpRef::int_op(1))
         );
     }

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -9,7 +9,6 @@ use majit_ir::{GcRef, Op, OpCode, OpRef, Value};
 
 use crate::optimizeopt::info::{PreambleOp, PtrInfoExt};
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
-use majit_ir::box_ref::BoxRef;
 
 /// pure.py:104,204-210: extra_call_pure entry.
 /// RPython stores AbstractResOp (or PreambleOp) directly in the list.
@@ -1309,6 +1308,7 @@ impl Optimization for OptPure {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use majit_ir::box_ref::BoxRef;
 
     fn initialize_imported_short_pure_builder(
         ctx: &mut OptContext,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1073,10 +1073,9 @@ impl Optimization for OptPure {
             // CSE: exact same operation already computed?
             if let Some(cached_ref) = self.lookup_pure(&key, ctx) {
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_cached = {
-                    let __t = ctx.get_box_replacement(cached_ref);
-                    ctx.operand_of_box(&__t)
-                };
+                let b_cached = ctx
+                    .get_box_replacement_operand_opt(cached_ref)
+                    .unwrap_or_else(|| ctx.materialize_operand_at(cached_ref));
                 ctx.make_equal_to(&b_old, &b_cached);
                 self.last_emitted_was_removed = true;
                 return OptimizationResult::Remove;

--- a/majit/majit-metainterp/src/optimizeopt/renamer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/renamer.rs
@@ -9,7 +9,7 @@ use majit_ir::resoperation::{Op, OpCode, OpRc};
 use majit_ir::{InputArg, OpRef, Type};
 
 use majit_ir::VecMap;
-use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 
 /// renamer.py:3-58: Renamer — maps old OpRefs to new OpRefs during unrolling.
 ///
@@ -24,7 +24,7 @@ use majit_ir::box_ref::BoxRef;
 /// `OpRef`), so the only observable change is the box KIND (bound vs
 /// position-only).
 pub struct Renamer {
-    rename_map: VecMap<OpRef, BoxRef>,
+    rename_map: VecMap<OpRef, Operand>,
     /// Producer `Rc`s minted by [`Renamer::bound_box`] to back the bound map
     /// values. The bound `BoxRef` holds only a `Weak<Op>` / `Weak<InputArg>`,
     /// so its producer must be rooted for the upgrade to stay live. The
@@ -46,7 +46,7 @@ impl Renamer {
         }
     }
 
-    fn lookup(&self, opref: OpRef) -> Option<BoxRef> {
+    fn lookup(&self, opref: OpRef) -> Option<Operand> {
         self.rename_map.get(&opref).cloned()
     }
 
@@ -54,7 +54,7 @@ impl Renamer {
     /// its `OpRef`) on a hit, so callers that re-install an op arg / failarg can
     /// carry the bound box directly instead of re-deriving a position-only box.
     /// `None` on a miss (the caller leaves the existing operand untouched).
-    pub fn lookup_box(&self, opref: OpRef) -> Option<BoxRef> {
+    pub fn lookup_box(&self, opref: OpRef) -> Option<Operand> {
         self.lookup(opref)
     }
 
@@ -66,7 +66,7 @@ impl Renamer {
         self.lookup(opref).map(|b| b.to_opref()).unwrap_or(opref)
     }
 
-    /// Materialise a BOUND `BoxRef` for `r` whose `to_opref()` equals `r`,
+    /// Materialise a BOUND `Operand` for `r` whose `to_opref()` equals `r`,
     /// rooting a synthetic producer so the bound box's `Weak` stays live.
     ///
     /// Const / None positions shed to `Operand::Const` / none through
@@ -76,16 +76,16 @@ impl Renamer {
     /// production analogue of the test fixtures' `rooted_resop_box` /
     /// `rooted_inputarg_box`: a real producer `Rc` is unavailable because the
     /// vectorizer's buffers hold `Op` values, not `OpRc`.
-    pub fn bound_box(&mut self, r: OpRef) -> BoxRef {
+    pub fn bound_box(&mut self, r: OpRef) -> Operand {
         if r.is_none() || r.is_constant() {
-            return BoxRef::from_opref(r);
+            return Operand::from_opref(r);
         }
         let ty = r.ty().unwrap_or(Type::Void);
         let pos = r.raw();
         match r {
             OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
                 let ia = Rc::new(InputArg::from_type(ty, pos));
-                let b = BoxRef::from_bound_inputarg(&ia);
+                let b = Operand::from_bound_inputarg(&ia);
                 self.producer_roots.push(ia);
                 b
             }
@@ -98,7 +98,7 @@ impl Renamer {
                 };
                 let op: OpRc = Rc::new(Op::new(opcode, &[]));
                 op.pos.set(OpRef::op_typed(pos, ty));
-                let b = BoxRef::from_bound_op(&op);
+                let b = Operand::from_bound_op(&op);
                 self.producer_roots.push(op);
                 b
             }
@@ -132,7 +132,7 @@ impl Renamer {
         for i in 0..op.num_args() {
             let arg = op.arg(i);
             if let Some(renamed) = self.rename_map.get(&arg.to_opref()) {
-                op.setarg(i, majit_ir::operand::Operand::from_boxref(&renamed.clone()));
+                op.setarg(i, renamed.clone());
             }
         }
 
@@ -144,7 +144,7 @@ impl Renamer {
             if let Some(fail_args) = op.fail_args_mut() {
                 for arg in fail_args.iter_mut() {
                     if let Some(renamed) = self.lookup(arg.to_opref()) {
-                        *arg = majit_ir::operand::Operand::from_boxref(&renamed);
+                        *arg = renamed;
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -434,8 +434,8 @@ impl OptRewrite {
         }
 
         // rewrite.py:528-531: null checks — fall back to OpRef for downstream
-        let arg0 = ctx.resolve_operand_box(&op.arg(0)).to_opref();
-        let arg1 = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+        let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let arg1 = ctx.get_replacement_opref(op.arg(1).to_opref());
         if info1.as_ref().is_some_and(|i| i.is_null()) {
             return self.optimize_nullness(op, arg0, expect_isnot, ctx);
         }
@@ -827,7 +827,7 @@ impl OptRewrite {
         // EnsuredPtrInfo borrow; downstream lookups re-acquire via
         // `getptrinfo` / `get_ptr_info` against the resolved OpRef.
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let obj = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let obj = ctx.get_replacement_opref(op.arg(0).to_opref());
         // rewrite.py:397-407: ensure_ptr_info_arg0 → info.py:880 getptrinfo.
         // `getptrinfo(ConstPtr)` returns a synthesized ConstPtrInfo, so a
         // constant Ref arg0 is handled uniformly with virtual / instance
@@ -1123,7 +1123,7 @@ impl OptRewrite {
                     && shift_op.num_args() >= 2
                     && shift_op.arg(0).get_box_replacement(false).const_int() == Some(1)
                 {
-                    let shiftvar = ctx.resolve_operand_box(&shift_op.arg(1)).to_opref();
+                    let shiftvar = ctx.get_replacement_opref(shift_op.arg(1).to_opref());
                     let shiftbound = {
                         let b = ctx.get_box_replacement_operand(shiftvar);
                         ctx.getintbound_handle(&b).borrow().clone()
@@ -1762,7 +1762,7 @@ impl Optimization for OptRewrite {
                 //         if info.is_null(): return
                 //         elif info.is_nonnull(): raise InvalidLoop(...)
                 //     return self.emit(op)
-                let obj = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+                let obj = ctx.get_replacement_opref(op.arg(0).to_opref());
                 let obj_box = ctx.resolve_operand_operand_opt(&op.arg(0));
                 if let Some(info) = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b)) {
                     if info.is_null() {
@@ -1903,8 +1903,8 @@ impl Optimization for OptRewrite {
                     //     arg0 = get_box_replacement(op.getarg(0))
                     //     arg1 = get_box_replacement(op.getarg(1))
                     //     self.pure_from_args2(rop.INSTANCE_PTR_EQ, arg1, arg0, op)
-                    let arg0 = ctx.resolve_operand_box(&op.arg(0)).to_opref();
-                    let arg1 = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+                    let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
+                    let arg1 = ctx.get_replacement_opref(op.arg(1).to_opref());
                     ctx.register_pure_from_args2(OpCode::InstancePtrEq, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, false, instance, ctx);
@@ -1913,8 +1913,8 @@ impl Optimization for OptRewrite {
                 let instance = matches!(op.opcode, OpCode::InstancePtrNe);
                 if instance {
                     // rewrite.py:568-571 optimize_INSTANCE_PTR_NE: same swap.
-                    let arg0 = ctx.resolve_operand_box(&op.arg(0)).to_opref();
-                    let arg1 = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+                    let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
+                    let arg1 = ctx.get_replacement_opref(op.arg(1).to_opref());
                     ctx.register_pure_from_args2(OpCode::InstancePtrNe, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, true, instance, ctx);
@@ -2522,7 +2522,7 @@ mod tests {
     }
 
     fn assert_forward(ctx: &OptContext, from: OpRef, to: OpRef) {
-        assert_eq!(ctx.get_box_replacement(from).to_opref(), to);
+        assert_eq!(ctx.get_replacement_opref(from), to);
     }
 
     /// Run the rewrite pass on a sequence of ops and return the optimized ops.
@@ -2927,7 +2927,7 @@ mod tests {
         // op0 is emitted, op1 is emitted (just a constant), op2 is removed.
         // After forwarding, any reference to op2 should resolve to op0.
         assert_eq!(
-            ctx.get_box_replacement(OpRef::int_op(2)).to_opref(),
+            ctx.get_replacement_opref(OpRef::int_op(2)),
             OpRef::int_op(0)
         );
     }
@@ -3164,7 +3164,7 @@ mod tests {
         let result2 = pass.propagate_forward(&resolved2, &__pf_rc, &mut ctx);
         assert!(matches!(result2, OptimizationResult::Remove));
         assert_eq!(
-            ctx.get_box_replacement(OpRef::float_op(2)).to_opref(),
+            ctx.get_replacement_opref(OpRef::float_op(2)),
             OpRef::float_op(0)
         );
     }
@@ -3250,7 +3250,7 @@ mod tests {
             &[(OpRef::int_op(0), Value::Int(42))],
         );
         assert_remove(&result);
-        let resolved = ctx.get_box_replacement(OpRef::int_op(3)).to_opref();
+        let resolved = ctx.get_replacement_opref(OpRef::int_op(3));
         assert!(resolved.is_constant());
         assert_eq!(
             ctx.get_box_replacement_operand_opt(resolved)

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -8,7 +8,6 @@ use majit_ir::{Op, OpCode, OpRef, Value};
 
 use crate::optimizeopt::info::{PreambleOp, PtrInfoExt};
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult, intdiv};
-use majit_ir::box_ref::BoxRef;
 
 /// rewrite.py: loop_invariant_results value.
 /// RPython stores PreambleOp or regular Box (AbstractResOp) directly
@@ -2339,6 +2338,7 @@ mod tests {
     use super::*;
     use crate::optimizeopt::optimizer::Optimizer;
     use majit_ir::GcRef;
+    use majit_ir::box_ref::BoxRef;
 
     /// Producer-position trace spec. A consumer's `args` name the result
     /// positions of earlier producers in the same spec slice, so no op-arg

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -8,7 +8,6 @@ use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
 
 use crate::jitexc::{NotAProfitableLoop, NotAVectorizeableLoop};
 use crate::optimizeopt::vector::CostModel;
-use majit_ir::box_ref::BoxRef;
 
 /// Resolve an `OpRef` to a producer-bound `Operand` against the supplied
 /// producer buffers. A hit binds to the canonical producer `OpRc`
@@ -503,7 +502,7 @@ impl VecScheduleState {
                     .flat_map(|b| b.iter())
                     .find(|p| p.pos.get() == r)
                 {
-                    *slot = BoxRef::from_bound_op(rc);
+                    *slot = Operand::from_bound_op(rc);
                     changed = true;
                 }
             }
@@ -870,7 +869,7 @@ pub fn prepare_fail_arguments(
         vecop.setfailargs(
             new_fail_args
                 .iter()
-                .map(|r| BoxRef::from_opref(*r))
+                .map(|r| Operand::from_opref(*r))
                 .collect(),
         );
     }

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -13,7 +13,11 @@ use crate::optimizeopt::vector::CostModel;
 /// producer buffers. A hit binds to the canonical producer `OpRc`
 /// (`from_bound_op` → `Operand::Op`, no mint); a miss (inputarg / external /
 /// constant) falls back to the position-only / const `from_opref` box.
-fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]], renamer: &mut super::renamer::Renamer) -> Operand {
+fn bound_boxref_in(
+    r: OpRef,
+    buffers: &[&[OpRc]],
+    renamer: &mut super::renamer::Renamer,
+) -> Operand {
     if r.is_constant() || r.is_none() {
         return Operand::from_opref(r);
     }
@@ -531,10 +535,7 @@ impl VecScheduleState {
         count: usize,
     ) -> Op {
         let ba: Vec<Operand> = args.iter().map(|a| self.bound_arg_boxref(*a)).collect();
-        let op = Op::new(
-            opcode,
-            &ba,
-        );
+        let op = Op::new(opcode, &ba);
         op.pos.set(self.alloc_op_pos(opcode.result_type()));
         let mut vinfo = majit_ir::VectorizationInfo::new();
         vinfo.setinfo(datatype, bytesize as i8, signed);
@@ -855,23 +856,21 @@ pub fn prepare_fail_arguments(
         return;
     }
     if let Some(fail_args) = first_op.getfailargs() {
-        let mut new_fail_args: smallvec::SmallVec<[OpRef; 3]> =
-            fail_args.iter().map(|b| b.to_opref()).collect();
-        for arg in new_fail_args.iter_mut() {
+        let mut new_fail_args: smallvec::SmallVec<[Operand; 3]> =
+            fail_args.iter().cloned().collect();
+        for slot in new_fail_args.iter_mut() {
+            let arg = slot.to_opref();
             // schedule.py:393-394: look up if arg is in a vector box
-            let (_pos, newarg) = state.getvector_of_box(*arg).unwrap_or((0, *arg));
-            if newarg != *arg {
+            let (_pos, newarg) = state.getvector_of_box(arg).unwrap_or((0, arg));
+            if newarg != arg {
                 // schedule.py:396-397: vector box → unpack at position 0
                 let unpacked = unpack_from_vector(state, newarg, 0, 1);
-                *arg = unpacked;
+                *slot = state.bound_arg_boxref(unpacked);
             }
+            // else newarg == arg: keep the original bound Operand
+            // (schedule.py:395 newarg = arg; args[i] = newarg).
         }
-        vecop.setfailargs(
-            new_fail_args
-                .iter()
-                .map(|r| Operand::from_opref(*r))
-                .collect(),
-        );
+        vecop.setfailargs(new_fail_args);
     }
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -10,20 +10,20 @@ use crate::jitexc::{NotAProfitableLoop, NotAVectorizeableLoop};
 use crate::optimizeopt::vector::CostModel;
 use majit_ir::box_ref::BoxRef;
 
-/// Resolve an `OpRef` to a producer-bound `BoxRef` against the supplied
+/// Resolve an `OpRef` to a producer-bound `Operand` against the supplied
 /// producer buffers. A hit binds to the canonical producer `OpRc`
 /// (`from_bound_op` → `Operand::Op`, no mint); a miss (inputarg / external /
 /// constant) falls back to the position-only / const `from_opref` box.
-fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]], renamer: &mut super::renamer::Renamer) -> BoxRef {
+fn bound_boxref_in(r: OpRef, buffers: &[&[OpRc]], renamer: &mut super::renamer::Renamer) -> Operand {
     if r.is_constant() || r.is_none() {
-        return BoxRef::from_opref(r);
+        return Operand::from_opref(r);
     }
     if let Some(rc) = buffers
         .iter()
         .flat_map(|b| b.iter())
         .find(|p| p.pos.get() == r)
     {
-        return BoxRef::from_bound_op(rc);
+        return Operand::from_bound_op(rc);
     }
     // No producer in the supplied buffers (e.g. a loop inputarg): bind to a
     // renamer-rooted producer box carrying the same `pos`, never a
@@ -437,7 +437,7 @@ impl VecScheduleState {
         pos
     }
 
-    /// Resolve an arg `OpRef` to a producer-bound `BoxRef`.
+    /// Resolve an arg `OpRef` to a producer-bound `Operand`.
     ///
     /// vector.py's renamer maps box→box and carries the box objects through
     /// the scheduler. pyre's args are integer positions, so to recover the
@@ -449,9 +449,9 @@ impl VecScheduleState {
     /// (an inputarg, or a scalar not yet emitted as a vector op) is bound
     /// to a renamer-rooted producer box carrying the same `pos`
     /// (`Renamer::bound_box`), so no position-only `Operand::Box` is minted.
-    pub fn bound_arg_boxref(&mut self, r: OpRef) -> BoxRef {
+    pub fn bound_arg_boxref(&mut self, r: OpRef) -> Operand {
         if r.is_constant() || r.is_none() {
-            return BoxRef::from_opref(r);
+            return Operand::from_opref(r);
         }
         if let Some(rc) = self
             .oplist
@@ -459,7 +459,7 @@ impl VecScheduleState {
             .chain(self.invariant_oplist.iter())
             .find(|op| op.pos.get() == r)
         {
-            return BoxRef::from_bound_op(rc);
+            return Operand::from_bound_op(rc);
         }
         self.renamer.bound_box(r)
     }
@@ -531,10 +531,10 @@ impl VecScheduleState {
         signed: bool,
         count: usize,
     ) -> Op {
-        let ba: Vec<BoxRef> = args.iter().map(|a| self.bound_arg_boxref(*a)).collect();
+        let ba: Vec<Operand> = args.iter().map(|a| self.bound_arg_boxref(*a)).collect();
         let op = Op::new(
             opcode,
-            &ba.iter().map(Operand::from_boxref).collect::<Vec<_>>(),
+            &ba,
         );
         op.pos.set(self.alloc_op_pos(opcode.result_type()));
         let mut vinfo = majit_ir::VectorizationInfo::new();
@@ -647,7 +647,7 @@ impl VecScheduleState {
         if !self.invariant_vector_vars.is_empty() || !loop_.prefix.is_empty() {
             // schedule.py:769-773: prefix_label.
             //   args = loop.label.getarglist_copy() + self.invariant_vector_vars
-            let mut args = loop_.label.getarglist_copy();
+            let mut args = loop_.label.getarglist_operand();
             // invariant_vector_vars is a VecSet (insertion-ordered re-export of
             // vecmap_rs::VecSet), so iterating reproduces RPython's list-append
             // order. RPython's list may hold dups but expand() only appends fresh
@@ -667,7 +667,7 @@ impl VecScheduleState {
             //   op = loop.label.copy_and_change(opnum, args).
             // The opcode ("opnum") is unchanged → loop_.label.opcode; descr None
             // means "keep self.descr"; copy_and_change preserves the result `pos`.
-            let args_ops: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
+            let args_ops: Vec<Operand> = args.to_vec();
             let mut prefix_label =
                 loop_
                     .label
@@ -679,7 +679,7 @@ impl VecScheduleState {
             loop_.prefix_label = Some(prefix_label); // schedule.py:773
 
             // schedule.py:775-779: jump.
-            let mut args = loop_.jump.getarglist_copy();
+            let mut args = loop_.jump.getarglist_operand();
             for r in &inv_vars {
                 args.push(bound_boxref_in(
                     *r,
@@ -687,7 +687,7 @@ impl VecScheduleState {
                     &mut self.renamer,
                 ));
             }
-            let args_ops2: Vec<Operand> = args.iter().map(Operand::from_boxref).collect();
+            let args_ops2: Vec<Operand> = args.to_vec();
             let mut new_jump =
                 loop_
                     .jump

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1877,9 +1877,10 @@ impl ProducedShortOp {
                 .and_then(|b| ctx.get_constant_box(b))
                 .is_some()
         {
-            if let Some(info) = obj_box.as_ref().and_then(|b| {
-                ctx.get_const_info_array_mut_box(b, descr.clone())
-            }) {
+            if let Some(info) = obj_box
+                .as_ref()
+                .and_then(|b| ctx.get_const_info_array_mut_box(b, descr.clone()))
+            {
                 info.set_preamble_item(index as usize, pop.clone());
             }
         } else {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1389,7 +1389,7 @@ pub(crate) fn classify_short_arg(
     // unit-test consumer ctxs without pre-seeded const pool), then consumer
     // ctx (production: pre-seeded at optimizer.rs:1927).
     if let Some(value) = short_box_const_values.get(&arg).cloned().or_else(|| {
-        ctx.get_box_replacement_box(arg)
+        ctx.get_box_replacement_operand_opt(arg)
             .and_then(|cb| cb.const_value())
     }) {
         let const_opref = imported_const_opref(imported_constants, arg, &value);
@@ -1870,15 +1870,15 @@ impl ProducedShortOp {
             preamble_op: replay_rc,
             same_as_source: self.same_as_source.clone(),
         };
-        let obj_box = ctx.get_box_replacement_box(obj_resolved);
+        let obj_box = ctx.get_box_replacement_operand_opt(obj_resolved);
         if obj_resolved.is_constant()
             || obj_box
                 .as_ref()
-                .and_then(|b| ctx.get_constant_box(&Operand::from_boxref(b)))
+                .and_then(|b| ctx.get_constant_box(b))
                 .is_some()
         {
             if let Some(info) = obj_box.as_ref().and_then(|b| {
-                ctx.get_const_info_array_mut_box(&Operand::from_boxref(b), descr.clone())
+                ctx.get_const_info_array_mut_box(b, descr.clone())
             }) {
                 info.set_preamble_item(index as usize, pop.clone());
             }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2733,7 +2733,8 @@ impl ExtendedShortPreambleBuilder {
                         // producer-less position-only box. Mirrors the mapped
                         // arm, which binds via `materialize_box_at`; falls back
                         // to a position-only box only if no producer exists.
-                        ctx.get_box_replacement_box(arg.to_opref())
+                        ctx.get_box_replacement_operand_opt(arg.to_opref())
+                            .map(|o| o.to_boxref())
                             .unwrap_or_else(|| BoxRef::from_opref(arg.to_opref()))
                     })
             })

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -3456,7 +3456,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rop(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
-        ops[1].setfailargs(vec![rooted_resop_box(Type::Int, 100)].into());
+        ops[1].setfailargs(vec![rooted_resop_operand(Type::Int, 100)].into());
         let sp = extract_short_preamble(&ops);
 
         assert_eq!(sp.len(), 2);
@@ -3476,7 +3476,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rop(Type::Int, 100)]),
         ];
         assign_positions(&mut ops, 0);
-        ops[1].setfailargs(vec![rooted_resop_box(Type::Int, 100)].into());
+        ops[1].setfailargs(vec![rooted_resop_operand(Type::Int, 100)].into());
         let sp = extract_short_preamble(&ops);
 
         assert!(sp.is_empty());

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3009,7 +3009,7 @@ impl OptUnroll {
                     continue;
                 }
                 if let Some(value) = ctx
-                    .get_box_replacement_box(arg)
+                    .get_box_replacement_operand_opt(arg)
                     .and_then(|cb| cb.const_value())
                 {
                     state.short_box_const_values.insert(arg, value);
@@ -3304,7 +3304,7 @@ impl OptUnroll {
                                 let arg = arg.to_opref();
                                 (
                                     arg,
-                                    ctx.get_box_replacement_box(arg)
+                                    ctx.get_box_replacement_operand_opt(arg)
                                         .and_then(|cb| cb.const_value()),
                                 )
                             })
@@ -4082,7 +4082,7 @@ impl OptUnroll {
                 // resolves them instead of fabricating a position-only box.
                 // Slot-mapped results (`short_args[slot]`) are already bound
                 // inputargs and resolve without minting.
-                if ctx.get_box_replacement_box(result).is_none() {
+                if ctx.get_box_replacement_operand_opt(result).is_none() {
                     ctx.mint_box_at(result);
                 }
                 result_map.insert(*source, result);
@@ -4193,7 +4193,7 @@ impl OptUnroll {
         };
         if resolved.is_constant() {
             if let Some(value) = ctx
-                .get_box_replacement_box(resolved)
+                .get_box_replacement_operand_opt(resolved)
                 .and_then(|cb| cb.const_value())
             {
                 return synthesize_const_info(value);
@@ -4202,7 +4202,7 @@ impl OptUnroll {
         // make_constant mirrors optimizer.py:432 as `Forwarded::Const(constval)`.
         // The walker has advanced to the constbox terminal — surface RPython's
         // ConstPtrInfo / FloatConstInfo / IntBound dispatch via const_value().
-        let resolved_box = ctx.get_box_replacement_box(opref);
+        let resolved_box = ctx.get_box_replacement_operand_opt(opref);
         if let Some(b) = resolved_box.as_ref() {
             if b.is_constant() {
                 if let Some(value) = b.const_value() {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6112,7 +6112,7 @@ mod tests {
             ),
             {
                 let mut guard = Op::new(OpCode::GuardTrue, &[rooted_resop_operand(Type::Int, 100)]);
-                guard.setfailargs(vec![rooted_resop_box(Type::Int, 0)].into()); // refs op0
+                guard.setfailargs(vec![rooted_resop_operand(Type::Int, 0)].into()); // refs op0
                 guard
             },
             Op::new(OpCode::Jump, &[]),
@@ -7464,7 +7464,7 @@ mod tests {
                         Operand::from_opref(OpRef::const_int(2)),
                     ],
                 );
-                op.setfailargs(vec![rooted_resop_box(Type::Void, 857)].into());
+                op.setfailargs(vec![rooted_resop_operand(Type::Void, 857)].into());
                 op
             },
             Op::new(
@@ -7629,7 +7629,7 @@ mod tests {
         let p2_ops = vec![
             {
                 let mut op = Op::new(OpCode::GuardTrue, &[rooted_resop_operand(Type::Int, 64)]);
-                op.setfailargs(vec![rooted_resop_box(Type::Int, 64)].into());
+                op.setfailargs(vec![rooted_resop_operand(Type::Int, 64)].into());
                 op
             },
             {
@@ -8046,7 +8046,7 @@ mod tests {
         let redirected_tail = vec![
             {
                 let mut op = Op::new(OpCode::GuardTrue, &[rooted_resop_operand(Type::Void, 3)]);
-                op.setfailargs(vec![rooted_resop_box(Type::Void, 3)].into());
+                op.setfailargs(vec![rooted_resop_operand(Type::Void, 3)].into());
                 op
             },
             Op::new(

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -7015,10 +7015,9 @@ mod tests {
         // chain inside force_box's add_preamble_op, so install a manual
         // forwarding to the body-visible OpRef to exercise that path.
         let b_src = ctx.materialize_box_at(OpRef::ref_op(19));
-        let b_tgt = {
-            let __t = ctx.get_box_replacement(OpRef::ref_op(14));
-            ctx.operand_of_box(&__t)
-        };
+        let b_tgt = ctx
+            .get_box_replacement_operand_opt(OpRef::ref_op(14))
+            .unwrap_or_else(|| ctx.materialize_operand_at(OpRef::ref_op(14)));
         ctx.make_equal_to(&Operand::from_boxref(&b_src), &b_tgt);
         let pop = crate::optimizeopt::info::PreambleOp {
             op: b_src.clone(),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1346,10 +1346,10 @@ impl UnrollOptimizer {
                 // Phase-2 info of the original box this short inputarg renames.
                 let original = slot_to_original[i];
                 let info = original
-                    .and_then(|o| final_ctx.get_box_replacement_box(o))
-                    .or_else(|| final_ctx.resolve_box_box_opt(inputarg))
+                    .and_then(|o| final_ctx.get_box_replacement_operand_opt(o))
+                    .or_else(|| final_ctx.get_box_replacement_operand_opt(inputarg.to_opref()))
                     .as_ref()
-                    .and_then(|b| final_ctx.peek_ptr_info(&Operand::from_boxref(b)));
+                    .and_then(|o| final_ctx.peek_ptr_info(o));
                 infos.push(info);
             }
             initial_sp.inputarg_infos = infos;
@@ -2752,8 +2752,8 @@ impl OptUnroll {
         // Const box per call, so two calls would NOT be ptr_eq.
         let end_arg_boxes: Vec<BoxRef> = end_args
             .iter()
-            .map(|&a| match ctx.get_box_replacement_box(a) {
-                Some(b) => b,
+            .map(|&a| match ctx.get_box_replacement_operand_opt(a) {
+                Some(o) => o.to_boxref(),
                 // The None arm fires only for an unregistered ResOp position
                 // (Const / InputArg always resolve); #157 drained those fires
                 // to zero. materialize_box_at mints+registers a canonical
@@ -2773,8 +2773,8 @@ impl OptUnroll {
             .expect("export_state make_inputargs_and_virtuals failed");
         // unroll.py:464-465: for arg in label_args: _expand_info(arg, infos)
         for &arg in &label_args {
-            let arg_box = match ctx.get_box_replacement_box(arg) {
-                Some(b) => b,
+            let arg_box = match ctx.get_box_replacement_operand_opt(arg) {
+                Some(o) => o.to_boxref(),
                 // Same canonical-key fallback as end_arg_boxes above: an
                 // unregistered ResOp position (drained to zero by #157) mints a
                 // canonical synthetic instead of a producer-less from_opref box,
@@ -3084,7 +3084,7 @@ impl OptUnroll {
         >,
         infos: &mut majit_ir::VecMap<BoxRef, crate::optimizeopt::info::OpInfo>,
     ) {
-        let opref_box = ctx.get_box_replacement_box(opref);
+        let opref_box = ctx.get_box_replacement_operand_opt(opref);
         // unroll.py:445-450 `_expand_infos_from_virtual`:
         //     items = info.all_items()
         //     for item in items:

--- a/majit/majit-metainterp/src/optimizeopt/util.rs
+++ b/majit/majit-metainterp/src/optimizeopt/util.rs
@@ -10,11 +10,6 @@ use std::hash::{Hash, Hasher};
 
 use majit_ir::box_ref::BoxRef;
 
-/// util.py:93-96 `get_box_replacement`.
-pub fn get_box_replacement(op: Option<&BoxRef>) -> Option<BoxRef> {
-    op.map(|op| op.get_box_replacement(false))
-}
-
 /// util.py:100-111 `args_eq`.
 ///
 /// Uses `same_box`, so constants compare by value while regular boxes compare
@@ -59,7 +54,7 @@ fn hash_arg<H: Hasher>(arg: &BoxRef, state: &mut H) {
 
 #[cfg(test)]
 mod tests {
-    use super::{args_eq, args_hash, get_box_replacement};
+    use super::{args_eq, args_hash};
     use majit_ir::Value;
     use majit_ir::box_ref::BoxRef;
 
@@ -76,10 +71,5 @@ mod tests {
         let a = Some(BoxRef::new_resop(majit_ir::Type::Int, 0));
         let b = Some(BoxRef::new_resop(majit_ir::Type::Int, 0));
         assert!(!args_eq(&[a], &[b]));
-    }
-
-    #[test]
-    fn get_box_replacement_preserves_none() {
-        assert!(get_box_replacement(None).is_none());
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -22,7 +22,6 @@ use crate::optimizeopt::dependency::{DependencyGraph, schedule_operations};
 use crate::optimizeopt::renamer::Renamer;
 use crate::optimizeopt::{OptContext, Optimization, OptimizationResult};
 use majit_ir::VecMap;
-use majit_ir::box_ref::BoxRef;
 
 pub use crate::jitexc::{NotAProfitableLoop, NotAVectorizeableLoop};
 pub use crate::optimizeopt::dependency::Node;
@@ -1553,7 +1552,7 @@ impl VectorizingOptimizer {
         if let Some(fail_args) = copied_op.getfailargs() {
             let fail_args_oprefs: Vec<OpRef> = fail_args.iter().map(|a| a.to_opref()).collect();
             let renamed = renamer.rename_failargs(&fail_args_oprefs);
-            copied_op.setfailargs(renamed.iter().map(|r| BoxRef::from_opref(*r)).collect());
+            copied_op.setfailargs(renamed.iter().map(|r| Operand::from_opref(*r)).collect());
         }
     }
 
@@ -2322,7 +2321,7 @@ fn pre_emit_guard_accum(state: &VecScheduleState, op: &mut Op) {
                         });
                     }
                 }
-                *arg = BoxRef::from_opref(entry.seed);
+                *arg = Operand::from_opref(entry.seed);
             }
         }
         op.setfailargs(new_fa);
@@ -2375,7 +2374,7 @@ pub(crate) fn ensure_args_unpacked(
                     let unpacked = unpack_from_vector(state, vec_ref, pos, 1);
                     state.renamer.start_renaming(arg.to_opref(), unpacked);
                     seen.insert(unpacked);
-                    *arg = state.bound_arg_boxref(unpacked).to_boxref();
+                    *arg = state.bound_arg_boxref(unpacked);
                 }
             }
             op.setfailargs(fail_args);

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1549,10 +1549,21 @@ impl VectorizingOptimizer {
     fn copy_guard_descr(renamer: &Renamer, copied_op: &mut Op) {
         // vector.py:349-350: descr.clone() — already cloned by copy_resop
         // vector.py:351: failargs = renamer.rename_failargs(copied_op, clone=True)
+        // renamer.py:40: args[i] = rename_map.get(arg, arg) — a hit installs the
+        // BOUND renamed box, a miss KEEPS the original box object. lookup_box
+        // returns the bound Operand on a hit (Some) and None on a miss; the miss
+        // arm keeps `orig`'s live-producer Operand. No `from_opref`, so no
+        // position-only fabrication / panic on a live producer.
         if let Some(fail_args) = copied_op.getfailargs() {
-            let fail_args_oprefs: Vec<OpRef> = fail_args.iter().map(|a| a.to_opref()).collect();
-            let renamed = renamer.rename_failargs(&fail_args_oprefs);
-            copied_op.setfailargs(renamed.iter().map(|r| Operand::from_opref(*r)).collect());
+            let renamed: smallvec::SmallVec<[Operand; 3]> = fail_args
+                .iter()
+                .map(|orig| {
+                    renamer
+                        .lookup_box(orig.to_opref())
+                        .unwrap_or_else(|| orig.clone())
+                })
+                .collect();
+            copied_op.setfailargs(renamed);
         }
     }
 
@@ -2305,7 +2316,16 @@ fn pre_emit_guard_accum(state: &VecScheduleState, op: &mut Op) {
                         });
                     }
                 }
-                *arg = Operand::from_opref(entry.seed);
+                // schedule.py:656-657: failargs[i] = renamer.rename_map.get(seed,
+                // seed) — a rename hit installs the bound renamed producer, a miss
+                // keeps the seed box. lookup_box returns the bound renamed Operand
+                // (Some) or None; on a miss bind the seed to a producer-carrying
+                // Operand (to_opref() == seed) instead of fabricating a
+                // position-only operand that would panic on a live producer.
+                *arg = state
+                    .renamer
+                    .lookup_box(entry.seed)
+                    .unwrap_or_else(|| Operand::bound_from_opref(entry.seed));
             }
         }
         op.setfailargs(new_fa);

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -2122,7 +2122,7 @@ impl VectorLoop {
         // vector.py:284 — bump count once for the alignment pass.
         let unroll_count = if align_unroll_once { count + 1 } else { count };
         let original_body = self.operations.clone();
-        let label_args = self.label.getarglist_copy();
+        let label_args = self.label.getarglist_operand();
         let jump_args = self.jump.getarglist_copy();
 
         // vector.py:281-283: prohibited opcodes — not duplicated during unroll
@@ -2156,13 +2156,13 @@ impl VectorLoop {
             original_body: &[OpRc],
             renamer: &mut Renamer,
             renamed: OpRef,
-        ) -> BoxRef {
+        ) -> Operand {
             if let Some(rc) = produced.get(&renamed) {
-                return BoxRef::from_bound_op(rc);
+                return Operand::from_bound_op(rc);
             }
             if !renamed.is_constant() && !renamed.is_none() {
                 if let Some(rc) = original_body.iter().find(|op| op.pos.get() == renamed) {
-                    return BoxRef::from_bound_op(rc);
+                    return Operand::from_bound_op(rc);
                 }
             }
             renamer.bound_box(renamed)
@@ -2210,12 +2210,12 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
                     copied_op.setarg(
                         i,
-                        Operand::from_boxref(&bind_unroll(
+                        bind_unroll(
                             &produced,
                             &original_body,
                             &mut renamer,
                             renamed,
-                        )),
+                        ),
                     );
                 }
 
@@ -2240,7 +2240,7 @@ impl VectorLoop {
             // args track the rename state at this point.
             if align_unroll_once && u == 0 {
                 let label_args_ops: Vec<Operand> =
-                    label_args.iter().map(Operand::from_boxref).collect();
+                    label_args.iter().cloned().collect();
                 let mut minted = Op::new(OpCode::Label, &label_args_ops);
                 if let Some(descr) = self.label.getdescr() {
                     minted.setdescr(descr);
@@ -2249,12 +2249,12 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
                     minted.setarg(
                         i,
-                        Operand::from_boxref(&bind_unroll(
+                        bind_unroll(
                             &produced,
                             &original_body,
                             &mut renamer,
                             renamed,
-                        )),
+                        ),
                     );
                 }
                 new_label = minted;
@@ -2266,12 +2266,12 @@ impl VectorLoop {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
             self.jump.setarg(
                 i,
-                Operand::from_boxref(&bind_unroll(
+                bind_unroll(
                     &produced,
                     &original_body,
                     &mut renamer,
                     renamed,
-                )),
+                ),
             );
         }
 
@@ -2358,7 +2358,7 @@ pub(crate) fn ensure_args_unpacked(
             seen.insert(unpacked);
             // The VecUnpack producer was just appended to `oplist`; bind the
             // arg to it (no position-only mint).
-            op.setarg(j, Operand::from_boxref(&state.bound_arg_boxref(unpacked)));
+            op.setarg(j, state.bound_arg_boxref(unpacked));
         }
     }
     // schedule.py:708-716: unpack guard failargs
@@ -2375,7 +2375,7 @@ pub(crate) fn ensure_args_unpacked(
                     let unpacked = unpack_from_vector(state, vec_ref, pos, 1);
                     state.renamer.start_renaming(arg.to_opref(), unpacked);
                     seen.insert(unpacked);
-                    *arg = state.bound_arg_boxref(unpacked);
+                    *arg = state.bound_arg_boxref(unpacked).to_boxref();
                 }
             }
             op.setfailargs(fail_args);

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -2209,12 +2209,7 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(copied_op.arg(i).to_opref());
                     copied_op.setarg(
                         i,
-                        bind_unroll(
-                            &produced,
-                            &original_body,
-                            &mut renamer,
-                            renamed,
-                        ),
+                        bind_unroll(&produced, &original_body, &mut renamer, renamed),
                     );
                 }
 
@@ -2238,8 +2233,7 @@ impl VectorLoop {
             // as the original label, then run the renamer over it so its
             // args track the rename state at this point.
             if align_unroll_once && u == 0 {
-                let label_args_ops: Vec<Operand> =
-                    label_args.iter().cloned().collect();
+                let label_args_ops: Vec<Operand> = label_args.iter().cloned().collect();
                 let mut minted = Op::new(OpCode::Label, &label_args_ops);
                 if let Some(descr) = self.label.getdescr() {
                     minted.setdescr(descr);
@@ -2248,12 +2242,7 @@ impl VectorLoop {
                     let renamed = renamer.rename_box(minted.arg(i).to_opref());
                     minted.setarg(
                         i,
-                        bind_unroll(
-                            &produced,
-                            &original_body,
-                            &mut renamer,
-                            renamed,
-                        ),
+                        bind_unroll(&produced, &original_body, &mut renamer, renamed),
                     );
                 }
                 new_label = minted;
@@ -2265,12 +2254,7 @@ impl VectorLoop {
             let renamed = renamer.rename_box(self.jump.arg(i).to_opref());
             self.jump.setarg(
                 i,
-                bind_unroll(
-                    &produced,
-                    &original_body,
-                    &mut renamer,
-                    renamed,
-                ),
+                bind_unroll(&produced, &original_body, &mut renamer, renamed),
             );
         }
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -906,10 +906,9 @@ impl OptVirtualize {
             };
             if let Some(val_ref) = field_val {
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_val = {
-                    let __t = ctx.get_box_replacement(val_ref);
-                    ctx.operand_of_box(&__t)
-                };
+                let b_val = ctx
+                    .get_box_replacement_operand_opt(val_ref)
+                    .unwrap_or_else(|| ctx.materialize_operand_at(val_ref));
                 ctx.make_equal_to(&b_old, &b_val);
                 return OptimizationResult::Remove;
             }
@@ -1040,10 +1039,9 @@ impl OptVirtualize {
                         );
                     }
                     let b_old = Operand::from_bound_op(op_rc);
-                    let b_item = {
-                        let __t = ctx.get_box_replacement(item_ref);
-                        ctx.operand_of_box(&__t)
-                    };
+                    let b_item = ctx
+                        .get_box_replacement_operand_opt(item_ref)
+                        .unwrap_or_else(|| ctx.materialize_operand_at(item_ref));
                     ctx.make_equal_to(&b_old, &b_item);
                     return OptimizationResult::Remove;
                 }
@@ -1145,10 +1143,9 @@ impl OptVirtualize {
                 }
                 let fld = fld.unwrap();
                 let b_old = Operand::from_bound_op(op_rc);
-                let b_fld = {
-                    let __t = ctx.get_box_replacement(fld);
-                    ctx.operand_of_box(&__t)
-                };
+                let b_fld = ctx
+                    .get_box_replacement_operand_opt(fld)
+                    .unwrap_or_else(|| ctx.materialize_operand_at(fld));
                 ctx.make_equal_to(&b_old, &b_fld);
                 return OptimizationResult::Remove;
             }
@@ -1313,10 +1310,9 @@ impl OptVirtualize {
                 // rawbuffer.py:120: read_value(offset, length, descr)
                 if let Ok(val_ref) = vinfo.read_value(lookup_offset, ad.item_size(), &descr) {
                     let b_old = Operand::from_bound_op(op_rc);
-                    let b_val = {
-                        let __t = ctx.get_box_replacement(val_ref);
-                        ctx.operand_of_box(&__t)
-                    };
+                    let b_val = ctx
+                        .get_box_replacement_operand_opt(val_ref)
+                        .unwrap_or_else(|| ctx.materialize_operand_at(val_ref));
                     ctx.make_equal_to(&b_old, &b_val);
                     return OptimizationResult::Remove;
                 }
@@ -1761,10 +1757,9 @@ impl OptVirtualize {
         // on-demand `BoxRef::new_const` and walks the chain terminal;
         // `is_const_null` reads `const_value()` and tolerates an unbound
         // terminal (non-const -> false), so the null check is read-only.
-        let obj_box = {
-            let __t = ctx.get_box_replacement(obj_ref);
-            ctx.operand_of_box(&__t)
-        };
+        let obj_box = ctx
+            .get_box_replacement_operand_opt(obj_ref)
+            .unwrap_or_else(|| ctx.materialize_operand_at(obj_ref));
         let obj_is_null = ctx.is_const_null(&obj_box);
 
         // If vref is still virtual, update the virtual struct fields directly

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -8,7 +8,6 @@
 /// it gets "forced" (materialized by emitting the allocation + setfield ops).
 use std::sync::Arc;
 
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{Descr, DescrRef, FieldDescr, OopSpecIndex, Op, OpCode, OpRef, Type, Value};
 
@@ -5685,7 +5684,7 @@ mod tests {
             )],
         );
         guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_box(Type::Ref, 0)].into());
+            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()), // pos=0
             Op::with_descr(
@@ -5772,9 +5771,9 @@ mod tests {
         );
         guard.setfailargs(
             vec![
-                crate::history::test_support::rooted_inputarg_box(Type::Int, 30),
-                crate::history::test_support::rooted_resop_box(Type::Ref, 0),
-                crate::history::test_support::rooted_inputarg_box(Type::Int, 40),
+                crate::history::test_support::rooted_inputarg_operand(Type::Int, 30),
+                crate::history::test_support::rooted_resop_operand(Type::Ref, 0),
+                crate::history::test_support::rooted_inputarg_operand(Type::Int, 40),
             ]
             .into(),
         );
@@ -5856,8 +5855,8 @@ mod tests {
         );
         guard.setfailargs(
             vec![
-                crate::history::test_support::rooted_inputarg_box(Type::Int, 20),
-                crate::history::test_support::rooted_inputarg_box(Type::Int, 30),
+                crate::history::test_support::rooted_inputarg_operand(Type::Int, 20),
+                crate::history::test_support::rooted_inputarg_operand(Type::Int, 30),
             ]
             .into(),
         );
@@ -5895,7 +5894,7 @@ mod tests {
             )],
         );
         guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_box(Type::Ref, 0)].into());
+            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], sd.clone()),
             Op::with_descr(
@@ -5964,7 +5963,7 @@ mod tests {
             )],
         );
         guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_box(Type::Ref, 0)].into());
+            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()),
             Op::with_descr(
@@ -6048,7 +6047,7 @@ mod tests {
             )],
         );
         guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_box(Type::Ref, 0)].into());
+            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], outer_sd),
             Op::with_descr(OpCode::New, &[], inner_sd),
@@ -6131,7 +6130,7 @@ mod tests {
             )],
         );
         guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_box(Type::Ref, 0)].into());
+            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -677,7 +677,7 @@ impl OptVirtualize {
 
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let struct_box = ctx.resolve_operand_operand_opt(&op.arg(0));
-        let value_ref = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+        let value_ref = ctx.get_replacement_opref(op.arg(1).to_opref());
         let setfield_descr_arc = op
             .getdescr()
             .expect("optimize_setfield_gc: field op without FieldDescr");
@@ -957,7 +957,7 @@ impl OptVirtualize {
 
     fn optimize_setarrayitem_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let array_box = ctx.resolve_operand_operand_opt(&op.arg(0));
-        let value_ref = ctx.resolve_operand_box(&op.arg(2)).to_opref();
+        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
 
         if let Some(index) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
@@ -1166,7 +1166,7 @@ impl OptVirtualize {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let array_box = ctx.resolve_operand_operand_opt(&op.arg(0));
-        let value_ref = ctx.resolve_operand_box(&op.arg(2)).to_opref();
+        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
         // `info.py:583-594 setinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Same shape as the GET
         // counterpart — strip the outer `InteriorFieldDescr` first.
@@ -1245,7 +1245,7 @@ impl OptVirtualize {
         if op.num_args() < 2 {
             return OptimizationResult::PassOn;
         }
-        let arg0 = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
         let Some(offset) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
             .and_then(|b| ctx.get_constant_int_box(&b))
@@ -1322,9 +1322,9 @@ impl OptVirtualize {
     }
 
     fn optimize_raw_store(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let buf_ref = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let buf_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
         let offset_ref = op.arg(1).to_opref();
-        let value_ref = ctx.resolve_operand_box(&op.arg(2)).to_opref();
+        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
 
         if let Some(offset) = ctx
             .get_box_replacement_operand_opt(offset_ref)
@@ -1413,7 +1413,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_ref = ctx.resolve_operand_box(&op.arg(0)).to_opref();
+        let array_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
 
         if let Some(index) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
@@ -1544,8 +1544,8 @@ impl OptVirtualize {
     ///     return self.emit(op)
     /// ```
     fn optimize_setarrayitem_raw(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_ref = ctx.resolve_operand_box(&op.arg(0)).to_opref();
-        let value_ref = ctx.resolve_operand_box(&op.arg(2)).to_opref();
+        let array_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
 
         if let Some(index) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
@@ -1748,8 +1748,8 @@ impl OptVirtualize {
     /// here on the VirtualStruct half and the setfield_gc emit path is
     /// taken only when the vref has already escaped.
     fn optimize_virtual_ref_finish(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let vref_ref = ctx.resolve_operand_box(&op.arg(0)).to_opref();
-        let obj_ref = ctx.resolve_operand_box(&op.arg(1)).to_opref();
+        let vref_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let obj_ref = ctx.get_replacement_opref(op.arg(1).to_opref());
 
         // virtualize.py:151: `CONST_NULL.same_constant(objbox)` — only a
         // Ref-typed null constant matches; a plain ConstInt(0) does not.

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -5678,8 +5678,13 @@ mod tests {
                 20,
             )],
         );
-        guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
+        guard.setfailargs(
+            vec![crate::history::test_support::rooted_resop_operand(
+                Type::Ref,
+                0,
+            )]
+            .into(),
+        );
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()), // pos=0
             Op::with_descr(
@@ -5888,8 +5893,13 @@ mod tests {
                 20,
             )],
         );
-        guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
+        guard.setfailargs(
+            vec![crate::history::test_support::rooted_resop_operand(
+                Type::Ref,
+                0,
+            )]
+            .into(),
+        );
         let mut ops = vec![
             Op::with_descr(OpCode::New, &[], sd.clone()),
             Op::with_descr(
@@ -5957,8 +5967,13 @@ mod tests {
                 30,
             )],
         );
-        guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
+        guard.setfailargs(
+            vec![crate::history::test_support::rooted_resop_operand(
+                Type::Ref,
+                0,
+            )]
+            .into(),
+        );
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], sd.clone()),
             Op::with_descr(
@@ -6041,8 +6056,13 @@ mod tests {
                 30,
             )],
         );
-        guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
+        guard.setfailargs(
+            vec![crate::history::test_support::rooted_resop_operand(
+                Type::Ref,
+                0,
+            )]
+            .into(),
+        );
         let mut ops = vec![
             Op::with_descr(OpCode::NewWithVtable, &[], outer_sd),
             Op::with_descr(OpCode::New, &[], inner_sd),
@@ -6124,8 +6144,13 @@ mod tests {
                 20,
             )],
         );
-        guard
-            .setfailargs(vec![crate::history::test_support::rooted_resop_operand(Type::Ref, 0)].into());
+        guard.setfailargs(
+            vec![crate::history::test_support::rooted_resop_operand(
+                Type::Ref,
+                0,
+            )]
+            .into(),
+        );
         let mut ops = vec![
             Op::with_descr(
                 OpCode::NewArray,

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -3361,7 +3361,7 @@ mod tests {
         assert_eq!(inputargs.len(), 1);
         assert_eq!(
             inputargs[0],
-            ctx.get_box_replacement(virtual_ref).to_opref()
+            ctx.get_replacement_opref(virtual_ref)
         );
         assert!(virtuals.is_empty());
     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -3076,7 +3076,7 @@ mod tests {
 
         assert_eq!(guard.opcode, OpCode::GuardValue);
         assert_eq!(
-            ctx.get_box_replacement_box(guard.arg(1).to_opref())
+            ctx.get_box_replacement_operand_opt(guard.arg(1).to_opref())
                 .and_then(|cb| cb.const_value()),
             Some(Value::Ref(expected))
         );

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -26,7 +26,6 @@ use std::rc::Rc;
 use majit_ir::vec_set::VecSet;
 
 use majit_ir::descr::descr_identity;
-use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, GcRef, Op, OpCode, OpRef, Type, Value};
 
 /// virtualstate.py: VirtualStatesCantMatch — raised when two virtual states
@@ -2790,6 +2789,7 @@ mod tests {
     use super::*;
     use crate::optimizeopt::info::VirtualStructInfo;
     use majit_ir::box_ref::BoxRef;
+    use majit_ir::operand::Operand;
     use majit_ir::{Descr, FieldDescr, GcRef, Type};
     use std::sync::Arc;
 

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -2550,21 +2550,18 @@ fn export_single_value(
     // onto the same VirtualStateInfo. Key the DAG cache by the resolved box's
     // identity (`Rc::ptr_eq`, const by value) — the bound producer's one
     // canonical `Rc`.
-    let box_ = ctx.get_box_replacement(opref);
+    let box_ = ctx.get_box_replacement_operand(opref);
     // bind-at-alloc invariant (see ExportCache): every position reaching
     // export resolves to a bound box, so `box_` is a stable canonical `Rc`
     // rather than a fresh `from_opref` placeholder that would split the cache.
     debug_assert!(
-        ctx.get_box_replacement_box(opref).is_some(),
+        ctx.get_box_replacement_operand_opt(opref).is_some(),
         "export_single_value: unbound position {opref:?} reached export — \
          bind-at-alloc invariant violated (every value reaching create_state \
          must be a bound box; virtualstate.py:711-720)"
     );
     // virtualstate.py:714-716: cache hit returns the cached state directly.
-    if let Some(cached) = cache
-        .finished
-        .get(&majit_ir::operand::Operand::from_boxref(&box_))
-    {
+    if let Some(cached) = cache.finished.get(&box_) {
         return Rc::clone(cached);
     }
     // Cycle: this opref is currently being exported on the parent stack.
@@ -2578,10 +2575,7 @@ fn export_single_value(
     // spectral_norm, inline_helper). The cyclic-virtual-graph regression
     // (RPython parity gap documented above) is therefore latent — no
     // benchmark constructs the necessary self-referential structures.
-    if cache
-        .in_progress
-        .contains(&majit_ir::operand::Operand::from_boxref(&box_))
-    {
+    if cache.in_progress.contains(&box_) {
         // Fallback to Ref for the cycle leaf: pyre's virtual DAGs only
         // form through ptr fields, so the only reachable cycles are on
         // Ref-typed nodes. Matches `not_virtual(cpu, 'r', None)` in
@@ -2589,7 +2583,7 @@ fn export_single_value(
         // with LEVEL_UNKNOWN.
         return VirtualStateInfoNode::new_rc(VirtualStateInfo::Unknown(Type::Ref));
     }
-    let key = majit_ir::operand::Operand::from_boxref(&box_);
+    let key = box_.clone();
     cache.in_progress.insert(key.clone());
 
     let info = export_single_value_inner(box_.to_opref(), ctx, cache);

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -3353,10 +3353,7 @@ mod tests {
         // forced allocation ref (which is what ctx.get_replacement
         // resolves the original virtual_ref to).
         assert_eq!(inputargs.len(), 1);
-        assert_eq!(
-            inputargs[0],
-            ctx.get_replacement_opref(virtual_ref)
-        );
+        assert_eq!(inputargs[0], ctx.get_replacement_opref(virtual_ref));
         assert!(virtuals.is_empty());
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1051,14 +1051,19 @@ impl OptString {
         if !crate::optimizeopt::earlyforce::OptEarlyForce::should_force_args(op) {
             return;
         }
-        // Collect boxes first to avoid borrow issues.
-        let args: Vec<BoxRef> = op
-            .getarglist()
+        // Collect operands first to avoid borrow issues. An unbound op-arg
+        // position (no producer / inputarg yet) has no resolvable Operand, so
+        // fall back to its canonical materialized stand-in rather than the
+        // total resolver's position-only panic.
+        let args: Vec<Operand> = op
+            .getarglist_operand()
             .iter()
-            .map(|a| ctx.resolve_box_box(&a))
+            .map(|a| match ctx.resolve_operand_operand_opt(a) {
+                Some(resolved) => resolved,
+                None => ctx.materialize_operand_at(a.to_opref()),
+            })
             .collect();
-        for arg in args {
-            let arg_op = ctx.operand_of_box(&arg);
+        for arg_op in args {
             if self.is_virtual(&arg_op, ctx) {
                 self.force_box(&arg_op, ctx);
             }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -18107,34 +18107,33 @@ mod tests {
     use majit_ir::{DescrRef, InputArg, Op, OpCode, OpRc, OpRef, Type, Value};
     use std::sync::{Arc, Mutex, OnceLock};
 
-    /// Bound-box view of an op-arg / fail-arg `OpRef`, oparser-faithful
+    /// Producer-bound `Operand` for an op-arg / fail-arg `OpRef`, oparser-faithful
     /// (`rpython/jit/tool/oparser.py`): a position-only ResOp / InputArg ref
-    /// resolves to a bound producer box (`rooted_resop_box` /
-    /// `rooted_inputarg_box`, shedding to `Operand::Op` / `Operand::InputArg`),
-    /// a `Const*` ref to a Const box, and `None` to the absent-slot sentinel.
-    /// `to_opref()` round-trips to the original `OpRef`, so position-keyed
-    /// assertions and backend layout keying are unchanged — but no
-    /// position-only `Operand::Box` is minted at `Op::new`.
-    fn bound_box(r: OpRef) -> BoxRef {
-        use crate::history::test_support::{rooted_inputarg_box, rooted_resop_box};
+    /// resolves to a bound producer (`rooted_resop_operand` /
+    /// `rooted_inputarg_operand` → `Operand::Op` / `Operand::InputArg`),
+    /// a `Const*` ref to an `Operand::Const`, and `None` to the absent-slot
+    /// sentinel. `to_opref()` round-trips to the original `OpRef`, so
+    /// position-keyed assertions and backend layout keying are unchanged.
+    fn bound_operand(r: OpRef) -> majit_ir::operand::Operand {
+        use crate::history::test_support::{rooted_inputarg_operand, rooted_resop_operand};
         if r.is_none() || r.is_constant() {
-            // None → `BoxRef::none()`; Const → `Operand::Const` (no mint).
-            return BoxRef::from_opref(r);
+            // None → `Operand::None`; Const → `Operand::Const` (no mint).
+            return majit_ir::operand::Operand::from_opref(r);
         }
         let ty = r.ty().unwrap_or(Type::Void);
         let pos = r.raw();
         match r {
             OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                rooted_inputarg_box(ty, pos)
+                rooted_inputarg_operand(ty, pos)
             }
-            _ => rooted_resop_box(ty, pos),
+            _ => rooted_resop_operand(ty, pos),
         }
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
         let args: Vec<majit_ir::operand::Operand> = args
             .iter()
-            .map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a)))
+            .map(|a| bound_operand(*a))
             .collect();
         let op = Op::new(opcode, &args);
         op.pos.set(if pos == OpRef::NONE.raw() {
@@ -18148,7 +18147,7 @@ mod tests {
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
         let args: Vec<majit_ir::operand::Operand> = args
             .iter()
-            .map(|a| majit_ir::operand::Operand::from_boxref(&bound_box(*a)))
+            .map(|a| bound_operand(*a))
             .collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(if pos == OpRef::NONE.raw() {
@@ -18230,8 +18229,8 @@ mod tests {
         let mut meta = MetaInterp::<()>::new(0);
         let guard = mk_op(OpCode::GuardTrue, &[OpRef::input_arg_int(0)], 11);
         guard.setfailargs(smallvec::smallvec![
-            BoxRef::from_opref(OpRef::const_ptr(GcRef(0x7000))),
-            BoxRef::from_opref(OpRef::const_int(123)),
+            Operand::from_opref(OpRef::const_ptr(GcRef(0x7000))),
+            Operand::from_opref(OpRef::const_int(123)),
         ]);
         meta.partial_trace = Some(PartialTrace {
             ops: vec![std::rc::Rc::new(guard)],
@@ -18931,7 +18930,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
+        guard.setfailargs(smallvec::smallvec![bound_operand(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19174,7 +19173,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
+        guard.setfailargs(smallvec::smallvec![bound_operand(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19252,7 +19251,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
+        guard.setfailargs(smallvec::smallvec![bound_operand(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19350,7 +19349,7 @@ mod tests {
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
         );
-        guard.setfailargs(smallvec::smallvec![bound_box(OpRef::input_arg_int(0))]);
+        guard.setfailargs(smallvec::smallvec![bound_operand(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
             guard,
@@ -19443,8 +19442,8 @@ mod tests {
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            bound_box(OpRef::int_op(1)),
-            bound_box(OpRef::int_op(0)),
+            bound_operand(OpRef::int_op(1)),
+            bound_operand(OpRef::int_op(0)),
         ]);
         // pyre cranelift test-fixture quirk (NOT RPython parity): the bare
         // OpRef::int_op(100) literal is paired with `constants.insert(100, ...)` below
@@ -20541,8 +20540,8 @@ mod tests {
         let const_zero = OpRef::int_op(101);
         let mut guard_op = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
-            bound_box(OpRef::input_arg_int(0)),
-            bound_box(OpRef::input_arg_int(1)),
+            bound_operand(OpRef::input_arg_int(0)),
+            bound_operand(OpRef::input_arg_int(1)),
         ]);
         let ops = vec![
             mk_op(
@@ -20559,8 +20558,8 @@ mod tests {
             {
                 let mut g = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
                 g.setfailargs(smallvec::smallvec![
-                    bound_box(OpRef::input_arg_int(0)),
-                    bound_box(OpRef::input_arg_int(1)),
+                    bound_operand(OpRef::input_arg_int(0)),
+                    bound_operand(OpRef::input_arg_int(1)),
                 ]);
                 g
             },

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -18131,10 +18131,8 @@ mod tests {
     }
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> Op {
-        let args: Vec<majit_ir::operand::Operand> = args
-            .iter()
-            .map(|a| bound_operand(*a))
-            .collect();
+        let args: Vec<majit_ir::operand::Operand> =
+            args.iter().map(|a| bound_operand(*a)).collect();
         let op = Op::new(opcode, &args);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE
@@ -18145,10 +18143,8 @@ mod tests {
     }
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
-        let args: Vec<majit_ir::operand::Operand> = args
-            .iter()
-            .map(|a| bound_operand(*a))
-            .collect();
+        let args: Vec<majit_ir::operand::Operand> =
+            args.iter().map(|a| bound_operand(*a)).collect();
         let op = Op::with_descr(opcode, &args, descr);
         op.pos.set(if pos == OpRef::NONE.raw() {
             OpRef::NONE

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -342,12 +342,7 @@ impl Trace {
             None => Op::new(opcode, &self.box_args(args)),
         };
         op.pos.set(opref);
-        op.setfailargs(
-            self.box_args(fail_args)
-                .iter()
-                .cloned()
-                .collect(),
-        );
+        op.setfailargs(self.box_args(fail_args).iter().cloned().collect());
         self.ops.push(OpRc::new(op));
         self.op_count += 1;
         if opcode.result_type() != Type::Void {
@@ -408,12 +403,7 @@ impl Trace {
             .rev()
             .find(|op| op.pos.get() == opref)
             .unwrap_or_else(|| panic!("set_op_fail_args: no op with pos {:?}", opref));
-        op.setfailargs(
-            self.box_args(fail_args)
-                .iter()
-                .cloned()
-                .collect(),
-        );
+        op.setfailargs(self.box_args(fail_args).iter().cloned().collect());
     }
 
     /// Set `fail_arg_types` on the last recorded op. Used by

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -345,7 +345,7 @@ impl Trace {
         op.setfailargs(
             self.box_args(fail_args)
                 .iter()
-                .map(Operand::to_boxref)
+                .cloned()
                 .collect(),
         );
         self.ops.push(OpRc::new(op));
@@ -411,7 +411,7 @@ impl Trace {
         op.setfailargs(
             self.box_args(fail_args)
                 .iter()
-                .map(Operand::to_boxref)
+                .cloned()
                 .collect(),
         );
     }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1107,18 +1107,23 @@ mod tests {
 
     #[test]
     fn pop_top_lookup() {
-        // Instruction::PopTop is arm_id=23 at build time. The opcode
-        // dispatch is sourced from the lowered MIR switch, which orders the
-        // arms by first-encounter target-block order of that switch.
-        // Confirm arm → jitcode resolution works end-to-end and the jitcode
-        // carries bytecode bytes (not an empty shell).
-        let jc = jitcode_for_arm(23).expect("PopTop arm should resolve to a jitcode");
+        // The opcode dispatch is sourced from the lowered MIR switch, which
+        // orders the arms by first-encounter target-block order of that
+        // switch — a build artifact that shifts when the switch gains or
+        // loses arms, so the arm id is resolved from the instruction rather
+        // than pinned to a literal. Confirm arm → jitcode resolution works
+        // end-to-end and the jitcode carries bytecode bytes (not an empty
+        // shell).
+        let arm_id =
+            arm_id_for_instruction(&Instruction::PopTop).expect("PopTop must resolve to an arm_id");
+        let jc = jitcode_for_arm(arm_id).expect("PopTop arm should resolve to a jitcode");
         assert!(
             !jc.code.is_empty(),
             "PopTop jitcode should have non-empty bytecode"
         );
         assert_eq!(
-            jc.name, "Instruction::PopTop#23",
+            jc.name,
+            format!("Instruction::PopTop#{arm_id}"),
             "jitcode name should match the arm selector"
         );
     }
@@ -1137,20 +1142,24 @@ mod tests {
     }
 
     #[test]
-    fn arm_id_for_pop_top_matches_arm_23() {
-        // PopTop is a single-variant arm; `Instruction::PopTop` must
-        // resolve to the same arm_id as the direct `jitcode_for_arm(23)`
-        // lookup above.
+    fn arm_id_for_pop_top_round_trips_to_jitcode() {
+        // PopTop is a single-variant arm; the arm_id from
+        // `arm_id_for_instruction` must address the same PopTop jitcode as a
+        // direct `jitcode_for_arm` lookup. The arm-id integer is a build
+        // artifact, so assert the round-trip rather than a literal.
         let arm_id =
             arm_id_for_instruction(&Instruction::PopTop).expect("PopTop must resolve to an arm_id");
-        assert_eq!(arm_id, 23);
+        let jc = jitcode_for_arm(arm_id).expect("PopTop arm_id must resolve to a jitcode");
+        assert_eq!(jc.name, format!("Instruction::PopTop#{arm_id}"));
     }
 
     #[test]
     fn jitcode_for_instruction_matches_arm_lookup() {
+        let arm_id =
+            arm_id_for_instruction(&Instruction::PopTop).expect("PopTop must resolve to an arm_id");
         let jc = jitcode_for_instruction(&Instruction::PopTop)
             .expect("PopTop must resolve to a jitcode");
-        assert_eq!(jc.name, "Instruction::PopTop#23");
+        assert_eq!(jc.name, format!("Instruction::PopTop#{arm_id}"));
         assert!(!jc.code.is_empty());
     }
 
@@ -1563,7 +1572,7 @@ mod tests {
         let bt_jc = jitcode_for_instruction(&Instruction::PopTop)
             .expect("PopTop must resolve to a jitcode");
         assert!(!bt_jc.code.is_empty());
-        assert_eq!(bt_jc.name, "Instruction::PopTop#23");
+        assert_eq!(bt_jc.name, format!("Instruction::PopTop#{arm_id}"));
         assert_eq!(arm.entry_jitcode_index, Some(bt_jc.index()));
         assert_eq!(
             bt_jc.num_regs_and_consts_i(),


### PR DESCRIPTION
Continues the #47 / #9 BoxRef teardown after #287. 12 commits; the headline is deleting the BoxRef resolver family now that every consumer carries `Operand` directly.

## Keystone — delete the BoxRef resolver family
- `optimizeopt: delete operand_of_box BoxRef bridge`
- `optimizeopt: route .to_opref() position reads through get_replacement_opref`
- `optimizeopt: drain get_box_replacement_box presence/value callers`
- `optimizeopt: route external resolver callers to Operand twins`
- `optimizeopt: delete the BoxRef resolver family` — removes the six box-returning resolvers (`get_box_replacement`, `resolve_box_box{,_opt}`, `resolve_operand_box{,_opt}`, `get_box_replacement_box`); production resolves through the `Operand` twins. The proven-equal box paths were deleted only after the debug tripwires were green across the corpus.

## Operand channel retyping
- `compile: retype BoxRef channels to Operand`
- `optimizeopt: vectorizer cluster carries Operand`
- `graphpage: key ResOpMemo by producer identity not OpRef`
- `op_descr: flip getfailargs/setfailargs API to Operand`

## Vector guard failarg / operand producer-binding
- `optimizeopt: bind vector guard failargs/operands to producers` — adds `Operand::bound_from_opref` (the binding sibling of `from_opref`) and replaces the flat-OpRef rebuilds in `guard.rs` (`transitive_imply` / `emit_operations`) and `vector.rs` (`copy_guard_descr` / `pre_emit_guard_accum`). The old paths round-tripped a producer-carrying operand/failarg through `Operand::from_opref`, which panics on a live producer and drops box identity. `to_opref()` stays byte-identical, so OpRef-keyed downstream state is unchanged. Mirrors `guard.py` / `renamer.py` / `schedule.py`, which carry box objects.

## Test fixes
- `backend-cranelift: migrate test fixtures off BoxRef op-args`
- `jitcode_runtime: resolve PopTop arm id in tests, drop 23` — the build-time MIR dispatch switch moved PopTop to arm 21; the tests now derive the arm id from the instruction instead of pinning a stale literal (PushNull now occupies 23).

## Verification
- `cargo test -p majit-metainterp --lib` — dynasm **1370**, cranelift **1368**
- `cargo test -p majit-ir --lib` — **333**
- `python pyre/check.py` — dynasm **160/160**, cranelift **160/160**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of guard and exit arguments so traces and JIT behavior stay consistent across more cases.
  * Fixed several optimizer and code-generation edge cases that could affect how values are preserved during rewrites and recovery paths.

* **Refactor**
  * Standardized internal value handling across the compiler and JIT pipeline for more consistent behavior.

* **Tests**
  * Updated and expanded test coverage to match the new argument-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->