### PR TITLE
wasm32 JIT: self-recursive CALL_ASSEMBLER on GC JitFrames + bridge-chaining groundwork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,8 @@ version = "0.0.2"
 dependencies = [
  "getrandom 0.4.2",
  "majit-backend",
+ "majit-backend-wasm",
+ "majit-metainterp",
  "pyre-interpreter",
  "pyre-jit",
  "pyre-object",

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -412,6 +412,55 @@ pub struct GuardGcTypeInfo {
 }
 
 /// Check if any op in the trace is a CALL variant.
+/// Lower an eligible residual CALL to a direct in-module `call_indirect` into
+/// the callee's `__indirect_function_table` slot, instead of routing through the
+/// `jit_call` host trampoline (guest→host→guest reflection + arg marshalling).
+/// The residual-call ABI is uniformly `(i64×n) -> i64` for Int/Ref args+result
+/// (verified: every fib residual call is `(i64,…)->i64`), so the static type is
+/// fixed by the arity alone. `false` = byte-identical jit_call baseline.
+const WASM_DIRECT_RESIDUAL_CALL: bool = true;
+
+/// If `op` is a residual CALL whose ABI is uniformly i64 (all Int/Ref args and
+/// an Int/Ref result), return its argument count — eligible for a direct
+/// `call_indirect` of type `(i64×n) -> i64`. `None` keeps the `jit_call`
+/// trampoline: void / float / release-GIL / cond / assembler calls, a missing
+/// call descr, or an arg-count/descr-shape mismatch (defensive).
+fn residual_call_i64_arity(op: &Op) -> Option<usize> {
+    use OpCode::*;
+    if !matches!(
+        op.opcode,
+        CallI
+            | CallR
+            | CallPureI
+            | CallPureR
+            | CallMayForceI
+            | CallMayForceR
+            | CallLoopinvariantI
+            | CallLoopinvariantR
+    ) {
+        return None;
+    }
+    if !matches!(op.result_type(), Type::Int | Type::Ref) {
+        return None;
+    }
+    let descr = op.getdescr()?;
+    let cd = descr.as_call_descr()?;
+    let arg_types = cd.arg_types();
+    if arg_types
+        .iter()
+        .any(|t| !matches!(t, Type::Int | Type::Ref))
+    {
+        return None;
+    }
+    // `getarglist()[0]` is the func pointer; the call args are `[1..]`. The
+    // descr's `arg_types` describes those call args, so the counts must match.
+    let nargs = op.getarglist().len().saturating_sub(1);
+    if arg_types.len() != nargs {
+        return None;
+    }
+    Some(nargs)
+}
+
 fn has_call_ops(ops: &[Op]) -> bool {
     // Allocation ops (`New*`, `Newstr`/`Newunicode`) also reach the host via
     // the `jit_call` trampoline, so the import must be present for them too.
@@ -485,26 +534,30 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
 /// `collect_guards_and_vars`), so a single map covers both. Int / Float /
 /// Void values are skipped — only GC references need a forwarding home.
 /// Allocate the per-guard bridge-slot cell array for inter-trace chaining and
-/// return its base address in the shared linear memory (`0` on native).
+/// return `(base address in the shared linear memory, owner)`.
 ///
-/// One zero-initialised i32 cell per guard, indexed by `fail_index`. The array
-/// is leaked: it must outlive the trace module that bakes its address in, and
-/// `compile_bridge` writes the bridge's table slot into the matching cell.
-/// `jit_free` reclaims it (the slot count is recorded on the compiled loop).
+/// One zero-initialised i32 cell per guard, indexed by `fail_index`;
+/// `compile_bridge` writes the bridge's table slot into the matching cell. The
+/// returned `Box<[u32]>` is the array's owner — the caller stores it on the
+/// compiled loop (or, for a bridge, on its source loop's owned-cells list) so
+/// it is freed on `Drop`. The base address aliases the box's heap buffer, which
+/// is stable across moves of the owning box, so baking it into the module here
+/// stays valid for the loop's lifetime.
 ///
 /// On native the trace is never executed, so the dispatch is omitted and no
-/// cells are needed — returning 0 avoids a per-codegen host leak and keeps the
-/// emitted module byte-identical to the pre-chaining output.
-fn alloc_bridge_cells(num_guards: usize) -> u32 {
+/// cells are needed — returning `(0, None)` keeps the emitted module
+/// byte-identical to the pre-chaining output and allocates nothing.
+fn alloc_bridge_cells(num_guards: usize) -> (u32, Option<Box<[u32]>>) {
     #[cfg(target_arch = "wasm32")]
     {
-        let cells = vec![0u32; num_guards].into_boxed_slice();
-        Box::leak(cells).as_mut_ptr() as usize as u32
+        let mut cells = vec![0u32; num_guards].into_boxed_slice();
+        let base = cells.as_mut_ptr() as usize as u32;
+        (base, Some(cells))
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
         let _ = num_guards;
-        0
+        (0, None)
     }
 }
 
@@ -527,7 +580,7 @@ pub fn build_wasm_module(
     // loop's table slot — a wasm tail call, so the loop⇄bridge cycle runs at
     // constant stack depth instead of growing one frame per iteration.
     external_jump_slot: u32,
-) -> Result<(Vec<u8>, Vec<GuardExit>, usize, u32), BackendError> {
+) -> Result<(Vec<u8>, Vec<GuardExit>, usize, u32, Option<Box<[u32]>>), BackendError> {
     let (mut guards, num_vars) = collect_guards_and_vars(inputargs, ops);
 
     // A bridge's guard/finish exits share one fail-index namespace with the
@@ -551,10 +604,10 @@ pub fn build_wasm_module(
     // builds the trace is never executed, so `alloc_bridge_cells` returns 0 and
     // the dispatch is omitted entirely — the module stays byte-identical.
     let want_dispatch = ops.iter().any(|op| op.opcode == OpCode::Label) && !guards.is_empty();
-    let cells_base = if want_dispatch {
+    let (cells_base, cells_owner) = if want_dispatch {
         alloc_bridge_cells(guards.len())
     } else {
-        0
+        (0, None)
     };
     let bridge_dispatch = cells_base != 0;
 
@@ -586,6 +639,16 @@ pub fn build_wasm_module(
     // dispatch and for the epilogue's bridge `call_indirect`.
     let needs_table = needs_call || bridge_dispatch;
 
+    // In-module residual calls (`WASM_DIRECT_RESIDUAL_CALL`): the largest
+    // eligible `(i64×n)->i64` residual-call arity in this trace, or `None` if
+    // there are none. Each distinct arity `0..=max` gets its own function type
+    // (declared below) so the CALL arm can `call_indirect` with a static type.
+    let residual_max_arity = if WASM_DIRECT_RESIDUAL_CALL {
+        ops.iter().filter_map(residual_call_i64_arity).max()
+    } else {
+        None
+    };
+
     let mut module = Module::new();
 
     // Type section
@@ -595,6 +658,16 @@ pub fn build_wasm_module(
     if needs_call {
         // Type 1: jit_call trampoline (param i32) -> ()
         types.ty().function(vec![ValType::I32], vec![]);
+    }
+    // Residual-call types follow: `(i64×n) -> i64` for arity `n`, indexed by
+    // `residual_type_base + n`. `residual_type_base` = the count of types above.
+    let residual_type_base = 1 + needs_call as u32;
+    if let Some(max) = residual_max_arity {
+        for n in 0..=max {
+            types
+                .ty()
+                .function(vec![ValType::I64; n], vec![ValType::I64]);
+        }
     }
     module.section(&types);
 
@@ -667,13 +740,21 @@ pub fn build_wasm_module(
         bridge_dispatch,
         fail_index_base,
         external_jump_slot,
+        residual_max_arity.map(|_| residual_type_base),
     )?;
     codes.function(&func);
     module.section(&codes);
 
-    Ok((module.finish(), guards, num_ref_homes, cells_base))
+    Ok((
+        module.finish(),
+        guards,
+        num_ref_homes,
+        cells_base,
+        cells_owner,
+    ))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_function(
     inputargs: &[InputArg],
     ops: &[Op],
@@ -691,6 +772,10 @@ fn build_function(
     bridge_dispatch: bool,
     fail_index_base: u32,
     external_jump_slot: u32,
+    // Base wasm type index of the `(i64×n)->i64` residual-call types (type
+    // `residual_type_base + n` for arity `n`), or `None` when the trace has no
+    // eligible residual call so the CALL arm always uses the `jit_call` path.
+    residual_type_base: Option<u32>,
 ) -> Result<Function, BackendError> {
     // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
     // locals past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) as scratch for
@@ -1772,53 +1857,81 @@ fn build_function(
             | OpCode::CallAssemblerF
             | OpCode::CallReleaseGilF => {
                 let vi = op.pos.get().raw();
-                let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
 
-                // args[0] = func_ptr, args[1..] = call arguments
-                let func_ptr_ref = op.arg(0).to_opref();
-                let call_args = &op.getarglist()[1..];
+                // Direct in-module residual call: skip the `jit_call` host hop and
+                // `call_indirect` the callee's table slot with a static
+                // `(i64×n)->i64` type. The residual ABI is uniformly i64 for
+                // Int/Ref args+result, so args/result move on the wasm stack with
+                // no marshalling and no call-area traffic. The callee uses the
+                // *no-collect* nursery hook (like the trampoline path), so no Ref
+                // reload is needed. Falls back below when ineligible.
+                if let (Some(base), Some(nargs)) = (residual_type_base, residual_call_i64_arity(op))
+                {
+                    let call_args = &op.getarglist()[1..];
+                    for arg in call_args {
+                        emit_resolve(&mut sink, constants, arg.to_opref());
+                    }
+                    // func_ptr (arg 0) is the table slot — wrap to i32 index.
+                    emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                    sink.i32_wrap_i64();
+                    // call_indirect(table_index, type_index): table 0, type for arity n.
+                    sink.call_indirect(0, base + nargs as u32);
+                    if !OpRef::raw_is_constant(vi) {
+                        sink.local_set(1 + vi);
+                    } else {
+                        sink.drop(); // value-producing call whose result is unused
+                    }
+                    // store-on-def (end of loop) homes a Ref result, so the
+                    // direct path must NOT `continue` past it.
+                } else {
+                    let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
 
-                // Store func_ptr to call area
-                sink.local_get(0);
-                emit_resolve(&mut sink, constants, func_ptr_ref);
-                sink.i64_store(mem64(CALL_FUNC_OFS));
+                    // args[0] = func_ptr, args[1..] = call arguments
+                    let func_ptr_ref = op.arg(0).to_opref();
+                    let call_args = &op.getarglist()[1..];
 
-                // Store num_args
-                sink.local_get(0);
-                sink.i64_const(call_args.len() as i64);
-                sink.i64_store(mem64(CALL_NARGS_OFS));
-
-                // Store each arg
-                for (i, arg) in call_args.iter().enumerate() {
+                    // Store func_ptr to call area
                     sink.local_get(0);
-                    emit_resolve(&mut sink, constants, arg.to_opref());
-                    sink.i64_store(mem64(CALL_ARGS_OFS + i as u64 * SLOT_SIZE));
-                }
+                    emit_resolve(&mut sink, constants, func_ptr_ref);
+                    sink.i64_store(mem64(CALL_FUNC_OFS));
 
-                // Call trampoline
-                sink.local_get(0);
-                sink.call(jit_call);
-
-                // Read result (for non-void calls)
-                let is_void = matches!(
-                    op.opcode,
-                    OpCode::CallN
-                        | OpCode::CallPureN
-                        | OpCode::CallMayForceN
-                        | OpCode::CallAssemblerN
-                        | OpCode::CallReleaseGilN
-                        | OpCode::CallLoopinvariantN
-                );
-                if !OpRef::raw_is_constant(vi) && !is_void {
+                    // Store num_args
                     sink.local_get(0);
-                    sink.i64_load(mem64(CALL_RESULT_OFS));
-                    sink.local_set(1 + vi);
+                    sink.i64_const(call_args.len() as i64);
+                    sink.i64_store(mem64(CALL_NARGS_OFS));
+
+                    // Store each arg
+                    for (i, arg) in call_args.iter().enumerate() {
+                        sink.local_get(0);
+                        emit_resolve(&mut sink, constants, arg.to_opref());
+                        sink.i64_store(mem64(CALL_ARGS_OFS + i as u64 * SLOT_SIZE));
+                    }
+
+                    // Call trampoline
+                    sink.local_get(0);
+                    sink.call(jit_call);
+
+                    // Read result (for non-void calls)
+                    let is_void = matches!(
+                        op.opcode,
+                        OpCode::CallN
+                            | OpCode::CallPureN
+                            | OpCode::CallMayForceN
+                            | OpCode::CallAssemblerN
+                            | OpCode::CallReleaseGilN
+                            | OpCode::CallLoopinvariantN
+                    );
+                    if !OpRef::raw_is_constant(vi) && !is_void {
+                        sink.local_get(0);
+                        sink.i64_load(mem64(CALL_RESULT_OFS));
+                        sink.local_set(1 + vi);
+                    }
+                    // No reload after a residual call: the interpreter's host-side
+                    // allocations use the *no-collect* nursery hook (their callers
+                    // hold unrooted raw pointers), so a residual callee never moves
+                    // objects. Only `New*` (which uses the collecting allocator)
+                    // needs a reload.
                 }
-                // No reload after a residual call: the interpreter's host-side
-                // allocations use the *no-collect* nursery hook (their callers
-                // hold unrooted raw pointers), so a residual callee never moves
-                // objects. Only `New*` (which uses the collecting allocator)
-                // needs a reload.
             }
 
             // ── Allocation (via trampoline — treated as CALL) ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -26,7 +26,7 @@ use wasm_encoder::{
 };
 
 /// Frame slot byte offset: slot[i] is at frame_ptr + 8 + i * 8.
-const FRAME_SLOT_BASE: u64 = 8;
+pub const FRAME_SLOT_BASE: u64 = 8;
 const SLOT_SIZE: u64 = 8;
 
 /// Scratch i64 locals reserved past the value locals for `emit_umulhi`
@@ -270,6 +270,14 @@ impl RefHomes {
             .filter(|&(_, h)| h != Self::NONE)
             .map(|(id, h)| (id as u32, h))
     }
+}
+
+/// Number of Ref-home slots a trace with these `inputargs`/`ops` reserves,
+/// matching the `num_ref_homes` [`build_wasm_module`] returns. Lets a CA-arena
+/// caller size the callee frame and the GC walker for a (wider) bridge's home
+/// region before codegen runs.
+pub fn count_ref_homes(inputargs: &[InputArg], ops: &[Op]) -> usize {
+    RefHomes::collect(inputargs, ops).len()
 }
 
 /// Argument index of the stored value for a GC ref-storing op. `SetfieldRaw` /
@@ -570,6 +578,50 @@ fn alloc_bridge_cells(num_guards: usize) -> (u32, Option<Box<[u32]>>) {
     }
 }
 
+/// Parameters for the self-recursive CALL_ASSEMBLER guest→guest `call_indirect`
+/// arm (`PYRE_WASM_CA`). `emit_ca == false` (the default) keeps every emitted
+/// module byte-identical to the pre-feature backend.
+#[derive(Clone, Copy, Default)]
+pub struct CaParams {
+    /// Emit the dedicated `CallAssemblerR` arm (an in-module `call_indirect`
+    /// into the source loop). Only set by `compile_bridge` for a self-recursive
+    /// single-int bridge; `compile_loop` never sets it.
+    pub emit_ca: bool,
+    /// Bytes to reserve per callee frame (the GC `JitFrame`'s data region, i.e.
+    /// its Signed item area). Sized for the SOURCE loop, widened to also fit THIS
+    /// bridge (which reuses the frame when the loop's guard-exit chains back into
+    /// it). The alloc trampoline derives the JitFrame item count from it.
+    pub callee_frame_bytes: u32,
+    /// `fail_index` the SOURCE loop's DoneWithThisFrame Finish writes to frame[0]
+    /// on the base-case return. The CA arm treats this — or this bridge's own
+    /// finish index — as a clean callee finish; anything else is a deopt.
+    pub loop_finish_fi: u32,
+    /// `__indirect_function_table` slot of `wasm_ca_resume_deopt`
+    /// (`lib.rs::ca_deopt_helper_slot`). When a callee `call_indirect` returns a
+    /// non-finish `fail_index` (a guard deopt), the CA arm `call_indirect`s this
+    /// slot to blackhole-resume the callee on the host and read back its result,
+    /// instead of trapping. `0` (unset) ⇒ no helper, so `compile_bridge` declines
+    /// the CA lift before reaching codegen.
+    pub deopt_helper_slot: u32,
+    /// Address of the source loop's `CompiledWasmLoop`, baked as the first
+    /// argument to the deopt helper so it can resolve the deopted callee frame's
+    /// `fail_descrs`.
+    pub source_compiled_ptr: u64,
+    /// `__indirect_function_table` slot (`fn as usize`) of
+    /// `lib.rs::wasm_jit_ca_alloc_frame`. The CA arm routes through the
+    /// `jit_call` trampoline to allocate each callee frame as a GC-managed
+    /// old-gen `JitFrame` (push_jf-rooted, traced by its own per-frame gcmap).
+    pub ca_alloc_fn_ptr: i64,
+    /// `__indirect_function_table` slot of `lib.rs::wasm_jit_ca_pop_frame`,
+    /// called on CA-arm exit to pop the callee frame off the jitframe shadow
+    /// stack (strict LIFO).
+    pub ca_pop_fn_ptr: i64,
+    /// Leaked per-bridge `jf_gcmap` (`lib.rs::build_callee_gcmap`) marking the
+    /// callee frame's CA input + home Ref slots; baked into each frame's
+    /// `jf_gcmap` field at alloc time.
+    pub callee_gcmap_ptr: i64,
+}
+
 /// Build a wasm module from majit IR.
 pub fn build_wasm_module(
     inputargs: &[InputArg],
@@ -589,6 +641,9 @@ pub fn build_wasm_module(
     // loop's table slot — a wasm tail call, so the loop⇄bridge cycle runs at
     // constant stack depth instead of growing one frame per iteration.
     external_jump_slot: u32,
+    // Self-recursive CALL_ASSEMBLER arm parameters (`PYRE_WASM_CA`); `emit_ca`
+    // off keeps the module byte-identical.
+    ca: CaParams,
 ) -> Result<(Vec<u8>, Vec<GuardExit>, usize, u32, Option<Box<[u32]>>), BackendError> {
     let (mut guards, num_vars) = collect_guards_and_vars(inputargs, ops);
 
@@ -612,7 +667,14 @@ pub fn build_wasm_module(
     // trace reads it and `compile_bridge` (guest-side) writes it. On native
     // builds the trace is never executed, so `alloc_bridge_cells` returns 0 and
     // the dispatch is omitted entirely — the module stays byte-identical.
-    let want_dispatch = ops.iter().any(|op| op.opcode == OpCode::Label) && !guards.is_empty();
+    // A loop-closing bridge needs a `Label` to chain into; the
+    // self-recursive CALL_ASSEMBLER case (`PYRE_WASM_CA`) chains a guard exit of
+    // a Label-less recursion loop (`fail_index_base == 0` ⇒ a loop, not a
+    // bridge) into its CA bridge, so allocate cells for that too. Gated on the
+    // flag, so flag-off stays byte-identical.
+    let want_dispatch = !guards.is_empty()
+        && (ops.iter().any(|op| op.opcode == OpCode::Label)
+            || (fail_index_base == 0 && crate::wasm_ca_enabled()));
     let (cells_base, cells_owner) = if want_dispatch {
         alloc_bridge_cells(guards.len())
     } else {
@@ -641,12 +703,40 @@ pub fn build_wasm_module(
 
     let ref_homes = RefHomes::collect(inputargs, ops);
     let num_ref_homes = ref_homes.len();
+
+    // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`): `bridge_finish_fi` is
+    // THIS bridge's own DoneWithThisFrame index (the recursive return), which the
+    // CA arm accepts as a clean callee finish alongside the source loop's
+    // base-case finish. Widen the callee-frame reservation to also fit this
+    // bridge's frame: the source loop's guard-exit chains into this bridge
+    // reusing the same arena frame, so an undersized frame would let the bridge's
+    // home-slot writes overflow into the next arena slot.
+    let bridge_finish_fi = guards
+        .iter()
+        .find(|g| g.is_finish)
+        .map(|g| g.fail_index)
+        .unwrap_or(0);
+    let ca = if ca.emit_ca {
+        let bridge_base_slots = (MIN_FRAME_BYTES / 8).max(max_value_slots);
+        let bridge_frame_bytes = ((bridge_base_slots + 1 + num_ref_homes) * 8) as u32;
+        CaParams {
+            callee_frame_bytes: ca.callee_frame_bytes.max(bridge_frame_bytes) + 128,
+            ..ca
+        }
+    } else {
+        ca
+    };
+
     // A ref-storing store needs the `jit_call` import for its write barrier,
-    // even when the trace has no `New*`/CALL of its own.
-    let needs_call = has_call_ops(ops) || has_ref_store_op(ops, &ref_homes);
+    // even when the trace has no `New*`/CALL of its own. The CA arm needs it too
+    // for the callee-frame GC-alloc / shadow-stack-pop trampolines (an emit_ca
+    // bridge always materializes its callee frame via NewWithVtable, so this is
+    // already true in practice — stated explicitly for robustness).
+    let needs_call = has_call_ops(ops) || has_ref_store_op(ops, &ref_homes) || ca.emit_ca;
     // The shared indirect-function table is imported for `jit_call`'s residual
-    // dispatch and for the epilogue's bridge `call_indirect`.
-    let needs_table = needs_call || bridge_dispatch;
+    // dispatch, the epilogue's bridge `call_indirect`, and the CA arm's
+    // self-recursive `call_indirect`.
+    let needs_table = needs_call || bridge_dispatch || ca.emit_ca;
 
     // In-module residual calls (`WASM_DIRECT_RESIDUAL_CALL`): the largest
     // eligible `(i64×n)->i64` residual-call arity in this trace, or `None` if
@@ -677,6 +767,17 @@ pub fn build_wasm_module(
                 .ty()
                 .function(vec![ValType::I64; n], vec![ValType::I64]);
         }
+    }
+    // CA deopt-helper type `(i64 frame_ptr, i64 compiled_ptr) -> i64`. The CA arm
+    // `call_indirect`s `wasm_ca_resume_deopt` through it when a self-recursive
+    // callee leaves its trace through a guard (a deopt). Declared after the
+    // residual-call type family so its index is independent of which residual
+    // arities the bridge happens to use.
+    let ca_helper_type_idx = residual_type_base + residual_max_arity.map_or(0, |m| m as u32 + 1);
+    if ca.emit_ca {
+        types
+            .ty()
+            .function(vec![ValType::I64, ValType::I64], vec![ValType::I64]);
     }
     module.section(&types);
 
@@ -750,6 +851,9 @@ pub fn build_wasm_module(
         fail_index_base,
         external_jump_slot,
         residual_max_arity.map(|_| residual_type_base),
+        ca,
+        bridge_finish_fi,
+        ca_helper_type_idx,
     )?;
     codes.function(&func);
     module.section(&codes);
@@ -785,6 +889,16 @@ fn build_function(
     // `residual_type_base + n` for arity `n`), or `None` when the trace has no
     // eligible residual call so the CALL arm always uses the `jit_call` path.
     residual_type_base: Option<u32>,
+    // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`). `ca.emit_ca` off keeps
+    // the body byte-identical.
+    ca: CaParams,
+    // This bridge's own DoneWithThisFrame Finish index (the recursive return);
+    // the CA arm accepts it or `ca.loop_finish_fi` as a clean callee finish.
+    bridge_finish_fi: u32,
+    // wasm type index of the CA deopt helper `(i64, i64) -> i64`, declared in the
+    // module type section when `ca.emit_ca`. The CA arm uses it to `call_indirect`
+    // `ca.deopt_helper_slot` for a deopted callee.
+    ca_helper_type_idx: u32,
 ) -> Result<Function, BackendError> {
     // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` extra i64
     // locals past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) as scratch for
@@ -792,9 +906,15 @@ fn build_function(
     // past those (`num_vars+UMULHI_SCRATCH+1`) holds the bridge table slot for
     // the epilogue `call_indirect` dispatch (unused when `!bridge_dispatch`).
     let bridge_slot_local = num_vars + UMULHI_SCRATCH + 1;
+    // The self-recursive CALL_ASSEMBLER arm needs two more i32 scratch locals:
+    // `ca_cfp_local` (the current callee frame pointer) and `ca_fi_local` (the
+    // returned frame[0] fail index). Reserve them only under `emit_ca` so a
+    // flag-off module keeps exactly one i32 local (byte-identical).
+    let ca_cfp_local = num_vars + UMULHI_SCRATCH + 2;
+    let ca_fi_local = num_vars + UMULHI_SCRATCH + 3;
     let mut func = Function::new(vec![
         (num_vars + UMULHI_SCRATCH, ValType::I64),
-        (1, ValType::I32),
+        (if ca.emit_ca { 3 } else { 1 }, ValType::I32),
     ]);
     let mut sink = func.instructions();
 
@@ -815,6 +935,16 @@ fn build_function(
     // inner loop header).
     let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
     let has_loop = loop_label_idx.is_some();
+
+    // A Label-less recursion loop with bridge dispatch (`PYRE_WASM_CA`): there is
+    // no `loop`, but its guard/Finish exits still need to `br` to the function
+    // epilogue so the epilogue's cell dispatch can chain a failing guard into its
+    // CA bridge (instead of each guard early-returning to the host). Wrap the
+    // body in one exit `block` and route exits through it, exactly as a loop
+    // does. Only loops reach here (`bridge_dispatch` is gated on
+    // `fail_index_base == 0` for the Label-less case), so a CA bridge — itself
+    // Label-less — keeps its byte-identical straight-line layout.
+    let ca_straightline_dispatch = !has_loop && bridge_dispatch;
 
     // Resume-at-LABEL: a peeled loop wraps its preamble in a dispatch so a
     // loop-closing bridge can re-enter AT the (last) LABEL — where the `loop`
@@ -865,8 +995,9 @@ fn build_function(
     }
 
     // Non-key_dispatch loop: the single exit block A (preamble + body share it).
-    // key_dispatch already opened A/B/C above.
-    if has_loop && !key_dispatch {
+    // key_dispatch already opened A/B/C above. A Label-less CA dispatch loop also
+    // opens A so its guard/Finish exits `br` out to the epilogue.
+    if (has_loop || ca_straightline_dispatch) && !key_dispatch {
         sink.block(BlockType::Empty);
     }
 
@@ -916,6 +1047,8 @@ fn build_function(
         // depth 2; the body is unchanged at 1 (B and C close before the loop).
         // `None` for straight-line traces (no block emitted).
         let block_exit_depth = match (has_loop, in_loop_body) {
+            // Label-less CA dispatch loop: one exit block A (depth 0), no `loop`.
+            (false, _) if ca_straightline_dispatch => Some(0u32),
             (false, _) => None,
             (true, false) => Some(if key_dispatch { 2u32 } else { 0u32 }),
             (true, true) => Some(1u32),
@@ -1908,6 +2041,136 @@ fn build_function(
                 );
             }
 
+            // ── Self-recursive CALL_ASSEMBLER (PYRE_WASM_CA) ──
+            // Lower `vi = CallAssemblerR(frame, ec)` into an in-module
+            // `call_indirect` into the SOURCE loop (self-recursion) instead of a
+            // host round-trip. A fresh callee frame is allocated as a real
+            // GC-managed `JitFrame` (old-gen ⇒ non-moving; push_jf-rooted on the
+            // jitframe shadow stack; traced by its OWN per-frame gcmap covering
+            // its input + home Ref slots), the two red inputs are written to its
+            // input slots, the loop runs on it (recursing through this same arm
+            // for deeper levels), then the result Ref is read back from output
+            // slot 0. Only emitted for the fib-shaped bridge `compile_bridge`
+            // validated (`bridge_is_self_recursive_int_ca`); a loop never sets
+            // `emit_ca`. The callee `call_indirect` runs the source loop's full
+            // recursion, which allocates and collects; each live callee frame is
+            // self-described by its gcmap so a collection forwards its Refs (no
+            // shared-arena single-stride walker). This bridge's own wasm-local
+            // Refs still hold pre-call (from-space) addresses on return, so
+            // reload them from the (forwarded) homes after the call.
+            OpCode::CallAssemblerR if ca.emit_ca => {
+                let jit_call =
+                    jit_call_idx.expect("CA arm needs jit_call for the frame trampolines");
+                let vi = op.pos.get().raw();
+                // `external_jump_slot` is the source loop's table slot (the CA
+                // self-target), plumbed by `compile_bridge`.
+                let self_slot = external_jump_slot as i32;
+
+                // Allocate the callee frame as a GC JitFrame via the jit_call
+                // trampoline (`wasm_jit_ca_alloc_frame(frame_bytes, gcmap_ptr)`);
+                // the call slots live in THIS (caller) frame at local 0.
+                // `ca_cfp_local = frame_base + FIRST_ITEM_OFFSET` is the
+                // bespoke-layout frame pointer — every `mem64(OFS)` below is
+                // relative to it, exactly as the source loop reads its local 0.
+                sink.local_get(0);
+                sink.i64_const(ca.ca_alloc_fn_ptr);
+                sink.i64_store(mem64(CALL_FUNC_OFS));
+                sink.local_get(0);
+                sink.i64_const(2);
+                sink.i64_store(mem64(CALL_NARGS_OFS));
+                sink.local_get(0);
+                sink.i64_const(ca.callee_frame_bytes as i64);
+                sink.i64_store(mem64(CALL_ARGS_OFS));
+                sink.local_get(0);
+                sink.i64_const(ca.callee_gcmap_ptr);
+                sink.i64_store(mem64(CALL_ARGS_OFS + SLOT_SIZE));
+                sink.local_get(0);
+                sink.call(jit_call);
+                sink.local_get(0);
+                sink.i64_load(mem64(CALL_RESULT_OFS));
+                sink.i32_wrap_i64();
+                sink.i32_const(majit_backend::jitframe::FIRST_ITEM_OFFSET as i32);
+                sink.i32_add();
+                sink.local_set(ca_cfp_local);
+                // dispatch key = 0: run the loop from its entry (preamble), not a
+                // LABEL resume — this is a fresh call.
+                sink.local_get(ca_cfp_local);
+                sink.i64_const(0);
+                sink.i64_store(mem64(DISPATCH_KEY_OFS));
+                // inputs: F'[1] = arg0 (callee frame), F'[2] = arg1 (ec).
+                sink.local_get(ca_cfp_local);
+                emit_resolve(&mut sink, constants, op.arg(0).to_opref());
+                sink.i64_store(mem64(FRAME_SLOT_BASE));
+                sink.local_get(ca_cfp_local);
+                emit_resolve(&mut sink, constants, op.arg(1).to_opref());
+                sink.i64_store(mem64(FRAME_SLOT_BASE + SLOT_SIZE));
+                // run the source loop on F' (non-tail: one wasm frame per
+                // recursion level); discard the returned frame_ptr.
+                sink.local_get(ca_cfp_local);
+                sink.i32_const(self_slot);
+                sink.call_indirect(0, 0);
+                sink.drop();
+                // F'[0] is the callee's exit `fail_index`. The base-case loop
+                // finish or this bridge's own recursive finish is a clean
+                // DoneWithThisFrame — the result is already in the callee output
+                // slot F'[1]. Any other value is a guard deopt the in-guest run
+                // cannot finish; hand the callee frame to `wasm_ca_resume_deopt`,
+                // which blackhole-resumes it on the host — resuming AT the guard,
+                // so pre-guard work is not re-executed — and returns the result.
+                sink.local_get(ca_cfp_local);
+                sink.i64_load(mem64(0));
+                sink.i32_wrap_i64();
+                sink.local_set(ca_fi_local);
+                // is_finish = (fi == loop_finish_fi) | (fi == bridge_finish_fi)
+                sink.local_get(ca_fi_local);
+                sink.i32_const(ca.loop_finish_fi as i32);
+                sink.i32_eq();
+                sink.local_get(ca_fi_local);
+                sink.i32_const(bridge_finish_fi as i32);
+                sink.i32_eq();
+                sink.i32_or();
+                sink.if_(BlockType::Result(ValType::I64));
+                // clean finish: result Ref = F'[1] (output slot 0).
+                sink.local_get(ca_cfp_local);
+                sink.i64_load(mem64(FRAME_SLOT_BASE));
+                sink.else_();
+                // deopt: wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64).
+                sink.local_get(ca_cfp_local);
+                sink.i64_extend_i32_u();
+                sink.i64_const(ca.source_compiled_ptr as i64);
+                sink.i32_const(ca.deopt_helper_slot as i32);
+                // call_indirect(table_index, type_index): the shared table is 0.
+                sink.call_indirect(0, ca_helper_type_idx);
+                sink.end();
+                // store-on-def homes the result Ref (from whichever branch).
+                if !OpRef::raw_is_constant(vi) {
+                    sink.local_set(1 + vi);
+                } else {
+                    sink.drop();
+                }
+                // Pop the callee frame off the jitframe shadow stack (strict
+                // LIFO) via the jit_call trampoline (`wasm_jit_ca_pop_frame`).
+                sink.local_get(0);
+                sink.i64_const(ca.ca_pop_fn_ptr);
+                sink.i64_store(mem64(CALL_FUNC_OFS));
+                sink.local_get(0);
+                sink.i64_const(1);
+                sink.i64_store(mem64(CALL_NARGS_OFS));
+                sink.local_get(0);
+                sink.local_get(ca_cfp_local);
+                sink.i64_extend_i32_u();
+                sink.i64_store(mem64(CALL_ARGS_OFS));
+                sink.local_get(0);
+                sink.call(jit_call);
+                // The callee recursion minor-collected; this bridge's other live
+                // Ref locals are now stale. Reload them from the forwarded homes.
+                // Skip the result `vi`: its local holds the just-read callee output
+                // and its home is not written until the store-on-def below, so a
+                // reload would clobber it with the home's pre-call (stale) value.
+                let skip = (!OpRef::raw_is_constant(vi)).then_some(vi);
+                emit_reload_refs_from_homes(&mut sink, ref_homes, skip);
+            }
+
             // ── CALL operations (via trampoline) ──
             OpCode::CallI
             | OpCode::CallR
@@ -2237,6 +2500,8 @@ fn build_function(
     if has_loop {
         sink.end(); // end loop
         sink.end(); // end block
+    } else if ca_straightline_dispatch {
+        sink.end(); // end exit block A (no `loop` in a Label-less CA loop)
     }
 
     // Epilogue bridge dispatch (loop traces only). Control reaches here only

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -443,24 +443,18 @@ const WASM_DIRECT_RESIDUAL_CALL: bool = true;
 /// trampoline: void / float / release-GIL / cond / assembler calls, a missing
 /// call descr, or an arg-count/descr-shape mismatch (defensive).
 ///
-/// `CallMayForce*` is eligible despite being forceable: the wasm backend has no
-/// force tokens or `guard_not_forced` (the virtualizable is materialized, not
-/// virtual), so a forceable residual call needs no pre-call `jf_descr` — a guard
-/// raised inside it deopts through the same `fail_index` path as any other call,
-/// and the caller's live Refs survive across it through the `JitFrame` gcmap
-/// rather than `jf_descr`. It therefore lowers as a plain `(i64×n) -> i64` call.
+/// `CallMayForce*` is deliberately excluded (kept on the `jit_call` trampoline):
+/// `jf_descr` "is also set immediately before doing CALL_MAY_FORCE", and the
+/// direct `call_indirect` does not reproduce that pre-call force-descr store
+/// (`guard_not_forced`'s source). The wasm backend has no force tokens (the
+/// virtualizable is materialized), so a plain call would in fact be sound — but
+/// the fast-path stays parity-conservative and only covers the non-forceable
+/// residual calls (`Call{,Pure,Loopinvariant}{I,R}`), which are the hot cases.
 fn residual_call_i64_arity(op: &Op) -> Option<usize> {
     use OpCode::*;
     if !matches!(
         op.opcode,
-        CallI
-            | CallR
-            | CallPureI
-            | CallPureR
-            | CallMayForceI
-            | CallMayForceR
-            | CallLoopinvariantI
-            | CallLoopinvariantR
+        CallI | CallR | CallPureI | CallPureR | CallLoopinvariantI | CallLoopinvariantR
     ) {
         return None;
     }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -60,7 +60,16 @@ pub const MIN_FRAME_BYTES: usize = 2024 + 16 * 8; // 16 max call args
 /// output slots (which sit below the call area at offset 2000) or the call
 /// trampoline area. Inert while `wasm_jit_alloc` is no-collect (epic B): the
 /// extra stores write a region nothing reads until the allocator collects.
-pub const HOME_SLOT_BASE: u64 = MIN_FRAME_BYTES as u64;
+pub const HOME_SLOT_BASE: u64 = MIN_FRAME_BYTES as u64 + SLOT_SIZE;
+
+/// Resume-at-LABEL dispatch key (one reserved frame slot, between the call
+/// area and the Ref-home region). 0 = preamble/host entry (the `vec![0i64]`
+/// frame is always 0 here on a fresh `execute_token`); non-zero = a
+/// loop-closing bridge re-entering a single-label peeled loop at its LABEL,
+/// skipping the preamble. Distinct from every value/fail-arg slot (< 2000) and
+/// the call trampoline (2000..2152); homes follow it at `HOME_SLOT_BASE`.
+pub const DISPATCH_KEY_OFS: u64 = MIN_FRAME_BYTES as u64;
+const _: () = assert!(HOME_SLOT_BASE == DISPATCH_KEY_OFS + SLOT_SIZE);
 
 fn mem64(offset: u64) -> MemArg {
     MemArg {
@@ -797,6 +806,36 @@ fn build_function(
         sink.i64_store(mem64(HOME_SLOT_BASE + h * SLOT_SIZE));
     }
 
+    // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
+    // preamble runs once on entry, the LABEL is the loop-back target, and
+    // JUMP branches back to it. Emit the `loop` at the LABEL (not the top)
+    // so the preamble is not re-executed every iteration; wrap everything in
+    // a `block` so guard exits `br` out to the function epilogue. Use the
+    // LAST label (a peeled trace may carry an outer entry label plus the
+    // inner loop header).
+    let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
+    let has_loop = loop_label_idx.is_some();
+
+    // Resume-at-LABEL: a single-label peeled loop wraps its preamble in a
+    // dispatch so a loop-closing bridge can re-enter AT the LABEL (skipping the
+    // preamble) in-module instead of round-tripping through the host. Keyed on
+    // the exact single-label-peeled shape, so every other trace (non-peeled
+    // loop, multi-label, straight-line, bridge) keeps its byte-identical layout.
+    let key_dispatch = is_single_label_peeled(ops);
+    if key_dispatch {
+        // block $exit (A) — guard/Finish exits br here -> epilogue.
+        // block $past_loader (B) — the preamble path br's over the resume loader.
+        // block $skip_preamble (C) — a resuming bridge br's out of here, past the
+        //   preamble + entry loader, landing in the resume loader.
+        sink.block(BlockType::Empty); // A $exit
+        sink.block(BlockType::Empty); // B $past_loader
+        sink.block(BlockType::Empty); // C $skip_preamble
+        sink.local_get(0);
+        sink.i64_load(mem64(DISPATCH_KEY_OFS));
+        sink.i32_wrap_i64();
+        sink.br_if(0); // key != 0 -> resume: skip the preamble + entry loader
+    }
+
     // Load inputs from frame into locals, and store Ref inputs to their homes.
     // The input value lives at the frame slot its producer wrote it to: the
     // caller fills slot `k` for the k-th input — `execute_token` for a loop
@@ -804,7 +843,11 @@ fn build_function(
     // so read from the POSITIONAL slot `k`, not `ia.index` (a value number that
     // equals `k` for a loop but not for a bridge, whose live-in args carry their
     // trace value numbers). The local index stays `1 + ia.index` because the
-    // body addresses each value by its number.
+    // body addresses each value by its number. For `key_dispatch` this runs on
+    // the key-0 (preamble) path only — past the `br_if` above — so a resuming
+    // bridge never scatters its frame-passed label values into the function
+    // inputargs' home slots; those stay null-initialized (GC-safe) and the
+    // resume loader sets the live label-arg homes.
     for (k, ia) in inputargs.iter().enumerate() {
         let local_idx = 1 + ia.index;
         let offset = FRAME_SLOT_BASE + k as u64 * SLOT_SIZE;
@@ -818,16 +861,9 @@ fn build_function(
         }
     }
 
-    // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
-    // preamble runs once on entry, the LABEL is the loop-back target, and
-    // JUMP branches back to it. Emit the `loop` at the LABEL (not the top)
-    // so the preamble is not re-executed every iteration; wrap everything in
-    // a `block` so guard exits `br` out to the function epilogue. Use the
-    // LAST label (a peeled trace may carry an outer entry label plus the
-    // inner loop header).
-    let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
-    let has_loop = loop_label_idx.is_some();
-    if has_loop {
+    // Non-key_dispatch loop: the single exit block A (preamble + body share it).
+    // key_dispatch already opened A/B/C above.
+    if has_loop && !key_dispatch {
         sink.block(BlockType::Empty);
     }
 
@@ -842,15 +878,43 @@ fn build_function(
 
     for (op_idx, op) in ops.iter().enumerate() {
         if Some(op_idx) == loop_label_idx {
+            if key_dispatch {
+                // End of the preamble (key-0 path). Branch over the resume
+                // loader to the loop, then close C, emit the loader (resume
+                // path only), close B, and open the loop. From inside C, `br 1`
+                // targets B's end (just before the loop), skipping the loader.
+                sink.br(1); // preamble done -> past_loader, over the resume loader
+                sink.end(); // end C $skip_preamble (resume path lands here)
+                // Resume loader: a loop-closing bridge wrote each label arg into
+                // frame slot i (positionally, matching the in-loop JUMP move);
+                // load them into the label-arg locals and refresh their Ref
+                // homes, mirroring the JUMP's ref-home refresh below. The
+                // preamble path skipped this via the `br 1` above.
+                let label_args = find_label_args(ops);
+                for (i, la) in label_args.iter().enumerate() {
+                    sink.local_get(0);
+                    sink.i64_load(mem64(FRAME_SLOT_BASE + i as u64 * SLOT_SIZE));
+                    sink.local_set(1 + la.raw());
+                    if let Some(h) = ref_homes.home(*la) {
+                        sink.local_get(0);
+                        sink.local_get(1 + la.raw());
+                        sink.i64_store(mem64(HOME_SLOT_BASE + h as u64 * SLOT_SIZE));
+                    }
+                }
+                sink.end(); // end B $past_loader
+            }
             sink.loop_(BlockType::Empty);
             in_loop_body = true;
         }
         // Depth (from statement level) of the enclosing `block` that guard
-        // exits `br` to: preamble = 0, loop body = 1 (the `loop` sits in
-        // between). `None` for straight-line traces (no block emitted).
+        // exits `br` to. Without `key_dispatch`: preamble = 0, loop body = 1
+        // (the `loop` sits between the body and block A). With `key_dispatch`
+        // the preamble sits two blocks deeper (inside B and C), so it br's to
+        // depth 2; the body is unchanged at 1 (B and C close before the loop).
+        // `None` for straight-line traces (no block emitted).
         let block_exit_depth = match (has_loop, in_loop_body) {
             (false, _) => None,
-            (true, false) => Some(0u32),
+            (true, false) => Some(if key_dispatch { 2u32 } else { 0u32 }),
             (true, true) => Some(1u32),
         };
         match op.opcode {
@@ -877,6 +941,15 @@ fn build_function(
                     emit_resolve(&mut sink, constants, jump_arg.to_opref());
                     sink.i64_store(mem64(FRAME_SLOT_BASE + i as u64 * SLOT_SIZE));
                 }
+                // Set the resume-at-LABEL dispatch key so a single-label peeled
+                // target re-enters at its LABEL (skipping the preamble) instead
+                // of re-running it from the function entry. Harmless for a
+                // non-peeled target, which has no dispatch and ignores the slot;
+                // a multi-label peeled target is declined in `compile_bridge`, so
+                // this bridge is never compiled for one.
+                sink.local_get(0); // frame_ptr
+                sink.i64_const(1); // dispatch key = resume at LABEL
+                sink.i64_store(mem64(DISPATCH_KEY_OFS));
                 sink.local_get(0); // frame_ptr argument to the loop
                 sink.i32_const(external_jump_slot as i32); // table slot
                 sink.return_call_indirect(0, 0); // table 0, type 0: (i32) -> i32
@@ -2202,6 +2275,25 @@ fn build_function(
 }
 
 // ── Helpers ──
+
+/// A single-label peeled loop: exactly one LABEL, preceded by real work (the
+/// unrolled first iteration = preamble). Such a loop emits the `loop` at its
+/// sole LABEL, so a loop-closing bridge can re-enter at that LABEL (skipping the
+/// preamble) via the resume-at-LABEL dispatch key. `build_function` keys its
+/// preamble-skip wrapper on this exact predicate, and `compile_loop` records it
+/// on `CompiledWasmLoop` so `compile_bridge` lifts its decline only for this
+/// shape — sharing this one function keeps codegen and the decline in lockstep.
+/// Multi-label peeled loops stay declined (the br_table form is a follow-up).
+pub fn is_single_label_peeled(ops: &[Op]) -> bool {
+    let Some(last_label) = ops.iter().rposition(|op| op.opcode == OpCode::Label) else {
+        return false;
+    };
+    let has_preamble = ops[..last_label]
+        .iter()
+        .any(|op| op.opcode != OpCode::Label);
+    let label_count = ops.iter().filter(|op| op.opcode == OpCode::Label).count();
+    has_preamble && label_count == 1
+}
 
 fn find_label_args(ops: &[Op]) -> Vec<OpRef> {
     // The JUMP branches back to the loop-header label, which is the LAST

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -442,6 +442,13 @@ const WASM_DIRECT_RESIDUAL_CALL: bool = true;
 /// `call_indirect` of type `(i64×n) -> i64`. `None` keeps the `jit_call`
 /// trampoline: void / float / release-GIL / cond / assembler calls, a missing
 /// call descr, or an arg-count/descr-shape mismatch (defensive).
+///
+/// `CallMayForce*` is eligible despite being forceable: the wasm backend has no
+/// force tokens or `guard_not_forced` (the virtualizable is materialized, not
+/// virtual), so a forceable residual call needs no pre-call `jf_descr` — a guard
+/// raised inside it deopts through the same `fail_index` path as any other call,
+/// and the caller's live Refs survive across it through the `JitFrame` gcmap
+/// rather than `jf_descr`. It therefore lowers as a plain `(i64×n) -> i64` call.
 fn residual_call_i64_arity(op: &Op) -> Option<usize> {
     use OpCode::*;
     if !matches!(
@@ -1751,7 +1758,13 @@ fn build_function(
 
             // ── Conditional calls ──
             OpCode::CondCallN | OpCode::CondCallGcWb | OpCode::CondCallGcWbArray => {
-                // GC write barriers and conditional void calls — no-op in wasm.
+                // No-op: the wasm backend does not consume the explicit
+                // COND_CALL_GC_WB / COND_CALL_GC_WB_ARRAY barrier ops. It emits
+                // the write barrier inline at each ref-store instead
+                // (`write_barrier_base` + `emit_write_barrier`, calling the
+                // `wasm_jit_write_barrier` host helper), so the standalone
+                // barrier op is redundant here. CondCallN is a conditional void
+                // call the wasm MVP does not need.
             }
 
             // x86/assembler.py:1919-1922 genop_guard_guard_gc_type:

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -816,12 +816,15 @@ fn build_function(
     let loop_label_idx = ops.iter().rposition(|op| op.opcode == OpCode::Label);
     let has_loop = loop_label_idx.is_some();
 
-    // Resume-at-LABEL: a single-label peeled loop wraps its preamble in a
-    // dispatch so a loop-closing bridge can re-enter AT the LABEL (skipping the
-    // preamble) in-module instead of round-tripping through the host. Keyed on
-    // the exact single-label-peeled shape, so every other trace (non-peeled
-    // loop, multi-label, straight-line, bridge) keeps its byte-identical layout.
-    let key_dispatch = is_single_label_peeled(ops);
+    // Resume-at-LABEL: a peeled loop wraps its preamble in a dispatch so a
+    // loop-closing bridge can re-enter AT the (last) LABEL — where the `loop`
+    // is — skipping the preamble, in-module instead of round-tripping through
+    // the host. Keyed on the peeled shape (single- OR multi-label); every other
+    // trace (non-peeled loop, straight-line, bridge) keeps its byte-identical
+    // layout. The dispatch resumes only at the LAST label, so the wrapper is
+    // byte-identical whether the source is single- or multi-label — the
+    // multi-label-but-non-last-label case is declined in `compile_bridge`.
+    let key_dispatch = is_resumable_peeled(ops);
     if key_dispatch {
         // block $exit (A) — guard/Finish exits br here -> epilogue.
         // block $past_loader (B) — the preamble path br's over the resume loader.
@@ -941,12 +944,14 @@ fn build_function(
                     emit_resolve(&mut sink, constants, jump_arg.to_opref());
                     sink.i64_store(mem64(FRAME_SLOT_BASE + i as u64 * SLOT_SIZE));
                 }
-                // Set the resume-at-LABEL dispatch key so a single-label peeled
-                // target re-enters at its LABEL (skipping the preamble) instead
+                // Set the resume-at-LABEL dispatch key so a peeled target
+                // re-enters at its (last) LABEL — skipping the preamble — instead
                 // of re-running it from the function entry. Harmless for a
-                // non-peeled target, which has no dispatch and ignores the slot;
-                // a multi-label peeled target is declined in `compile_bridge`, so
-                // this bridge is never compiled for one.
+                // non-peeled target, which has no dispatch and ignores the slot.
+                // `compile_bridge` only compiles this bridge when its JUMP
+                // resumes at the target's last label (always so for a single-
+                // label source; checked via the JUMP descr for a multi-label
+                // one), so key 1 always lands at the `loop`.
                 sink.local_get(0); // frame_ptr
                 sink.i64_const(1); // dispatch key = resume at LABEL
                 sink.i64_store(mem64(DISPATCH_KEY_OFS));
@@ -2276,23 +2281,34 @@ fn build_function(
 
 // ── Helpers ──
 
-/// A single-label peeled loop: exactly one LABEL, preceded by real work (the
-/// unrolled first iteration = preamble). Such a loop emits the `loop` at its
-/// sole LABEL, so a loop-closing bridge can re-enter at that LABEL (skipping the
-/// preamble) via the resume-at-LABEL dispatch key. `build_function` keys its
-/// preamble-skip wrapper on this exact predicate, and `compile_loop` records it
-/// on `CompiledWasmLoop` so `compile_bridge` lifts its decline only for this
-/// shape — sharing this one function keeps codegen and the decline in lockstep.
-/// Multi-label peeled loops stay declined (the br_table form is a follow-up).
-pub fn is_single_label_peeled(ops: &[Op]) -> bool {
+/// A peeled loop — real work (the unrolled first iteration = preamble) precedes
+/// the loop-header LABEL — whether it carries one LABEL or several. `loop` is
+/// emitted at the LAST label, so `build_function` wraps the preamble in the
+/// resume-at-LABEL dispatch (keyed on the frame dispatch-key slot) and a
+/// loop-closing bridge re-enters AT that last label, skipping the preamble,
+/// in-module. `build_function` keys its preamble-skip wrapper on this predicate;
+/// `compile_loop` records it on `CompiledWasmLoop`. The decline `compile_bridge`
+/// lifts is finer-grained: a single-label source is accepted directly
+/// (`is_single_label_peeled`), a multi-label source only when the bridge's JUMP
+/// targets that last label (recovered from its descr) — every other multi-label
+/// target needs the deferred br_table and stays declined.
+pub fn is_resumable_peeled(ops: &[Op]) -> bool {
     let Some(last_label) = ops.iter().rposition(|op| op.opcode == OpCode::Label) else {
         return false;
     };
-    let has_preamble = ops[..last_label]
+    ops[..last_label]
         .iter()
-        .any(|op| op.opcode != OpCode::Label);
+        .any(|op| op.opcode != OpCode::Label)
+}
+
+/// The single-label subset of `is_resumable_peeled`: exactly one LABEL. A
+/// loop-closing bridge into such a loop always targets that sole label, so
+/// `compile_bridge` accepts it without recovering the target ordinal. Kept a
+/// distinct predicate (not folded into `is_resumable_peeled`) so the bridge
+/// accept-condition can treat single- and multi-label sources differently.
+pub fn is_single_label_peeled(ops: &[Op]) -> bool {
     let label_count = ops.iter().filter(|op| op.opcode == OpCode::Label).count();
-    has_preamble && label_count == 1
+    is_resumable_peeled(ops) && label_count == 1
 }
 
 fn find_label_args(ops: &[Op]) -> Vec<OpRef> {

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -101,4 +101,19 @@ pub struct CompiledWasmLoop {
     /// infinite loop. `compile_bridge` declines a loop-closing bridge into such
     /// a loop so the guard falls back to blackhole resume instead of livelocking.
     pub has_preamble: bool,
+    /// `(source_fail_index, start, count)` ranges into `fail_descrs` for each
+    /// chained bridge `compile_bridge` appended (lib.rs extend site). Lets
+    /// `compiled_bridge_fail_descr_layouts` / `store_bridge_guard_hashes` map a
+    /// source guard back to its bridge's appended descr slice — the wasm analog
+    /// of dynasm's `lookup_bridge_addr` (runner.rs). Recorded in lockstep with
+    /// the `extend`, inside the same `borrow_mut` critical section.
+    pub bridge_descr_ranges: RefCell<Vec<(u32, usize, usize)>>,
+    /// Owns this loop's per-guard bridge-slot cell array so it is freed on
+    /// `Drop`; `bridge_cells_base` aliases its heap address (stable across the
+    /// struct move). `None` when the trace has no in-module dispatch.
+    pub _bridge_cells_owner: Option<Box<[u32]>>,
+    /// Owns the cell arrays of every bridge chained onto this loop. A bridge
+    /// module lives as long as the source loop it attaches to, so its cells are
+    /// freed when this loop drops. Appended by `compile_bridge`.
+    pub _bridge_owned_cells: RefCell<Vec<Box<[u32]>>>,
 }

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -1,7 +1,7 @@
 /// Guard failure descriptors and frame data for the wasm backend.
 ///
 /// Simplified from CraneliftFailDescr — no bridge data, GC maps, or force tokens.
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::Arc;
 
 use majit_ir::{Descr, DescrRef, FailDescr, Type};
@@ -135,4 +135,13 @@ pub struct CompiledWasmLoop {
     /// module lives as long as the source loop it attaches to, so its cells are
     /// freed when this loop drops. Appended by `compile_bridge`.
     pub _bridge_owned_cells: RefCell<Vec<Box<[u32]>>>,
+    /// Max `num_ref_homes` over the self-recursive `CallAssemblerR` bridges
+    /// (`PYRE_WASM_CA`) chained onto this loop, or 0 when there are none. Such a
+    /// bridge runs in the host entry frame `F0` for the outermost call, so
+    /// `execute_token` must size `F0` (and register its GC roots) for the LARGER
+    /// of the loop's own homes and this — the bridge's home writes would
+    /// otherwise overflow a loop-sized `F0`. Set by `compile_bridge` when it
+    /// accepts a CA bridge; `Cell` because the source token is shared (`&`) and
+    /// the wasm host is single-threaded.
+    pub ca_bridge_ref_homes: Cell<usize>,
 }

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -93,22 +93,33 @@ pub struct CompiledWasmLoop {
     /// guards (`source_fail_index < num_guard_cells`); descrs appended past this
     /// range belong to already-chained bridges and have no cell of their own.
     pub num_guard_cells: usize,
-    /// True when this is a peeled loop — there is real work (a preamble = the
-    /// unrolled first iteration) before the loop's `LABEL`. A loop-closing
-    /// bridge re-enters through the loop's table slot (the function entry), so
-    /// for a peeled loop it would re-run the preamble against mid-loop state
-    /// instead of resuming at the `LABEL`, never advancing the induction
-    /// variable — an infinite loop. `compile_bridge` therefore declines a
-    /// loop-closing bridge into a peeled loop UNLESS `is_single_label_peeled`,
-    /// where the resume-at-LABEL dispatch lets it re-enter at the LABEL safely.
+    /// True when this is a peeled loop (`codegen::is_resumable_peeled`) — there
+    /// is real work (a preamble = the unrolled first iteration) before the last
+    /// `LABEL`, single- or multi-label. Such a loop carries the resume-at-LABEL
+    /// preamble-skip dispatch and resumes at the LAST label (where the `loop`
+    /// is). A loop-closing bridge re-enters through the loop's table slot (the
+    /// function entry); for a peeled loop, re-running the preamble against
+    /// mid-loop state would never advance the induction variable — an infinite
+    /// loop. `compile_bridge` therefore declines a loop-closing bridge into a
+    /// peeled loop UNLESS it resumes at that last label: always so for a
+    /// single-label source (`is_single_label_peeled`), and for a multi-label
+    /// source only when the bridge's JUMP targets `last_label_block_id`.
     pub has_preamble: bool,
     /// True when this peeled loop has exactly one `LABEL`
-    /// (`codegen::is_single_label_peeled`). Its compiled function carries the
-    /// resume-at-LABEL preamble-skip dispatch (keyed on the frame dispatch-key
-    /// slot), so a loop-closing bridge can re-enter at the LABEL in-module —
-    /// `compile_bridge` lifts the `has_preamble` decline for this shape. A
-    /// multi-label peeled loop stays declined (its br_table form is a follow-up).
+    /// (`codegen::is_single_label_peeled`). A loop-closing bridge into such a
+    /// loop always targets that sole label, so `compile_bridge` accepts it
+    /// without recovering the JUMP's target ordinal.
     pub is_single_label_peeled: bool,
+    /// `label_block_id` of the LAST `LABEL` (= label_count − 1), the one carrying
+    /// the wasm `loop`. A loop-closing bridge into a multi-label source is
+    /// accepted only when its JUMP descr's recovered `label_block_id` equals this
+    /// — i.e. the bridge resumes at the label the resume dispatch lands on.
+    pub last_label_block_id: u32,
+    /// Argument count of the LAST `LABEL`. The accept-condition declines a bridge
+    /// whose closing JUMP arity differs from this, since the resume loader reads
+    /// exactly this many positional frame slots (an arity mismatch would resume
+    /// with stale/missing induction values).
+    pub last_label_num_args: usize,
     /// `(source_fail_index, start, count)` ranges into `fail_descrs` for each
     /// chained bridge `compile_bridge` appended (lib.rs extend site). Lets
     /// `compiled_bridge_fail_descr_layouts` / `store_bridge_guard_hashes` map a

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -96,11 +96,19 @@ pub struct CompiledWasmLoop {
     /// True when this is a peeled loop — there is real work (a preamble = the
     /// unrolled first iteration) before the loop's `LABEL`. A loop-closing
     /// bridge re-enters through the loop's table slot (the function entry), so
-    /// for a peeled loop it re-runs the preamble against mid-loop state instead
-    /// of resuming at the `LABEL`, never advancing the induction variable — an
-    /// infinite loop. `compile_bridge` declines a loop-closing bridge into such
-    /// a loop so the guard falls back to blackhole resume instead of livelocking.
+    /// for a peeled loop it would re-run the preamble against mid-loop state
+    /// instead of resuming at the `LABEL`, never advancing the induction
+    /// variable — an infinite loop. `compile_bridge` therefore declines a
+    /// loop-closing bridge into a peeled loop UNLESS `is_single_label_peeled`,
+    /// where the resume-at-LABEL dispatch lets it re-enter at the LABEL safely.
     pub has_preamble: bool,
+    /// True when this peeled loop has exactly one `LABEL`
+    /// (`codegen::is_single_label_peeled`). Its compiled function carries the
+    /// resume-at-LABEL preamble-skip dispatch (keyed on the frame dispatch-key
+    /// slot), so a loop-closing bridge can re-enter at the LABEL in-module —
+    /// `compile_bridge` lifts the `has_preamble` decline for this shape. A
+    /// multi-label peeled loop stays declined (its br_table form is a follow-up).
+    pub is_single_label_peeled: bool,
     /// `(source_fail_index, start, count)` ranges into `fail_descrs` for each
     /// chained bridge `compile_bridge` appended (lib.rs extend site). Lets
     /// `compiled_bridge_fail_descr_layouts` / `store_bridge_guard_hashes` map a

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -535,8 +535,10 @@ unsafe impl Send for WasmBackend {}
 fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool) -> Option<String> {
     for op in ops {
         if op.opcode.is_call_assembler() {
-            // CALL_ASSEMBLER enters another trace's compiled token; the wasm
-            // backend has no inter-module trace chaining (#62).
+            // CALL_ASSEMBLER inlines a loop-bearing callee by jumping into another
+            // trace's compiled token. The wasm backend has no inter-module trace
+            // chaining (each trace is its own module), so it cannot execute the
+            // target — decline (#62 loop-callee gap).
             return Some(format!(
                 "wasm backend: {:?} (loop-callee inline)",
                 op.opcode
@@ -572,6 +574,17 @@ impl majit_backend::Backend for WasmBackend {
 
     fn backend_name(&self) -> &'static str {
         "wasm"
+    }
+
+    fn bridge_decline_is_terminal(&self) -> bool {
+        // Every `compile_bridge` `Unsupported` return is a deterministic
+        // structural decline — a function of the (ops, source-loop) shape that
+        // re-tracing the same guard reproduces identically: CALL_ASSEMBLER /
+        // cross-loop JUMP shape, missing source loop, loop-closing bridge into a
+        // peeled preamble, non-direct loop guard, ref-home overflow, or the
+        // codegen frame-slot / unhandled-opcode declines. So re-firing the guard
+        // only rebuilds the same unsupported bridge; record it terminal.
+        true
     }
 
     // ── Blackhole allocation (llmodel.py:775-790) ──
@@ -691,7 +704,7 @@ impl majit_backend::Backend for WasmBackend {
         let alloc_fn_ptr = wasm_jit_alloc as *const () as usize as i64;
         let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
         let wb_fn_ptr = wasm_jit_write_barrier as *const () as usize as i64;
-        let (wasm_bytes, guard_exits, num_ref_homes, bridge_cells_base) =
+        let (wasm_bytes, guard_exits, num_ref_homes, bridge_cells_base, bridge_cells_owner) =
             codegen::build_wasm_module(
                 inputargs,
                 ops,
@@ -760,6 +773,9 @@ impl majit_backend::Backend for WasmBackend {
             bridge_cells_base,
             num_guard_cells: guard_exits.len(),
             has_preamble,
+            bridge_descr_ranges: std::cell::RefCell::new(Vec::new()),
+            _bridge_cells_owner: bridge_cells_owner,
+            _bridge_owned_cells: std::cell::RefCell::new(Vec::new()),
         };
 
         token.compiled = Some(Box::new(compiled));
@@ -892,7 +908,7 @@ impl majit_backend::Backend for WasmBackend {
         let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
         let wb_fn_ptr = wasm_jit_write_barrier as *const () as usize as i64;
 
-        let (wasm_bytes, guard_exits, num_ref_homes, _bridge_cells_base) =
+        let (wasm_bytes, guard_exits, num_ref_homes, _bridge_cells_base, bridge_cells_owner) =
             codegen::build_wasm_module(
                 inputargs,
                 ops,
@@ -910,9 +926,16 @@ impl majit_backend::Backend for WasmBackend {
             )?;
 
         // The bridge runs in the source loop's fixed-size frame, so it must not
-        // address more Ref-home slots than the loop reserved (value/output slots
-        // sit below the constant call area and always fit). If it would, decline:
-        // the host round-trip path allocates a frame sized for the bridge.
+        // address more Ref-home slots than the loop reserved. If it would,
+        // decline: the host round-trip path allocates a frame sized for the
+        // bridge. The bridge's value/output slots need no separate bound check:
+        // `build_wasm_module` already declined this bridge (above, via `?`) if
+        // its value slots reach `CALL_AREA_FIRST_SLOT` (codegen.rs), and
+        // `execute_token` floors the frame at `MIN_FRAME_BYTES/8` slots — which
+        // exceeds `CALL_AREA_FIRST_SLOT` — before the Ref-home region, so every
+        // in-bounds value-slot write lands strictly below both the call area and
+        // the home roots regardless of how the bridge's exit arity compares to
+        // the source loop's `max_output_slots`.
         if num_ref_homes > source_num_ref_homes {
             return Err(BackendError::Unsupported(format!(
                 "wasm backend: bridge needs {num_ref_homes} ref homes, source loop has \
@@ -949,7 +972,30 @@ impl majit_backend::Backend for WasmBackend {
                 .as_ref()
                 .and_then(|c| c.downcast_ref::<CompiledWasmLoop>())
                 .expect("source loop disappeared between borrows");
-            source_loop.fail_descrs.borrow_mut().extend(bridge_descrs);
+            // Append the bridge's exit descrs to the source loop's flat
+            // `fail_descrs` and record the slice they occupy, keyed by the
+            // source guard's `fail_index`. `compiled_bridge_fail_descr_layouts`
+            // / `store_bridge_guard_hashes` use that range to stamp jitcounter
+            // hashes onto these bridge-internal guards (compile.py:826-830
+            // store_hash). `start` is captured inside the same `borrow_mut`
+            // critical section as the `extend`, so the range stays in lockstep
+            // with the vec.
+            let count = bridge_descrs.len();
+            {
+                let mut descrs = source_loop.fail_descrs.borrow_mut();
+                let start = descrs.len();
+                descrs.extend(bridge_descrs);
+                source_loop.bridge_descr_ranges.borrow_mut().push((
+                    source_fail_index,
+                    start,
+                    count,
+                ));
+            }
+            // The bridge module lives as long as this source loop, so hand its
+            // own cell array (if any) to the loop, freed when the loop drops.
+            if let Some(owner) = bridge_cells_owner {
+                source_loop._bridge_owned_cells.borrow_mut().push(owner);
+            }
         }
 
         #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
@@ -1035,6 +1081,109 @@ impl majit_backend::Backend for WasmBackend {
         let descrs = compiled.fail_descrs.borrow();
         for (i, &hash) in hashes.iter().enumerate() {
             let Some(wfd) = descrs.get(i) else { break };
+            let Some(meta) = wfd.meta_descr.as_ref().and_then(|m| m.as_fail_descr()) else {
+                continue;
+            };
+            if (meta.is_resume_guard() || meta.is_resume_guard_copied()) && meta.get_status() == 0 {
+                meta.store_hash(hash);
+            }
+        }
+    }
+
+    /// `compile.py:826-830` store_hash for the guards INSIDE a compiled bridge.
+    /// `compile_bridge` appends a bridge's exit descrs to the source loop's flat
+    /// `fail_descrs` and records their `(source_fail_index, start, count)` slice
+    /// in `bridge_descr_ranges`. Return one layout per descr in that slice so
+    /// `assign_bridge_guard_hashes` stamps a jitcounter hash on each non-finish
+    /// bridge guard — without it they stay status 0 and collide in jitcounter
+    /// bucket 0. `fail_index` is the 0-based position within the bridge's own
+    /// exit list (matching the bridge's frontend `exit_layouts` keying and the
+    /// native backends' `compiled_bridge_fail_descr_layouts`); `trace_id` is the
+    /// bridge's own id, stamped on each appended `WasmFailDescr`.
+    fn compiled_bridge_fail_descr_layouts(
+        &self,
+        original_token: &JitCellToken,
+        _source_trace_id: u64,
+        source_fail_index: u32,
+    ) -> Option<Vec<majit_backend::FailDescrLayout>> {
+        let compiled = original_token
+            .compiled
+            .as_ref()
+            .and_then(|c| c.downcast_ref::<CompiledWasmLoop>())?;
+        // The most recently chained bridge at this source guard (last range).
+        let (start, count) = compiled
+            .bridge_descr_ranges
+            .borrow()
+            .iter()
+            .rev()
+            .find(|r| r.0 == source_fail_index)
+            .map(|&(_, start, count)| (start, count))?;
+        let descrs = compiled.fail_descrs.borrow();
+        let layouts = descrs
+            .get(start..start + count)?
+            .iter()
+            .enumerate()
+            .map(|(position, wfd)| {
+                let meta = wfd.meta_descr.as_ref().and_then(|m| m.as_fail_descr());
+                majit_backend::FailDescrLayout {
+                    fail_index: position as u32,
+                    source_op_index: meta.and_then(|fd| fd.source_op_index()),
+                    trace_id: wfd.trace_id,
+                    trace_info: None,
+                    fail_arg_types: wfd.fail_arg_types.clone(),
+                    is_finish: wfd.is_finish,
+                    is_exception_exit: meta
+                        .map(|fd| fd.is_exit_frame_with_exception())
+                        .unwrap_or(false),
+                    gc_ref_slots: Vec::new(),
+                    force_token_slots: Vec::new(),
+                    recovery_layout: None,
+                    frame_stack: None,
+                    rd_numb: None,
+                    rd_consts: None,
+                    rd_virtuals: None,
+                    rd_pendingfields: None,
+                }
+            })
+            .collect();
+        Some(layouts)
+    }
+
+    /// `compile.py:826-830` store_hash: stamp the hashes `assign_bridge_guard_hashes`
+    /// assigned onto the metainterp `ResumeGuardDescr` of each guard inside the
+    /// bridge attached at `source_fail_index`. Same `ResumeDescr`-family +
+    /// status-0 gate as `store_guard_hashes`; iterates the same slice in the
+    /// same order as `compiled_bridge_fail_descr_layouts` so the hash vector
+    /// lines up positionally.
+    fn store_bridge_guard_hashes(
+        &self,
+        token: &JitCellToken,
+        _source_trace_id: u64,
+        source_fail_index: u32,
+        hashes: &[u64],
+    ) {
+        let Some(compiled) = token
+            .compiled
+            .as_ref()
+            .and_then(|c| c.downcast_ref::<CompiledWasmLoop>())
+        else {
+            return;
+        };
+        let Some((start, _count)) = compiled
+            .bridge_descr_ranges
+            .borrow()
+            .iter()
+            .rev()
+            .find(|r| r.0 == source_fail_index)
+            .map(|&(_, start, count)| (start, count))
+        else {
+            return;
+        };
+        let descrs = compiled.fail_descrs.borrow();
+        for (i, &hash) in hashes.iter().enumerate() {
+            let Some(wfd) = descrs.get(start + i) else {
+                break;
+            };
             let Some(meta) = wfd.meta_descr.as_ref().and_then(|m| m.as_fail_descr()) else {
                 continue;
             };

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -31,9 +31,9 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// did not resolve (target_ord None), 9 = target_ord Some but != last label,
 /// 10 = arity mismatch, 11 = loop-closing bridge advances no loop-carried value
 /// (guard side-trace that would livelock the chained loop).
-pub static BRIDGE_DIAG: [AtomicU64; 12] = {
+pub static BRIDGE_DIAG: [AtomicU64; 14] = {
     const Z: AtomicU64 = AtomicU64::new(0);
-    [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
+    [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
 };
 
 /// Read a `BRIDGE_DIAG` tally (saturating index). Surfaced to the host through
@@ -318,6 +318,82 @@ pub extern "C" fn wasm_jit_write_barrier(obj: i64) -> i64 {
     0
 }
 
+/// Self-recursive CALL_ASSEMBLER (`PYRE_WASM_CA`) callee-frame allocation
+/// trampoline. Allocates the callee's execution frame as a real GC-managed
+/// `JitFrame` in **old-gen** (non-moving ⇒ the frame pointer the callee holds in
+/// its wasm local 0 never dangles across a collection; `alloc_in_oldgen` never
+/// itself collects, so the caller's still-unrooted Ref locals stay valid),
+/// initializes its header + per-frame `jf_gcmap` (covering the callee's input +
+/// home Ref slots), and pushes it on the jitframe shadow stack so a
+/// mid-recursion collection forwards those Refs via the gcmap custom trace.
+/// Returns the frame base (codegen adds `FIRST_ITEM_OFFSET` for the
+/// bespoke-layout frame pointer), or 0 if no GC / type id is installed.
+///
+/// Each callee frame self-describes through its own per-frame gcmap, so
+/// mixed-geometry frames from distinct CA bridges are each forwarded by their
+/// own geometry — no shared coarse single-stride scan that mis-reads a larger
+/// frame's interior as a smaller frame's slots.
+pub extern "C" fn wasm_jit_ca_alloc_frame(frame_bytes: i64, gcmap_ptr: i64) -> i64 {
+    use majit_backend::jitframe::JitFrame;
+    let tid = wasm_jitframe_tid();
+    if tid == 0 {
+        return 0;
+    }
+    let depth = frame_bytes as usize / std::mem::size_of::<isize>();
+    let frame = wasm_alloc_oldgen_typed(tid, JitFrame::alloc_size(depth));
+    if frame.0 == 0 {
+        return 0;
+    }
+    let jf = frame.0 as *mut JitFrame;
+    unsafe {
+        JitFrame::init(jf, std::ptr::null(), depth);
+        (*jf).jf_gcmap = gcmap_ptr as *const u8;
+    }
+    majit_gc::shadow_stack::push_jf(frame);
+    frame.0 as i64
+}
+
+/// Companion to [`wasm_jit_ca_alloc_frame`]: pop the top jitframe shadow-stack
+/// entry on CA-arm exit (the callee frame just ran to finish/deopt). The CA
+/// recursion is strict LIFO — each level pushes one frame before its
+/// `call_indirect` and pops after, and a deopt resume runs on the host's own
+/// shadow stack — so removing the top entry releases exactly this callee's
+/// frame.
+pub extern "C" fn wasm_jit_ca_pop_frame(_frame_base: i64) -> i64 {
+    let depth = majit_gc::shadow_stack::jf_depth();
+    if depth > 0 {
+        majit_gc::shadow_stack::pop_jf_to(depth - 1);
+    }
+    0
+}
+
+/// Build the per-frame `jf_gcmap` for a CA callee frame: mark the CA input slots
+/// (`v64` + `ec`, at `FRAME_SLOT_BASE`) AND the home slots (live SSA Refs), in
+/// the `JitFrame`'s Signed-granular item indexing (see [`build_home_gcmap`] for
+/// the wasm32 layout). Unlike the host-entry frame F0 (homes only), a callee
+/// frame keeps its virtualizable `v64` in an input slot (never homed by the
+/// loop), so the input slots are roots too. Returned buffer is leaked by the
+/// caller (one per bridge) and lives for the program's life.
+fn build_callee_gcmap(input_count: usize, home_count: usize) -> Box<[usize]> {
+    let sign = std::mem::size_of::<isize>();
+    let bits_per_word = std::mem::size_of::<usize>() * 8;
+    let mut indices: Vec<usize> = Vec::with_capacity(input_count + home_count);
+    for i in 0..input_count {
+        indices.push((codegen::FRAME_SLOT_BASE as usize + i * 8) / sign);
+    }
+    for h in 0..home_count {
+        indices.push((codegen::HOME_SLOT_BASE as usize + h * 8) / sign);
+    }
+    let max_index = indices.iter().copied().max().unwrap_or(0);
+    let num_words = max_index / bits_per_word + 1;
+    let mut buf = vec![0usize; 1 + num_words];
+    buf[0] = num_words;
+    for index in indices {
+        buf[1 + index / bits_per_word] |= 1usize << (index % bits_per_word);
+    }
+    buf.into_boxed_slice()
+}
+
 /// Host-side root-register trampoline.
 ///
 /// # Safety
@@ -388,6 +464,106 @@ pub struct WasmBackend {
     constants: majit_ir::VecMap<u32, i64>,
     /// llmodel.py:64-69 self.vtable_offset.
     vtable_offset: Option<usize>,
+    /// `PYRE_WASM_CA` (default off): compile a self-recursive single-int
+    /// `CallAssemblerR` bridge into an in-module `call_indirect` into the source
+    /// loop's table slot (guest→guest recursion) instead of declining it to a
+    /// per-call host round-trip. Read from the process-global [`WASM_CA_ENABLED`]
+    /// at construction so flag-off is byte-identical. Slice 1 is correct only
+    /// under a huge nursery (the fresh callee frames are not GC-rooted; see the
+    /// CA arm in codegen).
+    wasm_ca_enabled: bool,
+}
+
+/// Process-global toggle for the self-recursive CALL_ASSEMBLER arm. The wasm
+/// guest has no environment (`std::env::var` always fails there), so the host
+/// runner reads `PYRE_WASM_CA` and flips this through the `pyre_jit_set_wasm_ca`
+/// export — mirroring how `pyre_jit_set_enable_bridges` plumbs the bridge tracer
+/// flag. `WasmBackend::new` snapshots it.
+static WASM_CA_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Host entry point for the `pyre_jit_set_wasm_ca` export (and native tests).
+pub fn set_wasm_ca_enabled(enabled: bool) {
+    WASM_CA_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether the self-recursive CALL_ASSEMBLER arm is enabled. Read by `codegen`
+/// to allocate bridge-dispatch cells for a guarded *loop* even when it has no
+/// `Label` (the fib recursion shape), so its guard exit can chain into the CA
+/// bridge in-module instead of round-tripping to the host.
+pub fn wasm_ca_enabled() -> bool {
+    WASM_CA_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// GC type id of the `JitFrame`. The single registration authority is `eval.rs`
+/// (the type is registered there alongside the rest of the heap types, before
+/// `freeze_types`); it pushes the id here through `set_wasm_jitframe_tid`,
+/// mirroring how it feeds `majit_backend_{cranelift,dynasm}::set_jitframe_gc_type_id`.
+/// The orthodox (`PYRE_WASM_CA`) frame path allocates the host-entry frame as a
+/// real GC-managed `JitFrame` of this type so the collector forwards its Ref item
+/// slots through the `jf_gcmap` custom trace. 0 = not yet pushed (the orthodox
+/// path stays disabled until then).
+static WASM_JITFRAME_TID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Host entry point used by `eval.rs` to publish the registered `JitFrame` type
+/// id (counterpart to `set_jitframe_gc_type_id` on the native backends).
+pub fn set_wasm_jitframe_tid(id: u32) {
+    WASM_JITFRAME_TID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn wasm_jitframe_tid() -> u32 {
+    WASM_JITFRAME_TID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Build a `jf_gcmap` bitmap marking the Ref-home region as the frame's traced
+/// GC roots, in the `JitFrame`'s Signed-granular item indexing.
+///
+/// On wasm32 `isize` is 4 bytes, so `jf_frame` items are 4-byte Signed slots and
+/// each 8-byte data slot spans two items — the orthodox PyPy 32-bit layout where
+/// a one-word value (a `GcRef`) occupies a single item and a two-word value
+/// (i64) occupies a pair. A Ref home written as an i64 keeps the guest pointer in
+/// its LOW word (little-endian), at Signed item index `(HOME_SLOT_BASE + h *
+/// 8) / sign`. `jitframe_trace` strides items by `sign` and forwards one word per
+/// marked bit, so marking those indices exposes each home's `GcRef` (the high
+/// word stays unmarked). Returns `[data_word_count, word0, ...]` in `usize`
+/// words (GCMAP array layout: `gcmap[0]` = number of data words).
+fn build_home_gcmap(home_count: usize) -> Box<[usize]> {
+    let sign = std::mem::size_of::<isize>();
+    let bits_per_word = std::mem::size_of::<usize>() * 8;
+    if home_count == 0 {
+        // One empty data word: a non-null jf_gcmap that traces nothing.
+        return vec![1usize, 0usize].into_boxed_slice();
+    }
+    let last_index = (codegen::HOME_SLOT_BASE as usize + (home_count - 1) * 8) / sign;
+    let num_words = last_index / bits_per_word + 1;
+    let mut buf = vec![0usize; 1 + num_words];
+    buf[0] = num_words;
+    for h in 0..home_count {
+        let index = (codegen::HOME_SLOT_BASE as usize + h * 8) / sign;
+        buf[1 + index / bits_per_word] |= 1usize << (index % bits_per_word);
+    }
+    buf.into_boxed_slice()
+}
+
+/// `__indirect_function_table` slot of `call_jit::wasm_ca_resume_deopt`,
+/// published by pyre-jit at boot (`init_jit_hooks`). When an in-guest
+/// self-recursive CALL_ASSEMBLER callee leaves its trace through a guard with no
+/// bridge — a deopt the in-guest fast path cannot finish — the CA arm
+/// `call_indirect`s this slot to blackhole-resume that callee on the host (no
+/// re-execution of its pre-guard work) and read back its result. `0` (unset)
+/// makes `compile_bridge` decline the CA lift, since the arm would have no way
+/// to complete a deopt. Stored as `u64` to reuse the imported atomics.
+static CA_DEOPT_HELPER_SLOT: AtomicU64 = AtomicU64::new(0);
+
+/// Host entry point publishing [`CA_DEOPT_HELPER_SLOT`] (called from pyre-jit's
+/// `init_jit_hooks` with `wasm_ca_resume_deopt as *const () as usize`, which on
+/// wasm32 is the function's table index).
+pub fn set_ca_deopt_helper_slot(slot: u32) {
+    CA_DEOPT_HELPER_SLOT.store(slot as u64, Ordering::Relaxed);
+}
+
+/// Current CA deopt-helper table slot (0 = unset).
+pub fn ca_deopt_helper_slot() -> u32 {
+    CA_DEOPT_HELPER_SLOT.load(Ordering::Relaxed) as u32
 }
 
 /// A legacy pool-indexed const (`ConstInt(u32)` etc.) reached the wasm backend
@@ -413,6 +589,7 @@ impl WasmBackend {
             trace_counter: 0,
             constants: majit_ir::VecMap::new(),
             vtable_offset: None,
+            wasm_ca_enabled: WASM_CA_ENABLED.load(std::sync::atomic::Ordering::Relaxed),
         }
     }
 
@@ -435,7 +612,9 @@ impl WasmBackend {
         // gctypelayout.encode_type_shapes_now parity: close the
         // type-registration phase before any compile embeds the
         // type_info_group base address. Mirrors
-        // `CraneliftBackend::set_gc_allocator`.
+        // `CraneliftBackend::set_gc_allocator`. The JitFrame type is registered
+        // by eval.rs before this point (it pushes the id via
+        // `set_wasm_jitframe_tid`); the gc arrives already frozen here.
         gc.freeze_types();
         let supports_guard_gc_type = gc.supports_guard_gc_type();
         WASM_ACTIVE_GC.with(|cell| {
@@ -603,10 +782,13 @@ unsafe impl Send for WasmBackend {}
 /// Report why a trace cannot be compiled by the wasm backend, or `None` if it
 /// can. Declined traces fall back to the interpreter (correct, unaccelerated)
 /// instead of producing an invalid trace module. `is_loop` is true for
-/// `compile_loop`, false for `compile_bridge`.
-fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool) -> Option<String> {
+/// `compile_loop`, false for `compile_bridge`. `allow_ca` (set by
+/// `compile_bridge` only when `PYRE_WASM_CA` is on and the bridge is a
+/// self-recursive single-int `CallAssemblerR` shape) lifts the CALL_ASSEMBLER
+/// decline so the CA arm (guest→guest `call_indirect`) lowers it instead.
+fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool, allow_ca: bool) -> Option<String> {
     for op in ops {
-        if op.opcode.is_call_assembler() {
+        if op.opcode.is_call_assembler() && !allow_ca {
             // CALL_ASSEMBLER inlines a loop-bearing callee by jumping into another
             // trace's compiled token. The wasm backend has no inter-module trace
             // chaining (each trace is its own module), so it cannot execute the
@@ -637,6 +819,77 @@ fn wasm_unsupported_trace_reason(ops: &[Op], is_loop: bool) -> Option<String> {
     // lowered to a `return_call_indirect` into the source loop's table slot — a
     // wasm tail call — so it is accepted.
     None
+}
+
+/// True when `ops` is a bridge whose every `CallAssemblerR` op is a
+/// self-recursive single-int call into the source loop (`source_loop_number`):
+/// `[Ref, Ref] -> Ref` (the inline-built callee PyFrame + the EC), targeting the
+/// SAME token the bridge attaches to. This is the fib recursion shape — the only
+/// CA shape the wasm CA arm (codegen) lowers. `.all()` (not `.any()`) keeps a
+/// mixed self+foreign or wrong-arity bridge declined.
+fn bridge_is_self_recursive_int_ca(ops: &[Op], source_loop_number: u64) -> bool {
+    let cas: Vec<&Op> = ops
+        .iter()
+        .filter(|o| o.opcode.is_call_assembler())
+        .collect();
+    if cas.is_empty() {
+        return false;
+    }
+    cas.iter().all(|op| {
+        op.opcode == majit_ir::OpCode::CallAssemblerR
+            && op
+                .getdescr()
+                .and_then(|d| {
+                    d.as_call_descr().map(|cd| {
+                        let at = cd.arg_types();
+                        cd.call_target_token() == Some(source_loop_number)
+                            && at.len() == 2
+                            && at[0] == majit_ir::Type::Ref
+                            && at[1] == majit_ir::Type::Ref
+                            && cd.result_type() == majit_ir::Type::Ref
+                    })
+                })
+                .unwrap_or(false)
+    })
+}
+
+/// Reconstruct a [`DeadFrame`] from a callee frame an in-guest `call_indirect`
+/// already ran to a guard/finish exit (the self-recursive CALL_ASSEMBLER fast
+/// path, `PYRE_WASM_CA`). This is the post-`glue::execute` tail of
+/// [`WasmBackend::execute_token`] factored for a frame the host did not itself
+/// enter: `frame[0]` holds the exit `fail_index`, `frame[1..]` the exit slots,
+/// and the pending-exception cell is captured with `jit_exc_take` exactly as
+/// `execute_token` does after a GuardNoException / GuardException exit.
+/// `compiled_ptr` is the source loop's [`CompiledWasmLoop`] (baked into the
+/// trace by `compile_bridge`) whose `fail_descrs` resolves the index — the
+/// loop's own and its chained bridges' exits share that one array.
+///
+/// `pyre-jit`'s `call_jit::wasm_ca_resume_deopt` calls this, then drives the
+/// resulting `DeadFrame` through the same `get_latest_descr_arc` /
+/// `get_*_value` / `grab_exc_value` Backend path the host's outermost deopt
+/// handling uses, so the in-guest deopt completes identically.
+pub fn dead_frame_from_ran_frame(compiled_ptr: usize, frame_ptr: usize) -> DeadFrame {
+    let compiled = unsafe { &*(compiled_ptr as *const CompiledWasmLoop) };
+    let frame = frame_ptr as *const i64;
+    let exc_value = jit_exc_take();
+    let fail_index = unsafe { *frame } as u32;
+    let fail_descr = compiled
+        .fail_descrs
+        .borrow()
+        .get(fail_index as usize)
+        .expect("invalid fail_index from in-guest CA callee frame")
+        .clone();
+    let num_outputs = fail_descr.fail_arg_types.len();
+    let raw_values: Vec<i64> = (0..num_outputs)
+        .map(|i| unsafe { *frame.add(1 + i) })
+        .collect();
+    DeadFrame {
+        data: Box::new(WasmFrameData {
+            raw_values,
+            fail_descr,
+            exc_value,
+        }),
+    }
 }
 
 impl majit_backend::Backend for WasmBackend {
@@ -760,7 +1013,7 @@ impl majit_backend::Backend for WasmBackend {
         //     (jump-to-existing-trace); compile_loop cannot supply the target
         //     table slot, so codegen would tail-call slot 0 — the wrong
         //     function. Declined here (is_loop=true).
-        if let Some(reason) = wasm_unsupported_trace_reason(ops, true) {
+        if let Some(reason) = wasm_unsupported_trace_reason(ops, true, false) {
             return Err(BackendError::Unsupported(reason));
         }
 
@@ -789,6 +1042,7 @@ impl majit_backend::Backend for WasmBackend {
                 wb_fn_ptr,
                 0, // fail_index_base: a loop owns fail indices [0, num_guards)
                 0, // external_jump_slot: a loop's JUMP is a local back-edge `br`
+                codegen::CaParams::default(), // a loop never emits the CA arm
             )?;
 
         // Build fail descriptors
@@ -872,6 +1126,7 @@ impl majit_backend::Backend for WasmBackend {
             bridge_descr_ranges: std::cell::RefCell::new(Vec::new()),
             _bridge_cells_owner: bridge_cells_owner,
             _bridge_owned_cells: std::cell::RefCell::new(Vec::new()),
+            ca_bridge_ref_homes: std::cell::Cell::new(0),
         };
 
         token.compiled = Some(Box::new(compiled));
@@ -921,7 +1176,16 @@ impl majit_backend::Backend for WasmBackend {
 
         // is_loop=false: a bridge's terminal JUMP with no LABEL is a loop-closing
         // bridge whose re-entry target is plumbed via `external_jump_slot`.
-        if let Some(reason) = wasm_unsupported_trace_reason(ops, false) {
+        // PYRE_WASM_CA: lift the CALL_ASSEMBLER decline for a self-recursive
+        // single-int bridge (the fib shape) so the CA arm lowers it to an
+        // in-module `call_indirect` into the source loop instead.
+        // The CA arm must be able to complete a callee deopt; without the
+        // registered `wasm_ca_resume_deopt` slot it could not, so decline the
+        // lift (the host round-trip path still handles the CALL_ASSEMBLER).
+        let allow_ca = self.wasm_ca_enabled
+            && ca_deopt_helper_slot() != 0
+            && bridge_is_self_recursive_int_ca(ops, original_token.number);
+        if let Some(reason) = wasm_unsupported_trace_reason(ops, false, allow_ca) {
             diag_bump(1); // declined: CALL_ASSEMBLER
             return Err(BackendError::Unsupported(reason));
         }
@@ -945,6 +1209,10 @@ impl majit_backend::Backend for WasmBackend {
             source_last_label_block_id,
             source_last_label_num_args,
             base,
+            source_max_output_slots,
+            source_num_inputs,
+            source_loop_finish_fi,
+            source_compiled_ptr,
         ) = {
             let source_loop = original_token
                 .compiled
@@ -955,6 +1223,16 @@ impl majit_backend::Backend for WasmBackend {
                         "wasm backend: bridge source token has no compiled loop".into(),
                     )
                 })?;
+            // `fail_index` the source loop's DoneWithThisFrame Finish writes to
+            // frame[0] on the base-case return (the CA arm accepts it as a clean
+            // callee finish alongside this bridge's own finish).
+            let loop_finish_fi = source_loop
+                .fail_descrs
+                .borrow()
+                .iter()
+                .find(|d| d.is_finish)
+                .map(|d| d.fail_index)
+                .unwrap_or(0);
             (
                 source_loop.trace_id,
                 source_loop.bridge_cells_base,
@@ -966,6 +1244,16 @@ impl majit_backend::Backend for WasmBackend {
                 source_loop.last_label_block_id,
                 source_loop.last_label_num_args,
                 source_loop.fail_descrs.borrow().len() as u32,
+                source_loop.max_output_slots,
+                source_loop.num_inputs,
+                loop_finish_fi,
+                // Address of the source loop's metadata, baked into the CA arm so
+                // `wasm_ca_resume_deopt` can resolve a deopted callee's
+                // `fail_descrs`. Same lifetime assumption as `source_func_handle`
+                // below: a recompile invalidates this bridge before the loop's
+                // `CompiledWasmLoop` is replaced, so the arm is unreachable with a
+                // stale pointer.
+                source_loop as *const CompiledWasmLoop as usize as u64,
             )
         };
 
@@ -1019,7 +1307,7 @@ impl majit_backend::Backend for WasmBackend {
                 // last label (diagnostic: distinguishes the S2-needing non-last
                 // case from a stripped descr or an arity mismatch).
                 match target_ord {
-                    None => diag_bump(8),                                  // descr stripped
+                    None => diag_bump(8),                                       // descr stripped
                     Some(k) if k != source_last_label_block_id => diag_bump(9), // non-last label
                     _ if arity != source_last_label_num_args => diag_bump(10),  // arity mismatch
                     _ => {}
@@ -1097,6 +1385,50 @@ impl majit_backend::Backend for WasmBackend {
         let alloc_array_fn_ptr = wasm_jit_alloc_array as *const () as usize as i64;
         let wb_fn_ptr = wasm_jit_write_barrier as *const () as usize as i64;
 
+        // Self-recursive CALL_ASSEMBLER (PYRE_WASM_CA): the CA arm bump-allocates
+        // a fresh callee frame per recursive `call_indirect` into the source
+        // loop. Size it for the source loop's frame layout (base_slots + the
+        // dispatch-key slot + ref-home region, mirroring `execute_token`);
+        // `build_wasm_module` widens it to also fit THIS bridge, which reuses the
+        // same frame when the loop's guard-exit chains back into it.
+        // This bridge materializes the recursive callee frame and homes it (plus
+        // its other live Refs) in the SAME arena frame the source loop runs on,
+        // store-on-def'ing at its OWN home indices. A self-recursive fib bridge
+        // reserves more homes than the source loop, so the arena frame and the GC
+        // walker must cover the WIDER of the two: otherwise the callee `v64`'s
+        // home (index >= `source_num_ref_homes`) lands past the frame's walked
+        // region and a minor collection mid-recursion reclaims it, leaving a later
+        // deopt to read zeroed nursery memory. `count_ref_homes` matches the
+        // `num_ref_homes` `build_wasm_module` returns below.
+        let ca_ref_homes = if allow_ca {
+            source_num_ref_homes.max(codegen::count_ref_homes(inputargs, ops))
+        } else {
+            source_num_ref_homes
+        };
+        let ca_params = if allow_ca {
+            let min_slots = (codegen::MIN_FRAME_BYTES / 8) as u32;
+            let src_base_slots =
+                min_slots.max(1 + source_max_output_slots.max(source_num_inputs) as u32);
+            let src_frame_slots = src_base_slots + 1 + ca_ref_homes as u32;
+            // Per-bridge callee-frame gcmap (input + home Ref slots), leaked to
+            // live for the program — each callee frame's `jf_gcmap` points at it.
+            let callee_gcmap_ptr =
+                Box::leak(build_callee_gcmap(source_num_inputs as usize, ca_ref_homes)).as_ptr()
+                    as i64;
+            codegen::CaParams {
+                emit_ca: true,
+                callee_frame_bytes: src_frame_slots * 8,
+                loop_finish_fi: source_loop_finish_fi,
+                deopt_helper_slot: ca_deopt_helper_slot(),
+                source_compiled_ptr,
+                ca_alloc_fn_ptr: wasm_jit_ca_alloc_frame as *const () as usize as i64,
+                ca_pop_fn_ptr: wasm_jit_ca_pop_frame as *const () as usize as i64,
+                callee_gcmap_ptr,
+            }
+        } else {
+            codegen::CaParams::default()
+        };
+
         let (wasm_bytes, guard_exits, num_ref_homes, _bridge_cells_base, bridge_cells_owner) =
             codegen::build_wasm_module(
                 inputargs,
@@ -1112,6 +1444,7 @@ impl majit_backend::Backend for WasmBackend {
                 // A loop-closing bridge's terminal JUMP re-enters the source loop
                 // through its table slot via a tail call.
                 source_func_handle,
+                ca_params,
             )?;
 
         // The bridge runs in the source loop's fixed-size frame, so it must not
@@ -1125,7 +1458,12 @@ impl majit_backend::Backend for WasmBackend {
         // in-bounds value-slot write lands strictly below both the call area and
         // the home roots regardless of how the bridge's exit arity compares to
         // the source loop's `max_output_slots`.
-        if num_ref_homes > source_num_ref_homes {
+        // A self-recursive CALL_ASSEMBLER bridge (`allow_ca`) is exempt: its
+        // recursive calls run in arena callee frames sized for it
+        // (`callee_frame_bytes`), and the outermost call runs in the host entry
+        // frame `F0`, which `execute_token` widens via `ca_bridge_ref_homes`
+        // (set below). So its home writes never overflow.
+        if !allow_ca && num_ref_homes > source_num_ref_homes {
             diag_bump(4); // declined: ref-home overflow
             return Err(BackendError::Unsupported(format!(
                 "wasm backend: bridge needs {num_ref_homes} ref homes, source loop has \
@@ -1187,8 +1525,28 @@ impl majit_backend::Backend for WasmBackend {
             if let Some(owner) = bridge_cells_owner {
                 source_loop._bridge_owned_cells.borrow_mut().push(owner);
             }
+            // A self-recursive CALL_ASSEMBLER bridge runs its outermost call in
+            // the loop's host entry frame `F0`. Record its (possibly larger)
+            // home count so `execute_token` sizes `F0` and registers GC roots for
+            // it, not just the loop's own homes.
+            if allow_ca {
+                let prev = source_loop.ca_bridge_ref_homes.get();
+                source_loop.ca_bridge_ref_homes.set(prev.max(num_ref_homes));
+            }
         }
 
+        // CA dispatch diagnostics (guest `eprintln` is a no-op on wasm32, so
+        // route through the BRIDGE_DIAG tallies the host surfaces): 12 = CA bridge
+        // cell actually written (loop epilogue will tail into it); 13 = CA bridge
+        // but the source loop reserved no bridge cells (cells_base 0) so the guard
+        // never dispatches in-module — the recursion stays a host round-trip.
+        if allow_ca {
+            if source_cells_base != 0 && bridge_slot != 0 {
+                diag_bump(12);
+            } else {
+                diag_bump(13);
+            }
+        }
         #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
         if source_cells_base != 0 && bridge_slot != 0 {
             // cells[source_fail_index] = bridge_slot — the loop epilogue now
@@ -1402,45 +1760,22 @@ impl majit_backend::Backend for WasmBackend {
         // = MIN_FRAME_BYTES, slot `min_slots`), which sits between the call area
         // and the Ref-home region (now at HOME_SLOT_BASE = MIN_FRAME_BYTES + 8).
         // `vec![0i64]` zeroes it, so a fresh host entry reads key 0 (preamble).
-        let frame_size = base_slots + 1 + compiled.num_ref_homes;
-        let mut frame = vec![0i64; frame_size];
-
-        // Write inputs to frame[1..]
-        for (i, arg) in args.iter().enumerate() {
-            frame[1 + i] = match arg {
-                Value::Int(v) => *v,
-                Value::Float(v) => v.to_bits() as i64,
-                Value::Ref(r) => r.0 as i64,
-                Value::Void => 0,
-            };
-        }
-
-        // frame_ptr = byte offset of frame[0] in wasm linear memory
-        let _frame_ptr = frame.as_mut_ptr() as usize as u32;
-
+        //
+        // A self-recursive CALL_ASSEMBLER bridge (`PYRE_WASM_CA`) runs its
+        // outermost call in this frame and may home more Refs than the loop, so
+        // size for the LARGER of the two (`ca_bridge_ref_homes`); the extra slots
+        // are zeroed and GC-rooted below exactly like the loop's own homes.
+        let eff_ref_homes = compiled
+            .num_ref_homes
+            .max(compiled.ca_bridge_ref_homes.get());
+        let frame_size = base_slots + 1 + eff_ref_homes;
         #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
         {
+            let _ = (frame_size, eff_ref_homes, args);
             panic!("wasm backend execute_token requires a wasm host");
         }
         #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
         {
-            // Register each Ref-home slot (codegen::HOME_SLOT_BASE region) as a
-            // GC root so a collecting allocation inside the trace (epic B)
-            // forwards the live refs. A home slot only ever holds null (its
-            // entry init) or a valid GcRef (store-on-def), so forwarding is
-            // always safe without precise liveness.
-            //
-            // No RAII guard is needed for the removal below: the path from here
-            // to `wasm_gc_remove_root` is straight-line (no `?`/early return),
-            // and the wasm32 build is `panic=abort`, so `glue::execute` cannot
-            // unwind past this frame — a trap aborts the process rather than
-            // leaking the roots.
-            let home_base = codegen::HOME_SLOT_BASE as usize / 8;
-            for h in 0..compiled.num_ref_homes {
-                let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
-                unsafe { wasm_gc_add_root(slot) };
-            }
-
             // The pending-exception cell is global, unlike the native
             // per-jitframe `jf_guard_exc`. A residual raise on a blackhole
             // resume path (publish_residual_call_exception) writes it outside
@@ -1448,25 +1783,106 @@ impl majit_backend::Backend for WasmBackend {
             // trace; otherwise jit_exc_take below would surface a stale
             // exception from a previous frame's resume as this trace's.
             jit_exc_clear();
-            glue::execute(compiled.func_handle, _frame_ptr);
 
-            // Companion to the add_root loop above: drop the home-slot roots
-            // now the trace has returned (the host frame is freed on return).
-            for h in 0..compiled.num_ref_homes {
+            // Orthodox frame path (PYRE_WASM_CA): run the trace on a real
+            // GC-managed `JitFrame` so a collecting allocation forwards the live
+            // Ref-home slots through the `jf_gcmap` custom trace, discovered via
+            // the jitframe shadow stack — replacing the bespoke add_root-over-
+            // homes scheme. The frame is old-gen (non-moving), so the frame
+            // pointer held across `glue::execute` never dangles without a reload
+            // protocol. The data region (fail_index at 0, inputs/outputs at
+            // FRAME_SLOT_BASE, call area, dispatch key, Ref homes) lives in the
+            // `jf_frame` items area; passing `jf + FIRST_ITEM_OFFSET` as the wasm
+            // frame pointer keeps every local-0-relative codegen access
+            // unchanged. (See `build_home_gcmap` for the wasm32 Signed-item
+            // layout.)
+            if wasm_ca_enabled() && wasm_jitframe_tid() != 0 {
+                use majit_backend::jitframe::{JitFrame, FIRST_ITEM_OFFSET};
+                let sign = std::mem::size_of::<isize>();
+                // Data region (frame_size i64 slots) expressed in Signed items.
+                let depth = frame_size * 8 / sign;
+                let jf_ref =
+                    wasm_alloc_oldgen_typed(wasm_jitframe_tid(), JitFrame::alloc_size(depth));
+                assert!(jf_ref.0 != 0, "wasm JitFrame allocation failed");
+                let jf = jf_ref.0 as *mut JitFrame;
+                unsafe { JitFrame::init(jf, std::ptr::null(), depth) };
+
+                // Conservative per-loop gcmap over the Ref-home region. Held in
+                // this stack frame (jf_gcmap points at it) until the outputs are
+                // read after the trace returns.
+                let gcmap = build_home_gcmap(eff_ref_homes);
+                unsafe { (*jf).jf_gcmap = gcmap.as_ptr() as *const u8 };
+
+                let items_base = jf as usize + FIRST_ITEM_OFFSET;
+                let fsb = codegen::FRAME_SLOT_BASE as usize;
+                for (i, arg) in args.iter().enumerate() {
+                    let v = match arg {
+                        Value::Int(v) => *v,
+                        Value::Float(v) => v.to_bits() as i64,
+                        Value::Ref(r) => r.0 as i64,
+                        Value::Void => 0,
+                    };
+                    unsafe { *((items_base + fsb + i * 8) as *mut i64) = v };
+                }
+
+                let saved = majit_gc::shadow_stack::push_jf(jf_ref);
+                glue::execute(compiled.func_handle, items_base as u32);
+
+                let exc_value = jit_exc_take();
+                let fail_index = unsafe { *(items_base as *const i64) } as u32;
+                let fail_descr = compiled
+                    .fail_descrs
+                    .borrow()
+                    .get(fail_index as usize)
+                    .expect("invalid fail_index from compiled wasm")
+                    .clone();
+                let num_outputs = fail_descr.fail_arg_types.len();
+                let raw_values: Vec<i64> = (0..num_outputs)
+                    .map(|i| unsafe { *((items_base + fsb + i * 8) as *const i64) })
+                    .collect();
+
+                // Done reading the frame; release it from the jf shadow stack
+                // (it becomes collectible) and free the gcmap.
+                majit_gc::shadow_stack::pop_jf_to(saved);
+                drop(gcmap);
+
+                return DeadFrame {
+                    data: Box::new(WasmFrameData {
+                        raw_values,
+                        fail_descr,
+                        exc_value,
+                    }),
+                };
+            }
+
+            // Legacy host-Vec frame path (default, PYRE_WASM_CA off) — byte-
+            // identical to before: fail_index at frame[0], inputs/outputs at
+            // frame[1 + i], Ref homes manually rooted across the trace. A home
+            // slot only ever holds null (entry init) or a valid GcRef (store-on-
+            // def), so forwarding is safe without precise liveness. The path to
+            // `wasm_gc_remove_root` is straight-line and the wasm32 build is
+            // `panic=abort`, so `glue::execute` cannot unwind and leak roots.
+            let mut frame = vec![0i64; frame_size];
+            for (i, arg) in args.iter().enumerate() {
+                frame[1 + i] = match arg {
+                    Value::Int(v) => *v,
+                    Value::Float(v) => v.to_bits() as i64,
+                    Value::Ref(r) => r.0 as i64,
+                    Value::Void => 0,
+                };
+            }
+            let frame_ptr = frame.as_mut_ptr() as usize as u32;
+            let home_base = codegen::HOME_SLOT_BASE as usize / 8;
+            for h in 0..eff_ref_homes {
+                let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
+                unsafe { wasm_gc_add_root(slot) };
+            }
+            glue::execute(compiled.func_handle, frame_ptr);
+            for h in 0..eff_ref_homes {
                 let slot = unsafe { frame.as_mut_ptr().add(home_base + h) } as *mut GcRef;
                 wasm_gc_remove_root(slot);
             }
-
-            // A GuardNoException / GuardException exit leaves the pending
-            // exception in the global slot; capture and clear it here so
-            // grab_exc_value surfaces it to the meta-interpreter. Mirrors
-            // cranelift `emit_guard_exit`'s `must_save_exception` move into
-            // `jf_guard_exc`, done host-side after the trace returns.
             let exc_value = jit_exc_take();
-
-            // Read fail_index from frame[0]. A chained bridge exit writes its
-            // own (base-offset) index here, resolved through the same array
-            // because `compile_bridge` appended the bridge's descrs to it.
             let fail_index = frame[0] as u32;
             let fail_descr = compiled
                 .fail_descrs
@@ -1474,15 +1890,12 @@ impl majit_backend::Backend for WasmBackend {
                 .get(fail_index as usize)
                 .expect("invalid fail_index from compiled wasm")
                 .clone();
-
-            // Read output values
             let num_outputs = fail_descr.fail_arg_types.len();
             let raw_values: Vec<i64> = (0..num_outputs).map(|i| frame[1 + i]).collect();
-
             DeadFrame {
                 data: Box::new(WasmFrameData {
                     raw_values,
-                    fail_descr: fail_descr.clone(),
+                    fail_descr,
                     exc_value,
                 }),
             }
@@ -1592,5 +2005,76 @@ mod tests {
         assert_eq!(resolved, Some(int_tid));
         let unknown = backend.get_typeid_from_classptr_if_gcremovetypeptr(0xCAFE_F00D);
         assert_eq!(unknown, None);
+    }
+
+    /// S0 spike for the Option A wasm-JITFRAME refactor: prove the shared
+    /// `MiniMarkGC` forwards a JitFrame's interior Ref item through the
+    /// `jf_gcmap` custom-trace when the frame is discovered via the jitframe
+    /// shadow stack. This is the exact GC path the orthodox wasm loop would
+    /// depend on — a non-moving old-gen JitFrame whose live Ref item slots are
+    /// traced by `jf_gcmap` during a minor collection (`do_collect_nursery`
+    /// Phase 1c → `trace_and_update_object` → `jitframe_custom_trace`). The
+    /// wasm backend has none of the feeders yet; this confirms the collector
+    /// side works so the feeders can be built (S1–S3).
+    #[test]
+    fn jitframe_oldgen_gcmap_minor_forwards_ref_item() {
+        use majit_backend::jitframe::{
+            jitframe_type_info, JitFrame, FIRST_ITEM_OFFSET, JF_FRAME_OFS, JF_GCMAP_OFS,
+        };
+        use majit_gc::GcAllocator;
+
+        let mut gc = MiniMarkGC::new();
+        let jf_tid = gc.register_type(jitframe_type_info());
+        let payload_tid = gc.register_type(TypeInfo::simple(16));
+
+        let depth = 2usize;
+        // Non-moving old-gen JitFrame (jitframe_prefer_oldgen()).
+        let frame = gc.alloc_oldgen_typed(jf_tid, JitFrame::alloc_size(depth));
+        assert_ne!(frame.0, 0, "old-gen JitFrame alloc failed");
+        let frame_ptr = frame.0 as *mut JitFrame;
+        unsafe { JitFrame::init(frame_ptr, std::ptr::null(), depth) };
+
+        // A fresh nursery object reachable ONLY through the frame's item slot 0.
+        let young = gc.alloc_nursery_typed(payload_tid, 16);
+        assert_ne!(young.0, 0, "nursery alloc failed");
+        let young_before = young.0;
+        unsafe {
+            let item0 = (frame_ptr as *mut u8).add(FIRST_ITEM_OFFSET) as *mut usize;
+            *item0 = young_before;
+        }
+
+        // Per-loop gcmap marking item slot 0 as a Ref: [data_word_count, bits].
+        // jitframe_trace reads gcmap_lgt at +0, a data word at +GCMAPBASEOFS(8),
+        // and maps bit i (of word 0) to jf_frame item i.
+        let gcmap: [usize; 2] = [1, 0b1];
+        unsafe {
+            let gcmap_field = (frame_ptr as *mut u8).add(JF_GCMAP_OFS as usize) as *mut *const u8;
+            *gcmap_field = gcmap.as_ptr() as *const u8;
+        }
+
+        // Discover the frame the orthodox way: push it on the jitframe shadow
+        // stack so Phase 1c traces its interior via the gcmap.
+        let saved = majit_gc::shadow_stack::push_jf(frame);
+        gc.do_collect_nursery();
+        majit_gc::shadow_stack::pop_jf_to(saved);
+
+        // The young object must have been forwarded out of the nursery and the
+        // item slot rewritten to its new address — proving the gcmap bit was
+        // honored. An untraced slot would still hold young_before (now dangling).
+        let item0_after = unsafe { *((frame_ptr as *const u8).add(FIRST_ITEM_OFFSET) as *const usize) };
+        assert_ne!(item0_after, 0, "item0 cleared: frame interior not traced");
+        assert_ne!(
+            item0_after, young_before,
+            "item0 not forwarded: gcmap bit was not honored by the collector"
+        );
+        assert!(
+            gc.is_managed_heap_object(item0_after),
+            "forwarded item0 is not a live managed object"
+        );
+
+        // The old-gen frame must NOT have moved: its length header stays intact
+        // in place, so a wasm local holding frame_ptr would remain valid.
+        let len_after = unsafe { *((frame_ptr as *const u8).add(JF_FRAME_OFS) as *const isize) };
+        assert_eq!(len_after, depth as isize, "old-gen frame moved/corrupted");
     }
 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1797,7 +1797,7 @@ impl majit_backend::Backend for WasmBackend {
             // unchanged. (See `build_home_gcmap` for the wasm32 Signed-item
             // layout.)
             if wasm_ca_enabled() && wasm_jitframe_tid() != 0 {
-                use majit_backend::jitframe::{JitFrame, FIRST_ITEM_OFFSET};
+                use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JitFrame};
                 let sign = std::mem::size_of::<isize>();
                 // Data region (frame_size i64 slots) expressed in Signed items.
                 let depth = frame_size * 8 / sign;
@@ -2019,7 +2019,7 @@ mod tests {
     #[test]
     fn jitframe_oldgen_gcmap_minor_forwards_ref_item() {
         use majit_backend::jitframe::{
-            jitframe_type_info, JitFrame, FIRST_ITEM_OFFSET, JF_FRAME_OFS, JF_GCMAP_OFS,
+            FIRST_ITEM_OFFSET, JF_FRAME_OFS, JF_GCMAP_OFS, JitFrame, jitframe_type_info,
         };
         use majit_gc::GcAllocator;
 
@@ -2061,7 +2061,8 @@ mod tests {
         // The young object must have been forwarded out of the nursery and the
         // item slot rewritten to its new address — proving the gcmap bit was
         // honored. An untraced slot would still hold young_before (now dangling).
-        let item0_after = unsafe { *((frame_ptr as *const u8).add(FIRST_ITEM_OFFSET) as *const usize) };
+        let item0_after =
+            unsafe { *((frame_ptr as *const u8).add(FIRST_ITEM_OFFSET) as *const usize) };
         assert_ne!(item0_after, 0, "item0 cleared: frame interior not traced");
         assert_ne!(
             item0_after, young_before,

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -761,6 +761,11 @@ impl majit_backend::Backend for WasmBackend {
                 .iter()
                 .any(|op| op.opcode != majit_ir::OpCode::Label)
         });
+        // Exactly the shape codegen wraps with the resume-at-LABEL dispatch
+        // (shared predicate, so the field and the wrapper cannot drift). When
+        // true, a loop-closing bridge into this loop re-enters at the LABEL
+        // in-module rather than being declined (see compile_bridge).
+        let is_single_label_peeled = codegen::is_single_label_peeled(ops);
 
         let compiled = CompiledWasmLoop {
             trace_id,
@@ -773,6 +778,7 @@ impl majit_backend::Backend for WasmBackend {
             bridge_cells_base,
             num_guard_cells: guard_exits.len(),
             has_preamble,
+            is_single_label_peeled,
             bridge_descr_ranges: std::cell::RefCell::new(Vec::new()),
             _bridge_cells_owner: bridge_cells_owner,
             _bridge_owned_cells: std::cell::RefCell::new(Vec::new()),
@@ -842,6 +848,7 @@ impl majit_backend::Backend for WasmBackend {
             source_num_ref_homes,
             source_func_handle,
             source_has_preamble,
+            source_is_single_label_peeled,
             base,
         ) = {
             let source_loop = original_token
@@ -860,27 +867,35 @@ impl majit_backend::Backend for WasmBackend {
                 source_loop.num_ref_homes,
                 source_loop.func_handle,
                 source_loop.has_preamble,
+                source_loop.is_single_label_peeled,
                 source_loop.fail_descrs.borrow().len() as u32,
             )
         };
 
         // A loop-closing bridge (terminal JUMP, no local LABEL) re-enters the
         // source loop through `source_func_handle` — the function entry. For a
-        // peeled source loop that re-runs the preamble (the unrolled first
-        // iteration) against the bridge's mid-loop state instead of resuming at
-        // the LABEL, so the induction variable never advances: an infinite loop
-        // (observed as the wasm chaining hang on nbody / fannkuch). Decline so
-        // the guard falls back to blackhole resume; `declined_bridge_guards`
-        // then stops the metainterp re-tracing it. Non-peeled loops (entry ==
-        // LABEL) re-enter correctly and keep chaining.
+        // peeled source loop, entering at the function entry re-runs the preamble
+        // (the unrolled first iteration) against the bridge's mid-loop state
+        // instead of resuming at the LABEL, so the induction variable never
+        // advances: an infinite loop (the wasm chaining hang on nbody / fannkuch).
+        //
+        // A SINGLE-label peeled loop carries the resume-at-LABEL dispatch: the
+        // loop-closing JUMP arm sets the frame dispatch key, so re-entering
+        // through `source_func_handle` skips the preamble and resumes at the
+        // LABEL — chaining stays in-module. Only a MULTI-label peeled loop (the
+        // br_table form is a follow-up) still re-runs its preamble, so decline
+        // it; the guard then falls back to blackhole resume and
+        // `declined_bridge_guards` stops the metainterp re-tracing it. Non-peeled
+        // loops (entry == LABEL) re-enter correctly and keep chaining.
         let bridge_is_loop_closing = {
             let has_label = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Label);
             let has_jump = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Jump);
             has_jump && !has_label
         };
-        if bridge_is_loop_closing && source_has_preamble {
+        if bridge_is_loop_closing && source_has_preamble && !source_is_single_label_peeled {
             return Err(BackendError::Unsupported(
-                "wasm backend: loop-closing bridge re-enters a peeled loop (preamble re-run)"
+                "wasm backend: loop-closing bridge re-enters a multi-label peeled loop \
+                 (resume-at-LABEL br_table deferred)"
                     .into(),
             ));
         }
@@ -1207,7 +1222,11 @@ impl majit_backend::Backend for WasmBackend {
         // it, one slot per Ref-typed value (`num_ref_homes`).
         let min_slots = codegen::MIN_FRAME_BYTES / 8;
         let base_slots = min_slots.max(1 + compiled.max_output_slots.max(compiled.num_inputs));
-        let frame_size = base_slots + compiled.num_ref_homes;
+        // +1 for the resume-at-LABEL dispatch-key slot (codegen::DISPATCH_KEY_OFS
+        // = MIN_FRAME_BYTES, slot `min_slots`), which sits between the call area
+        // and the Ref-home region (now at HOME_SLOT_BASE = MIN_FRAME_BYTES + 8).
+        // `vec![0i64]` zeroes it, so a fresh host entry reads key 0 (preamble).
+        let frame_size = base_slots + 1 + compiled.num_ref_homes;
         let mut frame = vec![0i64; frame_size];
 
         // Write inputs to frame[1..]

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -26,10 +26,13 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// 1 = declined CALL_ASSEMBLER, 2 = declined multi-label peeled,
 /// 3 = declined not-a-direct-loop-guard, 4 = declined ref-home overflow,
 /// 5 = bridge compiled (chained in-module), 6 = loop-closing shape seen,
-/// 7 = source loop has a preamble.
-pub static BRIDGE_DIAG: [AtomicU64; 8] = {
+/// 7 = source loop has a preamble. Sub-breakdown of the index-2 multi-label
+/// decline (TEMP, for the resume-at-last-label measurement): 8 = JUMP descr
+/// did not resolve (target_ord None), 9 = target_ord Some but != last label,
+/// 10 = arity mismatch, 11 = spare.
+pub static BRIDGE_DIAG: [AtomicU64; 12] = {
     const Z: AtomicU64 = AtomicU64::new(0);
-    [Z, Z, Z, Z, Z, Z, Z, Z]
+    [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
 };
 
 /// Read a `BRIDGE_DIAG` tally (saturating index). Surfaced to the host through
@@ -781,18 +784,34 @@ impl majit_backend::Backend for WasmBackend {
         // A loop-closing bridge that re-enters through `func_handle` would
         // re-run this preamble; record the shape so `compile_bridge` can decline
         // such a bridge (see `has_preamble` doc on the struct).
-        let last_label = ops
-            .iter()
-            .rposition(|op| op.opcode == majit_ir::OpCode::Label);
-        let has_preamble = last_label.is_some_and(|idx| {
-            ops[..idx]
-                .iter()
-                .any(|op| op.opcode != majit_ir::OpCode::Label)
-        });
-        // Exactly the shape codegen wraps with the resume-at-LABEL dispatch
-        // (shared predicate, so the field and the wrapper cannot drift). When
-        // true, a loop-closing bridge into this loop re-enters at the LABEL
-        // in-module rather than being declined (see compile_bridge).
+        // A peeled loop (the resume-at-LABEL wrapper's shape) — real work before
+        // the last LABEL. Computed through the same predicate codegen's wrapper
+        // gates on, so the recorded field and the emitted wrapper cannot drift.
+        let has_preamble = codegen::is_resumable_peeled(ops);
+        // Stamp each LABEL's loop-target descr with its ordinal (0, 1, 2, …) so a
+        // loop-closing bridge can recover which label its terminal JUMP targets:
+        // the JUMP and the LABEL share the descr by Arc identity, so the ordinal
+        // written here is readable from the bridge's JUMP in `compile_bridge`.
+        // Pure metadata — emits no wasm bytes, so the module shape is unchanged.
+        // Skip a LABEL whose descr is not loop-target-backed (`set_label_block_id`
+        // would panic on a non-`AtomicU32` slot).
+        let mut label_block_id: u32 = 0;
+        let mut last_label_num_args: usize = 0;
+        for op in ops.iter() {
+            if op.opcode != majit_ir::OpCode::Label {
+                continue;
+            }
+            if let Some(descr) = op.getdescr() {
+                if let Some(target) = descr.as_loop_target_descr() {
+                    target.set_label_block_id(label_block_id);
+                }
+            }
+            last_label_num_args = op.getarglist().len();
+            label_block_id += 1;
+        }
+        // Ordinal of the LAST LABEL (the one codegen emits the `loop` at); 0 when
+        // there are no labels (then `has_preamble` is false and it is unused).
+        let last_label_block_id = label_block_id.saturating_sub(1);
         let is_single_label_peeled = codegen::is_single_label_peeled(ops);
 
         let compiled = CompiledWasmLoop {
@@ -807,6 +826,8 @@ impl majit_backend::Backend for WasmBackend {
             num_guard_cells: guard_exits.len(),
             has_preamble,
             is_single_label_peeled,
+            last_label_block_id,
+            last_label_num_args,
             bridge_descr_ranges: std::cell::RefCell::new(Vec::new()),
             _bridge_cells_owner: bridge_cells_owner,
             _bridge_owned_cells: std::cell::RefCell::new(Vec::new()),
@@ -880,6 +901,8 @@ impl majit_backend::Backend for WasmBackend {
             source_func_handle,
             source_has_preamble,
             source_is_single_label_peeled,
+            source_last_label_block_id,
+            source_last_label_num_args,
             base,
         ) = {
             let source_loop = original_token
@@ -899,6 +922,8 @@ impl majit_backend::Backend for WasmBackend {
                 source_loop.func_handle,
                 source_loop.has_preamble,
                 source_loop.is_single_label_peeled,
+                source_loop.last_label_block_id,
+                source_loop.last_label_num_args,
                 source_loop.fail_descrs.borrow().len() as u32,
             )
         };
@@ -929,13 +954,46 @@ impl majit_backend::Backend for WasmBackend {
         if source_has_preamble {
             diag_bump(7); // source loop has preamble
         }
-        if bridge_is_loop_closing && source_has_preamble && !source_is_single_label_peeled {
-            diag_bump(2); // declined: multi-label peeled
-            return Err(BackendError::Unsupported(
-                "wasm backend: loop-closing bridge re-enters a multi-label peeled loop \
-                 (resume-at-LABEL br_table deferred)"
-                    .into(),
-            ));
+        if bridge_is_loop_closing && source_has_preamble {
+            // The peeled source resumes at its LAST label (where the `loop` is)
+            // via the resume-at-LABEL dispatch. Accept this bridge only if its
+            // terminal JUMP re-enters at that last label: a single-label source
+            // has only that one label, so accept directly; a multi-label source
+            // is accepted only when the JUMP's target ordinal — recovered from
+            // its descr, which the source LABEL stamped with `set_label_block_id`
+            // (shared by Arc identity) — equals the source's last label and the
+            // arities match. Any other target (a non-last label) needs the
+            // deferred br_table, so decline → blackhole resume, and
+            // `declined_bridge_guards` stops the metainterp re-tracing it.
+            let resumes_at_last_label = source_is_single_label_peeled || {
+                let closing_jump = ops
+                    .iter()
+                    .rev()
+                    .find(|op| op.opcode == majit_ir::OpCode::Jump);
+                let target_ord = closing_jump
+                    .and_then(|j| j.getdescr())
+                    .and_then(|d| d.as_loop_target_descr().map(|t| t.label_block_id()));
+                let arity = closing_jump.map_or(0, |j| j.getarglist().len());
+                // Sub-breakdown of why a multi-label bridge does not resume at the
+                // last label (diagnostic: distinguishes the S2-needing non-last
+                // case from a stripped descr or an arity mismatch).
+                match target_ord {
+                    None => diag_bump(8),                                  // descr stripped
+                    Some(k) if k != source_last_label_block_id => diag_bump(9), // non-last label
+                    _ if arity != source_last_label_num_args => diag_bump(10),  // arity mismatch
+                    _ => {}
+                }
+                matches!(target_ord, Some(k) if k == source_last_label_block_id)
+                    && arity == source_last_label_num_args
+            };
+            if !resumes_at_last_label {
+                diag_bump(2); // declined: peeled source, JUMP not resuming at last label
+                return Err(BackendError::Unsupported(
+                    "wasm backend: loop-closing bridge re-enters a peeled loop at a \
+                     non-last label (resume-at-LABEL br_table deferred)"
+                        .into(),
+                ));
+            }
         }
 
         // This simple chaining handles a bridge attached directly to one of the

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -29,7 +29,8 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// 7 = source loop has a preamble. Sub-breakdown of the index-2 multi-label
 /// decline (TEMP, for the resume-at-last-label measurement): 8 = JUMP descr
 /// did not resolve (target_ord None), 9 = target_ord Some but != last label,
-/// 10 = arity mismatch, 11 = spare.
+/// 10 = arity mismatch, 11 = loop-closing bridge advances no loop-carried value
+/// (guard side-trace that would livelock the chained loop).
 pub static BRIDGE_DIAG: [AtomicU64; 12] = {
     const Z: AtomicU64 = AtomicU64::new(0);
     [Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z]
@@ -47,6 +48,46 @@ pub fn bridge_diag(i: usize) -> u64 {
 #[inline]
 fn diag_bump(i: usize) {
     BRIDGE_DIAG[i].fetch_add(1, Ordering::Relaxed);
+}
+
+/// An arithmetic op whose result advances a loop-carried numeric value (the
+/// `IntAdd`/`IntSub`/… and float-arithmetic block plus the overflow-checked
+/// variants and the unary `IntNeg`/`IntInvert`). Excludes copies (`SameAs*`),
+/// casts, comparisons, and allocations: those feed a JUMP arg without making
+/// the loop's induction walk toward its exit condition. Used to tell a
+/// state-advancing loop-closing bridge from a guard side-trace that re-presents
+/// the same loop state every pass.
+fn is_inductive_arith(opcode: majit_ir::OpCode) -> bool {
+    use majit_ir::OpCode::*;
+    matches!(
+        opcode,
+        IntAdd
+            | IntSub
+            | IntMul
+            | UintMulHigh
+            | IntFloorDiv
+            | IntMod
+            | IntAnd
+            | IntOr
+            | IntXor
+            | IntRshift
+            | IntLshift
+            | UintRshift
+            | IntSignext
+            | FloatAdd
+            | FloatSub
+            | FloatMul
+            | FloatTrueDiv
+            | FloatFloorDiv
+            | FloatMod
+            | FloatNeg
+            | FloatAbs
+            | IntNeg
+            | IntInvert
+            | IntAddOvf
+            | IntSubOvf
+            | IntMulOvf
+    )
 }
 
 use failguard::{CompiledWasmLoop, WasmFailDescr, WasmFrameData};
@@ -991,6 +1032,42 @@ impl majit_backend::Backend for WasmBackend {
                 return Err(BackendError::Unsupported(
                     "wasm backend: loop-closing bridge re-enters a peeled loop at a \
                      non-last label (resume-at-LABEL br_table deferred)"
+                        .into(),
+                ));
+            }
+        }
+
+        // A loop-closing bridge carries the source loop's loop-carried state in
+        // its terminal JUMP args and tail-calls the loop to iterate again. If no
+        // JUMP arg is the result of an induction-advancing arithmetic op — i.e.
+        // every loop-carried value is a verbatim input reload, a fresh
+        // allocation, or a baked constant — the bridge re-presents byte-identical
+        // induction/guard state on every pass, so the loop's exit guard never
+        // flips and the loop⇄bridge cycle spins forever (a control-flow
+        // livelock at constant stack depth and heap state). Such a bridge is a
+        // guard side-trace that omits the loop body's advancing arithmetic; it
+        // has no correct in-module resume, so decline it — the guard falls back
+        // to blackhole resume and `declined_bridge_guards` stops the metainterp
+        // re-tracing it. A genuinely advancing loop-closing bridge (an `i += 1`
+        // counter feeding a JUMP arg) passes and keeps chaining.
+        if bridge_is_loop_closing {
+            let advances = ops
+                .iter()
+                .rev()
+                .find(|op| op.opcode == majit_ir::OpCode::Jump)
+                .is_some_and(|jump| {
+                    jump.getarglist_operand().iter().any(|arg| match arg {
+                        majit_ir::operand::Operand::Op(producer) => {
+                            is_inductive_arith(producer.opcode)
+                        }
+                        _ => false,
+                    })
+                });
+            if !advances {
+                diag_bump(11); // declined: loop-closing bridge advances no loop-carried value
+                return Err(BackendError::Unsupported(
+                    "wasm backend: loop-closing bridge advances no loop-carried value \
+                     (guard side-trace would livelock the chained loop)"
                         .into(),
                 ));
             }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -16,7 +16,35 @@ mod glue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+/// Diagnostic-only `compile_bridge` outcome tallies, read out via the
+/// `pyre_jit_bridge_diag` guest export (the runner prints them at
+/// `PYRE_WASM_JIT_STATS` time). A static counter — NOT a host import, which
+/// would shift the wasm function-index space and break the JIT's baked
+/// `fn as usize` table indices. Index legend: 0 = compile_bridge entered,
+/// 1 = declined CALL_ASSEMBLER, 2 = declined multi-label peeled,
+/// 3 = declined not-a-direct-loop-guard, 4 = declined ref-home overflow,
+/// 5 = bridge compiled (chained in-module), 6 = loop-closing shape seen,
+/// 7 = source loop has a preamble.
+pub static BRIDGE_DIAG: [AtomicU64; 8] = {
+    const Z: AtomicU64 = AtomicU64::new(0);
+    [Z, Z, Z, Z, Z, Z, Z, Z]
+};
+
+/// Read a `BRIDGE_DIAG` tally (saturating index). Surfaced to the host through
+/// the `pyre_jit_bridge_diag` export in the `pyre-wasm` crate.
+pub fn bridge_diag(i: usize) -> u64 {
+    BRIDGE_DIAG
+        .get(i)
+        .map(|c| c.load(Ordering::Relaxed))
+        .unwrap_or(0)
+}
+
+#[inline]
+fn diag_bump(i: usize) {
+    BRIDGE_DIAG[i].fetch_add(1, Ordering::Relaxed);
+}
 
 use failguard::{CompiledWasmLoop, WasmFailDescr, WasmFrameData};
 use majit_backend::{AsmInfo, BackendError, DeadFrame, JitCellToken};
@@ -827,9 +855,12 @@ impl majit_backend::Backend for WasmBackend {
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();
         let ops: &[Op] = &ops_owned;
 
+        diag_bump(0); // compile_bridge entered
+
         // is_loop=false: a bridge's terminal JUMP with no LABEL is a loop-closing
         // bridge whose re-entry target is plumbed via `external_jump_slot`.
         if let Some(reason) = wasm_unsupported_trace_reason(ops, false) {
+            diag_bump(1); // declined: CALL_ASSEMBLER
             return Err(BackendError::Unsupported(reason));
         }
 
@@ -892,7 +923,14 @@ impl majit_backend::Backend for WasmBackend {
             let has_jump = ops.iter().any(|op| op.opcode == majit_ir::OpCode::Jump);
             has_jump && !has_label
         };
+        if bridge_is_loop_closing {
+            diag_bump(6); // loop-closing shape
+        }
+        if source_has_preamble {
+            diag_bump(7); // source loop has preamble
+        }
         if bridge_is_loop_closing && source_has_preamble && !source_is_single_label_peeled {
+            diag_bump(2); // declined: multi-label peeled
             return Err(BackendError::Unsupported(
                 "wasm backend: loop-closing bridge re-enters a multi-label peeled loop \
                  (resume-at-LABEL br_table deferred)"
@@ -908,6 +946,7 @@ impl majit_backend::Backend for WasmBackend {
         // bridge module.
         if source_trace_id != source_loop_trace_id || source_fail_index as usize >= source_num_cells
         {
+            diag_bump(3); // declined: not a direct loop guard
             return Err(BackendError::Unsupported(
                 "wasm backend: bridge source guard is not a direct loop guard".into(),
             ));
@@ -952,6 +991,7 @@ impl majit_backend::Backend for WasmBackend {
         // the home roots regardless of how the bridge's exit arity compares to
         // the source loop's `max_output_slots`.
         if num_ref_homes > source_num_ref_homes {
+            diag_bump(4); // declined: ref-home overflow
             return Err(BackendError::Unsupported(format!(
                 "wasm backend: bridge needs {num_ref_homes} ref homes, source loop has \
                  {source_num_ref_homes}"
@@ -980,6 +1020,7 @@ impl majit_backend::Backend for WasmBackend {
         let bridge_slot = glue::compile_module(&wasm_bytes);
         #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
         let bridge_slot = 0u32;
+        diag_bump(5); // bridge compiled — chained in-module
 
         {
             let source_loop = original_token

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -42,7 +42,7 @@ fn test_empty_trace() {
         op
     }];
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -102,7 +102,7 @@ fn test_int_add_loop() {
         Op::new(OpCode::Jump, &[rb(OpRef::int_op(3)), rb(OpRef::int_op(2))]),
     ];
 
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -164,7 +164,7 @@ fn test_float_ops() {
     ];
 
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -202,7 +202,7 @@ fn test_call_generates_import() {
         },
     ];
 
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -297,7 +297,7 @@ fn test_guard_types() {
     ];
 
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -342,7 +342,7 @@ fn test_exception_guards() {
     ];
 
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -383,7 +383,7 @@ fn test_guard_gc_type_uses_immediate_typeid() {
         Op::new(OpCode::Jump, &[rb(OpRef::input_arg_int(0))]),
     ];
 
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -446,7 +446,7 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
     ];
 
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -497,7 +497,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
     info.subclass_ranges.insert(0xCAFE, (10, 20));
 
     // gcremovetypeptr branch: vtable_offset = None.
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -515,7 +515,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
     assert_eq!(guards.len(), 1);
 
     // vtable-load branch: vtable_offset = Some(...).
-    let (bytes2, _, _, _) = codegen::build_wasm_module(
+    let (bytes2, _, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -582,7 +582,7 @@ fn test_sameas_and_conversions() {
     ];
 
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, _, _, _) = codegen::build_wasm_module(
+    let (bytes, _, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -635,7 +635,7 @@ fn test_overflow_ops() {
     ];
 
     let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-    let (bytes, guards, _, _) = codegen::build_wasm_module(
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
         &inputargs,
         &ops,
         &constants,
@@ -651,4 +651,62 @@ fn test_overflow_ops() {
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 3); // 2 GuardNoOverflow + 1 Finish
+}
+
+#[test]
+fn test_single_label_peeled_loop_validates() {
+    // A single-label PEELED loop: a preamble op (the unrolled first iteration)
+    // precedes the LABEL, so codegen wraps it in the resume-at-LABEL preamble-
+    // skip dispatch (block $exit / $past_loader / $skip_preamble + br_if, with
+    // the preamble at br-depth 2 and the body at 1). This validates the new
+    // control-flow nesting and br depths via wasmparser.
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)]; // i
+    let const_1 = OpRef::const_int(1);
+    let const_100 = OpRef::const_int(100);
+    let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
+
+    let ops = vec![
+        // preamble (unrolled first iteration): i + 1 -> v1
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(1),
+        ),
+        // loop header carrying v1 (single LABEL, with the preamble before it)
+        Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]),
+        // body: v1 + 1 -> v2 ; v2 < 100 -> v3 ; guard ; jump v2 back to LABEL
+        make_op(OpCode::IntAdd, &[OpRef::int_op(1), const_1], OpRef::int_op(2)),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(2), const_100],
+            OpRef::int_op(3),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(3)],
+            &[OpRef::int_op(2)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(2))]),
+    ];
+
+    // Must be classified as single-label peeled (exercises the dispatch wrapper).
+    assert!(codegen::is_single_label_peeled(&ops));
+
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
+        &inputargs,
+        &ops,
+        &constants,
+        Some(0),
+        &HashMap::new(),
+        &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
+        0,
+        0, // fail_index_base
+        0, // external_jump_slot
+    )
+    .expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert!(!guards[0].is_finish);
 }

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -54,6 +54,7 @@ fn test_empty_trace() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -114,6 +115,7 @@ fn test_int_add_loop() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -176,6 +178,7 @@ fn test_float_ops() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -214,6 +217,7 @@ fn test_call_generates_import() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -309,6 +313,7 @@ fn test_guard_types() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -354,6 +359,7 @@ fn test_exception_guards() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -395,6 +401,7 @@ fn test_guard_gc_type_uses_immediate_typeid() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -458,6 +465,7 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
@@ -509,6 +517,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed when supports_guard_gc_type=true");
     validate_wasm(&bytes);
@@ -527,6 +536,7 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed when vtable_offset is set");
     validate_wasm(&bytes2);
@@ -594,6 +604,7 @@ fn test_sameas_and_conversions() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -647,6 +658,7 @@ fn test_overflow_ops() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -704,6 +716,7 @@ fn test_single_label_peeled_loop_validates() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);
@@ -768,6 +781,7 @@ fn test_multi_label_peeled_resumes_at_last_label_validates() {
         0,
         0, // fail_index_base
         0, // external_jump_slot
+        codegen::CaParams::default(),
     )
     .expect("wasm codegen should succeed");
     validate_wasm(&bytes);

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -710,3 +710,103 @@ fn test_single_label_peeled_loop_validates() {
     assert_eq!(guards.len(), 1);
     assert!(!guards[0].is_finish);
 }
+
+#[test]
+fn test_multi_label_peeled_resumes_at_last_label_validates() {
+    // A MULTI-label peeled loop: a preamble precedes an outer entry LABEL and
+    // the inner loop-header LABEL. `is_single_label_peeled` is false (two
+    // labels) but `is_resumable_peeled` is true, so codegen emits the SAME
+    // resume-at-LABEL 3-block wrapper, resuming at the LAST label (where the
+    // `loop` is). This proves the wrapper + br depths stay valid for a
+    // multi-label source — the case `compile_bridge` newly accepts when a
+    // loop-closing bridge targets that last label.
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)]; // i
+    let const_1 = OpRef::const_int(1);
+    let const_100 = OpRef::const_int(100);
+    let constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
+
+    let ops = vec![
+        // preamble (unrolled first iteration): i + 1 -> v1
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), const_1],
+            OpRef::int_op(1),
+        ),
+        // outer entry LABEL carrying v1 (no `loop` — a codegen no-op)
+        Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]),
+        // inner loop-header LABEL carrying v1 (the LAST label — `loop` here)
+        Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]),
+        // body: v1 + 1 -> v2 ; v2 < 100 -> v3 ; guard ; jump v2 back to LABEL
+        make_op(OpCode::IntAdd, &[OpRef::int_op(1), const_1], OpRef::int_op(2)),
+        make_op(
+            OpCode::IntLt,
+            &[OpRef::int_op(2), const_100],
+            OpRef::int_op(3),
+        ),
+        make_guard(
+            OpCode::GuardTrue,
+            &[OpRef::int_op(3)],
+            &[OpRef::int_op(2)],
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(2))]),
+    ];
+
+    // Multi-label: NOT the single-label subset, but still resumable-peeled, so
+    // the wrapper is emitted and resumes at the last label.
+    assert!(!codegen::is_single_label_peeled(&ops));
+    assert!(codegen::is_resumable_peeled(&ops));
+
+    let (bytes, guards, _, _, _) = codegen::build_wasm_module(
+        &inputargs,
+        &ops,
+        &constants,
+        Some(0),
+        &HashMap::new(),
+        &codegen::GuardGcTypeInfo::default(),
+        0,
+        0,
+        0,
+        0, // fail_index_base
+        0, // external_jump_slot
+    )
+    .expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert!(!guards[0].is_finish);
+}
+
+#[test]
+fn test_registration_loop_stamps_label_block_id() {
+    // The bridge-side target-ordinal recovery rests on one fact: a LABEL and the
+    // closing JUMP that targets it share their loop-target descr by Arc identity,
+    // so the `label_block_id` `compile_loop` stamps on the LABEL is readable from
+    // the JUMP's descr in `compile_bridge`. Reproduce that here: build two LABELs
+    // each with its own descr, run the registration loop's stamping (ordinals 0,
+    // 1), and confirm the JUMP that shares the second LABEL's descr reads back 1.
+    let descr0 = majit_ir::make_loop_target_descr(10, false);
+    let descr1 = majit_ir::make_loop_target_descr(11, false);
+
+    let label0 = Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]);
+    label0.setdescr(descr0.clone());
+    let label1 = Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]);
+    label1.setdescr(descr1.clone());
+    // A loop-closing bridge's terminal JUMP carries the SAME descr Arc as the
+    // label it targets (here, the second/last label).
+    let jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(2))]);
+    jump.setdescr(descr1.clone());
+
+    // Registration loop (mirrors compile_loop): stamp each LABEL with its ordinal.
+    for (ordinal, label) in [&label0, &label1].iter().enumerate() {
+        let d = label.getdescr().expect("label has a descr");
+        d.as_loop_target_descr()
+            .expect("loop-target descr")
+            .set_label_block_id(ordinal as u32);
+    }
+
+    // Recover the JUMP's target ordinal — it must equal the LAST label's (1),
+    // via the shared Arc, NOT 0 (the default) or the first label's ordinal.
+    let recovered = jump
+        .getdescr()
+        .and_then(|d| d.as_loop_target_descr().map(|t| t.label_block_id()));
+    assert_eq!(recovered, Some(1));
+}

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -675,17 +675,17 @@ fn test_single_label_peeled_loop_validates() {
         // loop header carrying v1 (single LABEL, with the preamble before it)
         Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]),
         // body: v1 + 1 -> v2 ; v2 < 100 -> v3 ; guard ; jump v2 back to LABEL
-        make_op(OpCode::IntAdd, &[OpRef::int_op(1), const_1], OpRef::int_op(2)),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::int_op(1), const_1],
+            OpRef::int_op(2),
+        ),
         make_op(
             OpCode::IntLt,
             &[OpRef::int_op(2), const_100],
             OpRef::int_op(3),
         ),
-        make_guard(
-            OpCode::GuardTrue,
-            &[OpRef::int_op(3)],
-            &[OpRef::int_op(2)],
-        ),
+        make_guard(OpCode::GuardTrue, &[OpRef::int_op(3)], &[OpRef::int_op(2)]),
         Op::new(OpCode::Jump, &[rb(OpRef::int_op(2))]),
     ];
 
@@ -737,17 +737,17 @@ fn test_multi_label_peeled_resumes_at_last_label_validates() {
         // inner loop-header LABEL carrying v1 (the LAST label — `loop` here)
         Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]),
         // body: v1 + 1 -> v2 ; v2 < 100 -> v3 ; guard ; jump v2 back to LABEL
-        make_op(OpCode::IntAdd, &[OpRef::int_op(1), const_1], OpRef::int_op(2)),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::int_op(1), const_1],
+            OpRef::int_op(2),
+        ),
         make_op(
             OpCode::IntLt,
             &[OpRef::int_op(2), const_100],
             OpRef::int_op(3),
         ),
-        make_guard(
-            OpCode::GuardTrue,
-            &[OpRef::int_op(3)],
-            &[OpRef::int_op(2)],
-        ),
+        make_guard(OpCode::GuardTrue, &[OpRef::int_op(3)], &[OpRef::int_op(2)]),
         Op::new(OpCode::Jump, &[rb(OpRef::int_op(2))]),
     ];
 

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1705,6 +1705,18 @@ pub trait Backend: Send {
         caller_recovery_layout: Option<&ExitRecoveryLayout>,
     ) -> Result<AsmInfo, BackendError>;
 
+    /// Whether a `BackendError::Unsupported` returned by `compile_bridge`
+    /// is a deterministic structural decline that re-tracing the same guard
+    /// would reproduce identically (a compile storm). When `true`, the
+    /// metainterp records the guard so `must_compile_with_values` stops
+    /// re-firing it and the guard falls back to blackhole resume. The
+    /// default is `false`: backends that patch machine code in place never
+    /// decline structurally, so a transient failure is retried after the
+    /// jitcounter ticks again (`compile.py:790-795 done_compiling`).
+    fn bridge_decline_is_terminal(&self) -> bool {
+        false
+    }
+
     /// Register a freshly-compiled JitCellToken as still reachable from
     /// the frontend.  Backends that need to resolve `jf_descr` pointers
     /// across token boundaries (dynasm's `find_descr_by_ptr` cross-token

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -391,6 +391,30 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
     let _ = STACK_ALMOST_FULL_FN.set(f);
 }
 
+/// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
+/// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
+/// entered, 1 = declined_bridge_guards short-circuit, 2 = descr_addr==0 skip,
+/// 3 = status-busy skip, 4 = jitcounter FIRED (true), 5 = reserved (unused),
+/// 6 = start_retrace_from_guard entered, 7 = start_retrace bailed (source loop
+/// evicted: compiled_loops miss).
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; 8] = {
+    const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    [Z, Z, Z, Z, Z, Z, Z, Z]
+};
+
+/// Read an `MC_DIAG` tally (saturating). Surfaced via `pyre_jit_mc_diag`.
+pub fn mc_diag(i: usize) -> u64 {
+    MC_DIAG
+        .get(i)
+        .map(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(0)
+}
+
+#[inline]
+pub fn mc_diag_bump(i: usize) {
+    MC_DIAG[i].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// rpython/rlib/rstack.py:75-90 `stack_almost_full`. Returns `true` if
 /// the stack is more than 15/16ths full against the recursion-limit
 /// budget. Dispatches to the interpreter-registered hook; in tests or

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8820,6 +8820,7 @@ impl<M: Clone> MetaInterp<M> {
         fail_values: &[i64],
         fallback_green_key: u64,
     ) -> (bool, u64) {
+        crate::mc_diag_bump(0); // must_compile_with_values entered
         let descr_addr = std::sync::Arc::as_ptr(descr_arc) as *const () as usize;
         let descr_fd = descr_arc
             .as_fail_descr()
@@ -8837,6 +8838,7 @@ impl<M: Clone> MetaInterp<M> {
             .declined_bridge_guards
             .contains(&(trace_id, fail_index))
         {
+            crate::mc_diag_bump(1); // declined_bridge_guards short-circuit
             let owning_key = majit_backend::descr_owning_jct(descr_fd)
                 .map(|jct| jct.green_key)
                 .unwrap_or(fallback_green_key);
@@ -8854,6 +8856,7 @@ impl<M: Clone> MetaInterp<M> {
             .map(|jct| jct.green_key)
             .unwrap_or(fallback_green_key);
         if descr_addr == 0 {
+            crate::mc_diag_bump(2); // descr_addr==0 skip
             crate::debug::log_one("jit-tracing", "must_compile: descr_addr=0, skip");
             return (false, owning_key);
         }
@@ -8867,6 +8870,7 @@ impl<M: Clone> MetaInterp<M> {
             status
         } else if status & Self::ST_BUSY_FLAG != 0 {
             // compile.py:750-751: already busy tracing.
+            crate::mc_diag_bump(3); // status-busy skip
             return (false, owning_key);
         } else {
             // compile.py:753-781: GUARD_VALUE per-value hash.
@@ -8887,6 +8891,9 @@ impl<M: Clone> MetaInterp<M> {
         };
         // compile.py:783-784: jitcounter.tick(hash, increment)
         let fired = self.warm_state.tick_guard_failure(hash);
+        if fired {
+            crate::mc_diag_bump(4); // jitcounter FIRED
+        }
         if fired && crate::majit_log_enabled() {
             eprintln!(
                 "[jit] must_compile FIRED: key={} trace={} guard={}",
@@ -10318,6 +10325,7 @@ impl<M: Clone> MetaInterp<M> {
         // pyre's `compiled_loops` lookup below stands in for
         // `get_resumestorage`/`loop_token_wref()`; both gate the trace on
         // the source loop still being live.
+        crate::mc_diag_bump(6); // start_retrace_from_guard entered
         self.enter_profiler_tracing();
         self.try_to_free_some_loops();
         // bridgeopt.py:124 frontend_boxes come directly from the guard
@@ -10326,6 +10334,7 @@ impl<M: Clone> MetaInterp<M> {
         let _compiled = match self.compiled_loops.get(&green_key) {
             Some(c) => c,
             None => {
+                crate::mc_diag_bump(7); // start_retrace bailed: source loop evicted
                 // Source loop already evicted — bail out of the bridge
                 // before opening the M-ownership session.  Pair the
                 // `start_tracing` fired above so the profiler stack

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8826,10 +8826,13 @@ impl<M: Clone> MetaInterp<M> {
             .expect("must_compile_with_values: descr_arc must be a FailDescr");
         let trace_id = descr_fd.trace_id();
         let fail_index = descr_fd.fail_index_per_trace();
-        // A guard whose bridge the backend already declined as structurally
+        // A guard whose bridge a terminal-declining backend
+        // (`bridge_decline_is_terminal()`) already refused as structurally
         // `Unsupported` must not re-fire — re-tracing rebuilds the same
-        // unsupported bridge forever (a compile storm). Fall back to the
-        // blackhole resume the dormant path always used for this guard.
+        // unsupported bridge forever (a compile storm). Native backends never
+        // populate this set (their declines are transient), so this only ever
+        // short-circuits wasm guards. Fall back to the blackhole resume the
+        // dormant path always used for this guard.
         if self
             .declined_bridge_guards
             .contains(&(trace_id, fail_index))
@@ -10258,10 +10261,17 @@ impl<M: Clone> MetaInterp<M> {
                 // done_compiling). A structural `Unsupported` decline is the
                 // exception: it is deterministic in the source guard, so
                 // re-tracing rebuilds the identical unsupported bridge forever.
-                // Record the source guard so `must_compile_with_values` stops
-                // firing for it; the guard then resolves through blackhole
+                // Only backends that report `bridge_decline_is_terminal()` (the
+                // wasm backend, whose every decline is a structural shape
+                // mismatch) record it; native backends keep the transient-retry
+                // semantics above, since their `Unsupported` (cranelift
+                // op-lowering gaps) may be resolved on a differently-shaped
+                // retrace. Record the source guard so `must_compile_with_values`
+                // stops firing for it; the guard then resolves through blackhole
                 // resume (the always-correct fallback the dormant path uses).
-                if let majit_backend::BackendError::Unsupported(_) = e {
+                if matches!(e, majit_backend::BackendError::Unsupported(_))
+                    && self.backend.bridge_decline_is_terminal()
+                {
                     self.declined_bridge_guards
                         .insert((fail_descr.trace_id(), fail_descr.fail_index_per_trace()));
                 }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1828,6 +1828,63 @@ impl<M: Clone> MetaInterp<M> {
             .map(|layout| layout.public(owning_key, trace_id, fail_index))
     }
 
+    /// Build the `CompiledExitLayout` for an exit identified by `descr`, owned
+    /// by the loop registered under `green_key`. Mirrors the inline layout
+    /// construction in `run_compiled_detailed_with_values`; the wasm in-guest
+    /// CALL_ASSEMBLER deopt path (`call_jit::wasm_ca_resume_deopt`) reuses it to
+    /// blackhole-resume a callee frame that left its trace through a guard,
+    /// rather than re-running it from the entry.
+    pub fn build_exit_layout_for_descr(
+        &self,
+        green_key: u64,
+        descr: &dyn majit_ir::FailDescr,
+    ) -> CompiledExitLayout {
+        let fail_index = descr.fail_index();
+        let trace_id = descr.trace_id();
+        let is_finish = descr.is_finish();
+        let is_exit_frame_with_exception = descr.is_exit_frame_with_exception();
+        let exit_types = descr.fail_arg_types().to_vec();
+        let gc_ref_slots: Vec<usize> = exit_types
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, _)| descr.is_gc_ref_slot(slot).then_some(slot))
+            .collect();
+        let force_token_slots = descr.force_token_slots().to_vec();
+        let rd_loop_token = majit_backend::descr_owning_jct(descr).map(|jct| jct.green_key);
+
+        let default_layout = || CompiledExitLayout {
+            rd_loop_token: green_key,
+            trace_id,
+            fail_index,
+            source_op_index: None,
+            exit_types: exit_types.clone(),
+            is_finish,
+            is_exception_exit: is_exit_frame_with_exception,
+            gc_ref_slots: gc_ref_slots.clone(),
+            force_token_slots: force_token_slots.clone(),
+            recovery_layout: None,
+            resume_layout: None,
+            storage: None,
+        };
+
+        // FINISH descrs (singletons) have `trace_id == 0`; skip the trace lookup
+        // and synthesize the default layout, as `run_compiled_detailed_with_values`
+        // does for the is_finish arm.
+        if is_finish {
+            return default_layout();
+        }
+        let Some(compiled) = self.compiled_loops.get(&green_key) else {
+            return default_layout();
+        };
+        Self::trace_for_exit(compiled, trace_id)
+            .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
+            .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
+            .and_then(|(owning_key, resolved_id, trace)| {
+                Self::compiled_exit_layout_from_trace(trace, owning_key, resolved_id, fail_index)
+            })
+            .unwrap_or_else(default_layout)
+    }
+
     /// `compile.py:855 ResumeGuardDescr._attrs_` parity: per-guard exit
     /// types live on the descr object itself.  RPython has no such
     /// recovery helper because every `Box` already carries `.type`

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2690,6 +2690,94 @@ fn jit_ca_handle_guard_failure(
     compiled
 }
 
+/// Host completion for an in-guest self-recursive CALL_ASSEMBLER callee that
+/// deopted (`PYRE_WASM_CA`). The wasm CA arm `call_indirect`s this through the
+/// shared `__indirect_function_table` (its slot published via
+/// `majit_backend_wasm::set_ca_deopt_helper_slot` during `JIT_DRIVER` init)
+/// when an in-guest callee frame returns a non-finish `fail_index`.
+///
+/// It is the wasm analog of the dynasm/cranelift CA fast path's deopt leg
+/// (`call_assembler_fast_path_heap` → `jit_blackhole_resume_from_guard`): build
+/// a `DeadFrame` from the callee's already-run frame, then **blackhole-resume it
+/// AT the guard PC** — so the callee's pre-guard work is not re-executed (unlike
+/// a force / entry re-run) — and return the call result, a boxed Ref. A callee
+/// that actually finished (a base case, or a chained-bridge finish the arm's
+/// static fast-path set did not recognise) short-circuits to its output slot.
+///
+/// `frame_ptr` is the deopted callee arena frame; `compiled_ptr` is the source
+/// loop's `CompiledWasmLoop`, both baked into the trace by `compile_bridge`.
+#[cfg(target_arch = "wasm32")]
+pub extern "C" fn wasm_ca_resume_deopt(frame_ptr: i64, compiled_ptr: i64) -> i64 {
+    use majit_backend::Backend;
+    let frame =
+        majit_backend_wasm::dead_frame_from_ran_frame(compiled_ptr as usize, frame_ptr as usize);
+
+    // Decode the exit through the same Backend accessors the host's outermost
+    // deopt handling uses (`run_compiled_detailed_with_values`); extract owned
+    // values so the driver borrow is released before the blackhole re-enters it.
+    enum Outcome {
+        Finished(i64),
+        Deopt {
+            green_key: u64,
+            exit_layout: majit_metainterp::CompiledExitLayout,
+            raw_values: Vec<i64>,
+            guard_exc: i64,
+        },
+    }
+    let outcome = {
+        let (driver, _) = crate::eval::driver_pair();
+        let mi = driver.meta_interp();
+        let backend = mi.backend();
+        let descr_arc = backend.get_latest_descr_arc(&frame);
+        let descr = descr_arc
+            .as_fail_descr()
+            .expect("CA deopt: get_latest_descr_arc returned a non-FailDescr Descr");
+        if descr.is_finish() {
+            Outcome::Finished(backend.get_ref_value(&frame, 0).as_usize() as i64)
+        } else {
+            let green_key = majit_backend::descr_owning_jct(descr)
+                .map(|jct| jct.green_key)
+                .unwrap_or(0);
+            let exit_layout = mi.build_exit_layout_for_descr(green_key, descr);
+            let raw_values: Vec<i64> = descr
+                .fail_arg_types()
+                .iter()
+                .enumerate()
+                .map(|(i, &tp)| match tp {
+                    majit_ir::Type::Int => backend.get_int_value(&frame, i),
+                    majit_ir::Type::Ref => backend.get_ref_value(&frame, i).as_usize() as i64,
+                    majit_ir::Type::Float => backend.get_float_value(&frame, i).to_bits() as i64,
+                    majit_ir::Type::Void => 0,
+                })
+                .collect();
+            let guard_exc = backend.grab_exc_value(&frame).0 as i64;
+            Outcome::Deopt {
+                green_key,
+                exit_layout,
+                raw_values,
+                guard_exc,
+            }
+        }
+    };
+
+    match outcome {
+        Outcome::Finished(r) => r,
+        Outcome::Deopt {
+            green_key,
+            exit_layout,
+            raw_values,
+            guard_exc,
+        } => {
+            let bh = crate::eval::resume_in_blackhole_from_exit_layout(
+                &raw_values,
+                &exit_layout,
+                guard_exc,
+            );
+            handle_blackhole_result(bh, green_key).unwrap_or(0)
+        }
+    }
+}
+
 // ── Callee frame creation for call_assembler ─────────────────────
 
 /// Public wrapper for trace-through inlining.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2113,8 +2113,23 @@ fn bridge_source_identity_from_descr(
 /// On failure (trace abort, start failure), returns false so the caller
 /// falls through to resume_in_blackhole (RPython pyjitpl.py:2906-2907
 /// SwitchToBlackhole → run_blackhole_interp_to_cancel_tracing).
-// On wasm the early unconditional decline makes the native bridge body
-// unreachable; the suppression is intentional and wasm-only.
+/// Runtime toggle for the otherwise-dormant wasm bridge tracer (default off).
+/// Set by the runner via the `pyre_jit_set_enable_bridges` export so chaining
+/// can be enabled/measured without rebuilding the guest module. Kept off by
+/// default — chaining does not yet resolve the bench timeouts and re-enabling
+/// it surfaces a loop-closing bridge livelock on some traces (fannkuch).
+#[cfg(target_arch = "wasm32")]
+pub static WASM_BRIDGES_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Set the wasm bridge-tracer enable flag (see `WASM_BRIDGES_ENABLED`).
+#[cfg(target_arch = "wasm32")]
+pub fn set_wasm_bridges_enabled(enabled: bool) {
+    WASM_BRIDGES_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+// On wasm the early decline makes the native bridge body unreachable when the
+// tracer is disabled; the suppression is intentional and wasm-only.
 #[cfg_attr(target_arch = "wasm32", allow(unreachable_code))]
 pub fn trace_and_compile_from_bridge(
     // pyjitpl.py:2890 `handle_guard_failure(self, resumedescr, deadframe)`
@@ -2171,7 +2186,7 @@ pub fn trace_and_compile_from_bridge(
     // incremental-major pacing fix that is not yet safe) until that lands.
     // Removing this re-enables the (otherwise complete and verified) chaining.
     #[cfg(target_arch = "wasm32")]
-    {
+    if !WASM_BRIDGES_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
         let _ = (
             frame,
             raw_values,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -805,6 +805,11 @@ thread_local! {
         majit_backend_cranelift::set_jitframe_gc_type_id(jitframe_tid);
         #[cfg(feature = "dynasm")]
         majit_backend_dynasm::set_jitframe_gc_type_id(jitframe_tid);
+        // The orthodox (PYRE_WASM_CA) frame path allocates host-entry frames as
+        // GC-managed JitFrames of this type so the collector forwards their Ref
+        // item slots via the jf_gcmap custom trace.
+        #[cfg(target_arch = "wasm32")]
+        majit_backend_wasm::set_wasm_jitframe_tid(jitframe_tid);
         // llsupport/gc.py:563 vtable→typeid mapping. RPython derives the
         // typeid arithmetically from gc_get_type_info_group; pyre keeps an
         // explicit table because every PyType is a static global
@@ -2156,6 +2161,17 @@ thread_local! {
                 let _ = apply_jit_param_string(ws, text);
             }
         }
+        // Publish the wasm CA deopt-helper's `__indirect_function_table` slot so
+        // `compile_bridge` can lift a self-recursive CALL_ASSEMBLER bridge: the
+        // CA arm `call_indirect`s it to blackhole-resume a callee that left its
+        // trace through a guard. Taking the function's address keeps it in the
+        // table; on wasm32 the address IS the table index. Done here (not only in
+        // `init_jit_hooks`) because the wasm entry path reaches `driver_pair`
+        // without `init_jit_hooks`.
+        #[cfg(target_arch = "wasm32")]
+        majit_backend_wasm::set_ca_deopt_helper_slot(
+            crate::call_jit::wasm_ca_resume_deopt as *const () as usize as u32,
+        );
         (d, info)
     });
 }
@@ -4310,7 +4326,7 @@ fn blackhole_result_tag(r: &crate::call_jit::BlackholeResult) -> &'static str {
 /// RPython: resume_in_blackhole → blackhole_from_resumedata →
 /// consume_one_section → _run_forever → raises.
 ///
-fn resume_in_blackhole_from_exit_layout(
+pub(crate) fn resume_in_blackhole_from_exit_layout(
     raw_values: &[i64],
     exit_layout: &CompiledExitLayout,
     guard_exc: i64,

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -284,6 +284,33 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
                 eprintln!("[jit-stats] heap_buckets {}", parts.join(" "));
             }
         }
+        // compile_bridge outcome tallies (diagnostic). 0=entered 1=declCALL_ASM
+        // 2=declMultiPeel 3=declNotDirect 4=declRefHome 5=BRIDGE_OK
+        // 6=loopClosing 7=srcHasPreamble.
+        if let Ok(diag) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_bridge_diag") {
+            let labels = [
+                "entered", "decl_callasm", "decl_multipeel", "decl_notdirect",
+                "decl_refhome", "BRIDGE_OK", "loopclosing", "src_preamble",
+            ];
+            let mut parts = Vec::new();
+            for (i, lbl) in labels.iter().enumerate() {
+                let n = diag.call(&mut store, i as u32).unwrap_or(0);
+                parts.push(format!("{lbl}={n}"));
+            }
+            eprintln!("[jit-stats] bridge_diag {}", parts.join(" "));
+        }
+        // must_compile / start_retrace gate tallies (diagnostic).
+        if let Ok(mc) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_mc_diag") {
+            let labels = [
+                "mc_entered", "decl_shortcircuit", "descr0_skip", "busy_skip",
+                "FIRED", "reserved", "retrace_entered", "retrace_bailed",
+            ];
+            let mut parts = Vec::new();
+            for (i, lbl) in labels.iter().enumerate() {
+                parts.push(format!("{lbl}={}", mc.call(&mut store, i as u32).unwrap_or(0)));
+            }
+            eprintln!("[jit-stats] mc_diag {}", parts.join(" "));
+        }
         let host = store.data();
         eprintln!(
             "[jit-stats] compiles={} executes={} linear_mem={} gc_oldgen={} gc_nursery={} \

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -240,7 +240,17 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     // PYRE_WASM_ENABLE_BRIDGES is set, so chaining can be measured without
     // rebuilding the guest. No-op if the export is absent (older modules).
     if std::env::var_os("PYRE_WASM_ENABLE_BRIDGES").is_some() {
-        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_enable_bridges") {
+        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_enable_bridges")
+        {
+            f.call(&mut store, 1)?;
+        }
+    }
+
+    // Enable the self-recursive CALL_ASSEMBLER guest→guest `call_indirect` arm
+    // (`PYRE_WASM_CA`). The guest has no environment, so the flag is plumbed
+    // through this export. No-op if the export is absent (older modules).
+    if std::env::var_os("PYRE_WASM_CA").is_some() {
+        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_wasm_ca") {
             f.call(&mut store, 1)?;
         }
     }
@@ -308,9 +318,20 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
         // 6=loopClosing 7=srcHasPreamble.
         if let Ok(diag) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_bridge_diag") {
             let labels = [
-                "entered", "decl_callasm", "decl_multipeel", "decl_notdirect",
-                "decl_refhome", "BRIDGE_OK", "loopclosing", "src_preamble",
-                "ml_descr_none", "ml_nonlast", "ml_arity_mismatch", "decl_noadvance",
+                "entered",
+                "decl_callasm",
+                "decl_multipeel",
+                "decl_notdirect",
+                "decl_refhome",
+                "BRIDGE_OK",
+                "loopclosing",
+                "src_preamble",
+                "ml_descr_none",
+                "ml_nonlast",
+                "ml_arity_mismatch",
+                "decl_noadvance",
+                "ca_cell_set",
+                "ca_cells_zero",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {
@@ -322,12 +343,21 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
         // must_compile / start_retrace gate tallies (diagnostic).
         if let Ok(mc) = instance.get_typed_func::<u32, u64>(&mut store, "pyre_jit_mc_diag") {
             let labels = [
-                "mc_entered", "decl_shortcircuit", "descr0_skip", "busy_skip",
-                "FIRED", "reserved", "retrace_entered", "retrace_bailed",
+                "mc_entered",
+                "decl_shortcircuit",
+                "descr0_skip",
+                "busy_skip",
+                "FIRED",
+                "reserved",
+                "retrace_entered",
+                "retrace_bailed",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {
-                parts.push(format!("{lbl}={}", mc.call(&mut store, i as u32).unwrap_or(0)));
+                parts.push(format!(
+                    "{lbl}={}",
+                    mc.call(&mut store, i as u32).unwrap_or(0)
+                ));
             }
             eprintln!("[jit-stats] mc_diag {}", parts.join(" "));
         }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -310,7 +310,7 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             let labels = [
                 "entered", "decl_callasm", "decl_multipeel", "decl_notdirect",
                 "decl_refhome", "BRIDGE_OK", "loopclosing", "src_preamble",
-                "ml_descr_none", "ml_nonlast", "ml_arity_mismatch",
+                "ml_descr_none", "ml_nonlast", "ml_arity_mismatch", "decl_noadvance",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -194,12 +194,24 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     // JIT trace modules emit `return_call_indirect` to chain a loop-closing bridge
     // back into its loop at constant stack depth (the tail-call proposal).
     config.wasm_tail_call(true);
+    // Optional instruction budget: PYRE_WASM_FUEL=N traps the guest after N fuel
+    // units so a diagnostic run that livelocks (e.g. a buggy loop-closing bridge)
+    // still reaches the stats readout instead of hanging forever.
+    let fuel_limit: Option<u64> = std::env::var("PYRE_WASM_FUEL")
+        .ok()
+        .and_then(|s| s.parse().ok());
+    if fuel_limit.is_some() {
+        config.consume_fuel(true);
+    }
     let engine = Engine::new(&config)?;
 
     let module = load_main_module(&engine, module_path)?;
 
     let mut store = Store::new(&engine, Host::default());
     store.data_mut().stdlib_root = std::env::var("PYRE_STDLIB").ok();
+    if let Some(n) = fuel_limit {
+        store.set_fuel(n)?;
+    }
 
     let linker = build_linker(&engine)?;
     let instance = linker
@@ -243,19 +255,17 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
         p
     };
 
-    let packed = match run_python.call(&mut store, (in_ptr, len)) {
-        Ok(p) => p,
-        Err(e) => {
-            // wasm32-unknown-unknown has no stderr, but pyre-wasm's panic hook
-            // writes "panicked at …" into linear memory before the trap.
-            // Recover the formatted message (the heap String, not the static
-            // format template) so the real cause is visible.
-            for msg in recover_panic_messages(memory.data(&store)) {
-                eprintln!("pyre-wasm-runner: recovered panic: {msg}");
-            }
-            return Err(e);
-        }
-    };
+    // Keep the run result so the diagnostic stats can be read out even when the
+    // guest traps (a panic, or a PYRE_WASM_FUEL exhaustion that interrupts a
+    // livelock): the JIT counters are populated at compile time, before the run
+    // finishes, and the diag exports just read statics that survive a trap.
+    let run_result = run_python.call(&mut store, (in_ptr, len));
+    // After a fuel-exhaustion trap the store has no fuel, so the diagnostic
+    // export calls below would themselves immediately trap and read as 0.
+    // Refill so the readout reflects the real (compile-time) counter values.
+    if fuel_limit.is_some() {
+        let _ = store.set_fuel(u64::MAX);
+    }
     if std::env::var_os("PYRE_WASM_JIT_STATS").is_some() {
         let lin_mem = memory.data_size(&store);
         // Split linear-memory growth into GC-retained vs. host-heap: a leak that
@@ -334,6 +344,19 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             heap_live_count,
         );
     }
+    let packed = match run_result {
+        Ok(p) => p,
+        Err(e) => {
+            // wasm32-unknown-unknown has no stderr, but pyre-wasm's panic hook
+            // writes "panicked at …" into linear memory before the trap.
+            // Recover the formatted message (the heap String, not the static
+            // format template) so the real cause is visible.
+            for msg in recover_panic_messages(memory.data(&store)) {
+                eprintln!("pyre-wasm-runner: recovered panic: {msg}");
+            }
+            return Err(e);
+        }
+    };
     let out_ptr = (packed >> 32) as u32;
     let out_len = (packed & 0xffff_ffff) as u32;
 

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -224,6 +224,15 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     let run_python = instance.get_typed_func::<(u32, u32), u64>(&mut store, "pyre_run_python")?;
     let dealloc = instance.get_typed_func::<(u32, u32), ()>(&mut store, "pyre_dealloc")?;
 
+    // Enable the otherwise-dormant wasm bridge tracer (inter-trace chaining) when
+    // PYRE_WASM_ENABLE_BRIDGES is set, so chaining can be measured without
+    // rebuilding the guest. No-op if the export is absent (older modules).
+    if std::env::var_os("PYRE_WASM_ENABLE_BRIDGES").is_some() {
+        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_enable_bridges") {
+            f.call(&mut store, 1)?;
+        }
+    }
+
     let src = source.as_bytes();
     let len = src.len() as u32;
     let in_ptr = if len == 0 {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -291,6 +291,7 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
             let labels = [
                 "entered", "decl_callasm", "decl_multipeel", "decl_notdirect",
                 "decl_refhome", "BRIDGE_OK", "loopclosing", "src_preamble",
+                "ml_descr_none", "ml_nonlast", "ml_arity_mismatch",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyre-wasm/Cargo.toml
+++ b/pyre/pyre-wasm/Cargo.toml
@@ -34,7 +34,7 @@ web = [
 # `__getrandom_v03_custom` shim in `src/lib.rs`), selected by building with
 # `--cfg getrandom_backend="custom"`, so the module carries no wasm-bindgen
 # imports a non-JS embedder could not satisfy.
-wasm-host = ["pyre-jit/wasm-host", "dep:majit-backend"]
+wasm-host = ["pyre-jit/wasm-host", "dep:majit-backend", "dep:majit-backend-wasm", "dep:majit-metainterp"]
 # Diagnostic only: install a counting global allocator so the host runner can
 # read net-live guest-heap bytes/count (`pyre_heap_live_bytes` /
 # `pyre_heap_live_count`) and split a true Rust-heap leak from fragmentation.
@@ -54,3 +54,8 @@ getrandom = { workspace = true }
 # trampoline (`call_stub::set_residual_host_call`); the `web` build keeps
 # the in-module transmute path until the JS glue grows the matching import.
 majit-backend = { workspace = true, optional = true }
+# Diagnostic-only: lets the `pyre_jit_bridge_diag` export read the wasm
+# backend's `compile_bridge` outcome tallies (a static counter, not a host
+# import, which would shift the JIT's function-index space).
+majit-backend-wasm = { path = "../../majit/majit-backend-wasm", version = "0.0.2", optional = true, default-features = false }
+majit-metainterp = { path = "../../majit/majit-metainterp", version = "0.0.2", optional = true, default-features = false }

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -323,6 +323,17 @@ pub extern "C" fn pyre_jit_set_enable_bridges(enabled: u32) {
     pyre_jit::call_jit::set_wasm_bridges_enabled(enabled != 0);
 }
 
+/// Enable the self-recursive CALL_ASSEMBLER guest→guest `call_indirect` arm
+/// (`PYRE_WASM_CA`) at runtime, set by the host runner from an env flag. The
+/// guest has no environment, so this export is the only way to reach the flag;
+/// same export-not-import / function-index-stability rationale as the diag
+/// readers and `pyre_jit_set_enable_bridges`.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_set_wasm_ca(enabled: u32) {
+    majit_backend_wasm::set_wasm_ca_enabled(enabled != 0);
+}
+
 static PANIC_HOOK: Once = Once::new();
 
 fn install_panic_hook() {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -314,6 +314,15 @@ pub extern "C" fn pyre_jit_mc_diag(i: u32) -> u64 {
     majit_metainterp::mc_diag(i as usize)
 }
 
+/// Enable the otherwise-dormant wasm bridge tracer (inter-trace chaining) at
+/// runtime, set by the host runner from an env flag. Exported (not an import)
+/// for the same function-index-stability reason as the diag readers.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_set_enable_bridges(enabled: u32) {
+    pyre_jit::call_jit::set_wasm_bridges_enabled(enabled != 0);
+}
+
 static PANIC_HOOK: Once = Once::new();
 
 fn install_panic_hook() {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -294,6 +294,26 @@ pub extern "C" fn pyre_heap_bucket(i: u32) -> i64 {
     }
 }
 
+/// Diagnostic-only: read a `compile_bridge` outcome tally from the wasm JIT
+/// backend (index legend in `majit_backend_wasm::BRIDGE_DIAG`). Exported (not
+/// an import) so it does not shift the module's function-index space, which
+/// would break the JIT's baked `fn as usize` table indices. The host runner
+/// prints these at `PYRE_WASM_JIT_STATS` time.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_bridge_diag(i: u32) -> u64 {
+    majit_backend_wasm::bridge_diag(i as usize)
+}
+
+/// Diagnostic-only: read a guard-failure → bridge-trace gate tally from the
+/// metainterp (`majit_metainterp::MC_DIAG`). Same export-not-import rationale
+/// as `pyre_jit_bridge_diag`.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_mc_diag(i: u32) -> u64 {
+    majit_metainterp::mc_diag(i as usize)
+}
+
 static PANIC_HOOK: Once = Once::new();
 
 fn install_panic_hook() {


### PR DESCRIPTION
#262

## Summary

wasm32 JIT backend work layered on `main` (`1b45bbd712`); 8 commits, all wasm backend / runner. Headline is the self-recursive `CALL_ASSEMBLER` fast path on GC-managed `JitFrame`s; the rest is inter-trace bridge-chaining groundwork (default-off) plus runner diagnostics.

**Self-recursive `CALL_ASSEMBLER` on GC-managed `JitFrame`s (`PYRE_WASM_CA`, default-off)**
- Lower a self-recursive `CallAssemblerR` into an in-module `call_indirect` into the source loop instead of a host round-trip.
- Each callee frame is a GC-managed old-gen `JitFrame` (`wasm_jit_ca_alloc_frame` / `wasm_jit_ca_pop_frame` trampolines, `push_jf`-rooted, traced by a per-frame gcmap over its input + home Ref slots); the source loop runs on `frame_base + FIRST_ITEM_OFFSET`, so its local-0-relative slot accesses are unchanged.
- The wasm host entry frame `F0` and the non-CA loops also run on real `JitFrame`s (jitframe GC type id pushed into the wasm backend from `eval.rs`, the sole registration authority); `F0` is sized for the larger of the loop's and any chained CA bridge's ref homes.
- A guard deopt hands the callee frame to `wasm_ca_resume_deopt`, which blackhole-resumes it on the host.
- Verified: flag-OFF byte-identical; flag-ON `fib(20..30)` correct, and `fib(24)` under a tiny nursery (`PYPY_GC_NURSERY=131072`, forcing mid-recursion collections) correct.

**Inter-trace bridge-chaining groundwork (bridge tracer default-off via `PYRE_WASM_ENABLE_BRIDGES`)**
- Runtime toggle for the dormant wasm bridge tracer (`pyre_jit_set_enable_bridges` export — export, not host import, to keep the baked function-index space stable).
- Resume-at-LABEL preamble-skip extended from single-label to multi-label peeled loops (accept a loop-closing bridge that re-enters at the source's last LABEL).
- Direct `call_indirect` for eligible residual Int/Ref calls.
- Decline a loop-closing bridge whose terminal JUMP carries no induction-advancing arithmetic: such a bridge re-presents byte-identical loop state, so the exit guard never flips and the loop⇄bridge cycle livelocks (observed on fannkuch). It falls back to blackhole resume and is remembered so the metainterp stops re-tracing it.

**Runner / diagnostics**
- `PYRE_WASM_FUEL=N` instruction-budget interrupt so a diagnostic livelock traps after N units instead of hanging; the `PYRE_WASM_JIT_STATS` readout now runs on trap as well as on clean return.
- Static-counter diagnostics for the bridge-trace gate, read via guest exports.

## Self-review

This patch is AI-assisted (every commit carries an `Assisted-by: Claude` trailer).

A local Codex parity review (gpt-5.5, the prompt below) was run, but note the template's caveat that review should be done in a separate session — an independent review pass is still recommended before merge. For reference, that run reported section 1 (parity regressions introduced by this patch) = **None**; the only flagged mismatches were in `model_ssa.rs`, which belongs to the base (`#309`, already on `main`) and is outside this PR's diff.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wasm bridge and metainterp diagnostics with exported counters, plus runtime toggles to enable/disable bridges and wasm CALL_ASSEMBLER.
  * Extended wasm execution with CA deoptimization resume support and improved in-module bridging for compatible traces.
  * Improved support for resumable peeled loops, including correct re-entry at the last label.

* **Bug Fixes**
  * Strengthened generated WASM loop/control-flow validation and re-entry behavior for peeled loops.
  * Fixed wasm bridge deoptimization/frame recovery paths and refined handling of unsupported bridge declines.

* **Tests**
  * Added coverage for peeled-loop validation, resumable label behavior, and registration-loop label stamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->