### PR TITLE
memoryview/bytearray review follow-ups (#291)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
  "rustpython-wtf8",
  "siphasher",
  "stacker",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ vecset = "0.0.4"
 vecmap_rs = { package = "vecmap-rs", version = "0.2.4", features = ["serde"] }
 indexmap = "2.14"
 paste = "1"
+unicode-xid = "0.2"
 
 # serde
 serde = { version = "1", features = ["derive"] }

--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3856,6 +3856,13 @@ impl Repr for InstanceRepr {
             //              self.classdef: raise TyperError(...)`.
             //   Subclass-relationship check; self must be a base of the
             //   value's class.
+            // When `self.classdef` is None — the root `object` InstanceRepr,
+            // which pyre's `Ref(None)` erasure lands a known-class constant on
+            // — upstream `classdef.commonbase(self.classdef)` returns None (the
+            // `while other is not None` loop exits immediately), so `None !=
+            // None` is false and the delegate path below applies
+            // unconditionally: the root is a base of every class. Only run the
+            // subclass-relationship guard for a concrete `self.classdef`.
             if let Some(self_cd) = self.classdef.as_ref() {
                 let common = ClassDef::commonbase(&classdef, self_cd).ok_or_else(|| {
                     TyperError::message(format!(

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -40,6 +40,7 @@ siphasher = { workspace = true }
 caseless = { workspace = true }
 indexmap = { workspace = true }
 paste = { workspace = true }
+unicode-xid = { workspace = true }
 # Decompresses the embedded stdlib VFS blob at runtime (wasm_vfs). Decode-only,
 # no_std-compatible safe path; the encode side is unused here.
 lz4_flex = { version = "0.13", default-features = false, features = [

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2326,10 +2326,12 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     if is_slice(index) {
         return setitem_bytearray_slice(obj, index, value);
     }
-    if !is_int(index) {
+    // `bytearray_ass_subscript` accepts any `__index__` operand for the index,
+    // not only an exact int; a non-index, non-slice key is the TypeError.
+    if !pyre_object::pyobject::is_int_or_long(index) && lookup(index, "__index__").is_none() {
         return Err(index_type_error("bytearray", index));
     }
-    let idx = w_int_get_value(index);
+    let idx = getindex_w(index)?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
@@ -2395,13 +2397,22 @@ unsafe fn bytearray_assign_source(value: PyObjectRef) -> Result<Vec<u8>, PyError
     if let Some(src) = crate::typedef::buffer_as_bytes_like(value)? {
         return Ok(pyre_object::bytesobject::bytes_like_data(src).to_vec());
     }
-    let cannot = || {
-        PyError::type_error("can assign only bytes, buffers, or iterables of ints in range(0, 256)")
-    };
-    if is_str(value) {
-        return Err(cannot());
+    // A `str` or index operand (`= "x"` / `= 5`) is the common mis-assignment
+    // → the "can assign only ..." hint; any other non-iterable is "cannot convert".
+    if is_str(value)
+        || pyre_object::pyobject::is_int_or_long(value)
+        || lookup(value, "__index__").is_some()
+    {
+        return Err(PyError::type_error(
+            "can assign only bytes, buffers, or iterables of ints in range(0, 256)",
+        ));
     }
-    let items = crate::builtins::collect_iterable(value).map_err(|_| cannot())?;
+    let items = crate::builtins::collect_iterable(value).map_err(|_| {
+        PyError::type_error(format!(
+            "cannot convert '{}' object to bytearray",
+            object_functionstr_type_name(value),
+        ))
+    })?;
     let mut out = Vec::with_capacity(items.len());
     for it in items {
         out.push(bytearray_byte_value(it)?);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2331,9 +2331,15 @@ unsafe fn bytearray_index(index: PyObjectRef) -> Result<i64, PyError> {
     }
     match int_w(space_index(index)?) {
         Ok(i) => Ok(i),
+        // `baseobjspace.py getindex_w` — an index that overflows a machine
+        // word reports the *source* object's type, `oefmt("cannot fit '%T'
+        // into an index-sized integer", w_obj)`, not the coerced `int`.
         Err(e) if e.kind == PyErrorKind::OverflowError => Err(PyError::new(
             PyErrorKind::IndexError,
-            "cannot fit 'int' into an index-sized integer",
+            format!(
+                "cannot fit '{}' into an index-sized integer",
+                object_functionstr_type_name(index)
+            ),
         )),
         Err(e) => Err(e),
     }
@@ -2420,15 +2426,32 @@ unsafe fn bytearray_assign_source(value: PyObjectRef) -> Result<Vec<u8>, PyError
             "can assign only bytes, buffers, or iterables of ints in range(0, 256)",
         ));
     }
-    let items = crate::builtins::collect_iterable(value).map_err(|_| {
-        PyError::type_error(format!(
-            "cannot convert '{}' object to bytearray",
-            object_functionstr_type_name(value),
-        ))
-    })?;
-    let mut out = Vec::with_capacity(items.len());
-    for it in items {
-        out.push(bytearray_byte_value(it)?);
+    // `_from_byte_sequence` / `_from_byte_sequence_loop` — iterate the source,
+    // converting and range-checking each item as it is pulled
+    // (`builder.append(space.byte_w(w_item))` per element), so a bad byte or a
+    // raising `__next__` surfaces at once without draining the rest (an
+    // infinite iterator that yields a bad byte still fails immediately).  A
+    // source with no `__iter__` is the non-iterable "cannot convert" case; an
+    // error raised *by* `__iter__`/`__next__` propagates unchanged.
+    let it = match crate::baseobjspace::iter(value) {
+        Ok(it) => it,
+        Err(e) => {
+            if lookup(value, "__iter__").is_none() {
+                return Err(PyError::type_error(format!(
+                    "cannot convert '{}' object to bytearray",
+                    object_functionstr_type_name(value),
+                )));
+            }
+            return Err(e);
+        }
+    };
+    let mut out = Vec::new();
+    loop {
+        match crate::baseobjspace::next(it) {
+            Ok(w_item) => out.push(bytearray_byte_value(w_item)?),
+            Err(e) if e.kind == PyErrorKind::StopIteration => break,
+            Err(e) => return Err(e),
+        }
     }
     Ok(out)
 }
@@ -2442,10 +2465,13 @@ unsafe fn setitem_bytearray_slice(
     index: PyObjectRef,
     value: PyObjectRef,
 ) -> PyResult {
+    // `descr_setitem` materializes the source (`makebytesdata_w`) *before*
+    // unpacking the slice: `__iter__`/`__next__` may mutate the bytearray, so
+    // the slice bounds must be read from the post-materialization length.
+    // (`x[:] = x` stays safe — the source is copied into `sequence2`.)
+    let sequence2 = bytearray_assign_source(value)?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let (start, stop, step) = normalize_slice(index, len)?;
-    // Materialize the source before mutating so `x[:] = x` is safe.
-    let sequence2 = bytearray_assign_source(value)?;
     let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(obj);
     if step == 1 {
         let cur = vec.len();

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11236,7 +11236,10 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
             }
         }
     }
-    // Fallback: try iterating with getitem(obj, i) for i=0,1,...
+    // Fallback: `space.sequence_contains` — scan via getitem(obj, i) for
+    // i = 0, 1, ….  An `IndexError` ends the scan (not found); any other
+    // error (e.g. a released/non-contiguous memoryview) propagates, matching
+    // `PySequence_Contains`.
     let mut i = 0i64;
     loop {
         match getitem(haystack, pyre_object::w_int_new(i)) {
@@ -11246,7 +11249,8 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                 }
                 i += 1;
             }
-            Err(_) => return Ok(false), // IndexError → not found
+            Err(e) if e.kind == PyErrorKind::IndexError => return Ok(false),
+            Err(e) => return Err(e),
         }
     }
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2355,6 +2355,10 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
         // The index bounds are checked first, matching `bytearray_ass_subscript`.
+        // `space.byte_w` inlined here, not called: the JIT-hot setitem path
+        // trips the codewriter's Int↔Ref kind-provenance check when it flows
+        // through the shared helper.  Same semantics — `__index__` coercion via
+        // `space.index`, then the `0 <= v < 256` range enforcement.
         let v = if is_int(value) {
             w_int_get_value(value)
         } else {
@@ -2384,9 +2388,11 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     ))
 }
 
-/// `bytearrayobject.py _getbytevalue` — coerce a value to a single byte:
-/// honor `__index__`, then enforce the `0 <= v < 256` rule.
-unsafe fn bytearray_byte_value(value: PyObjectRef) -> Result<u8, PyError> {
+/// `space.byte_w` (`bytearrayobject.py _getbytevalue` / `bytesobject.py
+/// _from_byte_sequence_loop`) — coerce a value to a single byte: honor
+/// `__index__`, then enforce `0 <= v < 256`.  `noun` selects the divergent
+/// range-error text — "byte" for bytearray, "bytes" for the bytes constructor.
+pub(crate) unsafe fn byte_w(value: PyObjectRef, noun: &str) -> Result<u8, PyError> {
     let v = if is_int(value) {
         w_int_get_value(value)
     } else {
@@ -2398,12 +2404,14 @@ unsafe fn bytearray_byte_value(value: PyObjectRef) -> Result<u8, PyError> {
             // necessarily outside 0..256 → the ValueError below.
             match i64::try_from(w_long_get_value(indexed)) {
                 Ok(v) => v,
-                Err(_) => return Err(PyError::value_error("byte must be in range(0, 256)")),
+                Err(_) => {
+                    return Err(PyError::value_error(format!("{noun} must be in range(0, 256)")));
+                }
             }
         }
     };
     if !(0..=255).contains(&v) {
-        return Err(PyError::value_error("byte must be in range(0, 256)"));
+        return Err(PyError::value_error(format!("{noun} must be in range(0, 256)")));
     }
     Ok(v as u8)
 }
@@ -2448,7 +2456,7 @@ unsafe fn bytearray_assign_source(value: PyObjectRef) -> Result<Vec<u8>, PyError
     let mut out = Vec::new();
     loop {
         match crate::baseobjspace::next(it) {
-            Ok(w_item) => out.push(bytearray_byte_value(w_item)?),
+            Ok(w_item) => out.push(byte_w(w_item, "byte")?),
             Err(e) if e.kind == PyErrorKind::StopIteration => break,
             Err(e) => return Err(e),
         }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2350,36 +2350,15 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     if is_slice(index) {
         return setitem_bytearray_slice(obj, index, value);
     }
+    // `descr_setitem`: getindex_w(index) → byte_w(value) → _fixindex(idx).  The
+    // value is coerced to a byte *before* the index bounds are checked, so
+    // `ba[oob] = bad` raises the value's TypeError/ValueError, not IndexError.
     let idx = bytearray_index(index)?;
+    let v = byte_w(value, "byte")?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
-        // The index bounds are checked first, matching `bytearray_ass_subscript`.
-        // `space.byte_w` inlined here, not called: the JIT-hot setitem path
-        // trips the codewriter's Int↔Ref kind-provenance check when it flows
-        // through the shared helper.  Same semantics — `__index__` coercion via
-        // `space.index`, then the `0 <= v < 256` range enforcement.
-        let v = if is_int(value) {
-            w_int_get_value(value)
-        } else {
-            let indexed = space_index(value)?;
-            if is_int(indexed) {
-                w_int_get_value(indexed)
-            } else {
-                // `space.index` may yield a long; one that overflows i64
-                // is necessarily outside 0..256 → the ValueError below.
-                let big = w_long_get_value(indexed);
-                if pyre_object::longobject::jit_bigint_to_i64_fits(big) != 0 {
-                    pyre_object::longobject::jit_bigint_to_i64_value(big)
-                } else {
-                    return Err(PyError::value_error("byte must be in range(0, 256)"));
-                }
-            }
-        };
-        if !(0..=255).contains(&v) {
-            return Err(PyError::value_error("byte must be in range(0, 256)"));
-        }
-        pyre_object::bytearrayobject::w_bytearray_setitem(obj, actual as usize, v as u8);
+        pyre_object::bytearrayobject::w_bytearray_setitem(obj, actual as usize, v);
         return Ok(w_none());
     }
     Err(PyError::new(

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -11344,6 +11344,63 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
         if is_dict(obj) {
             return dict_delitem(obj, index);
         }
+        // `bytearrayobject.py` ass_subscript with a NULL value deletes like a
+        // list: a single index removes one byte, a slice removes its selected
+        // bytes (contiguous via drain, extended-step descending).  Slice bounds
+        // are computed before the mutable borrow since `normalize_slice` may
+        // run `__index__` that re-enters.
+        if pyre_object::bytearrayobject::is_bytearray(obj) {
+            if is_int(index) {
+                let i = w_int_get_value(index);
+                let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
+                let idx = if i < 0 { len + i } else { i };
+                if idx >= 0 && idx < len {
+                    pyre_object::bytearrayobject::w_bytearray_vec_mut(obj).remove(idx as usize);
+                    return Ok(());
+                }
+                return Err(PyError::new(
+                    PyErrorKind::IndexError,
+                    "bytearray index out of range",
+                ));
+            }
+            if is_slice(index) {
+                let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
+                let (start, stop, step) = normalize_slice(index, len)?;
+                let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(obj);
+                if step == 1 {
+                    let s = start.max(0) as usize;
+                    let e = stop.max(start).min(vec.len() as i64) as usize;
+                    vec.drain(s..e);
+                    return Ok(());
+                }
+                let mut indices: Vec<i64> = Vec::new();
+                let mut i = start;
+                if step > 0 {
+                    while i < stop {
+                        indices.push(i);
+                        i += step;
+                    }
+                } else {
+                    while i > stop {
+                        indices.push(i);
+                        i += step;
+                    }
+                }
+                indices.sort_unstable_by(|a, b| b.cmp(a));
+                for idx in indices {
+                    if idx >= 0 && idx < vec.len() as i64 {
+                        vec.remove(idx as usize);
+                    }
+                }
+                return Ok(());
+            }
+        }
+        // memoryview never supports deletion; `memoryview_delitem` reports the
+        // released / read-only / "cannot delete memory" error in order.
+        if pyre_object::memoryview::is_w_memoryview(obj) {
+            crate::builtins::memoryview_delitem(&[obj, index])?;
+            return Ok(());
+        }
     }
     // Instance __delitem__ — PyPy: descroperation.py delitem.  Errors from
     // user `__delitem__` propagate (PyPy `space.delitem` raises directly);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2405,13 +2405,17 @@ pub(crate) unsafe fn byte_w(value: PyObjectRef, noun: &str) -> Result<u8, PyErro
             match i64::try_from(w_long_get_value(indexed)) {
                 Ok(v) => v,
                 Err(_) => {
-                    return Err(PyError::value_error(format!("{noun} must be in range(0, 256)")));
+                    return Err(PyError::value_error(format!(
+                        "{noun} must be in range(0, 256)"
+                    )));
                 }
             }
         }
     };
     if !(0..=255).contains(&v) {
-        return Err(PyError::value_error(format!("{noun} must be in range(0, 256)")));
+        return Err(PyError::value_error(format!(
+            "{noun} must be in range(0, 256)"
+        )));
     }
     Ok(v as u8)
 }
@@ -2473,13 +2477,20 @@ unsafe fn setitem_bytearray_slice(
     index: PyObjectRef,
     value: PyObjectRef,
 ) -> PyResult {
-    // `descr_setitem` materializes the source (`makebytesdata_w`) *before*
-    // unpacking the slice: `__iter__`/`__next__` may mutate the bytearray, so
-    // the slice bounds must be read from the post-materialization length.
-    // (`x[:] = x` stays safe — the source is copied into `sequence2`.)
+    // `descr_setitem`: materialize the source (`makebytesdata_w`) first, then
+    // `_unpack_slice` — evaluate the slice's `__index__` before reading the
+    // length, since both the source's `__iter__`/`__next__` and the slice
+    // components' `__index__` may mutate the bytearray, and the bounds must be
+    // clamped against the post-mutation length. (`x[:] = x` stays safe — the
+    // source is copied into `sequence2`.)
     let sequence2 = bytearray_assign_source(value)?;
+    let (rs, rp, st) = crate::sliceobject::slice_unpack(
+        w_slice_get_start(index),
+        w_slice_get_stop(index),
+        w_slice_get_step(index),
+    )?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
-    let (start, stop, step) = normalize_slice(index, len)?;
+    let (start, stop, step, _) = crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
     let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(obj);
     if step == 1 {
         let cur = vec.len();
@@ -11504,13 +11515,20 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
         }
         // `bytearrayobject.py` ass_subscript with a NULL value deletes like a
         // list: a single index removes one byte, a slice removes its selected
-        // bytes (contiguous via drain, extended-step descending).  Slice bounds
-        // are computed before the mutable borrow since `normalize_slice` may
-        // run `__index__` that re-enters.
+        // bytes (contiguous via drain, extended-step descending).  `descr_delitem`
+        // runs `_unpack_slice` — the slice's `__index__` is evaluated before the
+        // length is read, so a mutation during index evaluation is reflected in
+        // the bounds.
         if pyre_object::bytearrayobject::is_bytearray(obj) {
             if is_slice(index) {
+                let (rs, rp, st) = crate::sliceobject::slice_unpack(
+                    w_slice_get_start(index),
+                    w_slice_get_stop(index),
+                    w_slice_get_step(index),
+                )?;
                 let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
-                let (start, stop, step) = normalize_slice(index, len)?;
+                let (start, stop, step, _) =
+                    crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
                 let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(obj);
                 if step == 1 {
                     let s = start.max(0) as usize;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2323,15 +2323,16 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
 
 #[inline(never)]
 unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
+    if is_slice(index) {
+        return setitem_bytearray_slice(obj, index, value);
+    }
     if !is_int(index) {
-        return Err(PyError::type_error("bytearray indices must be integers"));
+        return Err(index_type_error("bytearray", index));
     }
     let idx = w_int_get_value(index);
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
-        // bytearrayobject.py `_getbytevalue`: coerce via `space.index`
-        // (honoring `__index__`), then enforce the `0 <= v < 256` rule.
         // The index bounds are checked first, matching `bytearray_ass_subscript`.
         let v = if is_int(value) {
             w_int_get_value(value)
@@ -2360,6 +2361,101 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
         PyErrorKind::IndexError,
         "bytearray index out of range",
     ))
+}
+
+/// `bytearrayobject.py _getbytevalue` — coerce a value to a single byte:
+/// honor `__index__`, then enforce the `0 <= v < 256` rule.
+unsafe fn bytearray_byte_value(value: PyObjectRef) -> Result<u8, PyError> {
+    let v = if is_int(value) {
+        w_int_get_value(value)
+    } else {
+        let indexed = space_index(value)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            // `space.index` may yield a long; one that overflows i64 is
+            // necessarily outside 0..256 → the ValueError below.
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(v) => v,
+                Err(_) => return Err(PyError::value_error("byte must be in range(0, 256)")),
+            }
+        }
+    };
+    if !(0..=255).contains(&v) {
+        return Err(PyError::value_error("byte must be in range(0, 256)"));
+    }
+    Ok(v as u8)
+}
+
+/// `bytesobject.py makebytesdata_w` — coerce a slice-assignment source to
+/// raw bytes: a buffer (bytes/bytearray/array/memoryview) yields its bytes,
+/// otherwise an iterable of ints is range-checked element-wise.  A `str` or
+/// non-iterable source is rejected.
+unsafe fn bytearray_assign_source(value: PyObjectRef) -> Result<Vec<u8>, PyError> {
+    if let Some(src) = crate::typedef::buffer_as_bytes_like(value)? {
+        return Ok(pyre_object::bytesobject::bytes_like_data(src).to_vec());
+    }
+    let cannot = || {
+        PyError::type_error("can assign only bytes, buffers, or iterables of ints in range(0, 256)")
+    };
+    if is_str(value) {
+        return Err(cannot());
+    }
+    let items = crate::builtins::collect_iterable(value).map_err(|_| cannot())?;
+    let mut out = Vec::with_capacity(items.len());
+    for it in items {
+        out.push(bytearray_byte_value(it)?);
+    }
+    Ok(out)
+}
+
+/// `bytearrayobject.py descr_setitem` slice branch + `_setitem_slice_helper`
+/// — replace a (possibly extended) slice with the source bytes, resizing for
+/// step-1 slices and requiring equal length for extended slices.
+#[inline(never)]
+unsafe fn setitem_bytearray_slice(
+    obj: PyObjectRef,
+    index: PyObjectRef,
+    value: PyObjectRef,
+) -> PyResult {
+    let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
+    let (start, stop, step) = normalize_slice(index, len)?;
+    // Materialize the source before mutating so `x[:] = x` is safe.
+    let sequence2 = bytearray_assign_source(value)?;
+    let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(obj);
+    if step == 1 {
+        let cur = vec.len();
+        let s = (start.max(0) as usize).min(cur);
+        let e = (stop.max(start) as usize).min(cur).max(s);
+        vec.splice(s..e, sequence2.iter().copied());
+        return Ok(w_none());
+    }
+    // Extended slice: `descr_setitem` forbids resizing — the source length
+    // must equal the slice length; positions are written in order.
+    let mut indices = Vec::new();
+    let mut i = start;
+    while (step > 0 && i < stop) || (step < 0 && i > stop) {
+        if i >= 0 && i < len {
+            indices.push(i as usize);
+        }
+        i += step;
+    }
+    if sequence2.len() != indices.len() {
+        return Err(PyError::new(
+            PyErrorKind::ValueError,
+            format!(
+                "attempt to assign bytes of size {} to extended slice of size {}",
+                sequence2.len(),
+                indices.len()
+            ),
+        ));
+    }
+    for (k, &idx) in indices.iter().enumerate() {
+        if let Some(slot) = vec.get_mut(idx) {
+            *slot = sequence2[k];
+        }
+    }
+    Ok(w_none())
 }
 
 #[inline(never)]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2321,17 +2321,30 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
     Ok(w_none())
 }
 
+/// Resolve a `bytearray` subscript index (`bytearray_ass_subscript`): honor
+/// `__index__`, raise the "indices must be integers or slices" TypeError for a
+/// non-index, non-slice key, and raise IndexError for a value too large to fit
+/// an index (`PyNumber_AsSsize_t(index, IndexError)`).
+unsafe fn bytearray_index(index: PyObjectRef) -> Result<i64, PyError> {
+    if !pyre_object::pyobject::is_int_or_long(index) && lookup(index, "__index__").is_none() {
+        return Err(index_type_error("bytearray", index));
+    }
+    match int_w(space_index(index)?) {
+        Ok(i) => Ok(i),
+        Err(e) if e.kind == PyErrorKind::OverflowError => Err(PyError::new(
+            PyErrorKind::IndexError,
+            "cannot fit 'int' into an index-sized integer",
+        )),
+        Err(e) => Err(e),
+    }
+}
+
 #[inline(never)]
 unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
     if is_slice(index) {
         return setitem_bytearray_slice(obj, index, value);
     }
-    // `bytearray_ass_subscript` accepts any `__index__` operand for the index,
-    // not only an exact int; a non-index, non-slice key is the TypeError.
-    if !pyre_object::pyobject::is_int_or_long(index) && lookup(index, "__index__").is_none() {
-        return Err(index_type_error("bytearray", index));
-    }
-    let idx = getindex_w(index)?;
+    let idx = bytearray_index(index)?;
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
@@ -11461,19 +11474,6 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
         // are computed before the mutable borrow since `normalize_slice` may
         // run `__index__` that re-enters.
         if pyre_object::bytearrayobject::is_bytearray(obj) {
-            if is_int(index) {
-                let i = w_int_get_value(index);
-                let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
-                let idx = if i < 0 { len + i } else { i };
-                if idx >= 0 && idx < len {
-                    pyre_object::bytearrayobject::w_bytearray_vec_mut(obj).remove(idx as usize);
-                    return Ok(());
-                }
-                return Err(PyError::new(
-                    PyErrorKind::IndexError,
-                    "bytearray index out of range",
-                ));
-            }
             if is_slice(index) {
                 let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
                 let (start, stop, step) = normalize_slice(index, len)?;
@@ -11505,6 +11505,17 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 }
                 return Ok(());
             }
+            let i = bytearray_index(index)?;
+            let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
+            let idx = if i < 0 { len + i } else { i };
+            if idx >= 0 && idx < len {
+                pyre_object::bytearrayobject::w_bytearray_vec_mut(obj).remove(idx as usize);
+                return Ok(());
+            }
+            return Err(PyError::new(
+                PyErrorKind::IndexError,
+                "bytearray index out of range",
+            ));
         }
         // memoryview never supports deletion; `memoryview_delitem` reports the
         // released / read-only / "cannot delete memory" error in order.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2350,15 +2350,40 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     if is_slice(index) {
         return setitem_bytearray_slice(obj, index, value);
     }
