### PR TITLE
Value-based is/id, complex/pow numeric parity, and container-constructor kwargs

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -25,6 +25,11 @@ pub struct GcConfig {
     /// incminimark.py:275: card_page_indices (0 disables card marking).
     /// Must be a power of two.
     pub card_page_indices: u32,
+    /// translationoption.py:185 `taggedpointers` (default off). When set,
+    /// a small `int` may be stored as an unboxed immediate with an odd
+    /// low bit; the collector must then skip such fields rather than read
+    /// them as object headers (`is_valid_gc_object`, gc/base.py:380-383).
+    pub taggedpointers: bool,
 }
 
 /// env.py:17-36 `_read_float_and_factor_from_env`. Parse `varname` as a float
@@ -180,6 +185,7 @@ impl Default for GcConfig {
             nursery_size: default_nursery_size(),
             large_object_threshold: (16384 + 512) * 8,
             card_page_indices: 128,
+            taggedpointers: false,
         }
     }
 }
@@ -615,7 +621,20 @@ impl MiniMarkGC {
     /// Check if an address is in the nursery.
     #[inline]
     pub fn is_in_nursery(&self, addr: usize) -> bool {
-        self.nursery.contains(addr)
+        !self.is_tagged_immediate(addr) && self.nursery.contains(addr)
+    }
+
+    /// The tagged-immediate test from `is_valid_gc_object`
+    /// (gc/base.py:380-383). With `taggedpointers` set (enablement only;
+    /// default off per `translationoption.py:185`), a small `int` may be
+    /// stored as an unboxed immediate with an odd low bit; such a value is
+    /// not a heap object and must not be read as an object header. The
+    /// nursery / managed-heap predicates below consult this so a tagged
+    /// field is reported outside every GC region. The gate short-circuits
+    /// the bit test away until enablement, leaving them pure range checks.
+    #[inline]
+    fn is_tagged_immediate(&self, addr: usize) -> bool {
+        self.config.taggedpointers && (addr & 1 == 1)
     }
 
     /// incminimark.py range-check parity: nursery membership is a pure
@@ -624,13 +643,14 @@ impl MiniMarkGC {
     /// not stay in sync.
     #[inline]
     fn is_managed_heap_object(&self, addr: usize) -> bool {
-        self.nursery.contains(addr) || self.oldgen.contains(addr)
+        !self.is_tagged_immediate(addr)
+            && (self.nursery.contains(addr) || self.oldgen.contains(addr))
     }
 
     /// incminimark.py:1208 is_in_nursery parity.
     #[inline]
     fn is_nursery_object_start(&self, addr: usize) -> bool {
-        self.nursery.contains(addr)
+        !self.is_tagged_immediate(addr) && self.nursery.contains(addr)
     }
 
     /// Allocate a fixed-size object with the given type ID and size (excluding header).
@@ -2433,7 +2453,8 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn is_managed_heap_object(&self, addr: usize) -> bool {
-        self.nursery.contains(addr) || self.oldgen.contains(addr)
+        !self.is_tagged_immediate(addr)
+            && (self.nursery.contains(addr) || self.oldgen.contains(addr))
     }
 
     fn write_barrier(&mut self, obj: GcRef) {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -621,20 +621,27 @@ impl MiniMarkGC {
     /// Check if an address is in the nursery.
     #[inline]
     pub fn is_in_nursery(&self, addr: usize) -> bool {
-        !self.is_tagged_immediate(addr) && self.nursery.contains(addr)
+        debug_assert!(
+            !self.is_tagged_immediate(addr),
+            "odd-valued (i.e. tagged) pointer unexpected here"
+        );
+        self.nursery.contains(addr)
     }
 
-    /// The tagged-immediate test from `is_valid_gc_object`
+    /// The tagged-immediate test used by `is_valid_gc_object`
     /// (gc/base.py:380-383). With `taggedpointers` set (enablement only;
     /// default off per `translationoption.py:185`), a small `int` may be
     /// stored as an unboxed immediate with an odd low bit; such a value is
-    /// not a heap object and must not be read as an object header. The
-    /// nursery / managed-heap predicates below consult this so a tagged
-    /// field is reported outside every GC region. The gate short-circuits
-    /// the bit test away until enablement, leaving them pure range checks.
+    /// not a heap object and must not be read as an object header.
     #[inline]
     fn is_tagged_immediate(&self, addr: usize) -> bool {
         self.config.taggedpointers && (addr & 1 == 1)
+    }
+
+    /// gc/base.py:380-383 `is_valid_gc_object`.
+    #[inline]
+    fn is_valid_gc_object(&self, addr: usize) -> bool {
+        addr != 0 && !self.is_tagged_immediate(addr)
     }
 
     /// incminimark.py range-check parity: nursery membership is a pure
@@ -643,14 +650,13 @@ impl MiniMarkGC {
     /// not stay in sync.
     #[inline]
     fn is_managed_heap_object(&self, addr: usize) -> bool {
-        !self.is_tagged_immediate(addr)
-            && (self.nursery.contains(addr) || self.oldgen.contains(addr))
+        self.is_valid_gc_object(addr) && (self.nursery.contains(addr) || self.oldgen.contains(addr))
     }
 
-    /// incminimark.py:1208 is_in_nursery parity.
+    /// Valid-object nursery check for arbitrary GC fields/roots.
     #[inline]
     fn is_nursery_object_start(&self, addr: usize) -> bool {
-        !self.is_tagged_immediate(addr) && self.nursery.contains(addr)
+        self.is_valid_gc_object(addr) && self.is_in_nursery(addr)
     }
 
     /// Allocate a fixed-size object with the given type ID and size (excluding header).
@@ -1124,7 +1130,7 @@ impl MiniMarkGC {
     /// objects, returns the object's own address (old-gen objects don't
     /// move in mark-sweep).
     pub fn id_or_identityhash(&mut self, obj_addr: usize) -> usize {
-        if self.is_in_nursery(obj_addr) {
+        if self.is_valid_gc_object(obj_addr) && self.is_in_nursery(obj_addr) {
             return self.find_shadow(obj_addr);
         }
         obj_addr
@@ -1269,7 +1275,7 @@ impl MiniMarkGC {
             }
             for slot_ptr in slots {
                 let field_ref = unsafe { *slot_ptr };
-                if !field_ref.is_null() && self.is_in_nursery(field_ref.0) {
+                if self.is_nursery_object_start(field_ref.0) {
                     let new_ref = self.copy_nursery_object(field_ref.0);
                     unsafe {
                         *slot_ptr = new_ref;
@@ -1289,7 +1295,7 @@ impl MiniMarkGC {
         for &offset in &gc_ptr_offsets {
             let slot = (obj_addr + offset) as *mut GcRef;
             let field_ref = unsafe { *slot };
-            if !field_ref.is_null() && self.is_in_nursery(field_ref.0) {
+            if self.is_nursery_object_start(field_ref.0) {
                 let new_ref = self.copy_nursery_object(field_ref.0);
                 unsafe {
                     *slot = new_ref;
@@ -1304,7 +1310,7 @@ impl MiniMarkGC {
             for i in 0..length {
                 let slot = (items_start + i * item_size) as *mut GcRef;
                 let field_ref = unsafe { *slot };
-                if !field_ref.is_null() && self.is_in_nursery(field_ref.0) {
+                if self.is_nursery_object_start(field_ref.0) {
                     let new_ref = self.copy_nursery_object(field_ref.0);
                     unsafe {
                         *slot = new_ref;
@@ -2011,7 +2017,7 @@ impl MiniMarkGC {
                             for i in interval_start..interval_stop {
                                 let slot = (items_start + i * item_size) as *mut GcRef;
                                 let field_ref = unsafe { *slot };
-                                if !field_ref.is_null() && self.is_in_nursery(field_ref.0) {
+                                if self.is_nursery_object_start(field_ref.0) {
                                     let new_ref = self.copy_nursery_object(field_ref.0);
                                     unsafe {
                                         *slot = new_ref;
@@ -2453,8 +2459,7 @@ impl GcAllocator for MiniMarkGC {
     }
 
     fn is_managed_heap_object(&self, addr: usize) -> bool {
-        !self.is_tagged_immediate(addr)
-            && (self.nursery.contains(addr) || self.oldgen.contains(addr))
+        self.is_valid_gc_object(addr) && (self.nursery.contains(addr) || self.oldgen.contains(addr))
     }
 
     fn write_barrier(&mut self, obj: GcRef) {

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -8128,15 +8128,22 @@ fn handler_debug_fatalerror(
 ) -> Result<usize, DispatchError> {
     panic!("bhimpl_debug_fatalerror");
 }
-/// blackhole.py:602-606 `bhimpl_cast_ptr_to_int(a)`. Pyre uses identity cast
-/// pending Phase F tagged-int representation (`(i & 1) == 1` invariant).
+/// blackhole.py:602-606 `bhimpl_cast_ptr_to_int(a)`. The cast is identity
+/// (the tagging arithmetic lives at the erase site, never here); the
+/// `ll_assert((i & 1) == 1)` checks the operand is a tagged immediate.
+/// `debug_assert!` mirrors `ll_assert` — removed from the optimized
+/// build, and the cast op only enters a trace once tagging is live, so
+/// this is inert until enablement.
 fn bhimpl_cast_ptr_to_int(a: i64) -> i64 {
+    debug_assert!((a & 1) == 1, "bhimpl_cast_ptr_to_int: not an odd int");
     a
 }
 
-/// blackhole.py:607-610 `bhimpl_cast_int_to_ptr(i)`. Pyre uses identity cast
-/// pending Phase F tagged-int representation.
+/// blackhole.py:607-610 `bhimpl_cast_int_to_ptr(i)`. Identity cast; the
+/// `ll_assert((i & 1) == 1)` checks the operand is a tagged immediate
+/// before it is reinterpreted as a `GCREF`.
 fn bhimpl_cast_int_to_ptr(i: i64) -> i64 {
+    debug_assert!((i & 1) == 1, "bhimpl_cast_int_to_ptr: not an odd int");
     i
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2350,6 +2350,17 @@ pub fn is_w(w_one: PyObjectRef, w_two: PyObjectRef) -> bool {
             return pyre_object::functional::range_obj_to_bigint(w_one)
                 == pyre_object::functional::range_obj_to_bigint(w_two);
         }
+        // `W_FloatObject.is_w` (floatobject.py:196-204): two plain
+        // `float`s are identical when their bit patterns are equal
+        // (`float2longlong`), so `0.0 is -0.0` is false and a NaN is its
+        // own identity. `float` subclasses (`user_overridden_class`) keep
+        // pointer identity — the exact-type gate excludes them.
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::FLOAT_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::FLOAT_TYPE)
+        {
+            return pyre_object::floatobject::w_float_get_value(w_one).to_bits()
+                == pyre_object::floatobject::w_float_get_value(w_two).to_bits();
+        }
     }
     false
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2373,6 +2373,65 @@ pub fn is_w(w_one: PyObjectRef, w_two: PyObjectRef) -> bool {
                 && pyre_object::complexobject::w_complex_get_imag(w_one).to_bits()
                     == pyre_object::complexobject::w_complex_get_imag(w_two).to_bits();
         }
+        // `W_AbstractTupleObject.is_w` (tupleobject.py:47-55): a `tuple` is
+        // identical to another only when both are the empty tuple — "empty
+        // tuples are unique-ified". Non-empty tuples keep pointer identity
+        // (the `ptr::eq` above handled `self is w_other`); `tuple`
+        // subclasses keep pointer identity through the exact-type gate. The
+        // specialised arity-2 tuples carry the canonical `tuple` w_class, so
+        // they pass the gate but are never empty (length 2).
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::TUPLE_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::TUPLE_TYPE)
+        {
+            return pyre_object::tupleobject::w_tuple_len(w_one) == 0
+                && pyre_object::tupleobject::w_tuple_len(w_two) == 0;
+        }
+        // `W_AbstractBytesObject.is_w` (bytesobject.py:24-38): for distinct
+        // exact-`bytes` operands, `len(s2) > 1` returns `s1 is s2` (storage
+        // identity) — distinct `bytes` never share their backing buffer, so
+        // `false`; `len(s2) == 0` returns `len(s1) == 0`; `len(s2) == 1`
+        // (unique-ified) returns `len(s1) == 1 && s1[0] == s2[0]`.
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::bytesobject::BYTES_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::bytesobject::BYTES_TYPE)
+        {
+            let len1 = pyre_object::bytesobject::w_bytes_len(w_one);
+            let len2 = pyre_object::bytesobject::w_bytes_len(w_two);
+            if len2 > 1 {
+                return false;
+            }
+            if len2 == 0 {
+                return len1 == 0;
+            }
+            return len1 == 1
+                && pyre_object::bytesobject::w_bytes_getitem(w_one, 0)
+                    == pyre_object::bytesobject::w_bytes_getitem(w_two, 0);
+        }
+        // `W_UnicodeObject.is_w` (unicodeobject.py:101-113): `_len()` is the
+        // codepoint count. When it is > 1, upstream returns `s1 is s2`
+        // (utf8 storage identity) — distinct `str`s never share storage, so
+        // `false`; when it is <= 1 (unique-ified) it returns `s1 == s2`,
+        // i.e. WTF-8 byte equality. `str` subclasses keep pointer identity
+        // through the exact-type gate.
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::STR_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::STR_TYPE)
+        {
+            if pyre_object::unicodeobject::w_str_len(w_one) > 1 {
+                return false;
+            }
+            return pyre_object::unicodeobject::w_str_get_wtf8(w_one)
+                == pyre_object::unicodeobject::w_str_get_wtf8(w_two);
+        }
+        // `W_FrozensetObject.is_w` (setobject.py:592-600): two `frozenset`s
+        // are identical only when both are empty — "empty frozensets are
+        // unique-ified". The mutable `set` carries a distinct type tag and
+        // does not override `is_w`, so the `FROZENSET_TYPE` gate excludes
+        // it; `frozenset` subclasses are excluded too.
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::setobject::FROZENSET_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::setobject::FROZENSET_TYPE)
+        {
+            return pyre_object::setobject::w_set_len(w_one) == 0
+                && pyre_object::setobject::w_set_len(w_two) == 0;
+        }
     }
     false
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2361,6 +2361,18 @@ pub fn is_w(w_one: PyObjectRef, w_two: PyObjectRef) -> bool {
             return pyre_object::floatobject::w_float_get_value(w_one).to_bits()
                 == pyre_object::floatobject::w_float_get_value(w_two).to_bits();
         }
+        // `W_ComplexObject.is_w` (complexobject.py:287-301): two plain
+        // `complex`es are identical when both component bit patterns are
+        // equal (`float2longlong`). `complex` subclasses
+        // (`user_overridden_class`) keep pointer identity.
+        if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::COMPLEX_TYPE)
+            && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::COMPLEX_TYPE)
+        {
+            return pyre_object::complexobject::w_complex_get_real(w_one).to_bits()
+                == pyre_object::complexobject::w_complex_get_real(w_two).to_bits()
+                && pyre_object::complexobject::w_complex_get_imag(w_one).to_bits()
+                    == pyre_object::complexobject::w_complex_get_imag(w_two).to_bits();
+        }
     }
     false
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8287,27 +8287,32 @@ fn parse_complex_str(raw: &str) -> Option<(f64, f64)> {
     }
 }
 
-/// Coerce a value to `(real, imag)` for `complex()` construction.
+/// Coerce a value to `(real, imag, is_complex)` for `complex()`
+/// construction.
 ///
 /// `int`/`bool`/`float` become a real-only pair; a `complex` keeps both
 /// components; an instance is asked for `__complex__` then `__float__`.
-fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
+/// The `is_complex` flag mirrors `complex_new`'s `cr_is_complex` /
+/// `ci_is_complex` — it is set when the operand is itself complex (a
+/// `complex` object or a `__complex__` result), which selects whether the
+/// component-mixing arithmetic applies to it.
+fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64, bool), crate::PyError> {
     use pyre_object::*;
     unsafe {
         if is_complex(obj) {
-            return Ok((w_complex_get_real(obj), w_complex_get_imag(obj)));
+            return Ok((w_complex_get_real(obj), w_complex_get_imag(obj), true));
         }
         if is_bool(obj) {
-            return Ok((w_bool_get_value(obj) as i64 as f64, 0.0));
+            return Ok((w_bool_get_value(obj) as i64 as f64, 0.0, false));
         }
         if is_int(obj) {
-            return Ok((w_int_get_value(obj) as f64, 0.0));
+            return Ok((w_int_get_value(obj) as f64, 0.0, false));
         }
         if is_long(obj) {
-            return Ok((crate::baseobjspace::float_w(obj)?, 0.0));
+            return Ok((crate::baseobjspace::float_w(obj)?, 0.0, false));
         }
         if is_float(obj) {
-            return Ok((w_float_get_value(obj), 0.0));
+            return Ok((w_float_get_value(obj), 0.0, false));
         }
     }
     // `__complex__` then `__float__` (complexobject.c try_complex_special_method).
@@ -8321,7 +8326,7 @@ fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
                         .unwrap_or_else(|| crate::PyError::type_error("__complex__ call failed")));
                 }
                 if is_complex(res) {
-                    return Ok((w_complex_get_real(res), w_complex_get_imag(res)));
+                    return Ok((w_complex_get_real(res), w_complex_get_imag(res), true));
                 }
                 return Err(crate::PyError::type_error(
                     "__complex__ should return a complex object",
@@ -8330,7 +8335,7 @@ fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
         }
     }
     let f = crate::baseobjspace::float_w(obj)?;
-    Ok((f, 0.0))
+    Ok((f, 0.0, false))
 }
 
 /// `complex(real=0, imag=0)` — complexobject.c complex_new.
@@ -8354,9 +8359,9 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
             return Ok(w_complex_new(r, i));
         }
     }
-    let (mut real, mut imag) = match args.first() {
+    let (mut real, mut imag, a_is_complex) = match args.first() {
         Some(&a) => complex_coerce(a)?,
-        None => (0.0, 0.0),
+        None => (0.0, 0.0, false),
     };
     if let Some(&b) = args.get(1) {
         if unsafe { is_str(b) } {
@@ -8364,10 +8369,21 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
                 "complex() second arg can't be a string",
             ));
         }
-        // complex(a, b) = (a.real - b.imag) + (a.imag + b.real)j.
-        let (br, bi) = complex_coerce(b)?;
-        real -= bi;
-        imag += br;
+        // `complex(a, b)` mixes the two operands' components only where an
+        // operand is itself complex: `real -= b.imag` applies only when `b`
+        // is complex, and the imaginary part is `a.imag + b.real` only when
+        // `a` is complex — otherwise it is `b.real` taken directly, so a
+        // real `imag` argument keeps its signed zero (`0.0 + -0.0` would
+        // round to `+0.0`).
+        let (br, bi, b_is_complex) = complex_coerce(b)?;
+        if b_is_complex {
+            real -= bi;
+        }
+        if a_is_complex {
+            imag += br;
+        } else {
+            imag = br;
+        }
     }
     Ok(w_complex_new(real, imag))
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8341,10 +8341,17 @@ fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64, bool), crate::PyError> 
 /// `complex(real=0, imag=0)` — complexobject.c complex_new.
 pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     use pyre_object::*;
-    // String form accepts only a single argument.
-    if let Some(&a) = args.first() {
+    // `complex(real=0, imag=0)` — both arguments are positional-or-keyword
+    // (complexobject.py descr__new__ `w_real`/`w_imag`).
+    let (pos, kwargs) = split_builtin_kwargs(args);
+    kwarg_reject_unknown(kwargs, &["real", "imag"], "complex")?;
+    let w_real = resolve_pos_or_kw(pos.first().copied(), kwargs, "real", "complex", 1)?;
+    let w_imag = resolve_pos_or_kw(pos.get(1).copied(), kwargs, "imag", "complex", 2)?;
+
+    // String form accepts only the real argument.
+    if let Some(a) = w_real {
         if unsafe { is_str(a) } {
-            if args.len() > 1 {
+            if w_imag.is_some() {
                 return Err(crate::PyError::type_error(
                     "complex() can't take second arg if first is a string",
                 ));
@@ -8359,11 +8366,11 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
             return Ok(w_complex_new(r, i));
         }
     }
-    let (mut real, mut imag, a_is_complex) = match args.first() {
-        Some(&a) => complex_coerce(a)?,
+    let (mut real, mut imag, a_is_complex) = match w_real {
+        Some(a) => complex_coerce(a)?,
         None => (0.0, 0.0, false),
     };
-    if let Some(&b) = args.get(1) {
+    if let Some(b) = w_imag {
         if unsafe { is_str(b) } {
             return Err(crate::PyError::type_error(
                 "complex() second arg can't be a string",

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4807,6 +4807,14 @@ fn builtin_delattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 }
 
 pub(crate) fn builtin_tuple(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // `tuple.__new__` is positional-only, so any keyword is a TypeError
+    // (an empty `**{}` is not a keyword and is allowed).
+    let (args, kwargs) = split_builtin_kwargs(args);
+    if has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "tuple() takes no keyword arguments",
+        ));
+    }
     if args.is_empty() {
         return Ok(w_tuple_new(vec![]));
     }
@@ -4832,6 +4840,14 @@ pub(crate) fn builtin_tuple(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 pub(crate) fn builtin_list_ctor(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // `list.__new__` is positional-only, so any keyword is a TypeError
+    // (an empty `**{}` is not a keyword and is allowed).
+    let (args, kwargs) = split_builtin_kwargs(args);
+    if has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "list() takes no keyword arguments",
+        ));
+    }
     if args.is_empty() {
         return Ok(w_list_new(vec![]));
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8303,32 +8303,27 @@ fn parse_complex_str(raw: &str) -> Option<(f64, f64)> {
     }
 }
 
-/// Coerce a value to `(real, imag, is_complex)` for `complex()`
-/// construction.
+/// Coerce a value to `(real, imag)` for `complex()` construction.
 ///
 /// `int`/`bool`/`float` become a real-only pair; a `complex` keeps both
 /// components; an instance is asked for `__complex__` then `__float__`.
-/// The `is_complex` flag mirrors `complex_new`'s `cr_is_complex` /
-/// `ci_is_complex` — it is set when the operand is itself complex (a
-/// `complex` object or a `__complex__` result), which selects whether the
-/// component-mixing arithmetic applies to it.
-fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64, bool), crate::PyError> {
+fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64), crate::PyError> {
     use pyre_object::*;
     unsafe {
         if is_complex(obj) {
-            return Ok((w_complex_get_real(obj), w_complex_get_imag(obj), true));
+            return Ok((w_complex_get_real(obj), w_complex_get_imag(obj)));
         }
         if is_bool(obj) {
-            return Ok((w_bool_get_value(obj) as i64 as f64, 0.0, false));
+            return Ok((w_bool_get_value(obj) as i64 as f64, 0.0));
         }
         if is_int(obj) {
-            return Ok((w_int_get_value(obj) as f64, 0.0, false));
+            return Ok((w_int_get_value(obj) as f64, 0.0));
         }
         if is_long(obj) {
-            return Ok((crate::baseobjspace::float_w(obj)?, 0.0, false));
+            return Ok((crate::baseobjspace::float_w(obj)?, 0.0));
         }
         if is_float(obj) {
-            return Ok((w_float_get_value(obj), 0.0, false));
+            return Ok((w_float_get_value(obj), 0.0));
         }
     }
     // `__complex__` then `__float__` (complexobject.c try_complex_special_method).
@@ -8342,7 +8337,7 @@ fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64, bool), crate::PyError> 
                         .unwrap_or_else(|| crate::PyError::type_error("__complex__ call failed")));
                 }
                 if is_complex(res) {
-                    return Ok((w_complex_get_real(res), w_complex_get_imag(res), true));
+                    return Ok((w_complex_get_real(res), w_complex_get_imag(res)));
                 }
                 return Err(crate::PyError::type_error(
                     "__complex__ should return a complex object",
@@ -8351,7 +8346,7 @@ fn complex_coerce(obj: PyObjectRef) -> Result<(f64, f64, bool), crate::PyError> 
         }
     }
     let f = crate::baseobjspace::float_w(obj)?;
-    Ok((f, 0.0, false))
+    Ok((f, 0.0))
 }
 
 /// `complex(real=0, imag=0)` — complexobject.c complex_new.
@@ -8382,9 +8377,9 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
             return Ok(w_complex_new(r, i));
         }
     }
-    let (mut real, mut imag, a_is_complex) = match w_real {
+    let (mut real, mut imag) = match w_real {
         Some(a) => complex_coerce(a)?,
-        None => (0.0, 0.0, false),
+        None => (0.0, 0.0),
     };
     if let Some(b) = w_imag {
         if unsafe { is_str(b) } {
@@ -8392,17 +8387,13 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
                 "complex() second arg can't be a string",
             ));
         }
-        // `complex(a, b)` mixes the two operands' components only where an
-        // operand is itself complex: `real -= b.imag` applies only when `b`
-        // is complex, and the imaginary part is `a.imag + b.real` only when
-        // `a` is complex — otherwise it is `b.real` taken directly, so a
-        // real `imag` argument keeps its signed zero (`0.0 + -0.0` would
-        // round to `+0.0`).
-        let (br, bi, b_is_complex) = complex_coerce(b)?;
-        if b_is_complex {
+        // complexobject.py:370-377 preserves signed zeroes by checking the
+        // numeric components, not whether either operand is a complex object.
+        let (br, bi) = complex_coerce(b)?;
+        if bi != 0.0 {
             real -= bi;
         }
-        if a_is_complex {
+        if imag != 0.0 {
             imag += br;
         } else {
             imag = br;
@@ -8493,6 +8484,19 @@ mod tests {
         assert_eq!(
             unsafe { w_int_get_value(w_tuple_getitem(result, 1).unwrap()) },
             2
+        );
+    }
+
+    #[test]
+    fn test_builtin_complex_preserves_imag_arg_negative_zero_with_complex_real() {
+        let result = builtin_complex(&[w_complex_new(1.0, 0.0), w_float_new(-0.0)]).unwrap();
+        assert_eq!(
+            unsafe { w_complex_get_real(result).to_bits() },
+            1.0f64.to_bits()
+        );
+        assert_eq!(
+            unsafe { w_complex_get_imag(result).to_bits() },
+            (-0.0f64).to_bits()
         );
     }
 

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1643,6 +1643,7 @@ pub unsafe fn fdel_func_doc(obj: PyObjectRef) -> Result<(), crate::PyError> {
 const IDTAG_SHIFT: i64 = 4;
 const IDTAG_INT: i64 = 1;
 const IDTAG_FLOAT: i64 = 5;
+const IDTAG_COMPLEX: i64 = 7;
 
 #[inline]
 pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
@@ -1670,6 +1671,20 @@ pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
             let bits = pyre_object::floatobject::w_float_get_value(obj).to_bits() as i64;
             let b = (malachite_bigint::BigInt::from(bits) << IDTAG_SHIFT as usize)
                 + malachite_bigint::BigInt::from(IDTAG_FLOAT);
+            return Some(pyre_object::functional::range_bigint_to_obj(b));
+        }
+        if is_exact_type(obj, &COMPLEX_TYPE) {
+            // `(real_b << 64 | imag_b) << IDTAG_SHIFT | IDTAG_COMPLEX`
+            // (complexobject.py:303-314): the real bits are signed
+            // (`float2longlong`), the imag bits unsigned (`r_ulonglong`);
+            // the high/low 64-bit halves don't overlap, so each `|` is a
+            // `+`.
+            let real_bits = pyre_object::complexobject::w_complex_get_real(obj).to_bits() as i64;
+            let imag_bits = pyre_object::complexobject::w_complex_get_imag(obj).to_bits();
+            let combined = (malachite_bigint::BigInt::from(real_bits) << 64usize)
+                + malachite_bigint::BigInt::from(imag_bits);
+            let b = (combined << IDTAG_SHIFT as usize)
+                + malachite_bigint::BigInt::from(IDTAG_COMPLEX);
             return Some(pyre_object::functional::range_bigint_to_obj(b));
         }
     }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1638,12 +1638,15 @@ pub unsafe fn fdel_func_doc(obj: PyObjectRef) -> Result<(), crate::PyError> {
     unsafe { function_del_doc(obj) }
 }
 
-/// `pypy/objspace/std/util.py:6-11` — `id()` of a plain `int` /
-/// `float` is its value tagged `(value << IDTAG_SHIFT) | IDTAG_*`.
+/// `pypy/objspace/std/util.py:6-13` — `id()` of a plain `int` / `float`
+/// / `complex` is its value tagged `(value << IDTAG_SHIFT) | IDTAG_*`;
+/// the unique-ified immutables (empty/short `bytes`/`str`, empty
+/// `tuple`/`frozenset`) use `IDTAG_SPECIAL`.
 const IDTAG_SHIFT: i64 = 4;
 const IDTAG_INT: i64 = 1;
 const IDTAG_FLOAT: i64 = 5;
 const IDTAG_COMPLEX: i64 = 7;
+const IDTAG_SPECIAL: i64 = 11;
 
 #[inline]
 pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
@@ -1686,6 +1689,84 @@ pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
             let b = (combined << IDTAG_SHIFT as usize)
                 + malachite_bigint::BigInt::from(IDTAG_COMPLEX);
             return Some(pyre_object::functional::range_bigint_to_obj(b));
+        }
+        if is_exact_type(obj, &TUPLE_TYPE) {
+            // `W_AbstractTupleObject.immutable_unique_id`
+            // (tupleobject.py:57-62): only the empty tuple is unique-ified
+            // — a non-empty tuple (`length() > 0`) returns `None` and
+            // `space.id` falls back to the address-based uid. `tuple`
+            // subclasses (`user_overridden_class`) also return `None`; the
+            // exact-type gate excludes them. The empty tuple has base value
+            // 258: `(258 << IDTAG_SHIFT) | IDTAG_SPECIAL`; the shifted value
+            // has low 4 bits clear, so `| IDTAG_SPECIAL` == `+`. The uid
+            // fits i64, so it is wrapped with `w_int_new` (`space.newint`).
+            if pyre_object::tupleobject::w_tuple_len(obj) > 0 {
+                return None;
+            }
+            let uid = (258i64 << IDTAG_SHIFT) + IDTAG_SPECIAL;
+            return Some(pyre_object::intobject::w_int_new(uid));
+        }
+        if is_exact_type(obj, &pyre_object::bytesobject::BYTES_TYPE) {
+            // `W_AbstractBytesObject.immutable_unique_id`
+            // (bytesobject.py:40-52): `len(s) > 1` is address-based
+            // (`compute_unique_id(s)`) so returning `None` falls back to the
+            // object address (invariant-preserving — distinct `bytes` never
+            // share storage). `len(s) <= 1` is unique-ified:
+            // `base = ord(s[0])` (0..255) for one byte, `base = 256` for the
+            // empty bytes, `uid = (base << IDTAG_SHIFT) | IDTAG_SPECIAL`.
+            let len = pyre_object::bytesobject::w_bytes_len(obj);
+            if len > 1 {
+                return None;
+            }
+            let base: i64 = if len == 1 {
+                pyre_object::bytesobject::w_bytes_getitem(obj, 0) as i64
+            } else {
+                256
+            };
+            let uid = (base << IDTAG_SHIFT) + IDTAG_SPECIAL;
+            return Some(pyre_object::intobject::w_int_new(uid));
+        }
+        if is_exact_type(obj, &STR_TYPE) {
+            // `W_UnicodeObject.immutable_unique_id` (unicodeobject.py:115-131).
+            // `l` is the codepoint count (`_len()`), not the byte length.
+            // `l > 1` is address-based (upstream `compute_unique_id(_utf8) +
+            // IDTAG_ALT_UID`); returning `None` falls back to the object
+            // address, invariant-preserving with `is_w` returning `false`
+            // for distinct len>1 strings. `l <= 1` is unique-ified: for a
+            // single codepoint `base = ~codepoint_at_pos(_utf8, 0)`
+            // (negative), and `base = 257` for the empty string.
+            let l = pyre_object::unicodeobject::w_str_len(obj);
+            if l > 1 {
+                return None;
+            }
+            let base: i64 = if l == 1 {
+                // `code_points()` yields the codepoint regardless of
+                // surrogates, matching `rutf8.codepoint_at_pos`.
+                let cp = pyre_object::unicodeobject::w_str_get_wtf8(obj)
+                    .code_points()
+                    .next()
+                    .expect("len==1 str has a code point")
+                    .to_u32();
+                // `(neg << IDTAG_SHIFT) | IDTAG_SPECIAL` == `+` (low 4 bits 0).
+                !(cp as i64)
+            } else {
+                257
+            };
+            let uid = (base << IDTAG_SHIFT) + IDTAG_SPECIAL;
+            return Some(pyre_object::intobject::w_int_new(uid));
+        }
+        if is_exact_type(obj, &pyre_object::setobject::FROZENSET_TYPE) {
+            // `W_FrozensetObject.immutable_unique_id` (setobject.py:602-607):
+            // a non-empty frozenset (`length() > 0`) and `frozenset`
+            // subclasses (excluded by the exact-type gate) return `None`.
+            // The empty frozenset is unique-ified with base value 259. The
+            // mutable `set` has its own type and does not override this, so
+            // the `FROZENSET_TYPE` gate does not match it.
+            if pyre_object::setobject::w_set_len(obj) > 0 {
+                return None;
+            }
+            let uid = (259i64 << IDTAG_SHIFT) + IDTAG_SPECIAL;
+            return Some(pyre_object::intobject::w_int_new(uid));
         }
     }
     None

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1638,26 +1638,38 @@ pub unsafe fn fdel_func_doc(obj: PyObjectRef) -> Result<(), crate::PyError> {
     unsafe { function_del_doc(obj) }
 }
 
-/// `pypy/objspace/std/util.py:6,9` — `id()` of a plain `int` is its
-/// value tagged `(value << IDTAG_SHIFT) | IDTAG_INT`.
+/// `pypy/objspace/std/util.py:6-11` — `id()` of a plain `int` /
+/// `float` is its value tagged `(value << IDTAG_SHIFT) | IDTAG_*`.
 const IDTAG_SHIFT: i64 = 4;
 const IDTAG_INT: i64 = 1;
+const IDTAG_FLOAT: i64 = 5;
 
 #[inline]
 pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
     // `W_AbstractIntObject.immutable_unique_id` (intobject.py:55-60): a
     // plain `int` — `W_IntObject` or the BigInt-backed `W_LongObject` —
     // has a value-derived id `(bigint_w << IDTAG_SHIFT) | IDTAG_INT`,
-    // wrapped as an `int` (a `long` when it overflows i64). `bool`
-    // (`W_BoolObject.immutable_unique_id` returns None, boolobject.py:28)
-    // and `int` subclasses (`user_overridden_class`) return `None`, so
-    // `space.id` falls back to the address-based uid.
+    // wrapped as an `int` (a `long` when it overflows i64).
+    // `W_FloatObject.immutable_unique_id` (floatobject.py:206-215) does
+    // the same with the float bit pattern (`float2longlong`) and
+    // `IDTAG_FLOAT`. `bool` (`W_BoolObject.immutable_unique_id` returns
+    // None, boolobject.py:28) and `int`/`float` subclasses
+    // (`user_overridden_class`) return `None`, so `space.id` falls back
+    // to the address-based uid.
     unsafe {
         if is_exact_type(obj, &INT_TYPE) {
             // `b.lshift(IDTAG_SHIFT).int_or_(IDTAG_INT)`; the shifted
             // value is even, so `| IDTAG_INT` equals `+ IDTAG_INT`.
             let b = (pyre_object::functional::range_obj_to_bigint(obj) << IDTAG_SHIFT as usize)
                 + malachite_bigint::BigInt::from(IDTAG_INT);
+            return Some(pyre_object::functional::range_bigint_to_obj(b));
+        }
+        if is_exact_type(obj, &FLOAT_TYPE) {
+            // `float2longlong(float_w(self))` reinterprets the f64 bits as
+            // a signed i64; the same `| IDTAG_FLOAT` == `+ IDTAG_FLOAT`.
+            let bits = pyre_object::floatobject::w_float_get_value(obj).to_bits() as i64;
+            let b = (malachite_bigint::BigInt::from(bits) << IDTAG_SHIFT as usize)
+                + malachite_bigint::BigInt::from(IDTAG_FLOAT);
             return Some(pyre_object::functional::range_bigint_to_obj(b));
         }
     }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1686,8 +1686,8 @@ pub fn immutable_unique_id(obj: PyObjectRef) -> Option<PyObjectRef> {
             let imag_bits = pyre_object::complexobject::w_complex_get_imag(obj).to_bits();
             let combined = (malachite_bigint::BigInt::from(real_bits) << 64usize)
                 + malachite_bigint::BigInt::from(imag_bits);
-            let b = (combined << IDTAG_SHIFT as usize)
-                + malachite_bigint::BigInt::from(IDTAG_COMPLEX);
+            let b =
+                (combined << IDTAG_SHIFT as usize) + malachite_bigint::BigInt::from(IDTAG_COMPLEX);
             return Some(pyre_object::functional::range_bigint_to_obj(b));
         }
         if is_exact_type(obj, &TUPLE_TYPE) {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2434,7 +2434,15 @@ pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     Err(binary_builtin_type_error("divmod()", a, b))
 }
 
-pub fn float_pow_raw(x: f64, y: f64) -> Result<f64, PyError> {
+/// floatobject.py:862 `PowDomainError` — sentinel for a negative base raised to
+/// a fractional power, which `descr_pow` promotes to a complex result.
+enum FloatPowError {
+    Domain,
+    Py(PyError),
+}
+
+/// floatobject.py:865 `_pow`.
+fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
     // floatobject.py:800-801
     if y == 2.0 {
         return Ok(x * x);
@@ -2476,18 +2484,16 @@ pub fn float_pow_raw(x: f64, y: f64) -> Result<f64, PyError> {
     }
     // floatobject.py:844-847
     if x == 0.0 && y < 0.0 {
-        return Err(PyError::zero_division(
+        return Err(FloatPowError::Py(PyError::zero_division(
             "0.0 cannot be raised to a negative power",
-        ));
+        )));
     }
     // floatobject.py:849-862
     let mut negate_result = false;
     let mut bx = x;
     if bx < 0.0 {
         if y.floor() != y {
-            return Err(PyError::value_error(
-                "negative number cannot be raised to a fractional power",
-            ));
+            return Err(FloatPowError::Domain);
         }
         bx = -bx;
         negate_result = y.abs() % 2.0 == 1.0;
@@ -2499,17 +2505,34 @@ pub fn float_pow_raw(x: f64, y: f64) -> Result<f64, PyError> {
     // floatobject.py:871-877
     let z = bx.powf(y);
     if z.is_infinite() && !bx.is_infinite() {
-        return Err(PyError::overflow_error("float power"));
+        return Err(FloatPowError::Py(PyError::overflow_error("float power")));
     }
     // floatobject.py:879-881
     Ok(if negate_result { -z } else { z })
 }
 
-/// floatobject.py:562 `W_FloatObject.descr_pow` boxing wrapper over `_pow`.
-/// Calls `float_pow_raw` and boxes the raw result into W_FloatObject.
+/// Raw `x ** y` as an `f64` for the `int`/`long` negative-exponent path. The
+/// negative-base fractional case cannot arise with an integral exponent, but is
+/// mapped back to the ValueError that `_pow` raises via `PowDomainError`.
+pub fn float_pow_raw(x: f64, y: f64) -> Result<f64, PyError> {
+    float_pow_inner(x, y).map_err(|e| match e {
+        FloatPowError::Domain => {
+            PyError::value_error("negative number cannot be raised to a fractional power")
+        }
+        FloatPowError::Py(e) => e,
+    })
+}
+
+/// floatobject.py:584 `W_FloatObject.descr_pow`.
 fn float_pow_impl(x: f64, y: f64) -> PyResult {
-    use pyre_object::w_float_new;
-    Ok(w_float_new(float_pow_raw(x, y)?))
+    match float_pow_inner(x, y) {
+        Ok(z) => Ok(w_float_new(z)),
+        // Negative numbers raised to fractional powers become complex.
+        Err(FloatPowError::Domain) => unsafe {
+            complex_pow(w_complex_new(x, 0.0), w_complex_new(y, 0.0))
+        },
+        Err(FloatPowError::Py(e)) => Err(e),
+    }
 }
 
 /// Left shift dispatch (`<<` operator).

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1871,6 +1871,14 @@ fn set_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// w_iterable=None)` signature, so anything beyond `(cls, iterable)` is a
 /// TypeError; pyre enforces the same maxargs explicitly here.
 fn frozenset_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    // `frozenset.__new__` is positional-only, so any keyword is a TypeError
+    // (an empty `**{}` is not a keyword and is allowed).
+    let (args, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "frozenset() takes no keyword arguments",
+        ));
+    }
     if args.len() > 2 {
         return Err(crate::PyError::type_error(format!(
             "frozenset() takes at most 1 argument ({} given)",

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1913,12 +1913,6 @@ fn frozenset_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// so anything beyond `(self, iterable)` raises TypeError; pyre enforces the
 /// same maxargs explicitly here.
 fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() > 2 {
-        return Err(crate::PyError::type_error(format!(
-            "set expected at most 1 argument, got {}",
-            args.len() - 1,
-        )));
-    }
     let set_obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
     // gateway.interp2app(W_SetObject.descr_init) enforces that `self` is a
     // W_SetObject before the body runs; without this check pyre would cast
@@ -1934,14 +1928,49 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             tp_name,
         )));
     }
+    // setobject.py:161 `descr_init(self, space, w_iterable=None, __posonly__=None)`
+    // — `iterable` is a single positional-only optional argument.  Parse the
+    // gateway args against that signature (gateway interp2app `parse_into_scope`)
+    // so a keyword raises the matching TypeError instead of leaking the kwargs
+    // dict as the iterable: `set(iterable=[1])` → "set.__init__() got a
+    // positional-only argument passed as keyword argument: 'iterable'",
+    // `set(x=1)` → "set.__init__() got an unexpected keyword argument 'x'".
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let mut keyword_names_w: Vec<PyObjectRef> = Vec::new();
+    let mut keywords_w: Vec<PyObjectRef> = Vec::new();
+    if let Some(dict) = kwargs {
+        for (key, val) in unsafe { pyre_object::w_dict_str_entries_wtf8(dict) } {
+            if key.as_str() == Ok("__pyre_kw__") {
+                continue;
+            }
+            keyword_names_w.push(pyre_object::w_str_from_wtf8(key));
+            keywords_w.push(val);
+        }
+    }
+    let signature = crate::gateway::Signature::new(vec!["self", "iterable"], None, None, 0, 2);
+    let arguments = crate::argument::Arguments::with_kw(positional, &keyword_names_w, &keywords_w);
+    let defaults = [pyre_object::w_none()];
+    let mut scope_w = vec![pyre_object::PY_NULL; signature.scope_length()];
+    arguments.parse_into_scope(
+        set_obj,
+        &mut scope_w,
+        "set.__init__",
+        &signature,
+        Some(&defaults),
+        pyre_object::PY_NULL,
+    )?;
+    let w_iterable = scope_w[1];
+
     let existing = unsafe { pyre_object::w_set_items(set_obj) };
     for item in existing {
         unsafe {
             pyre_object::w_set_discard(set_obj, item);
         }
     }
-    if let Some(iterable) = args.get(1).copied() {
-        let items = crate::builtins::collect_iterable(iterable)?;
+    // setobject.py:1722 `_initialize_set` populates from the iterable when it
+    // is not None (the parsed default).
+    if !w_iterable.is_null() && !unsafe { pyre_object::is_none(w_iterable) } {
+        let items = crate::builtins::collect_iterable(w_iterable)?;
         for item in items {
             unsafe { pyre_object::w_set_add(set_obj, item) };
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7888,7 +7888,13 @@ pub(crate) fn complex_repr_string(re: f64, im: f64) -> String {
     if re == 0.0 && re.is_sign_positive() {
         format!("{}j", complex_part_repr(im))
     } else {
-        let sign = if im >= 0.0 || im.is_nan() { "+" } else { "-" };
+        // The sign follows the imaginary part's sign bit, so a negative
+        // zero prints as `-0j`; a NaN imaginary part prints with `+`.
+        let sign = if im.is_sign_negative() && !im.is_nan() {
+            "-"
+        } else {
+            "+"
+        };
         format!(
             "({}{}{}j)",
             complex_part_repr(re),


### PR DESCRIPTION
Continues the #122 tagged-int / value-based identity line on `ec-wiring`
(12 commits on top of `main`).

## Value-based `is` / `id` for immutables
- Skip tagged immediates in GC region predicates
- Assert the tagged-int invariant in the cast bhimpls
- Compare floats by bit pattern in `is_w` and `id()`
- Compare complexes by component bit patterns in `is_w` and `id()`
- Unique-ify empty/short `bytes`, `str`, `tuple`, `frozenset` in `is_w` and `id()`

## `complex` / `float` numeric parity
- Preserve a signed-zero imaginary part in `complex(real, imag)`, later mixed by numeric component (`complexobject.py:370-377`) rather than operand type
- Accept `real`/`imag` as keyword arguments to `complex()`
- Print a negative-zero imaginary part as `-0j` in `complex` repr
- Promote a negative base raised to a fractional exponent to `complex` in float `**` (`floatobject.py` `PowDomainError` → `descr_pow`)

## Container constructors
- Reject keyword arguments to `tuple()`, `list()`, `frozenset()`
- Parse `set.__init__` args through the interp2app signature so a keyword raises the matching `TypeError` instead of leaking the kwargs dict as the iterable

## GC
- Extract `is_valid_gc_object` and route the nursery / managed-heap predicates through it

Verified against `pypy3` (the parity target) with `pyre/check.py` green on both backends (dynasm 160/160 + cranelift 160/160).

Refs #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
