### PR TITLE
jit: #171 int list.append orthodox fold via SSA_to_SSI before regalloc

### DIFF
--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -665,14 +665,20 @@ impl CodeWriter {
             && graph_result_kind(rewritten_graph) == 'r'
         {
             crate::front::result_exc::widen_unit_return_to_void(rewritten_graph);
-            // Sweep the unit producers the widen just orphaned.  Clearing
-            // the returnblock args/inputargs leaves the `()` ctor (or a
-            // tail-forwarded `Ref` call result) unread; without a dead-op
-            // pass it would survive into flatten as a value the void
-            // return no longer consumes.  `rpython/translator/simplify.py`
-            // `remove_dead_links_and_setattrs` runs after exceptiontransform
-            // for the same reason — `prune_dead_phis` keeps raising/impure
-            // producers and only drops the genuinely pure dead unit shells.
+        }
+        // Sweep the orphaned unit producers of any void-returning graph.
+        // A void function's `()` value is built (a pure `ConstRefNull`
+        // after `fold_unit_variant_ctors`) but the void return never
+        // consumes it; without a dead-op pass it survives into flatten as
+        // a value regalloc must colour, colliding a register with a live
+        // parameter.  Run on every graph whose result kind is now void —
+        // both the just-widened `declared='v' && cfg='r'` case and graphs
+        // whose CFG already returns void (`cfg='v'`, e.g. `w_list_append`).
+        // `rpython/translator/simplify.py remove_dead_links_and_setattrs`
+        // runs after exceptiontransform for the same reason; `prune_dead_phis`
+        // keeps raising/impure producers and only drops genuinely pure dead
+        // shells.
+        if graph_result_kind(rewritten_graph) == 'v' {
             crate::model::prune_dead_phis(rewritten_graph);
         }
         crate::model::remove_duplicate_inputargs(rewritten_graph);

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -682,6 +682,28 @@ impl CodeWriter {
             crate::model::prune_dead_phis(rewritten_graph);
         }
         crate::model::remove_duplicate_inputargs(rewritten_graph);
+        // Re-establish SSI before register allocation.  RPython runs the
+        // codewriter on graphs the translator already converted to SSI via
+        // `SSA_to_SSI` (`simplify.py:1067`); `perform_register_allocation`
+        // (`regalloc.rs`, ported from `rpython/jit/codewriter/regalloc.py`)
+        // therefore derives cross-block liveness purely from link-threading
+        // — a value lives across a block boundary only when it is passed
+        // through an exit link's args into the successor's inputargs.  pyre's
+        // rtyper/front-end produces these model graphs in global-SSA form:
+        // a value defined in one block is referenced directly in a later
+        // block (one block per former call) without being threaded along the
+        // linear chain between them.  Without threading the colourer sees no
+        // interference between two values simultaneously live across such a
+        // chain (e.g. `w_list_append`'s `length` from `int_items.len` and
+        // `capacity` from `int_items.heap_cap`, both live into the `int_lt`
+        // capacity check) and aliases them to one register — the body
+        // miscompiles to `int_lt(cap, cap)` and always takes the resize
+        // path.  Run `SSA_to_SSI` (`model_ssa.rs`) here, after the dead-phi
+        // / duplicate-inputarg cleanups and immediately before regalloc, so
+        // every graph reaching the colourer is SSI.  Idempotent on graphs
+        // already in SSI form (empty pending set), so non-split graphs are
+        // unaffected.
+        crate::model_ssa::ssa_to_ssi(rewritten_graph);
         let mut regallocs = crate::codewriter::transform_profile::time_phase(
             "step2_perform_all_register_allocations",
             || crate::regalloc::perform_all_register_allocations(rewritten_graph),

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3206,6 +3206,104 @@ impl<'a> Transformer<'a> {
                     }],
                 )
             }