-    // `descr_setitem`: getindex_w(index) → byte_w(value) → _fixindex(idx).  The
-    // value is coerced to a byte *before* the index bounds are checked, so
-    // `ba[oob] = bad` raises the value's TypeError/ValueError, not IndexError.
-    let idx = bytearray_index(index)?;
-    let v = byte_w(value, "byte")?;
+    // `descr_setitem`: getindex_w(index) → _fixindex(idx) → coerce value.  The
+    // index gate and byte coercion are inlined (not routed through the shared
+    // `bytearray_index`/`byte_w`) and the coercion is kept inside the in-bounds
+    // block: a shared-function result fails to bind a concrete Int repr in the
+    // rtyper (concretetype None), which the codewriter then mis-colors Ref
+    // against its Int provenance.  `__index__` index support and coercing before
+    // the bounds check (so `ba[oob] = bad` reports the value error ahead of
+    // IndexError) are deferred on that same kind-provenance gap.
+    if !is_int(index) {
+        return Err(PyError::type_error("bytearray indices must be integers"));
+    }
+    let idx = w_int_get_value(index);
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
-        pyre_object::bytearrayobject::w_bytearray_setitem(obj, actual as usize, v);
+        let v = if is_int(value) {
+            w_int_get_value(value)
+        } else {
+            let indexed = space_index(value)?;
+            if is_int(indexed) {
+                w_int_get_value(indexed)
+            } else {
+                match i64::try_from(w_long_get_value(indexed)) {
+                    Ok(v) => v,
+                    Err(_) => {
+                        return Err(PyError::value_error("byte must be in range(0, 256)"));
+                    }
+                }
+            }
+        };
+        if !(0..=255).contains(&v) {
+            return Err(PyError::value_error("byte must be in range(0, 256)"));
+        }
+        pyre_object::bytearrayobject::w_bytearray_setitem(obj, actual as usize, v as u8);
         return Ok(w_none());
     }
     Err(PyError::new(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -722,6 +722,11 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
         // Slice assignment writes the rvalue's element bytes through to the
         // strided positions of the view (`_setitem_slice`).
         if pyre_object::is_slice(index) {
+            if w_memoryview_ndim(mv) != 1 {
+                return Err(crate::PyError::not_implemented(
+                    "memoryview slice assignments are currently restricted to ndim = 1",
+                ));
+            }
             let (start, stop, step) = crate::baseobjspace::normalize_slice(index, count)?;
             let mut indices = Vec::new();
             let mut i = start;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -424,9 +424,11 @@ unsafe fn memoryview_values(mv: PyObjectRef) -> Vec<PyObjectRef> {
 }
 
 /// A live strided sub-view `m[start:stop:step]`, sharing the same backing.
-/// Item-space slice indices map to a byte `offset += start*parent_stride`
-/// with `stride *= step` and `shape = (slicelength,)`, so the result reads
-/// through to the original storage (`buffer.py` `BufferSlice`).
+/// Slicing operates on dimension 0 (`buffer.py BufferSlice`): the element
+/// count is `shape[0]`, the step rides `strides[0]`, and dimensions `1..ndim`
+/// are preserved, so slicing an N-D view keeps its dimensionality.  The byte
+/// `offset += start*strides[0]` and `strides[0] *= step` make the result read
+/// through to the original storage.
 unsafe fn memoryview_slice_view(
     mv: PyObjectRef,
     index: PyObjectRef,
@@ -434,9 +436,19 @@ unsafe fn memoryview_slice_view(
     use pyre_object::memoryview::*;
     unsafe {
         let itemsize = w_memoryview_itemsize(mv);
-        let length = w_memoryview_length(mv);
-        let count = if itemsize > 0 { length / itemsize } else { 0 };
-        let stride_p = w_memoryview_stride0(mv);
+        let ndim = w_memoryview_ndim(mv);
+        let parent_shape = w_memoryview_shape(mv);
+        let parent_strides = w_memoryview_strides(mv);
+        let count = if ndim >= 1 {
+            memoryview_dim_value(parent_shape, 0)
+        } else {
+            0
+        };
+        let stride_p = if ndim >= 1 {
+            memoryview_dim_value(parent_strides, 0)
+        } else {
+            itemsize
+        };
         let offset_p = w_memoryview_offset(mv);
         let (start, stop, step) = crate::baseobjspace::normalize_slice(index, count)?;
         let slicelength = if step > 0 {
@@ -452,8 +464,17 @@ unsafe fn memoryview_slice_view(
         };
         let new_offset = offset_p + start * stride_p;
         let new_stride = stride_p * step;
-        let shape = pyre_object::w_tuple_new(vec![w_int_new(slicelength)]);
-        let strides = pyre_object::w_tuple_new(vec![w_int_new(new_stride)]);
+        // Dimension 0 takes the slice's shape/stride; later dimensions ride
+        // along unchanged.
+        let mut shape_v = vec![slicelength];
+        let mut strides_v = vec![new_stride];
+        for d in 1..ndim {
+            shape_v.push(memoryview_dim_value(parent_shape, d));
+            strides_v.push(memoryview_dim_value(parent_strides, d));
+        }
+        let new_length = shape_v.iter().product::<i64>() * itemsize;
+        let shape = pyre_object::w_tuple_new(shape_v.iter().map(|&x| w_int_new(x)).collect());
+        let strides = pyre_object::w_tuple_new(strides_v.iter().map(|&x| w_int_new(x)).collect());
         Ok(w_memoryview_alloc(
             w_memoryview_obj(mv),
             w_memoryview_backing(mv),
@@ -461,9 +482,9 @@ unsafe fn memoryview_slice_view(
             shape,
             strides,
             itemsize,
-            1,
+            ndim.max(1),
             new_offset,
-            slicelength * itemsize,
+            new_length,
             w_memoryview_readonly(mv),
             false,
         ))
@@ -968,7 +989,11 @@ fn memoryview_tolist(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     unsafe {
         memoryview_check_released(mv)?;
         let ndim = pyre_object::memoryview::w_memoryview_ndim(mv);
-        if ndim <= 1 {
+        if ndim == 0 {
+            // `buffer.py w_tolist` raises for a 0-dim view.
+            return Err(crate::PyError::not_implemented(""));
+        }
+        if ndim == 1 {
             return Ok(w_list_new(memoryview_values(mv)));
         }
         let isz = pyre_object::memoryview::w_memoryview_itemsize(mv) as usize;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1340,7 +1340,7 @@ fn memoryview_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 /// `memory_ass_sub` checks released, then read-only, before the delete
 /// rejection, so a released view reports the released error and a read-only
 /// view reports "cannot modify read-only memory".
-fn memoryview_delitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+pub(crate) fn memoryview_delitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
     unsafe {
         memoryview_check_released(mv)?;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1244,14 +1244,25 @@ unsafe fn memoryview_operand_bytes(obj: PyObjectRef) -> Option<Vec<u8>> {
     }
 }
 
+/// True when `mv` or a memoryview `other` operand is released — either side
+/// then compares by identity instead of reading a buffer past `release()`.
+unsafe fn memoryview_released_either(mv: PyObjectRef, other: PyObjectRef) -> bool {
+    unsafe {
+        pyre_object::memoryview::w_memoryview_released(mv)
+            || (pyre_object::memoryview::is_w_memoryview(other)
+                && pyre_object::memoryview::w_memoryview_released(other))
+    }
+}
+
 /// `memoryview.__eq__` — `descr__cmp('eq')`: compares the two views'
 /// raw byte strings (`as_str`); NotImplemented for any other operand.
 fn memoryview_eq(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
     let other = args.get(1).copied().unwrap_or(w_none());
     unsafe {
-        // A released view compares by identity (`view is None` branch).
-        if pyre_object::memoryview::w_memoryview_released(mv) {
+        // A released view (on either side) compares by identity (`view is None`
+        // branch); its backing must not be read after release.
+        if memoryview_released_either(mv, other) {
             return Ok(w_bool_from(mv == other));
         }
         let a = memoryview_gather_bytes(mv);
@@ -1267,7 +1278,7 @@ fn memoryview_ne(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
     let other = args.get(1).copied().unwrap_or(w_none());
     unsafe {
-        if pyre_object::memoryview::w_memoryview_released(mv) {
+        if memoryview_released_either(mv, other) {
             return Ok(w_bool_from(mv != other));
         }
         let a = memoryview_gather_bytes(mv);
@@ -1362,7 +1373,7 @@ fn memoryview_is_f_contiguous(shape: &[i64], strides: &[i64], itemsize: i64) -> 
 
 /// `(c_contiguous, f_contiguous)` for a view, from `_init_flags` /
 /// `PyBuffer_isContiguous`.  A 0-dim (scalar) view is both.
-unsafe fn memoryview_contiguity(mv: PyObjectRef) -> (bool, bool) {
+pub(crate) unsafe fn memoryview_contiguity(mv: PyObjectRef) -> (bool, bool) {
     use pyre_object::memoryview::*;
     unsafe {
         let ndim = w_memoryview_ndim(mv);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -1240,6 +1240,12 @@ unsafe fn memoryview_operand_bytes(obj: PyObjectRef) -> Option<Vec<u8>> {
         if pyre_object::bytesobject::is_bytes_like(obj) {
             return Some(pyre_object::bytesobject::bytes_like_data(obj).to_vec());
         }
+        // `memory_richcompare` acquires any contiguous buffer of the operand
+        // (`space.buffer_w(w_other, BUF_CONTIG_RO)`), so an `array` compares by
+        // its element bytes too; a non-buffer operand yields NotImplemented.
+        if let Ok(Some(b)) = crate::typedef::buffer_as_bytes_like(obj) {
+            return Some(pyre_object::bytesobject::bytes_like_data(b).to_vec());
+        }
         None
     }
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -822,27 +822,6 @@ fn memoryview_iter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     }
 }
 
-/// `memoryview.__contains__` — membership over the format-aware element
-/// values (value equality, so `1 in memoryview(array('i', [1]))`).
-fn memoryview_contains(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let mv = args.first().copied().unwrap_or(w_none());
-    let needle = args.get(1).copied().unwrap_or(w_none());
-    unsafe {
-        memoryview_check_released(mv)?;
-        for elem in memoryview_values(mv) {
-            let r = crate::objspace::descroperation::compare(
-                elem,
-                needle,
-                crate::objspace::descroperation::CompareOp::Eq,
-            )?;
-            if crate::baseobjspace::is_true(r)? {
-                return Ok(w_bool_from(true));
-            }
-        }
-        Ok(w_bool_from(false))
-    }
-}
-
 /// `memoryview.readonly` — true for a bytes / array (Stage-1) backing or a
 /// view explicitly made read-only via `toreadonly`.
 fn memoryview_readonly(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -1487,7 +1466,6 @@ pub(crate) fn init_memoryview_type(ns: &mut DictStorage) {
         ("__setitem__", memoryview_setitem, 3),
         ("__len__", memoryview_len, 1),
         ("__iter__", memoryview_iter, 1),
-        ("__contains__", memoryview_contains, 2),
         ("__repr__", memoryview_repr, 1),
         ("__eq__", memoryview_eq, 2),
         ("__ne__", memoryview_ne, 2),

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -327,12 +327,17 @@ fn memoryview_pack_value(
             Err(bad_type())
         }
     };
-    let int_val = || -> Result<i64, crate::PyError> {
+    // Integer formats coerce via `__index__` (`pack_single`/`PyNumber_Index`),
+    // not an exact-int check; a value with no `__index__` is the format error.
+    let as_index = || -> Result<PyObjectRef, crate::PyError> {
         if unsafe { pyre_object::is_int_or_long(w_val) } {
-            crate::baseobjspace::int_w(w_val).map_err(|_| bad_type())
+            Ok(w_val)
         } else {
-            Err(bad_type())
+            unsafe { crate::baseobjspace::space_index(w_val) }.map_err(|_| bad_type())
         }
+    };
+    let int_val = || -> Result<i64, crate::PyError> {
+        crate::baseobjspace::int_w(as_index()?).map_err(|_| bad_type())
     };
     let bytes = match memoryview_format_code(fmt) {
         b'b' => {
@@ -370,10 +375,7 @@ fn memoryview_pack_value(
             v.to_ne_bytes().to_vec()
         }
         b'L' | b'Q' | b'N' | b'P' => {
-            if !unsafe { pyre_object::is_int_or_long(w_val) } {
-                return Err(bad_type());
-            }
-            let v = crate::baseobjspace::uint_w(w_val).map_err(|_| bad_type())?;
+            let v = crate::baseobjspace::uint_w(as_index()?).map_err(|_| bad_type())?;
             v.to_ne_bytes().to_vec()
         }
         b'f' => {
@@ -780,6 +782,11 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
                 )));
             }
             let packed = memoryview_pack_value(&fmt, isz, value)?;
+            // memory_ass_sub: pack the value, then re-check release before the
+            // write — the value's `__index__`/`__float__` coercion may have
+            // released the view (`bytes_from_value` → `_check_released` →
+            // `setbytes`).
+            memoryview_check_released(mv)?;
             let start = memoryview_start_from_tuple(mv, index)?;
             let addr = (offset + start) as usize;
             let full =
@@ -800,6 +807,8 @@ fn memoryview_setitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
             return Err(crate::PyError::index_error("index out of bounds"));
         }
         let packed = memoryview_pack_value(&fmt, isz, value)?;
+        // Re-check release after value coercion (see tuple path above).
+        memoryview_check_released(mv)?;
         let addr = (offset + i * stride0) as usize;
         let full = memoryview_backing_bytes_mut(backing).expect("writable backing checked above");
         full[addr..addr + isz].copy_from_slice(&packed);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -864,6 +864,22 @@ fn memoryview_nbytes(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     }
 }
 
+/// `memoryview._pypy_raw_address` — the integer raw address of the view's
+/// backing store, base data pointer plus the view's byte offset
+/// (`descr_pypy_raw_address` → `get_raw_address`).  Every pyre backing
+/// (bytes / bytearray / array) is a contiguous in-heap store with a real
+/// data pointer, so the "no raw address" branch is structurally unreachable.
+fn memoryview_raw_address(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let mv = args.first().copied().unwrap_or(w_none());
+    unsafe {
+        memoryview_check_released(mv)?;
+        let backing = pyre_object::memoryview::w_memoryview_backing(mv);
+        let base = memoryview_backing_slice(backing).as_ptr() as usize;
+        let offset = pyre_object::memoryview::w_memoryview_offset(mv) as usize;
+        Ok(w_int_new((base + offset) as i64))
+    }
+}
+
 /// `memoryview.format` — the struct format string of an element.
 fn memoryview_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mv = args.first().copied().unwrap_or(w_none());
@@ -1321,7 +1337,17 @@ fn memoryview_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 }
 
 /// `memoryview.__delitem__` — memoryview does not support item deletion.
-fn memoryview_delitem(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+/// `memory_ass_sub` checks released, then read-only, before the delete
+/// rejection, so a released view reports the released error and a read-only
+/// view reports "cannot modify read-only memory".
+fn memoryview_delitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let mv = args.first().copied().unwrap_or(w_none());
+    unsafe {
+        memoryview_check_released(mv)?;
+        if pyre_object::memoryview::w_memoryview_readonly(mv) {
+            return Err(crate::PyError::type_error("cannot modify read-only memory"));
+        }
+    }
     Err(crate::PyError::type_error("cannot delete memory"))
 }
 
@@ -1471,6 +1497,7 @@ pub(crate) fn init_memoryview_type(ns: &mut DictStorage) {
         ("release", memoryview_release, 1),
         ("__enter__", memoryview_enter, 1),
         ("__hash__", memoryview_hash, 1),
+        ("_pypy_raw_address", memoryview_raw_address, 1),
     ] {
         crate::dict_storage_store(ns, name, make_builtin_function_with_arity(name, f, arity));
     }

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -40,7 +40,11 @@ impl W_PickleBuffer {
         Ok(())
     }
 
-    /// `raw()` — a memoryview onto the wrapped buffer.
+    /// `raw()` — a memoryview of the raw bytes underlying the wrapped buffer.
+    /// The result is a one-dimensional unsigned-byte view (`format='B'`,
+    /// itemsize 1) that aliases the source and preserves its read-only flag,
+    /// regardless of the source's element format; extracting it from a
+    /// non-contiguous buffer raises `BufferError`.
     fn raw(&self) -> Result<PyObjectRef, PyError> {
         let w_obj = self.w_obj;
         if unsafe { pyre_object::is_none(w_obj) } {
@@ -48,7 +52,18 @@ impl W_PickleBuffer {
         }
         let mv_type = memoryview_type()
             .ok_or_else(|| PyError::runtime_error("memoryview type unavailable"))?;
-        crate::module::_pickle::call_fn(mv_type, &[w_obj])
+        let mv = crate::module::_pickle::call_fn(mv_type, &[w_obj])?;
+        // Raw extraction is only defined for a C-contiguous buffer.
+        let w_contig = crate::baseobjspace::getattr_str(mv, "c_contiguous")?;
+        if !crate::baseobjspace::is_true(w_contig)? {
+            return Err(PyError::new(
+                crate::PyErrorKind::BufferError,
+                "cannot extract raw buffer from non-contiguous buffer",
+            ));
+        }
+        // Normalize to the raw byte layout via `cast('B')` so an `array('i')`
+        // or other non-`'B'` source still yields a byte view.
+        crate::module::_pickle::call_meth(mv, "cast", &[pyre_object::unicodeobject::w_str_new("B")])
     }
 
     /// `release()` — drop the reference to the underlying buffer.

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -191,12 +191,12 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
                 "a read-write bytes-like object is required, not 'memoryview'",
             ));
         }
-        // Only contiguous views are accepted; a strided slice (`m[::2]`,
-        // `m[::-1]`) would need a scatter writer pyre does not have.
-        if unsafe {
-            pyre_object::memoryview::w_memoryview_stride0(obj)
-                != pyre_object::memoryview::w_memoryview_itemsize(obj)
-        } {
+        // Only C-contiguous views are accepted; a strided slice (`m[::2]`,
+        // `m[::-1]`) would need a scatter writer pyre does not have.  A
+        // contiguous N-D view (`memoryview(ba).cast('B', shape=(2, 2))`)
+        // exposes its window as one flat byte range, so it qualifies even
+        // though its outermost stride is a row stride, not the itemsize.
+        if !unsafe { crate::builtins::memoryview_contiguity(obj).0 } {
             return Err(crate::PyError::type_error(
                 "a read-write bytes-like object is required, not 'memoryview'",
             ));
@@ -208,6 +208,13 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
             let off = unsafe { pyre_object::memoryview::w_memoryview_offset(obj) } as usize;
             let len = unsafe { pyre_object::memoryview::w_memoryview_length(obj) } as usize;
             let full = unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(backing) };
+            // The backing may have been resized after the view was taken;
+            // reject a window that no longer fits rather than panic.
+            if off.checked_add(len).is_none_or(|end| end > full.len()) {
+                return Err(crate::PyError::value_error(
+                    "memoryview buffer is no longer valid",
+                ));
+            }
             return Ok(&mut full[off..off + len]);
         }
         return Err(crate::PyError::type_error("cannot modify read-only memory"));

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -182,6 +182,12 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
     if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
         return Ok(unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(obj) });
     }
+    if unsafe { pyre_object::interp_array::is_array(obj) } {
+        // `space.writebuf_w` accepts any writable buffer exporter; an
+        // `array.array` exposes its element bytes as one writable window
+        // regardless of typecode (recv writes raw bytes into them).
+        return Ok(unsafe { pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice() });
+    }
     if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
         // `space.buffer_w` rejects a released view before exposing its storage.
         unsafe { crate::builtins::memoryview_check_released(obj) }?;
@@ -202,22 +208,26 @@ fn socket_writebuf(obj: pyre_object::PyObjectRef) -> Result<&'static mut [u8], c
             ));
         }
         let backing = unsafe { pyre_object::memoryview::w_memoryview_backing(obj) };
-        if unsafe { pyre_object::bytearrayobject::is_bytearray(backing) } {
-            // Honour the view window: write only into `[offset, offset+length)`
-            // of the backing store, not the whole buffer.
-            let off = unsafe { pyre_object::memoryview::w_memoryview_offset(obj) } as usize;
-            let len = unsafe { pyre_object::memoryview::w_memoryview_length(obj) } as usize;
-            let full = unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(backing) };
-            // The backing may have been resized after the view was taken;
-            // reject a window that no longer fits rather than panic.
-            if off.checked_add(len).is_none_or(|end| end > full.len()) {
-                return Err(crate::PyError::value_error(
-                    "memoryview buffer is no longer valid",
-                ));
-            }
-            return Ok(&mut full[off..off + len]);
+        // A writable view's backing is a `bytearray` or an `array.array`; both
+        // expose a mutable byte store.  Honour the view window: write only into
+        // `[offset, offset+length)` of the backing, not the whole buffer.
+        let full: &mut [u8] = if unsafe { pyre_object::bytearrayobject::is_bytearray(backing) } {
+            unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(backing) }
+        } else if unsafe { pyre_object::interp_array::is_array(backing) } {
+            unsafe { pyre_object::interp_array::w_array_vec_mut(backing).as_mut_slice() }
+        } else {
+            return Err(crate::PyError::type_error("cannot modify read-only memory"));
+        };
+        let off = unsafe { pyre_object::memoryview::w_memoryview_offset(obj) } as usize;
+        let len = unsafe { pyre_object::memoryview::w_memoryview_length(obj) } as usize;
+        // The backing may have been resized after the view was taken; reject a
+        // window that no longer fits rather than panic.
+        if off.checked_add(len).is_none_or(|end| end > full.len()) {
+            return Err(crate::PyError::value_error(
+                "memoryview buffer is no longer valid",
+            ));
         }
-        return Err(crate::PyError::type_error("cannot modify read-only memory"));
+        return Ok(&mut full[off..off + len]);
     }
     Err(crate::PyError::type_error(
         "a writable bytes-like object is required",

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -686,20 +686,17 @@ fn pattern_is_known_unicode(pat: PyObjectRef) -> bool {
 /// read-buffer subject that is not itself `bytes`/`bytearray`.  pyre's only
 /// such producer is `memoryview`; its live byte backing plays the captured
 /// `BufMatchContext._buffer` (kept alive by the match it is stored into).
-/// `PY_NULL` if `obj` is not a memoryview over a `bytes`/`bytearray`.
+/// `PY_NULL` if `obj` is not a memoryview.
 unsafe fn readbuf_obj(obj: PyObjectRef) -> PyObjectRef {
     if !unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
         return pyre_object::PY_NULL;
     }
-    let backing = unsafe { pyre_object::memoryview::w_memoryview_backing(obj) };
-    if unsafe { pyre_object::bytesobject::is_bytes_like(backing) } {
-        // The subject is the view window (offset/itemsize/length/strides),
-        // not the whole backing — materialize the gathered slice bytes.
-        let gathered = unsafe { crate::builtins::memoryview_gather_bytes(obj) };
-        pyre_object::bytesobject::w_bytes_from_bytes(&gathered)
-    } else {
-        pyre_object::PY_NULL
-    }
+    // The subject is the view window (offset/itemsize/length/strides), not the
+    // whole backing — materialize the gathered slice bytes.  Any live backing
+    // (bytes/bytearray/array) exports a readable byte buffer, so the regex
+    // subject is gathered regardless of the backing object's type.
+    let gathered = unsafe { crate::builtins::memoryview_gather_bytes(obj) };
+    pyre_object::bytesobject::w_bytes_from_bytes(&gathered)
 }
 
 /// The raw bytes of [`readbuf_obj`] — `BufMatchContext` matches against these.

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -688,15 +688,27 @@ fn pattern_is_known_unicode(pat: PyObjectRef) -> bool {
 /// `BufMatchContext._buffer` (kept alive by the match it is stored into).
 /// `PY_NULL` if `obj` is not a memoryview.
 unsafe fn readbuf_obj(obj: PyObjectRef) -> PyObjectRef {
-    if !unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
+    if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
+        // The subject is the view window (offset/itemsize/length/strides), not
+        // the whole backing — materialize the gathered slice bytes.  Any live
+        // backing (bytes/bytearray/array) exports a readable byte buffer, so
+        // the regex subject is gathered regardless of the backing type.
+        let gathered = unsafe { crate::builtins::memoryview_gather_bytes(obj) };
+        return pyre_object::bytesobject::w_bytes_from_bytes(&gathered);
+    }
+    // str / bytes / bytearray subjects are re-resolved directly from `string`
+    // (`subject_of`), so they need no captured `_buffer`.
+    if unsafe { is_str(obj) } || unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
         return pyre_object::PY_NULL;
     }
-    // The subject is the view window (offset/itemsize/length/strides), not the
-    // whole backing — materialize the gathered slice bytes.  Any live backing
-    // (bytes/bytearray/array) exports a readable byte buffer, so the regex
-    // subject is gathered regardless of the backing object's type.
-    let gathered = unsafe { crate::builtins::memoryview_gather_bytes(obj) };
-    pyre_object::bytesobject::w_bytes_from_bytes(&gathered)
+    // `readbuf_w` — any other readable-buffer exporter (e.g. `array.array`):
+    // capture its bytes as `ctx._buffer` so slicing re-reads them.
+    match unsafe { crate::typedef::buffer_as_bytes_like(obj) } {
+        Ok(Some(b)) => pyre_object::bytesobject::w_bytes_from_bytes(unsafe {
+            pyre_object::bytesobject::bytes_like_data(b)
+        }),
+        _ => pyre_object::PY_NULL,
+    }
 }
 
 /// The raw bytes of [`readbuf_obj`] — `BufMatchContext` matches against these.
@@ -732,25 +744,27 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
         Ok(Subject::Bytes(unsafe {
             pyre_object::bytesobject::bytes_like_data(string)
         }))
-    } else if unsafe { pyre_object::memoryview::is_w_memoryview(string) } {
-        // `make_ctx` acquires the subject through `readbuf_w` → `buffer_w`,
-        // which rejects a released view before reading its bytes.
-        unsafe { crate::builtins::memoryview_check_released(string) }?;
+    } else {
+        // `make_ctx` acquires any other readable-buffer subject through
+        // `readbuf_w` → `buffer_w` (a `memoryview`, or any buffer exporter such
+        // as `array.array`).  A released memoryview is rejected before its
+        // bytes are read.
+        if unsafe { pyre_object::memoryview::is_w_memoryview(string) } {
+            unsafe { crate::builtins::memoryview_check_released(string) }?;
+        }
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
                 "can't use a string pattern on a bytes-like object",
             ));
         }
+        // `readbuf_bytes` is `None` for a non-buffer object → the generic
+        // "expected string or bytes-like object" TypeError.
         let Some(buf) = (unsafe { readbuf_bytes(string) }) else {
             return Err(crate::PyError::type_error(
                 "expected string or bytes-like object",
             ));
         };
         Ok(Subject::Bytes(buf))
-    } else {
-        Err(crate::PyError::type_error(
-            "expected string or bytes-like object",
-        ))
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -731,14 +731,14 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
     if unsafe { is_str(string) } {
         if pattern_is_known_bytes(pat) {
             return Err(crate::PyError::type_error(
-                "can't use a bytes pattern on a string-like object",
+                "cannot use a bytes pattern on a string-like object",
             ));
         }
         Ok(Subject::Str(unsafe { w_str_get_value(string) }))
     } else if unsafe { pyre_object::bytesobject::is_bytes_like(string) } {
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
-                "can't use a string pattern on a bytes-like object",
+                "cannot use a string pattern on a bytes-like object",
             ));
         }
         Ok(Subject::Bytes(unsafe {
@@ -752,18 +752,21 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
         if unsafe { pyre_object::memoryview::is_w_memoryview(string) } {
             unsafe { crate::builtins::memoryview_check_released(string) }?;
         }
+        // `is_known_unicode`: prove the subject is buffer-like via `readbuf_w`
+        // *before* the pattern/subject-type check — a non-buffer object raises
+        // "expected string or bytes-like object", a real buffer (memoryview /
+        // array) raises the "string pattern on a bytes-like object" mismatch.
+        let Some(buf) = (unsafe { readbuf_bytes(string) }) else {
+            return Err(crate::PyError::type_error(format!(
+                "expected string or bytes-like object, got '{}'",
+                crate::baseobjspace::object_functionstr_type_name(string)
+            )));
+        };
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
-                "can't use a string pattern on a bytes-like object",
+                "cannot use a string pattern on a bytes-like object",
             ));
         }
-        // `readbuf_bytes` is `None` for a non-buffer object → the generic
-        // "expected string or bytes-like object" TypeError.
-        let Some(buf) = (unsafe { readbuf_bytes(string) }) else {
-            return Err(crate::PyError::type_error(
-                "expected string or bytes-like object",
-            ));
-        };
         Ok(Subject::Bytes(buf))
     }
 }

--- a/pyre/pyre-interpreter/src/sliceobject.rs
+++ b/pyre/pyre-interpreter/src/sliceobject.rs
@@ -60,16 +60,17 @@ pub fn unwrap_start_stop(
     Ok((start, end))
 }
 
-/// sliceobject.py:170 `W_SliceObject.indices3(space, length)`.
+/// sliceobject.py:130 `W_SliceObject.unpack(space)`.
 ///
-/// Computes the `(start, stop, step)` triple for a slice over a sequence
-/// of `length` items, clipping out-of-bounds endpoints consistently with
-/// extended-slice handling. A zero `step` raises `ValueError`.
-pub fn indices3(
+/// Evaluates `start`/`stop`/`step` through `__index__` **without** reading
+/// the container length: an `__index__` method may mutate the container, so
+/// the length must be consulted only afterwards (`_unpack_slice`). `None`
+/// endpoints map to the open-ended sentinels that [`slice_adjust_indices`]
+/// then clamps. A zero `step` raises `ValueError`.
+pub(crate) fn slice_unpack(
     w_start: PyObjectRef,
     w_stop: PyObjectRef,
     w_step: PyObjectRef,
-    length: i64,
 ) -> Result<(i64, i64, i64), crate::PyError> {
     let step = if unsafe { is_none(w_step) } {
         1
@@ -83,36 +84,69 @@ pub fn indices3(
         }
         step
     };
-
     let start = if unsafe { is_none(w_start) } {
-        if step < 0 { length - 1 } else { 0 }
+        if step < 0 { i64::MAX } else { 0 }
     } else {
-        let mut start = eval_slice_index(w_start)?;
-        if start < 0 {
-            start += length;
-            if start < 0 {
-                start = if step < 0 { -1 } else { 0 };
-            }
-        } else if start >= length {
-            start = if step < 0 { length - 1 } else { length };
-        }
-        start
+        eval_slice_index(w_start)?
     };
-
     let stop = if unsafe { is_none(w_stop) } {
-        if step < 0 { -1 } else { length }
+        if step < 0 { i64::MIN } else { i64::MAX }
     } else {
-        let mut stop = eval_slice_index(w_stop)?;
-        if stop < 0 {
-            stop += length;
-            if stop < 0 {
-                stop = if step < 0 { -1 } else { 0 };
-            }
-        } else if stop >= length {
-            stop = if step < 0 { length - 1 } else { length };
-        }
-        stop
+        eval_slice_index(w_stop)?
     };
+    Ok((start, stop, step))
+}
 
+/// sliceobject.py:139 `W_SliceObject.adjust_indices(start, stop, step, length)`.
+///
+/// Pure arithmetic: clamps the unpacked `(start, stop, step)` against
+/// `length`, clipping out-of-bounds endpoints consistently with
+/// extended-slice handling, and returns the triple plus the resulting
+/// `slicelength`.
+pub(crate) fn slice_adjust_indices(
+    mut start: i64,
+    mut stop: i64,
+    step: i64,
+    length: i64,
+) -> (i64, i64, i64, i64) {
+    if start < 0 {
+        start += length;
+        if start < 0 {
+            start = if step < 0 { -1 } else { 0 };
+        }
+    } else if start >= length {
+        start = if step < 0 { length - 1 } else { length };
+    }
+    if stop < 0 {
+        stop += length;
+        if stop < 0 {
+            stop = if step < 0 { -1 } else { 0 };
+        }
+    } else if stop >= length {
+        stop = if step < 0 { length - 1 } else { length };
+    }
+    let slicelength = if (step < 0 && stop >= start) || (step > 0 && start >= stop) {
+        0
+    } else if step < 0 {
+        (stop - start + 1) / step + 1
+    } else {
+        (stop - start - 1) / step + 1
+    };
+    (start, stop, step, slicelength)
+}
+
+/// sliceobject.py:170 `W_SliceObject.indices3(space, length)`.
+///
+/// Computes the `(start, stop, step)` triple for a slice over a sequence
+/// of `length` items — [`slice_unpack`] then [`slice_adjust_indices`]. A
+/// zero `step` raises `ValueError`.
+pub fn indices3(
+    w_start: PyObjectRef,
+    w_stop: PyObjectRef,
+    w_step: PyObjectRef,
+    length: i64,
+) -> Result<(i64, i64, i64), crate::PyError> {
+    let (start, stop, step) = slice_unpack(w_start, w_stop, w_step)?;
+    let (start, stop, step, _) = slice_adjust_indices(start, stop, step, length);
     Ok((start, stop, step))
 }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2594,19 +2594,14 @@ pub fn str_method_isidentifier(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
     Ok(w_bool_from(result))
 }
 
-/// Check if a string is a valid Python identifier.
-/// Python 3 identifiers: ID_Start ID_Continue*
-/// Simplified: accepts ASCII identifiers + Unicode letters/digits.
+/// Check if a string is a valid Python identifier: an `XID_Start` code point
+/// (or underscore) followed by `XID_Continue` code points.
+/// PyPy: unicodeobject.py `_isidentifier` via `unicodedb.isxidstart`/`isxidcontinue`.
 fn is_identifier(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
+    use unicode_xid::UnicodeXID;
     let mut chars = s.chars();
-    let first = chars.next().unwrap();
-    if !first.is_alphabetic() && first != '_' {
-        return false;
-    }
-    chars.all(|c| c.is_alphanumeric() || c == '_')
+    let valid_start = chars.next().is_some_and(|c| c == '_' || c.is_xid_start());
+    valid_start && chars.all(|c| c.is_xid_continue())
 }
 
 /// `pypy/objspace/std/unicodeobject.py W_UnicodeObject.descr_zfill`.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9152,8 +9152,25 @@ fn bytearray_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
                 type_name_of(arg)
             )));
         }
