### PR TITLE
rtyper: #131 follow-up — PR#306 review findings, to_vec copy, W_List/W_Tuple constructor residualize

### DIFF
--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2507,6 +2507,7 @@ impl Assembler {
                 OpKind::LoopHeader { .. } => "LoopHeader",
                 OpKind::Abort { .. } => "Abort",
                 OpKind::NewTuple { .. } => "NewTuple",
+                OpKind::NewList { .. } => "NewList",
                 OpKind::NewWithVtable { .. } => "NewWithVtable",
                 OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
                 OpKind::LoadStatic { .. } => "LoadStatic",
@@ -3836,6 +3837,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::RecordQuasiImmutField { .. } => "record_quasiimmut_field".into(),
         OpKind::Abort { .. } => "abort".into(),
         OpKind::NewTuple { .. } => "newtuple".into(),
+        OpKind::NewList { .. } => "newlist".into(),
         // The opname-dispatch spine lowers the rtyper helper graphs to
         // register-shaped blackhole insns, carrying the resolved opname
         // (`strlen`/`strgetitem`/`strsetitem`/`newstr`/…) verbatim.  The

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -6933,6 +6933,9 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // RPython `newtuple` is a `PureOperation` (`operation.py:542`);
         // pure tuple construction cannot raise.
         OpKind::NewTuple { .. } => RaiseClass::No,
+        // RPython `newlist` is a `PureOperation`; pure list construction
+        // cannot raise.
+        OpKind::NewList { .. } => RaiseClass::No,
         // `LoweredBlackholeOp` carries register-shaped blackhole insns
         // lowered from the rtyper helper graphs.  String allocation
         // (`newstr`/`newunicode`) has `canraise = (MemoryError,)`; the

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3050,6 +3050,7 @@ impl CallControl {
                         access_directly: false,
                         trait_root: None,
                         trait_qualified: None,
+                        returns_objectptr: false,
                     };
                     if policy.look_inside_graph(&func) {
                         self.candidate_graphs.insert(callee_path.clone());

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4881,6 +4881,9 @@ fn remap_op(
         OpKind::NewTuple { args } => OpKind::NewTuple {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
         },
+        OpKind::NewList { args } => OpKind::NewList {
+            args: args.iter().map(|a| remap_value(a, aliases)).collect(),
+        },
         OpKind::LoweredBlackholeOp { opname, args } => OpKind::LoweredBlackholeOp {
             opname: opname.clone(),
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),

--- a/majit/majit-translate/src/codewriter/policy.rs
+++ b/majit/majit-translate/src/codewriter/policy.rs
@@ -373,6 +373,7 @@ mod tests {
             access_directly: false,
             trait_root: None,
             trait_qualified: None,
+            returns_objectptr: false,
         }
     }
 
@@ -423,6 +424,7 @@ mod tests {
             access_directly: false,
             trait_root: None,
             trait_qualified: None,
+            returns_objectptr: false,
         };
         // Without `unroll_safe`, the loop disqualifies the graph.
         assert!(!policy.look_inside_graph(&loopy));
@@ -439,6 +441,7 @@ mod tests {
             access_directly: false,
             trait_root: None,
             trait_qualified: None,
+            returns_objectptr: false,
         };
         assert!(policy.look_inside_graph(&unroll_safe));
     }

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -388,13 +388,21 @@ fn rewire_one_next_site(graph: &mut FunctionGraph, opt: &Variable) -> Result<(),
     // slot in the chain is dead — never read by an op, tested by an
     // exitswitch, or escaping to the return/except block.  A chain reaching a
     // genuine use declines (the residual call keeps the rtyper Skip).
-    let opt_none_pos = none_link
+    // `opt_c` can be forwarded into MORE THAN ONE slot of `none_link` (the
+    // same Option merge-thread duplicated across slots); each occurrence roots
+    // its own transitive chain.  Collect every such slot, not just the first,
+    // so a surviving duplicate is not back-substituted onto the StopIteration
+    // edge below (where the native `next` result is not produced).  If any
+    // chain reaches a genuine use the whole rewrite declines.
+    let opt_none_positions: Vec<usize> = none_link
         .args
         .iter()
-        .position(|a| matches!(a, LinkArg::Value(v) if *v == opt_c));
+        .enumerate()
+        .filter_map(|(i, a)| matches!(a, LinkArg::Value(v) if *v == opt_c).then_some(i))
+        .collect();
     let mut dead: std::collections::BTreeMap<usize, std::collections::BTreeSet<usize>> =
         std::collections::BTreeMap::new();
-    if let Some(opt_none_pos) = opt_none_pos {
+    for opt_none_pos in opt_none_positions {
         let set = collect_transitive_dead_slots(graph, none_target.0, opt_none_pos).map_err(
             |reason| format!("{name}: None arm forwards a live Option value — {reason}"),
         )?;

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5398,49 +5398,19 @@ impl<'a> Lowering<'a> {
                     (segments, method_hint)
                 };
                 // `vec![e0, …, eN]` lowers to
-                // `box_assume_init_into_vec_unsafe(box [e0, …, eN])` — a Rust
-                // `Vec` construction the JIT cannot trace (its
-                // `box_assume_init` primitive is unregistered). The boxed
-                // contents are an `Array` aggregate written into the box
-                // through a single `FieldWrite`; recover the element vars and
-                // emit `newlist` directly (RPython list display:
-                // `ll_newlist` + positional `ll_setitem_fast`). The Rust
-                // `Vec<T>` lowers to the same resized `ListRepr` the rtyper
-                // models for `list(x)` (`rtype_bltn_list`), so a downstream
-                // residual taking the `Vec` receives the same value shape the
-                // `to_vec` → `list` path already produces.
-                if args.len() == 1
-                    && fmt_path_ends_with(&segments, &["boxed", "box_assume_init_into_vec_unsafe"])
-                {
-                    let box_var = args[0].clone();
-                    let mut elements: Option<Vec<crate::flowspace::model::Variable>> = None;
-                    'find: for blk in &self.graph.blocks {
-                        for op in &blk.operations {
-                            if let OpKind::FieldWrite { base, value, .. } = &op.kind
-                                && base.id() == box_var.id()
-                                && let Some(av) = value.as_variable()
-                                && let Some(elems) = read_array_literal_elements(&self.graph, av)
-                            {
-                                elements = Some(elems);
-                                break 'find;
-                            }
-                        }
-                    }
-                    if let Some(elements) = elements {
-                        let res = self
-                            .graph
-                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
-                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
-                            result: Some(res.clone()),
-                            kind: OpKind::NewList { args: elements },
-                        });
-                        self.local_var[dest_local] = Some(res);
-                        let target_bb = self.block_id[target];
-                        let link_args = self.edge_args(mir_bb, target)?;
-                        self.graph.set_goto(bb_id, target_bb, link_args);
-                        return Ok(());
-                    }
-                }
+                // `box_assume_init_into_vec_unsafe(box [e0, …, eN])`, whose
+                // `box_assume_init` primitive is unregistered, so the legacy
+                // CodeWriter residualizes it as a plain call (the same
+                // treatment `w_int_new` / `w_float_new` get).  An earlier
+                // recognizer rewrote this shape to `OpKind::NewList`, but those
+                // graphs fail the two-phase prepass on the dead cross-block
+                // `Box::new_uninit` and drop to the legacy CodeWriter, which
+                // cannot run `rtype_newlist` (the legacy annotator types the
+                // result `Ref`, not `ListRepr`).  The un-lowered `newlist`
+                // opname then reached the build-time `Assembler.insns` table
+                // with no blackhole handler.  Until the vec! graphs two-phase
+                // lift (`rtype_newlist` is implemented but dormant), the
+                // residual call is the correct lowering.
                 // For a method/direct callee this equals the callee's
                 // `name_path()`; the scope predicate keys on the module
                 // path, which the built `CallTarget::Method` drops.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -778,6 +778,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             .and_then(|p| p.rsplit("::").next())
             .map(str::to_string)
             .or_else(|| trait_default_owner_for_fundecl(fd, &known_trait_names));
