### PR TITLE
JIT: exception-unwind vstack mirror default-on + blackhole-resume GC-rooting (#267)

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -841,6 +841,19 @@ impl MiniMarkGC {
             }
         });
 
+        // blackhole resume construction roots (`resume.py:1312`): the
+        // virtuals_cache + each frame's registers_r are filled by lazily
+        // materializing virtuals before `run()` re-roots them via
+        // `push_bh_regs`; forward any already-materialized nursery refs so a
+        // later materialization's collection does not strand them.
+        crate::shadow_stack::walk_resume_ref_roots(|gcref| {
+            if self.is_nursery_object_start(gcref.0) {
+                if !self.pinned_objects.contains(&gcref.0) {
+                    *gcref = self.copy_nursery_object(gcref.0);
+                }
+            }
+        });
+
         // Phase 1e: framework.py `root_walker.walk_roots` parity — the
         // embedding runtime plugs a walker that visits
         // `PyFrame.locals_cells_stack_w` across the active f_backref chain
@@ -1414,6 +1427,13 @@ impl MiniMarkGC {
         }
 
         crate::shadow_stack::walk_bh_regs(|gcref| {
+            self.seed_major_root(*gcref);
+        });
+
+        // blackhole resume construction roots (`resume.py:1312`): see the
+        // minor-collection path for why the in-flight virtuals_cache /
+        // registers_r slices must be seeded as roots.
+        crate::shadow_stack::walk_resume_ref_roots(|gcref| {
             self.seed_major_root(*gcref);
         });
 

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -208,6 +208,19 @@ thread_local! {
     /// trace these slots during minor collection so nursery objects held only
     /// by a blackhole register survive across collecting calls.
     static BH_REGS_STACK: RefCell<Vec<BhRegsEntry>> = RefCell::new(Vec::with_capacity(16));
+
+    /// Thread-local stack of ref slices live only during blackhole resume
+    /// construction (`resume.py:1312 blackhole_from_resumedata`).  The
+    /// `virtuals_cache` and each frame's `registers_r` are filled by lazily
+    /// materializing virtuals (`getvirtual_ptr` → allocator); a minor
+    /// collection triggered while materializing a later virtual relocates
+    /// the earlier ones, but the unrooted raw `Vec` copies are not forwarded
+    /// until `run()` re-roots `registers_r` via `push_bh_regs`.  RPython
+    /// traces these through the GC-managed reader/blackhole objects; pyre
+    /// stores raw `i64`, so the slices are registered here for the
+    /// construction window and popped when it ends.
+    static RESUME_REF_ROOTS_STACK: RefCell<Vec<(*mut i64, usize)>> =
+        RefCell::new(Vec::with_capacity(16));
 }
 
 /// The shadow stack itself.