-        if pyre_object::is_int(arg) {
-            let n = pyre_object::w_int_get_value(arg);
+        // newbytesdata_w_tail: `getindex_w(source, OverflowError)` — any object
+        // exposing __index__ is a count of NUL bytes.  (bytearray does NOT
+        // honour __bytes__, so there is no invoke_bytes_method here.)
+        if pyre_object::pyobject::is_int_or_long(arg)
+            || crate::baseobjspace::lookup(arg, "__index__").is_some()
+        {
+            let n = match crate::baseobjspace::int_w(crate::baseobjspace::space_index(arg)?) {
+                Ok(n) => n,
+                Err(e) if e.kind == crate::PyErrorKind::OverflowError => {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::OverflowError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            crate::baseobjspace::object_functionstr_type_name(arg)
+                        ),
+                    ));
+                }
+                Err(e) => return Err(e),
+            };
             if n < 0 {
                 return Err(crate::PyError::value_error("negative count"));
             }
@@ -9171,20 +9188,34 @@ fn bytearray_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             return Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(&data));
         }
     }
-    // bytesobject.py:856 _from_byte_sequence_w
-    let items = crate::builtins::collect_iterable(arg)?;
-    let mut buf = Vec::with_capacity(items.len());
-    for item in items {
-        if !unsafe { pyre_object::is_int(item) } {
-            return Err(crate::PyError::type_error("an integer is required"));
+    // bytesobject.py:856 `_from_byte_sequence_loop`: stream the source through
+    // `byte_w` (honours __index__, "byte must be in range(0, 256)"; a non-index
+    // element → "'X' object cannot be interpreted as an integer").  A source
+    // with no __iter__ → "cannot convert 'X' object to bytearray"; an error
+    // raised by __iter__/__next__ propagates unchanged.
+    unsafe {
+        let it = match crate::baseobjspace::iter(arg) {
+            Ok(it) => it,
+            Err(e) => {
+                if crate::baseobjspace::lookup(arg, "__iter__").is_none() {
+                    return Err(crate::PyError::type_error(format!(
+                        "cannot convert '{}' object to bytearray",
+                        crate::baseobjspace::object_functionstr_type_name(arg)
+                    )));
+                }
+                return Err(e);
+            }
+        };
+        let mut buf = Vec::new();
+        loop {
+            match crate::baseobjspace::next(it) {
+                Ok(item) => buf.push(crate::baseobjspace::byte_w(item, "byte")?),
+                Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+                Err(e) => return Err(e),
+            }
         }
-        let v = unsafe { pyre_object::w_int_get_value(item) };
-        if !(0..=255).contains(&v) {
-            return Err(crate::PyError::value_error("byte must be in range(0, 256)"));
-        }
-        buf.push(v as u8);
+        Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(&buf))
     }
-    Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(&buf))
 }
 
 /// PyPy: bytesobject.py W_BytesObject.typedef
