### PR TITLE
jit/object: migrate list ItemsBlock and typed int/float storage onto the GC heap

### DIFF
--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1061,6 +1061,23 @@ impl TraceCtx {
         )
     }
 
+    /// Like [`for_test_types`] but seeds the trace green key (and thus
+    /// `root_green_key`).  A unit test that drives a loop-closing
+    /// `jit_merge_point` must model the trace as having STARTED at that
+    /// loop header: the close fires only when the arriving green key
+    /// matches `root_green_key` (the primary loop).
+    pub fn for_test_types_with_green_key(types: &[majit_ir::Type], green_key: u64) -> Self {
+        let mut recorder = Trace::new();
+        for &tp in types {
+            recorder.record_input_arg(tp);
+        }
+        Self::new(
+            recorder,
+            green_key,
+            std::sync::Arc::new(crate::MetaInterpStaticData::new()),
+        )
+    }
+
     /// Take the recorder out of this context (consumes self).
     pub fn into_recorder(self) -> Trace {
         self.recorder

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -998,7 +998,7 @@ static W_LIST_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 // flips it from Integer/Float to Object when an
                 // incompatible item is stored. A trace that folded
                 // `strategy == Float` at trace-time into a constant would
-                // then read from `float_items.ptr` (empty after the
+                // then read from `float_items.block` (empty after the
                 // switch) and dereference garbage — spectral_norm n=10
                 // SIGSEGV root cause diagnosed in
                 // memory/spectral_norm_small_n_crash_2026_04_17.md.
@@ -1022,15 +1022,6 @@ static W_LIST_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
             // the unwrap inline and doesn't add a separate backing
             // array).
             (
-                "W_ListObject.int_items.ptr",
-                std::mem::offset_of!(W_ListObject, int_items) + INT_ARRAY_PTR_OFFSET,
-                std::mem::size_of::<usize>(),
-                Type::Int,
-                false,
-                false,
-                false,
-            ),
-            (
                 "W_ListObject.int_items.len",
                 std::mem::offset_of!(W_ListObject, int_items) + INT_ARRAY_LEN_OFFSET,
                 std::mem::size_of::<usize>(),
@@ -1039,37 +1030,10 @@ static W_LIST_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 false,
                 false,
             ),
-            (
-                "W_ListObject.int_items.heap_cap",
-                std::mem::offset_of!(W_ListObject, int_items) + INT_ARRAY_HEAP_CAP_OFFSET,
-                std::mem::size_of::<usize>(),
-                Type::Int,
-                false,
-                false,
-                false,
-            ),
             // Float-strategy typed storage.
-            (
-                "W_ListObject.float_items.ptr",
-                std::mem::offset_of!(W_ListObject, float_items) + FLOAT_ARRAY_PTR_OFFSET,
-                std::mem::size_of::<usize>(),
-                Type::Int,
-                false,
-                false,
-                false,
-            ),
             (
                 "W_ListObject.float_items.len",
                 std::mem::offset_of!(W_ListObject, float_items) + FLOAT_ARRAY_LEN_OFFSET,
-                std::mem::size_of::<usize>(),
-                Type::Int,
-                false,
-                false,
-                false,
-            ),
-            (
-                "W_ListObject.float_items.heap_cap",
-                std::mem::offset_of!(W_ListObject, float_items) + FLOAT_ARRAY_HEAP_CAP_OFFSET,
                 std::mem::size_of::<usize>(),
                 Type::Int,
                 false,
@@ -1709,10 +1673,8 @@ use pyre_object::intobject::W_IntObject;
 use pyre_object::pyobject::{OB_TYPE_OFFSET, W_CLASS_OFFSET};
 use pyre_object::unicodeobject::UNICODE_LEN_OFFSET;
 use pyre_object::{
-    BOOL_INTVAL_OFFSET, FLOAT_ARRAY_BLOCK_OFFSET, FLOAT_ARRAY_HEAP_CAP_OFFSET,
-    FLOAT_ARRAY_LEN_OFFSET, FLOAT_ARRAY_PTR_OFFSET, INT_ARRAY_BLOCK_OFFSET,
-    INT_ARRAY_HEAP_CAP_OFFSET, INT_ARRAY_LEN_OFFSET, INT_ARRAY_PTR_OFFSET, INT_INTVAL_OFFSET,
-    W_ListObject, W_TupleObject,
+    BOOL_INTVAL_OFFSET, FLOAT_ARRAY_BLOCK_OFFSET, FLOAT_ARRAY_LEN_OFFSET, INT_ARRAY_BLOCK_OFFSET,
+    INT_ARRAY_LEN_OFFSET, INT_INTVAL_OFFSET, W_ListObject, W_TupleObject,
 };
 // Re-import the rest without duplication
 use pyre_object::{FLOAT_TYPE, INT_TYPE};
@@ -1845,42 +1807,26 @@ pub fn list_strategy_descr() -> DescrRef {
     field_descr_from_group(&W_LIST_DESCR_GROUP, 2)
 }
 
-pub fn list_int_items_ptr_descr() -> DescrRef {
+pub fn list_int_items_len_descr() -> DescrRef {
     field_descr_from_group(&W_LIST_DESCR_GROUP, 3)
 }
 
-pub fn list_int_items_len_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 4)
-}
-
-pub fn list_int_items_heap_cap_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 5)
-}
-
-pub fn list_float_items_ptr_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 6)
-}
-
 pub fn list_float_items_len_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 7)
-}
-
-pub fn list_float_items_heap_cap_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 8)
+    field_descr_from_group(&W_LIST_DESCR_GROUP, 4)
 }
 
 /// `Ptr(GcArray(Signed))` — the `int_items` backing block (`erase([int])`).
 /// Read as a Ref; combine with the GcArray(Signed) array descr
 /// (`int_gcarray_descr`) for `GetarrayitemGcI` / `SetarrayitemGc`.
 pub fn list_int_items_block_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 9)
+    field_descr_from_group(&W_LIST_DESCR_GROUP, 5)
 }
 
 /// `Ptr(GcArray(Float))` — the `float_items` backing block (`erase([float])`).
 /// Read as a Ref; combine with the GcArray(Float) array descr
 /// (`float_gcarray_descr`) for `GetarrayitemGcF` / `SetarrayitemGc`.
 pub fn list_float_items_block_descr() -> DescrRef {
-    field_descr_from_group(&W_LIST_DESCR_GROUP, 10)
+    field_descr_from_group(&W_LIST_DESCR_GROUP, 6)
 }
 
 /// `Ptr(GcArray(OBJECTPTR))` — `wrappeditems` body per