@@ -559,6 +572,50 @@ pub fn walk_bh_regs(mut visitor: impl FnMut(&mut GcRef)) {
 /// Current depth of the blackhole register bank stack.
 pub fn bh_regs_depth() -> usize {
     BH_REGS_STACK.with(|ss| ss.borrow().len())
+}
+
+/// Current depth of the resume-construction ref-slice root stack.
+pub fn resume_ref_roots_depth() -> usize {
+    RESUME_REF_ROOTS_STACK.with(|ss| ss.borrow().len())
+}
+
+/// Register a ref slice as a GC root for the blackhole resume
+/// construction window (`resume.py:1312 blackhole_from_resumedata`).
+///
+/// # Safety
+/// `slice` must remain alive and at a fixed address until the matching
+/// `pop_resume_ref_roots_to` runs.  Both the `virtuals_cache` and a
+/// blackhole frame's `registers_r` are stable after allocation
+/// (`prepare_virtuals` / `setposition` size them once; later fills only
+/// index), so the captured pointer stays valid for the whole window.
+pub unsafe fn push_resume_ref_roots(slice: &mut [i64]) {
+    RESUME_REF_ROOTS_STACK.with(|ss| {
+        ss.borrow_mut().push((slice.as_mut_ptr(), slice.len()));
+    });
+}
+
+/// Pop resume-construction ref-slice roots back to the given depth.
+pub fn pop_resume_ref_roots_to(depth: usize) {
+    let _ = RESUME_REF_ROOTS_STACK.try_with(|ss| {
+        ss.borrow_mut().truncate(depth);
+    });
+}
+
+/// Walk all registered resume-construction ref slices as GC roots.
+///
+/// Each `i64` slot is exposed as `&mut GcRef`; non-nursery values
+/// (unmaterialized `0` cache slots, old-gen pointers) pass through the
+/// visitor's `copy_nursery_object` guard unchanged.
+pub fn walk_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
+    RESUME_REF_ROOTS_STACK.with(|ss| {
+        for &(ptr, len) in ss.borrow().iter() {
+            let slots = unsafe { std::slice::from_raw_parts_mut(ptr, len) };
+            for slot in slots.iter_mut() {
+                let gcref = unsafe { &mut *(slot as *mut i64 as *mut GcRef) };
+                visitor(gcref);
+            }
+        }
+    });
 }
 
 // ── Extra root walkers registered by the embedder ───────────────

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -6519,13 +6519,20 @@ impl<'a> ResumeDataDirectReader<'a> {
         let vinfo = unsafe { &*rd_virtuals_ptr.add(index) };
         debug_assert!(index < rd_virtuals_len);
         let allocator = self.allocator as *const dyn BlackholeAllocator;
-        let v = vinfo.allocate(self, index, unsafe { &*allocator });
-        debug_assert_eq!(
-            v,
-            self.virtuals_cache.get_ptr(index),
-            "resume.py: bad cache"
-        );
-        v
+        // resume.py:954 `v = self.rd_virtuals[index].allocate(self, index)`.
+        // RPython returns `allocate`'s result and asserts `v == cache`,
+        // relying on `v` being a GC-traced stack local that a minor
+        // collection triggered while `allocate` fills the virtual's fields
+        // keeps equal to the (also-rooted) cache slot.  Pyre's `v` is a raw
+        // i64 — not a GC root — so such a collection forwards the rooted
+        // `virtuals_ptr_cache` slot in place (rooted by
+        // `blackhole_from_resumedata`) but leaves `v` pointing into
+        // from-space.  Return the live cache slot so callers (e.g. the
+        // pending-field `setfield` that publishes the exception into
+        // `EC.sys_exc_value`) store the forwarded pointer, not a dangling
+        // from-space one.
+        vinfo.allocate(self, index, unsafe { &*allocator });
+        self.virtuals_cache.get_ptr(index)
     }
 
     /// resume.py:958 getvirtual_int
@@ -7172,6 +7179,29 @@ pub fn read_frame_liveness_reg_indices(
     FrameLivenessRegIndices { int, ref_, float }
 }
 
+/// RAII guard that pops every resume-construction ref-slice root pushed
+/// during `blackhole_from_resumedata` back to the depth captured at entry.
+/// Drop runs on ordinary return, `?` propagation, and panic unwind, so the
+/// `virtuals_cache` / `registers_r` slices never outlive the construction
+/// window in the GC root set.
+struct ResumeRefRootsScope {
+    base_depth: usize,
+}
+
+impl ResumeRefRootsScope {
+    fn enter() -> Self {
+        ResumeRefRootsScope {
+            base_depth: majit_gc::shadow_stack::resume_ref_roots_depth(),
+        }
+    }
+}
+
+impl Drop for ResumeRefRootsScope {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(self.base_depth);
+    }
+}
+
 pub fn blackhole_from_resumedata<'a>(
     builder: &mut crate::blackhole::BlackholeInterpBuilder,
     resolve_jitcode: &dyn Fn(i32, i32, i32) -> Option<ResolvedJitCode>,