+        let returns_objectptr = output_type_is_objectptr(&fd.signature.output, llbc);
         functions.push(crate::front::semantic::SemanticFunction {
             name,
             graph,
@@ -788,6 +789,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             access_directly: false,
             trait_root,
             trait_qualified,
+            returns_objectptr,
         });
     }
     // Coverage gate. Every `skipped` entry is a function whose MIR shape
@@ -10200,6 +10202,27 @@ fn output_type_is_ref(ty: &TyRef, llbc: &Llbc) -> bool {
         return obj.contains_key("Ref");
     }
     false
+}
+
+/// True when `ty`'s top-level constructor — after the dedup /
+/// hash-cons / reference indirections [`strip_ty_wrappers`] follows —
+/// is a raw pointer (`*mut` / `*const`) onto `PyObject` (the
+/// `PyObjectRef` alias, `pyobject.rs:79`).
+///
+/// This is the return shape of the `W_ListObject` / `W_TupleObject`
+/// constructors (`listobject.rs w_list_new`, `tupleobject.rs
+/// w_tuple_new`).  `output_type_is_ref` only catches `&T`/`&mut T`
+/// references — a raw pointer carries the `RawPtr` constructor, not
+/// `Ref` — so the object-pointer return needs its own probe.  Feeds the
+/// `dont_look_inside` residual prefill (`cutover.rs`): without a
+/// `return_type` marker an object-pointer-returning opaque callee maps
+/// `None`→`Void`, residualizing to a void result the caller cannot use.
+fn output_type_is_objectptr(ty: &TyRef, llbc: &Llbc) -> bool {
+    tyref_node(ty, llbc)
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+        .and_then(|n| raw_ptr_pointee_class_root(n, llbc))
+        .as_deref()
+        == Some("PyObject")
 }
 
 /// Resolve a Charon [`TyRef`] to the Rust type STRING the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5382,6 +5382,19 @@ impl<'a> Lowering<'a> {
                 // `unaryop.rs:3587` (lib test
                 // `generic_handler_graphs_keep_symbolic_fnaddr_surface`).
                 let (segments, method_hint) = self.call_target_segments(mir_bb, &reg)?;
+                // `<[T]>::to_vec(slice)` copies the slice into an owned Vec —
+                // the RPython `list(slice)` builtin, whose `rtype_bltn_list`
+                // (`rlist.py:118-122`) `gendirectcall`s `ll_copy`. Retarget the
+                // call to the single-segment `list` builtin path so both the
+                // annotator (SomeList result) and the rtyper (`rtype_n` ->
+                // `rtype_bltn_list`) see a list construction. (The old
+                // slice-identity alias was a miscompile: `to_vec` is a fresh
+                // allocation, not an alias of the source.)
+                let (segments, method_hint) = if args.len() == 1 && is_slice_to_vec(&segments) {
+                    (vec!["list".to_string()], None)
+                } else {
+                    (segments, method_hint)
+                };
                 // For a method/direct callee this equals the callee's
                 // `name_path()`; the scope predicate keys on the module
                 // path, which the built `CallTarget::Method` drops.
@@ -11402,6 +11415,13 @@ fn fmt_path_ends_with(segments: &[String], tail: &[&str]) -> bool {
             .iter()
             .zip(tail)
             .all(|(s, t)| s.as_str() == *t)
+}
+
+/// `<[T]>::to_vec` — Rust MIR `alloc::slice::<Impl>::to_vec`, a slice→owned-Vec
+/// copy. Retargeted to the `list` builtin (`rtype_bltn_list` -> `ll_copy`).
+fn is_slice_to_vec(segments: &[String]) -> bool {
+    matches!(segments, [a, b, c, d]
+        if a == "alloc" && b == "slice" && c == "<Impl>" && d == "to_vec")
 }
 
 /// The `fmt::Arguments::new(pieces, args)` constructor that `format_args!`

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5397,6 +5397,50 @@ impl<'a> Lowering<'a> {
                 } else {
                     (segments, method_hint)
                 };
+                // `vec![e0, …, eN]` lowers to
+                // `box_assume_init_into_vec_unsafe(box [e0, …, eN])` — a Rust
+                // `Vec` construction the JIT cannot trace (its
+                // `box_assume_init` primitive is unregistered). The boxed
+                // contents are an `Array` aggregate written into the box
+                // through a single `FieldWrite`; recover the element vars and
+                // emit `newlist` directly (RPython list display:
+                // `ll_newlist` + positional `ll_setitem_fast`). The Rust
+                // `Vec<T>` lowers to the same resized `ListRepr` the rtyper
+                // models for `list(x)` (`rtype_bltn_list`), so a downstream
+                // residual taking the `Vec` receives the same value shape the
+                // `to_vec` → `list` path already produces.
+                if args.len() == 1
+                    && fmt_path_ends_with(&segments, &["boxed", "box_assume_init_into_vec_unsafe"])
+                {
+                    let box_var = args[0].clone();
+                    let mut elements: Option<Vec<crate::flowspace::model::Variable>> = None;
+                    'find: for blk in &self.graph.blocks {
+                        for op in &blk.operations {
+                            if let OpKind::FieldWrite { base, value, .. } = &op.kind
+                                && base.id() == box_var.id()
+                                && let Some(av) = value.as_variable()
+                                && let Some(elems) = read_array_literal_elements(&self.graph, av)
+                            {
+                                elements = Some(elems);
+                                break 'find;
+                            }
+                        }
+                    }
+                    if let Some(elements) = elements {
+                        let res = self
+                            .graph
+                            .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                        self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                            result: Some(res.clone()),
+                            kind: OpKind::NewList { args: elements },
+                        });
+                        self.local_var[dest_local] = Some(res);
+                        let target_bb = self.block_id[target];
+                        let link_args = self.edge_args(mir_bb, target)?;
+                        self.graph.set_goto(bb_id, target_bb, link_args);
+                        return Ok(());
+                    }
+                }
                 // For a method/direct callee this equals the callee's
                 // `name_path()`; the scope predicate keys on the module
                 // path, which the built `CallTarget::Method` drops.

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -624,6 +624,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         OpKind::Call { args, .. }
         | OpKind::JitDebug { args }
         | OpKind::NewTuple { args }
+        | OpKind::NewList { args }
         | OpKind::LoweredBlackholeOp { args, .. } => args.clone(),
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![cond.clone()],
         OpKind::GuardValue { value, .. }

--- a/majit/majit-translate/src/front/semantic.rs
+++ b/majit/majit-translate/src/front/semantic.rs
@@ -99,6 +99,16 @@ pub struct SemanticFunction {
     /// only the trait leaf segment, and they never feed the
     /// unique-impl map.
     pub trait_qualified: Option<String>,
+    /// `true` when the function returns `*mut PyObject` (a `PyObjectRef`),
+    /// detected structurally by `front::mir::output_type_is_objectptr`.
+    /// The MIR driver leaves every `return_type` `None`, so a
+    /// `dont_look_inside` callee returning an object pointer would
+    /// residualize as a `None`→`Void` stub (a miscompile — the caller
+    /// needs the pointer).  `merge_hints_from_llbcs` reads this flag and,
+    /// for a `dont_look_inside` callee, stamps the object-pointer
+    /// `return_type` marker so the residual prefill projects a `Ref`
+    /// result.
+    pub returns_objectptr: bool,
 }
 
 /// RPython: struct field type info for `heaptracker.all_interiorfielddescrs`.
