### PR TITLE
JIT: migrate resume-liveness readers from flat stack_slot_color_map to per-PC pcdep (#73)

### DIFF
--- a/pyre/pyre-jit-trace/src/canonical_bridge.rs
+++ b/pyre/pyre-jit-trace/src/canonical_bridge.rs
@@ -224,6 +224,9 @@ pub fn install_portal_for(code_ptr: *const pyre_interpreter::CodeObject) -> Arc<
             after_residual_call_resume_pc: Vec::new(),
             first_jit_pc_by_py_pc: Vec::new(),
             depth_at_py_pc,
+            // Portal bridges have an empty pc_map, so the inline multiframe
+            // capture declines before it reads this; keep it empty.
+            result_color_at_pc: Vec::new(),
             portal_frame_reg,
             portal_ec_reg,
             built_as_portal: true,
@@ -417,6 +420,7 @@ def f(x, y):
                 after_residual_call_resume_pc: vec![None],
                 first_jit_pc_by_py_pc: vec![0],
                 depth_at_py_pc: Vec::new(),
+                result_color_at_pc: Vec::new(),
                 portal_frame_reg: 0,
                 portal_ec_reg: 0,
                 built_as_portal: true,

--- a/pyre/pyre-jit-trace/src/canonical_bridge.rs
+++ b/pyre/pyre-jit-trace/src/canonical_bridge.rs
@@ -190,9 +190,9 @@ pub fn install_portal_for(code_ptr: *const pyre_interpreter::CodeObject) -> Arc<
     // collapsing to `stack_base + 0`. The contract is documented at
     // `PyreJitCode::stack_slot_color_map`. With no regalloc the color of each slot is
     // its own pre-color, hence the identity fill.
-    let (stack_base, depth_at_py_pc, stack_slot_color_map, pyre_color_for_semantic_local) =
+    let (stack_base, depth_at_py_pc, stack_slot_color_map, pyre_color_for_semantic_local, max_stackdepth) =
         if code_ptr.is_null() {
-            (0, Vec::new(), Vec::new(), Vec::new())
+            (0, Vec::new(), Vec::new(), Vec::new(), 0)
         } else {
             let code = unsafe { &*code_ptr };
             let nlocals = code.varnames.len();
@@ -208,6 +208,7 @@ pub fn install_portal_for(code_ptr: *const pyre_interpreter::CodeObject) -> Arc<
                 depth_at_py_pc,
                 stack_slot_color_map,
                 pyre_color_for_semantic_local,
+                max_stackdepth,
             )
         };
 
@@ -222,6 +223,7 @@ pub fn install_portal_for(code_ptr: *const pyre_interpreter::CodeObject) -> Arc<
             portal_ec_reg,
             built_as_portal: true,
             stack_base,
+            max_stackdepth,
             stack_slot_color_map,
             pyre_color_for_semantic_local,
             pcdep_color_slots: Vec::new(),
@@ -414,6 +416,7 @@ def f(x, y):
                 portal_ec_reg: 0,
                 built_as_portal: true,
                 stack_base: 0,
+                max_stackdepth: 0,
                 stack_slot_color_map: Vec::new(),
                 pyre_color_for_semantic_local: Vec::new(),
                 pcdep_color_slots: Vec::new(),

--- a/pyre/pyre-jit-trace/src/canonical_bridge.rs
+++ b/pyre/pyre-jit-trace/src/canonical_bridge.rs
@@ -190,27 +190,32 @@ pub fn install_portal_for(code_ptr: *const pyre_interpreter::CodeObject) -> Arc<
     // collapsing to `stack_base + 0`. The contract is documented at
     // `PyreJitCode::stack_slot_color_map`. With no regalloc the color of each slot is
     // its own pre-color, hence the identity fill.