@@ -7207,8 +7237,36 @@ pub fn blackhole_from_resumedata<'a>(
         allocator,
     );
 
-    // resume.py:1324
-    resumereader.prepare(rd_virtuals, rd_guard_pendingfields);
+    // resume.py:1324 _prepare = _prepare_virtuals + _prepare_pendingfields.
+    //
+    // Root the lazily-filled `virtuals_cache` (and, in the loop below, each
+    // frame's `registers_r`) for the whole construction window: decoding a
+    // virtual target (`getvirtual_ptr` → allocator) materializes a fresh
+    // boxed object, and a minor collection triggered by a later
+    // materialization relocates the already-built ones.  The raw `Vec`
+    // copies are not otherwise forwarded until `run()`'s `push_bh_regs`, so
+    // a from-space pointer would survive into the blackhole.  RPython traces
+    // these through the GC-managed reader/blackhole objects.
+    //
+    // The cache must be rooted BEFORE the first materialization.
+    // `_prepare_pendingfields` (resume.py:926) already materializes virtual
+    // targets via `decode_ref` → `getvirtual_ptr`, so split `_prepare` and
+    // register the ref cache between sizing it (`_prepare_virtuals`) and the
+    // pending-field application.  The cache buffer is stable after
+    // `_prepare_virtuals` (pre-sized; `set_ptr` only indexes), so the
+    // captured pointer stays valid for the window.
+    let _resume_roots = ResumeRefRootsScope::enter();
+    // resume.py:925 _prepare_virtuals
+    resumereader.prepare_virtuals(rd_virtuals);
+    unsafe {
+        majit_gc::shadow_stack::push_resume_ref_roots(
+            &mut resumereader.virtuals_cache.virtuals_ptr_cache,
+        );
+    }
+    // resume.py:926 _prepare_pendingfields
+    if let Some(guard_pf) = rd_guard_pendingfields {
+        resumereader.prepare_guard_pendingfields(guard_pf);
+    }
 
     // resume.py:1325
     resumereader.consume_vref_and_vable(vrefinfo, vinfo, ginfo);
@@ -7241,6 +7299,15 @@ pub fn blackhole_from_resumedata<'a>(
         nextbh.setposition(resolved.jitcode.clone(), resolved.pc);
         if let Some(stack_base) = resolved.virtualizable_stack_base {
             nextbh.virtualizable_stack_base = stack_base;
+        }
+
+        // `setposition` sized this frame's register files; root the ref
+        // bank before filling it so a materialization collection during
+        // `consume_one_section` forwards the refs already written here (the
+        // Vec buffer is stable — `setarg_r` only indexes — and survives the
+        // move into the chained `Box`).
+        unsafe {
+            majit_gc::shadow_stack::push_resume_ref_roots(&mut nextbh.registers_r);
         }
 
         // resume.py:1341

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1380,6 +1380,13 @@ pub fn walk(
                     // Mirrors `blackhole.rs route_to_catch`'s `BH_LAST_EXC_VALUE
                     // = 0` on handler entry.
                     majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
+                    // #370: re-seed the operand-stack mirror at the handler
+                    // entry so a kept-stack guard inside the handler compiles
+                    // from the mirror instead of declining (gated during
+                    // development; the unwind boundary is otherwise unmodeled).
+                    if std::env::var_os("PYRE_VSTACK_EXC").is_some() {
+                        vstack_enter_exception_handler(ctx, target, exc);
+                    }
                     pc = target;
                     continue;
                 }