@@ -2528,11 +2474,6 @@ mod tests {
         // SimpleFieldDescr at offset 0 (the list header).
         for (name, expected, ty) in [
             ("int_items.len", list_int_items_len_descr(), Type::Int),
-            (
-                "int_items.heap_cap",
-                list_int_items_heap_cap_descr(),
-                Type::Int,
-            ),
             ("int_items.block", list_int_items_block_descr(), Type::Ref),
         ] {
             let descr = make_descr_from_bh(&BhDescr::Field {
@@ -3410,26 +3351,25 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             // #171 codewriter descr-bridge: `_handle_list_call`
             // (codewriter/jtransform.rs) lowers Integer-strategy list
             // ops to fields on the dotted nested names
-            // `int_items.{len,heap_cap,block}` (owner `W_ListObject`).
+            // `int_items.{len,block}` (owner `W_ListObject`).
             // `bh_field_name` treats the dotted name as already-qualified,
             // and `W_ListObject` is a runtime Rust type absent from the
             // codewriter struct layouts, so the assembler's `fielddescrof`
             // leaves these at offset 0 (the list header). Map the leaves to
             // the canonical `W_LIST_DESCR_GROUP` entries the walker-native
             // list specializations already use so an assembled codewriter
-            // list body addresses `IntArray.{len,heap_cap,block}` rather
+            // list body addresses `IntArray.{len,block}` rather
             // than the header.
             if owner.as_str() == "W_ListObject" {
                 match name.as_str() {
                     "int_items.len" => return list_int_items_len_descr(),
-                    "int_items.heap_cap" => return list_int_items_heap_cap_descr(),
                     "int_items.block" => return list_int_items_block_descr(),
                     // A bare `int_items` / `float_items` read addresses the
                     // typed-storage struct base, which is its first field
                     // (`block`, `INT_ARRAY_BLOCK_OFFSET == 0`) — the same
                     // offset + `Ref` type as the `.block` leaf above. The
                     // `w_list_append` body reads `int_items` directly before
-                    // reaching `.ptr`/`.len`; bridge it to the canonical
+                    // reaching `.len`; bridge it to the canonical
                     // `.block` group entry so the read resolves a parent_descr.
                     "int_items" => return list_int_items_block_descr(),
                     "float_items" => return list_float_items_block_descr(),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -27161,7 +27161,15 @@ mod tests {
             0x02, 0x01, 0x02, // rr: len=2, [r1, r2]
             0x00, // rf: len=0
         ];
-        let mut tc = fresh_trace_ctx();
+        // Model the trace as having STARTED at this loop header: the close
+        // gate fires only when the arriving green key equals the primary
+        // `root_green_key` (a non-primary header re-arrival continues — the
+        // cross-loop-cut elimination).  The arriving key is
+        // `make_green_key(pycode, next_instr)` from the green concretes below.
+        let mut tc = TraceCtx::for_test_types_with_green_key(
+            &[Type::Ref],
+            crate::driver::make_green_key(0x1_0000 as *const (), 42),
+        );
         let next_instr = tc.const_int(42); // gi[0] = Python pc
         let pycode = tc.const_ref(0x1_0000); // gr[0] = PyCode ptr
         let red0 = tc.const_ref(0x2_0000); // rr[0]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -18594,13 +18594,31 @@ fn handle(
                 .trace_ctx
                 .has_merge_point_with_shape_assert(key, live_args.len())
             {
-                Ok((
-                    DispatchOutcome::CloseLoop {
-                        jump_args: live_args,
-                        loop_header_pc: next_instr,
-                    },
-                    op.next_pc,
-                ))
+                // pyjitpl.py:2994-3036 `reached_loop_header` closes the trace
+                // only at the loop whose green key MATCHES the one tracing
+                // started from. A top-level walk that re-arrives at a
+                // NON-primary header (an enclosing/sibling loop the recorded
+                // path crossed) must NOT close there: closing at a non-root
+                // header is the cross-loop cut (a pyre-only deviation) that
+                // retargets the green key and leaks the outer loop's
+                // exit-prediction guard into the cut inner-loop body
+                // (miscompiling a triangular nested loop). Continue the walk
+                // instead so it closes at the primary loop's own back-edge;
+                // an inner loop that is itself hot compiles as its OWN token
+                // and is reached via the compiled-target JUMP path above. Only
+                // the top-level walk is gated — a sub-walk keeps the prior
+                // close-on-match behaviour.
+                if !ctx.is_top_level || key == ctx.trace_ctx.root_green_key() {
+                    Ok((
+                        DispatchOutcome::CloseLoop {
+                            jump_args: live_args,
+                            loop_header_pc: next_instr,
+                        },
+                        op.next_pc,
+                    ))
+                } else {
+                    Ok((DispatchOutcome::Continue, op.next_pc))
+                }
             } else {
                 // This merge point registers (does not close) — the walk
                 // crossed a loop-boundary that did not match the primary

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2944,9 +2944,7 @@ fn walker_fill_materialized_array(
         return;
     }
     let block = match ctx.trace_ctx.box_value(array) {
-        Some(majit_ir::Value::Ref(r))
-            if r != majit_ir::GcRef(usize::MAX) && r.as_usize() != 0 =>
-        {
+        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) && r.as_usize() != 0 => {
             r.as_usize() as *mut pyre_object::object_array::ItemsBlock
         }
         // No stamped concrete → not materialized (gate off / non-ref / non-const).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -2914,7 +2914,80 @@ fn setarrayitem_gc_via_heapcache(
     // hit time.
     ctx.trace_ctx
         .heapcache_setarrayitem(array, index, descr_index, value);
+    walker_fill_materialized_array(ctx, array, index, value);
     Ok((DispatchOutcome::Continue, op.next_pc))
+}
+
+/// Walker virtual-force fill — companion to the `NEW_ARRAY_CLEAR`
+/// materialization in the `new_array_clear` handler (module-global
+/// fresh-container off-by-one fix). When `array` is a still-unescaped block we
+/// materialized to a concrete GC `ItemsBlock` at NEW_ARRAY_CLEAR, write the
+/// concrete element into it so a later BUILD_LIST / BUILD_TUPLE residual reads
+/// a complete block during the walk. If the element value (not a ref) or the
+/// index has no known concrete, the block cannot be completed, so revert the
+/// array to the no-concrete sentinel (`Ref(usize::MAX)`): the residual then
+/// declines and the void store aborts, exactly as without materialization.
+///
+/// A real (already-escaped) array store — whose `array` operand is a
+/// `GetfieldGcR` load of a live container's items block, not a fresh
+/// allocation — is left untouched because `is_unescaped(array)` is false, so
+/// the runtime trace's own SETARRAYITEM is never duplicated eagerly here.
+fn walker_fill_materialized_array(
+    ctx: &mut WalkContext<'_, '_>,
+    array: OpRef,
+    index: OpRef,
+    value: OpRef,
+) {
+    // heapcache.py:493 is_unescaped — only a fresh, not-yet-escaped allocation
+    // is a materialization candidate; a loaded (escaped) array is a real store.
+    if !ctx.trace_ctx.heap_cache().is_unescaped(array) {
+        return;
+    }
+    let block = match ctx.trace_ctx.box_value(array) {
+        Some(majit_ir::Value::Ref(r))
+            if r != majit_ir::GcRef(usize::MAX) && r.as_usize() != 0 =>
+        {
+            r.as_usize() as *mut pyre_object::object_array::ItemsBlock
+        }
+        // No stamped concrete → not materialized (gate off / non-ref / non-const).
+        _ => return,
+    };
+    // Confirm it is one of our GC-managed materialization blocks.
+    if !pyre_object::gc_hook::try_gc_owns_object(block as *mut u8) {
+        return;
+    }
+    let idx = match ctx.trace_ctx.box_value(index) {
+        Some(majit_ir::Value::Int(i)) if i >= 0 => i as usize,
+        _ => {
+            ctx.trace_ctx
+                .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef(usize::MAX)));
+            return;
+        }
+    };
+    let cap = unsafe { pyre_object::object_array::items_block_capacity(block) };
+    if idx >= cap {
+        ctx.trace_ctx
+            .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef(usize::MAX)));
+        return;
+    }
+    let elem = match ctx.trace_ctx.box_value(value) {
+        Some(majit_ir::Value::Ref(r)) if r != majit_ir::GcRef(usize::MAX) => {
+            r.as_usize() as pyre_object::PyObjectRef
+        }
+        _ => {
+            ctx.trace_ctx
+                .try_set_opref_concrete(array, majit_ir::Value::Ref(majit_ir::GcRef(usize::MAX)));
+            return;
+        }
+    };
+    unsafe {
+        let base = pyre_object::object_array::items_block_items_base(block);
+        *base.add(idx) = elem;
+    }
+    // Old→young barrier: the materialization block may have been promoted to
+    // old-gen while `elem` is still young (the construction-barrier gap). A
+    // nursery block carries no TRACK_YOUNG_PTRS so the barrier is a no-op.
+    pyre_object::gc_hook::try_gc_write_barrier(block as *mut u8);
 }
 
 /// `setfield_gc_<i|r>/<rid|rrd>` handler: read box (r-reg), valuebox
@@ -17590,6 +17663,7 @@ fn handle(
             );
             ctx.trace_ctx
                 .heapcache_setarrayitem(array, index, descr_index, value);
+            walker_fill_materialized_array(ctx, array, index, value);
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "setarrayitem_gc_f/rifd" => setarrayitem_gc_via_heapcache(code, op, ctx, 'f'),
@@ -17609,6 +17683,9 @@ fn handle(
                 read_int_reg(code, op, 0, ctx)?
             };
             let descr = read_descr(code, op, 1, ctx)?;
+            let is_ref_array = descr
+                .as_array_descr()
+                .map_or(false, |a| a.is_array_of_pointers());
             let resbox =
                 ctx.trace_ctx
                     .record_op_with_descr(OpCode::NewArrayClear, &[length], descr);
@@ -17619,9 +17696,40 @@ fn handle(
                 .heap_cache_mut()
                 .new_array(resbox, length, length.is_constant());
             let dst = code[op.pc + 4] as usize;
-            // A freshly recorded allocation has no runtime concrete —
-            // same Null posture as other recorded producers.
-            write_ref_reg(ctx, op.pc, dst, resbox, ConcreteValue::Null)?;
+            // Walker virtual-force (module-global fresh-container off-by-one
+            // fix): for a constant-length array of refs on the items-block GC
+            // path, eagerly allocate a real GC-traced block and stamp it as the
+            // recording-time concrete VALUE (`Op.value` — GC-rooted via
+            // `walk_op_const_ptr_refs`, NOT `make_constant`, so the compiled
+            // trace still allocates fresh per iteration; same posture as an
+            // executed residual's observed result). A later BUILD_LIST /
+            // BUILD_TUPLE residual then resolves a concrete array arg and runs
+            // during the walk, committing a container stored into an escaping
+            // slot (e.g. a module-global cell) for the recorded iteration
+            // instead of forcing the void-store abort. The companion
+            // `walker_fill_materialized_array` fills slots at `setarrayitem_gc`;
+            // if any element/index is non-concrete it reverts the array to the
+            // no-concrete sentinel so the residual declines (abort, as before).
+            // Non-ref / non-constant arrays and the gate-off fallback keep the
+            // Null posture.
+            let mut concrete = ConcreteValue::Null;
+            if is_ref_array && length.is_constant() {
+                if let Some(majit_ir::Value::Int(n)) = ctx.trace_ctx.box_value(length) {
+                    if let Ok(cap) = usize::try_from(n) {
+                        if let Some(block) = unsafe {
+                            pyre_object::object_array::alloc_cleared_ref_items_block_gc(cap)
+                        } {
+                            if ctx.trace_ctx.try_set_opref_concrete(
+                                resbox,
+                                majit_ir::Value::Ref(majit_ir::GcRef(block as usize)),
+                            ) {
+                                concrete = ConcreteValue::Ref(block as pyre_object::PyObjectRef);
+                            }
+                        }
+                    }
+                }
+            }
+            write_ref_reg(ctx, op.pc, dst, resbox, concrete)?;
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         "int_copy/i>i" => {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2558,35 +2558,6 @@ pub fn pyobject_gcarray_descr() -> DescrRef {
     )
 }
 
-pub(crate) fn int_array_descr() -> DescrRef {
-    // `nolength=True` view: caller already holds `*ItemsBlock`-style
-    // pointer to the items region, so no length header.  Stable
-    // identity carrier `"pyre::int_array_nolength"` so every
-    // `int_array_descr()` call returns the same Arc (PyPy
-    // `cpu.arraydescrof` singleton).
-    crate::descr::make_array_descr_with_full_id(
-        0,
-        8,
-        0,
-        None,
-        Type::Int,
-        true,
-        Some("pyre::int_array_nolength".to_string()),
-    )
-}
-
-pub(crate) fn float_array_descr() -> DescrRef {
-    crate::descr::make_array_descr_with_full_id(
-        0,
-        8,
-        0,
-        None,
-        Type::Float,
-        false,
-        Some("pyre::float_array_nolength".to_string()),
-    )
-}
-
 /// `Ptr(GcArray(Signed))` — the `IntegerListStrategy` backing block
 /// (`erase([int])`). Length-prefixed `[capacity][i64...]`: `base_size` skips
 /// the capacity header so `GetarrayitemGcI(block, i)` lands on items[i], and
@@ -3372,54 +3343,6 @@ pub(crate) fn trace_items_block_setitem_value(
     ctx.heapcache_setarrayitem(block, index, descr_idx, value);
 }
 
-pub(crate) fn trace_raw_int_array_getitem_value(
-    ctx: &mut TraceCtx,
-    array: OpRef,
-    index: OpRef,
-) -> OpRef {
-    let descr = int_array_descr();
-    let result = ctx.record_op_with_descr(OpCode::GetarrayitemRawI, &[array, index], descr.clone());
-    // Box(value) parity: executor.py:132 do_getarrayitem_raw_i projects
-    // `arraybox.getint()` (raw pointer carried as Int, not the
-    // `getref_base()` projection used by executor.py:117 do_get
-    // arrayitem_gc_i).  Route the sanity load through the raw helper
-    // family so the descriptor path matches `cpu.bh_getarrayitem_raw_i`.
-    if let (Some(majit_ir::Value::Int(arr_ptr)), Some(majit_ir::Value::Int(idx))) =
-        (ctx.box_value(array), ctx.box_value(index))
-    {
-        if arr_ptr != 0 {
-            if let Some(live) = ctx.raw_array_sanity_load(arr_ptr, idx, &descr, majit_ir::Type::Int)
-            {
-                ctx.set_opref_concrete(result, live);
-            }
-        }
-    }
-    result
-}
-
-pub(crate) fn trace_raw_float_array_getitem_value(
-    ctx: &mut TraceCtx,
-    array: OpRef,
-    index: OpRef,
-) -> OpRef {
-    let descr = float_array_descr();
-    let result = ctx.record_op_with_descr(OpCode::GetarrayitemRawF, &[array, index], descr.clone());
-    // executor.py:132 do_getarrayitem_raw_f — same Int-carried raw
-    // pointer projection as the int variant above.
-    if let (Some(majit_ir::Value::Int(arr_ptr)), Some(majit_ir::Value::Int(idx))) =
-        (ctx.box_value(array), ctx.box_value(index))
-    {
-        if arr_ptr != 0 {
-            if let Some(live) =
-                ctx.raw_array_sanity_load(arr_ptr, idx, &descr, majit_ir::Type::Float)
-            {
-                ctx.set_opref_concrete(result, live);
-            }
-        }
-    }
-    result
-}
-
 /// Write to frame's locals_cells_stack_w array.
 /// Uses Gc (GC-typed) to match RPython's SETARRAYITEM_GC.
 pub(crate) fn trace_raw_array_setitem_value(
@@ -3436,32 +3359,6 @@ pub(crate) fn trace_raw_array_setitem_value(
     // resolve the intrinsic value via `box_value(cached)` at hit
     // time.
     ctx.heapcache_setarrayitem(array, index, descr_idx, value);
-}
-
-pub(crate) fn trace_raw_int_array_setitem_value(
-    ctx: &mut TraceCtx,
-    array: OpRef,
-    index: OpRef,
-    value: OpRef,
-) {
-    ctx.record_op_with_descr(
-        OpCode::SetarrayitemRaw,
-        &[array, index, value],
-        int_array_descr(),
-    );
-}
-
-pub(crate) fn trace_raw_float_array_setitem_value(
-    ctx: &mut TraceCtx,
-    array: OpRef,
-    index: OpRef,
-    value: OpRef,
-) {
-    ctx.record_op_with_descr(
-        OpCode::SetarrayitemRaw,
-        &[array, index, value],
-        float_array_descr(),
-    );
 }
 
 /// `GetarrayitemGcI(block, index)` against `int_gcarray_descr` — the

--- a/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
+++ b/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
@@ -663,54 +663,32 @@ fn list_len_descr_for_strategy(strategy_id: i64) -> majit_ir::DescrRef {
 
 #[inline]
 fn list_heap_capacity_for_strategy(
-    frame: &mut crate::state::MIFrame,
+    _frame: &mut crate::state::MIFrame,
     ctx: &mut majit_metainterp::TraceCtx,
     list: majit_ir::OpRef,
     strategy_id: i64,
-    is_inline: bool,
+    _is_inline: bool,
 ) -> majit_ir::OpRef {
-    use majit_ir::OpCode;
-
-    match strategy_id {
-        0 => {
-            let items_block = load_items_block(ctx, list, crate::descr::list_items_descr());
-            crate::state::opimpl_arraylen_gc(
-                ctx,
-                items_block,
-                crate::state::pyobject_gcarray_descr(),
-            )
-        }
-        1 | 2 => {
-            let heap_cap_descr = match strategy_id {
-                1 => crate::descr::list_int_items_heap_cap_descr(),
-                2 => crate::descr::list_float_items_heap_cap_descr(),
-                _ => unreachable!(),
-            };
-            let heap_cap = crate::state::opimpl_getfield_gc_i(ctx, list, heap_cap_descr);
-            if is_inline {
-                // Pyre-only typed-list storage adaptation: inline arrays
-                // encode capacity as `heap_cap == 0`; the backing pointer is
-                // the fixed inline buffer. Guard that shape before using the
-                // compile-time inline capacity constant.
-                frame.implement_guard_value(ctx, heap_cap, 0);
-                let inline_cap = match strategy_id {
-                    1 => pyre_object::INT_ARRAY_INLINE_CAP,
-                    2 => pyre_object::FLOAT_ARRAY_INLINE_CAP,
-                    _ => unreachable!(),
-                };
-                ctx.const_int(inline_cap as i64)
-            } else {
-                let zero = ctx.const_int(0);
-                let heap_storage = ctx.record_op(OpCode::IntGt, &[heap_cap, zero]);
-                if let Some(majit_ir::Value::Int(c)) = ctx.box_value(heap_cap) {
-                    ctx.set_opref_concrete(heap_storage, majit_ir::Value::Int((c > 0) as i64));
-                }
-                frame.generate_guard(ctx, OpCode::GuardTrue, &[heap_storage]);
-                heap_cap
-            }
-        }
+    // Capacity is `len(l.items)` (rlist.py:251) — the GcArray length header of
+    // the backing block, read with `ArraylenGc`. Identical shape for every
+    // strategy; only the block field descr + array descr differ.
+    let (block_descr, gcarray_descr) = match strategy_id {
+        0 => (
+            crate::descr::list_items_descr(),
+            crate::state::pyobject_gcarray_descr(),
+        ),
+        1 => (
+            crate::descr::list_int_items_block_descr(),
+            crate::state::int_gcarray_descr(),
+        ),
+        2 => (
+            crate::descr::list_float_items_block_descr(),
+            crate::state::float_gcarray_descr(),
+        ),
         _ => unreachable!(),
-    }
+    };
+    let block = load_items_block(ctx, list, block_descr);
+    crate::state::opimpl_arraylen_gc(ctx, block, gcarray_descr)
 }
 
 #[inline]

--- a/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
+++ b/pyre/pyre-jit-trace/src/trace_helpers/typed_trace.rs
@@ -846,19 +846,19 @@ pub fn generated_list_setitem_by_strategy<F: pyre_jit_trace::walker_frame_ops::W
             );
         }
         1 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 frame.ctx_mut(),
                 obj,
-                crate::descr::list_int_items_ptr_descr(),
+                crate::descr::list_int_items_block_descr(),
             );
             let raw = unbox_int_or_long_for_int_strategy(frame, value, unbox_long);
-            crate::state::trace_raw_int_array_setitem_value(frame.ctx_mut(), items_ptr, index, raw);
+            crate::state::trace_int_block_setitem_value(frame.ctx_mut(), block, index, raw);
         }
         2 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 frame.ctx_mut(),
                 obj,
-                crate::descr::list_float_items_ptr_descr(),
+                crate::descr::list_float_items_block_descr(),
             );
             let raw = if frame.value_type(value) == majit_ir::Type::Float {
                 value
@@ -866,12 +866,7 @@ pub fn generated_list_setitem_by_strategy<F: pyre_jit_trace::walker_frame_ops::W
                 let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
                 crate::state::trace_unbox_float_with_resume(frame, value, float_type_addr)
             };
-            crate::state::trace_raw_float_array_setitem_value(
-                frame.ctx_mut(),
-                items_ptr,
-                index,
-                raw,
-            );
+            crate::state::trace_float_block_setitem_value(frame.ctx_mut(), block, index, raw);
         }
         _ => unreachable!(),
     }
