### PR TITLE
majit: switch dispatch, split_dispatch routing, and back-edge builder pooling for the wasmi JIT tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "i64env"
+version = "0.0.2"
+dependencies = [
+ "majit-ir",
+ "majit-macros",
+ "majit-metainterp",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "majit/examples/dualtape",
     "majit/examples/tlc",
     "majit/examples/calc",
+    "majit/examples/i64env",
     # pyre
     "pyre/pyre-object",
     "pyre/pyre-macros",

--- a/majit/examples/i64env/Cargo.toml
+++ b/majit/examples/i64env/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "i64env"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[features]
+default = ["cranelift"]
+cranelift = ["majit-metainterp/cranelift"]
+dynasm = ["majit-metainterp/dynasm"]
+
+[dependencies]
+majit-ir = { workspace = true }
+majit-macros = { workspace = true }
+majit-metainterp = { workspace = true }

--- a/majit/examples/i64env/src/main.rs
+++ b/majit/examples/i64env/src/main.rs
@@ -102,13 +102,26 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
 /// `n` are full i64 words (intentionally > 255 in tests).
 fn count_program(n: i64, step: i64) -> Vec<i64> {
     vec![
-        OP_LOAD, step, 1, // r1 = step
-        OP_LOAD, n, 2, // r2 = n
-        OP_LOAD, 0, 0, // r0 = 0
+        OP_LOAD,
+        step,
+        1, // r1 = step
+        OP_LOAD,
+        n,
+        2, // r2 = n
+        OP_LOAD,
+        0,
+        0, // r0 = 0
         // @l1 = pc 9
-        OP_ADD, 0, 1, 0, // r0 = r0 + r1
-        OP_JUMP_IF_ABOVE, 2, 0, 9, // if r2 > r0 goto @l1
-        OP_RETURN, 0, // return r0
+        OP_ADD,
+        0,
+        1,
+        0, // r0 = r0 + r1
+        OP_JUMP_IF_ABOVE,
+        2,
+        0,
+        9, // if r2 > r0 goto @l1
+        OP_RETURN,
+        0, // return r0
     ]
 }
 

--- a/majit/examples/i64env/src/main.rs
+++ b/majit/examples/i64env/src/main.rs
@@ -1,0 +1,160 @@
+//! `[i64]`-env regression example.
+//!
+//! Proves the `#[jit_interp]` macro reads an `env` whose element type is wider
+//! than a byte (`pub type Code = [i64];`) at the correct stride. The macro
+//! lowers every `program[pc + N]` read with a descr whose `item_size` matches
+//! the env element (`size_of::<<Code as Index<usize>>::Output>()` = 8), so the
+//! load scales the index by 8 instead of reading a stray byte. A byte-wide
+//! descr (the previous hardcoding) would read the wrong word and miscompile.
+//!
+//! The register file is `[int; virt]` because it is loop-carried: a plain
+//! `[int]` array element is not restored on a CloseLoop guard deopt. (See the
+//! macro's loop-carried-plain-array diagnostic.)
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// The env: an i64-word bytecode stream. The whole point of this example is
+/// that the element is 8 bytes wide, not 1.
+pub type Code = [i64];
+
+// Opcodes and operands are full i64 words. Values can exceed a byte to make a
+// byte-stride miscompile observable.
+const OP_LOAD: i64 = 0; // [LOAD, imm, dst]
+const OP_ADD: i64 = 1; // [ADD, a, b, dst]
+const OP_JUMP_IF_ABOVE: i64 = 2; // [JIA, a, b, target_pc]
+const OP_RETURN: i64 = 3; // [RETURN, reg]
+
+/// Hot loops majit compiled — evidence the JIT tier traced + compiled.
+pub static COMPILES: AtomicUsize = AtomicUsize::new(0);
+
+struct VmState {
+    regs: Vec<i64>,
+}
+
+#[majit_macros::jit_interp(
+    state = VmState,
+    env = Code,
+    greens = [pc, program],
+    state_fields = {
+        regs: [int; virt],
+    },
+)]
+fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<VmState> =
+        majit_metainterp::JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_green_key, _ops_before, _ops_after| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut stacksize: i32 = 0;
+    let mut state = VmState {
+        regs: vec![0; num_regs],
+    };
+
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    loop {
+        jit_merge_point!();
+        let opcode = program[pc];
+        match opcode {
+            OP_LOAD => {
+                let val = program[pc + 1];
+                let reg = program[pc + 2] as usize;
+                state.regs[reg] = val;
+                pc += 3;
+            }
+            OP_ADD => {
+                let a = program[pc + 1] as usize;
+                let b = program[pc + 2] as usize;
+                let d = program[pc + 3] as usize;
+                state.regs[d] = state.regs[a] + state.regs[b];
+                pc += 4;
+            }
+            OP_JUMP_IF_ABOVE => {
+                let a = program[pc + 1] as usize;
+                let b = program[pc + 2] as usize;
+                let tgt = program[pc + 3] as usize;
+                if state.regs[a] > state.regs[b] {
+                    if tgt < pc {
+                        can_enter_jit!(driver, tgt, &mut state, program, || {});
+                    }
+                    pc = tgt;
+                    continue;
+                }
+                pc += 4;
+            }
+            OP_RETURN => {
+                let r = program[pc + 1] as usize;
+                return state.regs[r];
+            }
+            _ => break,
+        }
+    }
+    panic!("fell off end of code");
+}
+
+/// `r0` counts up by `step` while `n` > `r0`, exiting at `r0 >= n`. `step` and
+/// `n` are full i64 words (intentionally > 255 in tests).
+fn count_program(n: i64, step: i64) -> Vec<i64> {
+    vec![
+        OP_LOAD, step, 1, // r1 = step
+        OP_LOAD, n, 2, // r2 = n
+        OP_LOAD, 0, 0, // r0 = 0
+        // @l1 = pc 9
+        OP_ADD, 0, 1, 0, // r0 = r0 + r1
+        OP_JUMP_IF_ABOVE, 2, 0, 9, // if r2 > r0 goto @l1
+        OP_RETURN, 0, // return r0
+    ]
+}
+
+fn run(program: &Code, num_regs: usize, threshold: u32) -> i64 {
+    mainloop(program, num_regs, threshold)
+}
+
+fn main() {
+    let result = run(&count_program(1000, 1), 3, 3);
+    println!("count to 1000 (step 1) = {result}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The env element is 8 bytes wide and the immediate `n = 1000` does not
+    /// fit a byte. A byte-stride descr would read the wrong word and never
+    /// reach 1000.
+    #[test]
+    fn i64_env_reads_wide_immediates() {
+        COMPILES.store(0, Ordering::Relaxed);
+        let program = count_program(1000, 1);
+        let result = run(&program, 3, 3);
+        assert_eq!(result, 1000, "i64-env loop must compute 1000");
+        assert!(
+            COMPILES.load(Ordering::Relaxed) >= 1,
+            "majit should have compiled the hot loop at least once"
+        );
+    }
+
+    /// Correctness across inputs (each exercises the CloseLoop guard-exit
+    /// deopt), all with byte-overflowing immediates.
+    #[test]
+    fn i64_env_varies_n() {
+        for n in [300_i64, 500, 1000, 4096, 100_000] {
+            let r = run(&count_program(n, 1), 3, 3);
+            assert_eq!(r, n, "count to {n} mismatch");
+        }
+    }
+
+    /// A step > 255 proves the ADD operand word is read at the right stride
+    /// too: counting by 7 up to a multiple of 7 lands exactly on `n`.
+    #[test]
+    fn i64_env_wide_step() {
+        let r = run(&count_program(7 * 300, 7), 3, 3);
+        assert_eq!(r, 7 * 300);
+    }
+}

--- a/majit/examples/tinyframe/src/jit_interp.rs
+++ b/majit/examples/tinyframe/src/jit_interp.rs
@@ -21,11 +21,19 @@ struct TinyFrameState {
 
 const DEFAULT_THRESHOLD: u32 = 3;
 
+// `greens = [pc, program]` lets the operand reads (`program[pc + N]`)
+// constant-fold so the loop traces and compiles. `regs` is `[int; virt]`
+// (virtualizable), not plain `[int]`: a loop-carried plain `[int]` element is
+// kept in a trace register and is *not* restored to the array on a CloseLoop
+// guard deopt, so the post-loop value reads back as the pre-loop one. A virt
+// array writes through to the heap-backing Vec, which the deopt path reads
+// directly — the same mechanism braininterp relies on.
 #[majit_macros::jit_interp(
     state = TinyFrameState,
     env = Bytecode,
+    greens = [pc, program],
     state_fields = {
-        regs: [int],
+        regs: [int; virt],
     },
 )]
 fn mainloop(

--- a/majit/examples/tl/src/jit_interp.rs
+++ b/majit/examples/tl/src/jit_interp.rs
@@ -8,6 +8,9 @@
 /// Reds:   [inputarg, stackpos, stack]  (inputarg is a function parameter — red by nature)
 use majit_metainterp::jit::promote;
 
+// [SPIKE-S0/FR] throwaway compile counter to measure portal-call compile-through.
+pub static SPIKE_COMPILES: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+
 /// Stack rotation — @dont_look_inside in RPython (tl.py:43).
 ///
 /// Operates on the live portion of the stack `stack[0..stackpos]`.
@@ -105,6 +108,10 @@ const PUSHARG: u8 = 22;
 pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<TlState> =
         majit_metainterp::JitDriver::new(threshold);
+    // [SPIKE-S0/FR] count compiled loops.
+    driver.set_on_compile_loop(|_gk, _b, _a| {
+        SPIKE_COMPILES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    });
     let mut pc: usize = 0;
     let mut stacksize: i32 = 0;
     let mut state = TlState {
@@ -393,12 +400,35 @@ mod tests {
         ]
     }
 
+    /// [SPIKE-S0/FR] Measure whether a portal call inside a hot loop compiles
+    /// through. Control = pure loop (no call). Probe = leaf call in loop body.
+    #[test]
+    fn spike_portal_call_compile_through() {
+        use core::sync::atomic::Ordering;
+
+        SPIKE_COMPILES.store(0, Ordering::Relaxed);
+        let bc = sum_bytecode();
+        let mut jit = JitTlInterp::new();
+        let got = jit.run(&bc, 500);
+        let control = SPIKE_COMPILES.load(Ordering::Relaxed);
+        eprintln!("[SPIKE] control sum(500)={got} compiles={control}");
+
+        SPIKE_COMPILES.store(0, Ordering::Relaxed);
+        let bc = call_loop_bytecode();
+        let mut jit = JitTlInterp::new();
+        let got = jit.run(&bc, 500);
+        let probe = SPIKE_COMPILES.load(Ordering::Relaxed);
+        eprintln!("[SPIKE] probe  call_loop(500)={got} compiles={probe}");
+
+        assert_eq!(got, 1500, "leaf-call loop still computes 3*N");
+    }
+
     #[test]
     fn jit_recursive_call_matches_interp() {
         let bc = call_loop_bytecode();
         // Sanity: the interpreter computes 3 * N.
         assert_eq!(interp::interpret(&bc, 4), 12);
-        for a in [1, 2, 3, 5, 10, 50, 100] {
+        for a in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 50, 100] {
             let expected = interp::interpret(&bc, a);
             let mut jit = JitTlInterp::new();
             let got = jit.run(&bc, a);

--- a/majit/examples/tlr/src/jit_interp.rs
+++ b/majit/examples/tlr/src/jit_interp.rs
@@ -32,12 +32,21 @@ const NEG_A: u8 = 8;
 
 const DEFAULT_THRESHOLD: u32 = 3;
 
+// `greens = [pc, program]` lets the operand reads (`program[pc + N]`)
+// constant-fold so the loop traces and compiles. `regs` is `[int; virt]`
+// (virtualizable), not plain `[int]`: a loop-carried plain `[int]` element is
+// kept in a trace register and is *not* restored to the array on a CloseLoop
+// guard deopt, so the post-loop value reads back as the pre-loop one. A virt
+// array writes through to the heap-backing Vec, which the deopt path reads
+// directly — the same mechanism braininterp relies on. (`a` is a plain scalar
+// red, which is restored correctly.)
 #[majit_macros::jit_interp(
     state = TlrState,
     env = Bytecode,
+    greens = [pc, program],
     state_fields = {
         a: int,
-        regs: [int],
+        regs: [int; virt],
     },
 )]
 fn mainloop(program: &Bytecode, initial_a: i64, threshold: u32) -> i64 {

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -394,6 +394,139 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         })
         .collect();
 
+    // ── seed_recursive_fresh_frame: fresh state as CONSTANTS ──
+    // Same slot layout as `populate_frame_int_regs`, but writes const OpRefs
+    // (a fresh inline callee's state is known at the call site) with fresh
+    // values: scalars 0, fixed-array cells 0, virt-array ptr 0 (the stack is
+    // virtual, its cells live in the vable shadow), virt-array len = caller's
+    // captured capacity (the fresh callee re-allocates at that size).
+    let seed_scalar_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, _f)| {
+            quote! {
+                if __slot < frame.int_regs.len() {
+                    frame.int_regs[__slot] = Some(majit_ir::OpRef::const_int(0));
+                    frame.int_values[__slot] = Some(0);
+                }
+                __slot += 1;
+            }
+        })
+        .collect();
+    let seed_array_parts: Vec<TokenStream> = arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            quote! {
+                for __i in 0..self.#fname.len() {
+                    if __slot + __i < frame.int_regs.len() {
+                        frame.int_regs[__slot + __i] = Some(majit_ir::OpRef::const_int(0));
+                        frame.int_values[__slot + __i] = Some(0);
+                    }
+                }
+                __slot += self.#fname.len();
+            }
+        })
+        .collect();
+    let seed_virt_array_parts: Vec<TokenStream> = virt_arrays
+        .iter()
+        .map(|(_, f)| {
+            let len_value_name = quote::format_ident!("{}_len_value", f.name);
+            quote! {
+                if __slot < frame.int_regs.len() {
+                    frame.int_regs[__slot] = Some(majit_ir::OpRef::const_int(0));
+                    frame.int_values[__slot] = Some(0);
+                }
+                __slot += 1;
+                let __cap = self.#len_value_name;
+                if __slot < frame.int_regs.len() {
+                    frame.int_regs[__slot] = Some(majit_ir::OpRef::const_int(__cap));
+                    frame.int_values[__slot] = Some(__cap);
+                }
+                __slot += 1;
+            }
+        })
+        .collect();
+
+    // ── snapshot/reset/restore inline scalar+fixed-array sym state ──
+    // The sym holds the WORKING scalar (and fixed-array) state read/written by
+    // `BC_LOAD/STORE_STATE_FIELD` / `_STATE_ARRAY`.  An inline recursive-portal
+    // callee overwrites it in place, so nest it: snapshot → reset fresh → run →
+    // restore.  Virt arrays are excluded (their cells live in the vable shadow).
+    let snapshot_scalar_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            let value_name = quote::format_ident!("{}_value", f.name);
+            quote! { __out.push((self.#fname, self.#value_name)); }
+        })
+        .collect();
+    let snapshot_array_parts: Vec<TokenStream> = arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            let value_name = quote::format_ident!("{}_values", f.name);
+            quote! {
+                for __i in 0..self.#fname.len() {
+                    __out.push((self.#fname[__i], self.#value_name[__i]));
+                }
+            }
+        })
+        .collect();
+    let reset_scalar_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            let value_name = quote::format_ident!("{}_value", f.name);
+            quote! {
+                self.#fname = majit_ir::OpRef::const_int(0);
+                self.#value_name = 0;
+            }
+        })
+        .collect();
+    let reset_array_parts: Vec<TokenStream> = arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            let value_name = quote::format_ident!("{}_values", f.name);
+            quote! {
+                for __i in 0..self.#fname.len() {
+                    self.#fname[__i] = majit_ir::OpRef::const_int(0);
+                    self.#value_name[__i] = 0;
+                }
+            }
+        })
+        .collect();
+    let restore_inline_scalar_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            let value_name = quote::format_ident!("{}_value", f.name);
+            quote! {
+                if __k < __snapshot.len() {
+                    self.#fname = __snapshot[__k].0;
+                    self.#value_name = __snapshot[__k].1;
+                    __k += 1;
+                }
+            }
+        })
+        .collect();
+    let restore_inline_array_parts: Vec<TokenStream> = arrays
+        .iter()
+        .map(|(_, f)| {
+            let fname = &f.name;
+            let value_name = quote::format_ident!("{}_values", f.name);
+            quote! {
+                for __i in 0..self.#fname.len() {
+                    if __k < __snapshot.len() {
+                        self.#fname[__i] = __snapshot[__k].0;
+                        self.#value_name[__i] = __snapshot[__k].1;
+                        __k += 1;
+                    }
+                }
+            }
+        })
+        .collect();
+
     // ── fail_args ──
     let fail_scalar_parts: Vec<TokenStream> = scalars
         .iter()
@@ -1485,6 +1618,10 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 #int_identity_base + self.total_slots()
             }
 
+            fn int_identity_slots_base(&self) -> usize {
+                #int_identity_base
+            }
+
             fn loop_header_pc(&self) -> usize {
                 self.loop_header_pc
             }
@@ -1578,6 +1715,37 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 #(#populate_virt_array_parts)*
                 let _ = __slot;
                 #(#populate_ref_scalar_parts)*
+            }
+
+            #[allow(unused_assignments, unused_variables)]
+            fn seed_recursive_fresh_frame(
+                &self,
+                frame: &mut majit_metainterp::MIFrame,
+            ) {
+                let mut __slot: usize = #int_identity_base;
+                #(#seed_scalar_parts)*
+                #(#seed_array_parts)*
+                #(#seed_virt_array_parts)*
+                let _ = __slot;
+            }
+
+            fn snapshot_inline_scalar_state(&self) -> Option<Vec<(majit_ir::OpRef, i64)>> {
+                let mut __out: Vec<(majit_ir::OpRef, i64)> = Vec::new();
+                #(#snapshot_scalar_parts)*
+                #(#snapshot_array_parts)*
+                Some(__out)
+            }
+
+            fn reset_inline_scalar_state_fresh(&mut self) {
+                #(#reset_scalar_parts)*
+                #(#reset_array_parts)*
+            }
+
+            #[allow(unused_assignments, unused_variables)]
+            fn restore_inline_scalar_state(&mut self, __snapshot: Vec<(majit_ir::OpRef, i64)>) {
+                let mut __k: usize = 0;
+                #(#restore_inline_scalar_parts)*
+                #(#restore_inline_array_parts)*
             }
 
             #recursive_fresh_entry_reds_override
@@ -1947,6 +2115,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     __virtualizable_boxes,
                     __virtualref_boxes,
                     __identity_const,
+                    Some((sym.int_identity_slots_base(), sym.int_identity_slots_end())),
                 );
                 let __root = &mut frames.frames[0];
                 __root.int_regs[..__n].copy_from_slice(&__saved_int_regs);

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -34,6 +34,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.env_type,
         &config.residual_writes,
         &config.pool_arrays,
+        config.split_dispatch,
     );
 
     let classified = classify_arms(&match_expr.arms);

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -35,6 +35,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.residual_writes,
         &config.pool_arrays,
         config.split_dispatch,
+        config.switch_dispatch,
     );
 
     let classified = classify_arms(&match_expr.arms);

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -119,6 +119,54 @@ pub(crate) fn assign_caller_local_layout(
     (layout, max_pre_bound)
 }
 