@@ -490,6 +500,7 @@ mod tests {
             access_directly: false,
             trait_root: None,
             trait_qualified: None,
+            returns_objectptr: false,
         }
     }
 

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -829,6 +829,9 @@ pub(crate) fn remap_op_kind(
         OpKind::NewTuple { args } => OpKind::NewTuple {
             args: args.iter().map(&remap_var).collect(),
         },
+        OpKind::NewList { args } => OpKind::NewList {
+            args: args.iter().map(&remap_var).collect(),
+        },
         OpKind::LoweredBlackholeOp { opname, args } => OpKind::LoweredBlackholeOp {
             opname: opname.clone(),
             args: args.iter().map(&remap_var).collect(),
@@ -873,6 +876,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
             vec![]
         }
         OpKind::NewTuple { args } => args.iter().map(clone_var).collect(),
+        OpKind::NewList { args } => args.iter().map(clone_var).collect(),
         OpKind::LoweredBlackholeOp { args, .. } => args.iter().map(clone_var).collect(),
         OpKind::VableForce { base } => vec![clone_var(base)],
         OpKind::Hint { value, .. } => vec![clone_var(value)],
@@ -1154,6 +1158,9 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         | OpKind::VtableMethodPtr { .. }
         // `newtuple` is `PureOperation` (`operation.py:542-548`).
         | OpKind::NewTuple { .. }
+        // `newlist` is `PureOperation` — a fresh list allocation has no
+        // observable effect on existing state.
+        | OpKind::NewList { .. }
         // `isinstance` lowers to `int_between` over `obj.typeptr`'s
         // subclass-range fields plus an optional null branch — all
         // pure reads, classified `canfold=True` upstream

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -324,6 +324,24 @@ fn merge_hints_from_llbcs(
         };
         if let Some(h) = hints_by_path.get(&path) {
             f.hints.clone_from(h);
+            // A `dont_look_inside` callee returning `*mut PyObject`
+            // (`SemanticFunction::returns_objectptr`, set structurally by
+            // `front::mir::output_type_is_objectptr`) residualizes as an
+            // opaque call.  The MIR driver leaves `return_type` `None`,
+            // which the cutover residual prefill maps `None`→`Void` — a
+            // miscompile for a callee the caller reads as a pointer.
+            // Stamp the object-pointer marker so the residual reports a
+            // `Ref` result instead.  Gated on the hint so non-opaque
+            // object-pointer-returning fns keep `return_type == None`
+            // (the call-signature validator's TyRef-label-misclassify
+            // safeguard, `front::mir`).
+            if f.return_type.is_none()
+                && f.returns_objectptr
+                && h.iter().any(|hint| hint == "dont_look_inside")
+            {
+                f.return_type =
+                    Some(translator::rtyper::cutover::OBJECTPTR_RETURN_TYPE.to_string());
+            }
         }
     }
 }

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -1104,6 +1104,14 @@ pub enum OpKind {
         args: Vec<crate::flowspace::model::Variable>,
     },
 
+    /// RPython `BUILD_LIST` (`flowspace/flowcontext.py`) / `newlist`
+    /// operation (`operation.py`).  Constructs a fresh resizable list
+    /// from N element values; the result is a new list object distinct
+    /// from any individual element.
+    NewList {
+        args: Vec<crate::flowspace::model::Variable>,
+    },
+
     /// A pre-lowered, register-shaped blackhole opcode emitted by the
     /// opname-dispatch convergence spine (`codewriter::jtransform_opname`).
     ///
@@ -2429,8 +2437,9 @@ pub fn clear_unreachable_blocks(graph: &mut FunctionGraph) {
 }
 
 /// Remove dead aggregate constructions — a `SyntheticTransparentCtor`
-/// call whose result escapes *only* into its own `FieldWrite` field
-/// stores (never read, returned, or passed) — along with those stores.
+/// (or a no-arg `Box::new_uninit`) call whose result escapes *only* into
+/// its own `FieldWrite` field stores (never read, returned, or passed) —
+/// along with those stores.
 ///
 /// This is the `remove_simple_mallocs` shape from
 /// `rpython/translator/backendopt/malloc.py`: a `malloc` whose result