@@ -11637,9 +11668,41 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
                 type_name_of(arg)
             )));
         }
-        if pyre_object::is_int(arg) {
+        // bytesobject.py:783 `invoke_bytes_method` — a `__bytes__` special
+        // method takes precedence over the count / buffer / iterable paths and
+        // must return a `bytes` instance.  (bytearray does NOT honour __bytes__.)
+        if let Some(method) = crate::baseobjspace::lookup(arg, "__bytes__") {
+            let w_bytes = crate::builtins::call_and_check(method, &[arg])?;
+            if !pyre_object::bytesobject::is_bytes(w_bytes) {
+                return Err(crate::PyError::type_error(format!(
+                    "__bytes__ returned non-bytes (type {})",
+                    type_name_of(w_bytes)
+                )));
+            }
+            return Ok(new_bytes_like(
+                args[0],
+                pyre_object::bytesobject::bytes_like_data(w_bytes),
+            ));
+        }
+        // newbytesdata_w_tail: `getindex_w(source, OverflowError)` — any object
+        // exposing __index__ (not just an exact int) is a count of NUL bytes.
+        if pyre_object::pyobject::is_int_or_long(arg)
+            || crate::baseobjspace::lookup(arg, "__index__").is_some()
+        {
+            let n = match crate::baseobjspace::int_w(crate::baseobjspace::space_index(arg)?) {
+                Ok(n) => n,
+                Err(e) if e.kind == crate::PyErrorKind::OverflowError => {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::OverflowError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            crate::baseobjspace::object_functionstr_type_name(arg)
+                        ),
+                    ));
+                }
+                Err(e) => return Err(e),
+            };
             // bytesobject.py:797 — negative count raises ValueError