-    let (stack_base, depth_at_py_pc, stack_slot_color_map, pyre_color_for_semantic_local, max_stackdepth) =
-        if code_ptr.is_null() {
-            (0, Vec::new(), Vec::new(), Vec::new(), 0)
-        } else {
-            let code = unsafe { &*code_ptr };
-            let nlocals = code.varnames.len();
-            let stack_base = nlocals + pyre_interpreter::pyframe::ncells(code);
-            let depth_at_py_pc = crate::liveness::liveness_for(code_ptr).depth_at_py_pc();
-            let max_stackdepth = code.max_stackdepth as usize;
-            let stack_slot_color_map: Vec<u16> = (0..max_stackdepth as u16)
-                .map(|d| stack_base as u16 + d)
-                .collect();
-            let pyre_color_for_semantic_local: Vec<u16> = (0..nlocals as u16).collect();
-            (
-                stack_base,
-                depth_at_py_pc,
-                stack_slot_color_map,
-                pyre_color_for_semantic_local,
-                max_stackdepth,
-            )
-        };
+    let (
+        stack_base,
+        depth_at_py_pc,
+        stack_slot_color_map,
+        pyre_color_for_semantic_local,
+        max_stackdepth,
+    ) = if code_ptr.is_null() {
+        (0, Vec::new(), Vec::new(), Vec::new(), 0)
+    } else {
+        let code = unsafe { &*code_ptr };
+        let nlocals = code.varnames.len();
+        let stack_base = nlocals + pyre_interpreter::pyframe::ncells(code);
+        let depth_at_py_pc = crate::liveness::liveness_for(code_ptr).depth_at_py_pc();
+        let max_stackdepth = code.max_stackdepth as usize;
+        let stack_slot_color_map: Vec<u16> = (0..max_stackdepth as u16)
+            .map(|d| stack_base as u16 + d)
+            .collect();
+        let pyre_color_for_semantic_local: Vec<u16> = (0..nlocals as u16).collect();
+        (
+            stack_base,
+            depth_at_py_pc,
+            stack_slot_color_map,
+            pyre_color_for_semantic_local,
+            max_stackdepth,
+        )
+    };
 
     Arc::new(PyJitCode::from_parts(
         runtime,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9229,9 +9229,12 @@ fn compute_inline_caller_frame(
     if depth == 0 {
         return None;
     }
-    let result_idx = depth - 1;
-    let stack_color_map = crate::state::stack_slot_color_map_at(jitcode_index as i32);
-    let result_color = *stack_color_map.get(result_idx)? as usize;
+    // #73: the result slot's color comes from the codewriter-precomputed
+    // `result_color_at_pc` (top-of-stack color at the return pc), not the flat
+    // `stack_slot_color_map` — the result is not a live Variable here, so it
+    // carries no pcdep entry.
+    let result_color =
+        crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)?;
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume).
@@ -9300,9 +9303,10 @@ fn compute_nested_inline_caller_frame(
     if depth == 0 {
         return None;
     }
-    let result_idx = depth - 1;
-    let stack_color_map = crate::state::stack_slot_color_map_at(jitcode_index as i32);
-    let result_color = *stack_color_map.get(result_idx)? as usize;
+    // #73: result slot color from the precomputed `result_color_at_pc`, not
+    // the flat `stack_slot_color_map` (see `compute_inline_caller_frame`).
+    let result_color =
+        crate::state::result_color_at_pc_at(jitcode_index as i32, fallthrough_py_pc as usize)?;
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume) — same as the top-level

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5775,15 +5775,41 @@ fn collect_outer_active_boxes(
     // `semantic_ref_slot_for_reg_color`, read the vable shadow for
     // portal-owner frames, and route the two portal red regs through
     // `sym.frame` / `sym.execution_context` directly.
-    let (nlocals, valid_stack_only, owns_vable, local_color_map, portal_frame_reg, portal_ec_reg) =
-        if sym.jitcode.is_null() {
-            (0usize, 0usize, false, Vec::new(), u16::MAX, u16::MAX)
-        } else {
-            unsafe {
-                let jc = &*sym.jitcode;
-                let payload = &jc.payload;
-                let stack_depth_at_pc = if payload.code_ptr.is_null() {
-                    0usize
+    let (
+        nlocals,
+        valid_stack_only,
+        owns_vable,
+        local_color_map,
+        portal_stack_color_map,
+        portal_live_locals,
+        portal_frame_reg,
+        portal_ec_reg,
+    ) = if sym.jitcode.is_null() {
+        (
+            0usize,
+            0usize,
+            false,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            u16::MAX,
+            u16::MAX,
+        )
+    } else {
+        unsafe {
+            let jc = &*sym.jitcode;
+            let payload = &jc.payload;
+            // A portal-bridge install leaves `pcdep_color_slots` empty by
+            // design (keyed off by `is_portal_bridge()`), so its color→slot
+            // inversion has no per-PC source and must keep flowing through the
+            // flat identity maps — the pre-#348 path. The non-portal common
+            // case is covered by `pcdep_opt` below, so its flat-map inputs stay
+            // empty (the #348 drain). Computing the liveness-derived
+            // `live_locals` only for portals preserves that drain.
+            let is_portal = payload.is_portal_bridge();
+            let (portal_stack_color_map, portal_live_locals, stack_depth_at_pc) =
+                if payload.code_ptr.is_null() {
+                    (Vec::new(), Vec::new(), 0usize)
                 } else {
                     let live_vars = crate::liveness::liveness_for(payload.code_ptr);
                     // Operand-stack depth AT the snapshot's `entry_py_pc`.  The
@@ -5798,33 +5824,45 @@ fn collect_outer_active_boxes(
                     // py_pc whose depth `> 0` while the walker stands at depth
                     // 0 — using the current depth there drops the kept temp's
                     // semantic slot, corrupting the resumed frame.
-                    live_vars
+                    let depth = live_vars
                         .depth_at_py_pc()
                         .get(entry_py_pc as usize)
                         .copied()
-                        .unwrap_or(0) as usize
+                        .unwrap_or(0) as usize;
+                    let (stack_color_map, live_locals) = if is_portal {
+                        let live_locals = (0..sym.nlocals)
+                            .filter(|&idx| live_vars.is_local_live(entry_py_pc as usize, idx))
+                            .collect::<Vec<usize>>();
+                        (payload.metadata.stack_slot_color_map.clone(), live_locals)
+                    } else {
+                        (Vec::new(), Vec::new())
+                    };
+                    (stack_color_map, live_locals, depth)
                 };
-                (
-                    sym.nlocals,
-                    stack_depth_at_pc,
-                    sym.owns_virtualizable_shadow(),
-                    payload.metadata.pyre_color_for_semantic_local.clone(),
-                    payload.metadata.portal_frame_reg,
-                    payload.metadata.portal_ec_reg,
-                )
-            }
-        };
-    // #348: per-PC color→slot entries at the snapshot PC — the sole color→slot
-    // source the inversions below consult, the per-program-point color space
-    // the `-live-` markers carry. Branch-guard resumes (`guard_py_pc.is_some()`)
-    // are fully covered here; a per-opcode-entry resume whose live Ref colors
-    // are all constants/leaked carries no entry (the resume snapshot records
-    // Variables only), so `semantic_ref_slot_for_reg_color` returns `None` and
-    // the live color falls to the `regs_r[color]` walk-bank read below. The flat
-    // `stack_slot_color_map` stack inversion and the local-position scan are no
-    // longer threaded in (the encoder passes empty stack/local-index slices);
-    // `local_color_map` (`pyre_color_for_semantic_local`) is still passed solely
-    // as the portal-identity (`is_empty`) discriminator the function keys on.
+            (
+                sym.nlocals,
+                stack_depth_at_pc,
+                sym.owns_virtualizable_shadow(),
+                payload.metadata.pyre_color_for_semantic_local.clone(),
+                portal_stack_color_map,
+                portal_live_locals,
+                payload.metadata.portal_frame_reg,
+                payload.metadata.portal_ec_reg,
+            )
+        }
+    };
+    // #348: per-PC color→slot entries at the snapshot PC — the color→slot source
+    // the inversions below consult for every drained (non-portal) jitcode, the
+    // per-program-point color space the `-live-` markers carry. Branch-guard
+    // resumes (`guard_py_pc.is_some()`) are fully covered here; a per-opcode-entry
+    // resume whose live Ref colors are all constants/leaked carries no entry (the
+    // resume snapshot records Variables only), so `semantic_ref_slot_for_reg_color`
+    // returns `None` and the live color falls to the `regs_r[color]` walk-bank
+    // read below. Portal-bridge frames carry no `pcdep` entry (empty by install),
+    // so for them `pcdep_opt` is `None` and the flat identity
+    // `portal_stack_color_map` / `portal_live_locals` (empty for non-portal) carry
+    // the inversion instead; `local_color_map` (`pyre_color_for_semantic_local`)
+    // backs the function's local-position scan on that path.
     let pcdep_entries: Vec<(u16, u16)> = if sym.jitcode.is_null() {
         Vec::new()
     } else {
@@ -5938,8 +5976,8 @@ fn collect_outer_active_boxes(
                         nlocals,
                         valid_stack_only,
                         &local_color_map,
-                        &[],
-                        &[],
+                        &portal_stack_color_map,
+                        &portal_live_locals,
                         pcdep_opt,
                         c as usize,
                     )?;
@@ -5982,8 +6020,8 @@ fn collect_outer_active_boxes(
                     nlocals,
                     valid_stack_only,
                     &local_color_map,
-                    &[],
-                    &[],
+                    &portal_stack_color_map,
+                    &portal_live_locals,
                     pcdep_opt,
                     c as usize,
                 ) else {
@@ -6031,8 +6069,8 @@ fn collect_outer_active_boxes(
                 nlocals,
                 valid_stack_only,
                 &local_color_map,
-                &[],
-                &[],
+                &portal_stack_color_map,
+                &portal_live_locals,
                 pcdep_opt,
                 color,
             ) {
@@ -6076,8 +6114,8 @@ fn collect_outer_active_boxes(
                 nlocals,
                 valid_stack_only,
                 &local_color_map,
-                &[],
-                &[],
+                &portal_stack_color_map,
+                &portal_live_locals,
                 pcdep_opt,
                 color,
             );

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5775,74 +5775,56 @@ fn collect_outer_active_boxes(
     // `semantic_ref_slot_for_reg_color`, read the vable shadow for
     // portal-owner frames, and route the two portal red regs through
     // `sym.frame` / `sym.execution_context` directly.
-    let (
-        nlocals,
-        valid_stack_only,
-        owns_vable,
-        local_color_map,
-        stack_color_map,
-        live_locals,
-        portal_frame_reg,
-        portal_ec_reg,
-    ) = if sym.jitcode.is_null() {
-        (
-            0usize,
-            0usize,
-            false,
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-            u16::MAX,
-            u16::MAX,
-        )
-    } else {
-        unsafe {
-            let jc = &*sym.jitcode;
-            let payload = &jc.payload;
-            let (live_locals, stack_depth_at_pc) = if payload.code_ptr.is_null() {
-                (Vec::new(), 0usize)
-            } else {
-                let live_vars = crate::liveness::liveness_for(payload.code_ptr);
-                let live_locals = (0..sym.nlocals)
-                    .filter(|&idx| live_vars.is_local_live(entry_py_pc as usize, idx))
-                    .collect::<Vec<usize>>();
-                // Operand-stack depth AT the snapshot's `entry_py_pc`.  The
-                // liveness banks (`frame_liveness_reg_indices_by_bank_at`)
-                // are read at that py_pc, so the stack-slot classification
-                // window must be the depth at that py_pc too — NOT
-                // `sym.valuestackdepth` (the walker's *current* position).
-                // For the per-opcode entry caller the two coincide, but a
-                // guard resuming at a not-taken branch target with a kept
-                // operand-stack temp (conditional expr / short-circuit /
-                // chained compare, #124/#281) resumes at a py_pc whose
-                // depth `> 0` while the walker stands at depth 0 — using
-                // the current depth there truncates `stack_color_map` and
-                // drops the kept temp's semantic slot, corrupting the
-                // resumed frame.
-                let depth = live_vars
-                    .depth_at_py_pc()
-                    .get(entry_py_pc as usize)
-                    .copied()
-                    .unwrap_or(0) as usize;
-                (live_locals, depth)
-            };
-            (
-                sym.nlocals,
-                stack_depth_at_pc,
-                sym.owns_virtualizable_shadow(),
-                payload.metadata.pyre_color_for_semantic_local.clone(),
-                payload.metadata.stack_slot_color_map.clone(),
-                live_locals,
-                payload.metadata.portal_frame_reg,
-                payload.metadata.portal_ec_reg,
-            )
-        }
-    };
-    // #348: per-PC color→slot entries at the snapshot PC. Populated for every
-    // production jitcode (empty only under the `PYRE_PCDEP_RESUME_OFF` escape
-    // hatch); when present, the color→slot inversions below consult it instead
-    // of the flat maps, the same per-program-point color space the `-live-`
-    // markers carry.
+    let (nlocals, valid_stack_only, owns_vable, local_color_map, portal_frame_reg, portal_ec_reg) =
+        if sym.jitcode.is_null() {
+            (0usize, 0usize, false, Vec::new(), u16::MAX, u16::MAX)
+        } else {
+            unsafe {
+                let jc = &*sym.jitcode;
+                let payload = &jc.payload;
+                let stack_depth_at_pc = if payload.code_ptr.is_null() {
+                    0usize
+                } else {
+                    let live_vars = crate::liveness::liveness_for(payload.code_ptr);
+                    // Operand-stack depth AT the snapshot's `entry_py_pc`.  The
+                    // liveness banks (`frame_liveness_reg_indices_by_bank_at`)
+                    // are read at that py_pc, so the per-PC color→slot window
+                    // (`pcdep_opt`'s stack clamp below) must be the depth at
+                    // that py_pc too — NOT `sym.valuestackdepth` (the walker's
+                    // *current* position).  For the per-opcode entry caller the
+                    // two coincide, but a guard resuming at a not-taken branch
+                    // target with a kept operand-stack temp (conditional expr /
+                    // short-circuit / chained compare, #124/#281) resumes at a
+                    // py_pc whose depth `> 0` while the walker stands at depth
+                    // 0 — using the current depth there drops the kept temp's
+                    // semantic slot, corrupting the resumed frame.
+                    live_vars
+                        .depth_at_py_pc()
+                        .get(entry_py_pc as usize)
+                        .copied()
+                        .unwrap_or(0) as usize
+                };
+                (
+                    sym.nlocals,
+                    stack_depth_at_pc,
+                    sym.owns_virtualizable_shadow(),
+                    payload.metadata.pyre_color_for_semantic_local.clone(),
+                    payload.metadata.portal_frame_reg,
+                    payload.metadata.portal_ec_reg,
+                )
+            }
+        };
+    // #348: per-PC color→slot entries at the snapshot PC — the sole color→slot
+    // source the inversions below consult, the per-program-point color space
+    // the `-live-` markers carry. Branch-guard resumes (`guard_py_pc.is_some()`)
+    // are fully covered here; a per-opcode-entry resume whose live Ref colors
+    // are all constants/leaked carries no entry (the resume snapshot records
+    // Variables only), so `semantic_ref_slot_for_reg_color` returns `None` and
+    // the live color falls to the `regs_r[color]` walk-bank read below. The flat
+    // `stack_slot_color_map` stack inversion and the local-position scan are no
+    // longer threaded in (the encoder passes empty stack/local-index slices);
+    // `local_color_map` (`pyre_color_for_semantic_local`) is still passed solely
+    // as the portal-identity (`is_empty`) discriminator the function keys on.
     let pcdep_entries: Vec<(u16, u16)> = if sym.jitcode.is_null() {
         Vec::new()
     } else {
@@ -5956,8 +5938,8 @@ fn collect_outer_active_boxes(
                         nlocals,
                         valid_stack_only,
                         &local_color_map,
-                        &stack_color_map,
-                        &live_locals,
+                        &[],
+                        &[],
                         pcdep_opt,
                         c as usize,
                     )?;
@@ -6000,8 +5982,8 @@ fn collect_outer_active_boxes(
                     nlocals,
                     valid_stack_only,
                     &local_color_map,
-                    &stack_color_map,
-                    &live_locals,
+                    &[],
+                    &[],
                     pcdep_opt,
                     c as usize,
                 ) else {
@@ -6049,8 +6031,8 @@ fn collect_outer_active_boxes(
                 nlocals,
                 valid_stack_only,
                 &local_color_map,
-                &stack_color_map,
-                &live_locals,
+                &[],
+                &[],
                 pcdep_opt,
                 color,
             ) {
@@ -6094,8 +6076,8 @@ fn collect_outer_active_boxes(
                 nlocals,
                 valid_stack_only,
                 &local_color_map,
-                &stack_color_map,
-                &live_locals,
+                &[],
+                &[],
                 pcdep_opt,
                 color,
             );

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5833,7 +5833,21 @@ fn collect_outer_active_boxes(
                         let live_locals = (0..sym.nlocals)
                             .filter(|&idx| live_vars.is_local_live(entry_py_pc as usize, idx))
                             .collect::<Vec<usize>>();
-                        (payload.metadata.stack_slot_color_map.clone(), live_locals)
+                        // #73: recompute the portal stack color map from its
+                        // defining formula instead of reading the flat
+                        // `stack_slot_color_map` field. A portal install
+                        // (`install_portal_for`) runs no regalloc, so the color
+                        // of stack slot `d` is its own PyFrame index
+                        // `stack_base + d` (`stack_base = nlocals + ncells`) —
+                        // byte-identical to the stored map. Draining this reader
+                        // moves the field one step closer to removal.
+                        let code = &*payload.code_ptr;
+                        let stack_base =
+                            code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
+                        let scm: Vec<u16> = (0..code.max_stackdepth as u16)
+                            .map(|d| stack_base as u16 + d)
+                            .collect();
+                        (scm, live_locals)
                     } else {
                         (Vec::new(), Vec::new())
                     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8152,10 +8152,10 @@ fn decode_branch_trampoline_ref_moves(code: &[u8], tramp_start: usize) -> Option
 }
 
 /// The frame whose JitCode byte offsets the branch-resume gate readers
-/// ([`branch_resume_target_stack_depth`] / [`branch_resume_stack_colors`])
+/// ([`branch_resume_target_stack_depth`] and the kept-slot hazard checks)
 /// resolve through.  Holds the frame's `PyJitCode` payload — its `metadata`
-/// (`pc_map` for the jitcode-pc → Python-pc inversion, `stack_slot_color_map`
-/// for the kept-slot resume colors) and `code_ptr` (the liveness key).
+/// (`pc_map` for the jitcode-pc → Python-pc inversion) and `code_ptr` (the
+/// liveness key).
 ///
 /// Two constructors mark the frame model: the gate must read the frame whose
 /// jitcode the `target` offset indexes, NOT a single global.
@@ -8236,44 +8236,6 @@ fn branch_resume_target_stack_depth(frame: &ActiveResumeFrame, target: usize) ->
             .depth_at_py_pc()
             .get(py)
             .copied()
-    }
-}
-
-/// The resume-merge Ref colors of a branch guard's kept operand-stack
-/// slots (`#420`): `stack_slot_color_map[0 .. depth_at_py_pc[resume]]`,
-/// the colors `collect_outer_active_boxes` / `stack_sync` look the kept
-/// values up by.  Used to decide whether the not-taken edge's decoded
-/// `ref_copy` moves cover *every* kept slot — only then is the depth > 1
-/// recovery complete and the guard safe to compile.  A slot the edge does
-/// not rename is "live-across"; its value sits at the possibly-collapsed
-/// `stack_slot_color_map[s]` color, unproven for depth > 1, so an
-/// uncovered slot keeps the conservative decline.  Same `frame` contract as
-/// `branch_resume_target_stack_depth`.
-fn branch_resume_stack_colors(frame: &ActiveResumeFrame, target: usize) -> Option<Vec<u16>> {
-    let pjc = &frame.0;
-    if pjc.code_ptr.is_null() {
-        return None;
-    }
-    // SAFETY: `code_ptr` / `metadata` are immutable payload layout fields;
-    // the frame holds an `Arc<PyJitCode>` keeping them alive for this read.
-    unsafe {
-        let code = &*pjc.code_ptr;
-        let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
-        let py = skip_python_trivia_forward(code, py);
-        let depth = crate::liveness::liveness_for(pjc.code_ptr)
-            .depth_at_py_pc()
-            .get(py)
-            .copied()? as usize;
-        let scm = &pjc.metadata.stack_slot_color_map;
-        // Defensive: a map shorter than the resume depth (only possible if
-        // stack_slot_color_map were under-sized below co_stacksize, the
-        // regression pyjitcode.rs warns about) must DECLINE, not silently
-        // truncate the kept-slot color list — a truncated list would let
-        // recovery_complete pass without checking every kept slot.
-        if depth > scm.len() {
-            return None;
-        }
-        Some((0..depth).map(|s| scm[s]).collect())
     }
 }
 
@@ -8371,7 +8333,8 @@ fn kept_stack_has_boxed_int_hazard(
 /// (`collect_outer_active_boxes` → `frame_liveness_reg_indices_by_bank_at`)
 /// plus the const-window registers at index `>= num_regs_r` (auto-loaded
 /// from `jitcode.constants_r` by `init_register_files_from_runtime_jitcode`).
-/// Same `FULL_BODY_SNAPSHOT_SYM` contract as [`branch_resume_stack_colors`].
+/// Same `FULL_BODY_SNAPSHOT_SYM` contract as
+/// [`branch_resume_target_stack_depth`].
 fn branch_arm_resume_ref_liveness(
     target: usize,
     outer_jitcode_index: u32,
@@ -16980,19 +16943,17 @@ fn handle(
                     );
                 }
                 // Resolve each `(dst, src)` move to `(dst, live guard value)`
-                // against the guard-state register file NOW — before gating.
-                // A move whose `src` is out of range or holds `OpRef::NONE`
-                // recovers no live kept value, so it must not count toward
-                // coverage; basing `recovery_complete` on the raw `dst` set
-                // would let such a move pass the gate and then silently drop
-                // at the snapshot step, leaving a kept slot unrecovered (a
-                // depth > 1 miscompile).  A const-source `ref_copy` patches
-                // `src` into the constants window of `registers_r`, so this
-                // one read covers register and const sources alike.  The same
-                // resolved set both gates and feeds the snapshot encoder
-                // (single source of truth); `record_guard` below records into
-                // the trace history only and does not mutate `registers_r`,
-                // so reading it here is identical to reading it post-guard.
+                // against the guard-state register file NOW, before recording
+                // the guard.  A move whose `src` is out of range or holds
+                // `OpRef::NONE` recovers no live kept value and is dropped so the
+                // snapshot encoder never records a dead kept slot.  A const-source
+                // `ref_copy` patches `src` into the constants window of
+                // `registers_r`, so this one read covers register and const
+                // sources alike.  This resolved set is the single source of truth
+                // the snapshot encoder reads (`BRANCH_GUARD_KEPT_RECOVERED_RESOLVED`
+                // below); `record_guard` records into the trace history only and
+                // does not mutate `registers_r`, so reading it here is identical
+                // to reading it post-guard.
                 let resolved_recovered: Option<Vec<(u16, OpRef)>> =
                     kept_recovered.as_ref().map(|mv| {
                         mv.iter()
@@ -17002,62 +16963,6 @@ fn handle(
                             })
                             .collect()
                     });
-                // Recover depth > 1 only when the decoded edge moves cover
-                // EVERY kept resume stack slot.  A slot the not-taken edge
-                // does not rename ("live-across") would fall through to the
-                // possibly-collapsed `stack_slot_color_map[s]` read — the
-                // original depth > 1 decline reason — so an uncovered slot,
-                // a cyclic `*_push`/`*_pop` (decodes to `None`), or unknown
-                // liveness keeps the conservative decline.  Depth-1 is handled
-                // by the positional heuristic below and is not gated here.
-                // `PYRE_RELAX_124` forces depth > 1 through for diagnosis.
-                let recovery_complete = match (
-                    resolved_recovered.as_ref(),
-                    gate_frame
-                        .as_ref()
-                        .and_then(|f| branch_resume_stack_colors(f, other_target)),
-                ) {
-                    (Some(resolved), Some(cols)) => {
-                        // Every kept slot's resume color must be DISTINCT — a
-                        // collapsed `stack_slot_color_map` aliasing two slots
-                        // onto one color would feed both the same recovered
-                        // value.
-                        let distinct = cols.iter().enumerate().all(|(i, c)| !cols[..i].contains(c));
-                        // Whether the not-taken edge renames at all: a non-empty
-                        // decoded `ref_copy` trampoline means a real merge that
-                        // moves SOME kept slots into fresh colors.
-                        let edge_renames = kept_recovered.as_ref().is_some_and(|m| !m.is_empty());
-                        let all_recoverable = if edge_renames {
-                            // Renaming edge: every kept color must be covered by
-                            // an explicit decoded move (#420).  An UNcovered slot
-                            // reads its (unwritten/stale) merge color — it is NOT
-                            // live-across, since the edge renamed siblings — so
-                            // keep the conservative decline.
-                            cols.iter()
-                                .all(|c| resolved.iter().any(|&(dst, _)| dst == *c))
-                        } else {
-                            // Empty trampoline: the not-taken edge does NO
-                            // renaming (an exception-handler / non-merge resume).
-                            // Every kept slot stays at the SAME color the walk
-                            // wrote — "live-across" — recovered from the guard-pc
-                            // register file at its own color (the snapshot
-                            // fallback, `walker_capture_snapshot_for_last_guard_impl`
-                            // :5471).  Exact iff distinct (no collapse) AND each
-                            // color holds a live value there; verify
-                            // `registers_r[color]` is in range and non-`NONE` (the
-                            // same file the snapshot reads; `record_guard` below
-                            // does not mutate it).
-                            cols.iter().all(|c| {
-                                ctx.registers_r
-                                    .get(*c as usize)
-                                    .copied()
-                                    .is_some_and(|v| v != OpRef::NONE)
-                            })
-                        };
-                        distinct && all_recoverable
-                    }
-                    _ => false,
-                };
                 // PARITY DEVIATION (converges at the symbolic-valuestack
                 // capture, #73/#423): `opimpl_goto_if_not` (pyjitpl.py:511/520)
                 // always records GUARD_TRUE/FALSE for a non-constant condition
@@ -17154,7 +17059,13 @@ fn handle(
                         });
                     }
                 }
-                if depth_gt_1 && !recovery_complete && !relax_124 && !mirror_covers_kept {
+                // A depth > 1 kept operand stack is recoverable on resume only
+                // from the symbolic-valuestack mirror (`mirror_covers_kept`).  When
+                // the mirror is invalid (an undermodeled walk: inline sub-walk /
+                // Unmodeled opcode), the kept slots have no reliable per-slot
+                // source, so decline → interpreter (correct).  `PYRE_RELAX_124`
+                // forces depth > 1 through for diagnosis.
+                if depth_gt_1 && !relax_124 && !mirror_covers_kept {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -100,6 +100,18 @@ pub struct PyJitCodeMetadata {
     pub first_jit_pc_by_py_pc: Vec<usize>,
     /// Value-stack depth at each Python PC, in slots above stack_base.
     pub depth_at_py_pc: Vec<u16>,
+    /// Post-regalloc Ref-bank color of the call-result operand-stack slot
+    /// (top of stack) at each Python PC: `result_color_at_pc[pc]` =
+    /// `stack_slot_color_map[depth_at_py_pc[pc] - 1]`, or `u16::MAX` where the
+    /// stack is empty. The inline multiframe capture
+    /// (`jitcode_dispatch::compute_inline_caller_frame` /
+    /// `compute_nested_inline_caller_frame`) nulls the not-yet-produced result
+    /// register before serializing the paused caller frame; that slot is not a
+    /// live Variable at the return PC, so it carries no `pcdep_color_slots`
+    /// entry. This precomputed table supplies its color so the capture no
+    /// longer reads the flat `stack_slot_color_map` at runtime. Same length as
+    /// `depth_at_py_pc`; empty for non-compiled skeleton metadata.
+    pub result_color_at_pc: Vec<u16>,
     /// Post-regalloc Ref-bank color of the portal jitdriver's first red
     /// argument (`frame`).  RPython parity: `pypy/module/pypyjit/
     /// interp_jit.py:67 reds = ['frame', 'ec']` declares the portal
@@ -605,6 +617,7 @@ impl PyJitCode {
                 after_residual_call_resume_pc: Vec::new(),
                 first_jit_pc_by_py_pc: Vec::new(),
                 depth_at_py_pc: Vec::new(),
+                result_color_at_pc: Vec::new(),
                 // u16::MAX sentinel mirrors `canonical_bridge::install_portal_for`
                 // (canonical_bridge.rs:165-166). Encoder/decoder readers in
                 // `get_list_of_active_boxes`, `regalloc::external/input_indices`,

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -129,6 +129,13 @@ pub struct PyJitCodeMetadata {
     pub built_as_portal: bool,
     /// Absolute start index of the operand stack in PyFrame.locals_cells_stack_w.
     pub stack_base: usize,
+    /// Maximum operand-stack depth (`code.max_stackdepth` = CPython
+    /// `co_stacksize`). Equals `stack_slot_color_map.len()` for a compiled
+    /// jitcode (the length invariant documented on that field) and `0` for
+    /// non-compiled skeleton metadata. Carries the operand-stack dimension so
+    /// the bridge frame-array sizing (`state.rs::setup_bridge_sym`) reads the
+    /// depth directly instead of `stack_slot_color_map.len()`.
+    pub max_stackdepth: usize,
     /// Post-regalloc
     /// color of each Python-semantic stack slot.
     /// `stack_slot_color_map[d]` = `apply_rename(Kind::Ref, nlocals + d)`
@@ -609,6 +616,7 @@ impl PyJitCode {
                 portal_ec_reg: u16::MAX,
                 built_as_portal: false,
                 stack_base: 0,
+                max_stackdepth: 0,
                 stack_slot_color_map: Vec::new(),
                 pyre_color_for_semantic_local: Vec::new(),
                 pcdep_color_slots: Vec::new(),

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7880,44 +7880,44 @@ impl JitState for PyreJitState {
             // Per-CodeObject: invert each live local/stack color to its slot.
             let mut mirror = vec![OpRef::NONE; semantic_prefix_len];
             let mut color_to_slot: Vec<usize> = vec![usize::MAX; bridge_registers_r.len()];
-            if !maps.pcdep_entries.is_empty() {
-                // #348 Part (2): per-PC color→slot inversion. Entries are
-                // sorted by `(color, slot)`, so for a color shared by an
-                // aliased local+stack pair the stack slot (larger slot)
-                // overwrites — matching `semantic_ref_slot_for_reg_color`'s
-                // stack-first tie-break. Out-of-prefix slots are dropped by
-                // the `s < mirror.len()` guard below.
-                for &(color, slot) in &maps.pcdep_entries {
-                    let s = slot as usize;
-                    // Clamp to the live semantic prefix so an out-of-range
-                    // stack entry never overwrites a valid in-range slot
-                    // for an aliased color.
-                    if s >= semantic_prefix_len {
-                        continue;
-                    }
-                    let col = color as usize;
-                    if col < color_to_slot.len() {
-                        color_to_slot[col] = s;
-                    }
+            // #348 Part (2): per-PC color→slot inversion. Entries are sorted
+            // by `(color, slot)`, so for a color shared by an aliased
+            // local+stack pair the stack slot (larger slot) overwrites —
+            // matching `semantic_ref_slot_for_reg_color`'s stack-first
+            // tie-break. Out-of-prefix slots are dropped by the
+            // `s >= semantic_prefix_len` guard.  #73: pcdep is the SOLE
+            // color→slot source here; the flat `local_color_map` /
+            // `stack_color_map` fallback is drained.
+            for &(color, slot) in &maps.pcdep_entries {
+                let s = slot as usize;
+                if s >= semantic_prefix_len {
+                    continue;
                 }
-            } else {
-                for &s in &maps.live_locals {
-                    if let Some(&col) = maps.local_color_map.get(s) {
-                        let col = col as usize;
-                        if col < color_to_slot.len() {
-                            color_to_slot[col] = s;
-                        }
-                    }
+                let col = color as usize;
+                if col < color_to_slot.len() {
+                    color_to_slot[col] = s;
                 }
+            }
+            // pcdep-totality guard (#73): the drained flat-else previously
+            // inverted live operand-stack slots from `stack_color_map` when
+            // `pcdep_entries` was empty.  The corpus proof
+            // (`validate_pcdep_color_map`, injective + total) shows an empty
+            // `pcdep_entries` here carries no live operand stack — locals
+            // still refill from the vable image via `overlay_local` below.
+            // Fail loud under `PYRE_PCDEP_VALIDATE` if a live stack slot ever
+            // reaches here uncovered (a totality regression).
+            if maps.pcdep_entries.is_empty() && std::env::var_os("PYRE_PCDEP_VALIDATE").is_some() {
                 let live_stack = maps
                     .stack_depth_at_pc
                     .min(maps.stack_color_map.len())
                     .min(stack_only);
-                for d in 0..live_stack {
-                    let col = maps.stack_color_map[d] as usize;
-                    if col < color_to_slot.len() {
-                        color_to_slot[col] = nlocals + d;
-                    }
+                if live_stack > 0 {
+                    eprintln!(
+                        "PCDEP-TOTALITY-VIOLATION: empty pcdep_entries with \
+                         {live_stack} live stack slot(s) at bridge resume \
+                         (jitcode_index={}, pc={})",
+                        frame0.jitcode_index, frame0.pc
+                    );
                 }
             }
             for (c, &s) in color_to_slot.iter().enumerate() {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -584,6 +584,9 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
         // its own containing-opcode coordinate for a helper frame.
         first_jit_pc_by_py_pc: (0..code_len).collect(),
         depth_at_py_pc: vec![0; code_len],
+        // Runtime helper: no inlined-callee multiframe capture, so no result
+        // slot color is consulted.
+        result_color_at_pc: Vec::new(),
         // The helper's residual_call (jit_list_append) sits outside any
         // try-block, so no pc lands on an after-residual-call catch.
         after_residual_call_resume_pc: vec![None; code_len],
@@ -1570,6 +1573,23 @@ pub fn stack_slot_color_map_at(jitcode_index: i32) -> Vec<u16> {
             .get(jitcode_index as usize)
             .map(|jc| jc.payload.metadata.stack_slot_color_map.clone())
             .unwrap_or_default()
+    })
+}
+
+/// The post-regalloc Ref-bank color of the call-result operand-stack slot
+/// (top of stack) at `pc` — the not-yet-produced slot the inline multiframe
+/// capture (`compute_inline_caller_frame`) nulls before serializing the
+/// paused caller frame.  Returns `None` when the stack is empty there
+/// (`u16::MAX` sentinel) or `pc` / the jitcode is out of range.  Sources the
+/// codewriter-precomputed `metadata.result_color_at_pc`, so the capture no
+/// longer reads the flat `stack_slot_color_map` at runtime.
+pub fn result_color_at_pc_at(jitcode_index: i32, pc: usize) -> Option<usize> {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        let jc = sd.jitcodes.get(jitcode_index as usize)?;
+        let c = jc.payload.metadata.result_color_at_pc.get(pc).copied()?;
+        (c != u16::MAX).then_some(c as usize)
     })
 }
 
@@ -11596,6 +11616,7 @@ mod tests {
                 after_residual_call_resume_pc: vec![None],
                 first_jit_pc_by_py_pc: vec![0],
                 depth_at_py_pc: vec![2],
+                result_color_at_pc: Vec::new(),
                 portal_frame_reg: 0,
                 portal_ec_reg: 0,
                 built_as_portal: true,
@@ -12408,6 +12429,7 @@ mod indirectcalltargets_tests {
             pc_map: (0..code_len).collect(),
             first_jit_pc_by_py_pc: (0..code_len).collect(),
             depth_at_py_pc: vec![0; code_len],
+            result_color_at_pc: Vec::new(),
             after_residual_call_resume_pc: vec![None; code_len],
             portal_frame_reg: u16::MAX,
             portal_ec_reg: u16::MAX,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -592,6 +592,7 @@ fn build_list_append_resize_helper_payload() -> std::sync::Arc<crate::PyJitCode>
         // Runtime helper, not a portal body.
         built_as_portal: false,
         stack_base: 0,
+        max_stackdepth: 0,
         stack_slot_color_map: Vec::new(),
         pyre_color_for_semantic_local: Vec::new(),
         pcdep_color_slots: Vec::new(),
@@ -8086,17 +8087,18 @@ impl JitState for PyreJitState {
         // (= 6 + 18 + 1) but a fannkuch bridge fell back to
         // `bridge_array_len=14` → `vable_boxes_len=21`, then pushed
         // `flat_idx=21` and panicked. Fall back to the metadata-derived
-        // size — `metadata.stack_base + metadata.stack_slot_color_map
-        // .len()` is the same `nlocals + ncells + max_stackdepth` the
-        // codewriter committed to and the runtime PyFrame allocates
-        // (pyframe.rs:1576).
+        // size — `metadata.stack_base + metadata.max_stackdepth` is the
+        // same `nlocals + ncells + max_stackdepth` the codewriter
+        // committed to and the runtime PyFrame allocates (pyframe.rs:1576).
+        // `max_stackdepth` equals `stack_slot_color_map.len()` for every
+        // compiled jitcode (the documented length invariant); reading the
+        // dimension directly keeps this size-calc independent of that map.
         let bridge_array_len = concrete_frame_array_len(sym.concrete_vable_ptr as usize)
             .or_else(|| {
                 METAINTERP_SD.with(|r| {
                     let sd = r.borrow();
                     sd.jitcodes.get(frame0.jitcode_index as usize).map(|jc| {
-                        jc.payload.metadata.stack_base
-                            + jc.payload.metadata.stack_slot_color_map.len()
+                        jc.payload.metadata.stack_base + jc.payload.metadata.max_stackdepth
                     })
                 })
             })
@@ -11598,6 +11600,7 @@ mod tests {
                 portal_ec_reg: 0,
                 built_as_portal: true,
                 stack_base: 1,
+                max_stackdepth: 0,
                 stack_slot_color_map: Vec::new(),
                 pyre_color_for_semantic_local: Vec::new(),
                 pcdep_color_slots: Vec::new(),
@@ -12410,6 +12413,7 @@ mod indirectcalltargets_tests {
             portal_ec_reg: u16::MAX,
             built_as_portal: false,
             stack_base: 0,
+            max_stackdepth: 0,
             stack_slot_color_map: Vec::new(),
             pyre_color_for_semantic_local: Vec::new(),
             pcdep_color_slots: Vec::new(),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3975,10 +3975,7 @@ fn register_helper_fn_pointers(
 fn filter_liveness_in_place(
     ssarepr: &mut super::flatten::SSARepr,
     code: &CodeObject,
-    depth_at_pc: &[u16],
-    local_color_map: &[u16],
-    stack_slot_color_map: &[u16],
-    pcdep_color_slots: Option<&[Vec<(u16, u16)>]>,
+    pcdep_color_slots: &[Vec<(u16, u16)>],
     portal_frame_reg: u16,
     portal_ec_reg: u16,
     walker_tracked_pc_live_indices: Option<&[usize]>,
@@ -4044,12 +4041,6 @@ fn filter_liveness_in_place(
     let live_vars = pyre_jit_trace::state::liveness_for(code as *const _);
     let nlocals = code.varnames.len();
     let live_markers_out = live_markers.clone();
-    assert!(
-        local_color_map.len() >= nlocals,
-        "local_color_map is shorter than nlocals: {} < {}",
-        local_color_map.len(),
-        nlocals
-    );
 
     // Snapshot original marker contents BEFORE any mutation so that
     // when multiple Python PCs share a single post-merge `-live-`
@@ -4089,13 +4080,8 @@ fn filter_liveness_in_place(
     // dropped restore). Build, per group, the union of all member PCs'
     // `(color, slot)` entries restricted to the marker's surviving colors,
     // and publish it to EVERY member PC — exactly the conservative-superset
-    // semantics the flat (PC-independent) maps already provide. Empty when
-    // the per-PC map is not supplied (gate off / flat path).
-    let mut marker_pcdep: Vec<Vec<(u16, u16)>> = if pcdep_color_slots.is_some() {
-        vec![Vec::new(); walker_tracked.len()]
-    } else {
-        Vec::new()
-    };
+    // semantics a per-program-point coloring guarantees.
+    let mut marker_pcdep: Vec<Vec<(u16, u16)>> = vec![Vec::new(); walker_tracked.len()];
 
     for (insn_idx, py_pcs) in groups {
         // Original snapshot is the same for every PC in the group
@@ -4165,30 +4151,16 @@ fn filter_liveness_in_place(
             // either (a) populating scratch colors during tracing
             // (graph regalloc) or (b) the encoder tolerating
             // NONE for non-frame live registers.
-            let depth = depth_at_pc[py_pc] as usize;
             let lv_live: std::collections::BTreeSet<u16> = {
-                // #348 Part (2): when the per-PC map is supplied (gated), the
-                // live frame colors at this PC are exactly its entries — each
-                // slot's TRUE per-program-point SSA color, already gated to
-                // live + restorable. This is the same color space the runtime
-                // encode/decode invert through, so the `-live-` markers stay
-                // consistent with the inversion. Otherwise fall back to the
-                // flat maps (one color per slot for the whole jitcode).
-                let mut s: std::collections::BTreeSet<u16> = if let Some(pcdep) = pcdep_color_slots
-                {
-                    pcdep
-                        .get(py_pc)
-                        .map(|entries| entries.iter().map(|&(color, _)| color).collect())
-                        .unwrap_or_default()
-                } else {
-                    let live_stack_colors = stack_slot_color_map.iter().copied().take(depth);
-                    let mut s: std::collections::BTreeSet<u16> = (0..nlocals)
-                        .filter(|&idx| live_vars.is_local_live(py_pc, idx))
-                        .map(|idx| local_color_map[idx])
-                        .collect();
-                    s.extend(live_stack_colors);
-                    s
-                };
+                // #348 Part (2): the per-PC map's entries at this PC are the
+                // live frame colors — each slot's TRUE per-program-point SSA
+                // color, already gated to live + restorable. This is the same
+                // color space the runtime encode/decode invert through, so the
+                // `-live-` markers stay consistent with the inversion.
+                let mut s: std::collections::BTreeSet<u16> = pcdep_color_slots
+                    .get(py_pc)
+                    .map(|entries| entries.iter().map(|&(color, _)| color).collect())
+                    .unwrap_or_default();
                 // Portal red args (`pypy/module/pypyjit/interp_jit.py:67
                 // reds = ['frame', 'ec']`) reach `live_r` through the
                 // RPython force-alive mechanism (`liveness.py:11-12`):
@@ -4275,7 +4247,8 @@ fn filter_liveness_in_place(
         // out of `registers_r` range or decode to NONE under the int-typed
         // trace, so the inversion is a no-op the overlay then fills — keeps the
         // map non-empty and the runtime on the correct (overlay) path.
-        if let Some(pcdep) = pcdep_color_slots {
+        {
+            let pcdep = pcdep_color_slots;
             // #367: publish each member PC's OWN per-PC color→slot entry, NOT
             // the cross-PC union. The folded `-live-` marker's `union_r` makes
             // the conservative-superset live SET correct (preserving extra
@@ -11418,10 +11391,7 @@ impl CodeWriter {
         ) = filter_liveness_in_place(
             &mut ssarepr,
             code,
-            &depth_at_pc,
-            &pyre_color_for_semantic_local,
-            &stack_slot_color_map,
-            Some(pcdep_color_slots.as_slice()),
+            pcdep_color_slots.as_slice(),
             portal_frame_reg,
             portal_ec_reg,
             walker_tracked_pc_live_indices_out.as_deref(),
@@ -12993,17 +12963,15 @@ mod tests {
             ]));
         }
 
-        let depth_at_pc: Vec<u16> = vec![0; code.instructions.len()];
-        let local_color_map: Vec<u16> = (0..code.varnames.len() as u16).collect();
-        let stack_slot_color_map: Vec<u16> = Vec::new();
+        // Drive `lv_live` via the per-PC map: color 0 (the live local `x`) maps
+        // to slot 0, so the LV∩SSA retain keeps color 0 and drops color 7.
+        let pcdep_color_slots: Vec<Vec<(u16, u16)>> =
+            vec![vec![(0, 0)]; code.instructions.len()];
         let (post_remove_live_indices, _after_call_post_merge, _first_insn_post_merge, _) =
             filter_liveness_in_place(
                 &mut ssarepr,
                 &code,
-                &depth_at_pc,
-                &local_color_map,
-                &stack_slot_color_map,
-                None,
+                &pcdep_color_slots,
                 u16::MAX,
                 u16::MAX,
                 Some(&walker_tracked_pc_live_indices),
@@ -13066,17 +13034,15 @@ mod tests {
             ]));
         }
 
-        let depth_at_pc: Vec<u16> = vec![0; code.instructions.len()];
-        let local_color_map: Vec<u16> = (0..code.varnames.len() as u16).collect();
-        let stack_slot_color_map: Vec<u16> = Vec::new();
+        // Drive `lv_live` via the per-PC map (color 0 = live local `x`), then
+        // assert the splice path clears the Int/Float banks.
+        let pcdep_color_slots: Vec<Vec<(u16, u16)>> =
+            vec![vec![(0, 0)]; code.instructions.len()];
         let (post_remove_live_indices, _after_call_post_merge, _first_insn_post_merge, _) =
             filter_liveness_in_place(
                 &mut ssarepr,
                 &code,
-                &depth_at_pc,
-                &local_color_map,
-                &stack_slot_color_map,
-                None,
+                &pcdep_color_slots,
                 u16::MAX,
                 u16::MAX,
                 Some(&walker_tracked_pc_live_indices),

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4419,8 +4419,19 @@ fn build_value_parent(
 /// per-PC resume map. The liveness-correct successor to the retired
 /// blanket `collect_distinct_slot_interference_pairs` clique: constrains
 /// ONLY slots co-live at a guard, not every distinct slot.
+///
+/// Edges are gathered from BOTH the post-dispatch snapshot
+/// (`pcdep_slot_var`, the after-opcode `-live-` markers) AND the
+/// pre-dispatch resume-depth snapshot (`pcdep_slot_var_resume`, the snapshot
+/// the shipped per-PC map is built from in `build_pcdep_color_slots`). A
+/// branch guard at orgpc resumes with the deeper pre-dispatch operand stack
+/// carrying the mid-opcode kept temps, so two Variables simultaneously live
+/// at that depth must also separate; without the resume-depth edges the
+/// coloring is free to collapse them onto one color and the color-indexed
+/// resume inversion is ambiguous (the kept-operand-stack `#424` family).
 fn build_colive_interference(
     pcdep_slot_var: &[Vec<(u16, u32)>],
+    pcdep_slot_var_resume: &[Vec<(u16, u32)>],
     value_parent: &std::collections::HashMap<u32, u32>,
     ref_coloring: &std::collections::HashMap<super::flow::VariableId, u16>,
     depth_at_pc: &[u16],
@@ -4431,32 +4442,34 @@ fn build_colive_interference(
     let mut interference_set: std::collections::HashSet<(u32, u32)> =
         std::collections::HashSet::new();
     let mut live_here: Vec<u32> = Vec::new();
-    for (py_pc, snap) in pcdep_slot_var.iter().enumerate() {
-        if snap.is_empty() || !lv.is_reachable(py_pc) {
-            continue;
-        }
-        let depth = depth_at_pc.get(py_pc).copied().unwrap_or(0) as usize;
-        live_here.clear();
-        for &(slot, var_id) in snap {
-            let slot = slot as usize;
-            if slot < nloc {
-                if !lv.is_local_live(py_pc, slot) {
-                    continue;
-                }
-            } else if slot - nloc >= depth {
+    for snap_table in [pcdep_slot_var, pcdep_slot_var_resume] {
+        for (py_pc, snap) in snap_table.iter().enumerate() {
+            if snap.is_empty() || !lv.is_reachable(py_pc) {
                 continue;
             }
-            if ref_coloring.contains_key(&super::flow::VariableId(var_id)) {
-                live_here.push(var_id);
-            }
-        }
-        for i in 0..live_here.len() {
-            for j in (i + 1)..live_here.len() {
-                let (a, b) = (live_here[i], live_here[j]);
-                if a == b || uf_find(value_parent, a) == uf_find(value_parent, b) {
+            let depth = depth_at_pc.get(py_pc).copied().unwrap_or(0) as usize;
+            live_here.clear();
+            for &(slot, var_id) in snap {
+                let slot = slot as usize;
+                if slot < nloc {
+                    if !lv.is_local_live(py_pc, slot) {
+                        continue;
+                    }
+                } else if slot - nloc >= depth {
                     continue;
                 }
-                interference_set.insert(if a < b { (a, b) } else { (b, a) });
+                if ref_coloring.contains_key(&super::flow::VariableId(var_id)) {
+                    live_here.push(var_id);
+                }
+            }
+            for i in 0..live_here.len() {
+                for j in (i + 1)..live_here.len() {
+                    let (a, b) = (live_here[i], live_here[j]);
+                    if a == b || uf_find(value_parent, a) == uf_find(value_parent, b) {
+                        continue;
+                    }
+                    interference_set.insert(if a < b { (a, b) } else { (b, a) });
+                }
             }
         }
     }
@@ -11021,6 +11034,7 @@ impl CodeWriter {
         let splice_value_parent = build_value_parent(&splice_pairs);
         let splice_interference = build_colive_interference(
             &pcdep_slot_var,
+            &pcdep_slot_var_resume,
             &splice_value_parent,
             &graph_regallocs[Kind::Ref.index()].coloring,
             &depth_at_pc,
@@ -11358,6 +11372,27 @@ impl CodeWriter {
                 &depth_at_pc,
                 &splice_value_parent,
                 "production",
+            );
+            // The SHIPPED per-PC map is built from `pcdep_slot_var_resume`
+            // (the PRE-dispatch resume-depth snapshot), not `pcdep_slot_var`
+            // (post-dispatch): a branch guard at orgpc resumes with the deeper
+            // operand stack carrying the mid-opcode kept temps. Those temps
+            // live only in the resume snapshot, so the "production" check above
+            // does not cover them. Validate the actual shipped source — its
+            // injectivity is what the resume-depth co-live interference in
+            // `build_colive_interference` now guarantees (expectation:
+            // `inj_violations=0`).
+            validate_pcdep_color_map(
+                &pcdep_slot_var_resume,
+                &pyre_color_for_semantic_local,
+                &stack_slot_color_map,
+                &splice_regallocs[Kind::Ref.index()].coloring,
+                &graph_regallocs[Kind::Ref.index()].coloring,
+                &alloc_result.rename,
+                code,
+                &depth_at_pc,
+                &splice_value_parent,
+                "production-resume",
             );
         }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -12965,8 +12965,7 @@ mod tests {
 
         // Drive `lv_live` via the per-PC map: color 0 (the live local `x`) maps
         // to slot 0, so the LV∩SSA retain keeps color 0 and drops color 7.
-        let pcdep_color_slots: Vec<Vec<(u16, u16)>> =
-            vec![vec![(0, 0)]; code.instructions.len()];
+        let pcdep_color_slots: Vec<Vec<(u16, u16)>> = vec![vec![(0, 0)]; code.instructions.len()];
         let (post_remove_live_indices, _after_call_post_merge, _first_insn_post_merge, _) =
             filter_liveness_in_place(
                 &mut ssarepr,
@@ -13036,8 +13035,7 @@ mod tests {
 
         // Drive `lv_live` via the per-PC map (color 0 = live local `x`), then
         // assert the splice path clears the Int/Float banks.
-        let pcdep_color_slots: Vec<Vec<(u16, u16)>> =
-            vec![vec![(0, 0)]; code.instructions.len()];
+        let pcdep_color_slots: Vec<Vec<(u16, u16)>> = vec![vec![(0, 0)]; code.instructions.len()];
         let (post_remove_live_indices, _after_call_post_merge, _first_insn_post_merge, _) =
             filter_liveness_in_place(
                 &mut ssarepr,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11568,11 +11568,30 @@ impl CodeWriter {
         // and attach it to BlackholeInterpreter setup when pyre needs it.
         let frame_stack_base = code.varnames.len() + pyre_interpreter::pyframe::ncells(code);
 
+        // #73 result_color_at_pc: the call-result operand-stack slot's color
+        // (top of stack = depth - 1) at each Python pc, so the inline
+        // multiframe capture (`compute_inline_caller_frame`) finds the
+        // not-yet-produced result register without reading the flat
+        // `stack_slot_color_map` at runtime. `u16::MAX` where the stack is
+        // empty (no result slot).
+        let result_color_at_pc: Vec<u16> = depth_at_pc
+            .iter()
+            .map(|&d| {
+                let d = d as usize;
+                if d == 0 {
+                    u16::MAX
+                } else {
+                    stack_slot_color_map.get(d - 1).copied().unwrap_or(u16::MAX)
+                }
+            })
+            .collect();
+
         let metadata = PyJitCodeMetadata {
             pc_map: pc_map_bytes,
             after_residual_call_resume_pc,
             first_jit_pc_by_py_pc,
             depth_at_py_pc: depth_at_pc,
+            result_color_at_pc,
             portal_frame_reg,
             portal_ec_reg,
             built_as_portal: is_portal,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -11607,6 +11607,7 @@ impl CodeWriter {
             portal_ec_reg,
             built_as_portal: is_portal,
             stack_base: frame_stack_base,
+            max_stackdepth: code.max_stackdepth as usize,
             stack_slot_color_map,
             pyre_color_for_semantic_local,
             pcdep_color_slots,


### PR DESCRIPTION
Part of #73 (eliminate `pc_map` and per-PC labels). This batch migrates the
resume-liveness machinery from the flat per-jitcode `stack_slot_color_map`
(operand-stack slot → merge color) to the per-PC `pcdep` color→slot coloring,
and drains two flat-map readers.

## Commits

- **codewriter: extend co-live interference to the resume-depth snapshot** —
  add the resume-depth operand-stack snapshot to the co-live interference set so
  the per-PC coloring stays unambiguous at resume points.
- **jitcode_dispatch: source collect_outer color→slot from pcdep only** —
  `collect_outer_active_boxes` reads the per-PC `pcdep` map instead of cloning
  the flat `stack_slot_color_map`.
- **jitcode_dispatch: drop recovery_complete kept-stack escape and
  branch_resume_stack_colors** — re-source the recovery-complete path off
  `pcdep` and remove the flat `branch_resume_stack_colors` side table.
- **jit: add PyJitCodeMetadata::max_stackdepth and size the bridge frame array
  from it** — record `code.max_stackdepth` (= `co_stacksize`) and size the
  bridge frame array from it, draining the size-calc reader of
  `stack_slot_color_map.len()`. Byte-identical (`code.max_stackdepth ==
  stack_slot_color_map.len()` for every compiled jitcode across the corpus).
- **codewriter: make filter_liveness_in_place pcdep-only, drop flat fallback** —
  delete the production-dead flat else-branch; the sole production caller always
  supplied the per-PC map (only `#[cfg(test)]` callers passed `None`). Drop the
  `depth_at_pc` / `local_color_map` / `stack_slot_color_map` params and make
  `pcdep_color_slots` non-optional. Byte-identical for production.

## Verification

`pyre/check.py` — dynasm 160/160 + cranelift 160/160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JIT metadata support for `max_stackdepth` (with skeleton defaults), improving runtime frame/stack reconstruction accuracy.
  * Portal-bridge resume logic now derives portal stack colors and live locals from portal-specific inputs for more reliable guard recovery.

* **Bug Fixes**
  * Corrected bridge setup sizing when live-frame length is unavailable.
  * Fixed per-PC color computations for result slots to avoid depth mismatches during guard resumption.

* **Tests**
  * Updated and extended tests to use the new stack-depth metadata and revised resume/bridge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->