@@ -2460,14 +2469,31 @@ pub fn clear_unreachable_blocks(graph: &mut FunctionGraph) {
 pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
     use crate::flowspace::model::Variable;
 
-    let is_synthetic_ctor = |kind: &OpKind| {
-        matches!(
-            kind,
-            OpKind::Call {
-                target: CallTarget::SyntheticTransparentCtor { .. },
-                ..
-            }
-        )
+    let is_removable_ctor = |kind: &OpKind| match kind {
+        OpKind::Call {
+            target: CallTarget::SyntheticTransparentCtor { .. },
+            ..
+        } => true,
+        // `Box::new_uninit()` — a no-arg heap-box allocation. The `vec![…]`
+        // construction (`box_assume_init_into_vec_unsafe(box [..])`) whose
+        // consumer `front::mir` rewrote to `newlist` leaves the box dead:
+        // its result flows only into the `FieldWrite` that stored the now-
+        // unused `Array` aggregate. Treat it as a removable ctor so the box,
+        // its store, and (once un-pinned) the `Array` cascade out together.
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } => {
+            let tail = ["boxed", "Box", "new_uninit"];
+            args.is_empty()
+                && segments.len() >= tail.len()
+                && segments[segments.len() - tail.len()..]
+                    .iter()
+                    .zip(tail.iter())
+                    .all(|(s, t)| s == t)
+        }
+        _ => false,
     };
 
     let mut total_removed = 0usize;
@@ -2524,7 +2550,7 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
         let mut dead: HashSet<Variable> = HashSet::new();
         for block in &graph.blocks {
             for op in &block.operations {
-                if !is_synthetic_ctor(&op.kind) {
+                if !is_removable_ctor(&op.kind) {
                     continue;
                 }
                 let Some(result) = &op.result else { continue };
@@ -2553,13 +2579,12 @@ pub fn remove_dead_aggregates(graph: &mut FunctionGraph) -> usize {
         let mut removed = 0usize;
         for block in &mut graph.blocks {
             block.operations.retain(|op| {
-                let drop = match &op.kind {
-                    OpKind::Call {
-                        target: CallTarget::SyntheticTransparentCtor { .. },
-                        ..
-                    } => op.result.as_ref().is_some_and(|r| dead.contains(r)),
-                    OpKind::FieldWrite { base, .. } => dead.contains(base),
-                    _ => false,
+                let drop = if is_removable_ctor(&op.kind) {
+                    op.result.as_ref().is_some_and(|r| dead.contains(r))
+                } else if let OpKind::FieldWrite { base, .. } = &op.kind {
+                    dead.contains(base)
+                } else {
+                    false
                 };
                 if drop {
                     removed += 1;

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -68,6 +68,16 @@ use crate::translator::rtyper::pyre_call_registry::{
     FunctionPathKey, PyreCallRegistry, PyreFunctionEntry,
 };
 
+/// The `graph.return_type` marker the front-end stamps on a
+/// `dont_look_inside` callee that returns `*mut PyObject` (a
+/// `PyObjectRef`).  `front::mir::output_type_is_objectptr` gates the
+/// stamp (`lib.rs merge_hints_from_llbcs`), so this string only ever
+/// labels a genuine object-pointer return; the residual prefill maps it
+/// to `OBJECTPTR` so the residualized constructor reports a `Ref` result
+/// rather than the `None`→`Void` default.  The literal doubles as the
+/// readable Rust return type.
+pub(crate) const OBJECTPTR_RETURN_TYPE: &str = "*mut PyObject";
+
 /// Project a post-`specialize` `LowLevelType` back to the legacy
 /// `ConcreteType` bucket the codewriter consumes (Signed / Float /
 /// GcRef / Void).
@@ -1196,15 +1206,22 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // (the `ExtRegistryEntry.compute_result_annotation` shape) so
         // callers annotate the declared unit/bool result and the
         // codewriter emits the residual call via the fn's registered
-        // C ABI address (`pyre/jit_fnaddr.rs`).  Non-scalar returns
-        // fall through to the normal lift — no current marker needs
-        // them, and the stub builder's coverage is unaudited for that
-        // case.
+        // C ABI address (`pyre/jit_fnaddr.rs`).  The object-pointer
+        // marker (`OBJECTPTR_RETURN_TYPE`, stamped by the front-end on a
+        // `*mut PyObject`-returning opaque callee) projects to
+        // `OBJECTPTR` — the `default_someshell_for_lltype` →
+        // `lltype_to_annotation` path already covers `Ptr(_)`.  Other
+        // non-scalar returns fall through to the normal lift — no
+        // current marker needs them, and the stub builder's coverage is
+        // unaudited for that case.
         if graph.hints.iter().any(|h| h == "dont_look_inside") {
             let return_lltype = match graph.return_type.as_deref() {
                 None | Some("()") => Some(LowLevelType::Void),
                 Some("bool") => Some(LowLevelType::Bool),
                 Some("i64") => Some(LowLevelType::Signed),
+                Some(s) if s == OBJECTPTR_RETURN_TYPE => {
+                    Some(crate::translator::rtyper::rclass::OBJECTPTR.clone())
+                }
                 _ => None,
             };
             if let Some(return_lltype) = return_lltype

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -565,8 +565,19 @@ fn reachable_defined_vars(graph: &LegacyGraph) -> std::collections::HashSet<Vari
                 read_vars.insert(v);
             }
         }
-        if let Some(crate::model::ExitSwitch::Value(v)) = &block.exitswitch {
-            read_vars.insert(v.clone());
+        match &block.exitswitch {
+            Some(crate::model::ExitSwitch::Value(v)) => {
+                read_vars.insert(v.clone());
+            }
+            // A fused guard (`jtransform optimize_goto_if_not`) reads its
+            // comparison operands directly off the exitswitch, so those vars
+            // are live even when no op consumes them.
+            Some(crate::model::ExitSwitch::Fused { args, .. }) => {
+                for v in args {
+                    read_vars.insert(v.clone());
+                }
+            }
+            Some(crate::model::ExitSwitch::LastException) | None => {}
         }
         for link in &block.exits {
             stack.push(link.target);

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -970,6 +970,21 @@ pub fn translate_op(
             Ok(vec![FlowspaceOp::new("newtuple", hl_args, result)])
         }
 
+        // ─── `newlist` — RPython `BUILD_LIST` / `space.newlist` ───
+        // `PureOperation`.  Same operand-routing discipline as
+        // `newtuple`: each `args[i]` Variable goes through `value_map`
+        // so the legacy SpaceOperation references the Hlvalue identities
+        // `checkgraph` tracks.
+        OpKind::NewList { args } => {
+            let mut hl_args: Vec<Hlvalue> = Vec::with_capacity(args.len());
+            for (i, var) in args.iter().enumerate() {
+                let role = format!("arg{i}");
+                hl_args.push(lookup_operand(value_map, var, op, &role)?);
+            }
+            let result = resolve_result_hlvalue(op, value_map)?;
+            Ok(vec![FlowspaceOp::new("newlist", hl_args, result)])
+        }
+
         // ─── `NewWithVtable` — boxing GC allocation (`fuse_boxing_alloc`) ───
         // The model-graph op carries the boxing struct leaf `owner` and flows
         // straight to the codewriter/assembler (`new_with_vtable`).  For the

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -675,6 +675,15 @@ fn is_slice_reverse_segments(segments: &[String]) -> bool {
 /// (`rlist.py:185`) via the `getattr(recv, "append") + simple_call` method
 /// shape, exactly like [`is_slice_reverse_segments`]; the Rust method name
 /// `push` maps to the RPython list method `append`.
+///
+/// This recognizer fires only on the `CallTarget::FunctionPath` shape, and
+/// that is complete: `vec::Vec` is a foreign type with no extracted LLBC ADT,
+/// so `front::mir::impl_method_owner` cannot resolve it to a classdef-bound
+/// owner and returns `None`, which forces every `Vec::push` call to the
+/// `[vec, Vec, push]` FunctionPath segments rather than `CallTarget::Method`.
+/// The generic Method arm (which would `getattr(recv, "push")` against a list
+/// that has no `push`) is therefore unreachable for it — only user-defined
+/// classdef-bound receivers route through Method.
 fn is_vec_push_segments(segments: &[String]) -> bool {
     segments.len() == 3 && segments[0] == "vec" && segments[1] == "Vec" && segments[2] == "push"
 }

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -388,6 +388,9 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // `newtuple` yields a `Ref` to the freshly allocated tuple
         // object (RPython `SomeTuple` lowers to `Ptr<GcStruct>`).
         OpKind::NewTuple { .. } => ValueType::Ref(None),
+        // `newlist` yields a `Ref` to the freshly allocated list object
+        // (RPython `SomeList` lowers to `Ptr<GcStruct>`).
+        OpKind::NewList { .. } => ValueType::Ref(None),
         // `LoweredBlackholeOp` is born only in the opname-dispatch spine
         // (`jtransform_opname::lower_graph`), whose graphs re-enter the
         // shared tail at `finalize_rewritten_graph_to_jitcode` and never

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -2665,9 +2665,11 @@ fn build_ll_append_helper_graph(
 /// BEFORE the resize (which overwrites `l1.length`), and `l1.items` AFTER
 /// (the resize may reallocate it). The copy lands the source elements at
 /// `l1.items[len1 ..]` via the general [`build_ll_arraycopy_general_helper_graph`].
-/// The `ovfcheck` OverflowError->MemoryError is not a Python-level exception
-/// (`rtype_method_extend` declares `exception_cannot_occur`), so the bare
-/// `int_add` is used, matching the append-path resize treatment.
+/// `ovfcheck(len1 + len2)` is modelled: both addends are non-negative list
+/// lengths, so the signed sum overflows iff `newlength < len1`, which branches
+/// to a MemoryError raise. `rtype_method_extend` still declares
+/// `exception_cannot_occur` — MemoryError is an implicit (always-possible)
+/// exception, not a Python-level one the caller's flow graph handles.
 fn build_ll_extend_helper_graph(
     rtyper: &RPythonTyper,
     name: &str,
@@ -2682,8 +2684,8 @@ fn build_ll_extend_helper_graph(
     let copy_const = sub_helper_funcptr_constant(rtyper, arraycopy_general)?;
     let items_ptr = items_array_ptr_lltype(&item_lltype);
 
-    let l1_arg = variable_with_lltype("l1", ptr_lltype);
-    let l2_arg = variable_with_lltype("l2", l2_lltype);
+    let l1_arg = variable_with_lltype("l1", ptr_lltype.clone());
+    let l2_arg = variable_with_lltype("l2", l2_lltype.clone());
     let startblock = Block::shared(vec![
         Hlvalue::Variable(l1_arg.clone()),
         Hlvalue::Variable(l2_arg.clone()),
@@ -2736,52 +2738,114 @@ fn build_ll_extend_helper_graph(
         ],
         Hlvalue::Variable(newlength.clone()),
     ));
+    // ovfcheck(len1 + len2): len1/len2 are list lengths (>= 0), so the signed
+    // sum overflows iff it wraps below len1 — that path raises MemoryError.
+    let overflow = variable_with_lltype("overflow", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(newlength.clone()),
+            Hlvalue::Variable(len1.clone()),
+        ],
+        Hlvalue::Variable(overflow.clone()),
+    ));
+
+    // ---- continue block (overflow false): resize l1 + copy l2 into it.
+    let l1_c = variable_with_lltype("l1", ptr_lltype.clone());
+    let l2_c = variable_with_lltype("l2", l2_lltype.clone());
+    let len1_c = variable_with_lltype("len1", LowLevelType::Signed);
+    let len2_c = variable_with_lltype("len2", LowLevelType::Signed);
+    let newlength_c = variable_with_lltype("newlength", LowLevelType::Signed);
+    let block_continue = Block::shared(vec![
+        Hlvalue::Variable(l1_c.clone()),
+        Hlvalue::Variable(l2_c.clone()),
+        Hlvalue::Variable(len1_c.clone()),
+        Hlvalue::Variable(len2_c.clone()),
+        Hlvalue::Variable(newlength_c.clone()),
+    ]);
+
+    // overflow true -> raise MemoryError; false -> block_continue.
+    let exc_args = exception_args("MemoryError")?;
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(overflow));
+    startblock.closeblock(vec![
+        Link::new(
+            exc_args,
+            Some(graph.exceptblock.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(l1_arg),
+                Hlvalue::Variable(l2_arg),
+                Hlvalue::Variable(len1),
+                Hlvalue::Variable(len2),
+                Hlvalue::Variable(newlength),
+            ],
+            Some(block_continue.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
     // _ll_list_resize_ge(l1, newlength) — sets l1.length = newlength, grows items.
     let resize_void = variable_with_lltype("v", LowLevelType::Void);
-    startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "direct_call",
-        vec![
-            Hlvalue::Constant(resize_const),
-            Hlvalue::Variable(l1_arg.clone()),
-            Hlvalue::Variable(newlength),
-        ],
-        Hlvalue::Variable(resize_void),
-    ));
+    block_continue
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(resize_const),
+                Hlvalue::Variable(l1_c.clone()),
+                Hlvalue::Variable(newlength_c),
+            ],
+            Hlvalue::Variable(resize_void),
+        ));
     // items1 = l1.items (read AFTER the resize: it may have reallocated).
     let items1 = variable_with_lltype("items1", items_ptr.clone());
-    startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "getfield",
-        vec![Hlvalue::Variable(l1_arg), void_field_const("items")],
-        Hlvalue::Variable(items1.clone()),
-    ));
+    block_continue
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "getfield",
+            vec![Hlvalue::Variable(l1_c), void_field_const("items")],
+            Hlvalue::Variable(items1.clone()),
+        ));
     // items2 = l2 items (per layout): the slice IS its own array.
     let items2_hlv = match l2_layout {
-        ListLayout::Fixed => Hlvalue::Variable(l2_arg),
+        ListLayout::Fixed => Hlvalue::Variable(l2_c),
         ListLayout::Resized => {
             let items2 = variable_with_lltype("items2", items_ptr.clone());
-            startblock.borrow_mut().operations.push(SpaceOperation::new(
-                "getfield",
-                vec![Hlvalue::Variable(l2_arg), void_field_const("items")],
-                Hlvalue::Variable(items2.clone()),
-            ));
+            block_continue
+                .borrow_mut()
+                .operations
+                .push(SpaceOperation::new(
+                    "getfield",
+                    vec![Hlvalue::Variable(l2_c), void_field_const("items")],
+                    Hlvalue::Variable(items2.clone()),
+                ));
             Hlvalue::Variable(items2)
         }
     };
     // ll_arraycopy(items2, items1, 0, len1, len2).
     let copy_void = variable_with_lltype("v", LowLevelType::Void);
-    startblock.borrow_mut().operations.push(SpaceOperation::new(
-        "direct_call",
-        vec![
-            Hlvalue::Constant(copy_const),
-            items2_hlv,
-            Hlvalue::Variable(items1),
-            signed_const(0),
-            Hlvalue::Variable(len1),
-            Hlvalue::Variable(len2),
-        ],
-        Hlvalue::Variable(copy_void),
-    ));
-    startblock.closeblock(vec![
+    block_continue
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(copy_const),
+                items2_hlv,
+                Hlvalue::Variable(items1),
+                signed_const(0),
+                Hlvalue::Variable(len1_c),
+                Hlvalue::Variable(len2_c),
+            ],
+            Hlvalue::Variable(copy_void),
+        ));
+    block_continue.closeblock(vec![
         Link::new(
             vec![none_void_const()],
             Some(graph.returnblock.clone()),

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -3062,10 +3062,7 @@ fn build_ll_copy_helper_graph(
         ListLayout::Resized => {
             startblock.borrow_mut().operations.push(SpaceOperation::new(
                 "getfield",
-                vec![
-                    Hlvalue::Variable(l_arg.clone()),
-                    void_field_const("length"),
-                ],
+                vec![Hlvalue::Variable(l_arg.clone()), void_field_const("length")],
                 Hlvalue::Variable(length.clone()),
             ));
         }
@@ -3135,7 +3132,11 @@ fn build_ll_copy_helper_graph(
         Constant::new(ConstValue::Dict(Default::default())),
     );
     graph.func = Some(func.clone());
-    Ok(helper_pygraph_from_graph(graph, vec!["l".to_string()], func))
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["l".to_string()],
+        func,
+    ))
 }
 
 /// Derive the [`ListLayout`] from a list repr's `Ptr` lltype: a resized list

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -299,6 +299,22 @@ impl Repr for FixedSizeListRepr {
         }
     }
 
+    /// RPython `AbstractBaseListRepr.rtype_bltn_list(self, hop)`
+    /// (`rlist.py:118-122`) — `list(slice)` copies the slice into a fresh
+    /// resized list via `ll_copy(RESLIST, l)`. The source is the fixed-size
+    /// receiver (bare `Ptr(GcArray)`).
+    fn rtype_bltn_list(&self, hop: &HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        hop.exception_is_here()?;
+        rtype_bltn_list_via_ll_copy(
+            hop,
+            ListLayout::Fixed,
+            self.lltype.clone(),
+            self.item_repr.lowleveltype().clone(),
+            vlist,
+        )
+    }
+
     /// RPython `lltypesystem/rlist.py` `make_iterator_repr` on the
     /// `AbstractBaseListRepr`: the no-variant case mints
     /// `ListIteratorRepr(self)`; the `("reversed",)` variant
@@ -984,6 +1000,21 @@ impl Repr for ListRepr {
                 "missing ListRepr.rtype_method_{method_name}"
             ))),
         }
+    }
+
+    /// RPython `AbstractBaseListRepr.rtype_bltn_list(self, hop)`
+    /// (`rlist.py:118-122`) — `list(l)` copies the resized receiver into a
+    /// fresh resized list via `ll_copy(RESLIST, l)`.
+    fn rtype_bltn_list(&self, hop: &HighLevelOp) -> RTypeResult {
+        let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+        hop.exception_is_here()?;
+        rtype_bltn_list_via_ll_copy(
+            hop,
+            ListLayout::Resized,
+            self.lltype.clone(),
+            self.item_repr.lowleveltype().clone(),
+            vlist,
+        )
     }
 
     /// RPython `lltypesystem/rlist.py` `make_iterator_repr` on the
@@ -2864,6 +2895,340 @@ fn build_ll_extend_helper_graph(
         vec!["l1".to_string(), "l2".to_string()],
         func,
     ))
+}
+
+/// Synthesise `RESLIST.ll_newlist(length)`
+/// (`rpython/rtyper/lltypesystem/rlist.py` `ll_newlist`): allocate a fresh
+/// list holding `length` items. The resized layout mallocs the
+/// `Ptr(GcStruct("list", length, items))` header plus a `malloc_varsize`
+/// items `GcArray`, then stores both fields; the fixed layout is the bare
+/// `Ptr(GcArray)`, so it is the `malloc_varsize` alone. `malloc_varsize`
+/// zero-fills the items; [`build_ll_copy_helper_graph`] overwrites them.
+fn build_ll_newlist_helper_graph(
+    name: &str,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
+    let length_arg = variable_with_lltype("length", LowLevelType::Signed);
+    let startblock = Block::shared(vec![Hlvalue::Variable(length_arg.clone())]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+    let array_type = LowLevelType::Array(Box::new(Array::gc(item_lltype.clone())));
+
+    let new_lst = match layout {
+        ListLayout::Fixed => {
+            let l = variable_with_lltype("l", ptr_lltype.clone());
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "malloc_varsize",
+                vec![
+                    lowlevel_type_const(array_type),
+                    gc_flavor_const()?,
+                    Hlvalue::Variable(length_arg),
+                ],
+                Hlvalue::Variable(l.clone()),
+            ));
+            l
+        }
+        ListLayout::Resized => {
+            let LowLevelType::Ptr(ptr) = &ptr_lltype else {
+                return Err(TyperError::message(
+                    "build_ll_newlist_helper_graph: resized list lltype is not Ptr",
+                ));
+            };
+            let inner_struct = match &ptr.TO {
+                PtrTarget::Struct(body) => body.clone(),
+                other => {
+                    return Err(TyperError::message(format!(
+                        "build_ll_newlist_helper_graph: resized Ptr target must be Struct, got {other:?}"
+                    )));
+                }
+            };
+            let header = variable_with_lltype("l", ptr_lltype.clone());
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "malloc",
+                vec![
+                    lowlevel_type_const(LowLevelType::Struct(Box::new(inner_struct))),
+                    gc_flavor_const()?,
+                ],
+                Hlvalue::Variable(header.clone()),
+            ));
+            let items = variable_with_lltype("items", items_array_ptr_lltype(&item_lltype));
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "malloc_varsize",
+                vec![
+                    lowlevel_type_const(array_type),
+                    gc_flavor_const()?,
+                    Hlvalue::Variable(length_arg.clone()),
+                ],
+                Hlvalue::Variable(items.clone()),
+            ));
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "setfield",
+                vec![
+                    Hlvalue::Variable(header.clone()),
+                    void_field_const("length"),
+                    Hlvalue::Variable(length_arg),
+                ],
+                Hlvalue::Variable(variable_with_lltype("v", LowLevelType::Void)),
+            ));
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "setfield",
+                vec![
+                    Hlvalue::Variable(header.clone()),
+                    void_field_const("items"),
+                    Hlvalue::Variable(items),
+                ],
+                Hlvalue::Variable(variable_with_lltype("v", LowLevelType::Void)),
+            ));
+            header
+        }
+    };
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(new_lst)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["length".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `ll_copy(RESLIST, l)` (`rpython/rtyper/rlist.py:565-569`):
+///
+/// ```python
+/// def ll_copy(RESLIST, l):
+///     length = l.ll_length()
+///     new_lst = RESLIST.ll_newlist(length)
+///     ll_arraycopy(l, new_lst, 0, 0, length)
+///     return new_lst
+/// ```
+///
+/// `l` is the source (`source_layout`); the `RESLIST` result is `result_layout`
+/// (`list(x)` yields a resized list, but a non-resized result is handled too).
+/// The length / items reads are layout-parameterised exactly like the
+/// getitem / extend CFGs.
+#[allow(clippy::too_many_arguments)]
+fn build_ll_copy_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    source_layout: ListLayout,
+    result_layout: ListLayout,
+    source_ptr_lltype: LowLevelType,
+    result_ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist: &LowLevelFunction,
+    arraycopy: &LowLevelFunction,
+) -> Result<PyGraph, TyperError> {
+    let newlist_const = sub_helper_funcptr_constant(rtyper, newlist)?;
+    let copy_const = sub_helper_funcptr_constant(rtyper, arraycopy)?;
+    let items_ptr = items_array_ptr_lltype(&item_lltype);
+
+    let l_arg = variable_with_lltype("l", source_ptr_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(l_arg.clone())]);
+    let return_var = variable_with_lltype("result", result_ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // length = l.ll_length() (per source layout).
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    match source_layout {
+        ListLayout::Fixed => {
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "getarraysize",
+                vec![Hlvalue::Variable(l_arg.clone())],
+                Hlvalue::Variable(length.clone()),
+            ));
+        }
+        ListLayout::Resized => {
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![
+                    Hlvalue::Variable(l_arg.clone()),
+                    void_field_const("length"),
+                ],
+                Hlvalue::Variable(length.clone()),
+            ));
+        }
+    }
+    // new_lst = RESLIST.ll_newlist(length).
+    let new_lst = variable_with_lltype("new_lst", result_ptr_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(newlist_const),
+            Hlvalue::Variable(length.clone()),
+        ],
+        Hlvalue::Variable(new_lst.clone()),
+    ));
+    // src/dst items (per layout): a FixedSizeListRepr value IS its items array;
+    // the resized header reaches the array through `items`.
+    let src_items = match source_layout {
+        ListLayout::Fixed => Hlvalue::Variable(l_arg),
+        ListLayout::Resized => {
+            let items = variable_with_lltype("src_items", items_ptr.clone());
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![Hlvalue::Variable(l_arg), void_field_const("items")],
+                Hlvalue::Variable(items.clone()),
+            ));
+            Hlvalue::Variable(items)
+        }
+    };
+    let dst_items = match result_layout {
+        ListLayout::Fixed => Hlvalue::Variable(new_lst.clone()),
+        ListLayout::Resized => {
+            let items = variable_with_lltype("dst_items", items_ptr);
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![
+                    Hlvalue::Variable(new_lst.clone()),
+                    void_field_const("items"),
+                ],
+                Hlvalue::Variable(items.clone()),
+            ));
+            Hlvalue::Variable(items)
+        }
+    };
+    // ll_arraycopy(src_items, dst_items, length) — 0-to-0 full copy.
+    let copy_void = variable_with_lltype("v", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(copy_const),
+            src_items,
+            dst_items,
+            Hlvalue::Variable(length),
+        ],
+        Hlvalue::Variable(copy_void),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(new_lst)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, vec!["l".to_string()], func))
+}
+
+/// Derive the [`ListLayout`] from a list repr's `Ptr` lltype: a resized list
+/// is `Ptr(GcStruct("list", …))`, a fixed list is `Ptr(GcArray)`.
+fn list_layout_from_lltype(ptr_lltype: &LowLevelType) -> Result<ListLayout, TyperError> {
+    let LowLevelType::Ptr(ptr) = ptr_lltype else {
+        return Err(TyperError::message(
+            "list_layout_from_lltype: not a Ptr lltype",
+        ));
+    };
+    match &ptr.TO {
+        PtrTarget::Struct(_) => Ok(ListLayout::Resized),
+        PtrTarget::Array(_) => Ok(ListLayout::Fixed),
+        other => Err(TyperError::message(format!(
+            "list_layout_from_lltype: unexpected Ptr target {other:?}"
+        ))),
+    }
+}
+
+/// Shared body of `FixedSizeListRepr` / `ListRepr` `rtype_bltn_list`
+/// (`rpython/rtyper/rlist.py:118-122` `rtype_bltn_list`): the receiver has
+/// already been threaded into `vlist` and `exception_is_here` declared. Mints
+/// `ll_arraycopy` <- `ll_newlist` <- `ll_copy` in dependency order (the
+/// result `RESLIST` is `hop.r_result`) and `gendirectcall`s `ll_copy`.
+fn rtype_bltn_list_via_ll_copy(
+    hop: &HighLevelOp,
+    source_layout: ListLayout,
+    source_ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    vlist: Vec<Hlvalue>,
+) -> RTypeResult {
+    let r_result = hop
+        .r_result
+        .borrow()
+        .as_ref()
+        .map(Arc::clone)
+        .ok_or_else(|| TyperError::message("rtype_bltn_list: r_result not populated"))?;
+    let result_ptr_lltype = r_result.lowleveltype().clone();
+    let result_layout = list_layout_from_lltype(&result_ptr_lltype)?;
+    let items_ptr = items_array_ptr_lltype(&item_lltype);
+
+    let arraycopy = {
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_arraycopy".to_string(),
+            vec![items_ptr.clone(), items_ptr.clone(), LowLevelType::Signed],
+            LowLevelType::Void,
+            move |_rtyper, _args, _result| {
+                build_ll_arraycopy_helper_graph("ll_arraycopy", item.clone())
+            },
+        )?
+    };
+    let newlist = {
+        let result_ptr = result_ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_newlist".to_string(),
+            vec![LowLevelType::Signed],
+            result_ptr_lltype.clone(),
+            move |_rtyper, _args, _result| {
+                build_ll_newlist_helper_graph(
+                    "ll_newlist",
+                    result_layout,
+                    result_ptr.clone(),
+                    item.clone(),
+                )
+            },
+        )?
+    };
+    let copy = {
+        let source_ptr = source_ptr_lltype.clone();
+        let result_ptr = result_ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_copy".to_string(),
+            vec![source_ptr_lltype],
+            result_ptr_lltype,
+            move |rtyper, _args, _result| {
+                build_ll_copy_helper_graph(
+                    rtyper,
+                    "ll_copy",
+                    source_layout,
+                    result_layout,
+                    source_ptr.clone(),
+                    result_ptr.clone(),
+                    item.clone(),
+                    &newlist,
+                    &arraycopy,
+                )
+            },
+        )?
+    };
+    hop.gendirectcall(&copy, vlist)
 }
 
 /// `FixedSizeListRepr` (bare `Ptr(GcArray)`) vs the resized `ListRepr`

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -351,8 +351,100 @@ fn rlist_runtime_deferred(name: &str) -> TyperError {
     TyperError::missing_rtype_operation(format!("rlist.{name} — list helper deferred"))
 }
 