@@ -7331,6 +7338,21 @@ enum VstackOpClass {
     /// (duplicating a deeper operand) is faithful.  The carried `usize` is
     /// the decoded `i`.
     Copy(usize),
+    /// An exception-machinery opcode (PUSH_EXC_INFO / CHECK_EXC_MATCH /
+    /// RERAISE / WITH_EXCEPT_START / RAISE_VARARGS) reached INSIDE an
+    /// exception handler.  Its operand-stack effect is not a simple
+    /// producer/pop — the unwinder and the exc-info machinery rewrite the
+    /// stack — but the lowering writes every resulting operand slot through
+    /// `setarrayitem_vable_r`, so the virtualizable shadow holds the correct
+    /// post-opcode operand stack.  Reconcile truncates to the new depth and
+    /// reseeds the slots from the shadow (`reseed_vstack_from_shadow`); a
+    /// slot the shadow cannot source (a genuine NULL exc-info slot, an
+    /// Int/Float temp) stays a NONE hole and `mirror_covers_kept` declines
+    /// for it (the conservative fallback).  Reached with a valid mirror only
+    /// via [`vstack_enter_exception_handler`]; without that handler-entry
+    /// reseed the mirror is already invalid at the unwind boundary, so this
+    /// arm is inert on the non-exception path.
+    ShadowReseed,
     /// Anything that does not fit the shapes above —
     /// UNPACK_SEQUENCE / UNPACK_EX (net push > 1), LOAD_GLOBAL pushing a
     /// NULL sentinel beneath the result, STORE_FAST__STORE_FAST (net pop
@@ -7456,9 +7478,23 @@ fn classify_vstack_opcode(
         // not `vstack_last_ref`, so `COPY i>1` is faithful).
         Instruction::Copy { i } => VstackOpClass::Copy(i.get(op_arg) as usize),
 
+        // Exception machinery inside a handler body.  The unwinder + exc-info
+        // operations rewrite the operand stack in ways a producer/pop model
+        // cannot express, but every resulting slot is written through
+        // `setarrayitem_vable_r`, so the virtualizable shadow is authoritative
+        // — `ShadowReseed` reconciles by reseeding from it.  Inert on the
+        // non-exception path: these are reached only via the unwind/catch
+        // edge, where the mirror is already invalid unless
+        // `vstack_enter_exception_handler` re-seeded it at handler entry.
+        Instruction::PushExcInfo
+        | Instruction::CheckExcMatch
+        | Instruction::Reraise { .. }
+        | Instruction::RaiseVarargs { .. }
+        | Instruction::WithExceptStart => VstackOpClass::ShadowReseed,
+
         // Everything else (UNPACK_*, FOR_ITER, STORE_FAST__STORE_FAST,
-        // TO_BOOL if present as a distinct variant, exception machinery,
-        // …) is not modeled — decline and fall back to the legacy read.
+        // TO_BOOL if present as a distinct variant, …) is not modeled —
+        // decline and fall back to the legacy read.
         _ => VstackOpClass::Unmodeled,
     }
 }
@@ -7558,6 +7594,16 @@ fn reconcile_vstack_at_boundary(
                 }
                 _ => ctx.vstack_valid = false,
             }
