### PR TITLE
optimizeopt: delete resolve_to_boxref + object-native operand resolution

### DIFF
--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -3263,7 +3263,6 @@ mod tests {
         op
     }
 
-    use majit_ir::box_ref::bound_box_from_opref as rb;
     use majit_ir::box_ref::bound_operand_from_opref as ro;
 
     fn mk_op_with_descr(opcode: OpCode, args: &[OpRef], pos: u32, descr: DescrRef) -> Op {
@@ -4102,9 +4101,9 @@ mod tests {
         int_lt.pos.set(OpRef::int_op(2));
         let guard = Op::new(OpCode::GuardTrue, &[ro(OpRef::int_op(2))]);
         guard.store_final_boxes(vec![
-            rb(OpRef::int_op(0)),
-            rb(OpRef::int_op(2)),
-            rb(OpRef::int_op(1)),
+            ro(OpRef::int_op(0)),
+            ro(OpRef::int_op(2)),
+            ro(OpRef::int_op(1)),
         ]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
@@ -4149,7 +4148,7 @@ mod tests {
         let int_eq = Op::new(OpCode::IntEq, &[ro(OpRef::int_op(0)), ro(OpRef::int_op(1))]);
         int_eq.pos.set(OpRef::int_op(2));
         let guard = Op::new(OpCode::GuardFalse, &[ro(OpRef::int_op(2))]);
-        guard.store_final_boxes(vec![rb(OpRef::int_op(2))]);
+        guard.store_final_boxes(vec![ro(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
         let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
@@ -4176,7 +4175,7 @@ mod tests {
         // copy_and_change.
         let rw = make_rewriter();
         let guard = Op::new(OpCode::GuardAlwaysFails, &[]);
-        guard.store_final_boxes(vec![rb(OpRef::int_op(10)), rb(OpRef::int_op(11))]);
+        guard.store_final_boxes(vec![ro(OpRef::int_op(10)), ro(OpRef::int_op(11))]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
         let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
@@ -4226,7 +4225,7 @@ mod tests {
         int_lt.pos.set(OpRef::int_op(2));
         // GuardTrue reads some unrelated OpRef::ref_op(5), not OpRef::ref_op(2).
         let guard = Op::new(OpCode::GuardTrue, &[ro(OpRef::int_op(5))]);
-        guard.store_final_boxes(vec![rb(OpRef::int_op(0)), rb(OpRef::int_op(1))]);
+        guard.store_final_boxes(vec![ro(OpRef::int_op(0)), ro(OpRef::int_op(1))]);
         let ops = vec![int_lt, guard, Op::new(OpCode::Finish, &[])];
 
         let result = rw.rewrite_for_gc(&ops);

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1610,16 +1610,16 @@ impl Op {
     /// compile.py: ResumeGuardDescr.store_final_boxes(guard_op, boxes, metainterp_sd)
     ///   guard_op.setfailargs(boxes)
     /// compile.py:874-876 store_final_boxes
-    pub fn store_final_boxes(&self, boxes: Vec<BoxRef>) {
+    pub fn store_final_boxes(&self, boxes: Vec<Operand>) {
         // optimizer.py:745-749: check no duplicates (debug only).
         // history.py:213/251 — `Const.same_constant` defines Const equality
         // by value (e.g. `ConstInt(7) == ConstInt(7)`), not identity. The
-        // duplicate detector uses `BoxRef::same_box` (ptr identity for
-        // bound boxes, `same_constant` for inline-Const boxes), matching the
-        // value-based semantics RPython's `op in seen` check relies on.
+        // duplicate detector uses `Operand::same_box` (ptr identity for
+        // bound producers, `same_constant` for inline-Const operands), matching
+        // the value-based semantics RPython's `op in seen` check relies on.
         #[cfg(debug_assertions)]
         {
-            let mut seen: Vec<&BoxRef> = Vec::new();
+            let mut seen: Vec<&Operand> = Vec::new();
             for b in &boxes {
                 if !b.is_none() {
                     debug_assert!(
@@ -1630,7 +1630,7 @@ impl Op {
                 }
             }
         }
-        *self.fail_args.borrow_mut() = Some(boxes.iter().map(Operand::from_boxref).collect());
+        *self.fail_args.borrow_mut() = Some(boxes.into_iter().collect());
     }
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -231,6 +231,15 @@ impl Guard {
             next_const_pos,
             const_values,
         );
+        // #175: GuardStrengthenOpt carries `Op` VALUES, not `OpRc` —
+        // `operations_as_ops` (vector.rs) deep-clones each producer and
+        // `emit_varops` returns a flat `OpRef`, so no real producer `Rc` is
+        // reachable here to carry the way guard.py:86 threads `box_rhs`.
+        // `bound_from_opref` mints a synthetic producer whose `to_opref()` is
+        // byte-identical (operand.rs:122-134); every reader in this pass keys by
+        // `OpRef` (renamer/strongest_guards/rename_op), so the synthetic is
+        // positionally equivalent. Carrying the live producer is deferred to
+        // #175 (E5b: bind dormant vectorizer guard args to producers).
         // guard.py:86-87: compare = ResOperation(opnum, [box_rhs, other_rhs])
         let compare = Op::new(
             opnum,
@@ -261,6 +270,12 @@ impl Guard {
         );
         guard_op.setdescr(fresh_descr);
         // guard.py:94: guard.setfailargs(loop.label.getarglist_copy())
+        // #175: `label_args` was reduced to `&[OpRef]` at the vectorizer
+        // boundary (the label op's `getarglist()` Operands were `.to_opref()`'d),
+        // so the live producers guard.py copies are not reachable here; re-bind
+        // positionally. Carrying the label operands end-to-end is deferred to
+        // #175 (the failargs channel re-narrows to OpRef downstream via
+        // rename_failargs, so a partial Operand carry would be cosmetic).
         guard_op.setfailargs(
             label_args
                 .iter()

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -14,7 +14,6 @@ use majit_ir::{Op, OpCode, OpRef};
 
 use crate::optimizeopt::OptContext;
 use crate::optimizeopt::dependency::IndexVar;
-use majit_ir::box_ref::BoxRef;
 
 /// guard.py:16-163: Guard — wraps a guard op with its comparison op for
 /// implication analysis (vector optimizer).
@@ -675,10 +674,7 @@ impl GuardStrengthenOpt {
         for i in 0..op.num_args() {
             let arg = op.arg(i).to_opref();
             if let Some(&replacement) = self.renamer.get(&arg) {
-                op.setarg(
-                    i,
-                    majit_ir::operand::Operand::from_boxref(&BoxRef::from_opref(replacement)),
-                );
+                op.setarg(i, majit_ir::operand::Operand::from_opref(replacement));
             }
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2333,7 +2333,7 @@ impl OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // heap.py:80 arg1 = get_box_replacement(self._get_rhs_from_set_op(op))
-        let arg1 = ctx.get_replacement_opref(Self::field_get_rhs(op));
+        let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
         let field_idx = Self::field_slot_index(descr);
         // heap.py:81-83 if self.possible_aliasing(structinfo):
         //                  self.force_lazy_set(optheap, op.getdescr())
@@ -2484,7 +2484,7 @@ impl OptHeap {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         // heap.py:80 arg1 = get_box_replacement(self._get_rhs_from_set_op(op))
-        let arg1 = ctx.get_replacement_opref(Self::array_get_rhs(op));
+        let arg1 = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
         // heap.py:81-83 if self.possible_aliasing(structinfo):
         //                  self.force_lazy_set(optheap, op.getdescr())
         let needs_force = self

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -348,7 +348,7 @@ impl CachedField {
             .as_ref()
             .map(OptHeap::field_slot_index)
             .unwrap_or(0);
-        let arg = ctx.get_replacement_opref(op.arg(1).to_opref());
+        let arg = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
         let struct_box = ctx.resolve_operand_operand(&op.arg(0));
         self.register_info(&struct_box);
         ctx.structinfo_setfield(op, descr_idx, arg);
@@ -610,7 +610,7 @@ impl ArrayCachedItem {
 
     /// heap.py:252-255 ArrayCachedItem.put_field_back_to_info
     fn put_field_back_to_info(&mut self, op: &Op, ctx: &mut OptContext) {
-        let arg = ctx.get_replacement_opref(op.arg(2).to_opref());
+        let arg = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
         let struct_box = ctx.resolve_operand_operand(&op.arg(0));
         self.register_info(&struct_box);
         ctx.arrayinfo_setitem(op, self.index as usize, arg);
@@ -990,7 +990,7 @@ impl OptHeap {
     /// Canonicalizes array and index through get_box_replacement.
     fn arrayitem_key(op: &Op, ctx: &mut OptContext) -> Option<ArrayItemKey> {
         let descr = op.getdescr()?;
-        let array = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let array = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
         let index_val = ctx
             .resolve_operand_operand_opt(&op.arg(1))
             .and_then(|b| ctx.get_constant_int_box(&b))?;
@@ -1668,7 +1668,7 @@ impl OptHeap {
         let mut stack: Vec<OpRef> = op
             .getarglist()
             .iter()
-            .map(|arg| ctx.get_replacement_opref(arg.to_opref()))
+            .map(|arg| arg.get_box_replacement(false).to_opref())
             .collect();
         while let Some(owner) = stack.pop() {
             // heap.py:173-174 resolves the owner through `get_box_replacement`
@@ -2358,7 +2358,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.get_replacement_opref(pop.op.to_opref());
+                    let cached_seen = pop.op.get_box_replacement(false).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2506,7 +2506,7 @@ impl OptHeap {
         {
             match entry {
                 crate::optimizeopt::info::FieldEntry::Preamble(pop) => {
-                    let cached_seen = ctx.get_replacement_opref(pop.op.to_opref());
+                    let cached_seen = pop.op.get_box_replacement(false).to_opref();
                     // heap.py:88 not cached_field.same_box(arg1)
                     if ctx.same_box(cached_seen, arg1) {
                         let cached = ctx.force_op_from_preamble_op(&pop);
@@ -2631,7 +2631,7 @@ impl OptHeap {
         // intermediate cache mutations can take &mut ctx without
         // tripping the borrow checker).
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let array_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let array_ref = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
 
         // Try constant-index cache first.
         if let Some(key) = Self::arrayitem_key(op, ctx) {
@@ -2846,7 +2846,7 @@ impl OptHeap {
 
             let descr_idx = descr.index();
             let arrayinfo = array_ref;
-            let indexbox = ctx.get_replacement_opref(op.arg(1).to_opref());
+            let indexbox = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
             if let Some(submap) = self.get_cached_array_submap(descr_idx) {
                 if let Some(cached) = submap.lookup_cached(arrayinfo, indexbox, ctx) {
                     let b_old = Operand::from_bound_op(op_rc);
@@ -2866,7 +2866,7 @@ impl OptHeap {
 
     fn optimize_setarrayitem(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         // heapcache.py:224-230 _escape_from_write parity:
-        let array_obj = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let array_obj = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
         let stored_value = op.arg(2).to_opref();
         self.escape_from_write(ctx, array_obj, stored_value);
 
@@ -2883,9 +2883,9 @@ impl OptHeap {
                         ctx.getintbound_handle(&b).borrow().clone()
                     };
                     self.force_lazy_setarrayitem(&descr, Some(&indexb), false, ctx);
-                    let arrayinfo = ctx.get_replacement_opref(op.arg(0).to_opref());
-                    let indexbox = ctx.get_replacement_opref(op.arg(1).to_opref());
-                    let resbox = ctx.get_replacement_opref(op.arg(2).to_opref());
+                    let arrayinfo = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+                    let indexbox = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
+                    let resbox = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
                     self.arrayitem_submap(&descr)
                         .cache_varindex_write(arrayinfo, indexbox, resbox);
                 }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1478,8 +1478,9 @@ fn force_box_impl(
                     let one = ctx.materialize_operand_at(one);
                     for ch in &info._chars {
                         if let Some(ch_ref) = ch {
-                            let ch_ref = ch_ref.to_opref();
-                            let ch_resolved = ctx.get_replacement_opref(ch_ref);
+                            // vstring.py:194 get_box_replacement(charbox) — walk the
+                            // char operand's own forwarding (object-native).
+                            let ch_resolved = ctx.resolve_operand_operand(ch_ref).to_opref();
                             let arg_newop = ctx.materialize_operand_at(newop);
                             let arg_offset = ctx.resolve_operand_operand(&offset);
                             let arg_ch = ctx.materialize_operand_at(ch_resolved);

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2263,15 +2263,15 @@ impl OptContext {
     /// the `None` arm of `get_box_replacement_box`; an already-minted or
     /// producer-backed opref resolves there. Mirrors `materialize_box_at`'s resop
     /// lazy-alloc arm (`mint_synthetic_resop` + bind).
-    pub(crate) fn mint_box_at(&mut self, opref: OpRef) -> majit_ir::box_ref::BoxRef {
+    pub(crate) fn mint_box_at(&mut self, opref: OpRef) -> Operand {
         let tp = opref.ty().unwrap_or(majit_ir::Type::Void);
         let synthetic = self.mint_synthetic_resop(opref, tp);
-        majit_ir::box_ref::BoxRef::from_bound_op(&synthetic)
+        Operand::from_bound_op(&synthetic)
     }
 
     pub(crate) fn reserve_virtual_box(&mut self, tp: majit_ir::Type) -> (OpRef, Operand) {
         let opref = self.reserve_pos_typed(tp);
-        let b = Operand::from_boxref(&self.mint_box_at(opref));
+        let b = self.mint_box_at(opref);
         (opref, b)
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1747,7 +1747,7 @@ impl OptContext {
     /// gets a fresh one (bound here) carrying the position's type. Stashing
     /// the strong ref in `inputarg_refs` keeps each bound `Weak<InputArg>`
     /// upgradable for the OptContext's lifetime AND gives the canonical-host
-    /// readers (`resolve_to_boxref` / `read_forwarded` / `clear_forwarded`)
+    /// readers (`resolve_to_operand` / `read_forwarded` / `clear_forwarded`)
     /// a live `InputArg.forwarded` host to resolve to.
     ///
     /// Phase 2 enters with a fresh per-iteration inputarg set whose earlier
@@ -1768,7 +1768,7 @@ impl OptContext {
         // `self.inputargs` because Phase 2 walks the body half with the same
         // per-arg types). Pre-populating `inputarg_refs` for both subsets makes
         // every InputArg OpRef resolve through `inputarg_refs` (read path:
-        // `resolve_to_boxref` / `read_forwarded`; write path: `materialize_box_at`'s
+        // `resolve_to_operand` / `read_forwarded`; write path: `materialize_box_at`'s
         // InputArg branch). `materialize_box_at` type-repairs any position this derive
         // misses. Both loops no-op when `self.inputargs` is empty
         // (`seed_boxes_canonical` fixtures populate `inputarg_refs` directly).
@@ -1796,7 +1796,7 @@ impl OptContext {
     }
 
     /// Ensure `inputarg_refs[pos]` holds a canonical `InputArgRc` of type
-    /// `tp` (the `_forwarded` host that `resolve_to_boxref` / `read_forwarded`
+    /// `tp` (the `_forwarded` host that `resolve_to_operand` / `read_forwarded`
     /// / `clear_forwarded` / `materialize_box_at` route the matching InputArg OpRef
     /// through). Idempotent: keeps an existing same-shape host (preserving any
     /// `_forwarded` chain / live `Weak<InputArg>` chain targets on it) and only
@@ -2008,70 +2008,16 @@ impl OptContext {
         }
     }
 
-    /// Resolve `opref` to a `BoxRef` bound to its canonical
-    /// `_forwarded` host (`Op` / `InputArg`). Materialises a fresh
-    /// `BoxRef::from_bound_op` / `from_bound_inputarg` per call; the
-    /// bound handle ensures every `set_forwarded_*` / `get_forwarded`
-    /// routes through the same `Op.forwarded` / `InputArg.forwarded`
-    /// slot, so two calls for the same `opref` observe each other's
-    /// writes via the canonical host even though the `BoxRef` wrapper
-    /// identities differ.
-    /// Const variants return `BoxRef::new_const`. Returns
-    /// `None` for sentinel `OpRef::none()` and for ResOp positions
-    /// without a producer in any canonical store.
-    ///
-    /// Production paths populate `inputarg_refs` via `bind_input_resops`
-    /// plus emit-time `bind_op`, so every
-    /// chain-walker-reachable position resolves to its bound `BoxRef`.
-    pub(crate) fn resolve_to_boxref(&self, opref: OpRef) -> Option<majit_ir::box_ref::BoxRef> {
-        if opref.is_none() {
-            return None;
-        }
-        if opref.is_constant() {
-            // history.py:227/268/314 — Const variants carry the value on the
-            // OpRef directly; mint a fresh inline-Const BoxRef so the chain
-            // round-trip (`box_to_opref`) reconstructs it from the value.
-            return match opref {
-                OpRef::ConstInt(v) => Some(majit_ir::box_ref::BoxRef::new_const(Value::Int(v))),
-                OpRef::ConstFloat(v) => Some(majit_ir::box_ref::BoxRef::new_const(Value::Float(v))),
-                OpRef::ConstPtr(v) => Some(majit_ir::box_ref::BoxRef::new_const(Value::Ref(v))),
-                _ => None,
-            };
-        }
-        if let Some(op) = self.find_producer_op(opref) {
-            return Some(majit_ir::box_ref::BoxRef::from_bound_op(&op));
-        }
-        let idx = opref.raw() as usize;
-        // InputArg variants resolve through the canonical `inputarg_refs`
-        // store — symmetric with the `clear_forwarded` write path
-        // (`inputarg_refs[idx].forwarded`). `ensure_inputarg_bindings`
-        // populates `inputarg_refs[idx]` with the canonical `InputArgRc`, so
-        // this returns the `InputArg.forwarded` host every other reader and
-        // writer observes.
-        match opref {
-            OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) => {
-                if let Some(ia) = self.inputarg_refs.get(idx) {
-                    return Some(majit_ir::box_ref::BoxRef::from_bound_inputarg(ia));
-                }
-            }
-            _ => {}
-        }
-        // A ResOp position with no producer in any canonical store resolves
-        // to `None`: the caller's `materialize_box_at` mints a `SameAs*` synthetic
-        // into `resop_refs[opref]` and binds it, so the next `find_producer_op`
-        // (and hence the next `resolve_to_boxref` / `make_constant` chain)
-        // reaches that same `_forwarded` host. Routing a ResOp OpRef to
-        // `inputarg_refs[idx]` here would re-introduce the raw-position
-        // collapse (`int_op(p)` aliasing `input_arg_int(p)`) the
-        // `find_producer_op` / `inputarg_refs` split exists to eliminate.
-        None
-    }
-
-    /// [`Operand`]-yielding sibling of [`resolve_to_boxref`](Self::resolve_to_boxref):
-    /// resolve a position to its canonical producer as an `Operand`
-    /// (`Op` / `InputArg` host, or inline-`Const`) without minting a `BoxRef`.
-    /// 1:1 mirror — `BoxRef::new_const`/`from_bound_op`/`from_bound_inputarg`
-    /// become `Operand::const_from_value`/`from_bound_op`/`from_bound_inputarg`.
+    /// Resolve a position to its canonical producer as an [`Operand`]
+    /// (`Op` / `InputArg` `_forwarded` host, or inline-`Const`). The bound
+    /// handle ensures every `set_forwarded_*` / `get_forwarded` routes
+    /// through the same `Op.forwarded` / `InputArg.forwarded` slot, so two
+    /// calls for the same `opref` observe each other's writes via the
+    /// canonical host. Const variants return `Operand::const_from_value`;
+    /// returns `None` for sentinel `OpRef::none()` and for ResOp positions
+    /// without a producer in any canonical store. Production paths populate
+    /// `inputarg_refs` via `bind_input_resops` plus emit-time `bind_op`, so
+    /// every chain-walker-reachable position resolves to its bound producer.
     pub(crate) fn resolve_to_operand(&self, opref: OpRef) -> Option<Operand> {
         if opref.is_none() {
             return None;
@@ -2129,7 +2075,7 @@ impl OptContext {
     /// is distributed by its bound identity: InputArg boxes land in
     /// `inputarg_refs[index]`, ResOp boxes in `resop_refs[pos]`. This
     /// replaces the retired `ctx.box_pool = vec![..]` fixture pattern so
-    /// `resolve_to_boxref` / `materialize_box_at` / `find_producer_op` resolve each
+    /// `resolve_to_operand` / `materialize_box_at` / `find_producer_op` resolve each
     /// OpRef through the same canonical hosts production uses, returning a
     /// fresh `BoxRef` bound to the seeded `Op` / `InputArg`.
     #[cfg(test)]
@@ -2583,7 +2529,7 @@ impl OptContext {
         let raw = self.allocate_next_pos_raw();
         // The position's canonical host is materialized lazily on first
         // *write* access (`materialize_box_at` mints a `SameAs*` synthetic
-        // into `resop_refs[raw]` keyed by the full OpRef; `resolve_to_boxref`
+        // into `resop_refs[raw]` keyed by the full OpRef; `resolve_to_operand`
         // is `&self` and returns `None` until then). No eager pre-mint here:
         // an eager synthetic for a position that is reserved but never
         // emitted (label / jump positions on an empty trace) would leak into
@@ -4488,43 +4434,42 @@ impl OptContext {
         if opref.is_constant() || opref.is_none() {
             return opref;
         }
-        let Some(start) = self.resolve_to_boxref(opref) else {
+        let Some(start) = self.resolve_to_operand(opref) else {
             return opref;
         };
-        // resoperation.py:57-68: walk box._forwarded on the box itself.
+        // resoperation.py:57-68: walk the operand's `_forwarded` chain.
         let terminal = start.get_box_replacement(not_const);
         // When the walker did not advance — chain root has Forwarded::None,
         // Forwarded::Info(_), or (not_const=true and the immediate target
-        // is Const) — return the source OpRef variant unchanged. The
-        // original walker terminated before reading position()/type_(),
-        // so callers expect the OpRef shape they passed in.
+        // is Const) — return the source OpRef variant unchanged. The walker
+        // terminated before reading position()/type_(), so callers expect
+        // the OpRef shape they passed in.
         if start == terminal {
             return opref;
         }
-        // Const targets reconstruct their `source_opref` from the inline
-        // value (history.py:227/268/314), so `box_to_opref` reconstruction
-        // is direct — every `BoxRef::new_const(value)` reconstructs an
-        // inline-Const source_opref via `source_opref()`'s value arm.
-        self.box_to_opref(&terminal, opref)
+        // Const targets reconstruct their inline source OpRef from the value
+        // (history.py:227/268/314), so `operand_to_opref` reconstruction is
+        // direct — `Operand::Const::to_opref` rebuilds the inline-Const OpRef.
+        self.operand_to_opref(&terminal, opref)
     }
 
-    /// Convert a chain-walk terminal `BoxRef` back into an `OpRef`. This
-    /// is the OpRef-side glue around `BoxRef::get_box_replacement`; PyPy
-    /// callers hold the box directly and skip this step.
+    /// Convert a chain-walk terminal [`Operand`] back into an `OpRef` — the
+    /// OpRef-side glue around [`Operand::get_box_replacement`]; PyPy callers
+    /// hold the operand directly and skip this step.
     ///
-    /// `BoxKind::Const` carries its `source_opref` (the OpRef the Box was
-    /// minted from), so reconstruction is direct — mirrors RPython where
-    /// the Box object IS the reference.
-    fn box_to_opref(&self, terminal: &majit_ir::box_ref::BoxRef, source: OpRef) -> OpRef {
-        if let Some(src) = terminal.source_opref() {
-            return src;
+    /// A `Const` terminal reconstructs its inline source OpRef from the value
+    /// (`history.py:227/268/314`); a position-bearing terminal rebuilds
+    /// `input_arg_typed` / `op_typed` from its `position()` + `type_()`. A
+    /// `Type::Void` phantom is a lazy-allocated placeholder (the
+    /// `bound_from_opref` fallback for OpRef variants with no `ty()`) carrying
+    /// no type information, so it preserves the `source` variant via `with_raw`
+    /// instead of promoting to `void_op` / `input_arg_typed(_, Void)`.
+    fn operand_to_opref(&self, terminal: &Operand, source: OpRef) -> OpRef {
+        if terminal.const_value().is_some() {
+            return terminal.to_opref();
         }
         if let Some(pos) = terminal.position() {
             let tp = terminal.type_();
-            // `Type::Void` targets are lazy-allocated phantom placeholders
-            // (`materialize_box_at` fallback for OpRef variants with no `ty()`); the
-            // placeholder carries no type information, so preserve the source variant via `with_raw`
-            // instead of promoting to `void_op` / `input_arg_typed(_, Void)`.
             if matches!(tp, majit_ir::Type::Void) {
                 return source.with_raw(pos);
             }
@@ -4595,7 +4540,7 @@ impl OptContext {
     ///
     /// Precondition: `find_producer_op` already missed (full type-tagged
     /// `OpRef` match across `new_operations` / `phase1_emit_ops` / `resop_refs`
-    /// / `input_ops`) and `resolve_to_boxref` returned `None`; `opref` is
+    /// / `input_ops`) and `resolve_to_operand` returned `None`; `opref` is
     /// non-`none`, non-`Const`.
     ///
     /// - `b-inputarg`: an InputArg position whose `inputarg_refs` slot is unbound.
@@ -4874,11 +4819,11 @@ impl OptContext {
     /// lazy-alloc arm). For a const-namespace OpRef returns a fresh
     /// `BoxRef::new_const` (`history.py:220` no-dedup; Const boxes have no
     /// `_forwarded`, so any write the caller attempts is a no-op). Unlike
-    /// `resolve_to_boxref` it never returns `None` for a value-bearing OpRef
+    /// `resolve_to_operand` it never returns `None` for a value-bearing OpRef
     /// — the explicit-mint endpoint (#47) at find-or-create write sites whose
     /// receiver may be unbound (test fixtures, short-preamble replay slots).
     /// The sentinel `OpRef::none()` has no box (debug-asserted); resolve it
-    /// with `resolve_to_boxref` / `get_box_replacement_box` instead.
+    /// with `resolve_to_operand` / `get_box_replacement_operand` instead.
     pub(crate) fn materialize_box_at(&mut self, opref: OpRef) -> majit_ir::box_ref::BoxRef {
         debug_assert!(
             !opref.is_none(),
@@ -4894,7 +4839,7 @@ impl OptContext {
             });
             return majit_ir::box_ref::BoxRef::new_const(value);
         }
-        // Align the write-path host with `resolve_to_boxref`
+        // Align the write-path host with `resolve_to_operand`
         // (the read path behind `get_box_replacement_box`). For ResOp
         // variants, resolve to the producing `Op`'s canonical `_forwarded`
         // host first. `find_producer_op` distinguishes the ResOp namespace
@@ -4909,10 +4854,10 @@ impl OptContext {
             return majit_ir::box_ref::BoxRef::from_bound_op(&op_rc);
         }
         // InputArg write path: route through the canonical `inputarg_refs`
-        // host (symmetric with `resolve_to_boxref`'s InputArg branch and the
+        // host (symmetric with `resolve_to_operand`'s InputArg branch and the
         // `read_forwarded` / `clear_forwarded` writers). The returned BoxRef is
         // bound to `inputarg_refs[idx]`, so a `set_forwarded_*` write lands the
-        // same `InputArg.forwarded` slot a later `resolve_to_boxref` read
+        // same `InputArg.forwarded` slot a later `resolve_to_operand` read
         // observes — without returning a position-collapsed InputArg slot
         // whose write would silently vanish in a release build where the
         // `BoxRef::write_forwarded` bound-precondition assert is off.
@@ -5533,8 +5478,8 @@ impl OptContext {
         // optimizer.py:432: box.set_forwarded(constbox). Terminate the
         // chain in an inline value-typed Const payload (history.py:227/
         // 268/314) — no separate BoxKind::Const carrier and no pool index.
-        // `get_box_replacement` rematerializes the const and `box_to_opref`
-        // recovers the inline-Const OpRef via `source_opref()`'s
+        // `get_box_replacement` rematerializes the const and `operand_to_opref`
+        // recovers the inline-Const OpRef via `Operand::Const::to_opref`'s
         // value-derived branch.
         if matches!(value, Value::Void) {
             panic!("make_constant: Value::Void has no ConstVoid upstream (history.py:220/261/307)");
@@ -5744,7 +5689,7 @@ impl OptContext {
     /// box object itself: `getint`/`getref_base` (resoperation.py:691) return
     /// `_resint`/`_resref` — the box's own value slot, set when the box was
     /// created — and never walk `_forwarded`. This resolves the box at
-    /// `opref`'s own position (`resolve_to_boxref`, the canonical host WITHOUT
+    /// `opref`'s own position (`resolve_to_operand`, the canonical host WITHOUT
     /// the `get_box_replacement` chain walk) and reads its value directly; an
     /// optimizer forwarding (`make_equal_to` / `make_constant`) never takes
     /// precedence over the box's own observed value.

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3431,13 +3431,13 @@ impl OptContext {
         // body-visible OpRef. Non-invented Pure has no forwarding installed,
         // so `get_box_replacement(source) == source` and the body references
         // source directly (RPython parity for non-invented `op = self.res`).
-        let resolved = self.get_box_replacement_operand_opt(preamble_op.op.to_opref());
-        let result = resolved
-            .as_ref()
-            .map(|o| o.to_opref())
-            .unwrap_or_else(|| preamble_op.op.to_opref());
+        // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()` —
+        // walk the box's own `_forwarded` chain (total; identity on a miss),
+        // object-native rather than positional.
+        let resolved = preamble_op.op.get_box_replacement(false);
+        let result = resolved.to_opref();
         let result_type = preamble_op.preamble_op.result_type();
-        let is_constant = resolved.and_then(|o| o.const_value()).is_some();
+        let is_constant = resolved.const_value().is_some();
         let first_use = !self.imported_short_preamble_used.contains(&preamble_source);
         if first_use {
             self.imported_short_preamble_used.push(preamble_source);
@@ -4544,13 +4544,17 @@ impl OptContext {
     /// `BoxRef`. Walks the chain via [`resolve_to_operand`](Self::resolve_to_operand)
     /// + [`Operand::get_box_replacement`].
     ///
-    /// The fallback arm differs from the `BoxRef` sibling by design: a position
-    /// that resolves to neither a producer `Op`, an `inputarg_refs` slot, nor a
-    /// Const has no `Operand` representation (E3 removed the position-only
-    /// `Operand::Box` variant), so `Operand::from_opref` PANICS there — the
-    /// armed hazard-5 tripwire. Every value-bearing op-arg position has a
-    /// findable producer, so the panic arm is unreachable for arg-resolution
-    /// callers (a fire signals an unbound operand fed as an op arg).
+    /// Total, like the `BoxRef` sibling [`BoxRef::get_box_replacement`]
+    /// (box_ref.rs:937 returns the position-only box on a miss) and
+    /// `get_box_replacement` (resoperation.py:57-68 returns `op` itself when the
+    /// `_forwarded` chain is empty). A position that resolves to neither a
+    /// producer `Op`, an `inputarg_refs` slot, nor a Const falls back to
+    /// [`Operand::bound_from_opref`], which mints a synthetic producer carrying
+    /// the same `pos` (`to_opref` byte-identical) rather than panicking. Every
+    /// value-bearing op-arg position has a findable producer, so the fallback
+    /// is unreachable for arg-resolution callers; `s9_probe_fire` records any
+    /// fire as an early warning (a fire signals an unbound operand fed as an op
+    /// arg, and would split the `Rc::ptr_eq` ExportCache rather than abort).
     pub(crate) fn get_box_replacement_operand(&self, opref: OpRef) -> Operand {
         if opref.is_none() {
             return Operand::None;
@@ -4559,7 +4563,7 @@ impl OptContext {
             return start.get_box_replacement(false);
         }
         self.s9_probe_fire(opref);
-        Operand::from_opref(opref)
+        Operand::bound_from_opref(opref)
     }
 
     /// Operand-yielding sibling of [`materialize_box_at`](Self::materialize_box_at):
@@ -5755,7 +5759,7 @@ impl OptContext {
     /// producing ops carry their own observed values, so this reads the real
     /// runtime value without consulting `_forwarded`.
     pub fn runtime_value_of(&self, opref: OpRef) -> Option<Value> {
-        let own = self.resolve_to_boxref(opref)?;
+        let own = self.resolve_to_operand(opref)?;
         own.const_value().or_else(|| own.get_value())
     }
 
@@ -6047,7 +6051,7 @@ impl OptContext {
     fn maybe_replace_guard_value(&self, op: &mut Op) {
         let arg0 = op.arg(0);
         // optimizer.py:755: if op.getarg(0).type == 'i'
-        let arg0_resolved = self.get_replacement_opref(arg0.to_opref());
+        let arg0_resolved = self.resolve_operand_operand(&arg0).to_opref();
         if self.opref_type(arg0_resolved) != Some(majit_ir::Type::Int) {
             return;
         }
@@ -6102,10 +6106,10 @@ impl OptContext {
             if let Some(preamble_op) = tracked {
                 // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
                 // — the resolved Box itself is handed to the builder.
-                let resolved_for_pop = self
-                    .get_box_replacement_operand_opt(preamble_op.op.to_opref())
-                    .map(|o| o.to_boxref())
-                    .unwrap_or_else(|| preamble_op.op.clone());
+                // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
+                // — walk the box's own `_forwarded` chain (total; identity on a
+                // miss), object-native rather than positional.
+                let resolved_for_pop = preamble_op.op.get_box_replacement(false);
                 if let Some(builder) = self.active_short_preamble_producer_mut() {
                     builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
                 } else if let Some(builder) = self.imported_short_preamble_builder.as_mut() {
@@ -8034,7 +8038,7 @@ impl OptContext {
     /// runs `ensure_ptr_info_arg0(op).as_mut().setfield(...)`.
     pub fn structinfo_setfield(&mut self, op: &Op, field_idx: u32, value: OpRef) {
         let value = self.materialize_operand_at(value);
-        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
+        let arg0 = self.resolve_operand_operand(&op.arg(0)).to_opref();
         if arg0.is_constant()
             || self
                 .get_box_replacement_operand_opt(arg0)
@@ -8175,7 +8179,7 @@ impl OptContext {
     /// `arrayinfo.getlenbound(...)` patterns.
     pub fn ensure_ptr_info_arg0(&mut self, op: &Op) -> EnsuredPtrInfo {
         // optimizer.py:464: arg0 = self.get_box_replacement(op.getarg(0))
-        let arg0 = self.get_replacement_opref(op.arg(0).to_opref());
+        let arg0 = self.resolve_operand_operand(&op.arg(0)).to_opref();
         // optimizer.py:465-466: if arg0.is_constant(): return info.ConstPtrInfo(arg0)
         //
         // PyPy's `info.ConstPtrInfo(arg0)` wraps the constant box itself,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6402,17 +6402,20 @@ impl OptContext {
 
         // optimizer.py:712 liveboxes are the canonical Box objects returned
         // by `resumedata.finish()`; resolve each numbering position to its
-        // canonical (possibly producer-bound) box so `store_final_boxes`
-        // can shed to a live-tracking operand. NONE holes and positions
-        // with no canonical box stay position-only.
-        let liveboxes_b: Vec<majit_ir::box_ref::BoxRef> = liveboxes
+        // canonical (possibly producer-bound) operand so `store_final_boxes`
+        // sheds straight to a live-tracking operand. A NONE hole resolves to
+        // `Operand::None`, a Const to `Operand::Const`; a producerless,
+        // non-Const position has no operand to bind and panics at
+        // `Operand::from_opref` — the same contract `store_final_boxes`'
+        // former `Operand::from_boxref` step enforced (#9).
+        let final_operands: Vec<Operand> = liveboxes
             .iter()
             .map(|a| {
-                self.resolve_to_boxref(*a)
-                    .unwrap_or_else(|| majit_ir::box_ref::BoxRef::from_opref(*a))
+                self.resolve_to_operand(*a)
+                    .unwrap_or_else(|| Operand::from_opref(*a))
             })
             .collect();
-        op.store_final_boxes(liveboxes_b);
+        op.store_final_boxes(final_operands);
         op.set_fail_arg_types(new_types.clone());
         // optimizer.py:722-730 `store_final_boxes_in_guard` parity:
         //   if op.getdescr() is not None:

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -4643,13 +4643,11 @@ impl OptContext {
     /// bound / const operand walks its own chain and defers to the store only
     /// when it self-resolves; an unbound operand resolves positionally.
     ///
-    /// The heal still keys on the bound `Op` host, so it is driven through a
-    /// transient `to_boxref()` (heal re-homes onto Op/InputArg in a later slice);
-    /// `BoxRef::get_box_replacement` delegates to the `Operand` walk
-    /// (`box.rs`), so the native walk is byte-identical to the legacy
+    /// The heal keys on the bound `Op` host directly off the `Operand`; the
+    /// native walk (`arg.get_box_replacement`) is byte-identical to the legacy
     /// resolve-then-rewrap, asserted below.
     pub fn resolve_operand_operand(&self, arg: &Operand) -> Operand {
-        self.heal_arg_to_canonical(&arg.to_boxref());
+        self.heal_arg_to_canonical(arg);
         let native = if arg.bound_op().is_some() || arg.is_constant() {
             let resolved = arg.get_box_replacement(false);
             // Self-resolved box-native: the canonical forwarding for this
@@ -4672,7 +4670,7 @@ impl OptContext {
     /// `materialize_*` mint) instead of tripping the position-only panic in the
     /// total [`get_box_replacement_operand`](Self::get_box_replacement_operand).
     pub fn resolve_operand_operand_opt(&self, arg: &Operand) -> Option<Operand> {
-        self.heal_arg_to_canonical(&arg.to_boxref());
+        self.heal_arg_to_canonical(arg);
         let native = if arg.bound_op().is_some() || arg.is_constant() {
             let resolved = arg.get_box_replacement(false);
             if resolved.same_box(arg) {
@@ -4714,14 +4712,16 @@ impl OptContext {
     /// this same-position duplication, leaving the operand's box-native walk
     /// stranded on the info-less input op while the OpRef store path reaches the
     /// info-bearing canonical. Linking those two distinct ops is the whole point
-    /// of the heal. But `get_box_replacement_box` can also re-mint a DIFFERENT
-    /// `BoxRef` wrapping the SAME bound `Op` as `arg` (a store wrapper vs the
-    /// memoized operand box); `same_box` (an `Rc::ptr_eq` on the boxes) misses
-    /// that, so an explicit `Rc::ptr_eq` on the bound ops is needed — without it
-    /// `set_forwarded_op` self-cycles (`arg.op -> arg.op`). The canonical is a
-    /// `get_box_replacement_box` terminal (`Forwarded::None`/`Info`, never a
-    /// `Box`), so once a genuinely distinct op is linked no chain cycle forms.
-    fn heal_arg_to_canonical(&self, arg: &majit_ir::box_ref::BoxRef) {
+    /// of the heal. But `get_box_replacement_operand_opt` can also re-resolve a
+    /// DIFFERENT `Operand` wrapping the SAME bound `Op` as `arg` (a store wrapper
+    /// vs the memoized operand); `same_box` (an `Rc::ptr_eq` on the producers)
+    /// catches that for an identical `Rc<Op>`, but the explicit `Rc::ptr_eq` on
+    /// the bound ops is kept as the cycle guard — without it `set_forwarded_op`
+    /// self-cycles (`arg.op -> arg.op`). The canonical is a
+    /// `get_box_replacement_operand` terminal (`Forwarded::None`/`Info`, never a
+    /// bound op chained on), so once a genuinely distinct op is linked no chain
+    /// cycle forms.
+    fn heal_arg_to_canonical(&self, arg: &Operand) {
         if arg.bound_op().is_none() {
             return;
         }
@@ -4731,8 +4731,7 @@ impl OptContext {
         let Some(canon) = self.get_box_replacement_operand_opt(arg.to_opref()) else {
             return;
         };
-        // `arg` is bound (checked above), so its `Operand` lowering is panic-free.
-        if Operand::from_boxref(arg).same_box(&canon) {
+        if arg.same_box(&canon) {
             return;
         }
         // Skip when `canon` wraps the same bound `Op` as `arg` under a distinct

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1794,10 +1794,10 @@ impl Optimizer {
             if let Some(preamble_op) = tracked {
                 // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
                 // — the resolved Box itself is handed to the builder.
-                let resolved_for_pop = ctx
-                    .get_box_replacement_operand_opt(preamble_op.op.to_opref())
-                    .map(|o| o.to_boxref())
-                    .unwrap_or_else(|| preamble_op.op.clone());
+                // shortpreamble.py:434 `op = preamble_op.op.get_box_replacement()`
+                // — walk the box's own `_forwarded` chain (total; identity on a
+                // miss), object-native rather than positional.
+                let resolved_for_pop = preamble_op.op.get_box_replacement(false);
                 if let Some(builder) = ctx.active_short_preamble_producer_mut() {
                     builder.add_preamble_op_from_pop(&preamble_op, resolved_for_pop);
                 } else if let Some(builder) = ctx.imported_short_preamble_builder.as_mut() {
@@ -2796,7 +2796,7 @@ impl Optimizer {
             let resolved_args: Vec<OpRef> = terminal_op
                 .getarglist()
                 .iter()
-                .map(|arg| ctx.get_replacement_opref(arg.to_opref()))
+                .map(|arg| arg.get_box_replacement(false).to_opref())
                 .collect();
             for &resolved in &resolved_args {
                 self.force_box_for_end_of_preamble(resolved, &mut ctx);
@@ -2808,7 +2808,7 @@ impl Optimizer {
             //   for i in range(op.numargs()): op.setarg(i, force_box(...))
             for i in 0..terminal_op.num_args() {
                 let arg = terminal_op.arg(i);
-                let resolved = ctx.get_replacement_opref(arg.to_opref());
+                let resolved = ctx.resolve_operand_operand(&arg).to_opref();
                 let expected_ref =
                     i < inputargs.len() && inputargs[i].ty() == Some(majit_ir::Type::Ref);
                 // setup_optimizations seeds `trace_inputargs` into
@@ -2979,7 +2979,7 @@ impl Optimizer {
                     .unwrap_or_else(|| {
                         jump.getarglist()
                             .iter()
-                            .map(|a| ctx.get_replacement_opref(a.to_opref()))
+                            .map(|a| a.get_box_replacement(false).to_opref())
                             .collect()
                     });
                 let mut resolved_args = original_jump_args.clone();
@@ -4955,8 +4955,8 @@ impl Optimizer {
                         majit_ir::GuardPendingFieldEntry {
                             descr: pf_op.getdescr(),
                             item_index,
-                            target: ctx.get_replacement_opref(target.to_opref()),
-                            value: ctx.get_replacement_opref(value.to_opref()),
+                            target: ctx.resolve_operand_operand(&target).to_opref(),
+                            value: ctx.resolve_operand_operand(&value).to_opref(),
                             target_tagged: majit_ir::resumedata::UNASSIGNED,
                             value_tagged: majit_ir::resumedata::UNASSIGNED,
                         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1482,7 +1482,7 @@ impl Optimizer {
     /// Record that a guard at the given position should be replaced when the
     /// future condition is realized. PyPy keys `replaces_guard` by the raw `op`
     /// object identity, and `_emit_operation` (optimizer.py:660) looks it up by
-    /// the raw `orig_op` — both before `get_box_replacement`. `resolve_to_boxref`
+    /// the raw `orig_op` — both before `get_box_replacement`. `resolve_to_operand`
     /// yields that producer box (chain root, before `_forwarded`), so insert and
     /// the emit-time lookup compare the same raw box.
     /// (The method keeps its historical name; the body performs replace_guard's
@@ -1548,7 +1548,7 @@ impl Optimizer {
             }
         }
         // optimizer.py:374 `if op in self._emittedoperations` keys by the op's
-        // own (raw) identity, not its forwarded replacement. `resolve_to_boxref`
+        // own (raw) identity, not its forwarded replacement. `resolve_to_operand`
         // is the producer box (chain root, before `_forwarded`); the emit set is
         // populated with the canonical box, so this matches iff the raw op is the
         // canonical op — exactly PyPy's `op in _emittedoperations`.
@@ -3135,8 +3135,8 @@ impl Optimizer {
                         // bind-at-alloc: `export_state` below keys its
                         // `ExportCache` by these resolved positions. A producer-less
                         // value-bearing position resolves to a throwaway `from_opref`
-                        // box, so each `resolve_to_boxref` returns a distinct Rc
-                        // (ptr-Eq-unstable) and `export_single_value` logs it as an
+                        // operand, so each `bound_from_opref` fallback returns a
+                        // distinct Rc (ptr-Eq-unstable) and `export_single_value` logs it as an
                         // unbound export key. Bind the canonical `_forwarded` host
                         // once via `materialize_box_at` (a `SameAs*` synthetic in
                         // `resop_refs`, memoized through `Op::box_cache`) so the

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -434,8 +434,8 @@ impl OptRewrite {
         }
 
         // rewrite.py:528-531: null checks — fall back to OpRef for downstream
-        let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
-        let arg1 = ctx.get_replacement_opref(op.arg(1).to_opref());
+        let arg0 = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+        let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
         if info1.as_ref().is_some_and(|i| i.is_null()) {
             return self.optimize_nullness(op, arg0, expect_isnot, ctx);
         }
@@ -827,7 +827,7 @@ impl OptRewrite {
         // EnsuredPtrInfo borrow; downstream lookups re-acquire via
         // `getptrinfo` / `get_ptr_info` against the resolved OpRef.
         let _ = ctx.ensure_ptr_info_arg0(op);
-        let obj = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let obj = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
         // rewrite.py:397-407: ensure_ptr_info_arg0 → info.py:880 getptrinfo.
         // `getptrinfo(ConstPtr)` returns a synthesized ConstPtrInfo, so a
         // constant Ref arg0 is handled uniformly with virtual / instance
@@ -1123,7 +1123,7 @@ impl OptRewrite {
                     && shift_op.num_args() >= 2
                     && shift_op.arg(0).get_box_replacement(false).const_int() == Some(1)
                 {
-                    let shiftvar = ctx.get_replacement_opref(shift_op.arg(1).to_opref());
+                    let shiftvar = ctx.resolve_operand_operand(&shift_op.arg(1)).to_opref();
                     let shiftbound = {
                         let b = ctx.get_box_replacement_operand(shiftvar);
                         ctx.getintbound_handle(&b).borrow().clone()
@@ -1762,7 +1762,7 @@ impl Optimization for OptRewrite {
                 //         if info.is_null(): return
                 //         elif info.is_nonnull(): raise InvalidLoop(...)
                 //     return self.emit(op)
-                let obj = ctx.get_replacement_opref(op.arg(0).to_opref());
+                let obj = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
                 let obj_box = ctx.resolve_operand_operand_opt(&op.arg(0));
                 if let Some(info) = obj_box.as_ref().and_then(|b| ctx.getptrinfo(b)) {
                     if info.is_null() {
@@ -1903,8 +1903,8 @@ impl Optimization for OptRewrite {
                     //     arg0 = get_box_replacement(op.getarg(0))
                     //     arg1 = get_box_replacement(op.getarg(1))
                     //     self.pure_from_args2(rop.INSTANCE_PTR_EQ, arg1, arg0, op)
-                    let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
-                    let arg1 = ctx.get_replacement_opref(op.arg(1).to_opref());
+                    let arg0 = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+                    let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
                     ctx.register_pure_from_args2(OpCode::InstancePtrEq, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, false, instance, ctx);
@@ -1913,8 +1913,8 @@ impl Optimization for OptRewrite {
                 let instance = matches!(op.opcode, OpCode::InstancePtrNe);
                 if instance {
                     // rewrite.py:568-571 optimize_INSTANCE_PTR_NE: same swap.
-                    let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
-                    let arg1 = ctx.get_replacement_opref(op.arg(1).to_opref());
+                    let arg0 = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+                    let arg1 = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
                     ctx.register_pure_from_args2(OpCode::InstancePtrNe, op.pos.get(), arg1, arg0);
                 }
                 return self.optimize_oois_ooisnot(op, true, instance, ctx);

--- a/majit/majit-metainterp/src/optimizeopt/schedule.rs
+++ b/majit/majit-metainterp/src/optimizeopt/schedule.rs
@@ -74,6 +74,17 @@ pub struct AccumPack {
 
 /// Accumulation info stored in the accumulation map.
 /// schedule.py:649: state.accumulation[arg] = pack
+///
+/// schedule.py keys `accumulation` by the failarg box and `getleftmostseed`
+/// returns a box object; pyre shapes `seed` as a flat `OpRef` and keys
+/// `accumulation` by `OpRef`. This is intentional, not a box-identity gap: the
+/// seed is always the loop-carried label arg fed through `accumulate_prepare`
+/// (schedule.py:666-669) — a `FlowValue::Variable` register, never a `Const` —
+/// so identity-by-position and identity-by-box coincide (the Const ptr-
+/// instability that forces #115/S7 to keep const-namespace tables OpRef-keyed
+/// never applies here). The consumer rebinds the producer at emit time
+/// (vector.rs `pre_emit_guard_accum`). Box-shaping `seed` is a cosmetic
+/// #169/#175 follow-up, not a correctness fix.
 #[derive(Clone, Debug)]
 pub struct AccumEntry {
     /// schedule.py:998: getleftmostseed() — first member's arg at `position`.

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -1801,12 +1801,17 @@ impl VectorizingOptimizer {
     /// by attaching a CompileLoopVersionDescr and setting failargs to
     /// the label's input args.
     ///
-    /// TODO: CompileLoopVersionDescr is not yet ported
-    /// to Rust. When it is, this should create the descr and attach it.
+    /// Stubbed: the descr itself IS ported (`make_compile_loop_version_descr_from`
+    /// in compile.rs, already used by `Guard::transitive_imply`), but the failargs
+    /// half — `label.getarglist_copy()` carrying the label's live producer boxes —
+    /// is blocked on #175 (the dormant vectorizer narrows label args to `OpRef`,
+    /// so a faithful copy has no producer `Rc` to carry; emitting failargs here
+    /// via `bound_from_opref` would only widen the synthetic-producer surface).
+    /// Reached only under the `vec_all()` debug gate.
     fn mark_guard(&self, _guard_idx: usize, _loop_: &VectorLoop) {
         // vector.py:588-594: create CompileLoopVersionDescr, copy attrs
         // vector.py:595-599: set failargs to label.getarglist_copy()
-        // Requires CompileLoopVersionDescr from compile.rs — not yet ported.
+        // Faithful failargs-carry deferred to #175 (producer-carrying label args).
     }
 
     // ── Optimization trait helper: try_vectorize ───────────────────────
@@ -2322,6 +2327,12 @@ fn pre_emit_guard_accum(state: &VecScheduleState, op: &mut Op) {
                 // (Some) or None; on a miss bind the seed to a producer-carrying
                 // Operand (to_opref() == seed) instead of fabricating a
                 // position-only operand that would panic on a live producer.
+                // #175: the hit arm is faithful (lookup_box yields the bound
+                // renamed Operand the renamer stored). The miss arm mints a
+                // synthetic because `AccumEntry.seed` is narrowed to `OpRef`
+                // (schedule.rs); the real producer is reachable at the seed
+                // capture site, so carrying it (seed: OpRef -> Operand) is
+                // deferred to #175.
                 *arg = state
                     .renamer
                     .lookup_box(entry.seed)

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -677,7 +677,7 @@ impl OptVirtualize {
 
     fn optimize_setfield_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let struct_box = ctx.resolve_operand_operand_opt(&op.arg(0));
-        let value_ref = ctx.get_replacement_opref(op.arg(1).to_opref());
+        let value_ref = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
         let setfield_descr_arc = op
             .getdescr()
             .expect("optimize_setfield_gc: field op without FieldDescr");
@@ -957,7 +957,7 @@ impl OptVirtualize {
 
     fn optimize_setarrayitem_gc(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         let array_box = ctx.resolve_operand_operand_opt(&op.arg(0));
-        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
+        let value_ref = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
 
         if let Some(index) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
@@ -1166,7 +1166,7 @@ impl OptVirtualize {
         ctx: &mut OptContext,
     ) -> OptimizationResult {
         let array_box = ctx.resolve_operand_operand_opt(&op.arg(0));
-        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
+        let value_ref = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
         // `info.py:583-594 setinteriorfield_virtual` indexes the per-element
         // field list by `fielddescr.get_index()`.  Same shape as the GET
         // counterpart — strip the outer `InteriorFieldDescr` first.
@@ -1245,7 +1245,7 @@ impl OptVirtualize {
         if op.num_args() < 2 {
             return OptimizationResult::PassOn;
         }
-        let arg0 = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let arg0 = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
         let Some(offset) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
             .and_then(|b| ctx.get_constant_int_box(&b))
@@ -1322,9 +1322,9 @@ impl OptVirtualize {
     }
 
     fn optimize_raw_store(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let buf_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let buf_ref = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
         let offset_ref = op.arg(1).to_opref();
-        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
+        let value_ref = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
 
         if let Some(offset) = ctx
             .get_box_replacement_operand_opt(offset_ref)
@@ -1413,7 +1413,7 @@ impl OptVirtualize {
         op_rc: &majit_ir::OpRc,
         ctx: &mut OptContext,
     ) -> OptimizationResult {
-        let array_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
+        let array_ref = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
 
         if let Some(index) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
@@ -1544,8 +1544,8 @@ impl OptVirtualize {
     ///     return self.emit(op)
     /// ```
     fn optimize_setarrayitem_raw(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let array_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
-        let value_ref = ctx.get_replacement_opref(op.arg(2).to_opref());
+        let array_ref = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+        let value_ref = ctx.resolve_operand_operand(&op.arg(2)).to_opref();
 
         if let Some(index) = ctx
             .resolve_operand_operand_opt(&op.arg(1))
@@ -1748,8 +1748,8 @@ impl OptVirtualize {
     /// here on the VirtualStruct half and the setfield_gc emit path is
     /// taken only when the vref has already escaped.
     fn optimize_virtual_ref_finish(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
-        let vref_ref = ctx.get_replacement_opref(op.arg(0).to_opref());
-        let obj_ref = ctx.get_replacement_opref(op.arg(1).to_opref());
+        let vref_ref = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+        let obj_ref = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
 
         // virtualize.py:151: `CONST_NULL.same_constant(objbox)` — only a
         // Ref-typed null constant matches; a plain ConstInt(0) does not.

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -11,7 +11,6 @@
 /// `history.rs` as `impl TraceCtx`.  Pyre callers reach the recorder via
 /// `MetaInterp.history.record*` mirroring
 /// `pyjitpl.py:2455+ self.history.record2(...)`.
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, InputArg, InputArgRc, Op, OpCode, OpRc, OpRef, Type, Value};
 
@@ -122,9 +121,9 @@ pub struct Trace {
     /// optimizer (`AbstractValue` object identity).
     ops: Vec<OpRc>,
     /// Input arguments to the trace (live variables at the loop header).
-    /// Stored as `InputArgRc` so the recorder's `box_args` bridge can mint a
-    /// canonical, identity-stable `BoxRef` per input arg (`from_bound_inputarg`
-    /// memoizes on `InputArg::box_cache`), and the same `Rc<InputArg>` flows
+    /// Stored as `InputArgRc` so the recorder's `box_args` bridge can resolve a
+    /// canonical, identity-stable `Operand` per input arg (`from_bound_inputarg`
+    /// carries the `Rc<InputArg>` directly), and the same `Rc<InputArg>` flows
     /// through `into_parts` / `from_oprc` into `TreeLoop.inputargs` unchanged.
     inputargs: Vec<InputArgRc>,
     /// Next OpRef index to assign.
@@ -192,21 +191,19 @@ impl Trace {
         opref
     }
 
-    /// Bridge the recorder's OpRef-operand API to the BoxRef-carrying
+    /// Bridge the recorder's OpRef-operand API to the `Operand`-carrying
     /// `Op.args` / `Op.fail_args` storage. Each operand resolves to its
-    /// *canonical* producer `BoxRef` so the stored args share one `Rc<Box>`
-    /// per producer (`AbstractValue` object identity): `from_bound_op` /
-    /// `from_bound_inputarg` memoize on `Op::box_cache` / `InputArg::box_cache`.
-    /// Frame registers and the public `record_*` API stay OpRef; the optimizer
-    /// bridges back with `BoxRef::to_opref`, which round-trips to the same
-    /// `OpRef` the frozen `from_opref` view produced.
+    /// *canonical* producer `Operand` so the stored args share one producer
+    /// `Rc` (`AbstractValue` object identity): `from_bound_op` /
+    /// `from_bound_inputarg` carry the producer `Rc<Op>` / `Rc<InputArg>`
+    /// directly. Frame registers and the public `record_*` API stay OpRef; the
+    /// optimizer bridges back with `Operand::to_opref`, which round-trips to the
+    /// same `OpRef` the `from_opref` view produced.
     fn box_args(&self, args: &[OpRef]) -> smallvec::SmallVec<[Operand; 3]> {
-        args.iter()
-            .map(|&a| Operand::from_boxref(&self.box_for_operand(a)))
-            .collect()
+        args.iter().map(|&a| self.box_for_operand(a)).collect()
     }
 
-    /// Resolve one operand `OpRef` to its canonical `BoxRef`. Const operands
+    /// Resolve one operand `OpRef` to its canonical `Operand`. Const operands
     /// carry their `Value` inline on the `OpRef` (history.py:227/268/314) and
     /// are minted via `from_opref`; InputArg / ResOp operands resolve to the
     /// producing `InputArg` / `Op` already held in `self.inputargs` / `self.ops`,
@@ -214,14 +211,15 @@ impl Trace {
     /// to a recorded producer is a recorder invariant violation and panics
     /// (opencoder.py:635/640 assert position rather than mint); the S0/#121 probe
     /// measured 0 hits across the corpus. `#[cfg(test)]` fixtures that build
-    /// position-only synthetic operands keep the `from_opref` view.
-    fn box_for_operand(&self, r: OpRef) -> BoxRef {
+    /// position-only synthetic operands bind a synthetic producer via
+    /// `bound_from_opref` (`to_opref`-identical) rather than panicking.
+    fn box_for_operand(&self, r: OpRef) -> Operand {
         if r.is_none() || r.is_constant() {
-            return BoxRef::from_opref(r);
+            return Operand::from_opref(r);
         }
         if let OpRef::InputArgInt(_) | OpRef::InputArgFloat(_) | OpRef::InputArgRef(_) = r {
             if let Some(ia) = self.inputargs.get(r.raw() as usize) {
-                return BoxRef::from_bound_inputarg(ia);
+                return Operand::from_bound_inputarg(ia);
             }
             // S3/#124: inputargs are dense `[0, n)`, so an InputArg operand
             // always resolves above (opencoder.py:635 asserts).
@@ -232,7 +230,7 @@ impl Trace {
                 self.inputargs.len()
             );
             #[cfg(test)]
-            return BoxRef::from_opref(r);
+            return Operand::bound_from_opref(r);
         }
         // ResOp operand: positions are dense in op_count order — inputargs
         // occupy `[0, n)`, recorded ops occupy `[n, ..)` — so the producing op
@@ -242,7 +240,7 @@ impl Trace {
         if let Some(idx) = (r.raw() as usize).checked_sub(n) {
             if let Some(op) = self.ops.get(idx) {
                 if op.pos.get().raw() == r.raw() {
-                    return BoxRef::from_bound_op(op);
+                    return Operand::from_bound_op(op);
                 }
             }
         }
@@ -255,7 +253,7 @@ impl Trace {
             self.ops.len()
         );
         #[cfg(test)]
-        BoxRef::from_opref(r)
+        Operand::bound_from_opref(r)
     }
 
     /// Record a regular (non-guard) operation.


### PR DESCRIPTION
Continues the #47/#169 BoxRef wrapper teardown. Three commits on top of `main`.

## Commits

1. **restore object-native operand resolution** (`271c4c1`) — addresses the PR #296 review. Op-arg sites resolve via `resolve_operand_operand(&op.arg(i))` — walking the live operand's own `get_box_replacement(false)` chain before deferring to the OpRef store — instead of collapsing the operand to an `OpRef` position first (`get_replacement_opref(op.arg(i).to_opref())`). Mirrors PyPy `get_box_replacement(op.getarg(i))`, which walks *that box object's* `_forwarded`. Sites across heap.rs / rewrite.rs / virtualize.rs / optimizer.rs / info.rs / mod.rs.

2. **flip `store_final_boxes` to `Vec<Operand>`** (`8630959`) — the guard final-boxes write adapter (`resoperation.rs`) now takes `Vec<Operand>` and writes the `fail_args` slot (already `SmallVec<[Operand;3]>` since the #186 failargs flip) without the per-element `Operand::from_boxref` conversion. The sole production caller builds the operands via `resolve_to_operand` + `Operand::from_opref` fallback. Drains a `resolve_to_boxref` caller and the `from_boxref` write-adapter.

3. **delete `resolve_to_boxref`; Operand-native chain walk** (`43aa59c`) — `get_box_replacement_impl` walks the forwarding chain in Operand space: `resolve_to_operand` + `Operand::get_box_replacement` + a new `operand_to_opref` reconstructor that mirrors the deleted `box_to_opref` arm-for-arm (Const inline reconstruction; `input_arg_typed` / `op_typed` rebuild; and the `Type::Void` phantom preserving the source variant via `with_raw` — the byte-exactness gap a naive `Operand::to_opref` reuse would miss). With their last callers gone, **`resolve_to_boxref` and `box_to_opref` are deleted**. Also resolves the `do_setfield_*` RHS object-natively (`heap.py:80` `get_box_replacement(self._get_rhs_from_set_op(op))`), completing the object-native sweep that had missed those two sites via the `field_get_rhs` / `array_get_rhs` helper indirection.

## Verification

Full per-slice gate, sequential, both backends — green at every commit:

- `cargo test -p majit-metainterp --features dynasm --lib` → 1370 passed
- `cargo test -p majit-metainterp --features cranelift --lib` → 1368 passed
- `cargo test -p majit-ir --lib` → 333 passed
- `cargo test -p majit-gc --lib` → 162 passed
- `python ./pyre/check.py --backend dynasm` → 160/160
- `python ./pyre/check.py --backend cranelift` → 160/160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operand tracking in optimization and guard handling, which should make generated results more consistent and reliable in edge cases.
  * Fixed several internal resolution paths so forwarded values are handled more accurately during guard, array, field, and virtual object processing.

* **Documentation**
  * Added clarifying comments around operand identity, guard accumulation, and resume handling to make the optimization flow easier to understand and maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->