+            // Object-strategy storage leaves. The live length is the
+            // `W_ListObject.length` header; the items live behind the
+            // `items` GcArray block (`Ptr(GcArray(OBJECTPTR))`) whose
+            // offset-0 length header IS the allocated capacity. Element
+            // stores are GC-ref writes, so the array store lowers to
+            // `setarrayitem_gc_r` (write barrier carried by the resop).
+            "list.obj_len" => {
+                let l = args.first()?.clone();
+                (
+                    "list.obj_len → getfield_gc_i(length)",
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind: OpKind::FieldRead {
+                            base: l,
+                            field: FieldDescriptor::new("length", Some(LIST_OWNER.to_string())),
+                            ty: ValueType::Int,
+                            pure: false,
+                        },
+                    }],
+                )
+            }
+            "list.obj_capacity" => {
+                let l = args.first()?.clone();
+                let block = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+                (
+                    "list.obj_capacity → getfield_gc_r(items) + getfield_gc_i(block.capacity)",
+                    vec![
+                        SpaceOperation {
+                            result: Some(block.clone()),
+                            kind: OpKind::FieldRead {
+                                base: l,
+                                field: FieldDescriptor::new("items", Some(LIST_OWNER.to_string())),
+                                ty: ValueType::Ref(None),
+                                pure: false,
+                            },
+                        },
+                        SpaceOperation {
+                            result: op.result.clone(),
+                            kind: OpKind::FieldRead {
+                                base: block,
+                                field: FieldDescriptor::new(
+                                    "capacity",
+                                    Some("ItemsBlock".to_string()),
+                                ),
+                                ty: ValueType::Int,
+                                pure: false,
+                            },
+                        },
+                    ],
+                )
+            }
+            "list.obj_set_len" => {
+                let l = args.first()?.clone();
+                let n = args.get(1)?.clone();
+                (
+                    "list.obj_set_len → setfield_gc_i(length)",
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind: OpKind::FieldWrite {
+                            base: l,
+                            field: FieldDescriptor::new("length", Some(LIST_OWNER.to_string())),
+                            value: crate::model::LinkArg::Value(n),
+                            ty: ValueType::Int,
+                        },
+                    }],
+                )
+            }
+            "list.obj_setitem" => {
+                let l = args.first()?.clone();
+                let index = args.get(1)?.clone();
+                let value = args.get(2)?.clone();
+                let block = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+                (
+                    "list.obj_setitem → getfield_gc_r(items) + setarrayitem_gc_r",
+                    vec![
+                        SpaceOperation {
+                            result: Some(block.clone()),
+                            kind: OpKind::FieldRead {
+                                base: l,
+                                field: FieldDescriptor::new("items", Some(LIST_OWNER.to_string())),
+                                ty: ValueType::Ref(None),
+                                pure: false,
+                            },
+                        },
+                        SpaceOperation {
+                            result: op.result.clone(),
+                            kind: OpKind::ArrayWrite {
+                                base: block,
+                                index,
+                                value: crate::model::LinkArg::Value(value),
+                                item_ty: ValueType::Ref(None),
+                                array_type_id: None,
+                                nolength: false,
+                            },
+                        },
+                    ],
+                )
+            }
             _ => return None,
         };
         self.notes.push(GraphTransformNote {

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -34,6 +34,7 @@ pub mod hints;
 pub mod inline;
 pub mod layout;
 pub mod model;
+pub mod model_ssa;
 pub mod opcode_dispatch;
 mod parse;
 pub mod pipeline;

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3263,13 +3263,33 @@ pub fn prune_dead_phis(graph: &mut FunctionGraph) {
         .iter()
         .flat_map(|b| b.exits.iter().map(|e| e.target))
         .collect();
+    // A no-predecessor block is a legitimate calling-convention entry
+    // only when every inputarg is a genuine parameter — the result of
+    // an `OpKind::Input` op in that same block (the closure-entry shape
+    // exercised by `prune_dead_phis_skips_non_canonical_entry_blocks`).
+    // jtransform can leave *unreachable* merge blocks whose inputargs
+    // are phi targets referencing values defined in reachable blocks; a
+    // phi with no predecessor to fill it is malformed, and pinning such
+    // a block as an entry would keep its dead operands (and any value
+    // sharing their register) alive into regalloc.  Restrict the
+    // orphan-entry roots to genuine parameter blocks so dead merge
+    // blocks are excluded.
+    let is_genuine_entry = |block: &Block| -> bool {
+        block.inputargs.iter().all(|iarg| {
+            block.operations.iter().any(|op| {
+                matches!(op.kind, OpKind::Input { .. }) && op.result.as_ref() == Some(iarg)
+            })
+        })
+    };
     let start_blocks: HashSet<BlockId> = std::iter::once(start)
         .chain(
             graph
                 .blocks
                 .iter()
-                .map(|b| b.id)
-                .filter(|id| !with_predecessor.contains(id)),
+                .filter(|b| {
+                    b.id != start && !with_predecessor.contains(&b.id) && is_genuine_entry(b)
+                })
+                .map(|b| b.id),
         )
         .collect();
 

--- a/majit/majit-translate/src/model_ssa.rs
+++ b/majit/majit-translate/src/model_ssa.rs
@@ -1,0 +1,356 @@
+//! `crate::model` (codewriter graph) port of RPython
+//! `rpython/translator/backendopt/ssa.py` `SSA_to_SSI` plus the
+//! `DataFlowFamilyBuilder.complete` family computation it relies on.
+//!
+//! The flowspace-model port of the same algorithm lives in
+//! [`crate::translator::backendopt::ssa`].  The codewriter pipeline,
+//! however, operates on the separate index-based
+//! [`crate::model::FunctionGraph`] — Spine A's `transform_graph_to_jitcode`
+//! receives one directly and Spine B's `jtransform_opname::lower_graph`
+//! produces one — so the same conversion is re-expressed here against
+//! that representation.  Both share the underlying
+//! [`crate::flowspace::model::Variable`] identity (`id`-keyed `Eq`/`Hash`),
+//! so the `UnionFind` families behave identically.
+//!
+//! ```python
+//! def SSA_to_SSI(graph, annotator=None):
+//!     entrymap = mkentrymap(graph)
+//!     del entrymap[graph.startblock]
+//!     variable_families = DataFlowFamilyBuilder(graph).get_variable_families()
+//!     pending = []
+//!     for block in graph.iterblocks():
+//!         if block not in entrymap: continue
+//!         variables_created = variables_created_in(block)
+//!         seen = set(variables_created)
+//!         variables_used = [used-but-not-created vars, in order]
+//!         for v in variables_used:
+//!             if isinstance(v, Variable) and v._name not in
+//!                     ('last_exception_', 'last_exc_value_'):
+//!                 pending.append((block, v))
+//!     while pending:
+//!         block, v = pending.pop()
+//!         v_rep = variable_families.find_rep(v)
+//!         if v in variables_created_in(block): continue
+//!         for w in variables_created:
+//!             if variable_families.find_rep(w) is v_rep:
+//!                 block.renamevariables({v: w}); break
+//!         else:
+//!             w = v.copy()
+//!             variable_families.union(v, w)
+//!             block.renamevariables({v: w})
+//!             block.inputargs.append(w)
+//!             for link in entrymap[block]:
+//!                 link.args.append(v); pending.append((link.prevblock, v))
+//! ```
+//!
+//! Every iteration that touches a `HashMap`/`HashSet` is ordered through
+//! [`FunctionGraph::iterblocks_order`] (block-id order) or a `Vec` so the
+//! pass is deterministic — the build-time codegen cache keys on output
+//! content, and non-deterministic `union` order would change the family
+//! representatives the reuse search picks.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::flowspace::model::Variable;
+use crate::model::{BlockId, ExitSwitch, FunctionGraph, LinkArg, SpaceOperation};
+use crate::tool::algo::unionfind::UnionFind;
+
+/// Incoming-link index: `target -> [(prevblock, exit index in prevblock.exits)]`.
+///
+/// RPython `mkentrymap` returns `{block: [Link, ...]}`; pyre's `Link`s
+/// are owned inside `prevblock.exits`, so an incoming link is addressed
+/// by its `(prevblock, index)` pair, which stays valid for the lifetime
+/// of the pass (`SSA_to_SSI` only appends to `inputargs` / `link.args`,
+/// never reorders blocks or exits).
+type EntryMap = HashMap<BlockId, Vec<(BlockId, usize)>>;
+
+/// RPython `mkentrymap(graph)` then `del entrymap[graph.startblock]`
+/// (`ssa.py:141-142`).  Scans every block's exits; the startblock has no
+/// real incoming edge, so removing it matches upstream's delete.
+fn build_entrymap(graph: &FunctionGraph) -> EntryMap {
+    let mut map: EntryMap = HashMap::new();
+    for src in graph.iterblocks_order() {
+        let exits_len = graph.block(src).exits.len();
+        for idx in 0..exits_len {
+            let target = graph.block(src).exits[idx].target;
+            map.entry(target).or_default().push((src, idx));
+        }
+    }
+    map.remove(&graph.startblock);
+    map
+}
+
+/// One `DataFlowFamilyBuilder` unification opportunity: a block input
+/// variable grouped with the matching nth arg of each incoming link.
+struct Opportunity {
+    inputvar: Variable,
+    linkvars: Vec<Variable>,
+}
+
+/// RPython `DataFlowFamilyBuilder(graph).get_variable_families()`
+/// (`ssa.py:4-90`), restricted to the `complete()` pass (`SSA_to_SSI`
+/// never needs `merge_identical_phi_nodes`).
+///
+/// Opportunities with any `Constant` link arg are dropped — upstream
+/// routes them to `opportunities_with_const`, which `complete()` skips.
+fn compute_variable_families(
+    graph: &FunctionGraph,
+    entrymap: &EntryMap,
+) -> UnionFind<Variable, ()> {
+    let mut opportunities: Vec<Opportunity> = Vec::new();
+    // Iterate targets in block-id order (deterministic) rather than over
+    // `entrymap`'s `HashMap` order.
+    for target in graph.iterblocks_order() {
+        let Some(links) = entrymap.get(&target) else {
+            continue;
+        };
+        let inputargs = graph.block(target).inputargs.clone();
+        for (n, inputvar) in inputargs.iter().enumerate() {
+            let mut linkvars: Vec<Variable> = Vec::with_capacity(links.len());
+            let mut has_const = false;
+            for &(src, idx) in links {
+                match graph.block(src).exits[idx].args.get(n) {
+                    Some(LinkArg::Value(v)) => linkvars.push(v.clone()),
+                    // Constant arg → upstream `opportunities_with_const`;
+                    // arity mismatch (a global-SSA link with fewer args
+                    // than the target has inputargs) likewise can't form
+                    // a Variable opportunity.
+                    Some(LinkArg::Const(_)) | None => has_const = true,
+                }
+            }
+            if !has_const && linkvars.len() == links.len() {
+                opportunities.push(Opportunity {
+                    inputvar: inputvar.clone(),
+                    linkvars,
+                });
+            }
+        }
+    }
+
+    let mut families: UnionFind<Variable, ()> = UnionFind::new(|_: &Variable| ());
+    // RPython `complete()`: union to a fixpoint.
+    let mut progress = true;
+    while progress {
+        progress = false;
+        let mut pending: Vec<Opportunity> = Vec::new();
+        for opp in std::mem::take(&mut opportunities) {
+            let mut repvars: Vec<Variable> = Vec::with_capacity(1 + opp.linkvars.len());
+            repvars.push(families.find_rep(opp.inputvar.clone()));
+            for v in &opp.linkvars {
+                repvars.push(families.find_rep(v.clone()));
+            }
+            // Insertion-ordered unique reps (RPython `dict.fromkeys`).
+            let mut unique: Vec<Variable> = Vec::new();
+            let mut seen: HashSet<Variable> = HashSet::new();
+            for v in &repvars {
+                if seen.insert(v.clone()) {
+                    unique.push(v.clone());
+                }
+            }
+            match unique.len() {
+                n if n > 2 => {
+                    // Recycle with representatives (RPython
+                    // `pending_opportunities.append(vars[:1] + repvars)`).
+                    let inputvar = repvars[0].clone();
+                    let linkvars = repvars[1..].to_vec();
+                    pending.push(Opportunity { inputvar, linkvars });
+                }
+                2 => {
+                    families.union(unique[0].clone(), unique[1].clone());
+                    progress = true;
+                }
+                _ => {}
+            }
+        }
+        opportunities = pending;
+    }
+    families
+}
+
+/// RPython `variables_created_in(block)` (`ssa.py:128-132`): inputargs
+/// plus every op result.
+fn variables_created_in(graph: &FunctionGraph, id: BlockId) -> HashSet<Variable> {
+    let b = graph.block(id);
+    let mut s: HashSet<Variable> = HashSet::with_capacity(b.inputargs.len() + b.operations.len());
+    for v in &b.inputargs {
+        s.insert(v.clone());
+    }
+    for op in &b.operations {
+        if let Some(r) = &op.result {
+            s.insert(r.clone());
+        }
+    }
+    s
+}
+
+/// RPython `Block.renamevariables({v: w})` (`flowspace/model.py:238-244`)
+/// specialised to a single `v -> w` rewrite: rewrites every variable
+/// occurrence in `id`'s inputargs, op args/results, exitswitch, and exit
+/// link args.  `v` is a used-but-not-created variable, so it appears only
+/// in uses; rewriting the definition slots too is a harmless no-op that
+/// keeps the call line-for-line with upstream's "rename everywhere".
+fn renamevariables(graph: &mut FunctionGraph, id: BlockId, v: &Variable, w: &Variable) {
+    let remap = |x: &Variable| -> Variable { if x == v { w.clone() } else { x.clone() } };
+    let (new_inputargs, new_ops, new_switch, new_exits) = {
+        let b = graph.block(id);
+        let new_inputargs: Vec<Variable> = b.inputargs.iter().map(|x| remap(x)).collect();
+        let new_ops: Vec<SpaceOperation> = b
+            .operations
+            .iter()
+            .map(|op| SpaceOperation {
+                result: op.result.as_ref().map(|r| remap(r)),
+                kind: crate::inline::remap_op_kind(&op.kind, &remap),
+            })
+            .collect();
+        let (switch, exits) =
+            crate::model::remap_control_flow_metadata_var(&b.exitswitch, &b.exits, &remap, |blk| {
+                blk
+            });
+        (new_inputargs, new_ops, switch, exits)
+    };
+    let bm = graph.block_mut(id);
+    bm.inputargs = new_inputargs;
+    bm.operations = new_ops;
+    bm.exitswitch = new_switch;
+    bm.exits = new_exits;
+}
+
+/// RPython `SSA_to_SSI(graph)` (`ssa.py:135-196`) against the codewriter
+/// model graph.  Threads every used-but-not-created variable up its
+/// incoming links until it reaches a block that already defines a value
+/// in the same family, restoring the SSI invariant the register
+/// allocator (`regalloc.rs`) assumes.  Idempotent on graphs already in
+/// SSI form: their per-block used-set is a subset of the created-set, so
+/// `pending` starts empty.
+pub fn ssa_to_ssi(graph: &mut FunctionGraph) {
+    let entrymap = build_entrymap(graph);
+    let mut families = compute_variable_families(graph, &entrymap);
+
+    // Initial pending list (ssa.py:147-169): used-but-not-created vars
+    // per non-start block, in block-id then in-block order.
+    let mut pending: Vec<(BlockId, Variable)> = Vec::new();
+    for id in graph.iterblocks_order() {
+        if !entrymap.contains_key(&id) {
+            continue;
+        }
+        let created = variables_created_in(graph, id);
+        let mut seen = created.clone();
+        let mut used: Vec<Variable> = Vec::new();
+        {
+            let b = graph.block(id);
+            for op in &b.operations {
+                for arg in crate::inline::op_variable_refs(&op.kind) {
+                    if seen.insert(arg.clone()) {
+                        used.push(arg);
+                    }
+                }
+            }
+            match &b.exitswitch {
+                Some(ExitSwitch::Value(var)) => {
+                    if seen.insert(var.clone()) {
+                        used.push(var.clone());
+                    }
+                }
+                Some(ExitSwitch::Fused { args, .. }) => {
+                    for a in args {
+                        if seen.insert(a.clone()) {
+                            used.push(a.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
+            for link in &b.exits {
+                for arg in &link.args {
+                    if let LinkArg::Value(var) = arg {
+                        if seen.insert(var.clone()) {
+                            used.push(var.clone());
+                        }
+                    }
+                }
+            }
+        }
+        for v in used {
+            // upstream skips the raw exception metadata variables; in the
+            // model graph those travel through `Link.last_exception` /
+            // `last_exc_value` (not collected above), so this filter is a
+            // defensive parity guard.
+            let prefix = v.name_prefix();
+            if prefix == "last_exception_" || prefix == "last_exc_value_" {
+                continue;
+            }
+            pending.push((id, v));
+        }
+    }
+
+    // Already in SSI form (the common case for graphs whose blocks all
+    // define what they use): nothing to thread, no snapshot needed.
+    if pending.is_empty() {
+        return;
+    }
+
+    // RPython only runs `SSA_to_SSI` on well-formed graphs, where every
+    // used variable is defined on all incoming paths, so threading always
+    // terminates at the defining block.  pyre, however, reaches this pass
+    // with graphs lowered from Charon MIR that can carry a genuinely
+    // undefined operand (the build logs them as "adapter invariant broken
+    // … every referenced operand must be defined as a block inputarg or op
+    // result"); threading such a variable walks off the top of the graph to
+    // the startblock, which has no incoming link to receive it.  Upstream
+    // would `KeyError` on `entrymap[startblock]`; instead, treat that as the
+    // signal that this graph violates the SSI precondition and leave it
+    // exactly as it was — the same already-degenerate jitcode the previous
+    // (pre-threading) pipeline produced, with no regression.  Well-formed
+    // graphs (e.g. `w_list_append`) thread to completion and are kept.
+    let snapshot = graph.clone();
+    let mut bailed = false;
+
+    while let Some((id, v)) = pending.pop() {
+        let v_rep = families.find_rep(v.clone());
+        let created = variables_created_in(graph, id);
+        if created.contains(&v) {
+            continue;
+        }
+        // Reuse a same-family value the block already defines.  Search a
+        // deterministic order (inputargs then op results) rather than the
+        // `HashSet` so codegen output is stable.
+        let mut matched: Option<Variable> = None;
+        {
+            let b = graph.block(id);
+            'find: for w in b
+                .inputargs
+                .iter()
+                .chain(b.operations.iter().filter_map(|op| op.result.as_ref()))
+            {
+                if families.find_rep(w.clone()) == v_rep {
+                    matched = Some(w.clone());
+                    break 'find;
+                }
+            }
+        }
+        if let Some(w) = matched {
+            renamevariables(graph, id, &v, &w);
+        } else {
+            let Some(links) = entrymap.get(&id).cloned() else {
+                // Undefined operand: threading reached a block with no
+                // incoming link.  Abandon the transform for this graph.
+                bailed = true;
+                break;
+            };
+            let w = v.copy();
+            families.union(v.clone(), w.clone());
+            renamevariables(graph, id, &v, &w);
+            graph.block_mut(id).inputargs.push(w);
+            for (src, idx) in links {
+                graph.block_mut(src).exits[idx]
+                    .args
+                    .push(LinkArg::Value(v.clone()));
+                pending.push((src, v.clone()));
+            }
+        }
+    }
+
+    if bailed {
+        *graph = snapshot;
+    }
+}

--- a/majit/majit-translate/src/translator/rtyper/unit_variant_fold.rs
+++ b/majit/majit-translate/src/translator/rtyper/unit_variant_fold.rs
@@ -122,6 +122,16 @@ pub fn fold_unit_variant_ctors(graph: &mut FunctionGraph) {
             if !args.is_empty() {
                 continue;
             }
+            // A 0-arg `Tuple` transparent ctor is the Rust unit `()` value
+            // — a ZST carrying no runtime data.  Lower it to the pure null
+            // ref so a void function's dead `()` producer is a pure op that
+            // `prune_dead_phis` can DCE, instead of a non-pure ctor `Call`
+            // that survives into regalloc and collides a register with a
+            // live parameter.
+            if owner_path.is_empty() && name == "Tuple" {
+                op.kind = OpKind::ConstRefNull;
+                continue;
+            }
             let mut segments = owner_path.clone();
             segments.push(name.clone());
             if !is_synthetic_unit_variant_path(&segments) {

--- a/pyre/bench/synth/list_obj_append_pop.py
+++ b/pyre/bench/synth/list_obj_append_pop.py
@@ -1,0 +1,21 @@
+N = 700000
+
+
+def main():
+    xs = []
+    i = 0
+    acc = 0
+    s = "x"
+    t = "y"
+    while i < N:
+        xs.append(s)
+        if len(xs) > 32:
+            xs.pop(0)
+        if (i & 7) == 0:
+            xs.append(t)
+            xs.pop()
+        i = i + 1
+    print(len(xs) + acc)
+
+
+main()

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3446,6 +3446,13 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
                     _ => {}
                 }
             }
+            // #171 object-strategy capacity read: `list.obj_capacity` lowers
+            // to getfield_gc_r(items) + getfield_gc_i(block.capacity). The
+            // block's offset-0 GcArray length header IS the allocated
+            // capacity (immutable for the block's lifetime).
+            if owner.as_str() == "ItemsBlock" && name.as_str() == "capacity" {
+                return items_block_capacity_descr();
+            }
             // #171 codewriter descr-bridge: a codewriter-lowered body reads a
             // box payload (`W_IntObject.intval` / `W_BoolObject.intval` /
             // `W_FloatObject.floatval`) through the producer's struct-layout

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14154,6 +14154,18 @@ fn pyre_171_orthodox_enabled() -> bool {
     std::env::var("PYRE_171_ORTHODOX").as_deref() != Ok("0")
 }
 
+/// #171 experimental gate (default OFF — `PYRE_171_OBJ_APPEND=1` opts in):
+/// extend the orthodox `list.append` descent to object-strategy lists
+/// (a `Ref` value stored into the object items block) in addition to the
+/// int-storage specialization.  Gated off by default while the
+/// object-storage store path through the `w_list_append` sub-walk is
+/// validated; an unresolved object-store leaf declines via
+/// `OrthodoxSubWalkTraceUnsupported` (graceful interpreter fallback), so a
+/// gate-on miss never commits a wrong trace.
+fn pyre_171_obj_append_enabled() -> bool {
+    std::env::var("PYRE_171_OBJ_APPEND").as_deref() == Ok("1")
+}
+
 /// Global descr-pool sub-jitcode lookup (resolves a global jitcode index
 /// through `ALL_JITCODES`, mirroring the shadow walker's lookup).  A
 /// build-time canonical sub-body (`w_list_append`) carries no per-fn descr
@@ -14246,11 +14258,22 @@ fn try_walker_orthodox_list_append(
         // literals, so the long arm is an unreachable optimization and the
         // decline is correctness-safe (the generic residual handles it).
         if !pyre_object::pyobject::is_list(inner_self)
-            || !pyre_object::w_list_uses_int_storage(inner_self)
-            || !pyre_object::is_plain_int1(value)
-            || pyre_object::pyobject::is_long(value)
             || !pyre_object::w_list_can_append_without_realloc(inner_self)
         {
+            return Ok(None);
+        }
+        // Int-storage specialization: plain-int value stored unboxed (a
+        // fits-int `W_LongObject` is declined, see note above).
+        let int_ok = pyre_object::w_list_uses_int_storage(inner_self)
+            && pyre_object::is_plain_int1(value)
+            && !pyre_object::pyobject::is_long(value);
+        // Object-storage extension (experimental, `PYRE_171_OBJ_APPEND=1`):
+        // any non-null `Ref` value stored into the object items block — no
+        // unboxing, so the value carries no type precondition.
+        let obj_ok = pyre_171_obj_append_enabled()
+            && pyre_object::w_list_uses_object_storage(inner_self)
+            && !value.is_null();
+        if !int_ok && !obj_ok {
             return Ok(None);
         }
         (inner_func, inner_self, pyre_object::w_list_len(inner_self))
@@ -14323,16 +14346,48 @@ fn try_walker_orthodox_list_append(
     // recognition gate already proved `is_plain_int1(value)`; this guard
     // enforces ob_type==INT_TYPE at runtime.  The value's integer payload
     // stays symbolic — only its class is pinned.
-    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-    if !value_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(value_op) {
-        let type_const = ctx.trace_ctx.const_int(int_type_addr);
+    //
+    // Object-storage append (`PYRE_171_OBJ_APPEND`) stores the value as a
+    // plain GC ref with no unboxing, so it carries no type precondition —
+    // skip the INT_TYPE pin (the sub-walk's object-storage store path does
+    // not read the value's class).
+    let is_obj_storage = unsafe { pyre_object::w_list_uses_object_storage(inner_self) };
+    if !is_obj_storage {
+        let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+        if !value_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(value_op) {
+            let type_const = ctx.trace_ctx.const_int(int_type_addr);
+            ctx.trace_ctx
+                .record_guard(OpCode::GuardClass, &[value_op, type_const], 0);
+            walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        }
         ctx.trace_ctx
-            .record_guard(OpCode::GuardClass, &[value_op, type_const], 0);
+            .heap_cache_mut()
+            .class_now_known(value_op, int_type_addr);
+        // `is_plain_int1` rejects int subclasses by reading `value.w_class`
+        // and requiring it null or == `get_instantiate(INT_TYPE)` (the exact
+        // int test, listobject.rs). The ob_type pin above only folds the
+        // `is_int`/`is_bool` typeptr reads; the w_class compare stays
+        // symbolic, so the inlined `is_plain_int1` result is non-concrete and
+        // the Integer-arm `if is_plain_int1(value)` branch cannot fold — the
+        // sub-walk then descends the dead else-leg `switch_to_object_strategy`,
+        // whose `ListStrategy::Object` unit-variant ctor is a symbolic fnaddr
+        // the descent declines (`OrthodoxSubWalkTraceUnsupported`). Pin
+        // w_class to the concrete value's field so the subclass test folds
+        // too (the recognition gate already proved `is_plain_int1(value)`).
+        let concrete_w_class = unsafe { (*value).w_class } as i64;
+        let w_class_ref = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            value_op,
+            crate::descr::w_class_descr(),
+        );
+        let w_class_const = ctx.trace_ctx.const_ref(concrete_w_class);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[w_class_ref, w_class_const], 0);
         walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(w_class_ref, w_class_const);
     }
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .class_now_known(value_op, int_type_addr);
 
     // Pre-publish the ONE call-site resume coordinate the sub-walk's guards
     // collapse to (mirror the full-body path's last_instr / valuestackdepth

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -610,6 +610,46 @@ pub fn ll_list_int_set_len(l: &mut W_ListObject, n: usize) {
     l.int_items.set_len(n);
 }
 
+// Object-strategy storage leaves, mirroring the Integer leaves above but
+// addressing the `length` header + the `items` GcArray block (`Ptr(GcArray
+// (OBJECTPTR))`). The element is a GC pointer, so the store carries the
+// list write barrier — the only structural difference from the unboxed
+// Integer/Float scalar stores.
+
+/// `ll_length` for the Object strategy: the live `length` header
+/// (rlist.py:116 `l.length`).
+#[majit_macros::oopspec("list.obj_len(l)")]
+pub fn ll_list_obj_length(l: &W_ListObject) -> usize {
+    l.length
+}
+
+/// Allocated capacity for the Object strategy — the `items` block's
+/// offset-0 GcArray length header (rlist.py:251 `len(l.items)`).
+#[majit_macros::oopspec("list.obj_capacity(l)")]
+pub fn ll_list_obj_capacity(l: &W_ListObject) -> usize {
+    unsafe { items_block_capacity(l.items) }
+}
+
+/// Store the Object-strategy live length (`_ll_list_resize_ge`'s
+/// `l.length = newsize`, rlist.py:293).
+#[majit_macros::oopspec("list.obj_set_len(l, n)")]
+pub fn ll_list_obj_set_len(l: &mut W_ListObject, n: usize) {
+    l.length = n;
+}
+
+/// `ll_setitem_fast` for the Object strategy: a write-barriered GC-ref
+/// store at a known-in-bounds index (the spare-capacity append's element
+/// write). The element is a GC pointer, so unlike the Integer leaf the
+/// store runs the list write barrier.
+#[majit_macros::oopspec("list.obj_setitem(l, index, item)")]
+pub fn ll_list_obj_setitem_fast(l: &mut W_ListObject, index: usize, item: PyObjectRef) {
+    unsafe {
+        let base = items_block_items_base(l.items);
+        *base.add(index) = item;
+        list_write_barrier(l as *mut W_ListObject as PyObjectRef);
+    }
+}
+
 /// Get the item at the given index from a list.
 ///
 /// Supports negative indexing. Returns None if out of bounds.
@@ -721,8 +761,19 @@ pub unsafe fn w_list_append(obj: PyObjectRef, value: PyObjectRef) {
         //   if self.is_correct_type(w_item): l.append(self.unwrap(w_item)); return
         //   self.switch_to_next_strategy(w_list, w_item); w_list.append(w_item)
         ListStrategy::Object => {
-            list.object_push(value);
-            list_write_barrier(obj);
+            // ll_append (rlist.py:588) resize-ge fast case (rlist.py:285):
+            // store in place while there is spare capacity (bump the length
+            // and write the GC ref); otherwise fall back to the resizing
+            // push. The element is a GC pointer, so the in-place store leaf
+            // carries the list write barrier itself.
+            let length = ll_list_obj_length(list);
+            if length < ll_list_obj_capacity(list) {
+                ll_list_obj_set_len(list, length + 1);
+                ll_list_obj_setitem_fast(list, length, value);
+            } else {
+                list.object_push(value);
+                list_write_barrier(obj);
+            }
         }
         ListStrategy::Integer => {
             if is_plain_int1(value) {
@@ -1415,6 +1466,17 @@ mod tests {
         );
         assert_eq!(oopspec_ll_list_int_capacity, "list.int_capacity(l)");
         assert_eq!(oopspec_ll_list_int_set_len, "list.int_set_len(l, n)");
+    }
+
+    #[test]
+    fn object_strategy_oopspec_tags_present() {
+        assert_eq!(oopspec_ll_list_obj_length, "list.obj_len(l)");
+        assert_eq!(oopspec_ll_list_obj_capacity, "list.obj_capacity(l)");
+        assert_eq!(oopspec_ll_list_obj_set_len, "list.obj_set_len(l, n)");
+        assert_eq!(
+            oopspec_ll_list_obj_setitem_fast,
+            "list.obj_setitem(l, index, item)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The headline change is the #171 `int list.append` orthodox fold finally compiling to a native `setarrayitem_gc`.

Root cause: the build-time per-block register allocator (`regalloc.rs`, ported from `rpython/jit/codewriter/regalloc.py`) derives cross-block liveness purely from link-threading. But pyre's codewriter model graphs arrive in global-SSA form (one block per former call, from Charon MIR), where a value defined in one block is referenced in a later block without being threaded along the linear chain. So `w_list_append`'s length (`int_items.len`) and capacity (`int_items.heap_cap`) — both live into the `int_lt` capacity check — got no interference edge and were aliased to one register. That produced `int_lt(cap, cap)`, which always reports "resize needed", forcing an `int_items.push` residual; the walker then declined with `OrthodoxSubWalkTraceUnsupported(pc=117)`.

Fix: a new `majit/majit-translate/src/model_ssa.rs` ports `rpython/translator/backendopt/ssa.py` `SSA_to_SSI` + `DataFlowFamilyBuilder.complete` onto `crate::model::FunctionGraph`, run in the codewriter `finalize` stage before regalloc. It threads every used-but-not-created variable up its incoming links to its definition, restoring SSI so the colourer sees the interference and assigns distinct registers. The int append then folds to a native `setarrayitem_gc`.

Bail-safe adaptation (not present upstream): pyre reaches `finalize` with some Charon-MIR graphs that carry a genuinely-undefined operand (logged as "adapter invariant broken"). Threading such a variable walks to the startblock, which has no incoming link, where upstream would `KeyError`. For those graphs the pass snapshots before mutation, and on bail restores the pre-threading graph and leaves it unchanged (no regression). Measured: 503 graphs threaded, 21 bailed.

## Commits

- `e7c4f8a5c5` jit: re-establish SSI before regalloc via `crate::model` `SSA_to_SSI` port — adds `model_ssa.rs`, wires the `mod` in `lib.rs`, and calls `ssa_to_ssi()` in `finalize_rewritten_graph_to_jitcode` after the DCE/dup-inputarg cleanup and before `perform_all_register_allocations`, matching the upstream relative order `DCE -> SSA_to_SSI -> regalloc`.
- `20c212ce44` jit: #171 orthodox `list.append` object-storage gate + int `w_class` pin — adds the object-storage oopspec leaves (`ll_list_obj_length/capacity/set_len/setitem_fast`) and their jtransform lowerings as structural twins of the existing int leaves (with the `list_write_barrier` difference on the GC-ref store), a default-OFF `PYRE_171_OBJ_APPEND` gate, the int `w_class` `GuardValue` pin, and `bench/synth/list_obj_append_pop.py`. The object append path is default-OFF.
- `741d60906f` jit: DCE the dead unit `()` value of void graphs in the codewriter — `fold_unit_variant_ctors` lowers an empty-owner 0-arg `Tuple` ctor to `OpKind::ConstRefNull` so a void function's dead `()` producer becomes a pure op that `prune_dead_phis` can DCE; `prune_dead_phis` tightens orphan-entry roots to genuine `Input` parameter blocks via `is_genuine_entry`.

## Verification

- `PYRE_JIT` bench `/tmp/list_append_pure.py` -> `1399999`, with the append folding to `setarrayitem_gc` and zero declines.
- `bench/synth/list_append_pop.py` -> `214374737532`.
- `check.py` GREEN on both backends: dynasm 166/166, cranelift 166/166.

## Notes / follow-ups

- A 4th commit (adding `_foldable` to `AbstractRangeRepr::make_iterator_repr`) was dropped during the rebase onto `origin/main` because origin already carries the identical fix (`fdae4f7679`).
- Object-storage append still does **not** fold (it stays a residual call) and the object path is default-OFF behind `PYRE_171_OBJ_APPEND`. Folding it needs `setarrayitem_gc_r` plus a GC write barrier; tracked as the next #171 slice. When that gate is flipped on, the `setarrayitem_gc_r` barrier emission rides the existing backend GC-store codegen and is worth a validation pass.
- The bail-safe snapshot/restore in `model_ssa.rs` is the only intentional deviation from upstream `ssa.py`: it replaces upstream's `KeyError` on reaching the startblock with a no-op revert, accommodating the genuinely-undefined Charon-MIR operands pyre can reach `finalize` with.
- Minor parity note: `compute_variable_families` adds a `linkvars.len() == links.len()` link-arity guard that upstream lacks (upstream would `IndexError` under that condition); it treats a missing nth link arg as a Constant and drops the opportunity. Benign — such an opportunity could not soundly unify, and the bail-safe handles the genuinely-undefined case — but it is a relaxation of upstream's strict link-arity invariant.
- Minor cosmetic: `bench/synth/list_obj_append_pop.py` carries a dead `acc` variable (always 0) that is printed as `len(xs) + acc`; harmless, keeps the oracle deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)