+        }
+        VstackOpClass::ShadowReseed => {
+            // Resize to the post-opcode depth, leaving every slot a NONE
+            // hole; the shadow-backed hole-fill below sources each slot from
+            // the virtualizable shadow the exception lowering just wrote.  An
+            // unsourceable slot (genuine NULL exc-info / Int temp) stays NONE
+            // and `mirror_covers_kept` declines for it — the conservative
+            // fallback, never a corrupt box.
+            ctx.vstack_boxes.clear();
+            ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
         }
         VstackOpClass::Unmodeled => {
             ctx.vstack_valid = false;
@@ -7817,6 +7863,87 @@ fn seed_vstack_mirror(ctx: &mut WalkContext<'_, '_>, sym: &crate::state::PyreSym
     ctx.vstack_cur_pypc = first_pypc;
     ctx.vstack_last_ref = OpRef::NONE;
     ctx.vstack_valid = true;
+}
+
+/// #370: model the exception-unwind boundary on the operand-stack mirror.
+/// When a raised exception is caught by THIS frame's handler (the SubRaise
+/// catch in the dispatch loop), the unwinder truncates the operand stack to
+/// the handler's setup depth and pushes the exception value.
+/// [`reconcile_vstack_at_boundary`] cannot model this NON-SEQUENTIAL
+/// transition — it explains a depth change via the previous opcode's normal
+/// stack effect — so without this hook the mirror latches `vstack_valid =
+/// false` at handler entry and every kept-stack guard inside the handler
+/// declines.  Re-seed the mirror at the handler-entry coordinate instead:
+/// place the caught `exc` box on the new TOS and source the surviving slots
+/// below it from the virtualizable shadow (the unwind only truncates ABOVE
+/// the handler depth, so those slots are unchanged at the raise point).
+/// Subsequent in-handler exception opcodes reconcile via
+/// [`VstackOpClass::ShadowReseed`], re-reading the shadow the lowering keeps
+/// current.  A survivor slot the shadow cannot source stays a NONE hole and
+/// the guard's `mirror_covers_kept` declines for it (safe fallback).
+///
+/// `handler_jit_pc` is the catch target (an OUTER full-body jitcode pc).
+/// No-op outside the full-body walk or inside an inline sub-walk (where the
+/// pc is a callee coordinate the outer metadata cannot map).
+fn vstack_enter_exception_handler(
+    ctx: &mut WalkContext<'_, '_>,
+    handler_jit_pc: usize,
+    exc: OpRef,
+) {
+    // The handler-entry operand stack is a FRESH reconstruction from the
+    // authoritative virtualizable shadow plus the caught `exc` — it does NOT
+    // depend on the pre-raise mirror being valid (the unwind discards the
+    // operand stack above the handler depth, and the surviving slots below
+    // are read from the shadow).  So REVIVE the mirror here even when the
+    // pre-raise walk invalidated it (e.g. at a `LOAD_GLOBAL` NULL-sentinel on
+    // the `raise` expression).  Only an inline sub-walk (callee coordinate)
+    // or a missing full-body sym is unrecoverable.
+    if INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get()) {
+        ctx.vstack_valid = false;
+        return;
+    }
+    let full_body_sym = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+    if full_body_sym.is_null() {
+        return;
+    }
+    // SAFETY: pointer live for the full-body walk; read-only layout fields.
+    let sym = unsafe { &*full_body_sym };
+    if sym.jitcode.is_null() {
+        ctx.vstack_valid = false;
+        return;
+    }
+    let (handler_py, code_ptr) = unsafe {
+        let jc = &*sym.jitcode;
+        if jc.payload.code_ptr.is_null() {
+            ctx.vstack_valid = false;
+            return;
+        }
+        (
+            vstack_containing_py_pc(&jc.payload.metadata, handler_jit_pc),
+            jc.payload.code_ptr,
+        )
+    };
+    let handler_depth = crate::liveness::liveness_for(code_ptr)
+        .depth_at_py_pc()
+        .get(handler_py as usize)
+        .copied()
+        .unwrap_or(0) as usize;
+    ctx.vstack_boxes.clear();
+    ctx.vstack_boxes.resize(handler_depth, OpRef::NONE);
+    // The unwinder pushes the caught exception onto the new TOS.
+    if handler_depth >= 1 && exc != OpRef::NONE {
+        ctx.vstack_boxes[handler_depth - 1] = exc;
+    }
+    ctx.vstack_cur_pypc = handler_py;
+    ctx.vstack_depth = handler_depth;
+    ctx.vstack_last_ref = OpRef::NONE;
+    // Revive: the handler-entry state is shadow-sourced, independent of the
+    // pre-raise mirror.
+    ctx.vstack_valid = true;
+    // Fill the surviving slots below the pushed exc from the shadow; reseed
+    // skips the already-set exc slot (non-NONE).  Leaves un-sourceable slots
+    // NONE (per-slot decline) rather than latching the whole mirror invalid.
+    let _ = reseed_vstack_from_shadow(ctx, handler_depth);
 }
 
 /// Map a JitCode byte offset back to the Python PC of the opcode whose

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1382,11 +1382,13 @@ pub fn walk(
                     majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
                     // #370: re-seed the operand-stack mirror at the handler
                     // entry so a kept-stack guard inside the handler compiles
-                    // from the mirror instead of declining (gated during
-                    // development; the unwind boundary is otherwise unmodeled).
-                    if std::env::var_os("PYRE_VSTACK_EXC").is_some() {
-                        vstack_enter_exception_handler(ctx, target, exc);
-                    }
+                    // from the mirror instead of declining.  The unwind
+                    // boundary is otherwise unmodeled, so without this the
+                    // mirror latches invalid and every in-handler kept-stack
+                    // guard declines.  `vstack_enter_exception_handler` falls
+                    // back safely (per-slot NONE hole / `vstack_valid = false`)
+                    // for the coordinates it cannot reconstruct.
+                    vstack_enter_exception_handler(ctx, target, exc);
                     pc = target;
                     continue;
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8382,36 +8382,6 @@ fn kept_stack_has_boxed_int_hazard(
     }
 }
 