+/// Floor for a split sub-JitCode body's flat `next_reg`: the max of the int
+/// and ref identity-slot ends, so body-side `alloc_reg()` never reuses a
+/// reserved identity slot. Inert (0) when `split_dispatch` is off or the
+/// kernel has no identity slots.
+fn split_identity_floor(config: Option<&LowererConfig>) -> u16 {
+    config
+        .filter(|c| c.split_dispatch)
+        .map(|c| {
+            let (int_end, ref_end) = c.split_identity_reg_ends();
+            int_end.max(ref_end)
+        })
+        .unwrap_or(0)
+}
+
+/// Compile-time guard for `split_dispatch`: no caller-local may be pre-bound
+/// into its bank's reserved identity range `[identity_base, identity_end)`.
+/// Those registers hold the virtualizable identity (array base/len, state
+/// scalars) that the arm body's `load/store_state_field` ops address and the
+/// resume path re-derives at deopt; a caller-local packed onto one would share
+/// the physical register and be read as the identity slot (or vice-versa) — a
+/// silent miscompile that the `frame.rs` trim's `is_none()` gate cannot catch,
+/// since the arg writes the slot `Some`. Caller-locals pack densely from reg 0,
+/// so the first int local lands at reg 0 (below `int_identity_base` = 1) and is
+/// safe; this only fires if an arm captures a SECOND identity-range local.
+/// Inert unless `split_dispatch` is on.
+fn assert_no_split_identity_alias(layout: &[CallerLocalLayout], config: Option<&LowererConfig>) {
+    let Some(config) = config.filter(|c| c.split_dispatch) else {
+        return;
+    };
+    let (int_end, ref_end) = config.split_identity_reg_ends();
+    for entry in layout {
+        let (base, end, bank) = match entry.kind {
+            BindingKind::Int => (config.int_identity_base(), int_end, "int"),
+            BindingKind::Ref => (config.ref_identity_base(), ref_end, "ref"),
+            BindingKind::Float => continue,
+        };
+        assert!(
+            !(base <= entry.callee_reg && entry.callee_reg < end),
+            "split_dispatch: caller-local `{}` binds {bank}-reg {} inside the \
+             reserved identity range [{base}, {end}). A split arm may capture at \
+             most {base} {bank} caller-local(s); offset the arg packing past the \
+             identity range or reduce the arm's captured locals.",
+            entry.name,
+            entry.callee_reg,
+        );
+    }
+}
+
 #[allow(private_interfaces)]
 pub(crate) fn try_generate_jitcode_body_parts_with_caller_bindings(
     body: &Expr,
@@ -142,6 +190,7 @@ pub(crate) fn try_generate_jitcode_body_parts_with_caller_bindings(
     lowerer.in_dispatch_arm_body = true;
 
     let (layout, max_pre_bound) = assign_caller_local_layout(caller_locals);
+    assert_no_split_identity_alias(&layout, config);
     for entry in &layout {
         lowerer.bindings.insert(
             entry.name.clone(),
@@ -156,7 +205,10 @@ pub(crate) fn try_generate_jitcode_body_parts_with_caller_bindings(
     // body-side `alloc_reg()` cannot reuse any pre-bound slot in any
     // bank.  Mirrors the `next_reg.max(1)` advance after the
     // pc=Int(0)+program=Ref(0) pre-bind in `lower_dispatch_body`.
-    lowerer.next_reg = lowerer.next_reg.max(max_pre_bound);
+    lowerer.next_reg = lowerer
+        .next_reg
+        .max(max_pre_bound)
+        .max(split_identity_floor(config));
 
     for stmt in &stmts {
         lowerer.lower_stmt(stmt)?;
@@ -206,6 +258,7 @@ pub(crate) fn try_generate_jitcode_pc_return_body_with_caller_bindings(
     lowerer.in_dispatch_arm_body = true;
 
     let (layout, max_pre_bound) = assign_caller_local_layout(caller_locals);
+    assert_no_split_identity_alias(&layout, config);
     for entry in &layout {
         lowerer.bindings.insert(
             entry.name.clone(),
@@ -216,7 +269,10 @@ pub(crate) fn try_generate_jitcode_pc_return_body_with_caller_bindings(
             },
         );
     }
-    lowerer.next_reg = lowerer.next_reg.max(max_pre_bound);
+    lowerer.next_reg = lowerer
+        .next_reg
+        .max(max_pre_bound)
+        .max(split_identity_floor(config));
 
     for stmt in work {
         lowerer.lower_stmt(stmt)?;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -182,6 +182,98 @@ pub(crate) fn try_generate_jitcode_body_parts_with_caller_bindings(
     ))
 }
 
+/// pc-returning variant of
+/// [`try_generate_jitcode_body_parts_with_caller_bindings`] for `split_dispatch`
+/// pure forward-advancing arms.  The body's straight-line `work` statements are
+/// lowered as usual; the trailing `pc += increment` is NOT lowered (on the
+/// non-pinned sub-JitCode path it is inert and dropped — the dispatch loop owns
+/// the pc register).  Instead, an explicit `BC_INT_RETURN(pc + increment)` is
+/// emitted so the paired `inline_call_<types>_i` writes the advanced pc back
+/// into the caller's green pc register (`next_instr = self.OPCODE(...)`).
+#[allow(private_interfaces)]
+pub(crate) fn try_generate_jitcode_pc_return_body_with_caller_bindings(
+    body: &Expr,
+    config: Option<&LowererConfig>,
+    caller_locals: &[(String, Binding)],
+    increment: i64,
+) -> Option<(GeneratedJitCodeBody, Vec<CallerLocalLayout>)> {
+    let stmts = extract_stmts(body);
+    // The predicate (`arm_is_pure_pc_advance`) guarantees a trailing `pc += N`,
+    // which is replaced by the explicit pc-return below.  Lower only the work.
+    let (_pc_advance, work) = stmts.split_last()?;
+
+    let mut lowerer = Lowerer::new(config);
+    lowerer.in_dispatch_arm_body = true;
+
+    let (layout, max_pre_bound) = assign_caller_local_layout(caller_locals);
+    for entry in &layout {
+        lowerer.bindings.insert(
+            entry.name.clone(),
+            Binding {
+                reg: entry.callee_reg,
+                kind: entry.kind,
+                depends_on_stack: false,
+            },
+        );
+    }
+    lowerer.next_reg = lowerer.next_reg.max(max_pre_bound);
+
+    for stmt in work {
+        lowerer.lower_stmt(stmt)?;
+    }
+
+    // `pc` is collected as a caller-local (the trailing `pc += N` references it),
+    // so it is pre-bound at its callee reg; the work statements only read it, so
+    // the binding still holds the incoming pc.  Return pc + increment.
+    let pc_reg = lowerer.bindings.get("pc")?.reg;
+    let tmp_reg = lowerer.alloc_reg();
+    lowerer.emit_op(
+        OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(tmp_reg)]),
+        quote! {
+            __builder.load_const_i_value(#tmp_reg as u16, #increment as i64);
+        },
+    );
+    let ret_reg = lowerer.alloc_reg();
+    lowerer.emit_op(
+        OpMeta::linear(
+            OpKind::BinopI,
+            vec![Register::int(pc_reg), Register::int(tmp_reg)],
+            vec![Register::int(ret_reg)],
+        ),
+        quote! {
+            __builder.record_binop_i(
+                #ret_reg as u16,
+                majit_ir::OpCode::IntAdd,
+                #pc_reg as u16,
+                #tmp_reg as u16,
+            );
+        },
+    );
+    lowerer.emit_op(
+        OpMeta::terminal(vec![Register::int(ret_reg)]),
+        quote! { __builder.int_return(#ret_reg as u16); },
+    );
+
+    annotate_live_markers_with_liveness(&mut lowerer.op_metadata);
+    remove_repeated_live(&mut lowerer.op_metadata, &mut lowerer.statements);
+    rewrite_live_marker_statements_with_triples(&lowerer.op_metadata, &mut lowerer.statements);
+    maybe_dump_liveness("jitcode_pc_return_body", &lowerer.op_metadata);
+    let liveness_prebuild =
+        liveness_prebuild_tokens(&lowerer.op_metadata, &lowerer.inline_liveness_prebuild);
+    let statements = lowerer.statements;
+    Some((
+        GeneratedJitCodeBody {
+            body: quote! {
+                #(#statements)*
+            },
+            liveness_prebuild,
+            green_schema: Vec::new(),
+            red_schema: Vec::new(),
+        },
+        layout,
+    ))
+}
+
 pub(crate) fn generate_inline_helper_jitcode_with_calls(
     func: &ItemFn,
     calls: &[crate::jit_interp::CallEntry],

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -1732,6 +1732,63 @@ pub(super) fn dispatch_arm_inline_call_tokens(
     }
 }
 
+/// pc-returning variant of [`dispatch_arm_inline_call_tokens`]: emits the
+/// `inline_call_<types>_i` form whose callee BC_INT_RETURN writes back into the
+/// caller's `return_i_reg` (the dispatch loop's green pc register).  Used by
+/// `split_dispatch` for pure forward-advancing arms so the heavy arm body lives
+/// in its own sub-JitCode yet still advances the green pc — the `next_instr =
+/// self.OPCODE(oparg, next_instr)` shape.
+pub(super) fn dispatch_arm_inline_call_tokens_i(
+    layout: &[CallerLocalLayout],
+    return_i_reg: u16,
+) -> proc_macro2::TokenStream {
+    use quote::quote;
+    let has_int = layout.iter().any(|l| matches!(l.kind, BindingKind::Int));
+    let has_float = layout.iter().any(|l| matches!(l.kind, BindingKind::Float));
+    let pair_tokens = |kind: BindingKind| -> Vec<proc_macro2::TokenStream> {
+        layout
+            .iter()
+            .filter(|l| l.kind == kind)
+            .map(|l| {
+                let parent = l.parent_reg;
+                let callee = l.callee_reg;
+                quote! { (#parent as u16, #callee as u16) }
+            })
+            .collect()
+    };
+    let args_i = pair_tokens(BindingKind::Int);
+    let args_r = pair_tokens(BindingKind::Ref);
+    let args_f = pair_tokens(BindingKind::Float);
+    if has_float {
+        quote! {
+            __builder.inline_call_irf_i(
+                __sub_idx,
+                &[#(#args_i),*],
+                &[#(#args_r),*],
+                &[#(#args_f),*],
+                Some(#return_i_reg as u16),
+            );
+        }
+    } else if has_int {
+        quote! {
+            __builder.inline_call_ir_i(
+                __sub_idx,
+                &[#(#args_i),*],
+                &[#(#args_r),*],
+                Some(#return_i_reg as u16),
+            );
+        }
+    } else {
+        quote! {
+            __builder.inline_call_r_i(
+                __sub_idx,
+                &[#(#args_r),*],
+                Some(#return_i_reg as u16),
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod dispatch_arm_inline_call_tokens_tests {
     use super::*;
@@ -1869,6 +1926,72 @@ fn pc_self_increment(expr: &Expr) -> Option<i64> {
         }
     }
     None
+}
+
+/// `Some(N)` if `body` is a pure forward-advancing dispatch arm: straight-line
+/// work followed by a single trailing `pc += N` (N > 0), with no back-edge
+/// (`can_enter_jit!` / `jit_merge_point!`), no early `return` / `continue` /
+/// `break`, and no other `pc` write.  Such an arm has no merge point of its
+/// own, so under `split_dispatch` it is lowered into a per-arm sub-JitCode that
+/// RETURNS the advanced pc (`next_instr = self.OPCODE(oparg, next_instr)`),
+/// keeping the dispatch JitCode's register/const footprint small.  Branch arms
+/// (`pc = target; continue;`) and `return` arms own a merge point / back-edge
+/// and are rejected here so they stay force-inlined.
+fn arm_is_pure_pc_advance(body: &Expr) -> Option<i64> {
+    use syn::visit::Visit;
+    struct Forbid {
+        hit: bool,
+    }
+    impl<'ast> Visit<'ast> for Forbid {
+        fn visit_expr_return(&mut self, _: &'ast syn::ExprReturn) {
+            self.hit = true;
+        }
+        fn visit_expr_continue(&mut self, _: &'ast syn::ExprContinue) {
+            self.hit = true;
+        }
+        fn visit_expr_break(&mut self, _: &'ast syn::ExprBreak) {
+            self.hit = true;
+        }
+        fn visit_macro(&mut self, m: &'ast syn::Macro) {
+            if let Some(id) = m.path.get_ident() {
+                let n = id.to_string();
+                if n == "can_enter_jit" || n == "jit_merge_point" {
+                    self.hit = true;
+                }
+            }
+            syn::visit::visit_macro(self, m);
+        }
+    }
+    let mut forbid = Forbid { hit: false };
+    forbid.visit_expr(body);
+    if forbid.hit {
+        return None;
+    }
+
+    let stmts = extract_stmts(body);
+    let (last, work) = stmts.split_last()?;
+    let Stmt::Expr(last_expr, _) = last else {
+        return None;
+    };
+    let increment = pc_self_increment(last_expr)?;
+    if increment <= 0 {
+        return None;
+    }
+    // No earlier statement may write `pc` (the advance must be the sole, final
+    // pc mutation — a mid-body pc write would not be a straight-line advance).
+    for s in work {
+        if let Stmt::Expr(e, _) = s {
+            if pc_self_increment(e).is_some() {
+                return None;
+            }
+            if let Expr::Assign(a) = e {
+                if expr_single_ident(&a.left).as_deref() == Some("pc") {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(increment)
 }
 
 impl<'c> Lowerer<'c> {
@@ -2197,7 +2320,27 @@ pub(super) fn lower_dispatch_chain(
         // makes a bare-path inferred-policy call — at which point the remedy is
         // either to lower that arm inline behind an abort guard, or to add an
         // explicit pc-writeback from the sub-JitCode into the caller's reg0.
-        let inlined = pc_is_green(config)
+        // `split_dispatch` opt-in: a pure forward-advancing green-pc arm is
+        // routed to the per-arm sub-JitCode path (below) with a pc-returning
+        // `inline_call_<types>_i` instead of being force-inlined here — this is
+        // what keeps the dispatch JitCode's register/const footprint small.
+        // `Some(N)` carries the arm's `pc += N` advance to the body generator.
+        // When `split_dispatch` is off this short-circuits to `None` before
+        // `arm_is_pure_pc_advance` runs, so the gate stays byte-identical.
+        let pc_return_increment = if config.split_dispatch
+            && pc_is_green(config)
+            && matches!(
+                arm.pattern,
+                crate::jit_interp::classify::ArmPattern::Lowerable
+            )
+            && !lowerer.arm_body_has_infer_call(&arm.original_body)
+        {
+            arm_is_pure_pc_advance(&arm.original_body)
+        } else {
+            None
+        };
+        let inlined = pc_return_increment.is_none()
+            && pc_is_green(config)
             && matches!(
                 arm.pattern,
                 crate::jit_interp::classify::ArmPattern::Lowerable
@@ -2250,12 +2393,35 @@ pub(super) fn lower_dispatch_chain(
                 crate::jit_interp::classify::ArmPattern::Lowerable => {
                     let caller_locals =
                         collect_arm_caller_locals(&arm.original_body, &arm.pat, &lowerer.bindings);
-                    match try_generate_jitcode_body_parts_with_caller_bindings(
-                        &arm.original_body,
-                        Some(config),
-                        &caller_locals,
-                    ) {
-                        Some((generated, layout)) => {
+                    let generated_parts = match pc_return_increment {
+                        // `split_dispatch` pure arm: lower into a sub-JitCode
+                        // that RETURNS pc + N; the third tuple slot carries the
+                        // caller pc register the `_i` writeback targets.
+                        Some(increment) => {
+                            try_generate_jitcode_pc_return_body_with_caller_bindings(
+                                &arm.original_body,
+                                Some(config),
+                                &caller_locals,
+                                increment,
+                            )
+                            .map(|(generated, layout)| {
+                                let pc_reg = layout
+                                    .iter()
+                                    .find(|e| e.name == "pc")
+                                    .map(|e| e.parent_reg)
+                                    .unwrap_or(0);
+                                (generated, layout, Some(pc_reg))
+                            })
+                        }
+                        None => try_generate_jitcode_body_parts_with_caller_bindings(
+                            &arm.original_body,
+                            Some(config),
+                            &caller_locals,
+                        )
+                        .map(|(generated, layout)| (generated, layout, None)),
+                    };
+                    match generated_parts {
+                        Some((generated, layout, pc_return_reg)) => {
                             let body = generated.body;
                             let liveness_prebuild = generated.liveness_prebuild;
                             lowerer.inline_liveness_prebuild.push(liveness_prebuild);
@@ -2267,7 +2433,12 @@ pub(super) fn lower_dispatch_chain(
                                 arm_inline_call_reads
                                     .push(Register::new(entry.kind, entry.parent_reg));
                             }
-                            let inline_call_emit = dispatch_arm_inline_call_tokens(&layout);
+                            let inline_call_emit = match pc_return_reg {
+                                Some(pc_reg) => {
+                                    dispatch_arm_inline_call_tokens_i(&layout, pc_reg)
+                                }
+                                None => dispatch_arm_inline_call_tokens(&layout),
+                            };
                             let min_i_regs = layout
                                 .iter()
                                 .filter(|e| matches!(e.kind, BindingKind::Int))

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -1889,8 +1889,7 @@ pub(super) fn pc_is_green(config: &LowererConfig) -> bool {
 /// operands read at the same stride. Falls back to the byte descr when the
 /// env type name does not parse as a type.
 pub(super) fn env_array_descr_expr(config: Option<&LowererConfig>) -> proc_macro2::TokenStream {
-    let env_ty = config
-        .and_then(|c| syn::parse_str::<syn::Type>(&c.env_type_name).ok());
+    let env_ty = config.and_then(|c| syn::parse_str::<syn::Type>(&c.env_type_name).ok());
     match env_ty {
         Some(env_ty) => quote::quote! {{
             let __env_item = ::core::mem::size_of::<
@@ -1962,14 +1961,11 @@ fn arm_is_pure_pc_advance(body: &Expr) -> Option<i64> {
         fn visit_expr_break(&mut self, _: &'ast syn::ExprBreak) {
             self.hit = true;
         }
-        fn visit_expr_call(&mut self, c: &'ast syn::ExprCall) {
-            self.hit = true;
-            syn::visit::visit_expr_call(self, c);
-        }
-        fn visit_expr_method_call(&mut self, c: &'ast syn::ExprMethodCall) {
-            self.hit = true;
-            syn::visit::visit_expr_method_call(self, c);
-        }
+        // Residual-call arms ARE eligible to split: their GuardNoException
+        // resume snapshot's identity-slot references resolve through the
+        // sized rd_virtuals (negative virtual numbering) and the reserved
+        // sub-JitCode identity prefix, so they no longer read uninitialized
+        // holes. Only control-flow / loop-header constructs below disqualify.
         fn visit_macro(&mut self, m: &'ast syn::Macro) {
             if let Some(id) = m.path.get_ident() {
                 let n = id.to_string();
@@ -2231,7 +2227,48 @@ pub(super) fn lower_dispatch_chain(
         _ => return default_label,
     };
 
-    for arm in classified_arms {
+    let mut switch_arm_labels: Vec<Option<syn::Ident>> = vec![None; classified_arms.len()];
+    if config.switch_dispatch {
+        let mut switch_case_emitters = Vec::new();
+        for (arm_idx, arm) in classified_arms.iter().enumerate() {
+            if matches!(arm.pat, Pat::Wild(_)) || is_lowercase_binding_pat(&arm.pat) {
+                continue;
+            }
+            let arm_label = lowerer.alloc_label();
+            lowerer.emit_aux(quote::quote! { let #arm_label = __builder.new_label(); });
+            match extract_pat_switch_case_tokens(&arm.pat, &arm_label) {
+                Some(mut emitters) => {
+                    switch_case_emitters.append(&mut emitters);
+                    switch_arm_labels[arm_idx] = Some(arm_label);
+                }
+                None => continue,
+            }
+        }
+        lowerer.emit_aux(quote::quote! {
+            let mut __switch_cases: Vec<(i64, u16)> = Vec::new();
+            #(#switch_case_emitters)*
+        });
+        let live_targets = switch_arm_labels
+            .iter()
+            .filter_map(|label| label.clone())
+            .collect::<Vec<_>>();
+        // RPython flatten.py:270-308 emits one `-live-` before `switch`;
+        // pyjitpl.py:598-617 records GuardValue on a hit and fallback guards
+        // on a miss. The marker keeps the opcode and all case targets live.
+        lowerer.emit_op(
+            OpMeta::live_marker_with(vec![Register::int(opcode_reg)], live_targets),
+            quote::quote! { let _ = __builder.live_placeholder(); },
+        );
+        lowerer.emit_op(
+            OpMeta::linear(OpKind::Aux, vec![Register::int(opcode_reg)], vec![]),
+            quote::quote! {
+                __builder.switch(#opcode_reg as u16, &__switch_cases);
+            },
+        );
+        lowerer.emit_jump(&default_label);
+    }
+
+    for (arm_idx, arm) in classified_arms.iter().enumerate() {
         // `_` wildcard: skip here; handled by the default GOTO below.
         // All other patterns (including Pat::Ident like `OP_NOP`) are
         // treated as constant tests and emitted as goto_if_not_int_eq.
@@ -2239,77 +2276,94 @@ pub(super) fn lower_dispatch_chain(
             continue;
         }
 
-        // Extract token expressions for each value in the pattern.
-        // extract_pat_value_tokens handles Pat::Lit, Pat::Path, Pat::Or.
-        let value_tokens = match extract_pat_value_tokens(&arm.pat) {
-            Some(v) => v,
-            None => continue, // unsupported pattern shape — skip
-        };
-
-        // Allocate a skip label: if opcode ≠ this arm's value, jump here.
-        // Task 1.6 will emit the arm body between the check and this label.
-        let skip_label = lowerer.alloc_label();
-        lowerer.emit_aux(quote::quote! { let #skip_label = __builder.new_label(); });
-
-        let matched_label = if value_tokens.len() > 1 {
-            let label = lowerer.alloc_label();
-            lowerer.emit_aux(quote::quote! { let #label = __builder.new_label(); });
-            Some(label)
+        let mut skip_label = None;
+        if let Some(match_label) = switch_arm_labels[arm_idx].as_ref() {
+            lowerer.emit_label_def(match_label);
+        } else if config.switch_dispatch {
+            continue;
         } else {
-            None
-        };
+            // Extract token expressions for each value in the pattern.
+            // extract_pat_value_tokens handles Pat::Lit, Pat::Path, Pat::Or.
+            let value_tokens = match extract_pat_value_tokens(&arm.pat) {
+                Some(v) => v,
+                None => {
+                    if pat_contains_range(&arm.pat) && !config.split_dispatch {
+                        lowerer.emit_aux(quote::quote! {
+                            compile_error!(
+                                "jit_interp dispatch range patterns require `switch_dispatch = true`"
+                            );
+                        });
+                    }
+                    continue; // unsupported pattern shape — skip
+                }
+            };
 
-        for (value_idx, val_tok) in value_tokens.iter().enumerate() {
-            // Load the pattern constant into a fresh int register.
-            let const_reg = lowerer.alloc_reg();
-            lowerer.emit_op(
-                OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
-                quote::quote! {
-                    __builder.load_const_i_value(#const_reg as u16, #val_tok);
-                },
-            );
-            let is_last_value = value_idx + 1 == value_tokens.len();
-            let miss_label = if is_last_value {
-                skip_label.clone()
-            } else {
+            // Allocate a skip label: if opcode ≠ this arm's value, jump here.
+            // Task 1.6 will emit the arm body between the check and this label.
+            let arm_skip_label = lowerer.alloc_label();
+            lowerer.emit_aux(quote::quote! { let #arm_skip_label = __builder.new_label(); });
+            skip_label = Some(arm_skip_label.clone());
+
+            let matched_label = if value_tokens.len() > 1 {
                 let label = lowerer.alloc_label();
                 lowerer.emit_aux(quote::quote! { let #label = __builder.new_label(); });
-                label
+                Some(label)
+            } else {
+                None
             };
-            // RPython flatten.py:258-260 emits `-live-` UNCONDITIONALLY ahead
-            // of every goto_if_not / goto_if_not_<cmp>; optimize_goto_if_not
-            // (jtransform.py:225) tags the fused compare `-live-before`. The
-            // tracer records this guard through record_state_guard →
-            // build_state_field_snapshot, which reads the LIVE marker at
-            // `guard_pc - SIZE_LIVE_OP`. Without a preceding `-live-` the
-            // snapshot mis-decodes the prior op's bytes as a liveness offset
-            // and indexes out of bounds. One marker per chained alternative so
-            // each goto_if_not_int_eq has its own preceding LIVE.
-            lowerer.emit_op(
-                OpMeta::live_marker(),
-                quote::quote! { let _ = __builder.live_placeholder(); },
-            );
-            // Fused goto_if_not_int_eq: branch to the next alternative (or the
-            // arm skip label) if opcode != const.
-            lowerer.emit_op(
-                OpMeta::conditional_guard_int_eq(
-                    Register::int(opcode_reg),
-                    Register::int(const_reg),
-                    miss_label.clone(),
-                ),
-                quote::quote! {
-                    __builder.goto_if_not_int_eq(#opcode_reg as u16, #const_reg as u16, #miss_label);
-                },
-            );
-            if let Some(matched_label) = matched_label.as_ref() {
-                lowerer.emit_jump(matched_label);
-                if !is_last_value {
-                    lowerer.emit_label_def(&miss_label);
+
+            for (value_idx, val_tok) in value_tokens.iter().enumerate() {
+                // Load the pattern constant into a fresh int register.
+                let const_reg = lowerer.alloc_reg();
+                lowerer.emit_op(
+                    OpMeta::linear(OpKind::LoadConstI, vec![], vec![Register::int(const_reg)]),
+                    quote::quote! {
+                        __builder.load_const_i_value(#const_reg as u16, #val_tok);
+                    },
+                );
+                let is_last_value = value_idx + 1 == value_tokens.len();
+                let miss_label = if is_last_value {
+                    arm_skip_label.clone()
+                } else {
+                    let label = lowerer.alloc_label();
+                    lowerer.emit_aux(quote::quote! { let #label = __builder.new_label(); });
+                    label
+                };
+                // RPython flatten.py:258-260 emits `-live-` UNCONDITIONALLY ahead
+                // of every goto_if_not / goto_if_not_<cmp>; optimize_goto_if_not
+                // (jtransform.py:225) tags the fused compare `-live-before`. The
+                // tracer records this guard through record_state_guard →
+                // build_state_field_snapshot, which reads the LIVE marker at
+                // `guard_pc - SIZE_LIVE_OP`. Without a preceding `-live-` the
+                // snapshot mis-decodes the prior op's bytes as a liveness offset
+                // and indexes out of bounds. One marker per chained alternative so
+                // each goto_if_not_int_eq has its own preceding LIVE.
+                lowerer.emit_op(
+                    OpMeta::live_marker(),
+                    quote::quote! { let _ = __builder.live_placeholder(); },
+                );
+                // Fused goto_if_not_int_eq: branch to the next alternative (or the
+                // arm skip label) if opcode != const.
+                lowerer.emit_op(
+                    OpMeta::conditional_guard_int_eq(
+                        Register::int(opcode_reg),
+                        Register::int(const_reg),
+                        miss_label.clone(),
+                    ),
+                    quote::quote! {
+                        __builder.goto_if_not_int_eq(#opcode_reg as u16, #const_reg as u16, #miss_label);
+                    },
+                );
+                if let Some(matched_label) = matched_label.as_ref() {
+                    lowerer.emit_jump(matched_label);
+                    if !is_last_value {
+                        lowerer.emit_label_def(&miss_label);
+                    }
                 }
             }
-        }
-        if let Some(matched_label) = matched_label.as_ref() {
-            lowerer.emit_label_def(matched_label);
+            if let Some(matched_label) = matched_label.as_ref() {
+                lowerer.emit_label_def(matched_label);
+            }
         }
 
         // Green-pc gated inline (Option A, #184): when `pc` is a declared
@@ -2452,23 +2506,33 @@ pub(super) fn lower_dispatch_chain(
                                     .push(Register::new(entry.kind, entry.parent_reg));
                             }
                             let inline_call_emit = match pc_return_reg {
-                                Some(pc_reg) => {
-                                    dispatch_arm_inline_call_tokens_i(&layout, pc_reg)
-                                }
+                                Some(pc_reg) => dispatch_arm_inline_call_tokens_i(&layout, pc_reg),
                                 None => dispatch_arm_inline_call_tokens(&layout),
                             };
-                            let min_i_regs = layout
+                            // Reserve the identity-slot prefix in the sub-JitCode
+                            // register file so int[int_identity_base..int_end) /
+                            // ref[ref_identity_base..ref_end) exist as real
+                            // registers — the arm body's state-field ops address
+                            // them and the resume path re-derives them at deopt.
+                            let (__split_int_end, __split_ref_end) = if config.split_dispatch {
+                                config.split_identity_reg_ends()
+                            } else {
+                                (0u16, 0u16)
+                            };
+                            let min_i_regs = (layout
                                 .iter()
                                 .filter(|e| matches!(e.kind, BindingKind::Int))
                                 .map(|e| e.callee_reg + 1)
                                 .max()
-                                .unwrap_or(0) as u16;
-                            let min_r_regs = layout
+                                .unwrap_or(0) as u16)
+                                .max(__split_int_end);
+                            let min_r_regs = (layout
                                 .iter()
                                 .filter(|e| matches!(e.kind, BindingKind::Ref))
                                 .map(|e| e.callee_reg + 1)
                                 .max()
-                                .unwrap_or(0) as u16;
+                                .unwrap_or(0) as u16)
+                                .max(__split_ref_end);
                             let min_f_regs = layout
                                 .iter()
                                 .filter(|e| matches!(e.kind, BindingKind::Float))
@@ -2606,13 +2670,17 @@ pub(super) fn lower_dispatch_chain(
 
         // Bind the skip label at the end of this arm's guard sequence.
         // Jumping here means "this arm did not match; proceed to next arm".
-        lowerer.emit_label_def(&skip_label);
+        if let Some(skip_label) = skip_label.as_ref() {
+            lowerer.emit_label_def(skip_label);
+        }
     }
 
     // After all arm guards, the default/exit path: unconditional GOTO.
     // default_label is bound at the typed-return emission site in
     // lower_dispatch_body (Task 1.7).
-    lowerer.emit_jump(&default_label);
+    if !config.switch_dispatch {
+        lowerer.emit_jump(&default_label);
+    }
     default_label
 }
 
@@ -2628,6 +2696,14 @@ fn is_lowercase_binding_pat(pat: &Pat) -> bool {
         .chars()
         .next()
         .is_some_and(|c| c.is_ascii_lowercase())
+}
+
+fn pat_contains_range(pat: &Pat) -> bool {
+    match pat {
+        Pat::Range(_) => true,
+        Pat::Or(pat_or) => pat_or.cases.iter().any(pat_contains_range),
+        _ => false,
+    }
 }
 
 /// A.3.5 — emit a `-live-` + `<kind>_guard_value` pair for each declared green.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -1931,12 +1931,22 @@ fn pc_self_increment(expr: &Expr) -> Option<i64> {
 /// `Some(N)` if `body` is a pure forward-advancing dispatch arm: straight-line
 /// work followed by a single trailing `pc += N` (N > 0), with no back-edge
 /// (`can_enter_jit!` / `jit_merge_point!`), no early `return` / `continue` /
-/// `break`, and no other `pc` write.  Such an arm has no merge point of its
-/// own, so under `split_dispatch` it is lowered into a per-arm sub-JitCode that
-/// RETURNS the advanced pc (`next_instr = self.OPCODE(oparg, next_instr)`),
-/// keeping the dispatch JitCode's register/const footprint small.  Branch arms
+/// `break`, no other `pc` write, and no function call.  Such an arm has no
+/// merge point of its own and takes no mid-body resume snapshot, so under
+/// `split_dispatch` it is lowered into a per-arm sub-JitCode that RETURNS the
+/// advanced pc (`next_instr = self.OPCODE(oparg, next_instr)`), keeping the
+/// dispatch JitCode's register/const footprint small.  Branch arms
 /// (`pc = target; continue;`) and `return` arms own a merge point / back-edge
-/// and are rejected here so they stay force-inlined.
+/// and are rejected so they stay force-inlined.
+///
+/// Arms that make a residual call are also rejected: a residual call records a
+/// GuardNoException resume snapshot whose canonical "all-live" liveness lists
+/// every int register `[0, num_regs_i)`, including the unused per-bank holes the
+/// caller-local layout leaves (e.g. int reg 1 when `pc` is the sole int
+/// caller-local but `program`/`state` occupy two ref regs); reading such a hole
+/// register at resume hits an uninitialized slot.  Such arms keep their heavy
+/// work out-of-line in the residual already, so force-inlining them costs the
+/// dispatch little — they do not need the split.
 fn arm_is_pure_pc_advance(body: &Expr) -> Option<i64> {
     use syn::visit::Visit;
     struct Forbid {
@@ -1951,6 +1961,14 @@ fn arm_is_pure_pc_advance(body: &Expr) -> Option<i64> {
         }
         fn visit_expr_break(&mut self, _: &'ast syn::ExprBreak) {
             self.hit = true;
+        }
+        fn visit_expr_call(&mut self, c: &'ast syn::ExprCall) {
+            self.hit = true;
+            syn::visit::visit_expr_call(self, c);
+        }
+        fn visit_expr_method_call(&mut self, c: &'ast syn::ExprMethodCall) {
+            self.hit = true;
+            syn::visit::visit_expr_method_call(self, c);
         }
         fn visit_macro(&mut self, m: &'ast syn::Macro) {
             if let Some(id) = m.path.get_ident() {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -973,10 +973,10 @@ fn try_lower_inner_byte_fetch(
         return false;
     };
     let program_reg = prog.reg;
+    let descr_tok = env_array_descr_expr(lowerer.config);
     let Some(index_reg) = lower_array_index_expr(lowerer, &idx.index) else {
         return false;
     };
-    let descr_tok = quote! { __builder.add_gc_byte_array_descr() };
     lowerer.emit_op(
         OpMeta::linear(
             OpKind::Vable,
@@ -1410,16 +1410,14 @@ fn try_lower_opcode_fetch_stmt(lowerer: &mut Lowerer, stmt: &Stmt) -> bool {
                     return false;
                 };
                 let program_reg = prog.reg;
+                let descr_tok = env_array_descr_expr(lowerer.config);
                 // Compute the index register: `pc` returns pc_reg directly,
                 // `pc + N` emits load_const + int_add into a fresh reg.
                 let Some(index_reg) = lower_array_index_expr(lowerer, idx_expr) else {
                     return false;
                 };
-                // Allocate a fresh Int register for the byte fetch result.
+                // Allocate a fresh Int register for the fetch result.
                 let result_reg = lowerer.alloc_reg();
-                let descr_tok = quote::quote! {
-                    __builder.add_gc_byte_array_descr()
-                };
                 lowerer.emit_op(
                     OpMeta::linear(
                         OpKind::Vable,
@@ -1820,6 +1818,31 @@ pub(super) fn pc_is_green(config: &LowererConfig) -> bool {
             if p.qself.is_none()
                 && p.path.get_ident().map(|id| id == "pc").unwrap_or(false))
     })
+}
+
+/// Expression that mints the array descr for an `env` (`program[...]`) read,
+/// scaling the index by the env element size. `&[u8]` keeps the historical
+/// `add_gc_byte_array_descr()` (itemsize 1, unsigned — no `movsx` on bytes
+/// ≥ 0x80); a wider element (`&[i64]`) reads the element at byte offset
+/// `size_of::<elem>() * index`. The element size is unknowable to the
+/// proc-macro (it holds only the alias name), so emit a
+/// `size_of::<<Env as Index<usize>>::Output>()` const computed in the user
+/// crate. All three `program[...]` lowering sites (operand reads, opcode
+/// aliasing, inline-dispatch fetch) share this so an env's opcode AND its
+/// operands read at the same stride. Falls back to the byte descr when the
+/// env type name does not parse as a type.
+pub(super) fn env_array_descr_expr(config: Option<&LowererConfig>) -> proc_macro2::TokenStream {
+    let env_ty = config
+        .and_then(|c| syn::parse_str::<syn::Type>(&c.env_type_name).ok());
+    match env_ty {
+        Some(env_ty) => quote::quote! {{
+            let __env_item = ::core::mem::size_of::<
+                <#env_ty as ::core::ops::Index<usize>>::Output,
+            >();
+            __builder.add_gc_int_array_descr(__env_item, __env_item != 1)
+        }},
+        None => quote::quote! { __builder.add_gc_byte_array_descr() },
+    }
 }
 
 /// Recognise a self-increment of `pc`: `pc += N` (BinOp::AddAssign) or

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/helpers.rs
@@ -115,6 +115,46 @@ pub(super) fn extract_pat_value_tokens(pat: &Pat) -> Option<Vec<TokenStream>> {
     }
 }
 
+/// Case emitters for `switch_dispatch`.
+///
+/// Literal/path/or arms become direct `cases.push((key, label))` statements.
+/// Range endpoints are emitted as generated-code expressions because const
+/// paths cannot be evaluated inside the proc macro; the user crate resolves
+/// them while building the JitCode.
+pub(super) fn extract_pat_switch_case_tokens(
+    pat: &Pat,
+    arm_label: &syn::Ident,
+) -> Option<Vec<TokenStream>> {
+    match pat {
+        Pat::Lit(_) | Pat::Path(_) | Pat::Ident(_) => {
+            let values = extract_pat_value_tokens(pat)?;
+            Some(
+                values
+                    .into_iter()
+                    .map(|value| quote! { __switch_cases.push(((#value), #arm_label)); })
+                    .collect(),
+            )
+        }
+        Pat::Or(pat_or) => {
+            let mut tokens = Vec::new();
+            for case in &pat_or.cases {
+                tokens.extend(extract_pat_switch_case_tokens(case, arm_label)?);
+            }
+            Some(tokens)
+        }
+        Pat::Range(range) => {
+            let start = range.start.as_ref()?;
+            let end = range.end.as_ref()?;
+            Some(vec![quote! {
+                for __v in ((#start as i64)..=(#end as i64)) {
+                    __switch_cases.push((__v, #arm_label));
+                }
+            }])
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn int_arg_regs(bindings: &[Binding]) -> Option<Vec<u16>> {
     bindings
         .iter()

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -40,6 +40,12 @@ impl<'c> Lowerer<'c> {
         }
         let index_reg = idx_binding.reg;
         let result_reg = self.alloc_reg();
+        // The descr scales the index by the env element size (see
+        // `env_array_descr_expr`): `&[u8]` reads a raw byte, a wider env
+        // (`&[i64]`) reads the element at byte offset `size_of::<elem>() *
+        // index`. Shared with the opcode-fetch sites so operands and opcodes
+        // read at the same stride.
+        let descr_tok = env_array_descr_expr(self.config);
         self.emit_op(
             OpMeta::linear(
                 OpKind::Vable,
@@ -47,7 +53,7 @@ impl<'c> Lowerer<'c> {
                 vec![Register::int(result_reg)],
             ),
             quote! {
-                let __descr_idx = __builder.add_gc_byte_array_descr();
+                let __descr_idx = #descr_tok;
                 __builder.getarrayitem_gc_i(
                     #result_reg as u16,
                     #program_reg as u16,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -29,9 +29,9 @@ mod reexports {
     pub(super) use super::api::bind_pre_merge_point_stmts;
     pub(super) use super::dispatch::{
         collect_arm_caller_locals, collect_pat_bound_idents, dispatch_arm_inline_call_tokens,
-        emit_promote_greens, find_dispatch_loop_body, green_schema, is_jit_merge_point_macro,
-        lower_dispatch_chain, lower_pre_dispatch_stmts, pc_is_green, red_schema, resolve_greens,
-        resolve_reds,
+        emit_promote_greens, env_array_descr_expr, find_dispatch_loop_body, green_schema,
+        is_jit_merge_point_macro, lower_dispatch_chain, lower_pre_dispatch_stmts, pc_is_green,
+        red_schema, resolve_greens, resolve_reds,
     };
     pub(super) use super::helpers::{
         binding_kind_for_inline_policy, binop_i_emit_tokens, block_has_loop_control,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use api::{
     CallerLocalLayout, assign_caller_local_layout, generate_inline_helper_jitcode_with_calls,
     inline_helper_param_counts, inline_helper_param_layout,
     try_generate_jitcode_body_parts_with_caller_bindings,
+    try_generate_jitcode_pc_return_body_with_caller_bindings,
 };
 #[allow(unused_imports)]
 pub use api::{try_generate_jitcode_body, try_generate_jitcode_body_with_config};
@@ -184,6 +185,11 @@ pub struct LowererConfig {
     /// lowers to `getarrayitem_gc_r` instead of a residual CALL_R.  Source:
     /// `JitInterpConfig.pool_arrays`.
     pub(super) pool_arrays: Vec<String>,
+    /// Source: `JitInterpConfig.split_dispatch`.  When set, the dispatch lowerer
+    /// routes pure forward-advancing green-pc arms through the per-arm
+    /// sub-JitCode path with a pc-returning `inline_call_<types>_i` instead of
+    /// force-inlining them into the dispatch JitCode.  Off → byte-identical.
+    pub(super) split_dispatch: bool,
 }
 
 impl LowererConfig {
@@ -764,6 +770,7 @@ impl LowererConfig {
         env_type: &Ident,
         residual_writes: &[crate::jit_interp::ResidualWriteEntry],
         pool_arrays: &[Ident],
+        split_dispatch: bool,
     ) -> Self {
         let io_shims = io_shims
             .iter()
@@ -901,6 +908,7 @@ impl LowererConfig {
             env_type_name: env_type.to_string(),
             residual_writes,
             pool_arrays: pool_arrays.iter().map(|i| i.to_string()).collect(),
+            split_dispatch,
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -37,11 +37,12 @@ mod reexports {
     pub(super) use super::helpers::{
         binding_kind_for_inline_policy, binop_i_emit_tokens, block_has_loop_control,
         expr_has_loop_control, extract_block_tail_int, extract_bool_branch_values,
-        extract_branch_int, extract_pat_literals, extract_pat_value_tokens, extract_stmts,
-        inline_builder_path, inline_call_tokens, inline_float_arg_tokens, inline_int_arg_tokens,
-        inline_prebuild_path, inline_ref_arg_tokens, int_arg_regs, is_supported_float_type,
-        is_supported_int_cast, is_supported_ref_type, opcode_for_assign_binop, opcode_for_binop,
-        stmt_has_loop_control, typed_call_arg_tokens,
+        extract_branch_int, extract_pat_literals, extract_pat_switch_case_tokens,
+        extract_pat_value_tokens, extract_stmts, inline_builder_path, inline_call_tokens,
+        inline_float_arg_tokens, inline_int_arg_tokens, inline_prebuild_path,
+        inline_ref_arg_tokens, int_arg_regs, is_supported_float_type, is_supported_int_cast,
+        is_supported_ref_type, opcode_for_assign_binop, opcode_for_binop, stmt_has_loop_control,
+        typed_call_arg_tokens,
     };
     pub(super) use super::liveness::{
         annotate_live_markers_with_liveness, compute_per_marker_liveness, get_liveness_info,
@@ -190,6 +191,10 @@ pub struct LowererConfig {
     /// sub-JitCode path with a pc-returning `inline_call_<types>_i` instead of
     /// force-inlining them into the dispatch JitCode.  Off → byte-identical.
     pub(super) split_dispatch: bool,
+    /// Source: `JitInterpConfig.switch_dispatch`.  When set, the dispatch
+    /// lowerer emits one RPython-style `switch/id` over opcode cases instead
+    /// of a per-arm guard chain. Off → byte-identical.
+    pub(super) switch_dispatch: bool,
 }
 
 impl LowererConfig {
@@ -211,6 +216,28 @@ impl LowererConfig {
     /// scalar where it expects the green pc.
     pub(super) fn int_identity_base(&self) -> u16 {
         1
+    }
+
+    /// Exclusive end of the int-bank and ref-bank identity-slot ranges
+    /// `[int_identity_base, int_end)` / `[ref_identity_base, ref_end)`.
+    ///
+    /// Mirrors the dispatch JitCode's identity reservation: int identity =
+    /// the scalar slots plus two words (ptr+len) per virtualizable array;
+    /// ref identity = the ref scalars. A split sub-JitCode must reserve the
+    /// SAME prefix so its register file spans the identity slots that the
+    /// arm body's `load/store_state_field` ops address and that the resume
+    /// path re-derives at deopt. Returns `0` for a bank with no identity
+    /// slots so the caller's `.max()` floor is inert there.
+    pub(super) fn split_identity_reg_ends(&self) -> (u16, u16) {
+        let int_end = self.int_identity_base()
+            + self.state_scalars.len() as u16
+            + 2 * self.state_virt_arrays.len() as u16;
+        let ref_end = if self.state_ref_scalars.is_empty() {
+            0
+        } else {
+            self.ref_identity_base() + self.state_ref_scalars.len() as u16
+        };
+        (int_end, ref_end)
     }
 }
 
@@ -771,6 +798,7 @@ impl LowererConfig {
         residual_writes: &[crate::jit_interp::ResidualWriteEntry],
         pool_arrays: &[Ident],
         split_dispatch: bool,
+        switch_dispatch: bool,
     ) -> Self {
         let io_shims = io_shims
             .iter()
@@ -909,6 +937,7 @@ impl LowererConfig {
             residual_writes,
             pool_arrays: pool_arrays.iter().map(|i| i.to_string()).collect(),
             split_dispatch,
+            switch_dispatch,
         }
     }
 

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -897,8 +897,135 @@ fn parse_helpers_list(input: ParseStream) -> syn::Result<Vec<CallEntry>> {
         .collect())
 }
 
+/// Reject a plain `[int]` state-array that is stored-to inside the traced
+/// loop. Such an array is *loop-carried*: its elements live only in trace
+/// registers and are NOT restored to the array on a guard deopt — they read
+/// back as the pre-loop value, silently producing a wrong result. The
+/// supported mechanism for a mutated, loop-carried array is `[int; virt]`,
+/// whose stores write through to the heap-backing `Vec` that the deopt path
+/// reads directly. A plain `[int]` array that is only *read* in the loop (or
+/// only written before it) is loop-invariant and stays valid, so the check
+/// fires solely on stores reached by the dispatch loop the lowerer traces.
+fn validate_state_fields(config: &JitInterpConfig, func: &ItemFn) -> syn::Result<()> {
+    let Some(sf) = &config.state_fields else {
+        return Ok(());
+    };
+    let plain_arrays: std::collections::HashSet<String> = sf
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, StateFieldKind::Array(_)))
+        .map(|f| f.name.to_string())
+        .collect();
+    if plain_arrays.is_empty() {
+        return Ok(());
+    }
+    // Only stores reached by the traced dispatch loop are a hazard; init
+    // stores before the loop are not traced.
+    let Some(loop_body) = find_traced_loop_body(&func.block) else {
+        return Ok(());
+    };
+    let mut finder = PlainArrayStoreFinder {
+        plain_arrays: &plain_arrays,
+        offender: None,
+    };
+    syn::visit::Visit::visit_block(&mut finder, loop_body);
+    if let Some((name, span)) = finder.offender {
+        return Err(syn::Error::new(
+            span,
+            format!(
+                "state field `{name}` is a plain `[int]` array stored inside the traced loop, \
+                 so it is loop-carried. A plain `[int]` element is held in a trace register and \
+                 is not restored to the array when a guard deopts (it reads back as the pre-loop \
+                 value, silently miscompiling). Declare it as `[int; virt]`: a virtualizable \
+                 array writes through to the heap-backing Vec that the deopt path reads directly."
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// The `loop {}` / `while {}` body that contains the `jit_merge_point!()`
+/// marker — the region the lowerer traces.
+fn find_traced_loop_body(block: &syn::Block) -> Option<&syn::Block> {
+    for stmt in &block.stmts {
+        let syn::Stmt::Expr(expr, _) = stmt else {
+            continue;
+        };
+        let body = match expr {
+            Expr::Loop(l) => &l.body,
+            Expr::While(w) => &w.body,
+            _ => continue,
+        };
+        let has_merge_point = body.stmts.iter().any(|s| {
+            matches!(s, syn::Stmt::Macro(m) if m.mac.path.is_ident("jit_merge_point"))
+        });
+        if has_merge_point {
+            return Some(body);
+        }
+    }
+    None
+}
+
+struct PlainArrayStoreFinder<'a> {
+    plain_arrays: &'a std::collections::HashSet<String>,
+    offender: Option<(String, proc_macro2::Span)>,
+}
+
+impl<'a> PlainArrayStoreFinder<'a> {
+    /// `state.<field>[_]` with `<field>` a plain array → the field name.
+    fn plain_array_index_target(&self, left: &Expr) -> Option<String> {
+        let Expr::Index(idx) = left else {
+            return None;
+        };
+        let Expr::Field(f) = &*idx.expr else {
+            return None;
+        };
+        if !matches!(&*f.base, Expr::Path(p) if p.qself.is_none() && p.path.is_ident("state")) {
+            return None;
+        }
+        let syn::Member::Named(member) = &f.member else {
+            return None;
+        };
+        let name = member.to_string();
+        self.plain_arrays.contains(&name).then_some(name)
+    }
+
+    fn check_assign_target(&mut self, left: &Expr) {
+        if self.offender.is_some() {
+            return;
+        }
+        if let Some(name) = self.plain_array_index_target(left) {
+            use syn::spanned::Spanned as _;
+            self.offender = Some((name, left.span()));
+        }
+    }
+}
+
+impl<'ast, 'a> syn::visit::Visit<'ast> for PlainArrayStoreFinder<'a> {
+    fn visit_expr_assign(&mut self, node: &'ast syn::ExprAssign) {
+        self.check_assign_target(&node.left);
+        syn::visit::visit_expr_assign(self, node);
+    }
+
+    fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
+        // Compound assignment (`state.regs[i] += 1`) is a store too.
+        use syn::BinOp::*;
+        if matches!(
+            node.op,
+            AddAssign(_) | SubAssign(_) | MulAssign(_) | DivAssign(_) | RemAssign(_)
+                | BitXorAssign(_) | BitAndAssign(_) | BitOrAssign(_) | ShlAssign(_) | ShrAssign(_)
+        ) {
+            self.check_assign_target(&node.left);
+        }
+        syn::visit::visit_expr_binary(self, node);
+    }
+}
+
 /// Main entry point: transform the function with JIT support.
 pub fn transform_jit_interp(config: JitInterpConfig, func: ItemFn) -> TokenStream {
+    if let Err(err) = validate_state_fields(&config, &func) {
+        return err.to_compile_error();
+    }
     let trace_fn = codegen_trace::generate_trace_fn(&config, &func);
     let state_impl = codegen_state::generate_jit_state(&config, &func);
     let merge_wrapper = generate_merge_wrapper(&config, &func);
@@ -2126,5 +2253,90 @@ mod tests {
                 panic!("expected embedded array layout");
             }
         }
+    }
+
+    fn validate(config_tokens: proc_macro2::TokenStream, func: ItemFn) -> syn::Result<()> {
+        let config: JitInterpConfig = syn::parse2(config_tokens).unwrap();
+        validate_state_fields(&config, &func)
+    }
+
+    /// A plain `[int]` array stored inside the traced loop must be rejected:
+    /// the loop-carried element is lost on a guard deopt.
+    #[test]
+    fn validate_rejects_loop_carried_plain_array() {
+        let func: ItemFn = parse_quote! {
+            fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
+                let mut state = S { regs: vec![0; 3] };
+                let mut pc: usize = 0;
+                loop {
+                    jit_merge_point!();
+                    let op = program[pc];
+                    match op {
+                        0 => { state.regs[0] = state.regs[0] + 1; pc += 1; }
+                        _ => return state.regs[0],
+                    }
+                }
+            }
+        };
+        let err = validate(
+            quote! { state = S, env = Bytecode, greens = [pc, program],
+                     state_fields = { regs: [int] } },
+            func,
+        )
+        .expect_err("loop-carried plain [int] store must be rejected");
+        assert!(err.to_string().contains("[int; virt]"));
+        assert!(err.to_string().contains("regs"));
+    }
+
+    /// `[int; virt]` is the supported loop-carried form — accepted.
+    #[test]
+    fn validate_accepts_virt_array() {
+        let func: ItemFn = parse_quote! {
+            fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
+                let mut state = S { regs: vec![0; 3] };
+                let mut pc: usize = 0;
+                loop {
+                    jit_merge_point!();
+                    let op = program[pc];
+                    match op {
+                        0 => { state.regs[0] = state.regs[0] + 1; pc += 1; }
+                        _ => return state.regs[0],
+                    }
+                }
+            }
+        };
+        validate(
+            quote! { state = S, env = Bytecode, greens = [pc, program],
+                     state_fields = { regs: [int; virt] } },
+            func,
+        )
+        .expect("virt array must be accepted");
+    }
+
+    /// A plain `[int]` array only *read* in the loop is loop-invariant and
+    /// stays valid — no false positive.
+    #[test]
+    fn validate_accepts_read_only_plain_array() {
+        let func: ItemFn = parse_quote! {
+            fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
+                let mut state = S { regs: vec![0; 3] };
+                let mut pc: usize = 0;
+                let mut acc: i64 = 0;
+                loop {
+                    jit_merge_point!();
+                    let op = program[pc];
+                    match op {
+                        0 => { acc += state.regs[0]; pc += 1; }
+                        _ => return acc,
+                    }
+                }
+            }
+        };
+        validate(
+            quote! { state = S, env = Bytecode, greens = [pc, program],
+                     state_fields = { regs: [int] } },
+            func,
+        )
+        .expect("read-only plain [int] array must be accepted");
     }
 }

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -124,6 +124,15 @@ pub struct JitInterpConfig {
     /// loop entry and the short preamble can re-emit it.  Empty for
     /// interpreters with no pool-array indexing.
     pub pool_arrays: Vec<Ident>,
+    /// Opt-in: route pure forward-advancing dispatch arms (those whose body
+    /// only does work then `pc += N`, with no back-edge / `can_enter_jit!` /
+    /// early return) through the per-arm sub-JitCode path with a pc-returning
+    /// `inline_call_<types>_i`, instead of force-inlining them into the
+    /// dispatch JitCode.  This keeps the dispatch JitCode's register/const
+    /// footprint small (the heavy arm bodies move into their own sub-JitCodes,
+    /// each with its own ≤256 budget) — mirrors `next_instr = self.OPCODE(...)`.
+    /// Off by default, so kernels that do not set it are byte-identical.
+    pub split_dispatch: bool,
 }
 
 /// Virtualizable frame field declaration for `#[jit_interp]`.
@@ -452,6 +461,7 @@ impl Parse for JitInterpConfig {
         let mut recursive_entry: Option<Path> = None;
         let mut residual_writes: Vec<ResidualWriteEntry> = Vec::new();
         let mut pool_arrays: Vec<Ident> = Vec::new();
+        let mut split_dispatch = false;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -508,6 +518,9 @@ impl Parse for JitInterpConfig {
                         content.parse_terminated(Ident::parse, Token![,])?;
                     pool_arrays = idents.into_iter().collect();
                 }
+                "split_dispatch" => {
+                    split_dispatch = input.parse::<LitBool>()?.value;
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -553,6 +566,7 @@ impl Parse for JitInterpConfig {
             recursive_entry,
             residual_writes,
             pool_arrays,
+            split_dispatch,
         })
     }
 }

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -133,6 +133,10 @@ pub struct JitInterpConfig {
     /// each with its own ≤256 budget) — mirrors `next_instr = self.OPCODE(...)`.
     /// Off by default, so kernels that do not set it are byte-identical.
     pub split_dispatch: bool,
+    /// Opt-in: lower the top-level opcode dispatch discrimination as one
+    /// `switch/id` op instead of a `goto_if_not_int_eq` guard chain. Off by
+    /// default so existing interpreters keep byte-identical dispatch JitCode.
+    pub switch_dispatch: bool,
 }
 
 /// Virtualizable frame field declaration for `#[jit_interp]`.
@@ -462,6 +466,7 @@ impl Parse for JitInterpConfig {
         let mut residual_writes: Vec<ResidualWriteEntry> = Vec::new();
         let mut pool_arrays: Vec<Ident> = Vec::new();
         let mut split_dispatch = false;
+        let mut switch_dispatch = false;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -521,6 +526,9 @@ impl Parse for JitInterpConfig {
                 "split_dispatch" => {
                     split_dispatch = input.parse::<LitBool>()?.value;
                 }
+                "switch_dispatch" => {
+                    switch_dispatch = input.parse::<LitBool>()?.value;
+                }
                 other => {
                     return Err(syn::Error::new(
                         key.span(),
@@ -567,6 +575,7 @@ impl Parse for JitInterpConfig {
             residual_writes,
             pool_arrays,
             split_dispatch,
+            switch_dispatch,
         })
     }
 }
@@ -970,9 +979,10 @@ fn find_traced_loop_body(block: &syn::Block) -> Option<&syn::Block> {
             Expr::While(w) => &w.body,
             _ => continue,
         };
-        let has_merge_point = body.stmts.iter().any(|s| {
-            matches!(s, syn::Stmt::Macro(m) if m.mac.path.is_ident("jit_merge_point"))
-        });
+        let has_merge_point = body
+            .stmts
+            .iter()
+            .any(|s| matches!(s, syn::Stmt::Macro(m) if m.mac.path.is_ident("jit_merge_point")));
         if has_merge_point {
             return Some(body);
         }
@@ -1026,8 +1036,16 @@ impl<'ast, 'a> syn::visit::Visit<'ast> for PlainArrayStoreFinder<'a> {
         use syn::BinOp::*;
         if matches!(
             node.op,
-            AddAssign(_) | SubAssign(_) | MulAssign(_) | DivAssign(_) | RemAssign(_)
-                | BitXorAssign(_) | BitAndAssign(_) | BitOrAssign(_) | ShlAssign(_) | ShrAssign(_)
+            AddAssign(_)
+                | SubAssign(_)
+                | MulAssign(_)
+                | DivAssign(_)
+                | RemAssign(_)
+                | BitXorAssign(_)
+                | BitAndAssign(_)
+                | BitOrAssign(_)
+                | ShlAssign(_)
+                | ShrAssign(_)
         ) {
             self.check_assign_target(&node.left);
         }
@@ -2294,7 +2312,7 @@ mod tests {
         };
         let err = validate(
             quote! { state = S, env = Bytecode, greens = [pc, program],
-                     state_fields = { regs: [int] } },
+            state_fields = { regs: [int] } },
             func,
         )
         .expect_err("loop-carried plain [int] store must be rejected");
@@ -2321,7 +2339,7 @@ mod tests {
         };
         validate(
             quote! { state = S, env = Bytecode, greens = [pc, program],
-                     state_fields = { regs: [int; virt] } },
+            state_fields = { regs: [int; virt] } },
             func,
         )
         .expect("virt array must be accepted");
@@ -2348,7 +2366,7 @@ mod tests {
         };
         validate(
             quote! { state = S, env = Bytecode, greens = [pc, program],
-                     state_fields = { regs: [int] } },
+            state_fields = { regs: [int] } },
             func,
         )
         .expect("read-only plain [int] array must be accepted");

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -68,6 +68,12 @@ pub struct JitCodeBuilder {
     /// `BC_RESIDUAL_CALL_*` operand is a 2-byte index into this pool
     /// (RPython `j`/`d` argcode → `descrs[idx]` dispatch).
     descrs: Vec<RuntimeBhDescr>,
+    /// Switch descriptors emitted before their target labels are known.
+    /// RPython `flatten.py:283-308` stores labels on `SwitchDictDescr`,
+    /// then `assembler.py:201-204` attaches concrete positions after
+    /// label resolution.  Keep the same two-stage flow for runtime-built
+    /// jitcodes.
+    pending_switches: Vec<(u16, Vec<(i64, u16)>)>,
     /// `descr.py:108-120` `gccache._cache_size[STRUCT]` analog: the
     /// per-struct `BhSizeSpec` (size + full `all_fielddescrs`) registered
     /// when a `new` for that struct type is emitted, so a following
@@ -1736,6 +1742,20 @@ impl JitCodeBuilder {
         self.push_u8(a as u8);
         self.push_u8(b as u8);
         self.push_label_ref(label);
+    }
+
+    /// Emit `switch/id`: one int register plus a 2-byte SwitchDictDescr
+    /// index.  RPython `flatten.py:270-308` emits the default path as the
+    /// fall-through after the switch; matching blackhole.py:954-960, a
+    /// missing key leaves the pc at the next instruction.
+    pub fn switch(&mut self, value: u16, cases: &[(i64, u16)]) {
+        self.touch_reg(value);
+        self.write_insn("switch/id");
+        self.push_reg_u8(value, "switch/id value");
+        let const_keys_in_order: Vec<i64> = cases.iter().map(|(key, _)| *key).collect();
+        let descr_idx = self.add_switch_descr(const_keys_in_order);
+        self.push_u16(descr_idx);
+        self.pending_switches.push((descr_idx, cases.to_vec()));
     }
 
     pub fn goto_if_not_int_ne(&mut self, a: u16, b: u16, label: u16) {
@@ -4245,9 +4265,23 @@ impl JitCodeBuilder {
         idx
     }
 
+    fn add_switch_descr(&mut self, mut const_keys_in_order: Vec<i64>) -> u16 {
+        const_keys_in_order.sort();
+        let idx = self.descrs.len() as u16;
+        // RPython creates one SwitchDictDescr object per switch site
+        // (`flatten.py:282-285`), so do not deduplicate.
+        self.descrs
+            .push(RuntimeBhDescr::Descr(CanonicalBhDescr::Switch {
+                dict: std::collections::HashMap::new(),
+                const_keys_in_order,
+            }));
+        idx
+    }
+
     pub fn finish(mut self) -> JitCode {
         self.flush_pending_resulttype();
         self.patch_labels();
+        self.patch_switch_descrs();
         self.patch_const_refs();
         self.patch_const_u8_refs();
         // RPython `jitcode.py:47 self._resulttypes = resulttypes`.
@@ -4766,6 +4800,33 @@ impl JitCodeBuilder {
         }
     }
 
+    fn patch_switch_descrs(&mut self) {
+        for (descr_idx, cases) in std::mem::take(&mut self.pending_switches) {
+            let dict = cases
+                .into_iter()
+                .map(|(key, label_idx)| {
+                    let target = self
+                        .labels
+                        .get(label_idx as usize)
+                        .copied()
+                        .flatten()
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "jitcode switch label {label_idx} was never marked for key {key}"
+                            )
+                        });
+                    (key, target)
+                })
+                .collect();
+            match self.descrs.get_mut(descr_idx as usize) {
+                Some(RuntimeBhDescr::Descr(CanonicalBhDescr::Switch { dict: slot, .. })) => {
+                    *slot = dict;
+                }
+                other => panic!("pending switch descr {descr_idx} is not Switch: {other:?}"),
+            }
+        }
+    }
+
     /// RPython `assembler.py:131-138` resolves a const-source operand
     /// to `count_regs[kind] + len(constants) - 1`. pyre performs the
     /// same resolution as a post-emission pass once per-kind
@@ -4878,6 +4939,7 @@ fn canonical_bh_descr_eq(lhs: &CanonicalBhDescr, rhs: &CanonicalBhDescr) -> bool
             CanonicalBhDescr::VableArray { index: lhs },
             CanonicalBhDescr::VableArray { index: rhs },
         ) => lhs == rhs,
+        (CanonicalBhDescr::Switch { .. }, CanonicalBhDescr::Switch { .. }) => false,
         (
             CanonicalBhDescr::Array {
                 base_size: lhs_base_size,
@@ -5011,6 +5073,7 @@ pub fn live_slots_for_state_field_jit(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::blackhole::{BlackholeInterpBuilder, wire_bhimpl_handlers};
     use majit_translate::codewriter::assembler::Assembler;
 
     fn assert_resulttype_after(emit: impl FnOnce(&mut JitCodeBuilder), kind: char) {
@@ -5123,6 +5186,52 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    fn switch_return_jitcode() -> JitCode {
+        let mut builder = JitCodeBuilder::new();
+        let case_a = builder.new_label();
+        let case_b = builder.new_label();
+        let case_c = builder.new_label();
+        builder.switch(0, &[(-3, case_a), (7, case_b), (42, case_c)]);
+        builder.load_const_i_value(1, 10);
+        builder.int_return(1);
+        builder.mark_label(case_a);
+        builder.load_const_i_value(1, 20);
+        builder.int_return(1);
+        builder.mark_label(case_b);
+        builder.load_const_i_value(1, 30);
+        builder.int_return(1);
+        builder.mark_label(case_c);
+        builder.load_const_i_value(1, 40);
+        builder.int_return(1);
+        builder.finish()
+    }
+
+    fn run_switch_blackhole(input: i64) -> i64 {
+        let mut entries: majit_ir::VecMap<String, u8> = majit_ir::VecMap::new();
+        entries.insert("switch/id".to_string(), jitcode::insns::BC_SWITCH);
+        entries.insert("int_copy/i>i".to_string(), jitcode::insns::BC_MOVE_I);
+        entries.insert("int_return/i".to_string(), jitcode::insns::BC_INT_RETURN);
+        let mut builder = BlackholeInterpBuilder::new();
+        builder.setup_insns(&entries);
+        wire_bhimpl_handlers(&mut builder);
+        let mut bh = builder.acquire_interp();
+        bh.setposition(std::sync::Arc::new(switch_return_jitcode()), 0);
+        bh.registers_i[0] = input;
+        let _ = bh.run();
+        bh.tmpreg_i
+    }
+
+    #[test]
+    fn switch_builder_patches_descr_labels_for_blackhole() {
+        // RPython `flatten.py:270-308` + `blackhole.py:954-960` parity:
+        // matching keys jump to attached label positions; misses fall
+        // through to the default path immediately after the switch.
+        assert_eq!(run_switch_blackhole(-3), 20);
+        assert_eq!(run_switch_blackhole(7), 30);
+        assert_eq!(run_switch_blackhole(42), 40);
+        assert_eq!(run_switch_blackhole(99), 10);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1374,22 +1374,35 @@ impl JitCodeBuilder {
     /// (codegen_trace.rs:193 `*const #env_type as *const ()`) point
     /// directly at the first element without any GC header.
     pub fn add_gc_byte_array_descr(&mut self) -> u16 {
+        self.add_gc_int_array_descr(1, false)
+    }
+
+    /// Add a GC-array descriptor for an integer-element `env` array whose
+    /// items are `item_size` bytes wide (`is_item_signed` selects sign- vs
+    /// zero-extension on sub-word loads).  Generalizes
+    /// `add_gc_byte_array_descr` so a wider env element type (`&[i64]`,
+    /// `item_size = 8`) reads the element at byte offset `item_size * index`
+    /// instead of the raw byte at `index`.  `base_size = 0` because Rust
+    /// slice (`&[T]`) data pointers point directly at items[0] with no GC
+    /// header; the structural tuple (base_size=0, itemsize, item_type=Int,
+    /// signedness) uniquely identifies the descr for `add_bh_descr` dedup.
+    /// For an 8-byte item signedness is moot (full-word load), but for `&[u8]`
+    /// it must stay unsigned: a signed byte descr makes the backend emit
+    /// `movsx` on bytes ≥ `0x80` and corrupt opcode dispatch.
+    pub fn add_gc_int_array_descr(&mut self, item_size: usize, is_item_signed: bool) -> u16 {
         self.add_bh_descr(CanonicalBhDescr::Array {
             base_size: 0,
-            itemsize: 1,
-            // base_size=0 → no length header (raw `&[u8]` data pointer
-            // points directly at items[0]); descr.py:359-362 nolength
-            // shape carries `lendescr=None`.
+            itemsize: item_size,
+            // base_size=0 → no length header (raw slice data pointer points
+            // directly at items[0]); descr.py:359-362 nolength shape carries
+            // `lendescr=None`.
             len_offset: None,
             type_id: 0,
             item_type: majit_ir::value::Type::Int,
             is_array_of_pointers: false,
             is_array_of_structs: false,
-            is_item_signed: false,
+            is_item_signed,
             ei_index: u32::MAX,
-            // `&[u8]` byte-array descrs are minted at assembler bootstrap
-            // with no source-level array_type_id; the structural tuple
-            // (base_size=0, itemsize=1, …) uniquely identifies them.
             array_type_id: None,
             interior_fields: Vec::new(),
         })

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -787,6 +787,20 @@ pub struct JitDriver<S: JitState> {
 impl<S: JitState> JitDriver<S> {
     /// Create a new JitDriver with the given hot-counting threshold.
     pub fn new(threshold: u32) -> Self {
+        Self::with_options(threshold, true)
+    }
+
+    /// Create a new JitDriver, optionally skipping the background timer that
+    /// periodically invalidates all compiled loops.
+    ///
+    /// The periodic invalidation is a portable stand-in for RPython's
+    /// GC/signal-triggered invalidation, used by quasi-immutable-bearing
+    /// consumers (a Python JIT). A consumer with no quasi-immutable state — e.g.
+    /// a fixed-bytecode interpreter over plain integer reds — has nothing to
+    /// invalidate; for it the timer only forces pointless re-tracing (and
+    /// exercises the GUARD_NOT_INVALIDATED resume path needlessly), so it should
+    /// pass `periodic_invalidation = false`.
+    pub fn with_options(threshold: u32, periodic_invalidation: bool) -> Self {
         let mut meta = MetaInterp::new(threshold);
         if let Some(info) = S::__build_virtualizable_info() {
             meta.set_virtualizable_info(info);
@@ -797,9 +811,9 @@ impl<S: JitState> JitDriver<S> {
         // RPython uses GC/signal-triggered invalidation; we use a timer as
         // a portable equivalent. Period matches PyPy's checkinterval (~10ms).
         #[cfg(not(target_arch = "wasm32"))]
-        let invalidation_thread = {
+        let invalidation_thread = if periodic_invalidation {
             let qmut = epoch_qmut.clone();
-            std::thread::spawn(move || {
+            Some(std::thread::spawn(move || {
                 loop {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     if let Ok(mut qmut) = qmut.lock() {
@@ -808,7 +822,9 @@ impl<S: JitState> JitDriver<S> {
                         }
                     }
                 }
-            })
+            }))
+        } else {
+            None
         };
         JitDriver {
             meta,
@@ -822,7 +838,7 @@ impl<S: JitState> JitDriver<S> {
             is_recursive: false,
             epoch_qmut,
             #[cfg(not(target_arch = "wasm32"))]
-            _invalidation_thread: Some(invalidation_thread),
+            _invalidation_thread: invalidation_thread,
             #[cfg(target_arch = "wasm32")]
             _invalidation_thread: None,
             blackhole_allocator: None,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -830,6 +830,84 @@ pub struct JitDriver<S: JitState> {
     /// RPython parity: `metainterp_sd.jitcodes[portal_jd.index]` global
     /// registry slot, scoped to the per-`#[jit_interp]` driver.
     dispatch_jitcode: Option<std::sync::Arc<crate::jitcode::JitCode>>,
+    /// Flat global jitcode registry, indexed by each jitcode's absolute
+    /// index (`JitCode::index`). Slot 0 = the dispatch JitCode; slots
+    /// 1..N = every sub-JitCode reachable through the descr pools. Built
+    /// at `register_dispatch_jitcode`. resume.py:1050/1338 `jitcode =
+    /// jitcodes[jitcode_pos]` — every resume frame resolves its jitcode
+    /// from this table by the self-describing index the snapshot stamped,
+    /// with no parent-relative walk or root/sub bookkeeping.
+    jitcode_registry: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
+}
+
+thread_local! {
+    /// Per-thread publication of the currently-installed state-field JIT's
+    /// flat jitcode registry + packed liveness, read by the stateless global
+    /// `frame_value_count` callback below. Mirrors pyre-jit-trace's
+    /// thread-local `METAINTERP_SD` (`jitcodes` + `liveness_info` + `op_live`).
+    static STATE_FIELD_FVC: std::cell::RefCell<Option<StateFieldFvcData>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+struct StateFieldFvcData {
+    jitcodes: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
+    all_liveness: Vec<u8>,
+    op_live: u8,
+}
+
+/// resume.py:1050/1338 `jitcode = metainterp_sd.jitcodes[jitcode_pos]` parity
+/// for the state-field JIT compile-time multi-frame decode
+/// (`rebuild_from_numbering`). Resolves each frame's jitcode STATELESSLY from
+/// the flat global registry by its self-describing absolute index, then
+/// derives the per-frame box count from that jitcode's liveness at pc
+/// (jitcode.py:147 `enumerate_vars` → `length_i + length_r + length_f`).
+/// Structural mirror of `pyre-jit-trace::state::frame_value_count_at`.
+fn state_field_frame_value_count(jitcode_index: i32, pc: i32, _carried_jitcode_pc: i32) -> usize {
+    STATE_FIELD_FVC.with(|cell| {
+        let data = cell.borrow();
+        let Some(data) = data.as_ref() else {
+            return 0;
+        };
+        let Some(jc) = data.jitcodes.get(jitcode_index as usize) else {
+            return 0;
+        };
+        // The rd_numb pc word may carry the after-residual-call marker; strip
+        // it to the plain JitCode position before the liveness lookup.
+        let real_pc = majit_ir::resumedata::decode_resume_pc(pc).0;
+        let off = jc.get_live_vars_info(real_pc as usize, data.op_live);
+        let all_liveness = &data.all_liveness;
+        if off + 2 < all_liveness.len() {
+            all_liveness[off] as usize
+                + all_liveness[off + 1] as usize
+                + all_liveness[off + 2] as usize
+        } else {
+            0
+        }
+    })
+}
+
+/// Publish the driver's flat jitcode registry + packed liveness for the
+/// stateless global `frame_value_count` decode. Both compile-time decoders
+/// (`compile.rs` build_guard_metadata and the cranelift backend) read the
+/// callback via `get_frame_value_count_fn`, so this single registration
+/// serves both. Registers the callback once (process-global slot), then
+/// refreshes the thread-local payload for the installing driver.
+fn install_state_field_fvc(
+    jitcodes: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
+    all_liveness: Vec<u8>,
+    op_live: u8,
+) {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        majit_ir::resumedata::set_frame_value_count_fn(state_field_frame_value_count);
+    });
+    STATE_FIELD_FVC.with(|cell| {
+        *cell.borrow_mut() = Some(StateFieldFvcData {
+            jitcodes,
+            all_liveness,
+            op_live,
+        });
+    });
 }
 
 impl<S: JitState> JitDriver<S> {
@@ -892,6 +970,7 @@ impl<S: JitState> JitDriver<S> {
             blackhole_allocator: None,
             portal_runner: None,
             dispatch_jitcode: None,
+            jitcode_registry: Vec::new(),
             shared_asm: std::sync::Arc::new(std::sync::Mutex::new(
                 majit_translate::codewriter::assembler::Assembler::new(),
             )),
@@ -980,7 +1059,37 @@ impl<S: JitState> JitDriver<S> {
         // Production-active — `warmspot.py:660-666
         // make_args_specification` translation-time assert parity.
         validate_dispatch_jitcode_payload(self, &jitcode);
-        self.dispatch_jitcode = Some(std::sync::Arc::new(jitcode));
+        // Assign the dispatch JitCode the root global index 0, then flatten
+        // every reachable sub-JitCode into one flat registry, assigning each
+        // its own absolute index (resume.py:1050 `metainterp_sd.jitcodes`).
+        // The worklist enumeration is depth-agnostic, so a future nested
+        // inline helper stays correctly indexed without a parent-relative walk.
+        jitcode.set_index(0);
+        let dispatch_arc = std::sync::Arc::new(jitcode);
+        let mut registry: Vec<std::sync::Arc<crate::jitcode::JitCode>> = vec![dispatch_arc.clone()];
+        let mut cursor = 0;
+        while cursor < registry.len() {
+            let current = registry[cursor].clone();
+            cursor += 1;
+            for descr in &current.exec.descrs {
+                if let Some(sub) = descr.as_jitcode() {
+                    if registry.iter().any(|j| std::sync::Arc::ptr_eq(j, sub)) {
+                        continue;
+                    }
+                    let idx = registry.len();
+                    sub.set_index(idx);
+                    registry.push(sub.clone());
+                }
+            }
+        }
+        self.dispatch_jitcode = Some(dispatch_arc);
+        self.jitcode_registry = registry.clone();
+        // Publish the registry + packed liveness for the stateless global
+        // `frame_value_count` decode. `install_canonical_liveness` ran just
+        // before this call, so staticdata carries the final liveness buffer.
+        let all_liveness = self.meta_interp().staticdata.liveness_info.clone();
+        let op_live = self.meta_interp().staticdata.op_live as u8;
+        install_state_field_fvc(registry, all_liveness, op_live);
     }
 
     /// Access the registered dispatch JitCode. Returns `None` until
@@ -2371,41 +2480,16 @@ impl<S: JitState> JitDriver<S> {
                 // the dispatch singleton is registered — the closure
                 // ignores it and clones `self.dispatch_jitcode`.
                 let _ = env;
-                let dispatch_jitcode = self.dispatch_jitcode.clone();
-                let last_resolved: std::cell::RefCell<
-                    Option<std::sync::Arc<majit_metainterp::JitCode>>,
-                > = std::cell::RefCell::new(None);
+                // resume.py:1338-1340 `jitcode = jitcodes[jitcode_pos]` —
+                // resolve every frame statelessly from the flat global
+                // registry by its self-describing absolute index (no root/sub
+                // branch, no parent-relative descrs walk, no last-frame state).
+                let jitcode_registry = self.jitcode_registry.clone();
                 let resolve_jitcode = |jitcode_index: i32,
                                        pc: i32,
                                        _carried_jitcode_pc: i32|
                  -> Option<crate::resume::ResolvedJitCode> {
-                    let resolved_jitcode = if last_resolved.borrow().is_none() {
-                        // Root frame: clone the dispatch JitCode
-                        // singleton registered at install time
-                        // (`register_dispatch_jitcode`).  Returns
-                        // None only when the proc-macro lowerer
-                        // rejected the dispatch body shape and
-                        // install skipped registration.
-                        dispatch_jitcode.as_ref()?.clone()
-                    } else {
-                        // Sub-frame: index into the parent's
-                        // `descrs` array.  Mirrors RPython
-                        // `BC_INLINE_CALL` operand decoding
-                        // (`blackhole.py:150-157`) where the `j`
-                        // argcode resolves through `descrs[idx]`.
-                        let parent = last_resolved
-                            .borrow()
-                            .as_ref()
-                            .expect("parent exists")
-                            .clone();
-                        parent
-                            .exec
-                            .descrs
-                            .get(jitcode_index as usize)
-                            .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)?
-                            .clone()
-                    };
-                    *last_resolved.borrow_mut() = Some(resolved_jitcode.clone());
+                    let resolved_jitcode = jitcode_registry.get(jitcode_index as usize)?.clone();
                     Some(crate::resume::ResolvedJitCode::new(
                         resolved_jitcode,
                         pc as usize,
@@ -2468,6 +2552,26 @@ impl<S: JitState> JitDriver<S> {
                     // layout before it runs.
                     let sf_layout = state.state_field_layout();
                     bh.state_field_layout = sf_layout.clone();
+                    // [FR] Seed the reconstructed blackhole chain with the
+                    // registered virtualizable info so an inlined portal
+                    // callee's vable-array opcodes (getarrayitem_vable_*) can
+                    // resolve their vinfo during resume. Gated behind the
+                    // experiment flag: the default state-field path never runs
+                    // vable-array ops in the blackhole, and seeding a non-null
+                    // vinfo would flip the `!vinfo.is_null()` branches in the
+                    // field handlers for existing consumers.
+                    let portal_vinfo_ptr =
+                        if crate::pyjitpl::dispatch::portal_inline_experiment_enabled() {
+                            self.meta
+                                .virtualizable_info()
+                                .map(std::sync::Arc::as_ptr)
+                                .unwrap_or(std::ptr::null())
+                        } else {
+                            std::ptr::null()
+                        };
+                    if !portal_vinfo_ptr.is_null() {
+                        bh.virtualizable_info = portal_vinfo_ptr;
+                    }
                     let exc = crate::blackhole::BlackholeInterpreter::prepare_resume_from_failure(
                         guard_exc,
                     );
@@ -2492,6 +2596,9 @@ impl<S: JitState> JitDriver<S> {
                             Ok(next_exc) => match bh.nextblackholeinterp.take() {
                                 Some(mut caller) => {
                                     caller.state_field_layout = sf_layout.clone();
+                                    if !portal_vinfo_ptr.is_null() {
+                                        caller.virtualizable_info = portal_vinfo_ptr;
+                                    }
                                     bh_builder.release_interp(bh);
                                     bh = *caller;
                                     cur_exc = next_exc;
@@ -2602,13 +2709,8 @@ impl<S: JitState> JitDriver<S> {
                         // already recovered `state` to the resume point, so the
                         // bridge sees the post-guard-failure values.
                         if should_bridge && pc != usize::MAX {
-                            let bridge_ok = self.start_bridge_tracing(
-                                &descr_arc,
-                                state,
-                                env,
-                                &raw_values,
-                                pc,
-                            );
+                            let bridge_ok =
+                                self.start_bridge_tracing(&descr_arc, state, env, &raw_values, pc);
                             if crate::majit_log_enabled() {
                                 eprintln!(
                                     "[bridge] start_bridge_tracing (green resume) key={} trace={} fail={} resume_pc={} ok={}",
@@ -4378,36 +4480,16 @@ impl<S: JitState> JitDriver<S> {
                 // index into the parent's `descrs` array per
                 // `BC_INLINE_CALL`'s `j` argcode (`blackhole.py:150-157`).
                 let _ = env;
-                let dispatch_jitcode = self.dispatch_jitcode.clone();
-                let last_resolved: std::cell::RefCell<
-                    Option<std::sync::Arc<majit_metainterp::JitCode>>,
-                > = std::cell::RefCell::new(None);
+                // resume.py:1338-1340 `jitcode = jitcodes[jitcode_pos]` —
+                // resolve every frame statelessly from the flat global
+                // registry by its self-describing absolute index (no root/sub
+                // branch, no parent-relative descrs walk, no last-frame state).
+                let jitcode_registry = self.jitcode_registry.clone();
                 let resolve_jitcode = |jitcode_index: i32,
                                        pc: i32,
                                        _carried_jitcode_pc: i32|
                  -> Option<crate::resume::ResolvedJitCode> {
-                    let resolved_jitcode = if last_resolved.borrow().is_none() {
-                        // Root frame: clone the dispatch JitCode
-                        // singleton registered at install time
-                        // (`register_dispatch_jitcode`).  Returns
-                        // None only when the proc-macro lowerer
-                        // rejected the dispatch body shape and
-                        // install skipped registration.
-                        dispatch_jitcode.as_ref()?.clone()
-                    } else {
-                        let parent = last_resolved
-                            .borrow()
-                            .as_ref()
-                            .expect("parent exists")
-                            .clone();
-                        parent
-                            .exec
-                            .descrs
-                            .get(jitcode_index as usize)
-                            .and_then(crate::jitcode::RuntimeBhDescr::as_jitcode)?
-                            .clone()
-                    };
-                    *last_resolved.borrow_mut() = Some(resolved_jitcode.clone());
+                    let resolved_jitcode = jitcode_registry.get(jitcode_index as usize)?.clone();
                     Some(crate::resume::ResolvedJitCode::new(
                         resolved_jitcode,
                         pc as usize,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2268,60 +2268,18 @@ impl<S: JitState> JitDriver<S> {
             // `resume_in_blackhole`; the two are mutually exclusive and
             // neither returns. majit adapts by returning the interpreter
             // resume pc.
-            if should_bridge {
-                // Reconstruct the concrete interpreter state from storage
-                // BEFORE tracing the bridge: a guard failure leaves `state`'s
-                // delta-tracked / carried reds (e.g. a `stacksize` recomputed
-                // from `selected_ref.size`) at their stale pre-run values, so
-                // recording the bridge body from the raw `state` bakes the
-                // wrong loop-control branch. `recover_after_compiled_run`
-                // (the macro's `recover` fn) re-derives them from the live
-                // storage so `build_meta(resume_pc)` and the recorded bridge
-                // see the post-guard-failure values.
-                state.recover_after_compiled_run();
-                // compile.py:704-709: _trace_and_compile_from_bridge
-                let bridge_ok =
-                    self.start_bridge_tracing(&descr_arc, state, env, &raw_values, guard_resume_pc);
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[bridge] start_bridge_tracing key={} trace={} fail={} resume_pc={} ok={}",
-                        green_key, trace_id, fail_index, guard_resume_pc, bridge_ok
-                    );
-                }
-                if bridge_ok {
-                    // The bridge tracing session is now active
-                    // (`begin_trace_session`). Resume the interpreter at the
-                    // guard's resume pc and let the mainloop record the bridge
-                    // body; it closes into a bridge attached to the failing
-                    // guard (`compile_bridge`), so the guard-failure case stops
-                    // re-tracing the loop. Do NOT tear the loop down — the
-                    // bridge attaches to it. (`back_edge_internal` is the macro
-                    // `#[jit_interp]`-only back edge; pyre-jit-trace forms
-                    // bridges through its own eval.rs path, so this does not
-                    // touch the rustpython JIT.)
-                    if crate::majit_log_enabled() {
-                        eprintln!(
-                            "[jit-run] guard failure (bridge-record) fail_index={}, resume_pc={}, target_pc={}, key={}",
-                            fail_index, guard_resume_pc, target_pc, green_key
-                        );
-                    }
-                    return Some(guard_resume_pc);
-                }
-                // start_bridge_tracing declined (dead jct / non-traceable /
-                // resume-decode gap): crude loop teardown + interpreter resume
-                // (status-quo fallback).
-                state.recover_after_compiled_run();
-                self.meta.invalidate_loop(green_key);
-                self.meta.remove_compiled_loop(green_key);
-                self.meta.warm_state_mut().abort_tracing(green_key, true);
-                if crate::majit_log_enabled() {
-                    eprintln!(
-                        "[jit-run] guard failure (bridge-decline) fail_index={}, resume_pc={}, target_pc={}, key={}",
-                        fail_index, guard_resume_pc, target_pc, green_key
-                    );
-                }
-                return Some(guard_resume_pc);
-            }
+            // Bridge tracing is deferred until AFTER the blackhole resume below
+            // computes the *green* resume pc. `guard_resume_pc`
+            // (`get_merge_point_pc`) is the guard's recovery `header_pc`, which
+            // for a `#[jit_interp]` state-field consumer is a byte offset into
+            // the dispatch *jitcode*, not an index into the interpreter's green
+            // `program`. Resuming the macro mainloop at that jitcode offset
+            // indexes `program[]` out of bounds. The blackhole walk re-derives
+            // the real green pc (the merge point the resumed jitcode reaches),
+            // and the bridge must be recorded from THAT pc — see `should_bridge`
+            // at the `ContinueRunningNormally` arm below. `back_edge_structured`
+            // is the macro-only back edge; pyre-jit-trace bridges via its own
+            // eval.rs path, so this does not touch the rustpython JIT.
 
             // compile.py:711 resume_in_blackhole
             // compile.py:853 `ResumeGuardDescr` storage — borrow
@@ -2586,6 +2544,30 @@ impl<S: JitState> JitDriver<S> {
                     };
                     bh_builder.release_interp(bh);
                     if let Some(pc) = resume_pc {
+                        // compile.py:702-709 _trace_and_compile_from_bridge,
+                        // deferred to here so the bridge records from the GREEN
+                        // resume pc the blackhole reported (`pc`), not the
+                        // jitcode-space `guard_resume_pc`. `pc == usize::MAX`
+                        // means the frame ran to completion in the blackhole
+                        // (DoneWithThisFrame) with no forward green pc to trace
+                        // from — nothing to bridge, just exit. The blackhole has
+                        // already recovered `state` to the resume point, so the
+                        // bridge sees the post-guard-failure values.
+                        if should_bridge && pc != usize::MAX {
+                            let bridge_ok = self.start_bridge_tracing(
+                                &descr_arc,
+                                state,
+                                env,
+                                &raw_values,
+                                pc,
+                            );
+                            if crate::majit_log_enabled() {
+                                eprintln!(
+                                    "[bridge] start_bridge_tracing (green resume) key={} trace={} fail={} resume_pc={} ok={}",
+                                    green_key, trace_id, fail_index, pc, bridge_ok
+                                );
+                            }
+                        }
                         return Some(pc);
                     }
                 }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -14,6 +14,54 @@ thread_local! {
     static TRACE_CONTINUATION_SUSPENDED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+thread_local! {
+    /// Per-thread pool for the structured back-edge blackhole resume.
+    /// `build_inline_call_only_bh_builder` wires ~100 string-keyed insns and
+    /// their handlers — a fixed dispatch table independent of any trace — so
+    /// rebuilding it on every guard failure is pure waste (the dominant
+    /// per-deopt cost). Built once, lent via [`BackEdgeBhBuilder`], and
+    /// re-pooled on drop, mirroring `call_jit.rs`'s `BH_BUILDER_RD`.
+    static BACK_EDGE_BH_BUILDER: std::cell::RefCell<Option<crate::blackhole::BlackholeInterpBuilder>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII lease of the thread-local back-edge blackhole builder. Takes the
+/// pooled builder out for the duration of one resume and returns it on drop,
+/// so every early `return` in the resume path re-pools it. If the slot is
+/// empty — first use, or a re-entrant resume already holds it — a fresh
+/// builder is constructed; the surplus is simply dropped when re-pooling.
+struct BackEdgeBhBuilder(Option<crate::blackhole::BlackholeInterpBuilder>);
+
+impl BackEdgeBhBuilder {
+    fn lease() -> Self {
+        let builder = BACK_EDGE_BH_BUILDER
+            .with(|c| c.borrow_mut().take())
+            .unwrap_or_else(crate::blackhole::build_inline_call_only_bh_builder);
+        Self(Some(builder))
+    }
+}
+
+impl Drop for BackEdgeBhBuilder {
+    fn drop(&mut self) {
+        if let Some(builder) = self.0.take() {
+            BACK_EDGE_BH_BUILDER.with(|c| *c.borrow_mut() = Some(builder));
+        }
+    }
+}
+
+impl std::ops::Deref for BackEdgeBhBuilder {
+    type Target = crate::blackhole::BlackholeInterpBuilder;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().expect("builder leased")
+    }
+}
+
+impl std::ops::DerefMut for BackEdgeBhBuilder {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut().expect("builder leased")
+    }
+}
+
 /// Whether re-entrant trace continuation is currently suspended — see
 /// [`TRACE_CONTINUATION_SUSPENDED`].
 pub fn trace_continuation_suspended() -> bool {
@@ -2380,7 +2428,7 @@ impl<S: JitState> JitDriver<S> {
                 // BC_LIVE/BC_CATCH_EXCEPTION/BC_RVMPROF_CODE defaults so
                 // the values match the metainterp's actual byte
                 // assignments.
-                let mut bh_builder = crate::blackhole::build_inline_call_only_bh_builder();
+                let mut bh_builder = BackEdgeBhBuilder::lease();
                 bh_builder.setup_cached_control_opcodes(
                     self.meta_interp().staticdata.op_live,
                     self.meta_interp().staticdata.op_catch_exception,
@@ -2388,7 +2436,7 @@ impl<S: JitState> JitDriver<S> {
                 );
                 let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
                 let bh = crate::resume::blackhole_from_resumedata(
-                    &mut bh_builder,
+                    &mut *bh_builder,
                     &resolve_jitcode,
                     rd_numb,
                     rd_consts_slice,
@@ -4382,7 +4430,7 @@ impl<S: JitState> JitDriver<S> {
                 // BC_LIVE/BC_CATCH_EXCEPTION/BC_RVMPROF_CODE defaults so
                 // the values match the metainterp's actual byte
                 // assignments.
-                let mut bh_builder = crate::blackhole::build_inline_call_only_bh_builder();
+                let mut bh_builder = BackEdgeBhBuilder::lease();
                 bh_builder.setup_cached_control_opcodes(
                     self.meta_interp().staticdata.op_live,
                     self.meta_interp().staticdata.op_catch_exception,
@@ -4390,7 +4438,7 @@ impl<S: JitState> JitDriver<S> {
                 );
                 let all_liveness = self.meta_interp().staticdata.liveness_info.as_slice();
                 let bh = crate::resume::blackhole_from_resumedata(
-                    &mut bh_builder,
+                    &mut *bh_builder,
                     &resolve_jitcode,
                     rd_numb,
                     rd_consts_slice,
@@ -4421,7 +4469,7 @@ impl<S: JitState> JitDriver<S> {
                         result_exc,
                     );
                     let jit_exc = crate::blackhole::run_forever_with_portal(
-                        &mut bh_builder,
+                        &mut *bh_builder,
                         bh,
                         exc,
                         self.portal_runner.as_ref().map(|r| {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1087,21 +1087,6 @@ pub(crate) fn portal_inline_experiment_enabled() -> bool {
     *ENABLED
 }
 
-thread_local! {
-    /// [FR-EXPERIMENT] One stable fresh-callee state per jitdriver, keyed by
-    /// `jd_index`.  A recursive-portal INLINE call re-uses this address as the
-    /// callee's vable identity so the const does not vary across unroll
-    /// iterations (a fresh leak per call bakes an iteration-varying const into
-    /// the callee's recorded ops and the loop never matches a prior iteration).
-    /// The callee's shadow is re-zeroed from `recursive_fresh_entry_reds` each
-    /// call, so re-using one backing object is safe.  Owners are leaked into
-    /// this map to keep the address valid for the process (experiment; a
-    /// trace-scoped arena is the follow-up).
-    static PORTAL_FRESH_STATE: std::cell::RefCell<
-        std::collections::HashMap<usize, majit_ir::GcRef>,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
-}
-
 pub struct ClosureRuntime<FLabel> {
     label_at: FLabel,
 }
@@ -2501,154 +2486,12 @@ where
         }
 
         // State-field production runtime leaves `portal_jitcode` None.  The
-        // Inline path for that shape is the [FR] re-entry rework, WIP and
-        // gated OFF by default so existing consumers keep the clean-abort
-        // fallback (dispatch.rs:2412 legacy behavior).
-        if !portal_inline_experiment_enabled() {
-            return TraceAction::Abort;
-        }
-
-        // [FR] State-field recursive-portal INLINE.  The portal jitcode is
-        // the dispatch-body jitcode currently being traced (one jitcode per
-        // program; self-recursion and same-program leaf calls re-enter the
-        // same body at a different interpreter pc).  The state-field body is
-        // entered at offset 0 with the interpreter pc carried as the `pc`
-        // green and the callee's own reds seeded by `setup_call`, exactly as
-        // a normal trace entry (`__trace_*` builds
-        // `[program(Ref), pc(Int), vable_identity(Ref)]`; setup_call packs
-        // per kind densely so program→ref0, vable→ref1, pc→int0).
-        let portal = self.frames.current_mut().jitcode.clone();
-
-        // The callee runs on a FRESH virtualizable (fresh stack, scalars
-        // zeroed).  `recursive_fresh_entry_reds` yields the extract_live
-        // image [scalars…, &state Ref, len…]; the entry argbox needs only
-        // the vable identity Ref (ref reg 1).  Its concrete shadow is real
-        // memory the inline walk reads/writes until the callee returns.
-        let (fresh_values, fresh_owner) = match sym.recursive_fresh_entry_reds() {
-            Some(pair) => pair,
-            None => return TraceAction::Abort,
-        };
-        // Reuse a STABLE fresh-callee address per driver (PORTAL_FRESH_STATE):
-        // a new leak per call would bake an iteration-varying const into the
-        // callee's recorded ops.  The shadow is re-zeroed each call, so reuse
-        // is safe.
-        let Some(fresh_ref) = fresh_values.iter().find_map(|v| match v {
-            majit_ir::Value::Ref(r) => Some(*r),
-            _ => None,
-        }) else {
-            return TraceAction::Abort;
-        };
-        let vable_ref = PORTAL_FRESH_STATE.with(|cell| {
-            let mut map = cell.borrow_mut();
-            *map.entry(jd_index).or_insert_with(|| {
-                let _: &'static mut dyn core::any::Any = Box::leak(fresh_owner);
-                fresh_ref
-            })
-        });
-        // The stable address supersedes this call's fresh Ref throughout.
-        let fresh_values: Vec<majit_ir::Value> = fresh_values
-            .into_iter()
-            .map(|v| match v {
-                majit_ir::Value::Ref(_) => majit_ir::Value::Ref(vable_ref),
-                other => other,
-            })
-            .collect();
-
-        // Entry argboxes: greens in declaration order, then the fresh vable
-        // identity.  Kind-dense packing puts the single ref green `program`
-        // in ref0 and the fresh vable in ref1, matching the compiled
-        // dispatch body's entry register layout.
-        let mut argboxes: Vec<(JitArgKind, OpRef, i64)> = Vec::with_capacity(green_srcs.len() + 1);
-        for (i, &(kind, _src)) in green_srcs.iter().enumerate() {
-            let concrete = green_values[i];
-            let opref = match kind {
-                JitArgKind::Ref => OpRef::const_ptr(majit_ir::GcRef(concrete as usize)),
-                _ => OpRef::const_int(concrete),
-            };
-            argboxes.push((kind, opref, concrete));
-        }
-        argboxes.push((
-            JitArgKind::Ref,
-            OpRef::const_ptr(vable_ref),
-            vable_ref.0 as i64,
-        ));
-
-        let mut portal_frame = MIFrame::setup(portal, 0, None, Some(ctx));
-        portal_frame.setup_call(&argboxes);
-        // Seed the callee's working state-field int registers (scalars +
-        // virt-array ptr/len) with fresh CONSTANTS.  `setup_call` only wired
-        // the greens + vable identity; the dispatch re-reads `stackpos` etc.
-        // from these int registers at the callee's offset-0 merge point, so
-        // without this seed the callee inherits the caller's promoted values.
-        sym.seed_recursive_fresh_frame(&mut portal_frame);
-        ctx.push_inline_frame((jd_index, green_pc), u32::MAX);
-        portal_frame.inline_frame = true;
-
-        // Install the callee's FRESH virtualizable as the standard vable for
-        // the duration of the inline walk (single standard vable nested across
-        // the call), saving the caller's to restore when the frame returns.
-        // `recursive_fresh_entry_reds` yields [scalars…, &state Ref, lengths…]
-        // in extract_live order: the vinfo's scalar field values, then the
-        // vable identity Ref, then one length per array field. The standard
-        // boxes want the fully flattened shape [field0…fieldN, arr0[0]…arr0[L0],
-        // arr1[0]…, vable_ref]; a fresh callee zero-fills every array element
-        // (item_type-typed zero).
-        if let Some(info) = ctx.current_virtualizable_info() {
-            let ref_pos = fresh_values
-                .iter()
-                .position(|v| matches!(v, majit_ir::Value::Ref(_)))
-                .unwrap_or(fresh_values.len());
-            let array_lengths: Vec<usize> = fresh_values[ref_pos.saturating_add(1)..]
-                .iter()
-                .map(|v| match v {
-                    majit_ir::Value::Int(n) => *n as usize,
-                    _ => 0,
-                })
-                .collect();
-            let mut vable_values: Vec<majit_ir::Value> = fresh_values[..ref_pos].to_vec();
-            for (a, &len) in array_lengths.iter().enumerate() {
-                let item_ty = info.array_fields[a].item_type;
-                for _ in 0..len {
-                    vable_values.push(super::heap_value_for_pub(item_ty, 0));
-                }
-            }
-            let vable_oprefs: Vec<OpRef> = vable_values
-                .iter()
-                .map(OpRef::const_inline_from_value)
-                .collect();
-            ctx.push_saved_virtualizable();
-            ctx.init_virtualizable_boxes(
-                &info,
-                OpRef::const_ptr(vable_ref),
-                majit_ir::Value::Ref(vable_ref),
-                &vable_oprefs,
-                &vable_values,
-                &array_lengths,
-            );
-            portal_frame.portal_vable_saved = true;
-        }
-
-        // Wire the return slot so the callee's typed return writes its
-        // result back into the caller's destination register
-        // (BC_INLINE_CALL:3348-3350).
-        match result_kind {
-            Some(JitArgKind::Int) => portal_frame.return_i = result_dst,
-            Some(JitArgKind::Ref) => portal_frame.return_r = result_dst,
-            Some(JitArgKind::Float) => portal_frame.return_f = result_dst,
-            None => {}
-        }
-
-        // Nest the shared sym's WORKING scalar/fixed-array state: the callee
-        // reads/writes it in place (dispatch.rs:2831 `BC_LOAD/STORE_STATE_FIELD`
-        // hit the single `sym`), so snapshot the caller's, reset to fresh, and
-        // restore when the frame returns (`run_one_step` pop).
-        if let Some(snapshot) = sym.snapshot_inline_scalar_state() {
-            portal_frame.portal_scalar_state = Some(snapshot);
-            sym.reset_inline_scalar_state_fresh();
-        }
-
-        self.frames.push(portal_frame);
-        TraceAction::Continue
+        // former inline re-entry path recorded a fresh per-driver callee
+        // vable identity leaked for the process lifetime — no RPython/PyPy
+        // analog (PyPy reconstructs the callee vable from resumedata per
+        // resume) — so it is removed.  This shape aborts to the clean
+        // CALL_ASSEMBLER / retry fallback until a trace-scoped rebuild lands.
+        TraceAction::Abort
     }
 
     /// pyjitpl.py:1425-1432 `do_recursive_call(assembler_call=True)` for a

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -838,6 +838,15 @@ pub trait JitCodeSym {
         self.total_slots()
     }
 
+    /// First int-bank register used as a canonical identity slot
+    /// (`int_scalar_base`). Identity slots occupy `[base, end)`; the base
+    /// keeps the dispatch JitCode's int argument registers (`pc` at i0)
+    /// out of the seeded range. Default 0 for symbols with no reserved
+    /// argument prefix; the macro-generated symbol overrides it.
+    fn int_identity_slots_base(&self) -> usize {
+        0
+    }
+
     /// Bridge state-field JIT's `__JitSym` storage onto
     /// `MIFrame.int_regs` / `int_values` ahead of guard capture.
     ///
@@ -892,6 +901,43 @@ pub trait JitCodeSym {
     /// value-mirror seeding from `JitState::initialize_sym`) is
     /// removed.
     fn populate_frame_int_regs(&self, _frame: &mut MIFrame) {}
+
+    /// [FR] Seed an INLINE recursive-portal callee frame's int register bank
+    /// with its FRESH state as compile-time CONSTANTS (scalars zeroed, virt
+    /// arrays sized at the caller's captured capacity).  The state-field
+    /// dispatch keeps each scalar (e.g. `stackpos`) in a working int register
+    /// threaded through the loop, distinct from the vable shadow; entering the
+    /// callee at offset 0 re-reads that register, so it must hold the fresh 0
+    /// rather than inheriting the caller's promoted value.  Constants (not the
+    /// input-arg OpRefs `populate_frame_int_regs` uses) because an inline
+    /// callee's fresh state is known at the call site.  Slot layout mirrors
+    /// `populate_frame_int_regs` / `live_slots_for_state_field_jit`.  Default
+    /// no-op: shapes without a fresh-entry (ref scalars / opaque carriers)
+    /// never reach the inline path.
+    fn seed_recursive_fresh_frame(&self, _frame: &mut MIFrame) {}
+
+    /// [FR] Snapshot the sym's WORKING scalar (and fixed-array) state before an
+    /// inline recursive-portal callee overwrites it.  `BC_LOAD/STORE_STATE_FIELD`
+    /// read/write the single shared sym (dispatch.rs:2831), not a per-frame
+    /// register, so an inline callee mutates the caller's live scalar state in
+    /// place; the caller's values must be saved here and restored on return.
+    /// Virt-array elements live in the vable shadow (nested separately), so only
+    /// scalars + fixed arrays are captured.  Flat `(OpRef, value)` pairs in
+    /// `state_field` then `state_array` order.  `None` default: non-state-field
+    /// syms never reach the inline path.
+    fn snapshot_inline_scalar_state(&self) -> Option<Vec<(majit_ir::OpRef, i64)>> {
+        None
+    }
+
+    /// [FR] Reset the sym's working scalar/fixed-array state to FRESH (zeroed),
+    /// so the inline callee starts from a clean state rather than inheriting the
+    /// caller's.  Paired with [`Self::snapshot_inline_scalar_state`].
+    fn reset_inline_scalar_state_fresh(&mut self) {}
+
+    /// [FR] Restore the sym's working scalar/fixed-array state from a snapshot
+    /// when the inline callee returns.  Paired with
+    /// [`Self::snapshot_inline_scalar_state`].
+    fn restore_inline_scalar_state(&mut self, _snapshot: Vec<(majit_ir::OpRef, i64)>) {}
 
     /// #184 recursive CALL_ASSEMBLER portal entry: build the fresh-frame
     /// reds for a recursive callee run.
@@ -1029,6 +1075,31 @@ pub trait JitCodeRuntime {
     ) -> Option<i64> {
         None
     }
+}
+
+/// [FR] WIP gate for the state-field recursive-portal Inline re-entry rework.
+/// OFF by default: the state-field `portal_jitcode`-None path keeps its
+/// clean-abort fallback so existing consumers are unaffected. Set
+/// `MAJIT_PORTAL_INLINE=1` to exercise the experimental inline path.
+pub(crate) fn portal_inline_experiment_enabled() -> bool {
+    static ENABLED: std::sync::LazyLock<bool> =
+        std::sync::LazyLock::new(|| std::env::var_os("MAJIT_PORTAL_INLINE").is_some());
+    *ENABLED
+}
+
+thread_local! {
+    /// [FR-EXPERIMENT] One stable fresh-callee state per jitdriver, keyed by
+    /// `jd_index`.  A recursive-portal INLINE call re-uses this address as the
+    /// callee's vable identity so the const does not vary across unroll
+    /// iterations (a fresh leak per call bakes an iteration-varying const into
+    /// the callee's recorded ops and the loop never matches a prior iteration).
+    /// The callee's shadow is re-zeroed from `recursive_fresh_entry_reds` each
+    /// call, so re-using one backing object is safe.  Owners are leaked into
+    /// this map to keep the address valid for the process (experiment; a
+    /// trace-scoped arena is the follow-up).
+    static PORTAL_FRESH_STATE: std::cell::RefCell<
+        std::collections::HashMap<usize, majit_ir::GcRef>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
 pub struct ClosureRuntime<FLabel> {
@@ -1430,6 +1501,7 @@ where
                 &virtualizable_snapshot,
                 &virtualref_snapshot,
                 identity_const,
+                Some((sym.int_identity_slots_base(), sym.int_identity_slots_end())),
             );
             for idx in 0..n {
                 // RPython pyjitpl.py:180-193 leaves the parent frame's
@@ -1826,11 +1898,24 @@ where
         crate::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(0));
     }
 
-    fn pop_exception_frame(&mut self, ctx: &mut TraceCtx) {
+    /// Pop the current frame during a return / exception unwind.  Restores
+    /// the caller's nested standard vable (installed by a recursive-portal
+    /// INLINE frame on push) and returns the frame's nested sym scalar-state
+    /// snapshot, if any, so a `sym`-holding caller can restore it (this
+    /// method has no `sym` in scope).
+    fn pop_exception_frame(&mut self, ctx: &mut TraceCtx) -> Option<Vec<(OpRef, i64)>> {
         if let Some(frame) = self.frames.pop() {
             if frame.inline_frame {
                 ctx.pop_inline_frame();
             }
+            // [FR] A recursive-portal INLINE frame installed its callee's
+            // fresh standard vable on push; restore the caller's on return.
+            if frame.portal_vable_saved {
+                ctx.restore_saved_virtualizable();
+            }
+            frame.portal_scalar_state
+        } else {
+            None
         }
     }
 
@@ -2379,57 +2464,171 @@ where
             // (pyjitpl.py falls to `do_residual_call`; pyre retries).
             return TraceAction::Abort;
         }
-        let portal = match runtime.portal_jitcode(jd_index) {
-            Some(portal) => portal,
+        // pc-aligned portal runtimes (dispatch.rs test fixtures) wire
+        // `portal_jitcode`; enter their portal at `green_pc` as before.
+        if let Some(portal) = runtime.portal_jitcode(jd_index) {
+            let mut portal_frame = MIFrame::setup(portal, green_pc, None, Some(ctx));
+            portal_frame.code_cursor = green_pc;
+            ctx.push_inline_frame((jd_index, green_pc), u32::MAX);
+            portal_frame.inline_frame = true;
+            for (kind, caller_src, callee_dst) in arg_triples {
+                match kind {
+                    JitArgKind::Int => {
+                        let (value, concrete) = self.read_int_reg(caller_src);
+                        portal_frame.int_regs[callee_dst] = Some(value);
+                        portal_frame.int_values[callee_dst] = Some(concrete);
+                    }
+                    JitArgKind::Ref => {
+                        let (value, concrete) = self.read_ref_reg(caller_src);
+                        portal_frame.ref_regs[callee_dst] = Some(value);
+                        portal_frame.ref_values[callee_dst] = Some(concrete);
+                    }
+                    JitArgKind::Float => {
+                        let (value, concrete) = self.read_float_reg(caller_src);
+                        portal_frame.float_regs[callee_dst] = Some(value);
+                        portal_frame.float_values[callee_dst] = Some(concrete);
+                    }
+                }
+            }
+            match result_kind {
+                Some(JitArgKind::Int) => portal_frame.return_i = result_dst,
+                Some(JitArgKind::Ref) => portal_frame.return_r = result_dst,
+                Some(JitArgKind::Float) => portal_frame.return_f = result_dst,
+                None => {}
+            }
+            self.frames.push(portal_frame);
+            return TraceAction::Continue;
+        }
+
+        // State-field production runtime leaves `portal_jitcode` None.  The
+        // Inline path for that shape is the [FR] re-entry rework, WIP and
+        // gated OFF by default so existing consumers keep the clean-abort
+        // fallback (dispatch.rs:2412 legacy behavior).
+        if !portal_inline_experiment_enabled() {
+            return TraceAction::Abort;
+        }
+
+        // [FR] State-field recursive-portal INLINE.  The portal jitcode is
+        // the dispatch-body jitcode currently being traced (one jitcode per
+        // program; self-recursion and same-program leaf calls re-enter the
+        // same body at a different interpreter pc).  The state-field body is
+        // entered at offset 0 with the interpreter pc carried as the `pc`
+        // green and the callee's own reds seeded by `setup_call`, exactly as
+        // a normal trace entry (`__trace_*` builds
+        // `[program(Ref), pc(Int), vable_identity(Ref)]`; setup_call packs
+        // per kind densely so program→ref0, vable→ref1, pc→int0).
+        let portal = self.frames.current_mut().jitcode.clone();
+
+        // The callee runs on a FRESH virtualizable (fresh stack, scalars
+        // zeroed).  `recursive_fresh_entry_reds` yields the extract_live
+        // image [scalars…, &state Ref, len…]; the entry argbox needs only
+        // the vable identity Ref (ref reg 1).  Its concrete shadow is real
+        // memory the inline walk reads/writes until the callee returns.
+        let (fresh_values, fresh_owner) = match sym.recursive_fresh_entry_reds() {
+            Some(pair) => pair,
             None => return TraceAction::Abort,
         };
+        // Reuse a STABLE fresh-callee address per driver (PORTAL_FRESH_STATE):
+        // a new leak per call would bake an iteration-varying const into the
+        // callee's recorded ops.  The shadow is re-zeroed each call, so reuse
+        // is safe.
+        let Some(fresh_ref) = fresh_values.iter().find_map(|v| match v {
+            majit_ir::Value::Ref(r) => Some(*r),
+            _ => None,
+        }) else {
+            return TraceAction::Abort;
+        };
+        let vable_ref = PORTAL_FRESH_STATE.with(|cell| {
+            let mut map = cell.borrow_mut();
+            *map.entry(jd_index).or_insert_with(|| {
+                let _: &'static mut dyn core::any::Any = Box::leak(fresh_owner);
+                fresh_ref
+            })
+        });
+        // The stable address supersedes this call's fresh Ref throughout.
+        let fresh_values: Vec<majit_ir::Value> = fresh_values
+            .into_iter()
+            .map(|v| match v {
+                majit_ir::Value::Ref(_) => majit_ir::Value::Ref(vable_ref),
+                other => other,
+            })
+            .collect();
 
-        // Build the portal frame entering at `green_pc`.  `code_cursor`
-        // must be set explicitly because `MIFrame::new` always starts the
-        // cursor at 0 regardless of the entry pc.
-        //
-        // NOTE: this `code_cursor = green_pc` entry models a *pc-aligned*
-        // portal jitcode (one jitcode per interpreter pc, the full-portal
-        // shape `opimpl_recursive_call` assumes).  The `#[jit_interp]`
-        // state-field JIT instead compiles a single dispatch-body jitcode
-        // entered at offset 0 with the interpreter pc carried as a
-        // green/red value (`trace_jitcode_with_args_and_runtime` resets
-        // `frame.pc = 0` via `setup_call` and tracks the interpreter pc as
-        // `outer_program_pc`).  For that shape this frame setup must instead
-        // enter at offset 0, seed the dispatch body's `program` / `pc` /
-        // fresh-vable reds, and let the inline-frame merge point walk the
-        // callee opcodes to its RETURN.  The state-field production runtime
-        // (`ClosureRuntimeWithResolver`) therefore leaves `portal_jitcode`
-        // at the `None` default so this path aborts cleanly (graceful
-        // interpreter fallback) until that re-entry rework lands; the
-        // pc-aligned form below is exercised only by pc-aligned-portal
-        // runtimes.
-        let mut portal_frame = MIFrame::setup(portal, green_pc, None, Some(ctx));
-        portal_frame.code_cursor = green_pc;
+        // Entry argboxes: greens in declaration order, then the fresh vable
+        // identity.  Kind-dense packing puts the single ref green `program`
+        // in ref0 and the fresh vable in ref1, matching the compiled
+        // dispatch body's entry register layout.
+        let mut argboxes: Vec<(JitArgKind, OpRef, i64)> = Vec::with_capacity(green_srcs.len() + 1);
+        for (i, &(kind, _src)) in green_srcs.iter().enumerate() {
+            let concrete = green_values[i];
+            let opref = match kind {
+                JitArgKind::Ref => OpRef::const_ptr(majit_ir::GcRef(concrete as usize)),
+                _ => OpRef::const_int(concrete),
+            };
+            argboxes.push((kind, opref, concrete));
+        }
+        argboxes.push((
+            JitArgKind::Ref,
+            OpRef::const_ptr(vable_ref),
+            vable_ref.0 as i64,
+        ));
+
+        let mut portal_frame = MIFrame::setup(portal, 0, None, Some(ctx));
+        portal_frame.setup_call(&argboxes);
+        // Seed the callee's working state-field int registers (scalars +
+        // virt-array ptr/len) with fresh CONSTANTS.  `setup_call` only wired
+        // the greens + vable identity; the dispatch re-reads `stackpos` etc.
+        // from these int registers at the callee's offset-0 merge point, so
+        // without this seed the callee inherits the caller's promoted values.
+        sym.seed_recursive_fresh_frame(&mut portal_frame);
         ctx.push_inline_frame((jd_index, green_pc), u32::MAX);
         portal_frame.inline_frame = true;
 
-        for (kind, caller_src, callee_dst) in arg_triples {
-            match kind {
-                JitArgKind::Int => {
-                    let (value, concrete) = self.read_int_reg(caller_src);
-                    portal_frame.int_regs[callee_dst] = Some(value);
-                    portal_frame.int_values[callee_dst] = Some(concrete);
-                }
-                JitArgKind::Ref => {
-                    let (value, concrete) = self.read_ref_reg(caller_src);
-                    portal_frame.ref_regs[callee_dst] = Some(value);
-                    portal_frame.ref_values[callee_dst] = Some(concrete);
-                }
-                JitArgKind::Float => {
-                    let (value, concrete) = self.read_float_reg(caller_src);
-                    portal_frame.float_regs[callee_dst] = Some(value);
-                    portal_frame.float_values[callee_dst] = Some(concrete);
+        // Install the callee's FRESH virtualizable as the standard vable for
+        // the duration of the inline walk (single standard vable nested across
+        // the call), saving the caller's to restore when the frame returns.
+        // `recursive_fresh_entry_reds` yields [scalars…, &state Ref, lengths…]
+        // in extract_live order: the vinfo's scalar field values, then the
+        // vable identity Ref, then one length per array field. The standard
+        // boxes want the fully flattened shape [field0…fieldN, arr0[0]…arr0[L0],
+        // arr1[0]…, vable_ref]; a fresh callee zero-fills every array element
+        // (item_type-typed zero).
+        if let Some(info) = ctx.current_virtualizable_info() {
+            let ref_pos = fresh_values
+                .iter()
+                .position(|v| matches!(v, majit_ir::Value::Ref(_)))
+                .unwrap_or(fresh_values.len());
+            let array_lengths: Vec<usize> = fresh_values[ref_pos.saturating_add(1)..]
+                .iter()
+                .map(|v| match v {
+                    majit_ir::Value::Int(n) => *n as usize,
+                    _ => 0,
+                })
+                .collect();
+            let mut vable_values: Vec<majit_ir::Value> = fresh_values[..ref_pos].to_vec();
+            for (a, &len) in array_lengths.iter().enumerate() {
+                let item_ty = info.array_fields[a].item_type;
+                for _ in 0..len {
+                    vable_values.push(super::heap_value_for_pub(item_ty, 0));
                 }
             }
+            let vable_oprefs: Vec<OpRef> = vable_values
+                .iter()
+                .map(OpRef::const_inline_from_value)
+                .collect();
+            ctx.push_saved_virtualizable();
+            ctx.init_virtualizable_boxes(
+                &info,
+                OpRef::const_ptr(vable_ref),
+                majit_ir::Value::Ref(vable_ref),
+                &vable_oprefs,
+                &vable_values,
+                &array_lengths,
+            );
+            portal_frame.portal_vable_saved = true;
         }
 
-        // Wire the return slot so the portal's `*_return` writes its
+        // Wire the return slot so the callee's typed return writes its
         // result back into the caller's destination register
         // (BC_INLINE_CALL:3348-3350).
         match result_kind {
@@ -2437,6 +2636,15 @@ where
             Some(JitArgKind::Ref) => portal_frame.return_r = result_dst,
             Some(JitArgKind::Float) => portal_frame.return_f = result_dst,
             None => {}
+        }
+
+        // Nest the shared sym's WORKING scalar/fixed-array state: the callee
+        // reads/writes it in place (dispatch.rs:2831 `BC_LOAD/STORE_STATE_FIELD`
+        // hit the single `sym`), so snapshot the caller's, reset to fresh, and
+        // restore when the frame returns (`run_one_step` pop).
+        if let Some(snapshot) = sym.snapshot_inline_scalar_state() {
+            portal_frame.portal_scalar_state = Some(snapshot);
+            sym.reset_inline_scalar_state_fresh();
         }
 
         self.frames.push(portal_frame);
@@ -2633,6 +2841,14 @@ where
             let finished_frame = self.frames.pop().expect("finished frame stack was empty");
             if finished_frame.inline_frame {
                 ctx.pop_inline_frame();
+            }
+            // [FR] Restore the caller's sym scalar/fixed-array state that this
+            // inline recursive-portal frame overwrote, and its nested vable.
+            if let Some(snapshot) = finished_frame.portal_scalar_state.clone() {
+                sym.restore_inline_scalar_state(snapshot);
+            }
+            if finished_frame.portal_vable_saved {
+                ctx.restore_saved_virtualizable();
             }
             if let Some(parent) = self.frames.frames.last_mut() {
                 if let Some((return_kind, callee_src)) =
@@ -3712,6 +3928,55 @@ where
                     ctx, sym, opcode, lhs, rhs, taken, opcode_pc, target,
                 );
             }
+            // RPython `pyjitpl.py:598-617 opimpl_switch`: a hit promotes the
+            // switched value with GUARD_VALUE and jumps to the case target;
+            // a miss records INT_EQ + GUARD_FALSE for every ordered key and
+            // falls through to the default path after the switch.
+            jitcode::insns::BC_SWITCH => {
+                // Canonical `id` encoding (`assembler.py:165-174,
+                // 197-207`): [value:u8][descr:u16].
+                let (opcode_pc, value_idx, descr_idx) = {
+                    let frame = self.frames.current_mut();
+                    let opcode_pc = frame.code_cursor - 1;
+                    (
+                        opcode_pc,
+                        frame.next_u8() as usize,
+                        frame.next_u16() as usize,
+                    )
+                };
+                let descr = self.frames.current_mut().jitcode.exec.descrs[descr_idx]
+                    .as_bh_descr()
+                    .unwrap_or_else(|| panic!("BC_SWITCH descrs[{descr_idx}] is not a BhDescr"))
+                    .clone();
+                let (value_box, concrete_value) = self.read_int_reg(value_idx);
+                if let Some(target) = descr.switch_lookup(concrete_value) {
+                    let const_ref = ctx.const_int(concrete_value);
+                    self.record_state_guard(
+                        ctx,
+                        sym,
+                        OpCode::GuardValue,
+                        &[value_box, const_ref],
+                        opcode_pc,
+                        false,
+                    );
+                    self.set_int_reg(value_idx, Some(const_ref), Some(concrete_value));
+                    self.frames.current_mut().code_cursor = target;
+                } else {
+                    for &key in descr.switch_const_keys_in_order() {
+                        let key_ref = ctx.const_int(key);
+                        let cond = ctx.record_op(OpCode::IntEq, &[value_box, key_ref]);
+                        ctx.set_opref_concrete(cond, majit_ir::Value::Int(0));
+                        self.record_state_guard(
+                            ctx,
+                            sym,
+                            OpCode::GuardFalse,
+                            &[cond],
+                            opcode_pc,
+                            false,
+                        );
+                    }
+                }
+            }
             jitcode::insns::BC_GOTO_IF_NOT_PTR_ISZERO
             | jitcode::insns::BC_GOTO_IF_NOT_PTR_NONZERO => {
                 // Canonical `rL` encoding: [src:u8][target:u16].
@@ -3985,6 +4250,19 @@ where
                         }
                     }
                 }
+                // [FR] pyjitpl.py:1551 `if self.metainterp.portal_call_depth:
+                // return` — a jit_merge_point reached INSIDE an inline
+                // recursive-portal callee is NOT the traced loop's header, so
+                // it is a pure no-op: skip both the auto loop-header stamp and
+                // the close protocol below.  Without this, the callee's merge
+                // point (it shares the caller's dispatch jitcode, entered at
+                // offset 0) resets `seen_loop_header_for_jdindex` to -1, and the
+                // real outer header then falls through instead of closing.  The
+                // payload cursor was already advanced above, so the callee
+                // continues to its next opcode.  Gated to the FR experiment.
+                if portal_inline_experiment_enabled() && ctx.inline_depth() > 0 {
+                    return TraceAction::Continue;
+                }
                 // pyjitpl.py:1547-1556 opimpl_jit_merge_point auto
                 // loop-header.  When `seen_loop_header_for_jdindex < 0`
                 // (no explicit `BC_LOOP_HEADER` has stamped the flag yet),
@@ -4191,13 +4469,6 @@ where
                 let mut sub_frame = MIFrame::setup(sub_jitcode, 0, None, Some(ctx));
                 ctx.push_inline_frame((sub_idx, pc), u32::MAX);
                 sub_frame.inline_frame = true;
-                // State-field-JIT multi-frame snapshot wiring: remember
-                // which descrs slot of the *parent* frame's jitcode
-                // produced this sub-jitcode so `build_state_field_snapshot`
-                // can pack it into the per-frame `SnapshotFrame.jitcode_index`
-                // (resolve_jitcode walks `parent.descrs[idx].as_jitcode()`
-                // on resume).
-                sub_frame.parent_descr_idx = sub_idx as u32;
                 for (kind, caller_src, callee_dst) in arg_triples {
                     match kind {
                         JitArgKind::Int => {
@@ -4278,7 +4549,9 @@ where
                 let src = self.frames.current_mut().next_u8() as usize;
                 let (opref, concrete) = self.read_int_reg(src);
                 let target = self.frames.current_mut().return_i;
-                self.pop_exception_frame(ctx);
+                if let Some(snapshot) = self.pop_exception_frame(ctx) {
+                    sym.restore_inline_scalar_state(snapshot);
+                }
                 if let Some(target_idx) = target {
                     debug_assert!(
                         !self.frames.is_empty(),
@@ -4307,7 +4580,9 @@ where
                 let value = self.frames.current_mut().next_u8() as i8 as i64;
                 let opref = OpRef::ConstInt(value);
                 let target = self.frames.current_mut().return_i;
-                self.pop_exception_frame(ctx);
+                if let Some(snapshot) = self.pop_exception_frame(ctx) {
+                    sym.restore_inline_scalar_state(snapshot);
+                }
                 if let Some(target_idx) = target {
                     debug_assert!(
                         !self.frames.is_empty(),
@@ -4332,7 +4607,9 @@ where
                 let src = self.frames.current_mut().next_u8() as usize;
                 let (opref, concrete) = self.read_ref_reg(src);
                 let target = self.frames.current_mut().return_r;
-                self.pop_exception_frame(ctx);
+                if let Some(snapshot) = self.pop_exception_frame(ctx) {
+                    sym.restore_inline_scalar_state(snapshot);
+                }
                 if let Some(target_idx) = target {
                     debug_assert!(
                         !self.frames.is_empty(),
@@ -4357,7 +4634,9 @@ where
                 let src = self.frames.current_mut().next_u8() as usize;
                 let (opref, concrete) = self.read_float_reg(src);
                 let target = self.frames.current_mut().return_f;
-                self.pop_exception_frame(ctx);
+                if let Some(snapshot) = self.pop_exception_frame(ctx) {
+                    sym.restore_inline_scalar_state(snapshot);
+                }
                 if let Some(target_idx) = target {
                     debug_assert!(
                         !self.frames.is_empty(),
@@ -4379,7 +4658,9 @@ where
             }
             jitcode::insns::BC_VOID_RETURN => {
                 self.clear_exception();
-                self.pop_exception_frame(ctx);
+                if let Some(snapshot) = self.pop_exception_frame(ctx) {
+                    sym.restore_inline_scalar_state(snapshot);
+                }
                 if self.frames.is_empty() {
                     // pyjitpl.py:3202 compile_done_with_this_frame exits=[];
                     // pyjitpl.rs:13136 maps empty finish_arg_types to
@@ -7257,14 +7538,12 @@ pub fn call_void_function(func_ptr: *const (), args: &[i64]) {
 /// `opencoder.py:769 _ensure_parent_resumedata`, so the in-flight inline
 /// call result register is cleared before liveness is read.
 ///
-/// `jitcode_index` mirrors RPython `resume.py:1338-1340`'s `jitcode_pos`
-/// (an index into `metainterp_sd.jitcodes`).  Per-driver pyre layout:
-/// - root frame → `0` sentinel; resume resolves through
-///   `JitDriver::dispatch_jitcode` (the singleton equivalent of
-///   `metainterp_sd.jitcodes[portal_jd.index]`).
-/// - non-root frames → `MIFrame.parent_descr_idx` (set by
-///   `BC_INLINE_CALL` at sub-frame setup); resume walks
-///   `parent.descrs[idx].as_jitcode()`.
+/// `jitcode_index` mirrors RPython `resume.py:1050/1338`'s `jitcode_pos`
+/// (an index into `metainterp_sd.jitcodes`). Every frame — root and inline —
+/// stamps its own ABSOLUTE global index (`JitCode::index`, assigned in
+/// `register_dispatch_jitcode`: root = 0, sub-JitCodes = their flat-registry
+/// slot). Resume resolves it statelessly via `jitcode_registry.get(index)`
+/// with no root/sub branch and no parent-relative `descrs` walk.
 pub fn build_state_field_snapshot(
     frames: &mut MIFrameStack,
     op_live: u8,
@@ -7273,6 +7552,7 @@ pub fn build_state_field_snapshot(
     virtualizable_boxes: &[OpRef],
     virtualref_boxes: &[(OpRef, usize)],
     identity_const: Option<i64>,
+    inline_int_identity: Option<(usize, usize)>,
 ) -> crate::recorder::Snapshot {
     let frame_count = frames.frames.len();
     let mut snapshot_frames = Vec::with_capacity(frame_count);
@@ -7287,22 +7567,25 @@ pub fn build_state_field_snapshot(
         // `after_residual_call` is propagated to the top frame only;
         // parent frames are always "in a call" relative to the top, so
         // pyjitpl.py:194-198's residual-call branch only fires once.
+        // Only NON-root (inline) frames trim their reserved identity-slot
+        // prefix to Const(0) placeholders; the root frame's identity slots
+        // are seeded and must be listed for real so the virtualizable is
+        // reconstructed once at the root.
+        let skip_int_identity = if i == 0 { None } else { inline_int_identity };
         let boxes = frame.get_list_of_active_snapshot_boxes(
             !is_top,
             /* clear_result_register */ !is_top,
             op_live,
             all_liveness,
             if is_top { after_residual_call } else { false },
+            skip_int_identity,
         );
-        let jitcode_index = if i == 0 {
-            // resume.py:1338-1340 — root frame resolves to
-            // `metainterp_sd.jitcodes[portal_jd.index]` (pyre's
-            // `JitDriver::dispatch_jitcode` singleton); the snapshot
-            // value is ignored by the resolve closure.
-            0
-        } else {
-            frame.parent_descr_idx
-        };
+        // resume.py:1050/1338 `jitcode = jitcodes[jitcode_pos]` — stamp each
+        // frame's own ABSOLUTE global jitcode index (`JitCode::index`, assigned
+        // in `register_dispatch_jitcode`: root = 0, sub-frames = their flat
+        // registry slot). The resume decoders resolve it statelessly with no
+        // root/sub branch and no parent-relative descrs walk.
+        let jitcode_index = frame.jitcode.try_index().unwrap_or(0) as u32;
         snapshot_frames.push(crate::recorder::SnapshotFrame {
             jitcode_index,
             pc: frame.pc as u32,
@@ -8458,6 +8741,105 @@ mod tests {
         );
     }
 
+    fn switch_return_jitcode() -> JitCode {
+        let mut builder = JitCodeBuilder::new();
+        let case_a = builder.new_label();
+        let case_b = builder.new_label();
+        let case_c = builder.new_label();
+        builder.switch(0, &[(-3, case_a), (7, case_b), (42, case_c)]);
+        builder.load_const_i_value(1, 10);
+        builder.int_return(1);
+        builder.mark_label(case_a);
+        builder.load_const_i_value(1, 20);
+        builder.int_return(1);
+        builder.mark_label(case_b);
+        builder.load_const_i_value(1, 30);
+        builder.int_return(1);
+        builder.mark_label(case_c);
+        builder.load_const_i_value(1, 40);
+        builder.int_return(1);
+        builder.finish()
+    }
+
+    #[test]
+    fn switch_hit_records_guard_value_and_jumps_to_case() {
+        // RPython `pyjitpl.py:598-606 opimpl_switch` hit path:
+        // promote the switched value with GUARD_VALUE, then jump to the
+        // target from SwitchDictDescr.dict.
+        let jitcode = switch_return_jitcode();
+        let mut ctx = TraceCtx::for_test(1);
+        let mut sym = DummySym::default();
+        let action = trace_jitcode_with_args(
+            &mut ctx,
+            &mut sym,
+            &jitcode,
+            0,
+            |_pc| 0,
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 7)],
+        );
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                exit_with_exception: false,
+                ..
+            } => finish_args,
+            other => panic!("expected switch hit to finish from case path, got {other:?}"),
+        };
+        assert_eq!(ctx.const_value(finish_args[0]), Some(30));
+        let recorder = ctx.into_recorder();
+        assert!(
+            recorder
+                .ops()
+                .iter()
+                .any(|op| op.opcode == OpCode::GuardValue),
+            "switch hit must promote the matched value",
+        );
+    }
+
+    #[test]
+    fn switch_miss_records_int_eq_guard_false_chain_and_falls_through() {
+        // RPython `pyjitpl.py:607-617 opimpl_switch` miss path:
+        // for each `const_keys_in_order`, emit INT_EQ plus GUARD_FALSE,
+        // then leave pc at the fall-through default path.
+        let jitcode = switch_return_jitcode();
+        let mut ctx = TraceCtx::for_test(1);
+        let mut sym = DummySym::default();
+        let action = trace_jitcode_with_args(
+            &mut ctx,
+            &mut sym,
+            &jitcode,
+            0,
+            |_pc| 0,
+            &[(JitArgKind::Int, OpRef::input_arg_int(0), 99)],
+        );
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                exit_with_exception: false,
+                ..
+            } => finish_args,
+            other => panic!("expected switch miss to finish from default path, got {other:?}"),
+        };
+        assert_eq!(ctx.const_value(finish_args[0]), Some(10));
+        let recorder = ctx.into_recorder();
+        assert_eq!(
+            recorder
+                .ops()
+                .iter()
+                .filter(|op| op.opcode == OpCode::IntEq)
+                .count(),
+            3,
+        );
+        assert_eq!(
+            recorder
+                .ops()
+                .iter()
+                .filter(|op| op.opcode == OpCode::GuardFalse)
+                .count(),
+            3,
+        );
+    }
+
     #[test]
     fn raise_catch_inline_call_routes_to_handler_and_preserves_last_exc_value() {
         // exc payload must be a valid OBJECTPTR (typeptr at offset 0) so
@@ -8885,16 +9267,17 @@ mod tests {
             &[],
             &[],
             None,
+            None,
         );
 
         assert_eq!(snapshot.frames.len(), 1);
         assert!(snapshot.vable_boxes.is_empty());
         assert!(snapshot.vref_boxes.is_empty());
         let f = &snapshot.frames[0];
-        // Root frame jitcode_index is a sentinel `0`; resume resolves
-        // through `JitDriver::dispatch_jitcode` rather than reading this
-        // value (resume.py:1338-1340).
-        assert_eq!(f.jitcode_index, 0);
+        // The snapshot stamps the frame's ABSOLUTE global jitcode index
+        // (`JitCode::index`, set to 7 above); resume resolves `jitcodes[7]`
+        // (resume.py:1050/1338).
+        assert_eq!(f.jitcode_index, 7);
         assert_eq!(f.pc, pc as u32);
         assert_eq!(
             f.boxes,
@@ -8946,6 +9329,7 @@ mod tests {
             &[],
             &[],
             None,
+            None,
         );
 
         let f = &snapshot.frames[0];
@@ -8966,7 +9350,11 @@ mod tests {
         root_builder.live(&mut asm, &[0], &[], &[]);
         let root_live_pc =
             root_builder.current_pos() - (majit_translate::liveness::OFFSET_SIZE + 1);
-        let root_jitcode = std::sync::Arc::new(root_builder.finish());
+        let root_jitcode = {
+            let jc = root_builder.finish();
+            jc.set_index(0);
+            std::sync::Arc::new(jc)
+        };
         let mut root = MIFrame::new(root_jitcode, root_live_pc);
         root.int_regs[0] = Some(majit_ir::OpRef::int_op(100));
         root.int_values[0] = Some(1000);
@@ -8979,9 +9367,15 @@ mod tests {
         sub_builder.load_const_f_value(0, 0);
         sub_builder.live(&mut asm, &[0], &[0], &[0]);
         let sub_pc = sub_builder.current_pos();
-        let sub_jitcode = std::sync::Arc::new(sub_builder.finish());
+        let sub_jitcode = {
+            let jc = sub_builder.finish();
+            // Stamp the sub-JitCode's ABSOLUTE global index; the snapshot
+            // writer reads `JitCode::index` (resume.py:1050), not the
+            // parent-relative descr slot.
+            jc.set_index(3);
+            std::sync::Arc::new(jc)
+        };
         let mut sub = MIFrame::new(sub_jitcode, sub_pc);
-        sub.parent_descr_idx = 3;
         sub.int_regs[0] = Some(majit_ir::OpRef::int_op(11));
         sub.int_values[0] = Some(110);
         sub.ref_regs[0] = Some(majit_ir::OpRef::ref_op(22));
@@ -9000,11 +9394,12 @@ mod tests {
             &[],
             &[],
             None,
+            None,
         );
         assert_eq!(snapshot.frames.len(), 2);
         let root_frame = &snapshot.frames[0];
-        // Root frame jitcode_index is a sentinel `0`; resume resolves
-        // through `JitDriver::dispatch_jitcode` (resume.py:1338-1340).
+        // Root frame stamps its ABSOLUTE global jitcode index (0 = dispatch
+        // slot); resume resolves `jitcodes[0]` (resume.py:1050/1338).
         assert_eq!(root_frame.jitcode_index, 0);
         assert_eq!(
             root_frame.boxes,
@@ -9057,6 +9452,7 @@ mod tests {
             false,
             &[],
             &[],
+            None,
             None,
         );
 

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -84,6 +84,14 @@ pub struct MIFrame {
     pub float_regs: Vec<Option<OpRef>>,
     pub float_values: Vec<Option<i64>>,
     pub inline_frame: bool,
+    /// [FR] True when this is a recursive-portal INLINE frame that installed
+    /// its callee's fresh standard virtualizable; the frame's pop restores the
+    /// caller's saved vable via `TraceCtx::restore_saved_virtualizable`.
+    pub portal_vable_saved: bool,
+    /// [FR] Saved caller sym scalar/fixed-array state for a recursive-portal
+    /// INLINE frame; restored into the shared sym when the frame returns so the
+    /// callee's in-place mutation of the single sym doesn't corrupt the caller.
+    pub portal_scalar_state: Option<Vec<(OpRef, i64)>>,
     pub return_i: Option<usize>,
     pub return_r: Option<usize>,
     pub return_f: Option<usize>,
@@ -125,22 +133,6 @@ pub struct MIFrame {
     pub parent_snapshot: i64,
     /// pyjitpl.py:95 `self.unroll_iterations = 1`.
     pub unroll_iterations: usize,
-    /// State-field-JIT multi-frame snapshot wiring.
-    ///
-    /// For frames pushed by `BC_INLINE_CALL` this holds the index into
-    /// the *parent* frame's `jitcode.descrs` array that the dispatcher
-    /// resolved into the sub-jitcode for this frame
-    /// (`pyjitpl/dispatch.rs` BC_INLINE_CALL `descrs.get(sub_idx)`). Root
-    /// frames (`trace_jitcode` portal entry) carry `u32::MAX`. The
-    /// snapshot-side `build_state_field_snapshot` packs this into
-    /// `SnapshotFrame.jitcode_index` for non-root frames, and the
-    /// resume-side `resolve_jitcode` closure uses it to walk
-    /// `parent.descrs[idx].as_jitcode()`.  RPython's equivalent is `frame.jitcode.index` —
-    /// resolvable through `metainterp_sd.jitcodes[idx]` because RPython
-    /// pre-registers every jitcode globally; per-opcode majit has no
-    /// such global registry, so the parent-relative index threads the
-    /// chain together.
-    pub parent_descr_idx: u32,
 }
 
 impl MIFrame {
@@ -176,6 +168,8 @@ impl MIFrame {
             float_regs: vec![None; regs_and_consts_f],
             float_values: vec![None; regs_and_consts_f],
             inline_frame: false,
+            portal_vable_saved: false,
+            portal_scalar_state: None,
             return_i: None,
             return_r: None,
             return_f: None,
@@ -185,7 +179,6 @@ impl MIFrame {
             pushed_box: None,
             parent_snapshot: -1,
             unroll_iterations: 1,
-            parent_descr_idx: u32::MAX,
         }
     }
 
@@ -790,6 +783,7 @@ impl MIFrame {
         op_live: u8,
         all_liveness: &[u8],
         after_residual_call: bool,
+        skip_int_identity: Option<(usize, usize)>,
     ) -> Vec<SnapshotTagged> {
         const SIZE_LIVE_OP: usize = majit_translate::liveness::OFFSET_SIZE + 1;
         use majit_translate::liveness::{LivenessIterator, decode_offset};
@@ -858,6 +852,19 @@ impl MIFrame {
             while let Some(index) = it.next() {
                 let idx = index as usize;
                 let tagged = if Some(idx) == clear_int_idx {
+                    SnapshotTagged::Const(0, Type::Int)
+                } else if skip_int_identity.is_some_and(|(b, e)| idx >= b && idx < e)
+                    && idx < num_regs_i
+                    && self.int_regs[idx].is_none()
+                {
+                    // A non-root (inline split-dispatch) frame reserves the
+                    // virtualizable identity-slot prefix int[base..end) so its
+                    // register file spans them, but the resume seeder fills only
+                    // the ROOT frame's identity slots — here they are unwritten
+                    // holes. Emit a count-preserving Const(0) placeholder (the
+                    // liveness marker's length_i is baked, so dropping would
+                    // desync the decoder); deopt re-derives the real ptr/len
+                    // from the single reconstructed root virtualizable.
                     SnapshotTagged::Const(0, Type::Int)
                 } else if idx < num_regs_i {
                     let opref = self.int_regs[idx]

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -230,6 +230,16 @@ pub struct TraceCtx {
     virtualizable_info: Option<std::sync::Arc<VirtualizableInfo>>,
     /// Lengths of each virtualizable array field, needed for flat index computation.
     virtualizable_array_lengths: Option<Vec<usize>>,
+    /// [FR] Saved standard-virtualizable state, pushed when a recursive-portal
+    /// INLINE frame installs its callee's fresh vable and popped when that
+    /// frame returns — the single standard vable nested across the inline call.
+    #[allow(clippy::type_complexity)]
+    portal_vable_saves: Vec<(
+        Option<Vec<OpRef>>,
+        Option<Vec<Value>>,
+        Option<std::sync::Arc<VirtualizableInfo>>,
+        Option<Vec<usize>>,
+    )>,
     /// Live virtualizable heap pointer (pyjitpl.py:3446 write_boxes target).
     /// Mirrored from `MetaInterp::vable_ptr` at trace/bridge-entry.  Used by
     /// `synchronize_virtualizable` to write `virtualizable_values` back to
@@ -1114,6 +1124,7 @@ impl TraceCtx {
             virtualizable_values: None,
             virtualizable_info: None,
             virtualizable_array_lengths: None,
+            portal_vable_saves: Vec::new(),
             virtualizable_heap_ptr: None,
             header_pc: 0,
             cut_inner_green_key: None,
@@ -1183,6 +1194,7 @@ impl TraceCtx {
             virtualizable_values: None,
             virtualizable_info: None,
             virtualizable_array_lengths: None,
+            portal_vable_saves: Vec::new(),
             virtualizable_heap_ptr: None,
             header_pc: 0,
             cut_inner_green_key: None,
@@ -1684,6 +1696,36 @@ impl TraceCtx {
         }
         self.virtualizable_info = Some(std::sync::Arc::new(info.clone()));
         self.virtualizable_array_lengths = Some(array_lengths.to_vec());
+    }
+
+    /// [FR] The current standard virtualizable's info (shape), if any.  A
+    /// recursive-portal INLINE callee shares the caller's vable shape (same
+    /// kernel), so it seeds its fresh vable with this same info.
+    pub fn current_virtualizable_info(&self) -> Option<std::sync::Arc<VirtualizableInfo>> {
+        self.virtualizable_info.clone()
+    }
+
+    /// [FR] Save the current standard-virtualizable state onto the portal
+    /// nesting stack, before a recursive-portal INLINE frame installs its
+    /// callee's fresh vable via `init_virtualizable_boxes`.
+    pub fn push_saved_virtualizable(&mut self) {
+        self.portal_vable_saves.push((
+            self.virtualizable_boxes.clone(),
+            self.virtualizable_values.clone(),
+            self.virtualizable_info.clone(),
+            self.virtualizable_array_lengths.clone(),
+        ));
+    }
+
+    /// [FR] Restore the caller's standard-virtualizable state when a
+    /// recursive-portal INLINE frame returns.  No-op if the stack is empty.
+    pub fn restore_saved_virtualizable(&mut self) {
+        if let Some((boxes, values, info, lengths)) = self.portal_vable_saves.pop() {
+            self.virtualizable_boxes = boxes;
+            self.virtualizable_values = values;
+            self.virtualizable_info = info;
+            self.virtualizable_array_lengths = lengths;
+        }
     }
 
     /// Collect the current virtualizable boxes (for close_loop / finish).

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -207,6 +207,81 @@ mod or_pattern {
     }
 }
 
+mod switch_dispatch {
+    use super::Bytecode;
+    use majit_metainterp::jitcode::insns::{BC_GOTO_IF_NOT_INT_EQ, BC_SWITCH};
+    use majit_metainterp::{Assembler, JitDriver};
+
+    const OP_LIT_A: u8 = 3;
+    const OP_LIT_B: u8 = 4;
+    const OP_RANGE_START: u8 = 10;
+    const OP_RANGE_END: u8 = 12;
+    const OP_END: u8 = 99;
+
+    struct SwitchDispatchState {
+        a: i64,
+    }
+
+    #[majit_macros::jit_interp(
+        state = SwitchDispatchState,
+        env = Bytecode,
+        state_fields = { a: int },
+        switch_dispatch = true,
+    )]
+    #[allow(unused_assignments, unused_variables)]
+    fn dispatch_switch_pattern(program: &Bytecode, threshold: u32) -> i64 {
+        let mut driver: JitDriver<SwitchDispatchState> = JitDriver::new(threshold);
+        let mut pc: usize = 0;
+        let mut state = SwitchDispatchState { a: 0 };
+        {
+            use majit_metainterp::JitState as _;
+            state
+                .build_meta(0, program)
+                .install_canonical_liveness(&mut driver);
+        }
+        while pc < program.len() {
+            jit_merge_point!();
+            let opcode = program[pc];
+            pc += 1;
+            match opcode {
+                OP_LIT_A | OP_LIT_B => state.a += 1,
+                OP_RANGE_START..=OP_RANGE_END => state.a += 10,
+                _ => break,
+            }
+        }
+        state.a
+    }
+
+    #[test]
+    fn switch_dispatch_lowers_match_to_single_switch() {
+        let mut asm = Assembler::new();
+        asm.set_canonical_liveness_triple(vec![0], vec![], vec![]);
+        __prebuild_jitcode_liveness_dispatch_switch_pattern(&mut asm);
+        let _ = asm.ensure_canonical_liveness_offset();
+        let dispatch_jc = __dispatch_jitcode_dispatch_switch_pattern(&mut asm, 0i64)
+            .expect("switch dispatch lower must succeed for fixture");
+        let code = &dispatch_jc.code;
+        assert_eq!(
+            code.iter().filter(|&&b| b == BC_SWITCH).count(),
+            1,
+            "switch_dispatch must emit one BC_SWITCH for the top-level dispatch; got bytes {:?}",
+            code
+        );
+        assert_eq!(
+            code.iter().filter(|&&b| b == BC_GOTO_IF_NOT_INT_EQ).count(),
+            0,
+            "switch_dispatch must not emit the old guard chain for the top-level dispatch"
+        );
+    }
+
+    #[test]
+    fn switch_dispatch_fixture_runs_literal_range_and_default() {
+        let program = [OP_LIT_A, OP_RANGE_START, OP_RANGE_END, OP_END];
+        let result = dispatch_switch_pattern(&program, 1);
+        assert_eq!(result, 21);
+    }
+}
+
 #[test]
 fn dispatch_jitcode_contains_loop_back_goto() {
     let mut asm = Assembler::new();

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -434,6 +434,8 @@ impl Assembler {
             let AssemblerDescr::PendingSwitch { cases } = descr else {
                 continue;
             };
+            let mut const_keys_in_order: Vec<i64> = cases.iter().map(|(key, _)| *key).collect();
+            const_keys_in_order.sort();
             let dict = cases
                 .iter()
                 .map(|(key, label)| {
@@ -447,7 +449,10 @@ impl Assembler {
                     (*key, target)
                 })
                 .collect();
-            *descr = AssemblerDescr::Ready(crate::jitcode::BhDescr::Switch { dict });
+            *descr = AssemblerDescr::Ready(crate::jitcode::BhDescr::Switch {
+                dict,
+                const_keys_in_order,
+            });
         }
 
         // RPython assembler.py:271-281: jitcode.setup(code, ...)
@@ -4205,7 +4210,7 @@ impl AssemblerDescrKey {
                 result_erased: calldescr.result_erased,
                 effect: EffectInfoKey::from_effect_info(&calldescr.extra_info),
             },
-            crate::jitcode::BhDescr::Switch { dict } => {
+            crate::jitcode::BhDescr::Switch { dict, .. } => {
                 let mut items: Vec<_> = dict.iter().map(|(key, value)| (*key, *value)).collect();
                 items.sort_unstable_by_key(|(key, _)| *key);
                 Self::Switch(items)

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1253,6 +1253,7 @@ pub enum BhDescr {
     /// SwitchDictDescr: maps int values to bytecode positions.
     Switch {
         dict: std::collections::HashMap<i64, usize>,
+        const_keys_in_order: Vec<i64>,
     },
     /// Virtualizable field descriptor: index into VirtualizableInfo.static_fields.
     /// NOT a byte offset — the blackhole resolves it via `vinfo.static_fields[index].offset`.
@@ -1575,8 +1576,19 @@ impl BhDescr {
     /// Lookup switch value → position.
     pub fn switch_lookup(&self, value: i64) -> Option<usize> {
         match self {
-            BhDescr::Switch { dict } => dict.get(&value).copied(),
+            BhDescr::Switch { dict, .. } => dict.get(&value).copied(),
             _ => None,
+        }
+    }
+
+    /// Ordered switch keys used by the tracer miss path.
+    pub fn switch_const_keys_in_order(&self) -> &[i64] {
+        match self {
+            BhDescr::Switch {
+                const_keys_in_order,
+                ..
+            } => const_keys_in_order,
+            _ => &[],
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3724,7 +3724,7 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
         }
         BhDescr::Call { calldescr } => make_call_descr_from_bh(calldescr),
         BhDescr::JitCode { jitcode_index, .. } => make_jitcode_descr(*jitcode_index),
-        BhDescr::Switch { dict } => Arc::new(PyreSwitchDescr::new(dict.clone())),
+        BhDescr::Switch { dict, .. } => Arc::new(PyreSwitchDescr::new(dict.clone())),
         BhDescr::VableField { index } => majit_ir::descr::vable_static_field_descr(*index as u16),
         BhDescr::VableArray { index } => majit_ir::descr::vable_array_field_descr(*index as u16),
         BhDescr::VtableMethod {


### PR DESCRIPTION
#286

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
