### PR TITLE
memoryview de-flatten layers + rtyper lowering fixes

### DIFF
--- a/majit/majit-gc/src/trace.rs
+++ b/majit/majit-gc/src/trace.rs
@@ -474,6 +474,17 @@ impl TypeInfo {
         self
     }
 
+    /// Builder: attach a lightweight `destructor` (see [`DestructorFn`]) to a
+    /// type built by another constructor. Composes with
+    /// `object_subclass_with_custom_trace` for an instance that both owns
+    /// inline GC refs discovered by the trace hook *and* an off-heap
+    /// allocation whose drop glue must run when the instance dies — e.g. the
+    /// `W_MemoryView` header owning its `*const BufferView` box.
+    pub fn with_destructor_fn(mut self, destructor: DestructorFn) -> Self {
+        self.destructor = Some(destructor);
+        self
+    }
+
     /// `gctypelayout.is_weakref_type(WEAKREF)` parity — TypeInfo for
     /// the singleton WEAKREF GcStruct itself (gctypelayout.py:587-589).
     /// The struct payload is one `weakptr: GcRef` slot; the collector

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2164,7 +2164,10 @@ impl Bookkeeper {
         // pointer as the conservative classdef-less Ref instance
         // (`getkind = 'ref'`), the GC-safe choice for a field that may
         // hold a managed pointer.
-        if let Some(pointee) = t.strip_prefix("*const ").or_else(|| t.strip_prefix("*mut ")) {
+        if let Some(pointee) = t
+            .strip_prefix("*const ")
+            .or_else(|| t.strip_prefix("*mut "))
+        {
             let s_pointee = self.project_pyre_field_type(pointee.trim());
             if matches!(
                 s_pointee,

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2150,6 +2150,39 @@ impl Bookkeeper {
     /// entry; unknown bare names fall to `Impossible`.
     pub fn project_pyre_field_type(self: &Rc<Self>, field_ty: &str) -> SomeValue {
         let t = field_ty.trim();
+        // A raw-pointer field (`*const T` / `*mut T`) holds a one-word
+        // pointer, not a `T`.  Projecting the pointee is right for an
+        // aggregate target (`*mut Vec<T>` / `*mut Struct`): the structural
+        // shell is already GcRef-kind and downstream element/field access
+        // relies on it.  But for a scalar / unit pointee the pointee shell
+        // (Signed / Void / …) discards the pointer-ness and diverges from
+        // the legacy walker, which folds every raw-pointer field-read to
+        // `Ref` → GcRef (the FieldRead op `ty` is
+        // `tyref_to_value_type(raw ptr) = Ref(None)`).  Mirror that fold —
+        // and the FORCE_ATTRIBUTES `tyref_to_attr_value_type` raw-ptr →
+        // `Ref(None)` projection — by shelling a scalar/unit-pointee raw
+        // pointer as the conservative classdef-less Ref instance
+        // (`getkind = 'ref'`), the GC-safe choice for a field that may
+        // hold a managed pointer.
+        if let Some(pointee) = t.strip_prefix("*const ").or_else(|| t.strip_prefix("*mut ")) {
+            let s_pointee = self.project_pyre_field_type(pointee.trim());
+            if matches!(
+                s_pointee,
+                SomeValue::Integer(_)
+                    | SomeValue::Bool(_)
+                    | SomeValue::Float(_)
+                    | SomeValue::SingleFloat(_)
+                    | SomeValue::Char(_)
+                    | SomeValue::None_(_)
+            ) {
+                return SomeValue::Instance(super::model::SomeInstance::new(
+                    None,
+                    false,
+                    std::collections::BTreeMap::new(),
+                ));
+            }
+            return s_pointee;
+        }
         let stripped = t
             .trim_start_matches('&')
             .trim_start_matches("mut ")

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -693,6 +693,20 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     );
 
     // ── Pass 2: lower every function body and build SemanticFunctions ─
+    // `@jit.dont_look_inside` (`rlib/jit.py:142`) callees declare a
+    // FUNC.RESULT that the legacy walker reads off the Call op's
+    // `result_ty` (`legacy_resolve.rs infer_concrete_from_op`), but the
+    // real path stubs the opaque body and otherwise drops the residual
+    // call result to void.  Harvest the marker set once (same
+    // `_jit_look_inside_` source as `merge_hints_from_llbcs`) so the
+    // per-fn push can stamp the matching `return_type` token, keyed by
+    // the identical `{module_path}::{name}` path the merge uses.
+    let dont_look_inside: std::collections::HashSet<String> =
+        crate::front::llbc_hints::harvest_hints_from_llbcs(std::slice::from_ref(llbc))
+            .into_iter()
+            .filter(|(_, hints)| hints.iter().any(|h| h == "dont_look_inside"))
+            .map(|(path, _)| path)
+            .collect();
     let mut functions = Vec::new();
     let mut skipped: Vec<(String, String)> = Vec::new();
     for fd in llbc.iter_local_fns() {
@@ -739,14 +753,19 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
                 continue;
             }
         };
-        // return_type is intentionally `None` until the Charon
-        // dedup-table resolution can map a `TyRef::Deduplicated{id}` to
-        // its primitive name. The codewriter's call-signature validator
-        // at `codewriter/call.rs:4234` skips the check when declared
-        // type is None, which is the right behaviour while the
+        // `return_type` stays `None` for ordinary fns: the Charon
+        // dedup-table resolution cannot yet map a
+        // `TyRef::Deduplicated{id}` to its primitive name, and the
+        // codewriter's call-signature validator skips the check when the
+        // declared type is None, which is the right behaviour while the
         // resolution gap is open — TyRef labels (`ty#170`) would
         // otherwise be classified as `Type::Ref` and trip a spurious
-        // mismatch panic against a real `Type::Int` callee result.
+        // mismatch panic against a real `Type::Int` callee result.  The
+        // `dont_look_inside` exception is stamped below: an opaque
+        // callee's FUNC.RESULT token is the only signal the rtyper stub
+        // has to shell its residual-call result to the same register
+        // kind the legacy walker derives, so it is filled in even though
+        // the general resolution gap remains open.
         // Surface the impl-method owner on the SemanticFunction so
         // `lib.rs:868` / `lib.rs:1086` and the
         // `extract_inherent_impl_methods` / `extract_trait_impls`
@@ -779,10 +798,24 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             .map(str::to_string)
             .or_else(|| trait_default_owner_for_fundecl(fd, &known_trait_names));
         let returns_objectptr = output_type_is_objectptr(&fd.signature.output, llbc);
+        // Stamp the FUNC.RESULT token for `dont_look_inside` callees only
+        // (keyed exactly as `merge_hints_from_llbcs`), so the narrow
+        // codewriter surface stays restricted to opaque stubs; every
+        // other fn keeps the declared-void default.
+        let fn_path = if module_path.is_empty() {
+            name.clone()
+        } else {
+            format!("{module_path}::{name}")
+        };
+        let return_type = if dont_look_inside.contains(&fn_path) {
+            dont_look_inside_return_token(&fd.signature.output, llbc)
+        } else {
+            None
+        };
         functions.push(crate::front::semantic::SemanticFunction {
             name,
             graph,
-            return_type: None,
+            return_type,
             self_ty_root,
             module_path,
             hints: Vec::new(),
@@ -9528,6 +9561,39 @@ fn tyref_to_value_type(ty: &TyRef, llbc: &Llbc) -> ValueType {
         return ValueType::Int;
     }
     ValueType::Ref(None)
+}
+
+/// Encode the FUNC.RESULT of a `dont_look_inside` callee into the
+/// canonical `FunctionGraph.return_type` token the rtyper stub
+/// classifier (`cutover.rs` `dont_look_inside` arm) decodes, so the
+/// residual-call result shells to the SAME register kind the legacy
+/// walker derives from the Call op's `result_ty`
+/// (`legacy_resolve.rs infer_concrete_from_op` →
+/// `valuetype_to_concrete`).  The classification mirrors `lower_call`'s
+/// `result_ty` derivation (`is_unit_type ? Void : tyref_to_value_type`)
+/// so the real path and the legacy walker converge by construction.
+///
+/// The tokens are the Rust primitive spellings the codewriter's
+/// `return_type_string_to_value_type` already recognizes (`bool`/`i64`/
+/// `u64`/`f64` → int/float), plus the `ref` sentinel for any pointer /
+/// reference / opaque-ADT return (codewriter wildcards it to
+/// `Type::Ref`, matching `valuetype_to_concrete(Ref) = GcRef`).  `None`
+/// keeps the historic declared-void behaviour for unit returns and for
+/// `Unknown` results (whose legacy concrete is also Unknown — the
+/// dead-var backfill family, not a genuine kind mismatch).
+fn dont_look_inside_return_token(output: &TyRef, llbc: &Llbc) -> Option<String> {
+    if is_unit_type(output, llbc) {
+        return None;
+    }
+    let token = match tyref_to_value_type(output, llbc) {
+        ValueType::Bool => "bool",
+        ValueType::Int => "i64",
+        ValueType::Unsigned => "u64",
+        ValueType::Float => "f64",
+        ValueType::Ref(_) => "ref",
+        ValueType::Void | ValueType::State | ValueType::Unknown => return None,
+    };
+    Some(token.to_string())
 }
 
 /// Classify a struct field [`TyRef`] into the RPython `lltype` register

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1249,9 +1249,7 @@ pub(crate) fn populate_call_registry_from_call_graphs(
                 Some("i64") => Some(LowLevelType::Signed),
                 Some("u64") => Some(LowLevelType::Unsigned),
                 Some("f64") => Some(LowLevelType::Float),
-                Some("ref") => {
-                    Some(crate::translator::rtyper::lltypesystem::lltype::GCREF.clone())
-                }
+                Some("ref") => Some(crate::translator::rtyper::lltypesystem::lltype::GCREF.clone()),
                 Some(s) if s == OBJECTPTR_RETURN_TYPE => {
                     Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
                 }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1227,21 +1227,31 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // lift failure would poison every caller.  Prefill the same
         // signature-only stub pygraph `register_unsafe_fn_stubs` uses
         // (the `ExtRegistryEntry.compute_result_annotation` shape) so
-        // callers annotate the declared unit/bool result and the
-        // codewriter emits the residual call via the fn's registered
-        // C ABI address (`pyre/jit_fnaddr.rs`).  The object-pointer
-        // marker (`OBJECTPTR_RETURN_TYPE`, stamped by the front-end on a
-        // `*mut PyObject`-returning opaque callee) projects to
-        // `OBJECTPTR` — the `default_someshell_for_lltype` →
-        // `lltype_to_annotation` path already covers `Ptr(_)`.  Other
-        // non-scalar returns fall through to the normal lift — no
-        // current marker needs them, and the stub builder's coverage is
-        // unaudited for that case.
+        // callers annotate the declared result and the codewriter emits
+        // the residual call via the fn's registered C ABI address
+        // (`pyre/jit_fnaddr.rs`).  The FUNC.RESULT token is the
+        // canonical spelling `front::mir::dont_look_inside_return_token`
+        // stamps from the callee's return `ValueType`, so each token
+        // decodes to the lltype whose `getkind` equals the legacy
+        // walker's `valuetype_to_concrete(result_ty)`: scalar tokens to
+        // their primitive lltype, `ref` to the generic `GCREF` Ptr
+        // (`getkind = 'ref'`).  The object-pointer marker
+        // (`OBJECTPTR_RETURN_TYPE`, stamped by `merge_hints_from_llbcs`
+        // for a `*mut PyObject`-returning opaque callee the front-end
+        // left untokened) projects to the typed `OBJECTPTR` — the
+        // `default_someshell_for_lltype` → `lltype_to_annotation` path
+        // already covers `Ptr(_)`.  An unrecognized token (none
+        // currently emitted) falls through to the normal lift.
         if graph.hints.iter().any(|h| h == "dont_look_inside") {
             let return_lltype = match graph.return_type.as_deref() {
                 None | Some("()") => Some(LowLevelType::Void),
                 Some("bool") => Some(LowLevelType::Bool),
                 Some("i64") => Some(LowLevelType::Signed),
+                Some("u64") => Some(LowLevelType::Unsigned),
+                Some("f64") => Some(LowLevelType::Float),
+                Some("ref") => {
+                    Some(crate::translator::rtyper::lltypesystem::lltype::GCREF.clone())
+                }
                 Some(s) if s == OBJECTPTR_RETURN_TYPE => {
                     Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
                 }

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1090,6 +1090,29 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // registering it as a user function: with no registry entry, callsites
         // resolve to the HOST_ENV builtin (translate_op Layer-3b) instead of
         // this failed user-graph entry (Layer-1 `call_registry.lookup`).
+        //
+        // NARROW-LOWERING HAZARD — the HOST_ENV resolution is faithful ONLY for
+        // the three numeric boxing structs (`W_FloatObject`/`W_IntObject`/
+        // `W_ComplexObject`) that `fuse_boxing_alloc` rewrites to a native
+        // `NewWithVtable` during MIR `simplify_lowered_graph`
+        // (`front/mir.rs:1409`, `model.rs` `payload_fields`) — *before* the
+        // rtyper runs, so a numeric `malloc_typed` never reaches Layer-3b.
+        // Upstream `jtransform.rewrite_op_malloc` (`jtransform.py:1012`) lowers
+        // EVERY mallocable GC struct to `new`/`new_with_vtable`; pyre has not
+        // ported that general path. So an UNFUSED `malloc_typed` (any non-numeric
+        // struct — `W_BytesObject`, `W_UnicodeObject`, the dict family, …)
+        // survives to Layer-3b and resolves to a residual `simple_call` carrying
+        // a symbolic fnaddr the executor cannot run. This is currently LATENT,
+        // not a live miscompile: the production tracer is FBW (non-numeric boxes
+        // run the genuine runtime `malloc_typed` GC helper), and the rtyper op
+        // stream is Path-2 census-only, never the assembled stream. Before any
+        // non-numeric box constructor is promoted toward Path-2 codegen, a
+        // fail-closed guard (the finding's "option (b)") must land FIRST in
+        // `flowspace_adapter::translate_op` — reject a surviving `[.., "lltype",
+        // "malloc_typed"]` `FunctionPath` with a `TyperError` (classified in
+        // `is_known_unported`) so the graph census-Skips to the legacy walker
+        // instead of silently matching a wrong residual call. Tracked by the
+        // boxing-lowering epic (#134/#142).
         if canonical_strip == ["lltype", "malloc_typed"] {
             continue;
         }

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
@@ -1444,6 +1444,23 @@ pub fn build_ll_dict_lookup_helper_graph(
 ///
 /// 8-block CFG plus the returnblock and exceptblock. Both the null-`dict`
 /// guard and the loop-exhausted tail raise `StopIteration` via `exceptblock`.
+///
+/// PORT STATUS — this is the leaf `_ll_dictnext` helper only; it is NOT yet
+/// wired into dict-iterator rtyping. Upstream `AbstractDictIteratorRepr`
+/// (`rdict.py:70-93`) reaches it via `newiter` → `rtype_next`, where
+/// `rtype_next` `gendirectcall`s `self._ll_dictnext`, reads `iter.dict.entries`,
+/// and recasts through `variant_keys/values/items` (`rdict.py:113-148`). None of
+/// that surface is ported: `OrderedDictRepr` does not override
+/// `make_iterator_repr`, and `DictIteratorRepr` overrides no `newiter`/
+/// `rtype_next`, so a dict-iteration graph errors at `make_iterator_repr`
+/// (`MissingRTypeOperation`, a clean census Skip) long before this helper could
+/// run. The only caller today is the unit test below, so the helper is inert
+/// (no production or census reach) — it cannot miscompile. Wiring `rtype_next`
+/// is blocked on the unported ordered-dict runtime: the `ll_dictiter` graph
+/// builder, `get_tuple_result` (tuple-malloc, `rdict.py:95-111`), the
+/// `variant_*` recast helpers, and a working `ll_newdict`/`ll_dict_getitem`/
+/// `ll_dict_setitem` chain (all `ordered_dict_runtime_deferred`). Tracked by the
+/// DictRepr port epic (#140).
 pub fn build_ll_dictnext_helper_graph(
     name: &str,
     iter_ptr_lltype: LowLevelType,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9,32 +9,40 @@ use crate::{
 use pyre_object::*;
 use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
-/// The full byte storage of a memoryview backing, selecting the layout
-/// accessor by concrete kind so a bytes / bytearray / array *subclass*
-/// backing is read through its own fields — `bytes_like_data` exact-branches
-/// on the type and would mis-read a subclass.
-unsafe fn memoryview_backing_slice(backing: PyObjectRef) -> &'static [u8] {
+/// `buffer_w` — select the byte-storage `Buffer` variant for a memoryview
+/// backing by concrete kind, so a bytes / bytearray / array *subclass* backing
+/// is tagged for its own fields (`bytes_like_data` exact-branches on the type
+/// and would mis-read a subclass).  Construction lives here, not in
+/// pyre-object's `Buffer`, because the subclass fallback needs `isinstance_w`.
+unsafe fn memoryview_backing_buffer(backing: PyObjectRef) -> pyre_object::buffer::Buffer {
+    use pyre_object::buffer::Buffer;
     unsafe {
         if pyre_object::interp_array::is_array(backing) {
-            pyre_object::interp_array::w_array_bytes(backing)
+            Buffer::Array { w_obj: backing }
         } else if pyre_object::bytearrayobject::is_bytearray(backing) {
-            pyre_object::bytearrayobject::w_bytearray_data(backing)
+            Buffer::Byte { w_obj: backing }
         } else if pyre_object::bytesobject::is_bytes(backing) {
-            pyre_object::bytesobject::w_bytes_data(backing)
+            Buffer::String { w_obj: backing }
         } else if crate::baseobjspace::isinstance_w(
             backing,
             crate::typedef::gettypeobject(&pyre_object::interp_array::ARRAY_TYPE),
         ) {
-            pyre_object::interp_array::w_array_bytes(backing)
+            Buffer::Array { w_obj: backing }
         } else if crate::baseobjspace::isinstance_w(
             backing,
             crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE),
         ) {
-            pyre_object::bytearrayobject::w_bytearray_data(backing)
+            Buffer::Byte { w_obj: backing }
         } else {
-            pyre_object::bytesobject::w_bytes_data(backing)
+            Buffer::String { w_obj: backing }
         }
     }
+}
+
+/// The full byte storage of a memoryview backing, read through its tagged
+/// `Buffer` variant.
+unsafe fn memoryview_backing_slice(backing: PyObjectRef) -> &'static [u8] {
+    unsafe { memoryview_backing_buffer(backing).as_bytes() }
 }
 
 /// Read element `i` of a memoryview shape/strides tuple as an `i64`.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -91,7 +91,7 @@ unsafe fn w_memoryview_alloc(
         let r_format = pyre_object::gc_roots::shadow_stack_get(sp + 2);
         let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 3);
         let r_strides = pyre_object::gc_roots::shadow_stack_get(sp + 4);
-        let view = pyre_object::bufferview::BufferView {
+        let view = pyre_object::bufferview::BufferView::Strided {
             backing: memoryview_backing_buffer(r_backing),
             w_obj: r_obj,
             w_format: r_format,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -54,86 +54,59 @@ unsafe fn memoryview_dim_value(tuple: PyObjectRef, i: i64) -> i64 {
     }
 }
 
-/// `_copy_base` — push one `isz`-wide element at byte offset `base`, dropping
-/// it when the address falls outside the backing (a reversed / strided slice
-/// past the end), so the gather never panics.
-fn memoryview_copy_base(full: &[u8], base: i64, isz: usize, out: &mut Vec<u8>) {
-    if isz > 0 && base >= 0 && base as usize + isz <= full.len() {
-        let b = base as usize;
-        out.extend_from_slice(&full[b..b + isz]);
-    }
-}
-
-/// `_copy_rec` — recursive C-order copy of dimension `idim`.  The innermost
-/// dimension walks `shape[ndim-1]` elements by `strides[ndim-1]`; an outer
-/// dimension recurses `shape[idim]` times, advancing `off` by `strides[idim]`.
-unsafe fn memoryview_copy_rec(
-    full: &[u8],
-    shape: PyObjectRef,
-    strides: PyObjectRef,
-    ndim: i64,
-    idim: i64,
-    mut off: i64,
-    isz: usize,
-    out: &mut Vec<u8>,
-) {
+/// Build the `BufferView` for a memoryview's current geometry.  A contiguous
+/// single-byte 1-D view takes the `SimpleView` fast path; everything else
+/// (multi-byte, strided, or N-D) becomes a `RawBufferView` carrying its
+/// shape/strides.  Construction lives here — not in pyre-object — because the
+/// backing `Buffer` variant is selected with `isinstance_w`.
+unsafe fn memoryview_view_of(mv: PyObjectRef) -> pyre_object::bufferview::BufferView {
+    use pyre_object::bufferview::BufferView;
+    use pyre_object::memoryview::*;
     unsafe {
-        let dimshape = memoryview_dim_value(shape, idim);
-        let dimstride = memoryview_dim_value(strides, idim);
-        if idim == ndim - 1 {
-            if dimstride == 0 {
-                return;
-            }
-            for _ in 0..dimshape {
-                memoryview_copy_base(full, off, isz, out);
-                off += dimstride;
-            }
-        } else {
-            for _ in 0..dimshape {
-                memoryview_copy_rec(full, shape, strides, ndim, idim + 1, off, isz, out);
-                off += dimstride;
-            }
+        let data = memoryview_backing_buffer(w_memoryview_backing(mv));
+        let itemsize = w_memoryview_itemsize(mv);
+        let ndim = w_memoryview_ndim(mv);
+        let offset = w_memoryview_offset(mv);
+        let length = w_memoryview_length(mv);
+        if itemsize == 1 && ndim == 1 && w_memoryview_stride0(mv) == 1 {
+            return BufferView::Simple {
+                data,
+                offset,
+                length,
+            };
+        }
+        let read_tuple = |t: PyObjectRef| -> Vec<i64> {
+            let n = pyre_object::w_tuple_len(t);
+            (0..n)
+                .map(|i| {
+                    pyre_object::tupleobject::w_tuple_getitem(t, i as i64)
+                        .map(|w| pyre_object::w_int_get_value(w))
+                        .unwrap_or(0)
+                })
+                .collect()
+        };
+        BufferView::Raw {
+            data,
+            itemsize,
+            ndim,
+            offset,
+            length,
+            shape: read_tuple(w_memoryview_shape(mv)),
+            strides: read_tuple(w_memoryview_strides(mv)),
         }
     }
 }
 
 /// The LIVE logical bytes of a view, honouring `offset`/strides/shape so a
 /// strided slice (`m[::2]`, `m[::-1]`) or an N-D view gathers the right
-/// elements in C order (`buffer.py as_str` → `_copy_rec` / `_copy_base`).
-/// Reads the backing object's own storage — no detached copy — so the view
-/// observes later mutation of a bytearray / array source.
+/// elements in C order (`buffer.py as_str`).  Reads the backing object's own
+/// storage — no detached copy — so the view observes later mutation of a
+/// bytearray / array source.
 ///
 /// # Safety
 /// `mv` must point to a valid `W_MemoryView` with a live backing.
 pub(crate) unsafe fn memoryview_gather_bytes(mv: PyObjectRef) -> Vec<u8> {
-    use pyre_object::memoryview::*;
-    unsafe {
-        let backing = w_memoryview_backing(mv);
-        let off = w_memoryview_offset(mv);
-        let itemsize = w_memoryview_itemsize(mv);
-        let length = w_memoryview_length(mv);
-        let ndim = w_memoryview_ndim(mv);
-        let isz = itemsize.max(0) as usize;
-        let full = memoryview_backing_slice(backing);
-        if ndim == 0 {
-            let mut out = Vec::with_capacity(isz);
-            memoryview_copy_base(full, off, isz, &mut out);
-            return out;
-        }
-        let count = if itemsize > 0 { length / itemsize } else { 0 };
-        let mut out = Vec::with_capacity(count.max(0) as usize * isz);
-        memoryview_copy_rec(
-            full,
-            w_memoryview_shape(mv),
-            w_memoryview_strides(mv),
-            ndim,
-            0,
-            off,
-            isz,
-            &mut out,
-        );
-        out
-    }
+    unsafe { memoryview_view_of(mv).gather() }
 }
 
 /// Buffer-acquisition parameters `(format, itemsize, readonly, total_bytes)`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -45,6 +45,29 @@ unsafe fn memoryview_backing_slice(backing: PyObjectRef) -> &'static [u8] {
     unsafe { memoryview_backing_buffer(backing).as_bytes() }
 }
 
+/// Mutable raw byte storage of a writable memoryview backing — `bytearray`
+/// or `array.array`, the two mutable buffer exporters.  `None` for a
+/// read-only exporter (`bytes`) or one without in-place byte storage, so a
+/// write assignment reports "cannot modify read-only memory".
+unsafe fn memoryview_backing_bytes_mut(backing: PyObjectRef) -> Option<&'static mut [u8]> {
+    unsafe {
+        let bytearray_ty =
+            crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE);
+        if pyre_object::bytearrayobject::is_bytearray(backing)
+            || crate::baseobjspace::isinstance_w(backing, bytearray_ty)
+        {
+            return Some(pyre_object::bytearrayobject::w_bytearray_data_mut(backing));
+        }
+        let array_ty = crate::typedef::gettypeobject(&pyre_object::interp_array::ARRAY_TYPE);
+        if pyre_object::interp_array::is_array(backing)
+            || crate::baseobjspace::isinstance_w(backing, array_ty)
+        {
+            return Some(pyre_object::interp_array::w_array_vec_mut(backing).as_mut_slice());
+        }
+        None
+    }
+}
+
 /// Read element `i` of a memoryview shape/strides tuple as an `i64`.
 unsafe fn memoryview_dim_value(tuple: PyObjectRef, i: i64) -> i64 {
     unsafe {
@@ -662,11 +685,7 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             return Err(crate::PyError::type_error("cannot modify read-only memory"));
         }
         let backing = w_memoryview_backing(mv);
-        let bytearray_ty =
-            crate::typedef::gettypeobject(&pyre_object::bytearrayobject::BYTEARRAY_TYPE);
-        if !(pyre_object::bytearrayobject::is_bytearray(backing)
-            || crate::baseobjspace::isinstance_w(backing, bytearray_ty))
-        {
+        if memoryview_backing_bytes_mut(backing).is_none() {
             return Err(crate::PyError::type_error("cannot modify read-only memory"));
         }
         let itemsize = w_memoryview_itemsize(mv);
@@ -702,7 +721,8 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                     "cannot modify size of memoryview object",
                 ));
             }
-            let full = pyre_object::bytearrayobject::w_bytearray_data_mut(backing);
+            let full =
+                memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
             for (k, &idx) in indices.iter().enumerate() {
                 let dst = (offset + idx * stride0) as usize;
                 full[dst..dst + isz].copy_from_slice(&src[k * isz..k * isz + isz]);
@@ -736,7 +756,8 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             let packed = memoryview_pack_value(&fmt, isz, value)?;
             let start = memoryview_start_from_tuple(mv, index)?;
             let addr = (offset + start) as usize;
-            let full = pyre_object::bytearrayobject::w_bytearray_data_mut(backing);
+            let full =
+                memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
             full[addr..addr + isz].copy_from_slice(&packed);
             return Ok(w_none());
         }
@@ -754,7 +775,7 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         }
         let packed = memoryview_pack_value(&fmt, isz, value)?;
         let addr = (offset + i * stride0) as usize;
-        let full = pyre_object::bytearrayobject::w_bytearray_data_mut(backing);
+        let full = memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
         full[addr..addr + isz].copy_from_slice(&packed);
         Ok(w_none())
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -54,46 +54,58 @@ unsafe fn memoryview_dim_value(tuple: PyObjectRef, i: i64) -> i64 {
     }
 }
 
-/// Build the `BufferView` for a memoryview's current geometry.  A contiguous
-/// single-byte 1-D view takes the `SimpleView` fast path; everything else
-/// (multi-byte, strided, or N-D) becomes a `RawBufferView` carrying its
-/// shape/strides.  Construction lives here — not in pyre-object — because the
-/// backing `Buffer` variant is selected with `isinstance_w`.
-unsafe fn memoryview_view_of(mv: PyObjectRef) -> pyre_object::bufferview::BufferView {
-    use pyre_object::bufferview::BufferView;
-    use pyre_object::memoryview::*;
+/// Allocate a `W_MemoryView` over a freshly built off-heap `BufferView`.
+/// Selects the backing `Buffer` variant (needs `isinstance_w`, hence here and
+/// not in pyre-object) and pins every ref across the allocation — building the
+/// box and allocating the object can trigger a collection before the new
+/// memoryview roots them.
+#[allow(clippy::too_many_arguments)]
+unsafe fn w_memoryview_alloc(
+    w_obj: PyObjectRef,
+    w_backing: PyObjectRef,
+    w_format: PyObjectRef,
+    w_shape: PyObjectRef,
+    w_strides: PyObjectRef,
+    itemsize: i64,
+    ndim: i64,
+    offset: i64,
+    length: i64,
+    readonly: bool,
+    released: bool,
+) -> PyObjectRef {
     unsafe {
-        let data = memoryview_backing_buffer(w_memoryview_backing(mv));
-        let itemsize = w_memoryview_itemsize(mv);
-        let ndim = w_memoryview_ndim(mv);
-        let offset = w_memoryview_offset(mv);
-        let length = w_memoryview_length(mv);
-        if itemsize == 1 && ndim == 1 && w_memoryview_stride0(mv) == 1 {
-            return BufferView::Simple {
-                data,
-                offset,
-                length,
-            };
-        }
-        let read_tuple = |t: PyObjectRef| -> Vec<i64> {
-            let n = pyre_object::w_tuple_len(t);
-            (0..n)
-                .map(|i| {
-                    pyre_object::tupleobject::w_tuple_getitem(t, i as i64)
-                        .map(|w| pyre_object::w_int_get_value(w))
-                        .unwrap_or(0)
-                })
-                .collect()
-        };
-        BufferView::Raw {
-            data,
+        let _roots = pyre_object::gc_roots::push_roots();
+        let sp = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_obj);
+        pyre_object::gc_roots::pin_root(w_backing);
+        pyre_object::gc_roots::pin_root(w_format);
+        pyre_object::gc_roots::pin_root(w_shape);
+        pyre_object::gc_roots::pin_root(w_strides);
+        // Allocate the managed header first; old-gen allocation may trigger a
+        // moving collection, so read the relocated refs back from the shadow
+        // stack before building the off-heap view (mirrors `W_TupleObject`
+        // filling its items block from the `pop_roots`-relocated slots).
+        let mv = pyre_object::memoryview::w_memoryview_alloc_header(released);
+        let r_obj = pyre_object::gc_roots::shadow_stack_get(sp);
+        let r_backing = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+        let r_format = pyre_object::gc_roots::shadow_stack_get(sp + 2);
+        let r_shape = pyre_object::gc_roots::shadow_stack_get(sp + 3);
+        let r_strides = pyre_object::gc_roots::shadow_stack_get(sp + 4);
+        let view = pyre_object::bufferview::BufferView {
+            backing: memoryview_backing_buffer(r_backing),
+            w_obj: r_obj,
+            w_format: r_format,
+            w_shape: r_shape,
+            w_strides: r_strides,
             itemsize,
             ndim,
             offset,
             length,
-            shape: read_tuple(w_memoryview_shape(mv)),
-            strides: read_tuple(w_memoryview_strides(mv)),
-        }
+            readonly,
+        };
+        let view_ptr = pyre_object::memoryview::bufferview_alloc(view);
+        pyre_object::memoryview::w_memoryview_set_view(mv, view_ptr);
+        mv
     }
 }
 
@@ -106,7 +118,7 @@ unsafe fn memoryview_view_of(mv: PyObjectRef) -> pyre_object::bufferview::Buffer
 /// # Safety
 /// `mv` must point to a valid `W_MemoryView` with a live backing.
 pub(crate) unsafe fn memoryview_gather_bytes(mv: PyObjectRef) -> Vec<u8> {
-    unsafe { memoryview_view_of(mv).gather() }
+    unsafe { pyre_object::memoryview::w_memoryview_view(mv).gather() }
 }
 
 /// Buffer-acquisition parameters `(format, itemsize, readonly, total_bytes)`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1184,6 +1184,11 @@ fn memoryview_exit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 unsafe fn memoryview_operand_bytes(obj: PyObjectRef) -> Option<Vec<u8>> {
     unsafe {
         if pyre_object::memoryview::is_w_memoryview(obj) {
+            // A released view has no buffer to gather (its box is dropped);
+            // `descr__cmp` falls through to identity, so report no bytes.
+            if pyre_object::memoryview::w_memoryview_released(obj) {
+                return None;
+            }
             return Some(memoryview_gather_bytes(obj));
         }
         if pyre_object::bytesobject::is_bytes_like(obj) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -513,6 +513,24 @@ unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
 /// Custom trace for `W_MemoryView`.  Its geometry and backing live in an
 /// off-heap `*const BufferView` (`memoryview.rs`), so the macro's empty
 /// `gc_ptr_offsets` reach none of the refs the collector must keep alive.
+/// Forward the root exporter `PyObjectRef` of a `Buffer`, descending through
+/// any `Sub` window to the leaf whose exporter actually owns the storage.
+fn trace_buffer_exporter(
+    buf: &mut pyre_object::buffer::Buffer,
+    f: &mut dyn FnMut(*mut majit_ir::GcRef),
+) {
+    match buf {
+        pyre_object::buffer::Buffer::String { w_obj }
+        | pyre_object::buffer::Buffer::Byte { w_obj }
+        | pyre_object::buffer::Buffer::Array { w_obj } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+        }
+        pyre_object::buffer::Buffer::Sub { parent, .. } => {
+            trace_buffer_exporter(parent, f);
+        }
+    }
+}
+
 /// Forward, in place, every `PyObjectRef` the view owns — the `.obj`
 /// exporter, the format / shape / strides objects, and the backing exporter
 /// inside its `Buffer` — exactly as `W_ListObject` walks its off-block
@@ -528,13 +546,7 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
     f(&mut view.w_format as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut view.w_shape as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     f(&mut view.w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    match &mut view.backing {
-        pyre_object::buffer::Buffer::String { w_obj }
-        | pyre_object::buffer::Buffer::Byte { w_obj }
-        | pyre_object::buffer::Buffer::Array { w_obj } => {
-            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-        }
-    }
+    trace_buffer_exporter(&mut view.backing, f);
 }
 
 /// RPython jitexc.py:53 ContinueRunningNormally parity.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -560,6 +560,22 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
     }
 }
 
+/// Reclaim the off-heap `BufferView` box (and any nested `Buffer::Sub`
+/// boxes it owns, via `Box`'s recursive drop glue) when a dead
+/// `W_MemoryView` header is swept.  The custom trace only keeps the box's
+/// `PyObjectRef`s alive while the header lives; without this the
+/// `std::alloc` box would leak on every memoryview / slice / cast that
+/// dies.  `release()` only flips the `released` flag (it does not null
+/// `view`), so the box is always freed here at header death; the null
+/// guard covers the brief header-allocated-before-`set_view` window.
+unsafe fn memoryview_object_destructor(obj_addr: usize) {
+    let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
+    let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;
+    if !view_ptr.is_null() {
+        drop(unsafe { Box::from_raw(view_ptr) });
+    }
+}
+
 /// RPython jitexc.py:53 ContinueRunningNormally parity.
 pub(crate) enum LoopResult {
     Done(PyResult),
@@ -2005,19 +2021,25 @@ thread_local! {
         // `*const BufferView`, so the macro's empty `gc_ptr_offsets` reach
         // none of the view's refs; register a custom trace
         // (`memoryview_object_custom_trace`) that walks the box, mirroring
-        // `W_ListObject` / `W_TupleObject`.  Absent from `all_foreign_pytypes`,
-        // so this is the only path that GC-manages it.  Registered at the tail
-        // of the tid chain so no earlier explicit-id / hardcoded-constant slot
+        // `W_ListObject` / `W_TupleObject`, plus a lightweight destructor
+        // (`memoryview_object_destructor`) that frees the `std::alloc` box
+        // itself when a dead header is swept so repeated view/slice/cast
+        // churn does not leak.  Absent from `all_foreign_pytypes`, so this is
+        // the only path that GC-manages it.  Registered at the tail of the
+        // tid chain so no earlier explicit-id / hardcoded-constant slot
         // shifts; this replicates `register_pyre_class`'s tid stamp /
         // vtable / `pytype_to_tid` wiring with the custom-trace `TypeInfo`.
         {
             let mv_descr = <pyre_object::memoryview::W_MemoryView
                 as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
-            let mv_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
-                mv_descr.object_size,
-                object_tid,
-                memoryview_object_custom_trace,
-            ));
+            let mv_tid = gc.register_type(
+                TypeInfo::object_subclass_with_custom_trace(
+                    mv_descr.object_size,
+                    object_tid,
+                    memoryview_object_custom_trace,
+                )
+                .with_destructor_fn(memoryview_object_destructor),
+            );
             mv_descr.gc_type_id.set(mv_tid);
             majit_gc::GcAllocator::register_vtable_for_type(
                 &mut gc,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -542,11 +542,22 @@ unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut
         return;
     }
     let view = unsafe { &mut *view_ptr };
-    f(&mut view.w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    f(&mut view.w_format as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    f(&mut view.w_shape as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    f(&mut view.w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
-    trace_buffer_exporter(&mut view.backing, f);
+    match view {
+        pyre_object::bufferview::BufferView::Strided {
+            backing,
+            w_obj,
+            w_format,
+            w_shape,
+            w_strides,
+            ..
+        } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_format as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_shape as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            f(w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+            trace_buffer_exporter(backing, f);
+        }
+    }
 }
 
 /// RPython jitexc.py:53 ContinueRunningNormally parity.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -510,6 +510,33 @@ unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit
     }
 }
 
+/// Custom trace for `W_MemoryView`.  Its geometry and backing live in an
+/// off-heap `*const BufferView` (`memoryview.rs`), so the macro's empty
+/// `gc_ptr_offsets` reach none of the refs the collector must keep alive.
+/// Forward, in place, every `PyObjectRef` the view owns — the `.obj`
+/// exporter, the format / shape / strides objects, and the backing exporter
+/// inside its `Buffer` — exactly as `W_ListObject` walks its off-block
+/// elements.  The box is `std::alloc` stationary, so `view` never moves.
+unsafe fn memoryview_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let mv = obj_addr as *const pyre_object::memoryview::W_MemoryView;
+    let view_ptr = unsafe { (*mv).view } as *mut pyre_object::bufferview::BufferView;
+    if view_ptr.is_null() {
+        return;
+    }
+    let view = unsafe { &mut *view_ptr };
+    f(&mut view.w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut view.w_format as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut view.w_shape as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut view.w_strides as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    match &mut view.backing {
+        pyre_object::buffer::Buffer::String { w_obj }
+        | pyre_object::buffer::Buffer::Byte { w_obj }
+        | pyre_object::buffer::Buffer::Array { w_obj } => {
+            f(w_obj as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+        }
+    }
+}
+
 /// RPython jitexc.py:53 ContinueRunningNormally parity.
 pub(crate) enum LoopResult {
     Done(PyResult),
@@ -1950,18 +1977,32 @@ thread_local! {
             <pyre_object::interp_array::W_Array
                 as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
         );
-        // W_MemoryView (`memoryview`) — typed payload via `#[pyre_class]`
-        // in AUTO-ID mode; its five `PyObjectRef` fields (obj / backing /
-        // format / shape / strides) are traced edges the collector must
-        // walk.  Absent from `all_foreign_pytypes`, so this is the only
-        // path that GC-manages it.  Registered at the tail of the tid chain
-        // so no earlier explicit-id / hardcoded-constant slot shifts.
-        register_pyre_class(
-            &mut gc,
-            &mut pytype_to_tid,
-            <pyre_object::memoryview::W_MemoryView
-                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
-        );
+        // W_MemoryView (`memoryview`) — typed payload via `#[pyre_class]` in
+        // AUTO-ID mode.  Its geometry and backing live in an off-heap
+        // `*const BufferView`, so the macro's empty `gc_ptr_offsets` reach
+        // none of the view's refs; register a custom trace
+        // (`memoryview_object_custom_trace`) that walks the box, mirroring
+        // `W_ListObject` / `W_TupleObject`.  Absent from `all_foreign_pytypes`,
+        // so this is the only path that GC-manages it.  Registered at the tail
+        // of the tid chain so no earlier explicit-id / hardcoded-constant slot
+        // shifts; this replicates `register_pyre_class`'s tid stamp /
+        // vtable / `pytype_to_tid` wiring with the custom-trace `TypeInfo`.
+        {
+            let mv_descr = <pyre_object::memoryview::W_MemoryView
+                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+            let mv_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
+                mv_descr.object_size,
+                object_tid,
+                memoryview_object_custom_trace,
+            ));
+            mv_descr.gc_type_id.set(mv_tid);
+            majit_gc::GcAllocator::register_vtable_for_type(
+                &mut gc,
+                mv_descr.pytype_ptr as usize,
+                mv_tid,
+            );
+            pytype_to_tid.insert(mv_descr.pytype_ptr as usize, mv_tid);
+        }
         // Raw `BigInt` payload backing every `W_LongObject.value` (and the JIT
         // `jit_w_long_*_raw` results). Not an `rclass.OBJECT` instance — a bare
         // payload with no gc-pointer fields (malachite's limb `Vec` is off-GC),

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -108,7 +108,13 @@ mod tests {
 
     #[test]
     fn sub_wraps_a_leaf_buffer() {
-        match Buffer::sub(Buffer::String { w_obj: fake(0x1000) }, 2, 5) {
+        match Buffer::sub(
+            Buffer::String {
+                w_obj: fake(0x1000),
+            },
+            2,
+            5,
+        ) {
             Buffer::Sub {
                 parent,
                 offset,
@@ -125,7 +131,9 @@ mod tests {
     fn sub_over_sub_collapses_to_depth_one() {
         // `SubBuffer.__init__` (buffer.py:397): the offsets sum and the parent
         // is the inner buffer, so the wrapper never nests.
-        let leaf = Buffer::Byte { w_obj: fake(0x2000) };
+        let leaf = Buffer::Byte {
+            w_obj: fake(0x2000),
+        };
         let nested = Buffer::sub(Buffer::sub(leaf, 2, 5), 1, 3);
         match nested {
             Buffer::Sub {
@@ -143,7 +151,17 @@ mod tests {
 
     #[test]
     fn sub_over_sub_clamps_size_to_inner_window() {
-        let nested = Buffer::sub(Buffer::sub(Buffer::Array { w_obj: fake(0x3000) }, 4, 6), 2, 100);
+        let nested = Buffer::sub(
+            Buffer::sub(
+                Buffer::Array {
+                    w_obj: fake(0x3000),
+                },
+                4,
+                6,
+            ),
+            2,
+            100,
+        );
         match nested {
             Buffer::Sub { offset, size, .. } => assert_eq!((offset, size), (6, 4)), // 4+2, 6-2
             _ => panic!("expected Sub"),
@@ -152,7 +170,13 @@ mod tests {
 
     #[test]
     fn w_obj_recurses_through_sub_to_the_root_exporter() {
-        let s = Buffer::sub(Buffer::Array { w_obj: fake(0x4000) }, 1, 2);
+        let s = Buffer::sub(
+            Buffer::Array {
+                w_obj: fake(0x4000),
+            },
+            1,
+            2,
+        );
         assert_eq!(s.w_obj(), fake(0x4000));
     }
 }

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -1,0 +1,39 @@
+//! Byte-storage layer for the buffer protocol — the pyre analogue of
+//! `rpython/rlib/buffer.py`'s `Buffer` hierarchy.
+//!
+//! Each variant tags the concrete exporter, so a byte read dispatches to that
+//! exporter's own storage accessor and a `bytes`/`bytearray`/`array` *subclass*
+//! is read through its own fields.  The concrete kind is decided once, at
+//! construction time, by the objspace-level `buffer_w` — which lives in the
+//! interpreter crate because picking the variant needs `isinstance_w`, a
+//! dependency pyre-object must not take.  The `memoryview` `BufferView` /
+//! `W_MemoryView` layers sit on top of this.
+
+use crate::pyobject::PyObjectRef;
+
+/// Flat byte storage behind a buffer-protocol exporter.
+pub enum Buffer {
+    /// `bytes` — read-only (`StringBuffer`).
+    String { w_obj: PyObjectRef },
+    /// `bytearray` — mutable (`ByteBuffer`).
+    Byte { w_obj: PyObjectRef },
+    /// `array.array` — its raw element bytes.
+    Array { w_obj: PyObjectRef },
+}
+
+impl Buffer {
+    /// The full byte storage of the exporter (`getlength` is its `.len()`).
+    ///
+    /// # Safety
+    /// The variant's `w_obj` must point to a live object of the tagged kind.
+    #[inline]
+    pub unsafe fn as_bytes(&self) -> &'static [u8] {
+        unsafe {
+            match self {
+                Buffer::String { w_obj } => crate::bytesobject::w_bytes_data(*w_obj),
+                Buffer::Byte { w_obj } => crate::bytearrayobject::w_bytearray_data(*w_obj),
+                Buffer::Array { w_obj } => crate::interp_array::w_array_bytes(*w_obj),
+            }
+        }
+    }
+}

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -22,6 +22,14 @@ pub enum Buffer {
 }
 
 impl Buffer {
+    /// The exporter object whose storage this buffer reads/writes.
+    #[inline]
+    pub fn w_obj(&self) -> PyObjectRef {
+        match self {
+            Buffer::String { w_obj } | Buffer::Byte { w_obj } | Buffer::Array { w_obj } => *w_obj,
+        }
+    }
+
     /// The full byte storage of the exporter (`getlength` is its `.len()`).
     ///
     /// # Safety

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -22,11 +22,14 @@ pub enum Buffer {
     /// A `[offset, offset+size)` window over another `Buffer` (`SubBuffer`,
     /// `rpython/rlib/buffer.py:389`).  Sub-buffers never nest — see [`sub`].
     ///
+    /// `size` is signed: a negative value (canonically `-1`) means "up to the
+    /// end of the parent" (`buffer.py:398`), so it cannot be a `usize`.
+    ///
     /// [`sub`]: Buffer::sub
     Sub {
         parent: Box<Buffer>,
         offset: usize,
-        size: usize,
+        size: i64,
     },
 }
 
@@ -34,19 +37,32 @@ impl Buffer {
     /// `SubBuffer(parent, offset, size)` (`rpython/rlib/buffer.py:389`).  A
     /// `Sub` over a `Sub` is collapsed to a single window over the inner
     /// buffer (`buffer.py:397` — "don't nest them"): the offsets sum and the
-    /// size clamps to the inner window, so the wrapper depth never exceeds 1.
-    pub fn sub(parent: Buffer, offset: usize, size: usize) -> Buffer {
+    /// outer window clamps to the inner one, so the wrapper depth never
+    /// exceeds 1.  A negative `size` means "up to the end" (`buffer.py:398`);
+    /// when the inner window is itself unbounded (`inner_size < 0`) the outer
+    /// `size` is carried through unchanged, otherwise it is clamped to the
+    /// bytes remaining in the inner window (`buffer.py:399-403`).
+    pub fn sub(parent: Buffer, offset: usize, size: i64) -> Buffer {
         match parent {
             Buffer::Sub {
                 parent: inner,
                 offset: inner_off,
                 size: inner_size,
             } => {
-                let at_most = inner_size.saturating_sub(offset);
+                let size = if inner_size < 0 {
+                    size
+                } else {
+                    let at_most = (inner_size - offset as i64).max(0);
+                    if size < 0 || size > at_most {
+                        at_most
+                    } else {
+                        size
+                    }
+                };
                 Buffer::Sub {
                     parent: inner,
                     offset: inner_off + offset,
-                    size: size.min(at_most),
+                    size,
                 }
             }
             other => Buffer::Sub {
@@ -86,10 +102,18 @@ impl Buffer {
                     offset,
                     size,
                 } => {
+                    // `SubBuffer.getlength` (buffer.py:411): the window is the
+                    // requested `size` clamped to the bytes remaining after
+                    // `offset`, with a negative `size` meaning "to the end".
                     let full = parent.as_bytes();
                     let off = (*offset).min(full.len());
-                    let end = off.saturating_add(*size).min(full.len());
-                    &full[off..end]
+                    let at_most = full.len() - off;
+                    let length = if *size >= 0 && (*size as usize) <= at_most {
+                        *size as usize
+                    } else {
+                        at_most
+                    };
+                    &full[off..off + length]
                 }
             }
         }
@@ -164,6 +188,32 @@ mod tests {
         );
         match nested {
             Buffer::Sub { offset, size, .. } => assert_eq!((offset, size), (6, 4)), // 4+2, 6-2
+            _ => panic!("expected Sub"),
+        }
+    }
+
+    #[test]
+    fn sub_to_end_sentinel_carries_through_unbounded_inner() {
+        // A negative size means "up to the end" (buffer.py:398); over an
+        // unbounded inner window the outer sentinel is carried through.
+        let leaf = Buffer::String {
+            w_obj: fake(0x5000),
+        };
+        match Buffer::sub(Buffer::sub(leaf, 2, -1), 3, -1) {
+            Buffer::Sub { offset, size, .. } => assert_eq!((offset, size), (5, -1)), // 2+3, -1
+            _ => panic!("expected Sub"),
+        }
+    }
+
+    #[test]
+    fn sub_to_end_resolves_over_bounded_inner() {
+        // Outer "to the end" (-1) over a bounded inner window resolves to the
+        // inner remainder (buffer.py:399-403).
+        let leaf = Buffer::Byte {
+            w_obj: fake(0x6000),
+        };
+        match Buffer::sub(Buffer::sub(leaf, 1, 8), 2, -1) {
+            Buffer::Sub { offset, size, .. } => assert_eq!((offset, size), (3, 6)), // 1+2, 8-2
             _ => panic!("expected Sub"),
         }
     }

--- a/pyre/pyre-object/src/buffer.rs
+++ b/pyre/pyre-object/src/buffer.rs
@@ -19,18 +19,58 @@ pub enum Buffer {
     Byte { w_obj: PyObjectRef },
     /// `array.array` — its raw element bytes.
     Array { w_obj: PyObjectRef },
+    /// A `[offset, offset+size)` window over another `Buffer` (`SubBuffer`,
+    /// `rpython/rlib/buffer.py:389`).  Sub-buffers never nest — see [`sub`].
+    ///
+    /// [`sub`]: Buffer::sub
+    Sub {
+        parent: Box<Buffer>,
+        offset: usize,
+        size: usize,
+    },
 }
 
 impl Buffer {
-    /// The exporter object whose storage this buffer reads/writes.
+    /// `SubBuffer(parent, offset, size)` (`rpython/rlib/buffer.py:389`).  A
+    /// `Sub` over a `Sub` is collapsed to a single window over the inner
+    /// buffer (`buffer.py:397` — "don't nest them"): the offsets sum and the
+    /// size clamps to the inner window, so the wrapper depth never exceeds 1.
+    pub fn sub(parent: Buffer, offset: usize, size: usize) -> Buffer {
+        match parent {
+            Buffer::Sub {
+                parent: inner,
+                offset: inner_off,
+                size: inner_size,
+            } => {
+                let at_most = inner_size.saturating_sub(offset);
+                Buffer::Sub {
+                    parent: inner,
+                    offset: inner_off + offset,
+                    size: size.min(at_most),
+                }
+            }
+            other => Buffer::Sub {
+                parent: Box::new(other),
+                offset,
+                size,
+            },
+        }
+    }
+
+    /// The root exporter object whose storage this buffer reads/writes; a
+    /// `Sub` reports its parent's exporter (`SubBuffer` has no `.obj` of its
+    /// own).
     #[inline]
     pub fn w_obj(&self) -> PyObjectRef {
         match self {
             Buffer::String { w_obj } | Buffer::Byte { w_obj } | Buffer::Array { w_obj } => *w_obj,
+            Buffer::Sub { parent, .. } => parent.w_obj(),
         }
     }
 
-    /// The full byte storage of the exporter (`getlength` is its `.len()`).
+    /// The byte storage this buffer exposes (`getlength` is its `.len()`).  A
+    /// `Sub` is the `[offset, offset+size)` window of its parent, clamped to
+    /// the parent's live length (`SubBuffer.getlength`, `buffer.py:413`).
     ///
     /// # Safety
     /// The variant's `w_obj` must point to a live object of the tagged kind.
@@ -41,7 +81,78 @@ impl Buffer {
                 Buffer::String { w_obj } => crate::bytesobject::w_bytes_data(*w_obj),
                 Buffer::Byte { w_obj } => crate::bytearrayobject::w_bytearray_data(*w_obj),
                 Buffer::Array { w_obj } => crate::interp_array::w_array_bytes(*w_obj),
+                Buffer::Sub {
+                    parent,
+                    offset,
+                    size,
+                } => {
+                    let full = parent.as_bytes();
+                    let off = (*offset).min(full.len());
+                    let end = off.saturating_add(*size).min(full.len());
+                    &full[off..end]
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `w_obj` / `sub` never dereference the exporter, so a fake address is a
+    // valid stand-in for the geometry-only tests below.
+    fn fake(addr: usize) -> PyObjectRef {
+        addr as PyObjectRef
+    }
+
+    #[test]
+    fn sub_wraps_a_leaf_buffer() {
+        match Buffer::sub(Buffer::String { w_obj: fake(0x1000) }, 2, 5) {
+            Buffer::Sub {
+                parent,
+                offset,
+                size,
+            } => {
+                assert_eq!((offset, size), (2, 5));
+                assert!(matches!(*parent, Buffer::String { .. }));
+            }
+            _ => panic!("expected Sub"),
+        }
+    }
+
+    #[test]
+    fn sub_over_sub_collapses_to_depth_one() {
+        // `SubBuffer.__init__` (buffer.py:397): the offsets sum and the parent
+        // is the inner buffer, so the wrapper never nests.
+        let leaf = Buffer::Byte { w_obj: fake(0x2000) };
+        let nested = Buffer::sub(Buffer::sub(leaf, 2, 5), 1, 3);
+        match nested {
+            Buffer::Sub {
+                parent,
+                offset,
+                size,
+            } => {
+                assert_eq!((offset, size), (3, 3)); // 2+1, min(3, 5-1)
+                assert!(matches!(*parent, Buffer::Byte { .. }));
+                assert_eq!(parent.w_obj(), fake(0x2000));
+            }
+            _ => panic!("expected collapsed Sub"),
+        }
+    }
+
+    #[test]
+    fn sub_over_sub_clamps_size_to_inner_window() {
+        let nested = Buffer::sub(Buffer::sub(Buffer::Array { w_obj: fake(0x3000) }, 4, 6), 2, 100);
+        match nested {
+            Buffer::Sub { offset, size, .. } => assert_eq!((offset, size), (6, 4)), // 4+2, 6-2
+            _ => panic!("expected Sub"),
+        }
+    }
+
+    #[test]
+    fn w_obj_recurses_through_sub_to_the_root_exporter() {
+        let s = Buffer::sub(Buffer::Array { w_obj: fake(0x4000) }, 1, 2);
+        assert_eq!(s.w_obj(), fake(0x4000));
     }
 }

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -1,0 +1,123 @@
+//! View layer for the buffer protocol — the pyre analogue of
+//! `pypy/interpreter/buffer.py`'s `BufferView` hierarchy.  A `BufferView`
+//! carries the geometry (offset / shape / strides) over a byte-level
+//! [`Buffer`] and gathers the live logical bytes in C order, honouring a
+//! strided or N-D layout, without detaching a copy of the backing.
+//!
+//! `memoryview`'s `W_MemoryView` sits on top of this; the format-aware
+//! element pack/unpack (`value_from_bytes` / `bytes_from_value`) is added in
+//! a later slice.
+
+use crate::buffer::Buffer;
+
+/// `_copy_base` — push one `isz`-wide element at byte offset `base`, dropping
+/// it when the address falls outside the backing (a reversed / strided slice
+/// past the end), so the gather never panics.
+fn copy_base(full: &[u8], base: i64, isz: usize, out: &mut Vec<u8>) {
+    if isz > 0 && base >= 0 && base as usize + isz <= full.len() {
+        let b = base as usize;
+        out.extend_from_slice(&full[b..b + isz]);
+    }
+}
+
+/// `_copy_rec` — recursive C-order copy of dimension `idim`.  The innermost
+/// dimension walks `shape[ndim-1]` elements by `strides[ndim-1]`; an outer
+/// dimension recurses `shape[idim]` times, advancing `off` by `strides[idim]`.
+fn copy_rec(
+    full: &[u8],
+    shape: &[i64],
+    strides: &[i64],
+    ndim: i64,
+    idim: i64,
+    mut off: i64,
+    isz: usize,
+    out: &mut Vec<u8>,
+) {
+    let dimshape = shape.get(idim as usize).copied().unwrap_or(0);
+    let dimstride = strides.get(idim as usize).copied().unwrap_or(0);
+    if idim == ndim - 1 {
+        if dimstride == 0 {
+            return;
+        }
+        for _ in 0..dimshape {
+            copy_base(full, off, isz, out);
+            off += dimstride;
+        }
+    } else {
+        for _ in 0..dimshape {
+            copy_rec(full, shape, strides, ndim, idim + 1, off, isz, out);
+            off += dimstride;
+        }
+    }
+}
+
+/// A view of a [`Buffer`]'s bytes with offset / shape / stride geometry.
+pub enum BufferView {
+    /// Contiguous single-byte 1-D view (`SimpleView`): the logical bytes are
+    /// a direct `offset..offset+length` window of the backing.
+    Simple {
+        data: Buffer,
+        offset: i64,
+        length: i64,
+    },
+    /// Format / shape / stride-aware view (`RawBufferView`): the logical
+    /// bytes are gathered in C order across `shape` by `strides`, so a
+    /// strided slice (`m[::2]`, `m[::-1]`) or an N-D view reads the right
+    /// elements.
+    Raw {
+        data: Buffer,
+        itemsize: i64,
+        ndim: i64,
+        offset: i64,
+        length: i64,
+        shape: Vec<i64>,
+        strides: Vec<i64>,
+    },
+}
+
+impl BufferView {
+    /// The LIVE logical bytes of the view (`buffer.py as_str`), read from the
+    /// backing object's own storage — no detached copy — so the view observes
+    /// later mutation of a bytearray / array source.
+    ///
+    /// # Safety
+    /// The backing [`Buffer`]'s `w_obj` must point to a live object of its
+    /// tagged kind.
+    pub unsafe fn gather(&self) -> Vec<u8> {
+        unsafe {
+            match self {
+                BufferView::Simple {
+                    data,
+                    offset,
+                    length,
+                } => {
+                    let full = data.as_bytes();
+                    let mut out = Vec::with_capacity((*length).max(0) as usize);
+                    copy_rec(full, &[*length], &[1], 1, 0, *offset, 1, &mut out);
+                    out
+                }
+                BufferView::Raw {
+                    data,
+                    itemsize,
+                    ndim,
+                    offset,
+                    length,
+                    shape,
+                    strides,
+                } => {
+                    let full = data.as_bytes();
+                    let isz = (*itemsize).max(0) as usize;
+                    if *ndim == 0 {
+                        let mut out = Vec::with_capacity(isz);
+                        copy_base(full, *offset, isz, &mut out);
+                        return out;
+                    }
+                    let count = if *itemsize > 0 { *length / *itemsize } else { 0 };
+                    let mut out = Vec::with_capacity(count.max(0) as usize * isz);
+                    copy_rec(full, shape, strides, *ndim, 0, *offset, isz, &mut out);
+                    out
+                }
+            }
+        }
+    }
+}

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -75,27 +75,106 @@ unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
 
 /// A view of a [`Buffer`]'s bytes with offset / shape / stride geometry and a
 /// buffer-protocol format.
-pub struct BufferView {
-    /// Byte storage actually read / written (the root exporter's buffer).
-    pub backing: Buffer,
-    /// The exporter reported by `memoryview.obj` — coincides with the backing
-    /// for a plain view, but a chained cast / slice keeps the root storage in
-    /// `backing` while `w_obj` still reports the original exporter.
-    pub w_obj: PyObjectRef,
-    /// Format string object (`memoryview.format`).
-    pub w_format: PyObjectRef,
-    /// Shape tuple (`memoryview.shape`).
-    pub w_shape: PyObjectRef,
-    /// Strides tuple (`memoryview.strides`).
-    pub w_strides: PyObjectRef,
-    pub itemsize: i64,
-    pub ndim: i64,
-    pub offset: i64,
-    pub length: i64,
-    pub readonly: bool,
+///
+/// PyPy splits this into a class hierarchy — `SimpleView` / `RawBufferView`
+/// (1-D), `BufferSlice` (strided), `BufferView1D` / `BufferViewND` (cast) —
+/// each carrying only the state it needs and deriving the rest.  The single
+/// [`Strided`](BufferView::Strided) variant is the general case that holds
+/// every geometry field explicitly; the specialised variants peel off in
+/// later slices, each routing its own constructor and deriving geometry
+/// GC-safely.
+pub enum BufferView {
+    /// General strided / N-dimensional view over the root [`Buffer`], carrying
+    /// absolute `offset` / `shape` / `strides` geometry.
+    Strided {
+        /// Byte storage actually read / written (the root exporter's buffer).
+        backing: Buffer,
+        /// The exporter reported by `memoryview.obj` — coincides with the
+        /// backing for a plain view, but a chained cast / slice keeps the root
+        /// storage in `backing` while `w_obj` still reports the original
+        /// exporter.
+        w_obj: PyObjectRef,
+        /// Format string object (`memoryview.format`).
+        w_format: PyObjectRef,
+        /// Shape tuple (`memoryview.shape`).
+        w_shape: PyObjectRef,
+        /// Strides tuple (`memoryview.strides`).
+        w_strides: PyObjectRef,
+        itemsize: i64,
+        ndim: i64,
+        offset: i64,
+        length: i64,
+        readonly: bool,
+    },
 }
 
 impl BufferView {
+    /// The backing byte storage (the root exporter's [`Buffer`]).
+    #[inline]
+    pub fn backing(&self) -> &Buffer {
+        match self {
+            BufferView::Strided { backing, .. } => backing,
+        }
+    }
+    /// The exporter reported by `memoryview.obj`.
+    #[inline]
+    pub fn w_obj(&self) -> PyObjectRef {
+        match self {
+            BufferView::Strided { w_obj, .. } => *w_obj,
+        }
+    }
+    /// Format string object (`memoryview.format`).
+    #[inline]
+    pub fn w_format(&self) -> PyObjectRef {
+        match self {
+            BufferView::Strided { w_format, .. } => *w_format,
+        }
+    }
+    /// Shape tuple (`memoryview.shape`).
+    #[inline]
+    pub fn w_shape(&self) -> PyObjectRef {
+        match self {
+            BufferView::Strided { w_shape, .. } => *w_shape,
+        }
+    }
+    /// Strides tuple (`memoryview.strides`).
+    #[inline]
+    pub fn w_strides(&self) -> PyObjectRef {
+        match self {
+            BufferView::Strided { w_strides, .. } => *w_strides,
+        }
+    }
+    #[inline]
+    pub fn itemsize(&self) -> i64 {
+        match self {
+            BufferView::Strided { itemsize, .. } => *itemsize,
+        }
+    }
+    #[inline]
+    pub fn ndim(&self) -> i64 {
+        match self {
+            BufferView::Strided { ndim, .. } => *ndim,
+        }
+    }
+    #[inline]
+    pub fn offset(&self) -> i64 {
+        match self {
+            BufferView::Strided { offset, .. } => *offset,
+        }
+    }
+    #[inline]
+    pub fn length(&self) -> i64 {
+        match self {
+            BufferView::Strided { length, .. } => *length,
+        }
+    }
+    #[inline]
+    pub fn readonly(&self) -> bool {
+        match self {
+            BufferView::Strided { readonly, .. } => *readonly,
+        }
+    }
+
     /// The LIVE logical bytes of the view (`buffer.py as_str`), read from the
     /// backing object's own storage — no detached copy — so the view observes
     /// later mutation of a bytearray / array source.  Honours offset / shape /
@@ -107,22 +186,32 @@ impl BufferView {
     /// tagged kind.
     pub unsafe fn gather(&self) -> Vec<u8> {
         unsafe {
-            let full = self.backing.as_bytes();
-            let isz = self.itemsize.max(0) as usize;
-            if self.ndim == 0 {
+            let BufferView::Strided {
+                backing,
+                w_shape,
+                w_strides,
+                itemsize,
+                ndim,
+                offset,
+                length,
+                ..
+            } = self;
+            let full = backing.as_bytes();
+            let isz = (*itemsize).max(0) as usize;
+            if *ndim == 0 {
                 let mut out = Vec::with_capacity(isz);
-                copy_base(full, self.offset, isz, &mut out);
+                copy_base(full, *offset, isz, &mut out);
                 return out;
             }
-            let shape = read_dims(self.w_shape);
-            let strides = read_dims(self.w_strides);
-            let count = if self.itemsize > 0 {
-                self.length / self.itemsize
+            let shape = read_dims(*w_shape);
+            let strides = read_dims(*w_strides);
+            let count = if *itemsize > 0 {
+                *length / *itemsize
             } else {
                 0
             };
             let mut out = Vec::with_capacity(count.max(0) as usize * isz);
-            copy_rec(full, &shape, &strides, self.ndim, 0, self.offset, isz, &mut out);
+            copy_rec(full, &shape, &strides, *ndim, 0, *offset, isz, &mut out);
             out
         }
     }

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -1,14 +1,19 @@
 //! View layer for the buffer protocol — the pyre analogue of
-//! `pypy/interpreter/buffer.py`'s `BufferView` hierarchy.  A `BufferView`
-//! carries the geometry (offset / shape / strides) over a byte-level
+//! `pypy/interpreter/buffer.py`'s `BufferView`.  A `BufferView` carries the
+//! geometry (offset / shape / strides / format / itemsize) over a byte-level
 //! [`Buffer`] and gathers the live logical bytes in C order, honouring a
 //! strided or N-D layout, without detaching a copy of the backing.
 //!
-//! `memoryview`'s `W_MemoryView` sits on top of this; the format-aware
-//! element pack/unpack (`value_from_bytes` / `bytes_from_value`) is added in
-//! a later slice.
+//! `memoryview`'s `W_MemoryView` holds one of these off the GC heap; the GC
+//! reaches the refs inside (the backing exporter, the `.obj` exporter, and
+//! the format / shape / strides objects) through `W_MemoryView`'s custom
+//! trace.  The format / shape / strides ride as their Python objects so the
+//! `W_MemoryView` accessors stay pure reads; lowering them to native Rust
+//! `str` / `Vec` (the `SimpleView` / `RawBufferView` subclass split) is a
+//! later slice.
 
 use crate::buffer::Buffer;
+use crate::pyobject::PyObjectRef;
 
 /// `_copy_base` — push one `isz`-wide element at byte offset `base`, dropping
 /// it when the address falls outside the backing (a reversed / strided slice
@@ -51,73 +56,74 @@ fn copy_rec(
     }
 }
 
-/// A view of a [`Buffer`]'s bytes with offset / shape / stride geometry.
-pub enum BufferView {
-    /// Contiguous single-byte 1-D view (`SimpleView`): the logical bytes are
-    /// a direct `offset..offset+length` window of the backing.
-    Simple {
-        data: Buffer,
-        offset: i64,
-        length: i64,
-    },
-    /// Format / shape / stride-aware view (`RawBufferView`): the logical
-    /// bytes are gathered in C order across `shape` by `strides`, so a
-    /// strided slice (`m[::2]`, `m[::-1]`) or an N-D view reads the right
-    /// elements.
-    Raw {
-        data: Buffer,
-        itemsize: i64,
-        ndim: i64,
-        offset: i64,
-        length: i64,
-        shape: Vec<i64>,
-        strides: Vec<i64>,
-    },
+/// Read a `tuple[int]` (shape or strides) into a native vector.
+///
+/// # Safety
+/// `t` must point to a valid tuple of ints.
+unsafe fn read_dims(t: PyObjectRef) -> Vec<i64> {
+    unsafe {
+        let n = crate::tupleobject::w_tuple_len(t);
+        (0..n)
+            .map(|i| {
+                crate::tupleobject::w_tuple_getitem(t, i as i64)
+                    .map(|w| crate::intobject::w_int_get_value(w))
+                    .unwrap_or(0)
+            })
+            .collect()
+    }
+}
+
+/// A view of a [`Buffer`]'s bytes with offset / shape / stride geometry and a
+/// buffer-protocol format.
+pub struct BufferView {
+    /// Byte storage actually read / written (the root exporter's buffer).
+    pub backing: Buffer,
+    /// The exporter reported by `memoryview.obj` — coincides with the backing
+    /// for a plain view, but a chained cast / slice keeps the root storage in
+    /// `backing` while `w_obj` still reports the original exporter.
+    pub w_obj: PyObjectRef,
+    /// Format string object (`memoryview.format`).
+    pub w_format: PyObjectRef,
+    /// Shape tuple (`memoryview.shape`).
+    pub w_shape: PyObjectRef,
+    /// Strides tuple (`memoryview.strides`).
+    pub w_strides: PyObjectRef,
+    pub itemsize: i64,
+    pub ndim: i64,
+    pub offset: i64,
+    pub length: i64,
+    pub readonly: bool,
 }
 
 impl BufferView {
     /// The LIVE logical bytes of the view (`buffer.py as_str`), read from the
     /// backing object's own storage — no detached copy — so the view observes
-    /// later mutation of a bytearray / array source.
+    /// later mutation of a bytearray / array source.  Honours offset / shape /
+    /// strides so a strided slice (`m[::2]`, `m[::-1]`) or an N-D view gathers
+    /// the right elements in C order.
     ///
     /// # Safety
     /// The backing [`Buffer`]'s `w_obj` must point to a live object of its
     /// tagged kind.
     pub unsafe fn gather(&self) -> Vec<u8> {
         unsafe {
-            match self {
-                BufferView::Simple {
-                    data,
-                    offset,
-                    length,
-                } => {
-                    let full = data.as_bytes();
-                    let mut out = Vec::with_capacity((*length).max(0) as usize);
-                    copy_rec(full, &[*length], &[1], 1, 0, *offset, 1, &mut out);
-                    out
-                }
-                BufferView::Raw {
-                    data,
-                    itemsize,
-                    ndim,
-                    offset,
-                    length,
-                    shape,
-                    strides,
-                } => {
-                    let full = data.as_bytes();
-                    let isz = (*itemsize).max(0) as usize;
-                    if *ndim == 0 {
-                        let mut out = Vec::with_capacity(isz);
-                        copy_base(full, *offset, isz, &mut out);
-                        return out;
-                    }
-                    let count = if *itemsize > 0 { *length / *itemsize } else { 0 };
-                    let mut out = Vec::with_capacity(count.max(0) as usize * isz);
-                    copy_rec(full, shape, strides, *ndim, 0, *offset, isz, &mut out);
-                    out
-                }
+            let full = self.backing.as_bytes();
+            let isz = self.itemsize.max(0) as usize;
+            if self.ndim == 0 {
+                let mut out = Vec::with_capacity(isz);
+                copy_base(full, self.offset, isz, &mut out);
+                return out;
             }
+            let shape = read_dims(self.w_shape);
+            let strides = read_dims(self.w_strides);
+            let count = if self.itemsize > 0 {
+                self.length / self.itemsize
+            } else {
+                0
+            };
+            let mut out = Vec::with_capacity(count.max(0) as usize * isz);
+            copy_rec(full, &shape, &strides, self.ndim, 0, self.offset, isz, &mut out);
+            out
         }
     }
 }

--- a/pyre/pyre-object/src/lib.rs
+++ b/pyre/pyre-object/src/lib.rs
@@ -11,6 +11,7 @@ pub use pyre_macros::pyre_class;
 pub mod _pypy_generic_alias;
 pub mod boolobject;
 pub mod buffer;
+pub mod bufferview;
 pub mod bytearrayobject;
 pub mod bytesobject;
 pub mod celldict;

--- a/pyre/pyre-object/src/lib.rs
+++ b/pyre/pyre-object/src/lib.rs
@@ -10,6 +10,7 @@ pub use pyre_macros::pyre_class;
 
 pub mod _pypy_generic_alias;
 pub mod boolobject;
+pub mod buffer;
 pub mod bytearrayobject;
 pub mod bytesobject;
 pub mod celldict;

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -1,89 +1,95 @@
-//! Native `memoryview` object — a flattened port of PyPy's
-//! `W_MemoryView` (`pypy/objspace/std/memoryobject.py`) over its
-//! interp-level `BufferView` (`pypy/interpreter/buffer.py`).
+//! Native `memoryview` object — `W_MemoryView`
+//! (`pypy/objspace/std/memoryobject.py`) over a [`BufferView`]
+//! (`pypy/interpreter/buffer.py`) over a byte-level
+//! [`Buffer`](crate::buffer::Buffer) (`rpython/rlib/buffer.py`).
 //!
-//! PyPy splits the view across two layers (`W_MemoryView` → `BufferView`
-//! → byte-level `Buffer`) for RPython's type system; at runtime the
-//! behaviour is a single view over a byte backing, so this collapses both
-//! layers into one `#[pyre_class]` struct (the same blessed structural
-//! adaptation as the other native collapses).  The struct holds only
-//! `PyObjectRef` + scalar fields so the GC tracer reaches every reference
-//! through the macro-derived `ptr_offsets`; shape/strides ride as Python
-//! tuple objects rather than inline `Vec`s.
+//! `W_MemoryView` holds an off-heap `*const BufferView`; the view carries the
+//! geometry plus the backing `Buffer`, so the three layers stay distinct
+//! rather than collapsed into one struct.  Byte access reads/writes the LIVE
+//! backing object through the view's `Buffer` — no copy — so a view observes
+//! later mutations of its source and writes through to it.
 //!
-//! Byte access reads/writes the LIVE backing object (`w_backing`) through
-//! the existing accessors — no copy — so a view observes later mutations
-//! to its source and writes through to it, fixing the dict-stub's
-//! detached-`to_vec` staleness bug.
+//! Because the refs the collector must keep alive (the backing exporter, the
+//! `.obj` exporter, the format / shape / strides objects) live *inside* the
+//! off-heap view rather than as inline `PyObjectRef` fields, the macro-derived
+//! `ptr_offsets` cannot reach them; the JIT driver registers
+//! `memoryview_object_custom_trace` (`pyre-jit/src/eval.rs`) to walk the view,
+//! mirroring `W_ListObject` / `W_TupleObject`'s off-block trace.
 
+use crate::bufferview::BufferView;
 use crate::pyobject::*;
 use pyre_macros::pyre_class;
 
-/// A `memoryview` over a contiguous byte backing.
-///
-/// `w_obj` is the original exporter (the `.obj` property); `w_backing` is
-/// the object actually read/written (bytes / bytearray / array.array) —
-/// for a plain view the two coincide, but a chained cast/slice keeps
-/// `w_backing` pinned to the root storage while `w_obj` still reports the
-/// exporter.  `offset`/`length` bound the live byte window inside
-/// `w_backing`; `w_shape`/`w_strides` are `tuple[int]` (1-D: `(count,)` /
-/// `(itemsize,)`).  `released` flips on `release()` / context-manager exit.
+/// A `memoryview` — a view over a byte backing, behind an off-heap
+/// [`BufferView`].
 #[pyre_class("memoryview", static_name = "MEMORYVIEW")]
 pub struct W_MemoryView {
-    pub w_obj: PyObjectRef,
-    pub w_backing: PyObjectRef,
-    pub w_format: PyObjectRef,
-    pub w_shape: PyObjectRef,
-    pub w_strides: PyObjectRef,
-    pub itemsize: i64,
-    pub ndim: i64,
-    pub offset: i64,
-    pub length: i64,
-    pub readonly: bool,
+    /// `self.view` (`memoryobject.py`).  Never null for a live memoryview; the
+    /// geometry and backing live here, off the GC heap, reached by the custom
+    /// trace.
+    pub view: *const BufferView,
+    /// Flips on `release()` / context-manager exit.
     pub released: bool,
 }
 
-/// Allocate a `W_MemoryView` from already-acquired view parameters.  Every
-/// `PyObjectRef` is pinned before `allocate`, which can trigger a
-/// collection that would otherwise move/free a ref held only in a Rust
-/// local (mirrors `w_range_new`).
-#[allow(clippy::too_many_arguments)]
-pub fn w_memoryview_alloc(
-    w_obj: PyObjectRef,
-    w_backing: PyObjectRef,
-    w_format: PyObjectRef,
-    w_shape: PyObjectRef,
-    w_strides: PyObjectRef,
-    itemsize: i64,
-    ndim: i64,
-    offset: i64,
-    length: i64,
-    readonly: bool,
-    released: bool,
-) -> PyObjectRef {
-    let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_obj);
-    crate::gc_roots::pin_root(w_backing);
-    crate::gc_roots::pin_root(w_format);
-    crate::gc_roots::pin_root(w_shape);
-    crate::gc_roots::pin_root(w_strides);
-    W_MemoryView::allocate(W_MemoryView {
+/// Allocate a [`BufferView`] off the GC heap (a stationary `Box`, like a
+/// list's `ItemsBlock`).  The collector reaches its refs through
+/// `memoryview_object_custom_trace` and never moves the box.
+pub fn bufferview_alloc(view: BufferView) -> *const BufferView {
+    Box::into_raw(Box::new(view)) as *const BufferView
+}
+
+/// Allocate the `W_MemoryView` header in GC old-gen with no view attached
+/// yet (mirrors `w_set_new` allocating an empty body).
+///
+/// Old-gen (`try_gc_alloc_stable`, non-moving mark-sweep) so the object
+/// carries `TRACK_YOUNG_PTRS` and `memoryview_object_custom_trace` runs on a
+/// minor collection once the header sits in the remembered set — without
+/// that, the managed `format` / `shape` / `strides` objects reachable only
+/// through the view's off-heap box would be swept.  Allocating the header
+/// *before* the ref-bearing box keeps no half-built box alive across the
+/// collection this call may trigger: the caller re-reads its pinned refs
+/// from the shadow stack (post-relocation) and attaches the box with
+/// [`w_memoryview_set_view`].  Falls back to `malloc_typed` when no GC hook
+/// is installed (unit tests).
+pub fn w_memoryview_alloc_header(released: bool) -> PyObjectRef {
+    let payload = W_MemoryView {
         ob: PyObject {
-            ob_type: std::ptr::null(),
-            w_class: std::ptr::null_mut(),
+            ob_type: &MEMORYVIEW_TYPE as *const PyType,
+            w_class: crate::pyobject::get_instantiate(&MEMORYVIEW_TYPE),
         },
-        w_obj,
-        w_backing,
-        w_format,
-        w_shape,
-        w_strides,
-        itemsize,
-        ndim,
-        offset,
-        length,
-        readonly,
+        view: std::ptr::null(),
         released,
-    })
+    };
+    match crate::gc_hook::try_gc_alloc_stable(
+        <W_MemoryView as crate::lltype::GcType>::type_id(),
+        <W_MemoryView as crate::lltype::GcType>::SIZE,
+    )
+    .filter(|p| !p.is_null())
+    {
+        Some(raw) => {
+            unsafe { std::ptr::write(raw as *mut W_MemoryView, payload) };
+            raw as PyObjectRef
+        }
+        None => crate::lltype::malloc_typed(payload) as PyObjectRef,
+    }
+}
+
+/// Attach the off-heap view to a header from [`w_memoryview_alloc_header`]
+/// and fire the GC write barrier so the old-gen `W_MemoryView` enters the
+/// remembered set; `memoryview_object_custom_trace` then forwards the view's
+/// refs on the next minor collection.  Mirrors `set_write_barrier` after a
+/// store into a set's off-heap items.
+///
+/// # Safety
+/// `mv` must point to a `W_MemoryView` from [`w_memoryview_alloc_header`] and
+/// `view` to a live [`bufferview_alloc`] box whose `PyObjectRef`s are already
+/// the post-collection (relocated) pointers.
+pub unsafe fn w_memoryview_set_view(mv: PyObjectRef, view: *const BufferView) {
+    unsafe {
+        (*(mv as *mut W_MemoryView)).view = view;
+    }
+    crate::gc_hook::try_gc_write_barrier(mv as *mut u8);
 }
 
 /// # Safety
@@ -93,38 +99,63 @@ pub unsafe fn is_w_memoryview(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &MEMORYVIEW_TYPE) }
 }
 
-macro_rules! mv_obj_accessor {
+/// The off-heap view backing `obj`.
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView` whose `view` is live (true for
+/// any memoryview before its box is dropped; `release()` only flips the flag).
+#[inline]
+pub unsafe fn w_memoryview_view(obj: PyObjectRef) -> &'static BufferView {
+    unsafe { &*(*(obj as *const W_MemoryView)).view }
+}
+
+macro_rules! mv_view_obj {
     ($name:ident, $field:ident) => {
         /// # Safety
         /// `obj` must point to a valid `W_MemoryView`.
         #[inline]
         pub unsafe fn $name(obj: PyObjectRef) -> PyObjectRef {
-            unsafe { (*(obj as *const W_MemoryView)).$field }
+            unsafe { w_memoryview_view(obj).$field }
         }
     };
 }
-macro_rules! mv_scalar_accessor {
+macro_rules! mv_view_scalar {
     ($name:ident, $field:ident, $ty:ty) => {
         /// # Safety
         /// `obj` must point to a valid `W_MemoryView`.
         #[inline]
         pub unsafe fn $name(obj: PyObjectRef) -> $ty {
-            unsafe { (*(obj as *const W_MemoryView)).$field }
+            unsafe { w_memoryview_view(obj).$field }
         }
     };
 }
 
-mv_obj_accessor!(w_memoryview_obj, w_obj);
-mv_obj_accessor!(w_memoryview_backing, w_backing);
-mv_obj_accessor!(w_memoryview_format, w_format);
-mv_obj_accessor!(w_memoryview_shape, w_shape);
-mv_obj_accessor!(w_memoryview_strides, w_strides);
-mv_scalar_accessor!(w_memoryview_itemsize, itemsize, i64);
-mv_scalar_accessor!(w_memoryview_ndim, ndim, i64);
-mv_scalar_accessor!(w_memoryview_offset, offset, i64);
-mv_scalar_accessor!(w_memoryview_length, length, i64);
-mv_scalar_accessor!(w_memoryview_readonly, readonly, bool);
-mv_scalar_accessor!(w_memoryview_released, released, bool);
+/// The exporter actually read/written (bytes / bytearray / array.array) — the
+/// `.obj` of the root storage.
+///
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_backing(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { w_memoryview_view(obj).backing.w_obj() }
+}
+
+mv_view_obj!(w_memoryview_obj, w_obj);
+mv_view_obj!(w_memoryview_format, w_format);
+mv_view_obj!(w_memoryview_shape, w_shape);
+mv_view_obj!(w_memoryview_strides, w_strides);
+mv_view_scalar!(w_memoryview_itemsize, itemsize, i64);
+mv_view_scalar!(w_memoryview_ndim, ndim, i64);
+mv_view_scalar!(w_memoryview_offset, offset, i64);
+mv_view_scalar!(w_memoryview_length, length, i64);
+mv_view_scalar!(w_memoryview_readonly, readonly, bool);
+
+/// # Safety
+/// `obj` must point to a valid `W_MemoryView`.
+#[inline]
+pub unsafe fn w_memoryview_released(obj: PyObjectRef) -> bool {
+    unsafe { (*(obj as *const W_MemoryView)).released }
+}
 
 /// Mark the view released.  `released` is an inline scalar, so no write
 /// barrier is needed (a barrier guards `PyObjectRef` stores only).
@@ -143,19 +174,15 @@ pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
 /// slice (`m[::2]`, `m[::-1]`) carries `parent_stride * step`, possibly
 /// negative.  Falls back to `itemsize` when the tuple is unexpectedly empty.
 ///
-/// Byte gathering that honours this stride lives in the interpreter crate
-/// (`builtins::memoryview_gather_bytes`) because a subclass-safe backing
-/// read needs `isinstance_w`, which pyre-object must not depend on.
-///
 /// # Safety
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_stride0(obj: PyObjectRef) -> i64 {
     unsafe {
-        let strides = (*(obj as *const W_MemoryView)).w_strides;
-        match crate::tupleobject::w_tuple_getitem(strides, 0) {
+        let view = w_memoryview_view(obj);
+        match crate::tupleobject::w_tuple_getitem(view.w_strides, 0) {
             Some(s) => crate::intobject::w_int_get_value(s),
-            None => (*(obj as *const W_MemoryView)).itemsize,
+            None => view.itemsize,
         }
     }
 }

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -110,22 +110,22 @@ pub unsafe fn w_memoryview_view(obj: PyObjectRef) -> &'static BufferView {
 }
 
 macro_rules! mv_view_obj {
-    ($name:ident, $field:ident) => {
+    ($name:ident, $accessor:ident) => {
         /// # Safety
         /// `obj` must point to a valid `W_MemoryView`.
         #[inline]
         pub unsafe fn $name(obj: PyObjectRef) -> PyObjectRef {
-            unsafe { w_memoryview_view(obj).$field }
+            unsafe { w_memoryview_view(obj).$accessor() }
         }
     };
 }
 macro_rules! mv_view_scalar {
-    ($name:ident, $field:ident, $ty:ty) => {
+    ($name:ident, $accessor:ident, $ty:ty) => {
         /// # Safety
         /// `obj` must point to a valid `W_MemoryView`.
         #[inline]
         pub unsafe fn $name(obj: PyObjectRef) -> $ty {
-            unsafe { w_memoryview_view(obj).$field }
+            unsafe { w_memoryview_view(obj).$accessor() }
         }
     };
 }
@@ -137,7 +137,7 @@ macro_rules! mv_view_scalar {
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_backing(obj: PyObjectRef) -> PyObjectRef {
-    unsafe { w_memoryview_view(obj).backing.w_obj() }
+    unsafe { w_memoryview_view(obj).backing().w_obj() }
 }
 
 mv_view_obj!(w_memoryview_obj, w_obj);
@@ -180,9 +180,9 @@ pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
 pub unsafe fn w_memoryview_stride0(obj: PyObjectRef) -> i64 {
     unsafe {
         let view = w_memoryview_view(obj);
-        match crate::tupleobject::w_tuple_getitem(view.w_strides, 0) {
+        match crate::tupleobject::w_tuple_getitem(view.w_strides(), 0) {
             Some(s) => crate::intobject::w_int_get_value(s),
-            None => view.itemsize,
+            None => view.itemsize(),
         }
     }
 }

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -102,8 +102,10 @@ pub unsafe fn is_w_memoryview(obj: PyObjectRef) -> bool {
 /// The off-heap view backing `obj`.
 ///
 /// # Safety
-/// `obj` must point to a valid `W_MemoryView` whose `view` is live (true for
-/// any memoryview before its box is dropped; `release()` only flips the flag).
+/// `obj` must point to a valid `W_MemoryView` whose `view` is live.  Once
+/// `w_memoryview_set_released` drops the box and nulls `view`, this
+/// dereferences a null pointer — every accessor must gate on
+/// `w_memoryview_released` first (as the interpreter methods do).
 #[inline]
 pub unsafe fn w_memoryview_view(obj: PyObjectRef) -> &'static BufferView {
     unsafe { &*(*(obj as *const W_MemoryView)).view }
@@ -157,15 +159,27 @@ pub unsafe fn w_memoryview_released(obj: PyObjectRef) -> bool {
     unsafe { (*(obj as *const W_MemoryView)).released }
 }
 
-/// Mark the view released.  `released` is an inline scalar, so no write
-/// barrier is needed (a barrier guards `PyObjectRef` stores only).
+/// Release the view: drop the off-heap `BufferView` box (reclaiming any
+/// nested `Buffer::Sub` boxes through `Box`'s recursive drop glue) and null
+/// `view`, then flip `released`.  Mirrors `descr_release` clearing
+/// `self.view = None` (`memoryobject.py`) so the backing / view graph is
+/// dropped eagerly on release rather than lingering until the header is
+/// GC-collected.  Idempotent: a second call finds `view` already null.  The
+/// `released` flag is an inline scalar, so no write barrier is needed (a
+/// barrier guards `PyObjectRef` stores only).
 ///
 /// # Safety
 /// `obj` must point to a valid `W_MemoryView`.
 #[inline]
 pub unsafe fn w_memoryview_set_released(obj: PyObjectRef) {
     unsafe {
-        (*(obj as *mut W_MemoryView)).released = true;
+        let mv = obj as *mut W_MemoryView;
+        let view_ptr = (*mv).view as *mut BufferView;
+        if !view_ptr.is_null() {
+            drop(Box::from_raw(view_ptr));
+            (*mv).view = std::ptr::null();
+        }
+        (*mv).released = true;
     }
 }
 


### PR DESCRIPTION
refs #97

Eight commits on `charon` beyond `main`: the memoryview de-flatten (5) and three rtyper/annotator lowering fixes (3). All landed gate-green and verified at the branch tip (`check.py` dynasm 160/160 + cranelift 160/160 ×2, GC-stress + `builtin_memoryview.py` on both backends, `cargo test -p pyre-object`).

## memoryview: de-flatten into `W_MemoryView → BufferView → Buffer`

Re-aligns the native `memoryview` to PyPy's three-layer structure (`pypy/objspace/std/memoryobject.py` → `pypy/interpreter/buffer.py` → `rpython/rlib/buffer.py`), replacing the single flat `#[pyre_class]` struct.

- **`01df8764c12` Buffer byte-storage layer** — `Buffer` enum {String/Byte/Array} + `as_bytes`; `memoryview_backing_slice` routes through it by variant tag. The `buffer_w` constructor (needs `isinstance_w`) stays in the interpreter crate, mirroring PyPy's rlib-Buffer / objspace-`buffer_w` split.
- **`9843fe6f8fd` BufferView gather layer** — the offset/stride/shape C-order copy extracted onto `BufferView`.
- **`7d9dd67d20c` off-heap BufferView with GC custom-trace** — `W_MemoryView` holds a `*const BufferView`; the header is GC-managed (`try_gc_alloc_stable` + write barrier, like `w_set_new`) so the custom trace keeps the backing / format / shape / strides reachable through the off-heap box across a collection.
- **`cecd5e3979e` `Buffer::Sub` window variant** — `Sub { parent: Box<Buffer>, offset, size }` (`SubBuffer`, `buffer.py:389`) with offset-summing nesting-collapse and a recursive trace arm. Inert (no constructor yet); confirms charon lowers the `Box<Self>` recursion as a concrete ADT.
- **`3c7282fcf7c` BufferView 1-variant enum scaffold** — `struct BufferView` → `enum { Strided {…} }` with reader methods; same layout / behaviour, the scaffold for the faithful `Simple` / `Raw` / `Slice` / `View1D` / `ViewND` class split.

## rtyper / annotator lowering fixes

- **`a7cda3b1ac7`** document `malloc_typed` narrow-lowering + `_ll_dictnext` unwired.
- **`298cac4e9f2`** stamp `dont_look_inside` `FUNC.RESULT` into `return_type`.
- **`27d10d40802`** shell a scalar-pointee raw-ptr field as a conservative `Ref` in the annotator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)