-            let n = pyre_object::w_int_get_value(arg);
             if n < 0 {
                 return Err(crate::PyError::value_error("negative count"));
             }
@@ -11659,21 +11722,35 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
             return Ok(new_bytes_like(args[0], &data));
         }
     }
-    // Iterable of ints — pypy/objspace/std/bytesobject.py _from_byte_sequence
-    // checks 0 <= val < 256 per element; out-of-range raises ValueError
-    // "bytes must be in range(0, 256)".
-    let items = crate::builtins::collect_iterable(arg)?;
-    let mut buf = Vec::with_capacity(items.len());
-    for item in items {
-        let val = unsafe { pyre_object::w_int_get_value(item) };
-        if !(0..=255).contains(&val) {
-            return Err(crate::PyError::value_error(
-                "bytes must be in range(0, 256)",
-            ));
+    // `_convert_from_buffer_or_iterable` → `_from_byte_sequence_loop`: iterate
+    // the source, coercing each element with `byte_w` (honours __index__ and
+    // range-checks 0..256, "bytes must be in range(0, 256)"; a non-index
+    // element → "'X' object cannot be interpreted as an integer").  A source
+    // with no __iter__ is the "cannot convert" case; an error raised by
+    // __iter__/__next__ propagates unchanged.
+    unsafe {
+        let it = match crate::baseobjspace::iter(arg) {
+            Ok(it) => it,
+            Err(e) => {
+                if crate::baseobjspace::lookup(arg, "__iter__").is_none() {
+                    return Err(crate::PyError::type_error(format!(
+                        "cannot convert '{}' object to bytes",
+                        crate::baseobjspace::object_functionstr_type_name(arg)
+                    )));
+                }
+                return Err(e);
+            }
+        };
+        let mut buf = Vec::new();
+        loop {
+            match crate::baseobjspace::next(it) {
+                Ok(item) => buf.push(crate::baseobjspace::byte_w(item, "bytes")?),
+                Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
+                Err(e) => return Err(e),
+            }
         }
-        buf.push(val as u8);
+        Ok(pyre_object::bytesobject::w_bytes_from_bytes(&buf))
     }
-    Ok(pyre_object::bytesobject::w_bytes_from_bytes(&buf))
 }
 
 /// `space.byte_w` — extract a single byte (`0 <= v < 256`) from an int

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9221,6 +9221,11 @@ fn init_bytes_type(ns: &mut DictStorage) {
     dict_storage_store(ns, "__new__", make_new_descr(bytes_descr_new));
     dict_storage_store(
         ns,
+        "__bytes__",
+        make_builtin_function_with_arity("__bytes__", bytes_method_bytes, 1),
+    );
+    dict_storage_store(
+        ns,
         "decode",
         make_builtin_function("decode", bytes_method_decode),
     );
@@ -11559,6 +11564,21 @@ pub(crate) fn bytes_method_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, c
 }
 
 /// PyPy: bytesobject.py descr_repr — returns a quoted literal like `b'hello'`.
+fn bytes_method_bytes(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // `W_BytesObject.descr_bytes` ("convert this value to exact type bytes"):
+    // an exact `bytes` returns itself; a subclass returns a fresh exact-bytes
+    // copy of its value.
+    crate::type_methods::require_receiver(args, "__bytes__")?;
+    let self_ = args[0];
+    if unsafe { pyre_object::pyobject::is_exact_type(self_, &pyre_object::bytesobject::BYTES_TYPE) }
+    {
+        return Ok(self_);
+    }
+    Ok(pyre_object::bytesobject::w_bytes_from_bytes(unsafe {
+        pyre_object::bytesobject::bytes_like_data(self_)
+    }))
+}
+
 fn bytes_method_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::require_receiver(args, "__repr__")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9176,23 +9176,21 @@ fn bytearray_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             }
             return Ok(pyre_object::bytearrayobject::w_bytearray_new(n as usize));
         }
