### PR TITLE
jit: vstack-mirror reconcile completion + function-entry CRN resume fix (#73)

### DIFF
--- a/pyre/bench/synth/short_circuit_falsy_func_entry_resume.py
+++ b/pyre/bench/synth/short_circuit_falsy_func_entry_resume.py
@@ -1,0 +1,43 @@
+# Loop-carried short-circuit `or` exercised on the FALSY leg, where the loop
+# lives in a callee invoked repeatedly from a hot outer loop.
+#
+# `x = x or b` lowers to a `POP_JUMP_IF_TRUE` over `POP_TOP; LOAD b; STORE x`.
+# When the callee `f` is hot enough to compile as a function-entry trace, the
+# next call re-enters the compiled loop through the function-entry path.  With
+# `x` falsy (`None`), the truthy-assuming guard fails; the blackhole resumes
+# the not-taken arm and reaches the loop header, raising ContinueRunningNormally
+# with the merge-point PC in its green args.  The function-entry resume must
+# write that merge-point PC back to the frame before re-entering the
+# interpreter.  Skipping it leaves the frame at the guard PC (operand depth 2)
+# while the merge-point restore set depth 0, so the next pop underflows
+# ("stack underflow during interpreter opcode").  The loop-back-edge resume
+# already writes the PC; the function-entry resume must match it.
+#
+# Deterministic: `s` counts the calls that returned the kept `b`.
+N = 4000
+
+
+def f(a, b, n):
+    x = a
+    i = 0
+    while i < n:
+        x = x or b
+        i = i + 1
+    return x
+
+
+def run():
+    s = 0
+    i = 0
+    while i < N:
+        if f(None, 5, 50) == 5:
+            s = s + 1
+        i = i + 1
+    return s
+
+
+def main():
+    print(run())
+
+
+main()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7562,17 +7562,19 @@ fn classify_vstack_opcode(
         | Instruction::JumpBackwardNoInterrupt { .. }
         | Instruction::ReturnValue => VstackOpClass::PopOnlyOrSideStore,
 
-        // LOAD_GLOBAL: when `namei & 1`, a NULL sentinel is pushed BENEATH
-        // the result (+2), so the result is not the sole new TOS box and a
-        // single `vstack_last_ref` write cannot reconstruct both slots —
-        // decline.  When `namei & 1 == 0` it is a plain single-result push.
-        Instruction::LoadGlobal { namei } => {
-            if namei.get(op_arg) as usize & 1 != 0 {
-                VstackOpClass::Unmodeled
-            } else {
-                VstackOpClass::ResultToTos
-            }
-        }
+        // LOAD_GLOBAL: the global value is the new TOS = the last Ref written.
+        // When `namei & 1` the lowering also pushes a NULL sentinel BENEATH the
+        // result (net +2, for the upcoming method CALL).  Exactly like the
+        // two-push `LoadFast*LoadFast*` super-instructions, that leaves the slot
+        // below the new TOS a NONE hole which the general hole-fill below
+        // recovers from the virtualizable shadow (or defers to the legacy read
+        // when unsourceable) WITHOUT invalidating the mirror.  The NULL sentinel
+        // is consumed by the CALL before any short-circuit branch guard, so it
+        // is never a live kept-stack slot at a resume.  (Pre-#73-SLICE-2 the
+        // `namei & 1` arm declined to `Unmodeled`; the hole-fill makes that
+        // unnecessary, and the decline killed the mirror for the rest of any
+        // walk with a method-form global load — the dominant mirror=NONE gap.)
+        Instruction::LoadGlobal { .. } => VstackOpClass::ResultToTos,
 
         // SWAP(i): exchange TOS with the box `i` positions below.  A pure
         // permutation (net depth 0); the decoded `i` drives the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7460,14 +7460,19 @@ enum VstackOpClass {
     /// reseed the mirror is already invalid at the unwind boundary, so this
     /// arm is inert on the non-exception path.
     ShadowReseed,
-    /// Anything that does not fit the shapes above —
-    /// UNPACK_SEQUENCE / UNPACK_EX (net push > 1), LOAD_GLOBAL pushing a
-    /// NULL sentinel beneath the result, STORE_FAST__STORE_FAST (net pop
-    /// 2), FOR_ITER, or any opcode this classifier does not recognise.
-    /// (The LOAD_FAST/STORE_FAST super-instructions whose net result is
-    /// the new TOS are modeled as `ResultToTos` above, not here.)
-    /// Latches `vstack_valid = false` so the overlay falls back to the
-    /// legacy behaviour (zero regression).
+    /// `UNPACK_SEQUENCE` / `UNPACK_EX`: pop one sequence and push its
+    /// elements (net push > 1), each written through `setarrayitem_vable_r`.
+    /// A single `vstack_last_ref` write cannot reconstruct the whole pushed
+    /// group, but every pushed element IS in the virtualizable shadow, so
+    /// reconcile clears the affected range `[pop_point .. new_depth)` (from
+    /// the popped sequence slot upward) to NONE holes and the general
+    /// hole-fill sources them from the shadow.  Slots BELOW the popped
+    /// sequence keep their mirror-tracked boxes (the hole-fill never
+    /// overwrites a non-NONE slot).  Never latches the mirror invalid.
+    MultiResultFromShadow,
+    /// Anything that does not fit the shapes above — FOR_ITER or any opcode
+    /// this classifier does not recognise.  Latches `vstack_valid = false`
+    /// so the overlay falls back to the legacy behaviour (zero regression).
     Unmodeled,
 }
 
@@ -7518,6 +7523,18 @@ fn classify_vstack_opcode(
         | Instruction::BuildSet { .. }
         | Instruction::BuildMap { .. }
         | Instruction::BuildString { .. }
+        // Compute opcodes that pop their operands and leave a single result on
+        // the new TOS (= the last Ref written, captured via `write_ref_reg` or
+        // the operand-stack push chokepoint) — same shape as the arithmetic /
+        // build group above.  PUSH_NULL's sole new TOS is the pushed NULL
+        // marker; FORMAT_SIMPLE/FORMAT_WITH_SPEC/CONVERT_VALUE/BINARY_SLICE/
+        // IMPORT_NAME each push exactly one result.
+        | Instruction::PushNull
+        | Instruction::FormatSimple
+        | Instruction::FormatWithSpec
+        | Instruction::ConvertValue { .. }
+        | Instruction::BinarySlice
+        | Instruction::ImportName { .. }
         // #73 SLICE 2: LOAD_FAST/STORE_FAST super-instructions.  Their net
         // result still lands on the new TOS as the LAST Ref written (the
         // second load, resp. the load following the store), so `ResultToTos`
@@ -7541,6 +7558,9 @@ fn classify_vstack_opcode(
         | Instruction::PopIter
         | Instruction::PopExcept
         | Instruction::StoreFast { .. }
+        // STORE_FAST__STORE_FAST: two consecutive local stores, pops 2 with no
+        // stack result — a pure side-store, the surviving slots just truncate.
+        | Instruction::StoreFastStoreFast { .. }
         | Instruction::StoreName { .. }
         | Instruction::StoreGlobal { .. }
         | Instruction::StoreDeref { .. }
@@ -7576,6 +7596,15 @@ fn classify_vstack_opcode(
         // walk with a method-form global load — the dominant mirror=NONE gap.)
         Instruction::LoadGlobal { .. } => VstackOpClass::ResultToTos,
 
+        // LOAD_SUPER_ATTR: the attribute (non-method form) is the sole new TOS.
+        // In the method form (`op_arg & 1`) it pushes `func` then `self` (net
+        // -1), so `self` is the new TOS (= last Ref written) and the `func` slot
+        // beneath becomes a NONE hole the general hole-fill recovers from the
+        // shadow (both pushed through `setarrayitem_vable_r`); like the
+        // method-form LOAD_GLOBAL the func slot is consumed by the CALL before
+        // any branch guard, so it is never a live kept-stack slot at a resume.
+        Instruction::LoadSuperAttr { .. } => VstackOpClass::ResultToTos,
+
         // SWAP(i): exchange TOS with the box `i` positions below.  A pure
         // permutation (net depth 0); the decoded `i` drives the
         // `vstack_boxes` exchange in `reconcile_vstack_at_boundary`.
@@ -7601,9 +7630,16 @@ fn classify_vstack_opcode(
         | Instruction::RaiseVarargs { .. }
         | Instruction::WithExceptStart => VstackOpClass::ShadowReseed,
 
-        // Everything else (UNPACK_*, FOR_ITER, STORE_FAST__STORE_FAST,
-        // TO_BOOL if present as a distinct variant, …) is not modeled —
-        // decline and fall back to the legacy read.
+        // UNPACK_SEQUENCE / UNPACK_EX: pop one sequence, push its elements
+        // (net push > 1).  Every pushed element is in the virtualizable
+        // shadow, so reconcile reseeds the pushed range from it.
+        Instruction::UnpackSequence { .. } | Instruction::UnpackEx { .. } => {
+            VstackOpClass::MultiResultFromShadow
+        }
+
+        // Everything else (FOR_ITER, TO_BOOL if present as a distinct
+        // variant, …) is not modeled — decline and fall back to the legacy
+        // read.
         _ => VstackOpClass::Unmodeled,
     }
 }
@@ -7713,6 +7749,22 @@ fn reconcile_vstack_at_boundary(
             // fallback, never a corrupt box.
             ctx.vstack_boxes.clear();
             ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+        }
+        VstackOpClass::MultiResultFromShadow => {
+            // UNPACK_* pops ONE sequence (at `prev_depth - 1`) and pushes its
+            // elements upward.  Clear only the affected range
+            // `[pop_point .. new_depth)` to NONE so the hole-fill below
+            // sources each pushed element from the shadow (all were written
+            // through `setarrayitem_vable_r`); slots BELOW the popped sequence
+            // keep their mirror-tracked boxes.
+            let pop_point = ctx.vstack_depth.saturating_sub(1);
+            ctx.vstack_boxes.truncate(new_depth);
+            if ctx.vstack_boxes.len() < new_depth {
+                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            }
+            for s in pop_point..new_depth {
+                ctx.vstack_boxes[s] = OpRef::NONE;
+            }
         }
         VstackOpClass::Unmodeled => {
             ctx.vstack_valid = false;

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5022,7 +5022,22 @@ pub fn try_function_entry_jit(frame: &mut PyFrame) -> Option<PyResult> {
                     let bh_result =
                         resume_in_blackhole_from_exit_layout(raw_values, exit_layout, guard_exc);
                     match &bh_result {
-                        crate::call_jit::BlackholeResult::ContinueRunningNormally { .. } => {
+                        crate::call_jit::BlackholeResult::ContinueRunningNormally {
+                            green_int,
+                            ..
+                        } => {
+                            // warmspot.py:961 handle_jitexception parity: CRN
+                            // carries merge-point args. Write next_instr back
+                            // to the frame so the fall-through eval_loop_jit
+                            // restarts at the merge point, not the
+                            // guard-failure PC. Without this the frame keeps
+                            // the guard's PC (whose operand depth the
+                            // merge-point resume does not restore) and the
+                            // interpreter underflows on the next pop. Mirrors
+                            // the execute_assembler CRN arm.
+                            if let Some(&ni) = green_int.first() {
+                                frame.set_last_instr_from_next_instr(ni as usize);
+                            }
                             // Fall through to eval_loop_jit
                         }
                         crate::call_jit::BlackholeResult::Failed => {


### PR DESCRIPTION
Three commits on top of `origin/main`.

## Commits

- **jit: model LOAD_GLOBAL method-form in the vstack mirror reconcile (#73)** — classify the CPython-style NULL-sentinel `LOAD_GLOBAL` forms in the vstack-mirror reconcile.
- **jit: model the remaining reconcile-unmodeled opcodes in the vstack mirror (#73)** — cover the opcodes still unmodeled by the mirror reconcile pass.
- **jit: write merge-point resume PC back to frame on function-entry CRN** — fix a pre-existing JIT resume miscompile.

## Function-entry CRN resume fix

`try_function_entry_jit`'s `ResumeInBlackhole` → `ContinueRunningNormally` arm dropped `green_int`, falling through to `eval_loop_jit` with the frame still at the guard-failure PC. The blackhole resume synced `valuestackdepth` to the merge-point depth, so re-dispatching at the stale guard PC popped past the restored operands ("stack underflow during interpreter opcode"). Now writes `green_int[0]` back via `set_last_instr_from_next_instr`, mirroring the `execute_assembler` CRN arm.

The loop-back-edge path already wrote it, so only the function-entry path (a hot callee's compiled loop re-entered on a subsequent call) crashed. This escaped the corpus because the existing `short_circuit_*` fixtures call the loop once and exercise only the loop-back-edge path; the new `short_circuit_falsy_func_entry_resume.py` invokes a loop-carried short-circuit `or` callee repeatedly from a hot outer loop so the function-entry JIT path runs.

## Verification

- `check.py`: dynasm 166/166, cranelift 166/166.
- Codex parity review: sections 1–3 clean; section 4 findings are documented structural adaptations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)