@@ -959,54 +954,54 @@ pub fn generated_list_setslice_same_len_by_strategy<
             }
         }
         1 => {
-            let dst_items = crate::state::opimpl_getfield_gc_i(
+            let dst_block = crate::state::opimpl_getfield_gc_r(
                 frame.ctx_mut(),
                 obj,
-                crate::descr::list_int_items_ptr_descr(),
+                crate::descr::list_int_items_block_descr(),
             );
-            let src_items = crate::state::opimpl_getfield_gc_i(
+            let src_block = crate::state::opimpl_getfield_gc_r(
                 frame.ctx_mut(),
                 value,
-                crate::descr::list_int_items_ptr_descr(),
+                crate::descr::list_int_items_block_descr(),
             );
             for i in 0..value_len {
                 let src_idx = frame.ctx_mut().const_int(i as i64);
                 let dst_idx = frame.ctx_mut().const_int(start + i as i64);
-                let item = crate::state::trace_raw_int_array_getitem_value(
+                let item = crate::state::trace_int_block_getitem_value(
                     frame.ctx_mut(),
-                    src_items,
+                    src_block,
                     src_idx,
                 );
-                crate::state::trace_raw_int_array_setitem_value(
+                crate::state::trace_int_block_setitem_value(
                     frame.ctx_mut(),
-                    dst_items,
+                    dst_block,
                     dst_idx,
                     item,
                 );
             }
         }
         2 => {
-            let dst_items = crate::state::opimpl_getfield_gc_i(
+            let dst_block = crate::state::opimpl_getfield_gc_r(
                 frame.ctx_mut(),
                 obj,
-                crate::descr::list_float_items_ptr_descr(),
+                crate::descr::list_float_items_block_descr(),
             );
-            let src_items = crate::state::opimpl_getfield_gc_i(
+            let src_block = crate::state::opimpl_getfield_gc_r(
                 frame.ctx_mut(),
                 value,
-                crate::descr::list_float_items_ptr_descr(),
+                crate::descr::list_float_items_block_descr(),
             );
             for i in 0..value_len {
                 let src_idx = frame.ctx_mut().const_int(i as i64);
                 let dst_idx = frame.ctx_mut().const_int(start + i as i64);
-                let item = crate::state::trace_raw_float_array_getitem_value(
+                let item = crate::state::trace_float_block_getitem_value(
                     frame.ctx_mut(),
-                    src_items,
+                    src_block,
                     src_idx,
                 );
-                crate::state::trace_raw_float_array_setitem_value(
+                crate::state::trace_float_block_setitem_value(
                     frame.ctx_mut(),
-                    dst_items,
+                    dst_block,
                     dst_idx,
                     item,
                 );
@@ -1316,19 +1311,19 @@ pub fn generated_list_append_by_strategy(
             crate::state::trace_items_block_setitem_value(ctx, items_block, len, value);
         }
         1 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 ctx,
                 list,
-                crate::descr::list_int_items_ptr_descr(),
+                crate::descr::list_int_items_block_descr(),
             );
             let raw = unbox_int_or_long_for_int_strategy(frame, value, unbox_long);
-            crate::state::trace_raw_int_array_setitem_value(ctx, items_ptr, len, raw);
+            crate::state::trace_int_block_setitem_value(ctx, block, len, raw);
         }
         2 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 ctx,
                 list,
-                crate::descr::list_float_items_ptr_descr(),
+                crate::descr::list_float_items_block_descr(),
             );
             let raw = if frame.value_type(value) == majit_ir::Type::Float {
                 value
@@ -1336,7 +1331,7 @@ pub fn generated_list_append_by_strategy(
                 let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
                 crate::state::trace_unbox_float_with_resume(frame, value, float_type_addr)
             };
-            crate::state::trace_raw_float_array_setitem_value(ctx, items_ptr, len, raw);
+            crate::state::trace_float_block_setitem_value(ctx, block, len, raw);
         }
         _ => unreachable!(),
     }
@@ -1470,12 +1465,12 @@ pub fn generated_list_pop_by_strategy(
             item
         }
         1 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 ctx,
                 list,
-                crate::descr::list_int_items_ptr_descr(),
+                crate::descr::list_int_items_block_descr(),
             );
-            let raw = crate::state::trace_raw_int_array_getitem_value(ctx, items_ptr, last_index);
+            let raw = crate::state::trace_int_block_getitem_value(ctx, block, last_index);
             ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
             ctx.heapcache_setfield_cached(list, len_descr_idx, new_len);
             let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
@@ -1489,12 +1484,12 @@ pub fn generated_list_pop_by_strategy(
             )
         }
         2 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 ctx,
                 list,
-                crate::descr::list_float_items_ptr_descr(),
+                crate::descr::list_float_items_block_descr(),
             );
-            let raw = crate::state::trace_raw_float_array_getitem_value(ctx, items_ptr, last_index);
+            let raw = crate::state::trace_float_block_getitem_value(ctx, block, last_index);
             ctx.record_op_with_descr(OpCode::SetfieldGc, &[list, new_len], len_descr);
             ctx.heapcache_setfield_cached(list, len_descr_idx, new_len);
             let float_type_addr = &pyre_object::pyobject::FLOAT_TYPE as *const _ as i64;
@@ -2205,20 +2200,20 @@ pub fn generated_list_getitem_by_strategy(
             crate::state::trace_items_block_getitem_value(ctx, items_block, index)
         }
         1 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 ctx,
                 obj,
-                crate::descr::list_int_items_ptr_descr(),
+                crate::descr::list_int_items_block_descr(),
             );
-            crate::state::trace_raw_int_array_getitem_value(ctx, items_ptr, index)
+            crate::state::trace_int_block_getitem_value(ctx, block, index)
         }
         2 => {
-            let items_ptr = crate::state::opimpl_getfield_gc_i(
+            let block = crate::state::opimpl_getfield_gc_r(
                 ctx,
                 obj,
-                crate::descr::list_float_items_ptr_descr(),
+                crate::descr::list_float_items_block_descr(),
             );
-            crate::state::trace_raw_float_array_getitem_value(ctx, items_ptr, index)
+            crate::state::trace_float_block_getitem_value(ctx, block, index)
         }
         _ => unreachable!(),
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -638,7 +638,7 @@ fn resolve_field_offset(owner: &str, field_name: &str) -> usize {
         "namespace" | "w_globals" => std::mem::offset_of!(PyFrame, w_globals),
         "vable_token" => std::mem::offset_of!(PyFrame, vable_token),
         // #171 codewriter descr-bridge (blackhole side): the dotted nested
-        // `int_items.{len,heap_cap,block}` leaves `_handle_list_call`
+        // `int_items.{len,block}` leaves `_handle_list_call`
         // emits resolve to offset 0 in the codewriter assembler because
         // `W_ListObject` is a runtime Rust type absent from its struct
         // layouts. Resolve them to the real `IntArray` offsets so a
@@ -648,10 +648,6 @@ fn resolve_field_offset(owner: &str, field_name: &str) -> usize {
         "int_items.len" => {
             std::mem::offset_of!(pyre_object::W_ListObject, int_items)
                 + pyre_object::INT_ARRAY_LEN_OFFSET
-        }
-        "int_items.heap_cap" => {
-            std::mem::offset_of!(pyre_object::W_ListObject, int_items)
-                + pyre_object::INT_ARRAY_HEAP_CAP_OFFSET
         }
         "int_items.block" => {
             std::mem::offset_of!(pyre_object::W_ListObject, int_items)

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -731,14 +731,14 @@ thread_local! {
         // item slot as a Ref; NULL-initialized spare slots past the
         // live length are benign.
         //
-        // This typeid only governs blocks allocated *through the GC*.
-        // `alloc_items_block` uses `std::alloc::alloc`, so no concrete
-        // allocation carries this typeid at runtime — the registration
-        // shapes the GC's type table but no walker ever visits a
-        // PY_OBJECT_ARRAY_GC_TYPE_ID-tagged object. It becomes live only
-        // once `items` blocks are allocated through the GC. See comments
-        // on `pyre_jit_trace::descr::PY_OBJECT_ARRAY_GC_TYPE_ID` and
-        // `pyre_object::object_array::ItemsBlock` for the companion
+        // This typeid governs blocks allocated *through the GC*, which is
+        // the default path (`object_array::alloc_*_block_gc` →
+        // `try_gc_alloc`); the nursery walker traces each item slot of such
+        // a block, and the list/tuple custom traces forward the block
+        // pointer. Under the `PYRE_GC_ITEMSBLOCK=0` fallback the blocks come
+        // from `std::alloc` instead and no allocation carries this typeid.
+        // See comments on `pyre_jit_trace::descr::PY_OBJECT_ARRAY_GC_TYPE_ID`
+        // and `pyre_object::object_array::ItemsBlock` for the companion
         // notices.
         let py_object_array_tid = gc.register_type(TypeInfo::varsize(
             pyre_object::object_array::ITEMS_BLOCK_ITEMS_OFFSET,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9089,7 +9089,7 @@ mod tests {
         let recorder = ctx.into_recorder();
         let mut saw_gc_field = false;
         let mut saw_raw_field = false;
-        let mut saw_raw_array = false;
+        let mut saw_gc_array = false;
         for pos in 2..(2 + recorder.num_ops() as u32) {
             let Some(op) = recorder.get_op_by_raw_pos(pos) else {
                 continue;
@@ -9105,17 +9105,17 @@ mod tests {
                 {
                     saw_raw_field = true
                 }
-                OpCode::GetarrayitemRawF => saw_raw_array = true,
+                OpCode::GetarrayitemGcF => saw_gc_array = true,
                 _ => {}
             }
         }
         assert!(saw_gc_field);
         assert!(!saw_raw_field);
-        assert!(saw_raw_array);
+        assert!(saw_gc_array);
     }
 
     #[test]
-    fn test_list_append_value_uses_raw_storage_fast_paths_with_compiled_trace_jitcode() {
+    fn test_list_append_value_uses_gc_storage_fast_paths_with_compiled_trace_jitcode() {
         use majit_ir::{OpCode, OpRef, Type};
         use majit_metainterp::TraceCtx;
         use pyre_jit_trace::state::{MIFrame, PyreSym};
@@ -9154,10 +9154,10 @@ mod tests {
 
             state
                 .capture_list_append_value(list, value, concrete_list, concrete_value)
-                .expect("raw-storage append fast path should trace");
+                .expect("typed-storage append fast path should trace");
 
             let recorder = ctx.into_recorder();
-            let mut saw_raw_setitem = false;
+            let mut saw_gc_setitem = false;
             let mut saw_len_update = false;
             let mut saw_call = false;
             let mut saw_new = false;
@@ -9174,8 +9174,8 @@ mod tests {
                 if op.opcode == OpCode::New {
                     saw_new = true;
                 }
-                if op.opcode == OpCode::SetarrayitemRaw {
-                    saw_raw_setitem = true;
+                if op.opcode == OpCode::SetarrayitemGc {
+                    saw_gc_setitem = true;
                 }
                 if op.opcode == OpCode::SetfieldGc
                     && op.getdescr().map(|d| d.index()) == Some(expected_len_descr_idx)
@@ -9183,7 +9183,7 @@ mod tests {
                     saw_len_update = true;
                 }
             }
-            assert!(saw_raw_setitem);
+            assert!(saw_gc_setitem);
             assert!(saw_len_update);
             assert!(!saw_call);
             assert_eq!(saw_new, expect_box_alloc);
@@ -9193,7 +9193,7 @@ mod tests {
             pyre_object::w_list_new(vec![pyre_object::w_int_new(1), pyre_object::w_int_new(2)]);
         unsafe {
             // A freshly built list allocates capacity == length, so append
-            // once to force the over-allocating grow that leaves the raw
+            // once to force the over-allocating grow that leaves the
             // append fast path spare capacity to write into.
             pyre_object::listobject::w_list_append(int_list, pyre_object::w_int_new(3));
             assert!(pyre_object::listobject::w_list_uses_int_storage(int_list));
@@ -9215,7 +9215,7 @@ mod tests {
         ]);
         unsafe {
             // Same as the int case: force the over-allocating grow so the
-            // raw append fast path has spare capacity.
+            // append fast path has spare capacity.
             pyre_object::listobject::w_list_append(float_list, pyre_object::w_float_new(3.5));
             assert!(pyre_object::listobject::w_list_uses_float_storage(
                 float_list

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -477,23 +477,36 @@ unsafe fn tuple_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maji
 unsafe fn list_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     let list_ptr = obj_addr as *mut pyre_object::listobject::W_ListObject;
     let list = unsafe { &*list_ptr };
-    if list.strategy != pyre_object::listobject::ListStrategy::Object || list.items.is_null() {
-        return;
-    }
-    if pyre_object::gc_hook::try_gc_owns_object(list.items as *mut u8) {
-        // Phase L2: a GC-managed (moving) block is forwarded by handing the
-        // collector the `items` field slot itself; the type-9 varsize walker
-        // then forwards items[0..capacity] (spare slots are NULL). This is
-        // the `gc_ptr_offsets = [offset_of!(items)]` edge that collector.rs:377
-        // declines while the block stays std::alloc.
-        let items_slot = unsafe { std::ptr::addr_of_mut!((*list_ptr).items) };
-        f(items_slot as *mut majit_ir::GcRef);
-    } else {
-        // std::alloc stationary block: forward each live element in place.
-        let base = unsafe { pyre_object::object_array::items_block_items_base(list.items) };
-        for i in 0..list.length {
-            f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+    if list.strategy == pyre_object::listobject::ListStrategy::Object && !list.items.is_null() {
+        if pyre_object::gc_hook::try_gc_owns_object(list.items as *mut u8) {
+            // Phase L2: a GC-managed (moving) block is forwarded by handing the
+            // collector the `items` field slot itself; the type-9 varsize walker
+            // then forwards items[0..capacity] (spare slots are NULL). This is
+            // the `gc_ptr_offsets = [offset_of!(items)]` edge that collector.rs:377
+            // declines while the block stays std::alloc.
+            let items_slot = unsafe { std::ptr::addr_of_mut!((*list_ptr).items) };
+            f(items_slot as *mut majit_ir::GcRef);
+        } else {
+            // std::alloc stationary block: forward each live element in place.
+            let base = unsafe { pyre_object::object_array::items_block_items_base(list.items) };
+            for i in 0..list.length {
+                f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+            }
         }
+    }
+    // Integer/Float backing blocks (`int_items.block` / `float_items.block`) are
+    // `GcArray(Signed)` / `GcArray(Float)` leaf arrays — no inner refs — so the
+    // collector relocates one by forwarding the owner slot itself. Forwarded for
+    // every strategy so a collection keeps the slots valid even when the strategy
+    // does not read them (`Drop` deallocs through them); a std::alloc block (gate
+    // off) is not GC-owned and stays in place.
+    let int_block_slot = unsafe { std::ptr::addr_of_mut!((*list_ptr).int_items.block) };
+    if pyre_object::gc_hook::try_gc_owns_object(unsafe { *int_block_slot } as *mut u8) {
+        f(int_block_slot as *mut majit_ir::GcRef);
+    }
+    let float_block_slot = unsafe { std::ptr::addr_of_mut!((*list_ptr).float_items.block) };
+    if pyre_object::gc_hook::try_gc_owns_object(unsafe { *float_block_slot } as *mut u8) {
+        f(float_block_slot as *mut majit_ir::GcRef);
     }
 }
 

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -10,67 +10,60 @@ pub const FLOAT_ARRAY_INLINE_CAP: usize = 8;
 /// Unboxed `float` list storage — `listobject.py` FloatListStrategy
 /// `lstorage = erase([float])`, i.e. a `Ptr(GcArray(Float))`.
 ///
-/// The data lives in a separate length-prefixed [`TypedItemsBlock`]
-/// (`[capacity][f64...]`) so the JIT can address it as a GC array
-/// (`GetfieldGcR(block) → GetarrayitemGcF`). `ptr` mirrors the block's items
-/// base (`block + ITEMS_OFFSET`) for the host slice API and the legacy raw-array
-/// trace sites; `heap_cap` mirrors the block capacity. Both are kept in sync by
-/// every method that reallocates the block.
+/// `rlist.py:116` `LIST = GcStruct("list", ("length", Signed), ("items",
+/// Ptr(GcArray(item))))`: the live length is `len` and the items array is the
+/// length-prefixed [`TypedItemsBlock`] (`[capacity][f64...]`) reached through
+/// `block`. The items base and allocated capacity are read from `block` on
+/// demand — there is no cached interior pointer, so the JIT addresses the array
+/// as a GC ref (`GetfieldGcR(block) → GetarrayitemGcF`) the gcmap relocates.
 #[repr(C)]
 pub struct FloatArray {
-    /// `Ptr(GcArray(Float))` — the backing block. Read as a Ref by the GC-array
-    /// trace path. Always non-null (allocated on construction).
+    /// `Ptr(GcArray(Float))` — the backing block (`l.items`). Always non-null.
     pub block: *mut TypedItemsBlock,
-    /// Items base (`= block + ITEMS_OFFSET`). Mirrors the block; used by the
-    /// host slice API and the legacy raw-array trace sites.
-    pub ptr: *mut f64,
     /// Live length (rlist.py:116 `("length", Signed)`).
     len: usize,
-    /// Allocated capacity, mirroring the block header. Read by the append/pop
-    /// inline-capacity trace path (`is_inline()` is always false, so that path
-    /// uses this field directly).
-    heap_cap: usize,
 }
 
 pub const FLOAT_ARRAY_BLOCK_OFFSET: usize = std::mem::offset_of!(FloatArray, block);
-pub const FLOAT_ARRAY_PTR_OFFSET: usize = std::mem::offset_of!(FloatArray, ptr);
 pub const FLOAT_ARRAY_LEN_OFFSET: usize = std::mem::offset_of!(FloatArray, len);
-pub const FLOAT_ARRAY_HEAP_CAP_OFFSET: usize = std::mem::offset_of!(FloatArray, heap_cap);
 
 impl FloatArray {
-    /// Re-derive `ptr`/`heap_cap` from the current `block`. Called after the
-    /// block is (re)allocated.
+    /// Items base pointer (`&l.items[0]`), derived from `block`.
     #[inline]
-    fn sync_from_block(&mut self) {
-        unsafe {
-            self.ptr = typed_items_block_items_base(self.block) as *mut f64;
-            self.heap_cap = typed_items_block_capacity(self.block);
-        }
+    fn base(&self) -> *mut f64 {
+        unsafe { typed_items_block_items_base(self.block) as *mut f64 }
     }
 
     pub fn from_vec(values: Vec<f64>) -> Self {
         let len = values.len();
-        let mut arr = Self {
+        let arr = Self {
             block: unsafe { alloc_typed_items_block(len) },
-            ptr: std::ptr::null_mut(),
             len,
-            heap_cap: 0,
         };
-        arr.sync_from_block();
         unsafe {
-            std::ptr::copy_nonoverlapping(values.as_ptr(), arr.ptr, len);
+            std::ptr::copy_nonoverlapping(values.as_ptr(), arr.base(), len);
         }
         arr
     }
 
+    /// Allocated capacity (`len(l.items)`, rlist.py:251), read from the block
+    /// header.
     #[inline]
     fn capacity(&self) -> usize {
-        self.heap_cap
+        unsafe { typed_items_block_capacity(self.block) }
     }
 
     #[inline]
     pub fn spare_capacity(&self) -> usize {
         self.capacity().saturating_sub(self.len)
+    }
+
+    /// Allocated capacity (block header). The no-resize append fast path
+    /// guards `len < heap_capacity()`, mirroring `_ll_list_resize_ge`
+    /// (rlist.py:285).
+    #[inline]
+    pub fn heap_capacity(&self) -> usize {
+        self.capacity()
     }
 
     /// Float list storage is always a separate block (no inline buffer);
@@ -82,28 +75,25 @@ impl FloatArray {
 
     fn grow(&mut self, min_cap: usize) {
         let target_cap = min_cap
-            .max(self.heap_cap.saturating_mul(2))
+            .max(self.capacity().saturating_mul(2))
             .max(FLOAT_ARRAY_INLINE_CAP);
         self.block = unsafe { grow_typed_items_block(self.block, target_cap, self.len) };
-        self.sync_from_block();
     }
 
     pub fn push(&mut self, value: f64) {
-        if self.len == self.heap_cap {
+        if self.len == self.capacity() {
             self.grow(self.len + 1);
         }
         unsafe {
-            *self.ptr.add(self.len) = value;
+            *self.base().add(self.len) = value;
         }
         self.len += 1;
     }
 
-    /// `ptr`/`heap_cap` are derived from the stable `block`, so a move of the
-    /// enclosing object leaves them valid. Re-derive defensively.
+    /// No-op: the items base is derived from `block` on every access, never
+    /// cached, so a move of the enclosing object needs no fixup.
     #[inline]
-    pub fn fix_ptr(&mut self) {
-        self.sync_from_block();
-    }
+    pub fn fix_ptr(&mut self) {}
 
     #[inline]
     pub fn len(&self) -> usize {
@@ -115,20 +105,20 @@ impl FloatArray {
     }
 
     pub fn as_slice(&self) -> &[f64] {
-        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        unsafe { std::slice::from_raw_parts(self.base(), self.len) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [f64] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        unsafe { std::slice::from_raw_parts_mut(self.base(), self.len) }
     }
 
     pub fn insert(&mut self, index: usize, value: f64) {
         assert!(index <= self.len);
-        if self.len == self.heap_cap {
+        if self.len == self.capacity() {
             self.grow(self.len + 1);
         }
         unsafe {
-            let p = self.ptr.add(index);
+            let p = self.base().add(index);
             std::ptr::copy(p, p.add(1), self.len - index);
             *p = value;
         }
@@ -139,7 +129,7 @@ impl FloatArray {
         assert!(index < self.len);
         let value = self.as_slice()[index];
         unsafe {
-            let p = self.ptr.add(index);
+            let p = self.base().add(index);
             std::ptr::copy(p.add(1), p, self.len - index - 1);
         }
         self.len -= 1;
@@ -164,22 +154,24 @@ impl FloatArray {
         let len2 = new_values.len();
         let new_len = old_len - slicelength + len2;
         if len2 > slicelength {
-            if new_len > self.heap_cap {
+            if new_len > self.capacity() {
                 self.grow(new_len);
             }
             unsafe {
+                let base = self.base();
                 std::ptr::copy(
-                    self.ptr.add(s + slicelength),
-                    self.ptr.add(s + len2),
+                    base.add(s + slicelength),
+                    base.add(s + len2),
                     old_len - s - slicelength,
                 );
             }
             self.len = new_len;
         } else if slicelength > len2 {
             unsafe {
+                let base = self.base();
                 std::ptr::copy(
-                    self.ptr.add(s + slicelength),
-                    self.ptr.add(s + len2),
+                    base.add(s + slicelength),
+                    base.add(s + len2),
                     old_len - s - slicelength,
                 );
             }
@@ -199,7 +191,7 @@ impl FloatArray {
             return;
         }
         unsafe {
-            let p = self.ptr.add(start);
+            let p = self.base().add(start);
             std::ptr::copy(p.add(count), p, self.len - end);
         }
         self.len -= count;
@@ -223,13 +215,13 @@ impl Index<usize> for FloatArray {
 
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
-        unsafe { &*self.ptr.add(index) }
+        unsafe { &*self.base().add(index) }
     }
 }
 
 impl IndexMut<usize> for FloatArray {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        unsafe { &mut *self.ptr.add(index) }
+        unsafe { &mut *self.base().add(index) }
     }
 }

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -1,8 +1,9 @@
 use std::ops::{Index, IndexMut};
 
 use crate::object_array::{
-    TypedItemsBlock, alloc_typed_items_block, dealloc_typed_items_block, grow_typed_items_block,
-    typed_items_block_capacity, typed_items_block_items_base,
+    GC_FLOAT_ARRAY_GC_TYPE_ID, TypedItemsBlock, alloc_typed_items_block,
+    dealloc_typed_items_block, grow_typed_items_block, typed_items_block_capacity,
+    typed_items_block_items_base,
 };
 
 pub const FLOAT_ARRAY_INLINE_CAP: usize = 8;
@@ -37,7 +38,7 @@ impl FloatArray {
     pub fn from_vec(values: Vec<f64>) -> Self {
         let len = values.len();
         let arr = Self {
-            block: unsafe { alloc_typed_items_block(len) },
+            block: unsafe { alloc_typed_items_block(len, GC_FLOAT_ARRAY_GC_TYPE_ID) },
             len,
         };
         unsafe {
@@ -77,7 +78,8 @@ impl FloatArray {
         let target_cap = min_cap
             .max(self.capacity().saturating_mul(2))
             .max(FLOAT_ARRAY_INLINE_CAP);
-        self.block = unsafe { grow_typed_items_block(self.block, target_cap, self.len) };
+        self.block =
+            unsafe { grow_typed_items_block(self.block, target_cap, self.len, GC_FLOAT_ARRAY_GC_TYPE_ID) };
     }
 
     pub fn push(&mut self, value: f64) {

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -1,9 +1,8 @@
 use std::ops::{Index, IndexMut};
 
 use crate::object_array::{
-    GC_FLOAT_ARRAY_GC_TYPE_ID, TypedItemsBlock, alloc_typed_items_block,
-    dealloc_typed_items_block, grow_typed_items_block, typed_items_block_capacity,
-    typed_items_block_items_base,
+    GC_FLOAT_ARRAY_GC_TYPE_ID, TypedItemsBlock, alloc_typed_items_block, dealloc_typed_items_block,
+    grow_typed_items_block, typed_items_block_capacity, typed_items_block_items_base,
 };
 
 pub const FLOAT_ARRAY_INLINE_CAP: usize = 8;
@@ -78,8 +77,9 @@ impl FloatArray {
         let target_cap = min_cap
             .max(self.capacity().saturating_mul(2))
             .max(FLOAT_ARRAY_INLINE_CAP);
-        self.block =
-            unsafe { grow_typed_items_block(self.block, target_cap, self.len, GC_FLOAT_ARRAY_GC_TYPE_ID) };
+        self.block = unsafe {
+            grow_typed_items_block(self.block, target_cap, self.len, GC_FLOAT_ARRAY_GC_TYPE_ID)
+        };
     }
 
     pub fn push(&mut self, value: f64) {

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -92,11 +92,6 @@ impl FloatArray {
         self.len += 1;
     }
 
-    /// No-op: the items base is derived from `block` on every access, never
-    /// cached, so a move of the enclosing object needs no fixup.
-    #[inline]
-    pub fn fix_ptr(&mut self) {}
-
     #[inline]
     pub fn len(&self) -> usize {
         self.len

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -13,55 +13,48 @@ pub const INT_ARRAY_INLINE_CAP: usize = 8;
 /// Unboxed `int` list storage — `listobject.py` IntegerListStrategy
 /// `lstorage = erase([int])`, i.e. a `Ptr(GcArray(Signed))`.
 ///
-/// The data lives in a separate length-prefixed [`TypedItemsBlock`]
-/// (`[capacity][i64...]`) so the JIT can address it as a GC array
-/// (`GetfieldGcR(block) → GetarrayitemGcI`). `ptr` mirrors the block's items
-/// base; `heap_cap` mirrors the block capacity. Both are kept in sync by every
-/// method that reallocates the block.
+/// `rlist.py:116` `LIST = GcStruct("list", ("length", Signed), ("items",
+/// Ptr(GcArray(item))))`: the live length is `len` and the items array is the
+/// length-prefixed [`TypedItemsBlock`] (`[capacity][i64...]`) reached through
+/// `block`. The items base and allocated capacity are read from `block` on
+/// demand (`len(l.items)` = the block's capacity header) — there is no cached
+/// interior pointer, so the JIT can address the array as a GC ref
+/// (`GetfieldGcR(block) → GetarrayitemGcI`) that the gcmap relocates on a move.
 #[repr(C)]
 pub struct IntArray {
-    /// `Ptr(GcArray(Signed))` — the backing block. Always non-null.
+    /// `Ptr(GcArray(Signed))` — the backing block (`l.items`). Always non-null.
     pub block: *mut TypedItemsBlock,
-    /// Items base (`= block + ITEMS_OFFSET`). Mirrors the block.
-    pub ptr: *mut i64,
     /// Live length (rlist.py:116 `("length", Signed)`).
     len: usize,
-    /// Allocated capacity, mirroring the block header.
-    heap_cap: usize,
 }
 
 pub const INT_ARRAY_BLOCK_OFFSET: usize = std::mem::offset_of!(IntArray, block);
-pub const INT_ARRAY_PTR_OFFSET: usize = std::mem::offset_of!(IntArray, ptr);
 pub const INT_ARRAY_LEN_OFFSET: usize = std::mem::offset_of!(IntArray, len);
-pub const INT_ARRAY_HEAP_CAP_OFFSET: usize = std::mem::offset_of!(IntArray, heap_cap);
 
 impl IntArray {
+    /// Items base pointer (`&l.items[0]`), derived from `block`.
     #[inline]
-    fn sync_from_block(&mut self) {
-        unsafe {
-            self.ptr = typed_items_block_items_base(self.block) as *mut i64;
-            self.heap_cap = typed_items_block_capacity(self.block);
-        }
+    fn base(&self) -> *mut i64 {
+        unsafe { typed_items_block_items_base(self.block) as *mut i64 }
     }
 
     pub fn from_vec(values: Vec<i64>) -> Self {
         let len = values.len();
-        let mut arr = Self {
+        let arr = Self {
             block: unsafe { alloc_typed_items_block(len) },
-            ptr: std::ptr::null_mut(),
             len,
-            heap_cap: 0,
         };
-        arr.sync_from_block();
         unsafe {
-            std::ptr::copy_nonoverlapping(values.as_ptr(), arr.ptr, len);
+            std::ptr::copy_nonoverlapping(values.as_ptr(), arr.base(), len);
         }
         arr
     }
 
+    /// Allocated capacity (`len(l.items)`, rlist.py:251), read from the block
+    /// header.
     #[inline]
     fn capacity(&self) -> usize {
-        self.heap_cap
+        unsafe { typed_items_block_capacity(self.block) }
     }
 
     #[inline]
@@ -75,7 +68,7 @@ impl IntArray {
     /// (rlist.py:285).
     #[inline]
     pub fn heap_capacity(&self) -> usize {
-        self.heap_cap
+        self.capacity()
     }
 
     /// Store the live length without touching the block. The caller must
@@ -86,10 +79,10 @@ impl IntArray {
     /// slices (UB).
     #[inline]
     pub fn set_len(&mut self, new_len: usize) {
+        let cap = self.capacity();
         assert!(
-            new_len <= self.heap_cap,
-            "IntArray::set_len precondition violated: new_len ({new_len}) > heap_cap ({})",
-            self.heap_cap
+            new_len <= cap,
+            "IntArray::set_len precondition violated: new_len ({new_len}) > capacity ({cap})"
         );
         self.len = new_len;
     }
@@ -102,26 +95,25 @@ impl IntArray {
 
     fn grow(&mut self, min_cap: usize) {
         let target_cap = min_cap
-            .max(self.heap_cap.saturating_mul(2))
+            .max(self.capacity().saturating_mul(2))
             .max(INT_ARRAY_INLINE_CAP);
         self.block = unsafe { grow_typed_items_block(self.block, target_cap, self.len) };
-        self.sync_from_block();
     }
 
     pub fn push(&mut self, value: i64) {
-        if self.len == self.heap_cap {
+        if self.len == self.capacity() {
             self.grow(self.len + 1);
         }
         unsafe {
-            *self.ptr.add(self.len) = value;
+            *self.base().add(self.len) = value;
         }
         self.len += 1;
     }
 
+    /// No-op: the items base is derived from `block` on every access, never
+    /// cached, so a move of the enclosing object needs no fixup.
     #[inline]
-    pub fn fix_ptr(&mut self) {
-        self.sync_from_block();
-    }
+    pub fn fix_ptr(&mut self) {}
 
     #[inline]
     pub fn len(&self) -> usize {
@@ -129,11 +121,11 @@ impl IntArray {
     }
 
     pub fn as_slice(&self) -> &[i64] {
-        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        unsafe { std::slice::from_raw_parts(self.base(), self.len) }
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [i64] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        unsafe { std::slice::from_raw_parts_mut(self.base(), self.len) }
     }
 
     pub fn to_vec(&self) -> Vec<i64> {
@@ -142,11 +134,11 @@ impl IntArray {
 
     pub fn insert(&mut self, index: usize, value: i64) {
         assert!(index <= self.len);
-        if self.len == self.heap_cap {
+        if self.len == self.capacity() {
             self.grow(self.len + 1);
         }
         unsafe {
-            let p = self.ptr.add(index);
+            let p = self.base().add(index);
             std::ptr::copy(p, p.add(1), self.len - index);
             *p = value;
         }
@@ -157,7 +149,7 @@ impl IntArray {
         assert!(index < self.len);
         let value = self.as_slice()[index];
         unsafe {
-            let p = self.ptr.add(index);
+            let p = self.base().add(index);
             std::ptr::copy(p.add(1), p, self.len - index - 1);
         }
         self.len -= 1;
@@ -182,22 +174,24 @@ impl IntArray {
         let len2 = new_values.len();
         let new_len = old_len - slicelength + len2;
         if len2 > slicelength {
-            if new_len > self.heap_cap {
+            if new_len > self.capacity() {
                 self.grow(new_len);
             }
             unsafe {
+                let base = self.base();
                 std::ptr::copy(
-                    self.ptr.add(s + slicelength),
-                    self.ptr.add(s + len2),
+                    base.add(s + slicelength),
+                    base.add(s + len2),
                     old_len - s - slicelength,
                 );
             }
             self.len = new_len;
         } else if slicelength > len2 {
             unsafe {
+                let base = self.base();
                 std::ptr::copy(
-                    self.ptr.add(s + slicelength),
-                    self.ptr.add(s + len2),
+                    base.add(s + slicelength),
+                    base.add(s + len2),
                     old_len - s - slicelength,
                 );
             }
@@ -217,7 +211,7 @@ impl IntArray {
             return;
         }
         unsafe {
-            let p = self.ptr.add(start);
+            let p = self.base().add(start);
             std::ptr::copy(p.add(count), p, self.len - end);
         }
         self.len -= count;
@@ -241,13 +235,13 @@ impl Index<usize> for IntArray {
 
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
-        unsafe { &*self.ptr.add(index) }
+        unsafe { &*self.base().add(index) }
     }
 }
 
 impl IndexMut<usize> for IntArray {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        unsafe { &mut *self.ptr.add(index) }
+        unsafe { &mut *self.base().add(index) }
     }
 }

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -111,11 +111,6 @@ impl IntArray {
         self.len += 1;
     }
 
-    /// No-op: the items base is derived from `block` on every access, never
-    /// cached, so a move of the enclosing object needs no fixup.
-    #[inline]
-    pub fn fix_ptr(&mut self) {}
-
     #[inline]
     pub fn len(&self) -> usize {
         self.len

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -1,8 +1,8 @@
 use std::ops::{Index, IndexMut};
 
 use crate::object_array::{
-    TypedItemsBlock, alloc_typed_items_block, dealloc_typed_items_block, grow_typed_items_block,
-    typed_items_block_capacity, typed_items_block_items_base,
+    GC_INT_ARRAY_GC_TYPE_ID, TypedItemsBlock, alloc_typed_items_block, dealloc_typed_items_block,
+    grow_typed_items_block, typed_items_block_capacity, typed_items_block_items_base,
 };
 
 /// Small-buffer capacity constant retained for the append/pop inline-capacity
@@ -41,7 +41,7 @@ impl IntArray {
     pub fn from_vec(values: Vec<i64>) -> Self {
         let len = values.len();
         let arr = Self {
-            block: unsafe { alloc_typed_items_block(len) },
+            block: unsafe { alloc_typed_items_block(len, GC_INT_ARRAY_GC_TYPE_ID) },
             len,
         };
         unsafe {
@@ -97,7 +97,8 @@ impl IntArray {
         let target_cap = min_cap
             .max(self.capacity().saturating_mul(2))
             .max(INT_ARRAY_INLINE_CAP);
-        self.block = unsafe { grow_typed_items_block(self.block, target_cap, self.len) };
+        self.block =
+            unsafe { grow_typed_items_block(self.block, target_cap, self.len, GC_INT_ARRAY_GC_TYPE_ID) };
     }
 
     pub fn push(&mut self, value: i64) {

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -97,8 +97,9 @@ impl IntArray {
         let target_cap = min_cap
             .max(self.capacity().saturating_mul(2))
             .max(INT_ARRAY_INLINE_CAP);
-        self.block =
-            unsafe { grow_typed_items_block(self.block, target_cap, self.len, GC_INT_ARRAY_GC_TYPE_ID) };
+        self.block = unsafe {
+            grow_typed_items_block(self.block, target_cap, self.len, GC_INT_ARRAY_GC_TYPE_ID)
+        };
     }
 
     pub fn push(&mut self, value: i64) {

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -368,9 +368,7 @@ unsafe fn switch_to_object_strategy(list: &mut W_ListObject) {
     };
     list.set_object_items_from_vec(seed);
     list.int_items = IntArray::from_vec(Vec::new());
-    list.int_items.fix_ptr();
     list.float_items = FloatArray::from_vec(Vec::new());
-    list.float_items.fix_ptr();
     list.strategy = ListStrategy::Object;
 }
 
@@ -382,11 +380,9 @@ unsafe fn switch_to_object_strategy(list: &mut W_ListObject) {
 unsafe fn switch_to_correct_strategy(list: &mut W_ListObject, w_item: PyObjectRef) {
     if is_plain_int1(w_item) {
         list.int_items = IntArray::from_vec(Vec::new());
-        list.int_items.fix_ptr();
         list.strategy = ListStrategy::Integer;
     } else if !w_item.is_null() && is_float(w_item) {
         list.float_items = FloatArray::from_vec(Vec::new());
-        list.float_items.fix_ptr();
         list.strategy = ListStrategy::Float;
     } else {
         list.set_object_items_from_vec(Vec::new());
@@ -1058,9 +1054,7 @@ pub unsafe fn w_list_clear(obj: PyObjectRef) {
     let list = &mut *(obj as *mut W_ListObject);
     list.drop_object_items();
     list.int_items = IntArray::from_vec(Vec::new());
-    list.int_items.fix_ptr();
     list.float_items = FloatArray::from_vec(Vec::new());
-    list.float_items.fix_ptr();
     list.strategy = ListStrategy::Empty;
 }
 
@@ -1265,13 +1259,11 @@ pub unsafe fn w_list_setslice(
                 ListStrategy::Empty => return Ok(()),
                 ListStrategy::Integer => {
                     list.int_items = IntArray::from_vec(other.int_items.to_vec());
-                    list.int_items.fix_ptr();
                     list.strategy = ListStrategy::Integer;
                     return Ok(());
                 }
                 ListStrategy::Float => {
                     list.float_items = FloatArray::from_vec(other.float_items.to_vec());
-                    list.float_items.fix_ptr();
                     list.strategy = ListStrategy::Float;
                     return Ok(());
                 }
@@ -1302,7 +1294,6 @@ pub unsafe fn w_list_setslice(
                         let mut v = list.int_items.to_vec();
                         v.splice(s..e, new_items.iter().copied());
                         list.int_items = IntArray::from_vec(v);
-                        list.int_items.fix_ptr();
                     } else {
                         // RPython AbstractUnwrappedStrategy.setslice mutates
                         // the unerased typed storage directly.
@@ -1322,7 +1313,6 @@ pub unsafe fn w_list_setslice(
                         let mut v = list.float_items.to_vec();
                         v.splice(s..e, new_items.iter().copied());
                         list.float_items = FloatArray::from_vec(v);
-                        list.float_items.fix_ptr();
                     } else {
                         // RPython AbstractUnwrappedStrategy.setslice mutates
                         // the unerased typed storage directly.

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -462,38 +462,34 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
         crate::gc_roots::pin_root(item);
     }
 
-    let (length, mut items_block, int_items, float_items) = match strategy {
-        ListStrategy::Empty | ListStrategy::Integer | ListStrategy::Float => {
-            let int_items = if let ListStrategy::Integer = strategy {
-                let values = items
-                    .iter()
-                    .map(|&item| unsafe { plain_int_w(item) })
-                    .collect();
-                IntArray::from_vec(values)
-            } else {
-                IntArray::from_vec(Vec::new())
-            };
-            let float_items = if let ListStrategy::Float = strategy {
-                let values = items
-                    .iter()
-                    .map(|&item| unsafe { w_float_get_value(item) })
-                    .collect();
-                FloatArray::from_vec(values)
-            } else {
-                FloatArray::from_vec(Vec::new())
-            };
-            (0usize, std::ptr::null_mut(), int_items, float_items)
-        }
-        ListStrategy::Object => {
-            let length = items.len();
-            let items_block = unsafe { alloc_list_items_block_gc(&items) };
-            (
-                length,
-                items_block,
-                IntArray::from_vec(Vec::new()),
-                FloatArray::from_vec(Vec::new()),
-            )
-        }
+    // Build the typed backing blocks (empty unless the matching strategy) first,
+    // then the Object-strategy items block. The typed blocks are old-gen
+    // (non-moving), so they need no shadow-stack pin; the nursery `items_block` is
+    // allocated last and pinned across the `try_gc_alloc_stable` header alloc —
+    // the only allocation that can relocate it, since the typed-block allocs
+    // precede it.
+    let int_seed: Vec<i64> = if let ListStrategy::Integer = strategy {
+        items
+            .iter()
+            .map(|&item| unsafe { plain_int_w(item) })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let int_items = IntArray::from_vec(int_seed);
+    let float_seed: Vec<f64> = if let ListStrategy::Float = strategy {
+        items
+            .iter()
+            .map(|&item| unsafe { w_float_get_value(item) })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let float_items = FloatArray::from_vec(float_seed);
+    let (length, mut items_block) = if let ListStrategy::Object = strategy {
+        (items.len(), unsafe { alloc_list_items_block_gc(&items) })
+    } else {
+        (0usize, std::ptr::null_mut())
     };
     // Phase L2: pin the (possibly young, GC-managed) items block across the
     // W_ListObject header allocation below — `try_gc_alloc_stable` may trigger a
@@ -510,18 +506,17 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
         ob_type: &LIST_TYPE as *const PyType,
         w_class: get_instantiate(&LIST_TYPE),
     };
-    // Allocate body via GC old-gen (mark-sweep, non-moving). The
-    // `items` field carries `gc_ptr_offsets = [offset_of(items)]`
-    // (`eval.rs:274`) and still points at a `std::alloc`'d
-    // `ItemsBlock`; the mark walker's
-    // `is_managed_heap_object` guard (collector.rs:991/1008) keeps
-    // that stepping-stone correctness-safe.
+    // Allocate body via GC old-gen (mark-sweep, non-moving). `items` (Object
+    // strategy) points at a moving nursery block forwarded by
+    // `list_object_custom_trace` and remembered by `list_write_barrier` below;
+    // `int_items.block` / `float_items.block` are old-gen leaf arrays the same
+    // trace marks live.
     let raw = match crate::gc_hook::try_gc_alloc_stable(W_LIST_GC_TYPE_ID, W_LIST_OBJECT_SIZE)
         .filter(|p| !p.is_null())
     {
         Some(p) => p,
         None => {
-            let mut boxed = Box::new(W_ListObject {
+            let boxed = Box::new(W_ListObject {
                 ob_header: header,
                 length,
                 items: items_block,
@@ -529,12 +524,10 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
                 int_items,
                 float_items,
             });
-            boxed.int_items.fix_ptr();
-            boxed.float_items.fix_ptr();
             return Box::into_raw(boxed) as PyObjectRef;
         }
     };
-    // Re-read the (possibly relocated) block address the header alloc may have moved.
+    // Re-read the (possibly relocated) nursery items block after the header alloc.
     if let Some(s) = block_root {
         items_block = crate::gc_roots::shadow_stack_get(s) as *mut ItemsBlock;
     }
@@ -550,13 +543,10 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
                 float_items,
             },
         );
-        let obj = &mut *(raw as *mut W_ListObject);
-        obj.int_items.fix_ptr();
-        obj.float_items.fix_ptr();
     }
-    // Object-strategy creation seeds the `ItemsBlock` with the (possibly
-    // young) initial elements; remember the old-gen list so the next minor
-    // GC forwards them. Integer/Float blocks hold unboxed scalars — no refs.
+    // Object-strategy creation seeds the nursery `items` block with the (possibly
+    // young) initial elements; remember the old-gen list so the next minor GC
+    // forwards them. Integer/Float blocks are old-gen — no young pointer to track.
     if strategy == ListStrategy::Object {
         list_write_barrier(raw as PyObjectRef);
     }

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -41,20 +41,19 @@ pub const GC_FLOAT_ARRAY_GC_TYPE_ID: u32 = 42;
 /// offset 8 = items[0..capacity]. Total allocation size =
 /// `ITEMS_BLOCK_ITEMS_OFFSET + capacity * sizeof(PyObjectRef)`.
 ///
-/// STEPPING-STONE (metadata precedes runtime, Phase L2 pending).
-/// The header layout already matches upstream but the allocator
-/// does NOT: `alloc_items_block` / `grow_items_block` below still
-/// use `std::alloc::alloc`, not
-/// `MiniMarkGC::alloc_varsize_typed(PY_OBJECT_ARRAY_GC_TYPE_ID,
-/// cap)`. Until Phase L2 cuts the allocator over (blocked on
-/// GC-root infrastructure + Drop source-of-truth
-/// decision), the matching `PY_OBJECT_ARRAY_GC_TYPE_ID` and
-/// `W_LIST_GC_TYPE_ID.gc_ptr_offsets = [offset_of!(items)]` are
-/// inactive at collection time — the walker rejects the
-/// non-nursery block pointer (collector.rs:377). Phase L1 of the
-/// epic already landed: `W_ListObject` / `W_TupleObject` hold
-/// `{length: usize, items: *mut ItemsBlock}` fields directly
-/// (no more `PyObjectArray` fat wrapper for list/tuple).
+/// The header layout matches upstream and, by default, the allocator
+/// now routes object-strategy blocks through the moving nursery
+/// (`alloc_list_items_block_gc` / `alloc_tuple_items_block_gc` /
+/// `grow_list_items_block_gc` → `try_gc_alloc(PY_OBJECT_ARRAY_GC_TYPE_ID,
+/// cap)`), so `PY_OBJECT_ARRAY_GC_TYPE_ID` and the list/tuple custom
+/// traces that forward the block-pointer field (eval.rs
+/// `list_object_custom_trace` / `tuple_object_custom_trace`) are live at
+/// collection time. `W_ListObject` / `W_TupleObject` hold
+/// `{length: usize, items: *mut ItemsBlock}` fields directly (no
+/// `PyObjectArray` fat wrapper for list/tuple). The `std::alloc`
+/// `alloc_items_block` / `grow_items_block` below are the
+/// `PYRE_GC_ITEMSBLOCK=0` fallback (provably identical pre-migration
+/// behaviour).
 #[repr(C)]
 pub struct ItemsBlock {
     /// Allocated capacity — treated as the GcArray-length header
@@ -163,15 +162,22 @@ pub unsafe fn dealloc_list_items_block(block: *mut ItemsBlock) {
     unsafe { dealloc_items_block(block) }
 }
 
-/// Phase L2 gate: route object-strategy `ItemsBlock` allocations through
-/// the moving nursery (`PY_OBJECT_ARRAY_GC_TYPE_ID`) instead of
-/// `std::alloc`. Read once; default off keeps the std::alloc stepping
-/// stone provably identical to pre-L2 behaviour, so the nursery path can
-/// be validated under GC stress before it becomes the default.
+/// Route object-strategy `ItemsBlock` allocations through the moving
+/// nursery (`PY_OBJECT_ARRAY_GC_TYPE_ID`) instead of `std::alloc`. Read
+/// once; default ON — the nursery path mirrors RPython's
+/// `GcArray(OBJECTPTR)` (rlist.py:84) and is validated identical to the
+/// `std::alloc` fallback (check.py 158 both backends, both gate states;
+/// fannkuch/nbody/spectral_norm timings unchanged). `PYRE_GC_ITEMSBLOCK=0`
+/// (or `off`/`false`) restores the `std::alloc` fallback to bisect a
+/// suspected block-GC regression.
 fn itemsblock_gc_enabled() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("PYRE_GC_ITEMSBLOCK").is_some())
+    *ENABLED.get_or_init(|| {
+        std::env::var("PYRE_GC_ITEMSBLOCK")
+            .map(|v| !matches!(v.trim(), "0" | "off" | "false" | ""))
+            .unwrap_or(true)
+    })
 }
 
 /// Phase L2 nursery allocation of a fresh `ItemsBlock` with `cap` slots,
@@ -303,19 +309,15 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     block
 }
 
-/// Allocate a fresh `ItemsBlock` with the given capacity.
-///
-/// STEPPING-STONE: still uses `std::alloc::alloc`. The
-/// `try_gc_alloc_stable` migration was attempted but routes the
-/// per-iteration list allocations through MiniMark's old-gen
-/// (mark-sweep, non-moving), which regresses bench (cranelift
-/// fannkuch timeout, dynasm nbody timeout) — old-gen-only
-/// containers accumulate until major GC fires. The correct
-/// long-term path is a nursery allocation behind caller-side
-/// root tracking; the `try_gc_owns_object` infra in
-/// `gc_hook.rs` is in place to support that follow-up. See
-/// `40d4a041d7` docstring for the same finding on `w_int_new`/
-/// `w_float_new`.
+/// Allocate a fresh `ItemsBlock` with the given capacity via
+/// `std::alloc::alloc`. This is the `PYRE_GC_ITEMSBLOCK=0` fallback;
+/// the default path is the moving-nursery `alloc_items_block_gc` above
+/// (`try_gc_alloc`, caller-side root tracking via `gc_roots::pin_root` +
+/// the block write-barrier). An earlier `try_gc_alloc_stable` attempt was
+/// abandoned because old-gen (non-moving) allocation accumulates
+/// per-iteration containers until a major GC; the nursery path avoids that
+/// (minor GC reclaims short-lived blocks) and is perf-neutral on
+/// fannkuch/nbody.
 ///
 /// The capacity header is initialized; items are left uninitialized —
 /// the caller must write all `capacity` slots before exposing the

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -222,6 +222,12 @@ pub unsafe fn alloc_list_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBlo
     for i in len..cap {
         unsafe { *base.add(i) = PY_NULL };
     }
+    // Old→young barrier if the block landed in old-gen (see
+    // alloc_tuple_items_block_gc): registers an old-gen block holding young
+    // elements onto the remembered set, no-op for a nursery block.
+    if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
+        crate::gc_hook::try_gc_write_barrier(block as *mut u8);
+    }
     block
 }
 
@@ -254,6 +260,11 @@ pub unsafe fn grow_list_items_block_gc(
     for i in live_len..new_cap {
         unsafe { *new_base.add(i) = PY_NULL };
     }
+    // Old→young barrier if the grown block landed in old-gen (see
+    // alloc_tuple_items_block_gc).
+    if crate::gc_hook::try_gc_owns_object(new_block as *mut u8) {
+        crate::gc_hook::try_gc_write_barrier(new_block as *mut u8);
+    }
     unsafe { dealloc_list_items_block(old) };
     new_block
 }
@@ -278,6 +289,16 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     let base = unsafe { items_block_items_base(block) };
     for i in 0..cap {
         unsafe { *base.add(i) = crate::gc_roots::shadow_stack_get(save + i) };
+    }
+    // The block may have landed in old-gen (nursery-full fallback) while its
+    // elements are still young. That old→young edge is invisible to a minor
+    // collection unless the block is on the remembered set, so write-barrier
+    // it here. A nursery block carries no TRACK_YOUNG_PTRS and the barrier is
+    // a no-op; an old-gen block is registered so the next minor collection
+    // walks its items (write_barrier_from_array, incminimark.py:1495). Guard
+    // on GC ownership exactly like `list_write_barrier`.
+    if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
+        crate::gc_hook::try_gc_write_barrier(block as *mut u8);
     }
     block
 }

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -309,6 +309,36 @@ pub unsafe fn alloc_tuple_items_block_gc(values: &[PyObjectRef]) -> *mut ItemsBl
     block
 }
 
+/// Allocate an exact-`cap` NULL-filled GC-managed `ItemsBlock` of refs for
+/// the walker's recording-time materialization of a virtual
+/// `NEW_ARRAY_CLEAR` (BUILD_LIST / BUILD_TUPLE). Returns `None` when the gate
+/// is off or no GC hook is installed, so the caller declines materialization
+/// rather than handing back a `std::alloc` block that would never be freed.
+/// The block is a `PY_OBJECT_ARRAY_GC_TYPE_ID` varsize array, so its items are
+/// GC-traced and the NULL prefix is benign until the caller fills slots via
+/// `setarrayitem_ref` + a block write barrier. No `std::alloc` fallback here
+/// (unlike [`alloc_items_block_gc`]): the materialization requires a GC-traced
+/// block whose escaping young element refs are forwarded by a collection.
+pub unsafe fn alloc_cleared_ref_items_block_gc(cap: usize) -> Option<*mut ItemsBlock> {
+    if !itemsblock_gc_enabled() {
+        return None;
+    }
+    let payload = ITEMS_BLOCK_ITEMS_OFFSET + cap * std::mem::size_of::<PyObjectRef>();
+    let raw = crate::gc_hook::try_gc_alloc(PY_OBJECT_ARRAY_GC_TYPE_ID, payload)?;
+    if raw.is_null() {
+        return None;
+    }
+    let block = raw as *mut ItemsBlock;
+    unsafe {
+        (*block).capacity = cap;
+        let base = items_block_items_base(block);
+        for i in 0..cap {
+            *base.add(i) = PY_NULL;
+        }
+    }
+    Some(block)
+}
+
 /// Allocate a fresh `ItemsBlock` with the given capacity via
 /// `std::alloc::alloc`. This is the `PYRE_GC_ITEMSBLOCK=0` fallback;
 /// the default path is the moving-nursery `alloc_items_block_gc` above

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -486,12 +486,41 @@ fn typed_items_block_layout(cap: usize) -> Layout {
         .expect("TypedItemsBlock layout")
 }
 
-/// Allocate a fresh zero-filled `TypedItemsBlock` with the given capacity.
-/// Zero-fill matches `gc_malloc_array` (rlist.py:262-267 `_ll_list_resize_really`)
-/// and the Float/Int strategy `_none_value` (0.0 / 0). `cap` is clamped to at
-/// least 1 (rlist.py:251 overallocation policy keeps a slot for in-place growth).
-pub unsafe fn alloc_typed_items_block(cap: usize) -> *mut TypedItemsBlock {
+/// Allocate a fresh zero-filled `TypedItemsBlock` with the given capacity, as a
+/// `tid` (`GC_INT_ARRAY` / `GC_FLOAT_ARRAY`) varsize GcArray. Zero-fill matches
+/// `gc_malloc_array` (rlist.py:262-267 `_ll_list_resize_really`) and the
+/// Float/Int strategy `_none_value` (0.0 / 0); `try_gc_alloc_stable` memory is
+/// not guaranteed zeroed, so the items are cleared explicitly. `cap` is clamped
+/// to at least 1 (rlist.py:251 overallocation policy). Falls back to
+/// `std::alloc::alloc_zeroed` when the gate is off or no GC hook is installed
+/// (pure interpreter / early startup).
+///
+/// The block is allocated `stable` (old-gen, mark-sweep, non-moving) — the same
+/// tier as its `W_ListObject` owner (`listobject.rs` `try_gc_alloc_stable`).
+/// The items are plain scalars (no GC pointers), so the block is a varsize leaf
+/// the collector marks (it never relocates and never holds a young pointer, so
+/// the owning list needs no remembered-set barrier when the block changes); its
+/// `int_items.block` / `float_items.block` owner slot is marked-live by
+/// `list_object_custom_trace`.
+pub unsafe fn alloc_typed_items_block(cap: usize, tid: u32) -> *mut TypedItemsBlock {
     let cap = cap.max(1);
+    if itemsblock_gc_enabled() {
+        let payload = TYPED_ITEMS_BLOCK_ITEMS_OFFSET + cap * std::mem::size_of::<u64>();
+        if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(tid, payload) {
+            if !raw.is_null() {
+                let block = raw as *mut TypedItemsBlock;
+                unsafe {
+                    (*block).capacity = cap;
+                    std::ptr::write_bytes(
+                        typed_items_block_items_base(block),
+                        0,
+                        cap * std::mem::size_of::<u64>(),
+                    );
+                }
+                return block;
+            }
+        }
+    }
     let layout = typed_items_block_layout(cap);
     unsafe {
         let raw = alloc_zeroed(layout);
@@ -506,14 +535,17 @@ pub unsafe fn alloc_typed_items_block(cap: usize) -> *mut TypedItemsBlock {
 
 /// Grow a `TypedItemsBlock` to `new_cap`, copying `live_len` words from `old`,
 /// zero-filling the rest, and deallocating `old`. `old` may be null.
-/// rlist.py:262-267 parity.
+/// rlist.py:262-267 parity. `old` is allocated `stable` (old-gen, non-moving),
+/// so it keeps its address across the (possibly collecting) allocation of
+/// `fresh` and the live words are copied directly.
 pub unsafe fn grow_typed_items_block(
     old: *mut TypedItemsBlock,
     new_cap: usize,
     live_len: usize,
+    tid: u32,
 ) -> *mut TypedItemsBlock {
     unsafe {
-        let fresh = alloc_typed_items_block(new_cap);
+        let fresh = alloc_typed_items_block(new_cap, tid);
         if !old.is_null() && live_len > 0 {
             std::ptr::copy_nonoverlapping(
                 typed_items_block_items_base(old),
@@ -528,9 +560,15 @@ pub unsafe fn grow_typed_items_block(
     }
 }
 
-/// Deallocate a `TypedItemsBlock`. No-op on null.
+/// Deallocate a `TypedItemsBlock`. No-op on null. A GC-managed block is reclaimed
+/// by the collector and must never be freed here — its allocation is prefixed by
+/// a `GcHeader` the `std::alloc` layout knows nothing about. `try_gc_owns_object`
+/// gates the `std::alloc` free to the gate-off / no-hook fallback blocks.
 pub unsafe fn dealloc_typed_items_block(block: *mut TypedItemsBlock) {
     if block.is_null() {
+        return;
+    }
+    if crate::gc_hook::try_gc_owns_object(block as *mut u8) {
         return;
     }
     unsafe {


### PR DESCRIPTION
Completes the `ItemsBlock` `std::alloc` → GC-heap migration on the list/typed-storage path. Refs #128 — the typed int/float list backing store is on the nbody-hot path, and the walker-materialization fix removes the module-global list off-by-1 that surfaced during the nbody residency work.

## Changes

- **`5629b101e0`** — write-barrier object items blocks after the construction fill (old→young edge from a freshly-built old-gen list to its nursery items block).
- **`0d9daf11ad`** — default `PYRE_GC_ITEMSBLOCK` ON: object list/tuple items blocks allocate on the moving nursery in production; `PYRE_GC_ITEMSBLOCK=0` keeps the `std::alloc` fallback.
- **`7f23c56b88`** — materialize a const-length ref items-block during walker recording instead of aborting, so a fresh container stored into an escaping (module-global) slot commits for the recorded iteration. Removes the seeding-iteration off-by-1.
- **`0eeab8133c`** — JIT lowers int/float list access via the GC-ref block (`GetfieldGcR(block) → GetarrayitemGcI`) instead of a raw cached interior pointer, so the gcmap can relocate the block.
- **`ee1b3efdca`** — `IntArray`/`FloatArray` drop the cached `ptr`/`heap_cap`, holding only `{block, len}` (rlist.py:116 `GcStruct(... ("items", Ptr(GcArray)))`); base + capacity are derived from `block` (capacity via `ArraylenGc`).
- **`709c441876`** — typed int/float blocks allocate as GC varsize leaf arrays on the **old-gen** heap (same non-moving tier as the `W_ListObject` body), marked by `list_object_custom_trace`. Old-gen avoids any old→young edge, so a typed block change needs no remembered-set barrier — sidestepping the manual-barrier completeness hazard a moving (nursery) typed block would impose at every realloc site.
- **`c33b342aef`** — remove the now-dead no-op `fix_ptr` (method + 10 call sites).

## Validation

- `pyre/check.py` **160/160 × {dynasm, cranelift}**.
- GC stress (`MAJIT_GC_STRESS=1`, small `PYPY_GC_NURSERY`, and `PYRE_GC_ITEMSBLOCK=0`): typed-list build/grow/in-place setitem with a live population across allocation churn — correct on both backends.
- nbody correct (`-0.035117363568587606`) on dynasm/cranelift and under GC stress; perf-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed list and array operations now consistently use the newer typed-items block storage path (integer, float, and object-backed).
  * Enabled GC-backed backing blocks for more allocation flows, including cleared ref-block allocation for constant-length ref arrays.

* **Bug Fixes**
  * Improved heapcache dispatch for array item materialization to safely abort and revert when indices/values are not valid for the backing block.
  * Updated tracing and loop-header handling to close walks only from the intended root, improving correctness across GC cycles.

* **Tests**
  * Updated trace test helpers and related expectations to match the new GC/typed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->