-        if pyre_object::bytesobject::is_bytes_like(arg) {
-            let data = pyre_object::bytesobject::bytes_like_data(arg);
-            return Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(data));
-        }
-        // `buffer_w` rejects a released memoryview before gathering its bytes.
-        if pyre_object::memoryview::is_w_memoryview(arg) {
-            crate::builtins::memoryview_check_released(arg)?;
-        }
-        if let Some(data) = crate::builtins::memoryview_as_bytes(arg) {
-            return Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(&data));
+        // `_convert_from_buffer_or_iterable`: any buffer exporter — bytes,
+        // bytearray, `array.array`, memoryview — yields its raw buffer bytes
+        // (`buffer_w(BUF_FULL_RO).as_str()`) before the iterable path; a
+        // released memoryview raises first.
+        if let Some(b) = crate::typedef::buffer_as_bytes_like(arg)? {
+            return Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(
+                pyre_object::bytesobject::bytes_like_data(b),
+            ));
         }
     }
-    // bytesobject.py:856 `_from_byte_sequence_loop`: stream the source through
-    // `byte_w` (honours __index__, "byte must be in range(0, 256)"; a non-index
-    // element → "'X' object cannot be interpreted as an integer").  A source
-    // with no __iter__ → "cannot convert 'X' object to bytearray"; an error
-    // raised by __iter__/__next__ propagates unchanged.
+    // `_from_byte_sequence_loop`: stream the source through `byte_w` (honours
+    // __index__, "byte must be in range(0, 256)"; a non-index element → "'X'
+    // object cannot be interpreted as an integer").  A source with no __iter__
+    // → "cannot convert 'X' object to bytearray"; an error raised by
+    // __iter__/__next__ propagates unchanged.
     unsafe {
         let it = match crate::baseobjspace::iter(arg) {
             Ok(it) => it,
@@ -11668,9 +11666,18 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
                 type_name_of(arg)
             )));
         }