-pub fn rtype_newlist() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("rtype_newlist"))
+/// RPython `rtype_newlist(hop, v_sizehint=None)` (`rlist.py:30-40`) +
+/// `newlist(llops, r_list, items_v, v_sizehint=None)` (`rlist.py:44-66`):
+///
+/// ```python
+/// def rtype_newlist(hop, v_sizehint=None):
+///     nb_args = hop.nb_args
+///     r_list = hop.r_result
+///     r_listitem = r_list.item_repr
+///     items_v = [hop.inputarg(r_listitem, arg=i) for i in range(nb_args)]
+///     return newlist(hop.llops, r_list, items_v, v_sizehint)
+///
+/// def newlist(llops, r_list, items_v, v_sizehint=None):
+///     LIST = r_list.lowleveltype.TO
+///     cno = inputconst(Signed, len(items_v))
+///     v_result = llops.gendirectcall(LIST.ll_newlist, cno)
+///     v_func = inputconst(Void, dum_nocheck)
+///     for i, v_item in enumerate(items_v):
+///         ci = inputconst(Signed, i)
+///         llops.gendirectcall(ll_setitem_nonneg, v_func, v_result, ci, v_item)
+///     return v_result
+/// ```
+///
+/// Constructs a fresh resized list (`Ptr(GcStruct("list", length, items))`)
+/// via the shared [`build_ll_newlist_helper_graph`] (`ListLayout::Resized`),
+/// then fills it positionally with `ll_setitem_fast` calls
+/// ([`build_ll_setitem_fast_helper_graph`]); the `dum_nocheck` index is
+/// statically `0..n`, so the negative-index / bound-check wrappers are
+/// skipped exactly as upstream's `ll_setitem_nonneg`-fast-path does. Each
+/// element is coerced to `r_list.item_repr` (the internal gcref-wrapped
+/// element repr) before being stored.
+pub fn rtype_newlist(hop: &HighLevelOp) -> RTypeResult {
+    let r_result = hop
+        .r_result
+        .borrow()
+        .clone()
+        .ok_or_else(|| TyperError::message("rtype_newlist: r_result missing"))?;
+    let any_r: &dyn std::any::Any = r_result.as_ref();
+    let r_list = any_r
+        .downcast_ref::<ListRepr>()
+        .ok_or_else(|| TyperError::message("rtype_newlist: hop.r_result is not a ListRepr"))?;
+    let ptr_lltype = r_list.lltype.clone();
+    let item_lltype = r_list.item_repr.lowleveltype().clone();
+    let n = hop.nb_args();
+
+    // upstream `items_v = [hop.inputarg(r_list.item_repr, i) for i in range(n)]`.
+    let converted: Vec<ConvertedTo<'_>> = (0..n)
+        .map(|_| ConvertedTo::Repr(r_list.item_repr.as_ref()))
+        .collect();
+    let items_v = hop.inputargs(converted)?;
+
+    // upstream `v_result = llops.gendirectcall(LIST.ll_newlist, cno)`.
+    let newlist_fn = {
+        let ptr = ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_newlist".to_string(),
+            vec![LowLevelType::Signed],
+            ptr_lltype.clone(),
+            move |_rtyper, _args, _result| {
+                build_ll_newlist_helper_graph(
+                    "ll_newlist",
+                    ListLayout::Resized,
+                    ptr.clone(),
+                    item.clone(),
+                )
+            },
+        )?
+    };
+    let v_result = hop
+        .gendirectcall(&newlist_fn, vec![signed_const(n as i64)])?
+        .ok_or_else(|| TyperError::message("rtype_newlist: ll_newlist returned Void"))?;
+
+    // upstream loop — `ll_setitem_nonneg(dum_nocheck, v_result, ci, v_item)`,
+    // which bottoms out at `l.ll_setitem_fast(index, item)`. The index is the
+    // static enumeration position, so the fast helper is called directly.
+    let setitem_fn = {
+        let ptr = ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            "ll_setitem_fast".to_string(),
+            vec![ptr_lltype, LowLevelType::Signed, item_lltype],
+            LowLevelType::Void,
+            move |_rtyper, _args, _result| {
+                build_ll_setitem_fast_helper_graph("ll_setitem_fast", ptr.clone(), item.clone())
+            },
+        )?
+    };
+    for (i, v_item) in items_v.into_iter().enumerate() {
+        hop.gendirectcall(
+            &setitem_fn,
+            vec![v_result.clone(), signed_const(i as i64), v_item],
+        )?;
+    }
+    Ok(Some(v_result))
 }
 
 pub fn rtype_alloc_and_set() -> Result<(), TyperError> {
@@ -5141,6 +5233,74 @@ mod tests {
         assert!(
             matches!(items_ptr.TO, PtrTarget::Array(_)),
             "items must point to a GcArray"
+        );
+    }
+
+    /// `translate_operation("newlist")` routes to [`rtype_newlist`], which
+    /// lowers an N-element list display to `ll_newlist(N)` followed by one
+    /// `ll_setitem_fast` per element (RPython `rtype_newlist` / `newlist`,
+    /// `rlist.py`). The dispatch is reached only here in two-phase rtyping;
+    /// the `vec!` front-end emitter that produces `OpKind::NewList` is the
+    /// other producer.
+    #[test]
+    fn translate_operation_newlist_emits_ll_newlist_and_setitems() {
+        use crate::annotator::model::SomeValue;
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        // Minting the `ll_newlist` / `ll_setitem_fast` helpers derefs the
+        // typer's annotator weak ref, so `ann` must outlive the call.
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+
+        let v_a = Variable::new();
+        v_a.set_concretetype(Some(LowLevelType::Signed));
+        let v_b = Variable::new();
+        v_b.set_concretetype(Some(LowLevelType::Signed));
+        let v_a_h = Hlvalue::Variable(v_a);
+        let v_b_h = Hlvalue::Variable(v_b);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "newlist".to_string(),
+            vec![v_a_h.clone(), v_b_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        // Per-element args, each typed at the list's item repr (Signed).
+        hop.args_v.borrow_mut().push(v_a_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_b_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        let out = rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation newlist must dispatch to rtype_newlist")
+            .expect("newlist returns the fresh list Variable");
+        let Hlvalue::Variable(_) = out else {
+            panic!("newlist must return a Variable (the ll_newlist result)");
+        };
+        let ops = hop.llops.borrow();
+        let direct_calls = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .count();
+        // `ll_newlist(len)` + one `ll_setitem_fast` per element (2) = 3.
+        assert_eq!(
+            direct_calls,
+            3,
+            "expected ll_newlist + 2×ll_setitem_fast direct_calls, got {:?}",
+            ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2213,6 +2213,10 @@ impl RPythonTyper {
             // free function `rtuple.rtype_newtuple(hop)` which routes
             // to `TupleRepr._rtype_newtuple`. No per-Repr dispatch.
             "newtuple" => super::rtuple::TupleRepr::rtype_newtuple(hop),
+            // rtyper.py:543-545 — `translate_op_newlist` calls the free
+            // function `rlist.rtype_newlist(hop)` (`ll_newlist` +
+            // positional `ll_setitem_fast`). No per-Repr dispatch.
+            "newlist" => super::rlist::rtype_newlist(hop),
             // rtuple.py:292-315 — `pairtype(TupleRepr, Repr).rtype_contains`.
             "contains" => self.translate_pair_operation(hop, super::pairtype::pair_rtype_contains),
             // `same_as` (rtyper.py:478-481) is RPython's internal

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -438,6 +438,15 @@ pub extern "C" fn list_write_barrier(obj: PyObjectRef) {
 }
 
 /// Allocate a new W_ListObject from a Vec of items.
+///
+/// Residualized: the storage construction below
+/// (`w_list_new_with_strategy`) drives the moving collector through
+/// `push_roots` / `pin_root` / `alloc_list_items_block_gc` /
+/// `try_gc_alloc_stable` — shadow-stack and `box_assume_init` plumbing
+/// the tracer cannot model. The JIT leaves the call as a residual
+/// returning the fresh object pointer rather than tracing into the GC
+/// allocator.
+#[majit_macros::dont_look_inside]
 pub fn w_list_new(items: Vec<PyObjectRef>) -> PyObjectRef {
     let strategy = list_strategy_for(&items);
     w_list_new_with_strategy(items, strategy)
@@ -447,6 +456,9 @@ pub fn w_list_new(items: Vec<PyObjectRef>) -> PyObjectRef {
 /// every element stays boxed by pointer identity (an all-int item set is NOT
 /// unboxed into `int_items`). Used where element identity must survive, e.g. the
 /// unpickler memo array.
+///
+/// Residualized for the same GC-allocator reason as `w_list_new`.
+#[majit_macros::dont_look_inside]
 pub fn w_list_new_object(items: Vec<PyObjectRef>) -> PyObjectRef {
     w_list_new_with_strategy(items, ListStrategy::Object)
 }

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -71,6 +71,12 @@ pub const W_TUPLE_OBJECT_SIZE: usize = std::mem::size_of::<W_TupleObject>();
 /// Arity-2 tuples are routed through `makespecialisedtuple2`
 /// (`pypy/objspace/std/specialisedtupleobject.py:161-167`); other
 /// arities use the array-backed `W_TupleObject`.
+///
+/// Residualized: tuple construction drives the moving collector through
+/// `push_roots` / `pin_root` / `try_gc_alloc_stable` shadow-stack
+/// plumbing the tracer cannot model. The JIT leaves the call as a
+/// residual returning the fresh object pointer.
+#[majit_macros::dont_look_inside]
 pub fn w_tuple_new(items: Vec<PyObjectRef>) -> PyObjectRef {
     if items.len() == 2 {
         return makespecialisedtuple2(items[0], items[1]);
@@ -89,6 +95,9 @@ pub fn w_tuple_new(items: Vec<PyObjectRef>) -> PyObjectRef {
 /// (`eval.rs`) which walks the block, and this constructor write-barriers
 /// the old-gen tuple so a minor collection actually runs that hook on a
 /// tuple holding young elements.
+///
+/// Residualized for the same GC-allocator reason as `w_tuple_new`.
+#[majit_macros::dont_look_inside]
 pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`):
     //   livevars = self.push_roots(hop)


### PR DESCRIPTION
## Summary

#131 follow-up: PR#306 deferred review findings (A), to_vec coverage restore (B), and W_List/W_Tuple constructor residualize (C). 6 commits on top of `origin/main`.

### A — PR#306 deferred review findings
- `5f9aa42276` front/iter_next: prune every forwarded opt_c slot (was `.position()` first-only)
- `cb8b22964b` rtyper/cutover: count `ExitSwitch::Fused{args}` operands as reads (kills false `real=Unknown` dual-gate divergence)
- `cc8bcb6a41` rtyper/rlist: model `ovfcheck` in the `ll_extend` helper graph (int_add + overflow guard → MemoryError exceptblock). pyre has no `int_add_ovf` intrinsic in the helper-graph context, so the overflow is detected manually (`newlength < len1`)
- `76c26bd187` rtyper/flowspace_adapter: document that `Vec::push`/`extend_from_slice` are unreachable as `CallTarget::Method` (foreign Vec → always `FunctionPath`)

### B — to_vec coverage restore (#26)
- `8d240497d9` rtyper/rlist, front/mir: lower `<[T]>::to_vec` to `list()` via `rtype_bltn_list` → `ll_copy`/`ll_newlist` (a real copy, two layouts: Resized GcStruct + Fixed GcArray)

### C — W_List/W_Tuple constructor residualize (#27)
- `43389e3d86` rtyper: residualize `w_list_new` / `w_list_new_object` / `w_tuple_new` / `w_tuple_new_array_backed` via `#[majit_macros::dont_look_inside]`, leaving their GC-allocation bodies (push_roots / pin_root / try_gc_alloc_stable / box_assume_init) as opaque residual calls.
  - These constructors return `*mut PyObject` (PyObjectRef) — a **raw pointer**, not `&T`. The residual prefill could not project that return: `front::mir` leaves every `return_type` None and cutover mapped None → Void.
  - `front::mir::output_type_is_objectptr` (raw-pointer-to-PyObject probe) → `SemanticFunction::returns_objectptr`.
  - `lib::merge_hints_from_llbcs`: for a `dont_look_inside` callee returning `*mut PyObject`, stamp the `OBJECTPTR_RETURN_TYPE` marker on `return_type` (non-hinted fns keep None — the call-signature validator's TyRef-label-misclassify safeguard).
  - `rtyper::cutover`: map `OBJECTPTR_RETURN_TYPE` → `OBJECTPTR` in the `dont_look_inside` residual prefill (`default_someshell_for_lltype` → `lltype_to_annotation` already covers `Ptr(_)`).
  - `build_list_from_refs` / `build_tuple_from_refs` now lift without reaching `box_assume_init` through the constructors; not-registered drops 296 → 290.

## Verification
- `pyre/check.py`: **dynasm 166/166 + cranelift 166/166 = ALL PASSED** (GC-stress benches green — the residual call returning a fresh GC object is properly rooted).
- Codex parity review: **no parity regressions introduced** (section 1 = None; section-2 items trace to pre-existing/external code, not this branch's new work; section-4 adaptations documented in-code).

## Known follow-up (out of scope, tracked)
`compute_mro` and `make_generic_alias` still fail at `box_assume_init_into_vec_unsafe` via their own `vec![...]` macro (array→Vec), NOT the constructors. `compute_mro` is also structurally non-liftable (nested `Vec<Vec>`, `.retain()` closure, C3 loop). A separate `vec!`/array→Vec lever (lowering or list-Ref residualize), each needing its own GC-stress cycle.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for list construction and list-related operations, including more reliable handling of newly created lists.
  * Added better detection of functions that return object pointers, improving type handling in supported cases.

* **Bug Fixes**
  * Fixed several edge cases in list rewriting and dead-code handling so list creation is processed correctly.
  * Improved call analysis and lowering for list-building paths, reducing incorrect fallback behavior.
  * Updated function reachability and liveness tracking to avoid missing live values in complex control-flow cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->