-/// Flat-free (#267) hazard: a kept-stack branch guard whose not-taken arm
-/// resumes at a PC protected by an exception handler.  The kept operand stack
-/// there can hold exception-handler state (the value `PUSH_EXC_INFO` pushed and
-/// the bare `raise` re-reads) that the partial walker snapshot does not
-/// reconstruct on a blackhole resume: the re-raise then reads NULL and the
-/// outer `CHECK_EXC_MATCH` dereferences it.  This is the principled decline the
-/// flat `stack_slot_color_map` boxed-int read used to trigger only by accident
-/// (a stale merge color aliasing a boxed int at the same slot).  Conservative —
-/// any kept-stack arm under an active handler declines to the interpreter;
-/// subsumed once the #73 symbolic-valuestack capture reconstructs the kept
-/// exception operand directly.
-fn branch_resume_inside_exc_region(frame: &ActiveResumeFrame, target: usize) -> bool {
-    let pjc = &frame.0;
-    if pjc.code_ptr.is_null() {
-        return false;
-    }
-    // SAFETY: `code_ptr` is an immutable payload field kept alive by the
-    // frame's `Arc<PyJitCode>`; `exceptiontable` is read-only.
-    unsafe {
-        let code = &*pjc.code_ptr;
-        let py = python_pc_for_jitcode_pc(&pjc.metadata, target) as usize;
-        let py = skip_python_trivia_forward(code, py);
-        // `lookup_exceptiontable` takes byte offsets; pyre tracks `py` as an
-        // instruction index (2 bytes / instruction), so scale (`trace_opcode.rs`
-        // parity).
-        pyre_interpreter::pycode::lookup_exceptiontable(&code.exceptiontable, (py * 2) as u32)
-            .is_some()
-    }
-}
-
 /// The resume snapshot's live Ref register colors at a kept-stack branch
 /// guard's not-taken arm, plus the jitcode `num_regs_r` (the const-window
 /// boundary `n()`).  These are exactly the registers the blackhole restores