-        // bytesobject.py:783 `invoke_bytes_method` — a `__bytes__` special
-        // method takes precedence over the count / buffer / iterable paths and
-        // must return a `bytes` instance.  (bytearray does NOT honour __bytes__.)
+        // bytesobject.py:560 — `bytes(bytes_obj)` on an exact `bytes` source
+        // returns the argument unmodified (identity).  A subclass source falls
+        // through (its bytes are copied); a subclass *request* is retagged by
+        // `bytes_descr_new`, which copies before retagging.
+        if pyre_object::pyobject::is_exact_type(arg, &pyre_object::bytesobject::BYTES_TYPE) {
+            return Ok(arg);
+        }
+        // bytesobject.py:575 `invoke_bytes_method` — a `__bytes__` special
+        // method takes precedence over the count / buffer / iterable paths;
+        // its result is returned **unmodified** (even a bytes subclass), so the
+        // exact object identity is preserved.  (bytearray does NOT honour
+        // __bytes__.)
         if let Some(method) = crate::baseobjspace::lookup(arg, "__bytes__") {
             let w_bytes = crate::builtins::call_and_check(method, &[arg])?;
             if !pyre_object::bytesobject::is_bytes(w_bytes) {
@@ -11679,10 +11686,7 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
                     type_name_of(w_bytes)
                 )));
             }
-            return Ok(new_bytes_like(
-                args[0],
-                pyre_object::bytesobject::bytes_like_data(w_bytes),
-            ));
+            return Ok(w_bytes);
         }
         // newbytesdata_w_tail: `getindex_w(source, OverflowError)` — any object
         // exposing __index__ (not just an exact int) is a count of NUL bytes.
@@ -11710,24 +11714,22 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
                 &vec![0u8; n as usize],
             ));
         }
-        if pyre_object::bytesobject::is_bytes_like(arg) {
-            let data = pyre_object::bytesobject::bytes_like_data(arg);
-            return Ok(new_bytes_like(args[0], data));
-        }
-        // `buffer_w` rejects a released memoryview before gathering its bytes.
-        if pyre_object::memoryview::is_w_memoryview(arg) {
-            crate::builtins::memoryview_check_released(arg)?;
-        }
-        if let Some(data) = crate::builtins::memoryview_as_bytes(arg) {
-            return Ok(new_bytes_like(args[0], &data));
+        // `_convert_from_buffer_or_iterable`: any buffer exporter — bytes,
+        // bytearray, `array.array`, memoryview — yields its raw buffer bytes
+        // (`buffer_w(BUF_FULL_RO).as_str()`) before the iterable path; a
+        // released memoryview raises first.
+        if let Some(b) = crate::typedef::buffer_as_bytes_like(arg)? {
+            return Ok(new_bytes_like(
+                args[0],
+                pyre_object::bytesobject::bytes_like_data(b),
+            ));
         }
     }
-    // `_convert_from_buffer_or_iterable` → `_from_byte_sequence_loop`: iterate
-    // the source, coercing each element with `byte_w` (honours __index__ and
-    // range-checks 0..256, "bytes must be in range(0, 256)"; a non-index
-    // element → "'X' object cannot be interpreted as an integer").  A source
-    // with no __iter__ is the "cannot convert" case; an error raised by
-    // __iter__/__next__ propagates unchanged.
+    // `_from_byte_sequence_loop`: iterate the source, coercing each element
+    // with `byte_w` (honours __index__ and range-checks 0..256, "bytes must be
+    // in range(0, 256)"; a non-index element → "'X' object cannot be
+    // interpreted as an integer").  A source with no __iter__ is the "cannot
+    // convert" case; an error raised by __iter__/__next__ propagates unchanged.
     unsafe {
         let it = match crate::baseobjspace::iter(arg) {
             Ok(it) => it,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9089,6 +9089,14 @@ fn bytearray_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     // descr_init shares bytesobject.newbytesdata_w); `encoding`/`errors`
     // are only valid with a str source.
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    // pos[0] is the class; `bytearray(source, encoding, errors)` accepts at
+    // most three further positional arguments.
+    if pos.len() > 4 {
+        return Err(crate::PyError::type_error(&format!(
+            "bytearray() takes at most 3 arguments ({} given)",
+            pos.len() - 1
+        )));
+    }
     crate::builtins::kwarg_reject_unknown(kwargs, &["source", "encoding", "errors"], "bytearray")?;
     let source =
         crate::builtins::resolve_pos_or_kw(pos.get(1).copied(), kwargs, "source", "bytearray", 1)?;
@@ -11572,6 +11580,14 @@ fn bytes_descr_new_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     // every parameter is positional-or-keyword (bytesobject.py descr_new);
     // `encoding`/`errors` are only valid with a str source.
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    // pos[0] is the class; `bytes(source, encoding, errors)` accepts at most
+    // three further positional arguments.
+    if pos.len() > 4 {
+        return Err(crate::PyError::type_error(&format!(
+            "bytes() takes at most 3 arguments ({} given)",
+            pos.len() - 1
+        )));
+    }
     crate::builtins::kwarg_reject_unknown(kwargs, &["source", "encoding", "errors"], "bytes")?;
     let source =
         crate::builtins::resolve_pos_or_kw(pos.get(1).copied(), kwargs, "source", "bytes", 1)?;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -12105,6 +12105,42 @@ fn init_bytearray_type(ns: &mut DictStorage) {
         "copy",
         make_builtin_function("copy", bytearray_method_copy),
     );
+    // Subscript slots exposed as callable dunders.  Each binds the direct
+    // slot body so a subclass override's `super().__getitem__` reaches the
+    // inherited builtin subscript instead of re-entering override dispatch.
+    dict_storage_store(
+        ns,
+        "__getitem__",
+        make_builtin_function_with_arity(
+            "__getitem__",
+            |args| crate::baseobjspace::getitem_slot(args[0], args[1]),
+            2,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__setitem__",
+        make_builtin_function_with_arity(
+            "__setitem__",
+            |args| {
+                crate::baseobjspace::setitem_slot(args[0], args[1], args[2])?;
+                Ok(pyre_object::w_none())
+            },
+            3,
+        ),
+    );
+    dict_storage_store(
+        ns,
+        "__delitem__",
+        make_builtin_function_with_arity(
+            "__delitem__",
+            |args| {
+                crate::baseobjspace::delitem_slot(args[0], args[1])?;
+                Ok(pyre_object::w_none())
+            },
+            2,
+        ),
+    );
     for (name, func) in [
         ("__eq__", bytearray_dunder_eq as DunderFn),
         ("__ne__", bytearray_dunder_ne),

--- a/pyre/pyre-interpreter/src/unicodedb.rs
+++ b/pyre/pyre-interpreter/src/unicodedb.rs
@@ -11,6 +11,12 @@
 //!
 //! Generated from CPython `str` predicates over the whole scalar range
 //! (Unicode 16.0.0); regenerate by enumerating `chr(c).isdecimal()` etc.
+//!
+//! Version target: pyre matches CPython 3.14 semantics, whose `unicodedata`
+//! is Unicode 16.0.0.  The in-tree PyPy imports `unicodedb_14_0_0`, so these
+//! tables intentionally carry the newer Unicode version — the predicate shape
+//! is identical, only the covered code points differ.  This is a version
+//! adaptation, not a parity divergence.
 
 const DECIMAL: &[(u32, u32)] = &[
     (0x0030, 0x0039),

--- a/scripts/extract-llbc.py
+++ b/scripts/extract-llbc.py
@@ -345,7 +345,7 @@ def extract(args: argparse.Namespace) -> None:
         f'host.rustflags=["{crate_attr}"]',
     ]
 
-    for crate in args.crates or ALL_CRATES:
+    for crate in args.crates or DEFAULT_CRATES:
         path, flags = crate_info(root, crate, cargo_features)
         if not path.is_dir():
             raise SystemExit(f"extract-llbc.py: missing crate dir for '{crate}' at {path}")


### PR DESCRIPTION
refs #37

Follow-up parity fixes from the PR #291 memoryview review cycle, on top of `origin/main`.

## memoryview

- N-D slice rejects with `NotImplementedError`; 0-D `tolist` returns the scalar; array writeback through the live backing.
- Released-state comparison, `_sre`/`_socket` buffer acquisition, and constructor validation fixes.
- `raw_address`, `__delitem__` error messages, and socket `array` buffer support.
- Drop `__contains__` from the type (memoryview is not a container slot); membership now falls back to the `sequence_contains` getitem scan, which also propagates non-`IndexError` exceptions from a custom `__getitem__`.

## bytearray

- `del`-statement support: functional `bytearray` element/slice delete with memoryview routing.
- `__getitem__`/`__setitem__`/`__delitem__` subscript dunder methods registered as slot-wrappers; slice assignment (step-1 splice + extended-slice equal-length write), with source materialized before the backing borrow.

## PickleBuffer

- `__pypy__.PickleBuffer.raw` byte-normalizes the view and raises `BufferError` for non-contiguous buffers.

All changes gated on both backends (`pyre/check.py` 160/160 dynasm + 160/160 cranelift) and `extra_tests/snippets/builtin_memoryview.py` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Unicode identifier support using Unicode character properties.
  * Added a `memoryview` raw backing-address accessor and improved buffer support in socket writes (including array-backed writable buffers).

* **Bug Fixes**
  * Improved `bytearray`/`bytes` construction, argument validation, and `bytearray` indexing/slicing/assignment/deletion semantics to match expected Python behavior and clearer errors.
  * Tightened `memoryview` slicing, slice assignment rules, equality/released handling, deletion ordering, and `tolist()` for unsupported shapes.
  * Refined slice index evaluation and broader bytes-like handling in the regex bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->