@@ -17009,7 +16979,7 @@ fn handle(
                 // SIGSEGV + silent miscompile.  Until that capture lands pyre
                 // deviates by declining here.  A kept-stack guard's not-taken
                 // arm is only safe to compile when the blackhole can reconstruct
-                // every value the arm reads on resume.  Two resume hazards make
+                // every value the arm reads on resume.  Three resume hazards make
                 // a kept-stack arm unsafe; each is described at its check below.
                 // Decline → interpreter (correct).  Applies to depth-1 and
                 // depth > 1.
@@ -17079,14 +17049,14 @@ fn handle(
                     let kept_boxed_int = gate_frame.as_ref().is_some_and(|f| {
                         kept_stack_has_boxed_int_hazard(f, other_target, ctx.concrete_registers_r)
                     });
-                    // Hazard (4): the not-taken arm resumes at an
-                    // exception-handler-protected PC whose kept operand stack
-                    // holds exception state the partial snapshot cannot
-                    // reconstruct (the bare-`raise` re-raise reads NULL).
-                    let inside_exc_region = gate_frame
-                        .as_ref()
-                        .is_some_and(|f| branch_resume_inside_exc_region(f, other_target));
-                    if reads_null_ref || uses_edge_recovery || kept_boxed_int || inside_exc_region {
+                    // A not-taken arm resuming at an exception-handler-protected
+                    // PC carries the kept exception operand (`PUSH_EXC_INFO`'s
+                    // Ref) on its operand stack; the handler-entry mirror reseed
+                    // reconstructs it directly (so `mirror_covers_kept` gates this
+                    // whole block out), and where the mirror still does not cover,
+                    // that kept Ref always also trips Hazard (1)/(2)/(3) — so the
+                    // exc-region case needs no decline of its own.
+                    if reads_null_ref || uses_edge_recovery || kept_boxed_int {
                         return Err(DispatchError::BranchGuardUnrestorableKeptStackPermanent {
                             pc: op.pc,
                         });


### PR DESCRIPTION
Advances #267 (retire the JIT walker register/slot-pinning resume model) by extending the symbolic operand-stack mirror to the exception-unwind path and retiring the first kept-stack decline it subsumes.

## Commits

- **jit-trace: gated exception-unwind vstack-mirror reconstruction (PYRE_VSTACK_EXC)** — re-seed the operand-stack mirror at the in-frame SubRaise catch landing so an in-handler kept-stack guard compiles from the mirror instead of declining. Introduced behind an env gate.
- **jit-resume: GC-root the blackhole-construction virtuals cache and frame registers** — fixes a backend-agnostic GC bug the exc-mirror exposed on cranelift: `blackhole_from_resumedata` materialized resume virtuals into raw `i64` Vecs that a minor collection during pending-field materialization left pointing into from-space; the pending-field setfield then published a from-space exception pointer into `EC.sys_exc_value`, and a later resumed read dereferenced freed memory (SIGSEGV). Roots the virtuals cache + each frame's `registers_r` for the construction window, walks them on both GC paths, and makes `getvirtual_ptr` return the rooted (forwarded) cache slot.
- **jit-trace: make the exception-unwind vstack-mirror reconstruction unconditional** — removes the `PYRE_VSTACK_EXC` gate (default-on). `vstack_enter_exception_handler` self-guards (per-slot NONE hole / `vstack_valid = false`) for coordinates it cannot reconstruct.
- **jit-trace: retire the inside_exc_region kept-stack branch-guard decline** — the handler-entry mirror reseed now reconstructs the kept exception operand (gated out by `mirror_covers_kept`), and where the mirror still does not cover, the kept exception Ref always also trips the existing `reads_null_ref` / `uses_edge_recovery` / `kept_boxed_int` hazards, so this decline is fully subsumed.

## Verification

- `pyre/check.py` 160/160 on **both** backends (dynasm + cranelift), production default (no env var).
- Exception soak 120/120 byte-exact (60 programs × 2 backends).
- Adversarial byte-exact hunt of the default-on flip: 140 programs / 14 lenses; **0 flip-caused miscompiles**. The 6 surfaced divergences were all proven pre-existing and flip-independent by a decisive flip-off == flip-on byte-identical experiment (they belong to separate tracked epics).
- `inside_exc_region` deletion proven subsumed by 4 independent methods: decline census (351 programs, 0 sole-reason fires), force-off byte-exact (350 programs, 0 regression), adversarial refute hunt (96 niche programs, 0 refutations), and a deleted-build sweep (446 programs, 0 new divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
