### PR TITLE
CPython suite: GC-root/UAF fixes, builtin arity→TypeError, surrogate I/O, rename dir_fd, binary file bytes

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -5816,11 +5816,11 @@ mod tests {
         // n: nursery-resident weakref target, kept live by a root.
         let n = gc.alloc_with_type(target_tid, 16);
         assert!(gc.is_in_nursery(n.0));
-        // w: old-gen weakref pointing at n; registered as an old weakref
-        // (what `invalidate_young_weakrefs` would do for an oldgen survivor).
+        // w: weakref born directly in the old generation, pointing at n.
+        // `alloc_in_oldgen` records born-old weakrefs onto
+        // `old_objects_with_weakrefs`, so no manual registration is needed.
         let w = gc.alloc_in_oldgen(wref_tid, GcHeader::SIZE + crate::weakref::SIZEOF_WEAKREF);
         unsafe { *((w.0 + crate::weakref::WEAKPTR_OFFSET) as *mut GcRef) = n };
-        gc.old_objects_with_weakrefs.push(w.0);
 
         let mut w_root = w;
         let mut n_root = n;

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -842,12 +842,23 @@ impl MiniMarkGC {
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
         let obj_addr = (ptr as usize) + GcHeader::SIZE;
-        // A destructor-bearing object that never passes through the
-        // nursery (large object, or nursery-full fallback) is recorded
-        // straight onto the old-destructor list so a later major
-        // collection runs its destructor when it dies.
-        if (type_id as usize) < self.types.len() && self.types.get(type_id).destructor.is_some() {
-            self.old_objects_with_destructors.push(obj_addr);
+        if (type_id as usize) < self.types.len() {
+            let info = self.types.get(type_id);
+            // A destructor-bearing object that never passes through the
+            // nursery (large object, or nursery-full fallback) is recorded
+            // straight onto the old-destructor list so a later major
+            // collection runs its destructor when it dies.
+            if info.destructor.is_some() {
+                self.old_objects_with_destructors.push(obj_addr);
+            }
+            // A weakref born directly in the old generation (large object or
+            // nursery-full fallback) skips the young registration path, so
+            // record it straight onto the old-weakref list. Without this its
+            // `weakptr` is never invalidated and `weakref()` returns a
+            // dangling pointer once the target dies.
+            if info.is_weakref {
+                self.old_objects_with_weakrefs.push(obj_addr);
+            }
         }
         GcRef(obj_addr)
     }
@@ -1833,9 +1844,19 @@ impl MiniMarkGC {
             if pointing_to == 0 {
                 continue;
             }
-            // Minor collection only adds oldgen-resident targets here; the
-            // foreign-address path is filtered upstream. If the
-            // target's header reports VISITED, the weakref survives.
+            // A target that is not an old-gen object is immortal
+            // (`malloc_typed`): it carries no GcHeader to read a VISITED bit
+            // from and never dies, so the weakref stays valid. Keep tracking
+            // it with the slot intact, mirroring the foreign-target handling
+            // in `invalidate_young_weakrefs`. `alloc_in_oldgen` registers
+            // born-old weakrefs whose target may be such an immortal object
+            // (e.g. a weakref to a type), so this is reachable; the nursery is
+            // empty at this point, so any non-old-gen target is immortal.
+            if !self.oldgen.contains(pointing_to) {
+                new_with_weakref.push(obj_addr);
+                continue;
+            }
+            // The target's header reports VISITED → the weakref survives.
             let target_hdr = (pointing_to - GcHeader::SIZE) as *const GcHeader;
             if unsafe { (*target_hdr).has_flag(flags::VISITED) } {
                 new_with_weakref.push(obj_addr);

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -639,13 +639,15 @@ pub fn walk_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
 /// root if the GC moved the referenced object.
 pub type ExtraRootWalkerFn = fn(&mut dyn FnMut(&mut GcRef));
 
-// Walkers registered today: eval.rs registers eight (rd_consts, partial
-// trace, active trace, compile snapshot, pyre interpreter side tables, and
-// pyre objects), plus gcreftracer.rs registers the per-loop gc_table
-// walker — nine total. Leave headroom above that so a future root source
-// does not overflow the array and poison the registry lock with a
-// "capacity exceeded" panic on first use.
-const MAX_EXTRA_ROOT_WALKERS: usize = 12;
+// Walkers registered today: eval.rs registers twelve (rd_consts, partial
+// trace, active trace, compile snapshot, jitcode constants, fbw store
+// journal, fbw finish concrete, pyre interpreter side tables, signal
+// handlers, weakref-box inner, jit callee frames, and pyre objects), plus
+// gcreftracer.rs registers the per-loop gc_table walker — thirteen total.
+// Leave headroom above that so a future root source does not overflow the
+// array and poison the registry lock with a "capacity exceeded" panic on
+// first use.
+const MAX_EXTRA_ROOT_WALKERS: usize = 16;
 
 /// Registered root walkers. Each slot is either `None` or a function
 /// pointer. We cap the count to keep the set stack-allocatable and

--- a/pyre/bench/synth/finally_bare_raise.py
+++ b/pyre/bench/synth/finally_bare_raise.py
@@ -1,0 +1,73 @@
+# A hot loop FOLLOWED by a `finally` (or nested `finally`) containing a
+# bare `raise` (RAISE_VARARGS argc==0).  When such a bare re-raise is
+# reached by normal fall-through — no `PUSH_EXC_INFO` seeded the handler
+# exception — the RAISE_VARARGS(0) PC is uncovered and the FrameState
+# carries no `last_exception` pair.  The codewriter previously routed this
+# unconditionally to `emit_reraise!`, whose `exception_edge_extravars`
+# asserts a materialized pair, so `transform_graph_to_jitcode` panicked
+# ("exception edge state missing last_exception pair") while building the
+# jitcode for any hot function shaped like this.  The parity-correct coding
+# is the explicit `raise/r` of the current exception
+# (`get_current_exception()` + raise), as the `Reraise` no-catch arm
+# already does.  This bench pins that such functions compile and run
+# byte-identically to CPython.
+N = 2000000
+
+
+def finally_bare_raise_cold(n):
+    # Bare `raise` in a `finally` reached by fall-through, guarded off for
+    # the tested input.  The value path (`return s`) executes, but the
+    # codewriter must still lower the cold RAISE_VARARGS(0) edge.
+    i = 0
+    s = 0
+    while i < n:
+        s = s + i
+        i = i + 1
+    try:
+        return s
+    finally:
+        if s < 0:
+            raise
+    return 0
+
+
+def finally_bare_raise_fires(n):
+    # Bare `raise` in a `finally` with no active exception actually fires:
+    # RuntimeError ("No active exception to re-raise"), caught by the outer
+    # handler.  Exercises the runtime `get_current_exception()` == null →
+    # raise → RuntimeError path.
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        try:
+            i = i + 0
+        finally:
+            raise
+    except RuntimeError:
+        return i - 7
+
+
+def finally_bare_raise_reraises(n):
+    # The try body raises and the `finally`'s bare `raise` re-raises the
+    # in-flight exception, caught by the outer handler.  Here an active
+    # exception IS present when the bare raise runs.
+    i = 0
+    while i < n:
+        i = i + 1
+    try:
+        try:
+            raise ValueError(i)
+        finally:
+            raise
+    except ValueError as e:
+        return e.args[0] + 3
+
+
+def main():
+    print(finally_bare_raise_cold(N))
+    print(finally_bare_raise_fires(N))
+    print(finally_bare_raise_reraises(N))
+
+
+main()

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -16,8 +16,9 @@ pyre's plain-Python runner convention (no pytest / RPython dependency).
   a clean drop-in; see `lib-python/stdlib-upgrade.txt`).
 - **External baseline.** `baseline.json` records the expected status of every
   module per backend. A module recorded `PASS` that stops passing is a
-  regression and fails CI; a newly-passing module is reported (run
-  `--update-baseline` to record it) but does not fail the run.
+  regression and fails CI. The default gate runs only the `PASS` subset (for CI
+  budget), so newly-passing modules surface under `--strict-baseline`, `--full`,
+  or `--update-baseline`, which also run the non-`PASS` modules.
 
 ## Usage
 

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1325,8 +1325,8 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_xpickle": {
-      "cranelift": "PASS",
-      "dynasm": "PASS"
+      "dynasm": "SKIP",
+      "reason": "spawns per-version pythonX.Y subprocesses (PATH-dependent, can deadlock)"
     },
     "test.test_xxlimited": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -28,10 +28,13 @@ A (module, backend) result is classified as:
   IMPORTERROR module could not even be imported (an interpreter/stdlib gap;
               this is the Phase-0 backlog the suite self-populates)
 
-Gating (default): a module recorded PASS in the baseline that no longer
-passes is a REGRESSION and makes the run exit nonzero. A module that newly
-passes is reported as an improvement but does not fail the run (run with
-`--update-baseline` to record it). `SKIP` baseline entries are not run.
+Gating (default): the run executes only the baseline-PASS subset — the
+non-PASS modules carry no gate signal and running the whole suite at the
+per-module timeout overruns the CI budget. A module recorded PASS that no
+longer passes is a REGRESSION and makes the run exit nonzero. Newly-passing
+modules surface only when the non-PASS modules are actually run, so use
+`--strict-baseline` (gates on unrecorded improvements), `--full`, or
+`--update-baseline` to detect them. `SKIP` baseline entries are not run.
 
 Usage:
     python3 pyre/cpython_tests/run.py [--backend dynasm|cranelift]

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -96,6 +96,7 @@ KNOWN_SKIPS = {
     "test.test_zipfile64": "demands too many resources",
     "test.test_largefile": "demands too many resources",
     "test.test_embed": "needs embedded CPython",
+    "test.test_xpickle": "spawns per-version pythonX.Y subprocesses (PATH-dependent, can deadlock)",
 }
 
 # ── classification ───────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1009,7 +1009,10 @@ fn is_native_coroutine(w_obj: PyObjectRef) -> bool {
         if frame_ptr.is_null() {
             return false;
         }
-        (*frame_ptr).code().flags.contains(crate::CodeFlags::COROUTINE)
+        (*frame_ptr)
+            .code()
+            .flags
+            .contains(crate::CodeFlags::COROUTINE)
     }
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4279,6 +4279,14 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
                     return Ok(w_tuple_new((*mro_ptr).clone()));
                 }
             }
+            if name == "__flags__" {
+                // typeobject.py:1237 descr__flags — the `tp_flags` bitmask.
+                // A getset on `type`, so a metaclass (a `type` subclass) carries
+                // it in its own MRO; without this short-circuit the type's-own-MRO
+                // path below would bind it with `obj=None` and yield the raw
+                // descriptor instead of the bitmask.
+                return Ok(w_int_new(w_type_get_flags(obj)));
+            }
             if name == "__dict__" {
                 // `pypy/objspace/std/typeobject.py:1277 descr_get_dict`
                 // returns `W_DictProxyObject(w_dict)` — a read-only

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9316,14 +9316,17 @@ pub fn next(obj: PyObjectRef) -> PyResult {
     unsafe {
         // Seq iterator
         if is_seq_iter(obj) {
-            let iter = &mut *(obj as *mut pyre_object::W_SeqIterObject);
-            let seq = iter.seq;
+            // Read through a raw pointer rather than a long-lived `&mut`: the
+            // generic branch below runs Python (which can relocate `obj`), so
+            // its writes go through a re-read pointer instead.
+            let iter_ptr = obj as *mut pyre_object::W_SeqIterObject;
+            let seq = (*iter_ptr).seq;
             // iterobject.py W_SeqIterObject.descr_next — a None (null) seq
             // marks an iterator already exhausted by an earlier IndexError.
             if seq.is_null() {
                 return Err(PyError::stop_iteration());
             }
-            let idx = iter.index;
+            let idx = (*iter_ptr).index;
             let item = if is_list(seq) {
                 pyre_object::w_list_getitem(seq, idx)
             } else if is_tuple(seq) {
@@ -9365,26 +9368,40 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                 // `W_SeqIterObject.descr_next` (iterobject.py:75-79), which
                 // catches only IndexError and clears `w_seq` on every error;
                 // the observable behaviour target is 3.14.
+                //
+                // `getitem` runs Python (`__getitem__`), which can relocate
+                // `obj`, so pin it and read the iterator state back through the
+                // re-read pointer rather than the now-stale `iter` reference.
+                let _roots = pyre_object::gc_roots::push_roots();
+                pyre_object::gc_roots::pin_root(obj);
+                let obj_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
                 match getitem(seq, w_int_new(idx)) {
-                    Ok(v) => Some(v),
+                    Ok(v) => {
+                        let p = pyre_object::gc_roots::shadow_stack_get(obj_slot)
+                            as *mut pyre_object::W_SeqIterObject;
+                        (*p).index += 1;
+                        return Ok(v);
+                    }
                     Err(e)
                         if e.kind == crate::PyErrorKind::IndexError
                             || e.kind == crate::PyErrorKind::StopIteration =>
                     {
-                        iter.seq = std::ptr::null_mut();
-                        None
+                        let p = pyre_object::gc_roots::shadow_stack_get(obj_slot)
+                            as *mut pyre_object::W_SeqIterObject;
+                        (*p).seq = std::ptr::null_mut();
+                        return Err(PyError::stop_iteration());
                     }
                     Err(e) => return Err(e),
                 }
             };
             if let Some(v) = item {
-                iter.index += 1;
+                (*iter_ptr).index += 1;
                 return Ok(v);
             }
             // iterobject.py:90-98 — an exhausted cursor clears its sequence ref
             // (the generic arm above already did so on IndexError); the builtin
             // arms clear it here so a held iterator reports as exhausted.
-            iter.seq = std::ptr::null_mut();
+            (*iter_ptr).seq = std::ptr::null_mut();
             return Err(PyError::stop_iteration());
         }
         // Range iterator

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -996,6 +996,23 @@ fn is_coroutine(w_obj: PyObjectRef) -> bool {
     }
 }
 
+/// True only for a native `async def` coroutine (`CO_COROUTINE`), excluding
+/// `@types.coroutine`-wrapped generators (`CO_ITERABLE_COROUTINE`).  Mirrors
+/// `PyCoro_CheckExact`, which gates the GET_AWAITABLE already-awaited guard.
+fn is_native_coroutine(w_obj: PyObjectRef) -> bool {
+    unsafe {
+        if !pyre_object::generator::is_generator(w_obj) {
+            return false;
+        }
+        let frame_ptr =
+            pyre_object::generator::w_generator_get_frame(w_obj) as *const crate::pyframe::PyFrame;
+        if frame_ptr.is_null() {
+            return false;
+        }
+        (*frame_ptr).code().flags.contains(crate::CodeFlags::COROUTINE)
+    }
+}
+
 /// `generator.py:563 get_awaitable_iter` — return the iterator implementing the
 /// awaitable protocol for `w_obj`:
 ///   - `w_obj` itself when it is a coroutine (or `@types.coroutine` generator);
@@ -1005,6 +1022,19 @@ fn is_coroutine(w_obj: PyObjectRef) -> bool {
 /// missing-`__await__` error message differs.
 pub fn get_awaitable_iter(w_obj: PyObjectRef, context: u32) -> PyResult {
     if is_coroutine(w_obj) {
+        // GET_AWAITABLE: re-awaiting a native coroutine that is already
+        // suspended at an `await` raises (`_PyGen_yf(coro) != NULL`). A native
+        // coroutine only ever suspends at an `await`, so "started, not
+        // exhausted, not currently running" is exactly that delegating state.
+        if is_native_coroutine(w_obj)
+            && unsafe {
+                pyre_object::generator::w_generator_is_started(w_obj)
+                    && !pyre_object::generator::w_generator_is_exhausted(w_obj)
+                    && !pyre_object::generator::w_generator_is_running(w_obj)
+            }
+        {
+            return Err(PyError::runtime_error("coroutine is being awaited already"));
+        }
         return Ok(w_obj);
     }
     let w_await = crate::typedef::r#type(w_obj)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7227,12 +7227,17 @@ fn init_file_wrapper_type(ns: &mut DictStorage) {
     );
 }
 
-fn file_get_data(self_obj: PyObjectRef) -> String {
+/// The path-backed file object's buffered contents as raw bytes.  Binary and
+/// text streams both hold the exact file bytes here; text reads decode on the
+/// way out (`fd_bytes_to_obj`), so non-UTF-8 content survives a round trip.
+fn file_get_data(self_obj: PyObjectRef) -> Vec<u8> {
     crate::baseobjspace::getattr_str(self_obj, "__file_data__")
         .ok()
         .and_then(|d| unsafe {
-            if pyre_object::is_str(d) {
-                Some(pyre_object::w_str_get_value(d).to_string())
+            if pyre_object::bytesobject::is_bytes_like(d) {
+                Some(pyre_object::bytesobject::bytes_like_data(d).to_vec())
+            } else if pyre_object::is_str(d) {
+                Some(pyre_object::w_str_get_wtf8(d).as_bytes().to_vec())
             } else {
                 None
             }
@@ -7360,9 +7365,8 @@ fn file_method_read(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         }
     }
     let data = file_get_data(args[0]);
-    let bytes = data.as_bytes();
-    let pos = file_get_pos(args[0]).min(bytes.len());
-    let remaining = &bytes[pos..];
+    let pos = file_get_pos(args[0]).min(data.len());
+    let remaining = &data[pos..];
     let n = if args.len() >= 2 {
         let n_val = unsafe { pyre_object::w_int_get_value(args[1]) };
         if n_val < 0 {
@@ -7425,12 +7429,11 @@ fn file_method_readline(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         }
     }
     let data = file_get_data(args[0]);
-    let bytes = data.as_bytes();
     let pos = file_get_pos(args[0]);
-    if pos >= bytes.len() {
+    if pos >= data.len() {
         return Ok(fd_bytes_to_obj(args[0], Vec::new()));
     }
-    let rest = &bytes[pos..];
+    let rest = &data[pos..];
     let mut end = rest
         .iter()
         .position(|&b| b == b'\n')
@@ -7507,25 +7510,27 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     }
     // Append to __file_data__ and update on close.
     unsafe {
-        let prev = file_get_data(args[0]);
-        let (s, len) = if pyre_object::is_str(args[1]) {
+        let mut prev = file_get_data(args[0]);
+        let (bytes, len) = if pyre_object::is_str(args[1]) {
             // Encode through the stream's codec + error handler so a lone
             // surrogate raises (`strict`) instead of panicking in
-            // `w_str_get_value`.
+            // `w_str_get_value`. The reported count is characters written.
             let (encoding, errors) = stream_encoding_errors(args[0]);
             let bytes = crate::type_methods::encode_object(args[1], &encoding, &errors)?;
-            (
-                String::from_utf8_lossy(&bytes).into_owned(),
-                pyre_object::w_str_len(args[1]),
-            )
+            (bytes, pyre_object::w_str_len(args[1]))
         } else if pyre_object::bytesobject::is_bytes_like(args[1]) {
-            let data = pyre_object::bytesobject::bytes_like_data(args[1]);
-            (String::from_utf8_lossy(data).into_owned(), data.len())
+            let data = pyre_object::bytesobject::bytes_like_data(args[1]).to_vec();
+            let len = data.len();
+            (data, len)
         } else {
             return Err(crate::PyError::type_error("write() expects str or bytes"));
         };
-        let new_data = format!("{prev}{s}");
-        let _ = crate::baseobjspace::setattr_str(args[0], "__file_data__", w_str_new(&new_data));
+        prev.extend_from_slice(&bytes);
+        let _ = crate::baseobjspace::setattr_str(
+            args[0],
+            "__file_data__",
+            pyre_object::bytesobject::w_bytes_from_bytes(&prev),
+        );
         let _ = crate::baseobjspace::setattr_str(args[0], "__file_dirty__", w_bool_from(true));
         Ok(w_int_new(len as i64))
     }
@@ -7580,9 +7585,9 @@ fn file_flush_dirty(obj: PyObjectRef) -> Result<(), crate::PyError> {
                 .append(true)
                 .create(true)
                 .open(&name_s)
-                .and_then(|mut f| std::io::Write::write_all(&mut f, data.as_bytes()))
+                .and_then(|mut f| std::io::Write::write_all(&mut f, &data))
         } else {
-            std::fs::write(&name_s, data.as_bytes())
+            std::fs::write(&name_s, &data)
         };
         if let Err(e) = write_res {
             return Err(crate::PyError::os_error_with_errno(
@@ -7737,7 +7742,7 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         }
     }
 
-    let data: String = if reading && !mode.contains('w') && !mode.contains('x') {
+    let data: Vec<u8> = if reading && !mode.contains('w') && !mode.contains('x') {
         #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
         {
             // Sandbox-intentional: with the host_env feature off the
@@ -7754,18 +7759,10 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         let read_result = rustpython_host_env::fs::read(&path);
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
         match read_result {
-            Ok(bytes) => {
-                if binary {
-                    // Store bytes-as-string for now; we only support ASCII binary.
-                    String::from_utf8_lossy(&bytes).into_owned()
-                } else {
-                    match String::from_utf8(bytes) {
-                        Ok(s) => s,
-                        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
-                    }
-                }
-            }
-            Err(_e) if writing => String::new(),
+            // Hold the exact file bytes; text-mode reads decode on the way
+            // out (`fd_bytes_to_obj`), so non-UTF-8 content is preserved.
+            Ok(bytes) => bytes,
+            Err(_e) if writing => Vec::new(),
             Err(e) => {
                 return Err(crate::PyError::os_error_with_errno(
                     e.raw_os_error().unwrap_or(2),
@@ -7774,11 +7771,15 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             }
         }
     } else {
-        String::new()
+        Vec::new()
     };
 
     let wrapper = pyre_object::w_instance_new(file_wrapper_type());
-    let _ = crate::baseobjspace::setattr_str(wrapper, "__file_data__", w_str_new(&data));
+    let _ = crate::baseobjspace::setattr_str(
+        wrapper,
+        "__file_data__",
+        pyre_object::bytesobject::w_bytes_from_bytes(&data),
+    );
     let _ = crate::baseobjspace::setattr_str(wrapper, "__file_pos__", w_int_new(0));
     let _ = crate::baseobjspace::setattr_str(wrapper, "__file_name__", w_str_new(&path));
     let _ = crate::baseobjspace::setattr_str(wrapper, "__file_mode__", w_str_new(&mode));

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2053,6 +2053,34 @@ fn print_sep_check(
     )))
 }
 
+/// Render `str(obj)` for writing to the (utf-8, strict) stdout stream.  The
+/// common all-UTF-8 result is returned directly; a lone surrogate is routed
+/// through `encode_object`'s strict handler, raising `UnicodeEncodeError`
+/// rather than panicking in `w_str_get_value`.
+unsafe fn print_render(obj: PyObjectRef) -> Result<String, crate::PyError> {
+    let w = unsafe { crate::py_str_wtf8(obj)? };
+    if let Ok(s) = w.as_str() {
+        return Ok(s.to_owned());
+    }
+    let s_obj = pyre_object::w_str_from_wtf8(w);
+    let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "strict")?;
+    Ok(String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8"))
+}
+
+/// A text stream's `encoding`/`errors` (defaults `utf-8`/`strict`), read so a
+/// `str` write encodes through `encode_object` — routing a lone surrogate to
+/// the error handler instead of panicking in `w_str_get_value`.
+unsafe fn stream_encoding_errors(stream: PyObjectRef) -> (String, String) {
+    let attr = |name: &str, default: &str| -> String {
+        crate::baseobjspace::getattr_str(stream, name)
+            .ok()
+            .filter(|v| !v.is_null() && unsafe { pyre_object::is_str(*v) })
+            .map(|v| unsafe { pyre_object::w_str_get_value(v) }.to_string())
+            .unwrap_or_else(|| default.to_string())
+    };
+    (attr("encoding", "utf-8"), attr("errors", "strict"))
+}
+
 /// `print(*args)` — write space-separated str representations to stdout.
 fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // Check if last arg is a kwargs dict (from CALL_KW builtin dispatch).
@@ -2083,14 +2111,14 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     for (i, &obj) in positional.iter().enumerate() {
         if i > 0 {
             match sep {
-                Some(s) => crate::print_output(&unsafe { crate::py_str(s)? }),
+                Some(s) => crate::print_output(&unsafe { print_render(s)? }),
                 None => crate::print_output(" "),
             }
         }
-        crate::print_output(&unsafe { crate::py_str(obj)? });
+        crate::print_output(&unsafe { print_render(obj)? });
     }
     match end {
-        Some(e) => crate::print_output(&unsafe { crate::py_str(e)? }),
+        Some(e) => crate::print_output(&unsafe { print_render(e)? }),
         None => crate::print_output("\n"),
     }
     Ok(w_none())
@@ -5193,7 +5221,11 @@ fn builtin_compile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     let mode_obj = args[2];
     let source_str = unsafe {
         if pyre_object::is_str(source) {
-            pyre_object::w_str_get_value(source).to_string()
+            // The source is decoded to UTF-8 for the tokenizer; a lone
+            // surrogate raises `UnicodeEncodeError` (strict) rather than
+            // panicking in `w_str_get_value`.
+            let bytes = crate::type_methods::encode_object(source, "utf-8", "strict")?;
+            String::from_utf8(bytes).expect("strict utf-8 encode yields valid utf-8")
         } else if pyre_object::bytesobject::is_bytes_like(source) {
             String::from_utf8_lossy(pyre_object::bytesobject::bytes_like_data(source)).into_owned()
         } else {
@@ -7443,7 +7475,12 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     if let Some(fd) = file_get_fd(args[0]) {
         let bytes: Vec<u8> = unsafe {
             if pyre_object::is_str(args[1]) {
-                pyre_object::w_str_get_value(args[1]).as_bytes().to_vec()
+                // Encode through the stream's codec + error handler; a lone
+                // surrogate is routed to the handler (`strict` →
+                // UnicodeEncodeError) rather than panicking in
+                // `w_str_get_value`.
+                let (encoding, errors) = stream_encoding_errors(args[0]);
+                crate::type_methods::encode_object(args[1], &encoding, &errors)?
             } else if pyre_object::bytesobject::is_bytes_like(args[1]) {
                 pyre_object::bytesobject::bytes_like_data(args[1]).to_vec()
             } else {
@@ -7471,16 +7508,23 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // Append to __file_data__ and update on close.
     unsafe {
         let prev = file_get_data(args[0]);
-        let s = if pyre_object::is_str(args[1]) {
-            pyre_object::w_str_get_value(args[1]).to_string()
+        let (s, len) = if pyre_object::is_str(args[1]) {
+            // Encode through the stream's codec + error handler so a lone
+            // surrogate raises (`strict`) instead of panicking in
+            // `w_str_get_value`.
+            let (encoding, errors) = stream_encoding_errors(args[0]);
+            let bytes = crate::type_methods::encode_object(args[1], &encoding, &errors)?;
+            (
+                String::from_utf8_lossy(&bytes).into_owned(),
+                pyre_object::w_str_len(args[1]),
+            )
         } else if pyre_object::bytesobject::is_bytes_like(args[1]) {
             let data = pyre_object::bytesobject::bytes_like_data(args[1]);
-            String::from_utf8_lossy(data).into_owned()
+            (String::from_utf8_lossy(data).into_owned(), data.len())
         } else {
             return Err(crate::PyError::type_error("write() expects str or bytes"));
         };
         let new_data = format!("{prev}{s}");
-        let len = s.len();
         let _ = crate::baseobjspace::setattr_str(args[0], "__file_data__", w_str_new(&new_data));
         let _ = crate::baseobjspace::setattr_str(args[0], "__file_dirty__", w_bool_from(true));
         Ok(w_int_new(len as i64))
@@ -7903,16 +7947,18 @@ fn textio_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     if args.len() < 2 {
         return Err(crate::PyError::type_error("write() requires (self, data)"));
     }
-    let s = unsafe {
-        if pyre_object::is_str(args[1]) {
-            pyre_object::w_str_get_value(args[1]).to_string()
-        } else {
-            return Err(crate::PyError::type_error("write() expects str"));
-        }
-    };
-    let bytes = pyre_object::bytesobject::w_bytes_from_bytes(s.as_bytes());
+    if unsafe { !pyre_object::is_str(args[1]) } {
+        return Err(crate::PyError::type_error("write() expects str"));
+    }
+    // Encode through the stream's codec + error handler so a lone surrogate is
+    // routed to the handler (`strict` → UnicodeEncodeError) instead of
+    // panicking in `w_str_get_value`.
+    let (encoding, errors) = unsafe { stream_encoding_errors(args[0]) };
+    let encoded = crate::type_methods::encode_object(args[1], &encoding, &errors)?;
+    let nchars = unsafe { pyre_object::w_str_len(args[1]) };
+    let bytes = pyre_object::bytesobject::w_bytes_from_bytes(&encoded);
     textio_call_buffer(args[0], "write", &[bytes])?;
-    Ok(w_int_new(s.chars().count() as i64))
+    Ok(w_int_new(nchars as i64))
 }
 
 fn textio_method_close(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2888,7 +2888,12 @@ fn type_descr_new_with_metaclass(
 /// `isinstance(obj, cls)` — pypy/module/__builtin__/abstractinst.py
 /// `app_isinstance` → `abstract_isinstance_w(allow_override=True)`.
 fn builtin_isinstance(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2, "isinstance() takes exactly two arguments");
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "isinstance() takes exactly two arguments ({} given)",
+            args.len()
+        )));
+    }
     Ok(w_bool_from(crate::baseobjspace::isinstance(
         args[0], args[1],
     )?))
@@ -2911,7 +2916,12 @@ pub fn call_isinstance(obj: PyObjectRef, cls: PyObjectRef) -> Option<bool> {
 /// `issubclass(cls, classinfo)` — pypy/module/__builtin__/abstractinst.py
 /// `app_issubclass` → `abstract_issubclass_w(allow_override=True)`.
 fn builtin_issubclass(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2, "issubclass() takes exactly two arguments");
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "issubclass() takes exactly two arguments ({} given)",
+            args.len()
+        )));
+    }
     Ok(w_bool_from(crate::baseobjspace::issubclass(
         args[0], args[1],
     )?))
@@ -4347,7 +4357,12 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// `repr(obj)` → string representation
 fn builtin_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "repr() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "repr() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let s = unsafe { crate::py_repr(args[0])? };
     Ok(w_str_new(&s))
 }
@@ -4377,7 +4392,12 @@ pub(crate) fn py_ascii(obj: PyObjectRef) -> Result<String, crate::PyError> {
 /// `bltinmodule.c:builtin_ascii` — like `repr`, but escape every
 /// non-ASCII code point in the repr as `\xXX` / `\uXXXX` / `\UXXXXXXXX`.
 fn builtin_ascii(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "ascii() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "ascii() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     Ok(w_str_new(&py_ascii(args[0])?))
 }
 
@@ -4756,7 +4776,12 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
 /// `hasattr(obj, name)` → bool — direct call (no callback needed after merge)
 fn builtin_hasattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2, "hasattr() takes exactly two arguments");
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "hasattr() takes exactly two arguments ({} given)",
+            args.len()
+        )));
+    }
     let obj = args[0];
     Ok(w_bool_from(
         crate::baseobjspace::getattr(obj, args[1]).is_ok(),
@@ -4765,7 +4790,12 @@ fn builtin_hasattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 
 /// `getattr(obj, name[, default])` → value — direct call
 fn builtin_getattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "getattr() takes at least two arguments");
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error(format!(
+            "getattr() takes at least two arguments ({} given)",
+            args.len()
+        )));
+    }
     let obj = args[0];
     match crate::baseobjspace::getattr(obj, args[1]) {
         Ok(val) => Ok(val),
@@ -4792,7 +4822,12 @@ fn builtin_getattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 /// descriptors, TypeError on wrong-type values, etc.) and PyPy
 /// propagates those errors — they are NOT swallowed here.
 fn builtin_setattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 3, "setattr() takes exactly three arguments");
+    if args.len() != 3 {
+        return Err(crate::PyError::type_error(format!(
+            "setattr() takes exactly three arguments ({} given)",
+            args.len()
+        )));
+    }
     let obj = args[0];
     crate::baseobjspace::setattr(obj, args[1], args[2])?;
     Ok(w_none())
@@ -4800,7 +4835,12 @@ fn builtin_setattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
 
 /// `delattr(obj, name)` — PyPy: baseobjspace.py delattr
 fn builtin_delattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2, "delattr() takes exactly 2 arguments");
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "delattr() takes exactly 2 arguments ({} given)",
+            args.len()
+        )));
+    }
     let obj = args[0];
     crate::baseobjspace::delattr(obj, args[1])?;
     Ok(w_none())
@@ -5845,7 +5885,12 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// `id(obj)` — PyPy: baseobjspace.py id → object identity as int
 fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "id() takes exactly one argument");
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "id() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     // `space.id` (baseobjspace.py:843-854): a plain `int` yields its
     // value-derived `immutable_unique_id`; every other object falls back
     // to `compute_unique_id` — its address.
@@ -5867,7 +5912,12 @@ fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// unhashables, recurses through tuple/frozenset contents, and
 /// propagates user `__hash__` errors.
 pub(crate) fn builtin_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "hash() takes exactly one argument");
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "hash() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     Ok(w_int_new(try_hash_value(args[0])?))
 }
 
@@ -6493,7 +6543,12 @@ fn builtin_ord(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// `chr(i)` — PyPy: operation.py chr
 fn builtin_chr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "chr() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "chr() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let obj = args[0];
     // operation.py:28 — space.int_w unwraps to int
     let val = if unsafe { is_int(obj) } {
@@ -6899,7 +6954,12 @@ pub fn builtin_any_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     builtin_any(args)
 }
 fn builtin_any(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "any() takes exactly one argument");
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "any() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let items = collect_iterable(args[0])?;
     for item in items {
         if crate::baseobjspace::is_true(item)? {
@@ -8009,7 +8069,12 @@ pub fn builtin_all_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
     builtin_all(args)
 }
 fn builtin_all(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "all() takes exactly one argument");
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "all() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let items = collect_iterable(args[0])?;
     for item in items {
         if !crate::baseobjspace::is_true(item)? {
@@ -8198,13 +8263,23 @@ pub(crate) fn builtin_round(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
 /// `divmod(a, b)` — pypy/interpreter/baseobjspace.py:2159 divmod row.
 fn builtin_divmod(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2, "divmod() takes exactly two arguments");
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "divmod() takes exactly two arguments ({} given)",
+            args.len()
+        )));
+    }
     crate::baseobjspace::divmod(args[0], args[1])
 }
 
 /// `pow(base, exp[, mod])` — pypy/interpreter/baseobjspace.py:2160 pow row.
 fn builtin_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "pow() takes at least two arguments");
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error(format!(
+            "pow() takes at least two arguments ({} given)",
+            args.len()
+        )));
+    }
     if args.len() >= 3 && !unsafe { is_none(args[2]) } {
         crate::baseobjspace::pow3(args[0], args[1], args[2])
     } else {
@@ -8214,7 +8289,12 @@ fn builtin_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// `hex(x)` — PyPy: operation.py hex
 fn builtin_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "hex() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "hex() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let v = unsafe { w_int_get_value(args[0]) };
     let s = if v < 0 {
         format!("-0x{:x}", -v)
@@ -8226,7 +8306,12 @@ fn builtin_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// `oct(x)` — PyPy: operation.py oct
 fn builtin_oct(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "oct() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "oct() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let v = unsafe { w_int_get_value(args[0]) };
     let s = if v < 0 {
         format!("-0o{:o}", -v)
@@ -8238,7 +8323,12 @@ fn builtin_oct(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 /// `bin(x)` — PyPy: operation.py bin
 fn builtin_bin(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "bin() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "bin() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let v = unsafe { w_int_get_value(args[0]) };
     let s = if v < 0 {
         format!("-0b{:b}", -v)
@@ -8404,7 +8494,12 @@ pub(crate) fn builtin_complex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
 
 /// `format(value, format_spec='')` — operation.py format → space.format
 fn builtin_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "format() takes at least one argument");
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "format() takes at least one argument ({} given)",
+            args.len()
+        )));
+    }
     let value = args[0];
     // `builtin_format_impl`: the `format_spec` must be a `str` — validated
     // here, before dispatch, so `format(value, 34)` reports `format()

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3662,7 +3662,7 @@ unsafe fn check_and_find_best_base(
         // bool and NoneType are not acceptable in Python 3.
         if !is_acceptable_base_class(w_bestbase) {
             return Err(crate::PyError::type_error(format!(
-                "type '{}' is not an acceptable base class",
+                "type '{}' is not an acceptable base type",
                 pyre_object::w_type_get_name(w_bestbase),
             )));
         }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3425,6 +3425,23 @@ pub unsafe fn create_all_slots(
         // typeobject.py:1507-1508: inherit flag_map_or_seq from bases
         pyre_object::typeobject::inherit_flag_map_or_seq(w_type, w_bases);
 
+        // typeobject.c type_new: a class body carrying `__abc_tpflags__`
+        // (`collections.abc` Mapping = `1<<6`, Sequence = `1<<5`) folds its
+        // COLLECTION_FLAGS into the structural-match marker, so subclasses of
+        // `abc.Mapping` / `abc.Sequence` match `case {..}` / `case [..]`. The
+        // bit lives only in the defining body's namespace, so subclasses pick
+        // it up through `inherit_flag_map_or_seq` above rather than re-reading.
+        if let Some(&w_flags) = ns.get("__abc_tpflags__") {
+            if pyre_object::is_int(w_flags) {
+                let flags = pyre_object::w_int_get_value(w_flags);
+                if flags & (1 << 6) != 0 {
+                    pyre_object::typeobject::w_type_set_flag_map_or_seq(w_type, b'M');
+                } else if flags & (1 << 5) != 0 {
+                    pyre_object::typeobject::w_type_set_flag_map_or_seq(w_type, b'S');
+                }
+            }
+        }
+
         // typeobject.py:1510: copy_flags_from_bases — inherit hasdict/weakrefable
         copy_flags_from_bases(w_type, w_bases);
 

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -278,6 +278,20 @@ pub(crate) unsafe fn builtin_subclass_dunder(
     name: &str,
 ) -> Result<Option<String>, crate::PyError> {
     unsafe {
+        Ok(builtin_subclass_dunder_obj(obj, tp, name)?
+            .map(|r| pyre_object::w_str_get_value(r).to_string()))
+    }
+}
+
+/// `builtin_subclass_dunder` returning the raw `str` result object so a
+/// WTF-8-preserving caller (`py_str_wtf8`) can read a lone-surrogate result
+/// via `w_str_get_wtf8` instead of the panicking `w_str_get_value`.
+pub(crate) unsafe fn builtin_subclass_dunder_obj(
+    obj: PyObjectRef,
+    tp: *const PyType,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    unsafe {
         let is_leaf = std::ptr::eq(tp, &INT_TYPE as *const PyType)
             || std::ptr::eq(tp, &LONG_TYPE as *const PyType)
             || std::ptr::eq(tp, &FLOAT_TYPE as *const PyType)
@@ -305,7 +319,7 @@ pub(crate) unsafe fn builtin_subclass_dunder(
         // A raising override propagates; a non-string return is a TypeError.
         let r = crate::builtins::call_and_check(found, &[obj])?;
         if pyre_object::is_str(r) {
-            return Ok(Some(pyre_object::w_str_get_value(r).to_string()));
+            return Ok(Some(r));
         }
         Err(dunder_returned_non_string(name, r))
     }
@@ -930,9 +944,11 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
             let tp = (*obj).ob_type;
             if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
                 // A `str` subclass's `__str__` override wins over the raw value,
-                // mirroring `py_str`'s STR_TYPE branch.
-                if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__")? {
-                    return Ok(Wtf8Buf::from_string(s));
+                // mirroring `py_str`'s STR_TYPE branch. Read the result via
+                // `w_str_get_wtf8` so a lone-surrogate return is preserved
+                // rather than panicking in `w_str_get_value`.
+                if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__str__")? {
+                    return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
                 }
                 return Ok(pyre_object::w_str_get_wtf8(obj).to_wtf8_buf());
             }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -929,6 +929,11 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
         if !obj.is_null() {
             let tp = (*obj).ob_type;
             if std::ptr::eq(tp, &STR_TYPE as *const PyType) {
+                // A `str` subclass's `__str__` override wins over the raw value,
+                // mirroring `py_str`'s STR_TYPE branch.
+                if let Some(s) = builtin_subclass_dunder(obj, tp, "__str__")? {
+                    return Ok(Wtf8Buf::from_string(s));
+                }
                 return Ok(pyre_object::w_str_get_wtf8(obj).to_wtf8_buf());
             }
             if pyre_object::is_exception(obj) {
@@ -949,6 +954,30 @@ pub unsafe fn py_str_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
             }
         }
         Ok(Wtf8Buf::from_string(py_str(obj)?))
+    }
+}
+
+/// `str(obj)` for diagnostic display (traceback headers / messages written to
+/// stderr): like [`py_str`], but a lone surrogate is backslash-escaped
+/// (`\udcXX`, the `backslashreplace` handler stderr uses) and a raising
+/// `__str__` degrades to a placeholder, so rendering a diagnostic never panics.
+///
+/// # Safety
+/// `obj` must be a valid object.
+pub unsafe fn py_str_display(obj: PyObjectRef) -> String {
+    unsafe {
+        let w = match py_str_wtf8(obj) {
+            Ok(w) => w,
+            Err(_) => return "<unprintable>".to_string(),
+        };
+        if let Ok(s) = w.as_str() {
+            return s.to_owned();
+        }
+        let s_obj = pyre_object::w_str_from_wtf8(w);
+        crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
+            .ok()
+            .and_then(|b| String::from_utf8(b).ok())
+            .unwrap_or_else(|| "<unprintable>".to_string())
     }
 }
 

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -658,6 +658,16 @@ impl PyError {
             let msg = pyre_object::w_str_new(&self.message);
             let args_list = pyre_object::w_list_new(vec![msg]);
             unsafe { pyre_object::interp_exceptions::w_exception_set_args(exc, args_list) };
+            // `ImportError` / `ModuleNotFoundError` expose the message through a
+            // dedicated `msg` slot (`ImportError.__init__` stores `args[0]`
+            // there). The raw-message raise path bypasses `__init__`, so stamp
+            // `msg` here too — otherwise `e.msg` reads back `None`.
+            if matches!(
+                self.kind,
+                PyErrorKind::ImportError | PyErrorKind::ModuleNotFoundError
+            ) {
+                unsafe { pyre_object::interp_exceptions::w_exception_set_import_msg(exc, msg) };
+            }
         }
         // Stamp the deferred `name` / `obj` context onto the freshly
         // materialised NameError / AttributeError instance, the lazy

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -811,9 +811,9 @@ impl PyError {
             return self.message.clone();
         }
         // Infallible Display-side context: a raising `__str__` degrades to
-        // the placeholder rather than propagating.
-        unsafe { crate::display::py_str(self.exc_object) }
-            .unwrap_or_else(|_| "<unprintable>".to_string())
+        // the placeholder rather than propagating, and a lone surrogate is
+        // backslash-escaped rather than panicking.
+        unsafe { crate::display::py_str_display(self.exc_object) }
     }
 
     pub fn render_exception(&self) -> String {
@@ -974,7 +974,7 @@ fn render_exc_object(exc: PyObjectRef) -> String {
                 if first.is_null() {
                     String::new()
                 } else {
-                    crate::display::py_str(first).unwrap_or_else(|_| "<unprintable>".to_string())
+                    crate::display::py_str_display(first)
                 }
             } else {
                 // Multi-arg exceptions render as tuple repr — matches

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1325,12 +1325,33 @@ fn eval_loop(frame: &mut PyFrame) -> PyResult {
         // no-tracer hot path is a single null-check + ticker decrement.
         let ec = frame.execution_context as *mut crate::PyExecutionContext;
         if !ec.is_null() {
-            unsafe {
+            let trace_result = unsafe {
                 (*ec).bytecode_trace(
                     frame as *mut PyFrame,
                     crate::executioncontext::TICK_COUNTER_STEP,
-                )?
+                )
             };
+            // pypy/interpreter/pyopcode.py:71-97 `handle_bytecode` wraps
+            // `dispatch_bytecode` (which runs `bytecode_trace` at :203) in the
+            // same `except OperationError`/`KeyboardInterrupt` that routes an
+            // opcode error through `handle_operation_error`.  An exception a
+            // signal handler delivers from `bytecode_trace` (e.g.
+            // `CheckSignalAction` raising `KeyboardInterrupt`) must therefore
+            // search this frame's exception blocks at `last_instr`, exactly
+            // like the opcode error path below — not unwind the frame.
+            // Propagating with `?` skipped that block search, so a `try`
+            // around the interrupted instruction was bypassed and the
+            // exception surfaced one frame up.
+            if let Err(mut err) = trace_result {
+                if err.kind == crate::PyErrorKind::GeneratorReturn {
+                    let gen_ptr = err.message.parse::<usize>().unwrap_or(0);
+                    return Ok(gen_ptr as pyre_object::PyObjectRef);
+                }
+                if handle_exception(frame, &mut err, &mut next_instr) {
+                    continue;
+                }
+                return Err(err);
+            }
         }
         let (opcode_pc, instruction, op_arg) = decode_instruction_for_dispatch(code, pc)?;
         let fallthrough = opcode_pc + 1;

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1102,12 +1102,20 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
         }
     }
     if err.attach_tb && !ec.is_null() && unsafe { !(*ec).gettrace().is_null() } {
+        // `exception_trace` fabricates an `OperationError` whose
+        // `normalize_exception` follows the `raise inst` shape
+        // (error.py:238-245): the raised instance must sit in the
+        // `w_type` slot with a null value so the `(inst, None)` path
+        // derives the class.  Passing the instance as `w_value` with a
+        // null `w_type` makes `normalize_exception` take `w_inst = w_type`
+        // (null) and raise "exceptions must derive from BaseException".
+        let w_tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc_obj) };
         if let Err(trace_err) = unsafe {
             (*ec).exception_trace(
                 frame as *mut PyFrame,
-                pyre_object::PY_NULL,
                 exc_obj,
                 pyre_object::PY_NULL,
+                w_tb,
             )
         } {
             // pyopcode.py:148 `ec.exception_trace(self, operr)` is

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1111,12 +1111,7 @@ pub fn handle_exception(frame: &mut PyFrame, err: &mut PyError, next_instr: &mut
         // (null) and raise "exceptions must derive from BaseException".
         let w_tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(exc_obj) };
         if let Err(trace_err) = unsafe {
-            (*ec).exception_trace(
-                frame as *mut PyFrame,
-                exc_obj,
-                pyre_object::PY_NULL,
-                w_tb,
-            )
+            (*ec).exception_trace(frame as *mut PyFrame, exc_obj, pyre_object::PY_NULL, w_tb)
         } {
             // pyopcode.py:148 `ec.exception_trace(self, operr)` is
             // outside the except-block; a raise here propagates past

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -352,14 +352,28 @@ fn function_new_impl(
         w_new_self: PY_NULL,
     };
 
-    if let Some(raw) =
-        pyre_object::gc_hook::try_gc_alloc_stable(FUNCTION_GC_TYPE_ID, FUNCTION_OBJECT_SIZE)
-            .filter(|p| !p.is_null())
-    {
-        unsafe {
-            std::ptr::write(raw as *mut Function, function);
+    // A `BuiltinCode`-backed function is a permanent type / module slot (the
+    // interp2app analogue of a translation-time prebuilt object): its code is
+    // immortal (`gateway.rs builtin_code_new_full` malloc_typed) and its only
+    // other fields are null for a freshly-made builtin. Allocate it immortal so
+    // a full mark-sweep can never reclaim it out of an off-GC builtin type dict
+    // — the collector assumes no immortal object holds heap pointers and so does
+    // not trace such dicts (collector.rs:1803), which would otherwise free the
+    // method functions of a builtin type built lazily at runtime (weakref, …)
+    // after the GC hook is wired. Startup builtin functions are already immortal
+    // (no hook installed yet); this extends that to runtime-created ones. User
+    // functions (`PyCode`) stay GC-managed.
+    let is_builtin = !code.is_null() && unsafe { crate::gateway::is_builtin_code(code as PyObjectRef) };
+    if !is_builtin {
+        if let Some(raw) =
+            pyre_object::gc_hook::try_gc_alloc_stable(FUNCTION_GC_TYPE_ID, FUNCTION_OBJECT_SIZE)
+                .filter(|p| !p.is_null())
+        {
+            unsafe {
+                std::ptr::write(raw as *mut Function, function);
+            }
+            return raw as PyObjectRef;
         }
-        return raw as PyObjectRef;
     }
 
     pyre_object::lltype::malloc_typed(function) as PyObjectRef

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -363,7 +363,8 @@ fn function_new_impl(
     // after the GC hook is wired. Startup builtin functions are already immortal
     // (no hook installed yet); this extends that to runtime-created ones. User
     // functions (`PyCode`) stay GC-managed.
-    let is_builtin = !code.is_null() && unsafe { crate::gateway::is_builtin_code(code as PyObjectRef) };
+    let is_builtin =
+        !code.is_null() && unsafe { crate::gateway::is_builtin_code(code as PyObjectRef) };
     if !is_builtin {
         if let Some(raw) =
             pyre_object::gc_hook::try_gc_alloc_stable(FUNCTION_GC_TYPE_ID, FUNCTION_OBJECT_SIZE)

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -922,6 +922,19 @@ pub fn set_sys_argv(args: &[String]) {
 thread_local! {
     static SYS_ARGV_PENDING: std::cell::Cell<pyre_object::PyObjectRef> =
         const { std::cell::Cell::new(pyre_object::PY_NULL) };
+    static SYS_NO_SITE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Record whether the launcher was given `-S` (no `site` import), so the
+/// `sys.flags.no_site` field built during sys module init reflects it. Set
+/// before the first `import sys`.
+pub fn set_no_site(no_site: bool) {
+    SYS_NO_SITE.with(|p| p.set(no_site));
+}
+
+/// Read the `-S` flag for `sys.flags.no_site`.
+pub fn no_site_flag() -> bool {
+    SYS_NO_SITE.with(|p| p.get())
 }
 
 /// Called from sys module init to pick up any pending argv.

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -1388,7 +1388,7 @@ fn parse_replacement_template(
                 pyre_object::w_none(),
                 pyre_object::w_none(),
                 0,
-                std::ptr::null(),
+                crate::call::getexecutioncontext(),
             )?;
             crate::baseobjspace::getattr_str(w_re, "_parser")?
         }

--- a/pyre/pyre-interpreter/src/module/_template/_template_app.py
+++ b/pyre/pyre-interpreter/src/module/_template/_template_app.py
@@ -17,6 +17,21 @@ class Interpolation:
     __match_args__ = ('value', 'expression', 'conversion', 'format_spec')
 
     def __init__(self, value, expression='', conversion=None, format_spec=''):
+        # `expression` / `format_spec` are typed `str` and `conversion` is
+        # restricted to None / 's' / 'r' / 'a'; reject anything else rather
+        # than store it unchecked.
+        if not isinstance(expression, str):
+            raise TypeError(
+                "Interpolation() argument 'expression' must be str, "
+                f'not {type(expression).__name__}')
+        if conversion is not None and conversion not in ('s', 'r', 'a'):
+            raise ValueError(
+                "Interpolation() argument 'conversion' must be one of "
+                "'s', 'r', or 'a'")
+        if not isinstance(format_spec, str):
+            raise TypeError(
+                "Interpolation() argument 'format_spec' must be str, "
+                f'not {type(format_spec).__name__}')
         self._value = value
         self._expression = expression
         self._conversion = conversion

--- a/pyre/pyre-interpreter/src/module/_template/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_template/mod.rs
@@ -12,4 +12,15 @@ crate::py_module! {
             "_build_template", "_build_interpolation", "_reconstruct",
         ],
     },
+    extra_init: |ns| {
+        // `Template` and `Interpolation` are final: the C runtime types lack
+        // `Py_TPFLAGS_BASETYPE`, so `class Sub(Template)` raises TypeError.
+        // App-level classes default to `acceptable_as_base_class=true`, so
+        // flip it off here to reject subclassing.
+        for name in ["Template", "Interpolation"] {
+            if let Some(t) = crate::runtime_ops::dict_storage_get(ns, name) {
+                unsafe { pyre_object::w_type_set_acceptable_as_base_class(t, false) };
+            }
+        }
+    },
 }

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -64,6 +64,36 @@ fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
     }
 }
 
+/// Scoped GC root for a freshly-allocated instance still held only in a
+/// Rust local. The weakref / proxy constructors allocate the instance,
+/// then allocate a `GcWeakrefBox` (an `rweakref` `Weakref` via
+/// `try_gc_alloc`) and grow the instance dict — each is a nursery
+/// allocation that can drive a minor collection. Without a root the
+/// not-yet-reachable instance is swept (its header zeroed), and a later
+/// `write_attr` / `typedef::r#type` dereferences the dangling pointer.
+/// Registering the slot keeps the instance alive and relocates the local
+/// in place when the collector promotes it, mirroring `FrameLocalsRoot`.
+struct InstanceRoot {
+    slot: *mut *mut u8,
+    registered: bool,
+}
+
+impl InstanceRoot {
+    fn new(obj: &mut PyObjectRef) -> Self {
+        let slot = obj as *mut PyObjectRef as *mut *mut u8;
+        let registered = unsafe { pyre_object::gc_hook::try_gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for InstanceRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            pyre_object::gc_hook::try_gc_remove_root(self.slot);
+        }
+    }
+}
+
 // ── Type registration ─────────────────────────────────────────────────
 
 fn weakref_lifeline_type() -> PyObjectRef {
@@ -262,7 +292,8 @@ pub fn callable_proxy_type() -> PyObjectRef {
 /// ```
 pub fn weakref_lifeline_new() -> PyObjectRef {
     use pyre_object::objectobject::w_instance_new;
-    let obj = w_instance_new(weakref_lifeline_type());
+    let mut obj = w_instance_new(weakref_lifeline_type());
+    let _root = InstanceRoot::new(&mut obj);
     write_attr(obj, ATTR_CACHED_WEAKREF, pyre_object::w_none());
     write_attr(obj, ATTR_CACHED_PROXY, pyre_object::w_none());
     obj
@@ -305,12 +336,10 @@ pub fn get_or_make_weakref(
         if !cached.is_null() {
             return cached;
         }
-        let w_ref = W_Weakref_new(w_subtype, w_obj, PY_NULL);
-        write_attr(
-            self_lifeline,
-            ATTR_CACHED_WEAKREF,
-            pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_ref),
-        );
+        let mut w_ref = W_Weakref_new(w_subtype, w_obj, PY_NULL);
+        let _root = InstanceRoot::new(&mut w_ref);
+        let cached = pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_ref);
+        write_attr(self_lifeline, ATTR_CACHED_WEAKREF, cached);
         w_ref
     } else {
         // subclass: cannot cache
@@ -461,18 +490,19 @@ pub fn W_Weakref_new(
     } else {
         w_subtype
     };
-    let obj = w_instance_new(actual_type);
-    // W_WeakrefBase.__init__: self.w_obj_weak = weakref.ref(w_obj)
-    write_attr(
-        obj,
-        ATTR_W_OBJ_WEAK,
-        pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_obj),
-    );
-    if !w_callable.is_null() && !unsafe { pyre_object::is_none(w_callable) } {
-        write_attr(obj, ATTR_W_CALLABLE, w_callable);
+    let mut obj = w_instance_new(actual_type);
+    let _root = InstanceRoot::new(&mut obj);
+    // W_WeakrefBase.__init__: self.w_obj_weak = weakref.ref(w_obj).
+    // Compute the box before `write_attr`: the allocation must not happen
+    // while a stale `obj` is captured as the call's receiver argument.
+    let w_obj_weak = pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_obj);
+    write_attr(obj, ATTR_W_OBJ_WEAK, w_obj_weak);
+    let w_callable = if !w_callable.is_null() && !unsafe { pyre_object::is_none(w_callable) } {
+        w_callable
     } else {
-        write_attr(obj, ATTR_W_CALLABLE, pyre_object::w_none());
-    }
+        pyre_object::w_none()
+    };
+    write_attr(obj, ATTR_W_CALLABLE, w_callable);
     // W_Weakref.__init__: self.w_hash = None
     write_attr(obj, ATTR_W_HASH, pyre_object::w_none());
     obj
@@ -481,34 +511,32 @@ pub fn W_Weakref_new(
 #[allow(non_snake_case)]
 pub fn W_Proxy_new(w_obj: PyObjectRef, w_callable: PyObjectRef) -> PyObjectRef {
     use pyre_object::objectobject::w_instance_new;
-    let obj = w_instance_new(proxy_type());
-    write_attr(
-        obj,
-        ATTR_W_OBJ_WEAK,
-        pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_obj),
-    );
-    if !w_callable.is_null() && !unsafe { pyre_object::is_none(w_callable) } {
-        write_attr(obj, ATTR_W_CALLABLE, w_callable);
+    let mut obj = w_instance_new(proxy_type());
+    let _root = InstanceRoot::new(&mut obj);
+    let w_obj_weak = pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_obj);
+    write_attr(obj, ATTR_W_OBJ_WEAK, w_obj_weak);
+    let w_callable = if !w_callable.is_null() && !unsafe { pyre_object::is_none(w_callable) } {
+        w_callable
     } else {
-        write_attr(obj, ATTR_W_CALLABLE, pyre_object::w_none());
-    }
+        pyre_object::w_none()
+    };
+    write_attr(obj, ATTR_W_CALLABLE, w_callable);
     obj
 }
 
 #[allow(non_snake_case)]
 pub fn W_CallableProxy_new(w_obj: PyObjectRef, w_callable: PyObjectRef) -> PyObjectRef {
     use pyre_object::objectobject::w_instance_new;
-    let obj = w_instance_new(callable_proxy_type());
-    write_attr(
-        obj,
-        ATTR_W_OBJ_WEAK,
-        pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_obj),
-    );
-    if !w_callable.is_null() && !unsafe { pyre_object::is_none(w_callable) } {
-        write_attr(obj, ATTR_W_CALLABLE, w_callable);
+    let mut obj = w_instance_new(callable_proxy_type());
+    let _root = InstanceRoot::new(&mut obj);
+    let w_obj_weak = pyre_object::weakref::w_gc_weakref_box_new_or_strong(w_obj);
+    write_attr(obj, ATTR_W_OBJ_WEAK, w_obj_weak);
+    let w_callable = if !w_callable.is_null() && !unsafe { pyre_object::is_none(w_callable) } {
+        w_callable
     } else {
-        write_attr(obj, ATTR_W_CALLABLE, pyre_object::w_none());
-    }
+        pyre_object::w_none()
+    };
+    write_attr(obj, ATTR_W_CALLABLE, w_callable);
     obj
 }
 

--- a/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
+++ b/pyre/pyre-interpreter/src/module/faulthandler/handler.rs
@@ -84,7 +84,9 @@ pub fn register_module(ns: &mut DictStorage) {
                 "faulthandler.enable requires host_env feature",
             ))
             },
-            crate::Signature::new(vec!["file", "all_threads"], None, None, 0, 0),
+            // `enable(file=sys.stderr, all_threads=True, c_stack=True)` —
+            // `c_stack` (3.14) selects C-stack dumping; accept and ignore it.
+            crate::Signature::new(vec!["file", "all_threads", "c_stack"], None, None, 0, 0),
         ),
     );
     crate::dict_storage_store(

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -74,12 +74,27 @@ pub fn register_module(ns: &mut DictStorage) {
             Ok(pyre_object::w_none())
         }),
     );
+    // `_imp.get_frozen_object(name, data=None)` — pyre has no frozen modules,
+    // so every name is unknown and `set_frozen_error(FROZEN_NOT_FOUND)` raises
+    // `ImportError("No such frozen object named %R")`.
     crate::dict_storage_store(
         ns,
         "get_frozen_object",
         crate::make_builtin_function_with_arity(
             "get_frozen_object",
-            |_| Ok(pyre_object::w_none()),
+            |args| {
+                let Some(&name) = args.first() else {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::TypeError,
+                        "get_frozen_object expected at least 1 argument, got 0".to_string(),
+                    ));
+                };
+                let name_repr = unsafe { crate::display::py_repr(name)? };
+                Err(crate::PyError::new(
+                    crate::PyErrorKind::ImportError,
+                    format!("No such frozen object named {name_repr}"),
+                ))
+            },
             1,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/importlib/interp_importlib.rs
+++ b/pyre/pyre-interpreter/src/module/importlib/interp_importlib.rs
@@ -27,12 +27,15 @@ pub fn register_pkg(ns: &mut DictStorage) {
                     ));
                 }
                 let name_str = pyre_object::w_str_get_value(name).to_string();
+                // `load_source_module` reads `execution_context.builtins_module`
+                // to seed a fresh module namespace, so it must be the live EC,
+                // not null — pass the thread's current context.
                 crate::importing::importhook(
                     &name_str,
                     pyre_object::w_none(),
                     pyre_object::w_list_new(vec![pyre_object::w_str_new("*")]),
                     0,
-                    std::ptr::null(),
+                    crate::call::getexecutioncontext(),
                 )
             }
         }),

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -3,7 +3,12 @@
 use pyre_object::*;
 
 fn op_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "index() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "index() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     let obj = args[0];
     unsafe {
         if is_int(obj) {
@@ -136,12 +141,12 @@ crate::py_module! {
         "setitem"  / 3 = |args| { setitem(args[0], args[1], args[2])?; Ok(w_none()) },
         "delitem"  / 2 = |args| { delitem(args[0], args[1])?; Ok(w_none()) },
         // Underscore aliases (__add__ / __sub__ / __mul__ via operator).
-        "__add__"  / 2 = |args| { assert!(args.len() == 2); Ok(add(args[0], args[1]).unwrap_or(w_none())) },
-        "__sub__"  / 2 = |args| { assert!(args.len() == 2); Ok(sub(args[0], args[1]).unwrap_or(w_none())) },
-        "__mul__"  / 2 = |args| { assert!(args.len() == 2); Ok(mul(args[0], args[1]).unwrap_or(w_none())) },
-        "eq" / 2 = |args| { assert!(args.len() == 2); Ok(baseobjspace::compare(args[0], args[1], CompareOp::Eq).unwrap_or(w_none())) },
-        "lt" / 2 = |args| { assert!(args.len() == 2); Ok(baseobjspace::compare(args[0], args[1], CompareOp::Lt).unwrap_or(w_none())) },
-        "gt" / 2 = |args| { assert!(args.len() == 2); Ok(baseobjspace::compare(args[0], args[1], CompareOp::Gt).unwrap_or(w_none())) },
+        "__add__"  / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("__add__() takes exactly 2 arguments ({} given)", args.len()))); } Ok(add(args[0], args[1]).unwrap_or(w_none())) },
+        "__sub__"  / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("__sub__() takes exactly 2 arguments ({} given)", args.len()))); } Ok(sub(args[0], args[1]).unwrap_or(w_none())) },
+        "__mul__"  / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("__mul__() takes exactly 2 arguments ({} given)", args.len()))); } Ok(mul(args[0], args[1]).unwrap_or(w_none())) },
+        "eq" / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("eq() takes exactly 2 arguments ({} given)", args.len()))); } Ok(baseobjspace::compare(args[0], args[1], CompareOp::Eq).unwrap_or(w_none())) },
+        "lt" / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("lt() takes exactly 2 arguments ({} given)", args.len()))); } Ok(baseobjspace::compare(args[0], args[1], CompareOp::Lt).unwrap_or(w_none())) },
+        "gt" / 2 = |args| { if args.len() != 2 { return Err(crate::PyError::type_error(format!("gt() takes exactly 2 arguments ({} given)", args.len()))); } Ok(baseobjspace::compare(args[0], args[1], CompareOp::Gt).unwrap_or(w_none())) },
         "le" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Le),
         "ge" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Ge),
         "ne" / 2 = |args| baseobjspace::compare(args[0], args[1], CompareOp::Ne),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -649,23 +649,46 @@ pub fn register_module(ns: &mut DictStorage) {
         ),
     );
 
-    // ── posix.rename(src, dst) ──
+    // ── posix.rename(src, dst, *, src_dir_fd=None, dst_dir_fd=None) ──
+    // A non-None `src_dir_fd` / `dst_dir_fd` resolves the path relative to the
+    // open directory descriptor (`renameat`); the descriptors are only usable
+    // where `renameat` exists (unix).
     crate::dict_storage_store(
         ns,
         "rename",
-        crate::make_builtin_function_with_arity(
-            "rename",
-            |args| {
-                if args.len() < 2 {
-                    return Err(crate::PyError::type_error("rename() requires 2 arguments"));
+        crate::make_builtin_function("rename", |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            if pos.len() < 2 {
+                return Err(crate::PyError::type_error("rename() requires 2 arguments"));
+            }
+            let src = extract_path(pos[0])?;
+            let dst = extract_path(pos[1])?;
+            let dir_fd = |name: &str| -> Option<i32> {
+                match crate::builtins::kwarg_get(kwargs, name) {
+                    Some(v) if !unsafe { pyre_object::is_none(v) } => {
+                        Some((unsafe { pyre_object::w_int_get_value(v) }) as i32)
+                    }
+                    _ => None,
                 }
-                let src = extract_path(args[0])?;
-                let dst = extract_path(args[1])?;
-                host_os::rename(&src, None, &dst, None).map_err(|e| io_err(e, &src))?;
-                Ok(pyre_object::w_none())
-            },
-            2,
-        ),
+            };
+            let src_fd = dir_fd("src_dir_fd");
+            let dst_fd = dir_fd("dst_dir_fd");
+            #[cfg(unix)]
+            let (src_b, dst_b) = {
+                use rustpython_host_env::crt_fd::Borrowed;
+                (
+                    src_fd.map(|fd| unsafe { Borrowed::borrow_raw(fd) }),
+                    dst_fd.map(|fd| unsafe { Borrowed::borrow_raw(fd) }),
+                )
+            };
+            #[cfg(not(unix))]
+            let (src_b, dst_b) = {
+                let _ = (src_fd, dst_fd);
+                (None, None)
+            };
+            host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;
+            Ok(pyre_object::w_none())
+        }),
     );
 
     // ── posix.listdir(path=".") → list of str ──

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -663,16 +663,24 @@ pub fn register_module(ns: &mut DictStorage) {
             }
             let src = extract_path(pos[0])?;
             let dst = extract_path(pos[1])?;
-            let dir_fd = |name: &str| -> Option<i32> {
+            let dir_fd = |name: &str| -> Result<Option<i32>, crate::PyError> {
                 match crate::builtins::kwarg_get(kwargs, name) {
                     Some(v) if !unsafe { pyre_object::is_none(v) } => {
-                        Some((unsafe { pyre_object::w_int_get_value(v) }) as i32)
+                        if !unsafe { pyre_object::is_int(v) } {
+                            let type_name = crate::typedef::r#type(v)
+                                .map(|t| unsafe { pyre_object::typeobject::w_type_get_name(t) })
+                                .unwrap_or("object");
+                            return Err(crate::PyError::type_error(format!(
+                                "argument should be integer or None, not {type_name}"
+                            )));
+                        }
+                        Ok(Some((unsafe { pyre_object::w_int_get_value(v) }) as i32))
                     }
-                    _ => None,
+                    _ => Ok(None),
                 }
             };
-            let src_fd = dir_fd("src_dir_fd");
-            let dst_fd = dir_fd("dst_dir_fd");
+            let src_fd = dir_fd("src_dir_fd")?;
+            let dst_fd = dir_fd("dst_dir_fd")?;
             #[cfg(unix)]
             let (src_b, dst_b) = {
                 use rustpython_host_env::crt_fd::Borrowed;

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -116,6 +116,34 @@ pub fn set_handler(signum: i32, handler: PyObjectRef) {
     unsafe { pyre_object::w_dict_setitem(d, signum as i64, handler) };
 }
 
+/// GC root walker over the signal-handler table's value slots.
+///
+/// `handlers_dict()` is first reached during interpreter bootstrap,
+/// before the GC heap is wired, so `w_dict_new` takes its immortal
+/// (`malloc_typed`) fallback.  The collector never traces into off-GC
+/// objects, so a handler callable reachable only through this dict — a
+/// `unittest._InterruptHandler` instance, say — is reclaimed by
+/// `gc.collect`, after which `getsignal` / `signal` hand back a dangling
+/// pointer.  Expose the dict's value slots as roots so the handlers
+/// survive (and are relocated when they move), mirroring
+/// `walk_mapdict_roots` for the immortal mapdict side tables.  The table
+/// is int-keyed (`signum`), so the strategy's `walk_gc_refs` visits only
+/// the value slots — dispatched exactly as `dict_object_custom_trace`.
+pub fn walk_signal_handler_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
+    HANDLERS.with(|cell| {
+        let d = cell.get();
+        if d.is_null() {
+            return;
+        }
+        unsafe {
+            let strategy = pyre_object::dictmultiobject::w_dict_get_strategy(d);
+            strategy.walk_gc_refs(d, &mut |slot: *mut PyObjectRef| {
+                visitor(&mut *slot);
+            });
+        }
+    });
+}
+
 /// `@unwrap_spec(signum=int)` — coerce the signal-number argument to an
 /// `i32`.  The gateway `int` converter is `space.gateway_int_w`
 /// (`gateway.py:646-665` → `int_w(allow_conversion=True)`), which runs

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -54,7 +54,9 @@ fn make_sys_namespace_instance() -> PyObjectRef {
 /// allocation per live frame on every `_getframe` call; an
 /// acceptable price for stack-walking parity until the proper
 /// PyFrame typedef port lands.
-fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
+fn build_frame_stub_chain(
+    top: *mut crate::pyframe::PyFrame,
+) -> Result<PyObjectRef, crate::PyError> {
     let mut frames: Vec<*mut crate::pyframe::PyFrame> = Vec::new();
     let mut cursor = top;
     while !cursor.is_null() {
@@ -71,8 +73,10 @@ fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
         let frame_ref = unsafe { &mut *frame_ptr };
         // `pyframe.py:540-545 getdictscope`: PyPy materialises
         // `f_locals` by running `fast2locals()` and exposing the
-        // resulting `debugdata.w_locals` dict.
-        let w_locals_obj = frame_ref.getdictscope().unwrap_or(pyre_object::PY_NULL);
+        // resulting `debugdata.w_locals` dict.  `fast2locals` writes through
+        // the live locals mapping and can raise, so propagate the error rather
+        // than masking it as an empty `f_locals`.
+        let w_locals_obj = frame_ref.getdictscope()?;
         // pyframe.py:128 get_w_globals_storage returns the globals dict object.  The
         // canonical `w_globals` is seeded by every frame constructor and
         // is the source of truth for the frame's globals.
@@ -103,7 +107,7 @@ fn build_frame_stub_chain(top: *mut crate::pyframe::PyFrame) -> PyObjectRef {
         prev_stub = stub;
         top_stub = stub;
     }
-    top_stub
+    Ok(top_stub)
 }
 
 /// Build a `sys.namespace` frame stub for `traceback.tb_frame`
@@ -389,7 +393,7 @@ pub fn register_module(ns: &mut DictStorage) {
             // greedily so each stub's `f_back` points to the next
             // stub instead of `None`, otherwise traversal patterns
             // (`while f: f = f.f_back`) terminate at depth 1.
-            Ok(build_frame_stub_chain(current))
+            build_frame_stub_chain(current)
         }),
     );
     // sys.exc_info() → (type, value, traceback)

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -434,7 +434,12 @@ pub fn register_module(ns: &mut DictStorage) {
             dict_storage_store(fns, "optimize", w_int_new(0));
             dict_storage_store(fns, "dont_write_bytecode", w_int_new(0));
             dict_storage_store(fns, "no_user_site", w_int_new(0));
-            dict_storage_store(fns, "no_site", w_int_new(0));
+            // `-S` (skip `import site`) is recorded by the launcher.
+            dict_storage_store(
+                fns,
+                "no_site",
+                w_int_new(i64::from(crate::importing::no_site_flag())),
+            );
             dict_storage_store(fns, "ignore_environment", w_int_new(0));
             dict_storage_store(fns, "verbose", w_int_new(0));
             dict_storage_store(fns, "bytes_warning", w_int_new(0));

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1030,7 +1030,14 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     let stream = pyre_object::w_instance_new(crate::builtins::text_io_wrapper_type());
     let _ = crate::baseobjspace::setattr_str(stream, "name", w_str_new(name));
     let _ = crate::baseobjspace::setattr_str(stream, "encoding", w_str_new("utf-8"));
-    let _ = crate::baseobjspace::setattr_str(stream, "errors", w_str_new("strict"));
+    // `pylifecycle.c init_set_builtins_open`/`init_sys_streams`: stderr uses the
+    // `backslashreplace` handler so traceback printing never fails on a lone
+    // surrogate; stdout/stdin default to `strict`.
+    let _ = crate::baseobjspace::setattr_str(
+        stream,
+        "errors",
+        w_str_new(if to_stderr { "backslashreplace" } else { "strict" }),
+    );
     let _ = crate::baseobjspace::setattr_str(
         stream,
         "mode",
@@ -1041,29 +1048,34 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     // Instance-stored builtin methods do not get `self` prepended (see
     // pyopcode load_method dispatch), so the first arg may be the string
     // directly. Pick whichever element is a real str.
-    fn pick_str(args: &[PyObjectRef]) -> Option<&str> {
+    fn pick_str(args: &[PyObjectRef]) -> Option<PyObjectRef> {
         for &a in args {
             if !a.is_null() && unsafe { is_str(a) } {
-                return Some(unsafe { w_str_get_value(a) });
+                return Some(a);
             }
         }
         None
     }
+    // Encode through `encode_object` with the stream's error handler so a lone
+    // surrogate is routed there (stdout `strict` → UnicodeEncodeError; stderr
+    // `backslashreplace` → escaped) instead of panicking in `w_str_get_value`.
     let write_fn = if to_stderr {
         crate::make_builtin_function("write", |args| {
             use std::io::Write;
-            if let Some(text) = pick_str(args) {
-                let _ = std::io::stderr().write_all(text.as_bytes());
-                return Ok(w_int_new(text.len() as i64));
+            if let Some(s_obj) = pick_str(args) {
+                let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")?;
+                let _ = std::io::stderr().write_all(&bytes);
+                return Ok(w_int_new(unsafe { w_str_len(s_obj) } as i64));
             }
             Ok(w_int_new(0))
         })
     } else {
         crate::make_builtin_function("write", |args| {
             use std::io::Write;
-            if let Some(text) = pick_str(args) {
-                let _ = std::io::stdout().write_all(text.as_bytes());
-                return Ok(w_int_new(text.len() as i64));
+            if let Some(s_obj) = pick_str(args) {
+                let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "strict")?;
+                let _ = std::io::stdout().write_all(&bytes);
+                return Ok(w_int_new(unsafe { w_str_len(s_obj) } as i64));
             }
             Ok(w_int_new(0))
         })

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -84,7 +84,12 @@ pub fn monotonic(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// that signal-driven wakeups propagate; falls back to
 /// `std::thread::sleep` otherwise.
 pub fn sleep(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 1, "sleep() takes exactly one argument");
+    if args.len() != 1 {
+        return Err(crate::PyError::type_error(format!(
+            "sleep() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
     // `timeutils.py:20-38 timestamp_w` — reduce the argument to an integer
     // number of nanoseconds. A float scales then `math.ceil`s, with an
     // `ovfcheck_float_to_longlong` overflow guard and a NaN ValueError; an

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -733,37 +733,44 @@ pub fn hidden_local(code: &CodeObject, idx: usize) -> bool {
 /// `idx` follows the `npure_cellvars` slot layout: `varnames` occupy
 /// `[0, nvarnames)`, pure cellvars (those not also varnames) the next
 /// `npure_cellvars` slots, then freevars.
-pub fn deref_unbound_error(code: &CodeObject, idx: usize) -> crate::PyError {
+/// The name and free/cell kind of the local / cell / free variable at
+/// localsplus index `idx`, following the `[varnames, pure cellvars, freevars]`
+/// layout.  Used to resolve the name behind a `*_DEREF` oparg; an out-of-range
+/// index yields an empty name rather than panicking.
+pub fn deref_name_and_kind(code: &CodeObject, idx: usize) -> (&str, bool) {
     let nvarnames = code.varnames.len();
-    let (name, is_free): (&str, bool) = if idx < nvarnames {
-        (code.varnames[idx].as_ref(), false)
-    } else {
-        let cell_slot = idx - nvarnames;
-        let npure = npure_cellvars(code);
-        if cell_slot < npure {
-            let name = code
-                .cellvars
-                .iter()
-                .filter(|c| {
-                    let cs: &str = c.as_ref();
-                    !code.varnames.iter().any(|v| {
-                        let vs: &str = v.as_ref();
-                        vs == cs
-                    })
+    if idx < nvarnames {
+        return (code.varnames[idx].as_ref(), false);
+    }
+    let cell_slot = idx - nvarnames;
+    let npure = npure_cellvars(code);
+    if cell_slot < npure {
+        let name = code
+            .cellvars
+            .iter()
+            .filter(|c| {
+                let cs: &str = c.as_ref();
+                !code.varnames.iter().any(|v| {
+                    let vs: &str = v.as_ref();
+                    vs == cs
                 })
-                .nth(cell_slot)
-                .map(|c| c.as_ref())
-                .unwrap_or("");
-            (name, false)
-        } else {
-            let name = code
-                .freevars
-                .get(cell_slot - npure)
-                .map(|f| f.as_ref())
-                .unwrap_or("");
-            (name, true)
-        }
-    };
+            })
+            .nth(cell_slot)
+            .map(|c| c.as_ref())
+            .unwrap_or("");
+        (name, false)
+    } else {
+        let name = code
+            .freevars
+            .get(cell_slot - npure)
+            .map(|f| f.as_ref())
+            .unwrap_or("");
+        (name, true)
+    }
+}
+
+pub fn deref_unbound_error(code: &CodeObject, idx: usize) -> crate::PyError {
+    let (name, is_free) = deref_name_and_kind(code, idx);
     let message = if is_free {
         format!("free variable '{name}' referenced before assignment in enclosing scope")
     } else {

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -3008,7 +3008,9 @@ pub fn execute_load_from_dict_or_deref<E: OpcodeStepExecutor>(
         unreachable!()
     };
     let idx = i.get(op_arg).as_usize();
-    executor.load_from_dict_or_deref(idx, code.names[idx].as_ref())?;
+    // `idx` is a localsplus offset (cell / free var), not a `co_names` index.
+    let name = crate::pyframe::deref_name_and_kind(code, idx).0;
+    executor.load_from_dict_or_deref(idx, name)?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3727,7 +3727,12 @@ mod dict_method_tests {
 
 /// PyPy: tupleobject.py descr_index — tuple.index(value)
 pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "index() takes at least 1 argument");
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error(format!(
+            "index expected at least 1 argument, got {}",
+            args.len().saturating_sub(1)
+        )));
+    }
     let tup = args[0];
     let value = args[1];
     unsafe {
@@ -3751,7 +3756,12 @@ pub fn tuple_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: tupleobject.py descr_count — tuple.count(value)
 pub fn tuple_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "count() takes exactly 1 argument");
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(format!(
+            "tuple.count() takes exactly one argument ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
     let tup = args[0];
     let value = args[1];
     let mut count: i64 = 0;

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -12,17 +12,74 @@
 use pyre_object::*;
 use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
+// ── Arity checks for builtin methods ─────────────────────────────────
+// A builtin method registered with `make_builtin_function_with_arity`
+// records an arity only as a fast-path dispatch hint — some stubs register
+// a hint that differs from their real signature, so the call machinery
+// cannot treat it as a contract. Methods therefore validate their own
+// argument count and raise instead of asserting. `args[0]` is the bound
+// receiver, so the counts in these messages exclude it.
+
+/// TypeError for a method requiring exactly `n` positional arguments after
+/// the receiver, called with a different count.
+pub(crate) fn arity_exact(
+    args: &[PyObjectRef],
+    name: &str,
+    n: usize,
+) -> Result<(), crate::PyError> {
+    if args.len() != n + 1 {
+        let expected = match n {
+            0 => "no arguments".to_string(),
+            1 => "exactly one argument".to_string(),
+            k => format!("exactly {k} arguments"),
+        };
+        return Err(crate::PyError::type_error(format!(
+            "{name}() takes {expected} ({} given)",
+            args.len().saturating_sub(1),
+        )));
+    }
+    Ok(())
+}
+
+/// TypeError for a method requiring at least `min` positional arguments
+/// after the receiver, called with fewer.
+pub(crate) fn arity_at_least(
+    args: &[PyObjectRef],
+    name: &str,
+    min: usize,
+) -> Result<(), crate::PyError> {
+    if args.len() < min + 1 {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() takes at least {min} argument{} ({} given)",
+            if min == 1 { "" } else { "s" },
+            args.len().saturating_sub(1),
+        )));
+    }
+    Ok(())
+}
+
+/// TypeError for an unbound method descriptor invoked with no receiver
+/// (`list.append()` with zero arguments) — `args` is empty.
+pub(crate) fn require_receiver(args: &[PyObjectRef], name: &str) -> Result<(), crate::PyError> {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' of object needs an argument"
+        )));
+    }
+    Ok(())
+}
+
 // ── List methods ─────────────────────────────────────────────────────
 // All take self (list) as first arg.
 
 pub fn list_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2, "append() takes exactly one argument");
+    arity_exact(args, "append", 1)?;
     unsafe { w_list_append(args[0], args[1]) };
     Ok(w_none())
 }
 
 pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2);
+    arity_exact(args, "extend", 1)?;
     let list = args[0];
     let other = args[1];
     unsafe {
@@ -53,7 +110,7 @@ pub fn list_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: listobject.py descr_insert — list.insert(index, item)
 pub fn list_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 3, "insert() takes exactly 2 arguments");
+    arity_exact(args, "insert", 2)?;
     let index = unsafe { w_int_get_value(args[1]) };
     unsafe { pyre_object::listobject::w_list_insert(args[0], index, args[2]) };
     Ok(w_none())
@@ -63,7 +120,7 @@ pub fn list_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// listobject.py:759-772 — empty list raises "pop from empty list",
 /// otherwise out-of-range raises "pop index out of range".
 pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "pop() requires self");
+    require_receiver(args, "pop")?;
     let index = if args.len() > 1 {
         unsafe { w_int_get_value(args[1]) }
     } else {
@@ -87,14 +144,14 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 
 /// PyPy: listobject.py descr_clear — list.clear()
 pub fn list_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "clear")?;
     unsafe { pyre_object::listobject::w_list_clear(args[0]) };
     Ok(w_none())
 }
 
 /// PyPy: listobject.py descr_copy — list.copy()
 pub fn list_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "copy")?;
     let list = args[0];
     unsafe {
         let n = w_list_len(list);
@@ -110,14 +167,14 @@ pub fn list_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// PyPy: listobject.py descr_reverse — list.reverse()
 pub fn list_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "reverse")?;
     unsafe { pyre_object::listobject::w_list_reverse(args[0]) };
     Ok(w_none())
 }
 
 /// PyPy: listobject.py descr_sort — list.sort()
 pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "sort")?;
     let list = args[0];
     // listobject.py `descr_sort` shares `rpython/rlib/listsort.py`'s comparison
     // machinery (general `space.lt`, `key=`, `reverse=`) with `sorted()`.
@@ -140,7 +197,7 @@ pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// listobject.py:795 `descr_index` — list.index(value[, start[, stop]]).
 pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "index() takes at least 1 argument");
+    arity_at_least(args, "index", 1)?;
     let list = args[0];
     let value = args[1];
     // listobject.py:799 unwrap_spec defaults: w_start=0 / w_stop=sys.maxint.
@@ -180,7 +237,7 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// listobject.py:744 `descr_count` — list.count(value)
 pub fn list_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "count() takes exactly 1 argument");
+    arity_at_least(args, "count", 1)?;
     let list = args[0];
     let value = args[1];
     match crate::listobject::w_list_find_or_count(list, value, 0, i64::MAX, true)? {
@@ -194,7 +251,7 @@ pub fn list_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// listobject.py:782 `descr_remove` — list.remove(value).
 pub fn list_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "remove() takes exactly 1 argument");
+    arity_at_least(args, "remove", 1)?;
     crate::listobject::w_list_remove(args[0], args[1])?;
     Ok(w_none())
 }
@@ -202,7 +259,7 @@ pub fn list_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 // ── String methods ───────────────────────────────────────────────────
 
 pub fn str_method_join(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() == 2);
+    arity_exact(args, "join", 1)?;
     let sep = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
     let iterable = args[1];
     let items: Vec<PyObjectRef> = unsafe {
@@ -351,7 +408,7 @@ fn wtf8_rsplit_whitespace(s: &Wtf8, maxsplit: i64) -> Vec<PyObjectRef> {
 }
 
 pub fn str_method_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "split")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let (sep_arg, maxsplit_arg) = resolve_split_args(args, "split")?;
     let sep = parse_split_sep(sep_arg)?;
@@ -422,7 +479,7 @@ fn parse_split_maxsplit(value: PyObjectRef) -> Result<i64, crate::PyError> {
 /// `@unwrap_spec(maxsplit=int)` + `convert_arg_to_w_unicode` shape
 /// as `descr_split`.
 pub fn str_method_rsplit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "rsplit")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let (sep_arg, maxsplit_arg) = resolve_split_args(args, "rsplit")?;
     let sep = parse_split_sep(sep_arg)?;
@@ -466,7 +523,7 @@ pub fn str_method_rsplit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// generated from `CaseFolding.txt` status-C+F entries, so the
 /// surface matches `unicode_casefold` for every Unicode code point.
 pub fn str_method_casefold(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "casefold")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     // Fast path: no lone surrogate, fold the whole &str at once.
     if let Ok(valid) = s.as_str() {
@@ -526,7 +583,7 @@ fn casefold_basic(s: &str) -> String {
 /// custom `Mapping` subclasses, and any object that only implements
 /// `__getitem__`.
 pub fn str_method_format_map(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "format_map", 1)?;
     let fmt = args[0];
     let mapping = args[1];
     str_method_format_core(fmt, &[], None, Some(mapping))
@@ -574,7 +631,7 @@ fn extract_strip_chars(arg: PyObjectRef, fn_name: &str) -> Result<Option<Wtf8Buf
 }
 
 pub fn str_method_strip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "strip")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let chars = match args.get(1) {
         Some(&a) => extract_strip_chars(a, "strip")?,
@@ -589,7 +646,7 @@ pub fn str_method_strip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 }
 
 pub fn str_method_lstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "lstrip")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let chars = match args.get(1) {
         Some(&a) => extract_strip_chars(a, "lstrip")?,
@@ -604,7 +661,7 @@ pub fn str_method_lstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 }
 
 pub fn str_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "rstrip")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let chars = match args.get(1) {
         Some(&a) => extract_strip_chars(a, "rstrip")?,
@@ -622,14 +679,14 @@ pub fn str_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// prefix or a tuple of str prefixes (CPython parity).
 /// unicodeobject.py:848 descr_startswith(self, prefix, start=0, end=sys.maxsize)
 pub fn str_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "startswith", 1)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
     let slice = str_slice_args(s, args);
     str_prefix_match(slice, args[1], "startswith", true).map(w_bool_from)
 }
 
 pub fn str_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "endswith", 1)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
     let slice = str_slice_args(s, args);
     str_prefix_match(slice, args[1], "endswith", false).map(w_bool_from)
@@ -719,7 +776,7 @@ fn str_prefix_match(
 }
 
 pub fn str_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 3);
+    arity_at_least(args, "replace", 2)?;
     // pypy/objspace/std/unicodeobject.py:1132-1148 descr_replace —
     // both `old` and `new` must be str / W_UnicodeObject; otherwise
     // TypeError("replace() argument N must be str, not ...").
@@ -783,17 +840,17 @@ fn wtf8_idx_window(
 }
 
 pub fn str_method_find(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "find", 1)?;
     Ok(w_int_new(str_unwrap_and_search(args, true)?.unwrap_or(-1)))
 }
 
 pub fn str_method_rfind(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "rfind", 1)?;
     Ok(w_int_new(str_unwrap_and_search(args, false)?.unwrap_or(-1)))
 }
 
 pub fn str_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "upper")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let out = wtf8_map_chars(s, |c, out| {
         for u in c.to_uppercase() {
@@ -804,7 +861,7 @@ pub fn str_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 }
 
 pub fn str_method_lower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "lower")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let out = wtf8_map_chars(s, |c, out| {
         for l in c.to_lowercase() {
@@ -818,7 +875,7 @@ pub fn str_method_lower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// Requires format spec parser — correct for no-arg case only.
 /// `str.format(*args)` — PyPy: unicodeobject.py descr_format → newformat.py
 pub fn str_method_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "format")?;
     // `pypy/objspace/std/newformat.py Formatter.format` —
     // positional args are slots 1.. of the receiver; keyword args
     // (`{name}` lookups) live in the trailing CALL_KW dict.
@@ -1771,7 +1828,7 @@ fn encode_utf8_with_errors(
 /// For the common 'utf-8' / 'ascii' fast paths, returns the UTF-8 bytes
 /// of the string. Other codecs fall through to a best-effort UTF-8 encoding.
 pub fn str_method_encode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "encode")?;
     // `encoding` and `errors` arrive positionally or by keyword; builtin
     // kwargs are packed in a trailing `__pyre_kw__` dict.
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
@@ -2432,7 +2489,7 @@ fn wtf8_map_chars(s: &Wtf8, f: impl Fn(char, &mut Wtf8Buf)) -> Wtf8Buf {
 }
 
 pub fn str_method_isdigit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isdigit")?;
     // A lone surrogate satisfies no character class, so a non-UTF-8
     // backing is never all-digit (and the empty string is false too).
     let s = unsafe { w_str_get_wtf8(args[0]) };
@@ -2444,7 +2501,7 @@ pub fn str_method_isdigit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 pub fn str_method_isdecimal(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isdecimal")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(crate::unicodedb::isdecimal),
@@ -2454,7 +2511,7 @@ pub fn str_method_isdecimal(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 pub fn str_method_isnumeric(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isnumeric")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(crate::unicodedb::isnumeric),
@@ -2464,7 +2521,7 @@ pub fn str_method_isnumeric(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 pub fn str_method_istitle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "istitle")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let mut cased = false;
     let mut prev_cased = false;
@@ -2496,7 +2553,7 @@ pub fn str_method_istitle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 pub fn str_method_isalpha(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isalpha")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(|c| c.is_alphabetic()),
@@ -2507,7 +2564,7 @@ pub fn str_method_isalpha(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: unicodeobject.py descr_isidentifier
 pub fn str_method_isidentifier(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isidentifier")?;
     // An identifier cannot contain a lone surrogate, so a non-UTF-8
     // backing is never an identifier.
     let s = unsafe { w_str_get_wtf8(args[0]) };
@@ -2538,7 +2595,7 @@ fn is_identifier(s: &str) -> bool {
 /// a sign character (`+`/`-`), the sign stays at the front and zeros
 /// fill between it and the digits (`'-42'.zfill(5) == '-0042'`).
 pub fn str_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "zfill", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
     let len = s.code_points().count();
@@ -2669,7 +2726,7 @@ fn str_unwrap_and_search(
 
 /// PyPy: unicodeobject.py descr_count
 pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "count", 1)?;
     // Operands read as WTF-8 so lone surrogates do not panic; the optional
     // start / end arguments bound the count window over the code points.
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
@@ -2686,7 +2743,7 @@ pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// `unicodeobject.py:1006-1010 _descr_index` — missing substring raises
 /// "substring not found" (ValueError).
 pub fn str_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "index", 1)?;
     match str_unwrap_and_search(args, true)? {
         Some(i) => Ok(w_int_new(i)),
         None => Err(crate::PyError::value_error("substring not found")),
@@ -2697,7 +2754,7 @@ pub fn str_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// when the substring is absent.
 /// unicodeobject.py:572 descr_rindex
 pub fn str_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "rindex", 1)?;
     match str_unwrap_and_search(args, false)? {
         Some(i) => Ok(w_int_new(i)),
         None => Err(crate::PyError::value_error("substring not found")),
@@ -2706,7 +2763,7 @@ pub fn str_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// PyPy: unicodeobject.py descr_title
 pub fn str_method_title(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "title")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let mut result = Wtf8Buf::with_capacity(s.len());
     let mut prev_is_sep = true;
@@ -2736,7 +2793,7 @@ pub fn str_method_title(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// PyPy: unicodeobject.py descr_capitalize
 pub fn str_method_capitalize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "capitalize")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let mut result = Wtf8Buf::with_capacity(s.len());
     let mut cps = s.code_points();
@@ -2765,7 +2822,7 @@ pub fn str_method_capitalize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 
 /// PyPy: unicodeobject.py descr_swapcase
 pub fn str_method_swapcase(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "swapcase")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let out = wtf8_map_chars(s, |c, out| {
         if c.is_uppercase() {
@@ -2814,7 +2871,7 @@ fn push_cp_repeated(out: &mut Wtf8Buf, cp: CodePoint, n: usize) {
 }
 
 pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "center", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
     let fillchar = pad_fillchar(args, "center")?;
@@ -2835,7 +2892,7 @@ pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// PyPy: unicodeobject.py descr_ljust
 pub fn str_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "ljust", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
     let fillchar = pad_fillchar(args, "ljust")?;
@@ -2851,7 +2908,7 @@ pub fn str_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// PyPy: unicodeobject.py descr_rjust
 pub fn str_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "rjust", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
     let fillchar = pad_fillchar(args, "rjust")?;
@@ -2884,7 +2941,7 @@ pub fn str_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// For now: approximate via `!c.is_control() && c != ' ' || c == ' '`
 /// which catches the common ASCII-only cases.
 pub fn str_method_isprintable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isprintable")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     // Empty returns True (vacuous); a lone surrogate is not printable.
     let result = match s.as_str() {
@@ -2902,7 +2959,7 @@ pub fn str_method_isprintable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
 
 /// PyPy: unicodeobject.py descr_isspace
 pub fn str_method_isspace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isspace")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(|c| c.is_whitespace()),
@@ -2939,21 +2996,21 @@ fn wtf8_cased_all(s: &Wtf8, want_upper: bool) -> bool {
 
 /// PyPy: unicodeobject.py descr_isupper
 pub fn str_method_isupper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isupper")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     Ok(w_bool_from(wtf8_cased_all(s, true)))
 }
 
 /// PyPy: unicodeobject.py descr_islower
 pub fn str_method_islower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "islower")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     Ok(w_bool_from(wtf8_cased_all(s, false)))
 }
 
 /// PyPy: unicodeobject.py descr_isalnum
 pub fn str_method_isalnum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isalnum")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(|c| c.is_alphanumeric()),
@@ -2964,7 +3021,7 @@ pub fn str_method_isalnum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: unicodeobject.py descr_isascii
 pub fn str_method_isascii(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "isascii")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => v.is_ascii(),
@@ -3028,7 +3085,7 @@ fn wtf8_replace(input: &Wtf8, sub: &Wtf8, by: &Wtf8, maxcount: i64) -> Wtf8Buf {
 
 /// PyPy: unicodeobject.py descr_partition
 pub fn str_method_partition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "partition", 1)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) }.as_bytes();
     let sep = unsafe { pyre_object::w_str_get_wtf8(args[1]) }.as_bytes();
     match wtf8_find_bounded(s, sep, 0, s.len()) {
@@ -3043,7 +3100,7 @@ pub fn str_method_partition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
 /// PyPy: unicodeobject.py descr_rpartition
 pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "rpartition", 1)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) }.as_bytes();
     let sep = unsafe { pyre_object::w_str_get_wtf8(args[1]) }.as_bytes();
     match wtf8_rfind_bounded(s, sep, 0, s.len()) {
@@ -3062,7 +3119,7 @@ pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 /// trailing `\n` does NOT produce an extra empty entry — matching
 /// `'a\nb\n'.splitlines() == ['a', 'b']`.
 pub fn str_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "splitlines")?;
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
     // `\n` / `\r` are single bytes that cannot occur inside a multi-byte
     // WTF-8 sequence, so the line boundaries are found by walking bytes;
@@ -3133,7 +3190,7 @@ pub fn str_method_removesuffix(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
 
 /// PyPy: unicodeobject.py descr_expandtabs
 pub fn str_method_expandtabs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "expandtabs")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let tabsize = if args.len() > 1 {
         unsafe { w_int_get_value(args[1]) }
@@ -3174,7 +3231,7 @@ pub fn str_method_expandtabs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 /// str.translate(table) — table is a dict mapping ordinals (int) to
 /// ordinals (int), strings (str), or None (delete).
 pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "translate() takes exactly one argument");
+    arity_at_least(args, "translate", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let table = args[1];
     let mut result = Wtf8Buf::with_capacity(s.len());
@@ -3259,7 +3316,7 @@ pub(crate) fn dict_store_checked(
 }
 
 pub fn dict_method_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "get", 1)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
     let default = args.get(2).copied().unwrap_or_else(w_none);
@@ -3276,7 +3333,7 @@ pub fn dict_method_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// mutations on the dict are visible through the view, matching
 /// `W_DictViewKeysObject`'s behaviour.
 pub fn dict_method_keys(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "keys")?;
     let dict = resolve_dict_backing(args[0]);
     if dict.is_null() {
         // Type-erased fallback: the receiver isn't a dict, surface
@@ -3297,7 +3354,7 @@ pub fn dict_method_keys(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// `pypy/objspace/std/dictmultiobject.py:descr_values` parity — same
 /// shape as `descr_keys`, kind tag `Values`.
 pub fn dict_method_values(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "values")?;
     let dict = resolve_dict_backing(args[0]);
     if dict.is_null() {
         return Ok(pyre_object::dictmultiobject::w_dict_view_new(
@@ -3314,7 +3371,7 @@ pub fn dict_method_values(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// `pypy/objspace/std/dictmultiobject.py:descr_items` parity — same
 /// shape as `descr_keys`, kind tag `Items`.
 pub fn dict_method_items(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "items")?;
     let dict = resolve_dict_backing(args[0]);
     if dict.is_null() {
         return Ok(pyre_object::dictmultiobject::w_dict_view_new(
@@ -3455,7 +3512,7 @@ pub fn dict_init_or_update(
     args: &[PyObjectRef],
     name: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "dict init_or_update needs the receiver");
+    require_receiver(args, "update")?;
     let (positional, kwargs_dict) = crate::builtins::split_builtin_kwargs(args);
     if positional.len() > 2 {
         return Err(crate::PyError::type_error(format!(
@@ -3494,7 +3551,7 @@ pub fn dict_init_or_update(
 /// `dictmultiobject.py:137-139 descr_update` → `init_or_update`; the verb in
 /// the arity error is `update`.
 pub fn dict_method_update(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty(), "dict.update() needs the receiver");
+    require_receiver(args, "update")?;
     dict_init_or_update(args, "update")
 }
 
@@ -3573,7 +3630,7 @@ fn dict_sync_dict_storage_proxy(dict: PyObjectRef) {
 /// `strategy.pop(self, w_key, w_default)` — single-operation pop
 /// via strategy dispatch (one hash).
 pub fn dict_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "dict.pop() takes at least 1 argument");
+    arity_at_least(args, "pop", 1)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
     let default = args.get(2).copied();
@@ -3604,7 +3661,7 @@ pub fn dict_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// inserted pair); pyre's `w_dict_items` preserves insertion order
 /// so popping the last entry matches the spec.
 pub fn dict_method_popitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    require_receiver(args, "popitem")?;
     let dict = resolve_dict_backing(args[0]);
     if dict.is_null() {
         return Err(crate::PyError::key_error("popitem(): dictionary is empty"));
@@ -3627,7 +3684,7 @@ pub fn dict_method_popitem(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `self.setdefault(w_key, w_default)` — delegates to
 /// `strategy.setdefault` as a single atomic operation (one hash).
 pub fn dict_method_setdefault(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2);
+    arity_at_least(args, "setdefault", 1)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
     let default = args.get(2).copied().unwrap_or_else(w_none);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -9527,17 +9527,17 @@ fn bytes_search(args: &[PyObjectRef], forward: bool) -> Result<i64, crate::PyErr
 }
 
 fn bytes_method_find(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "find() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "find", 1)?;
     Ok(pyre_object::w_int_new(bytes_search(args, true)?))
 }
 
 fn bytes_method_rfind(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "rfind() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "rfind", 1)?;
     Ok(pyre_object::w_int_new(bytes_search(args, false)?))
 }
 
 fn bytes_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "index() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "index", 1)?;
     let res = bytes_search(args, true)?;
     if res < 0 {
         return Err(crate::PyError::value_error("subsection not found"));
@@ -9546,7 +9546,7 @@ fn bytes_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 }
 
 fn bytes_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "rindex() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "rindex", 1)?;
     let res = bytes_search(args, false)?;
     if res < 0 {
         return Err(crate::PyError::value_error("subsection not found"));
@@ -9555,7 +9555,7 @@ fn bytes_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 }
 
 fn bytes_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "count() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "count", 1)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let sub = bytes_sub_arg(args[1])?;
     let Some((start, end)) = bytes_idx_window(data.len(), args)? else {
@@ -9616,7 +9616,7 @@ fn bytes_prefix_match(
 }
 
 fn bytes_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "startswith() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "startswith", 1)?;
     Ok(pyre_object::w_bool_from(bytes_prefix_match(
         args,
         "startswith",
@@ -9625,7 +9625,7 @@ fn bytes_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 }
 
 fn bytes_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "endswith() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "endswith", 1)?;
     Ok(pyre_object::w_bool_from(bytes_prefix_match(
         args, "endswith", false,
     )?))
@@ -9651,7 +9651,7 @@ fn empty_bytes_like(recv: PyObjectRef) -> PyObjectRef {
 }
 
 fn bytes_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "upper")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let out: Vec<u8> = data.iter().map(|b| b.to_ascii_uppercase()).collect();
     Ok(new_bytes_like(args[0], &out))
@@ -9659,7 +9659,7 @@ fn bytes_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 
 /// `bytesobject.py:247 descr_lower` — ASCII-only case mapping.
 fn bytes_method_lower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "lower")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let out: Vec<u8> = data.iter().map(|b| b.to_ascii_lowercase()).collect();
     Ok(new_bytes_like(args[0], &out))
@@ -9708,17 +9708,17 @@ fn bytes_strip(
 }
 
 fn bytes_method_strip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "strip")?;
     bytes_strip(args, true, true)
 }
 
 fn bytes_method_lstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "lstrip")?;
     bytes_strip(args, true, false)
 }
 
 fn bytes_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "rstrip")?;
     bytes_strip(args, false, true)
 }
 
@@ -9968,12 +9968,12 @@ fn bytes_split(args: &[PyObjectRef], forward: bool) -> Result<PyObjectRef, crate
 }
 
 fn bytes_method_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "split")?;
     bytes_split(args, true)
 }
 
 fn bytes_method_rsplit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "rsplit")?;
     bytes_split(args, false)
 }
 
@@ -10236,7 +10236,7 @@ fn bytes_fill_char(args: &[PyObjectRef], idx: usize, method: &str) -> Result<u8,
 
 /// `stringmethods.py:descr_ljust` — left-justify within `width`.
 fn bytes_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "ljust() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "ljust", 1)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let fill = bytes_fill_char(args, 2, "ljust")?;
@@ -10251,7 +10251,7 @@ fn bytes_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 
 /// `stringmethods.py:descr_rjust` — right-justify within `width`.
 fn bytes_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "rjust() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "rjust", 1)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let fill = bytes_fill_char(args, 2, "rjust")?;
@@ -10268,7 +10268,7 @@ fn bytes_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 /// fill byte (for odd padding) follows PyPy's `d//2 + (d & width & 1)`
 /// left-offset.
 fn bytes_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "center() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "center", 1)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let fill = bytes_fill_char(args, 2, "center")?;
@@ -10287,7 +10287,7 @@ fn bytes_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// `bytesobject.py:descr_zfill` — left-pad with `b'0'` to `width`,
 /// keeping a leading `+`/`-` sign ahead of the zeros.
 fn bytes_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "zfill() takes exactly one argument");
+    crate::type_methods::arity_at_least(args, "zfill", 1)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let len = data.len() as i64;
@@ -10417,7 +10417,7 @@ fn bytes_method_removesuffix(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 /// the optional `delete` set.  `delete` may be positional or the
 /// `delete=` keyword.
 fn bytes_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "translate() takes at least 1 argument");
+    crate::type_methods::arity_at_least(args, "translate", 1)?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     let Some(&table_obj) = positional.first() else {
@@ -10481,7 +10481,7 @@ fn bytes_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// on each emitted line, and a trailing terminator does not produce an
 /// extra empty entry.
 fn bytes_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "splitlines")?;
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
     crate::builtins::kwarg_reject_unknown(kwargs, &["keepends"], "splitlines")?;
     crate::builtins::kwarg_reject_duplicate(
@@ -10526,7 +10526,7 @@ fn bytes_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// current line (the column resets on `\n` / `\r`); a non-positive
 /// `tabsize` drops tabs entirely.
 fn bytes_method_expandtabs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "expandtabs")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
     let tabsize = match pos
@@ -10800,7 +10800,7 @@ fn bytearray_fromhex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 /// Returns a string of hex pairs.  Optional `sep` (single byte/char)
 /// inserts between pairs; `bytes_per_sep` controls the grouping.
 pub(crate) fn bytes_method_hex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "hex")?;
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
     crate::builtins::kwarg_reject_unknown(kwargs, &["sep", "bytes_per_sep"], "hex")?;
     crate::builtins::kwarg_reject_duplicate(kwargs, "hex", "sep", pos.get(1).is_some())?;
@@ -11393,7 +11393,7 @@ fn decode_utf8_with_errors(data: &[u8], err_mode: &str) -> Result<Wtf8Buf, crate
 
 /// bytesobject.py descr_decode → stringmethods.py:196 decode_object
 pub(crate) fn bytes_method_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "decode")?;
     // `bytes.decode(encoding='utf-8', errors='strict')` — both parameters
     // are positional-or-keyword, so accept them from either side.
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
@@ -11523,7 +11523,7 @@ pub(crate) fn bytes_method_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, c
 
 /// PyPy: bytesobject.py descr_repr — returns a quoted literal like `b'hello'`.
 fn bytes_method_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "__repr__")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     // Determine preferred quote: single unless the data contains single but
     // not double quote (matches CPython).
@@ -11682,7 +11682,7 @@ fn bytearray_byte_arg(obj: PyObjectRef) -> Result<u8, crate::PyError> {
 
 /// `bytearrayobject.py:descr_append` — append one byte in place.
 fn bytearray_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "append() takes exactly one argument");
+    crate::type_methods::arity_at_least(args, "append", 1)?;
     let b = bytearray_byte_arg(args[1])?;
     unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).push(b) };
     Ok(pyre_object::w_none())
@@ -11691,7 +11691,7 @@ fn bytearray_method_append(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `bytearrayobject.py:descr_extend` — append a bytes-like object's
 /// bytes, or each integer yielded by an iterable.
 fn bytearray_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "extend() takes exactly one argument");
+    crate::type_methods::arity_at_least(args, "extend", 1)?;
     let other = args[1];
     // Materialize the new bytes before mutating so `x.extend(x)` is safe.
     let appended: Vec<u8> = unsafe {
@@ -11713,7 +11713,7 @@ fn bytearray_method_extend(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `bytearrayobject.py:descr_insert` — insert one byte before `index`,
 /// clamping out-of-range indices (negative counts from the end).
 fn bytearray_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 3, "insert() takes exactly 2 arguments");
+    crate::type_methods::arity_at_least(args, "insert", 2)?;
     let index = crate::builtins::space_index_w(args[1])?;
     let b = bytearray_byte_arg(args[2])?;
     unsafe {
@@ -11728,7 +11728,7 @@ fn bytearray_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `bytearrayobject.py:descr_remove` — remove the first byte equal to
 /// `value`; ValueError when absent.
 fn bytearray_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(args.len() >= 2, "remove() takes exactly one argument");
+    crate::type_methods::arity_at_least(args, "remove", 1)?;
     let b = bytearray_byte_arg(args[1])?;
     unsafe {
         let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]);
@@ -11745,7 +11745,7 @@ fn bytearray_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// `bytearrayobject.py:descr_pop` — remove and return the byte at
 /// `index` (default last); IndexError when empty or out of range.
 fn bytearray_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "pop")?;
     unsafe {
         let vec = pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]);
         let len = vec.len() as i64;
@@ -11774,14 +11774,14 @@ fn bytearray_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// `bytearrayobject.py:descr_reverse` — reverse the bytes in place.
 fn bytearray_method_reverse(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "reverse")?;
     unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).reverse() };
     Ok(pyre_object::w_none())
 }
 
 /// `bytearrayobject.py:descr_clear` — empty the bytearray in place.
 fn bytearray_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "clear")?;
     unsafe { pyre_object::bytearrayobject::w_bytearray_vec_mut(args[0]).clear() };
     Ok(pyre_object::w_none())
 }
@@ -11789,7 +11789,7 @@ fn bytearray_method_clear(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 /// `bytearrayobject.py:descr_copy` — return a new bytearray with the
 /// same bytes.
 fn bytearray_method_copy(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    assert!(!args.is_empty());
+    crate::type_methods::require_receiver(args, "copy")?;
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     Ok(pyre_object::bytearrayobject::w_bytearray_from_bytes(data))
 }
@@ -11885,7 +11885,7 @@ fn init_bytearray_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "__add__",
             |args| {
-                assert!(args.len() >= 2, "__add__ requires 2 arguments");
+                crate::type_methods::arity_at_least(args, "__add__", 1)?;
                 let a = args[0];
                 let b = args[1];
                 unsafe {
@@ -11910,7 +11910,7 @@ fn init_bytearray_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "__iadd__",
             |args| {
-                assert!(args.len() >= 2);
+                crate::type_methods::arity_at_least(args, "__iadd__", 1)?;
                 let ba = args[0];
                 let other = args[1];
                 unsafe {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5004,6 +5004,29 @@ pub extern "C" fn bh_get_current_exception() -> i64 {
     pyre_interpreter::eval::get_current_exception() as i64
 }
 
+/// `eval.rs:2624-2637 raise_varargs(0)` — the value a bare `raise` re-raises.
+///
+/// Returns the active exception when `sys_exc_value` holds a live
+/// `BaseException`; otherwise (null / `None` / non-exception) returns a fresh
+/// `RuntimeError("No active exception to reraise")` instance.  The codewriter
+/// emits this for a bare `RAISE_VARARGS(0)` whose FrameState carries no
+/// `last_exception` pair — where the runtime current-exception may be absent —
+/// so the following `raise/r` always receives a non-null value
+/// (`blackhole.py:1002` asserts non-null).  Unlike raw `get_current_exception`,
+/// this can allocate (the `RuntimeError`), so it is registered `Plain`, not
+/// `PlainCannotRaiseNoHeap`.
+pub extern "C" fn bh_reraise_varargs_zero() -> i64 {
+    let exc = pyre_interpreter::eval::get_current_exception();
+    unsafe {
+        if !exc.is_null() && pyre_object::is_exception(exc) {
+            exc as i64
+        } else {
+            pyre_interpreter::PyError::runtime_error("No active exception to reraise")
+                .to_exc_object() as i64
+        }
+    }
+}
+
 /// Store `exc` into the per-thread `CURRENT_EXCEPTION` slot. Matches
 /// the write at `pyopcode.py:778 POP_EXCEPT` (restore of saved
 /// sys_exc_info) and at `pyopcode.py:786 PUSH_EXC_INFO` (new raised

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2071,6 +2071,11 @@ thread_local! {
         // coherent across collections (otherwise `get_or_make_weakref`'s
         // cache returns a dangling pointer after a minor cycle).
         majit_gc::shadow_stack::register_extra_root_walker(weakref_box_inner_root_walker);
+        // `W_SRE_Pattern` instances are immortal, so the collector never
+        // traces their GC-heap `w_pattern` / `w_groupindex` / `w_indexgroup`
+        // slots. Walk them as roots so a compiled pattern's named-group dict
+        // stays live (otherwise `groupdict()` iterates a reclaimed dict).
+        majit_gc::shadow_stack::register_extra_root_walker(sre_pattern_root_walker);
         // JIT-created callee frames (frame arena + heap fallbacks) hold
         // GC refs in their locals arrays but sit on no
         // `CURRENT_FRAME`/`f_backref` chain while compiled code runs,
@@ -2290,6 +2295,12 @@ fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 
 fn weakref_box_inner_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_object::weakref::walk_gc_weakref_box_inner_roots(|slot| {
+        visit_pyobject_root(slot, visitor);
+    });
+}
+
+fn sre_pattern_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    pyre_object::interp_sre::walk_sre_pattern_roots(|slot| {
         visit_pyobject_root(slot, visitor);
     });
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2063,7 +2063,9 @@ thread_local! {
         // The signal-handler table (`signal.interp_signal::HANDLERS`) is an
         // immortal dict, so the collector does not trace its heap handler
         // callables. Walk its value slots as roots so a handler reachable
-        // only through it survives `gc.collect`.
+        // only through it survives `gc.collect`. The `signal` module is not
+        // built for wasm, so there is no handler table to walk there.
+        #[cfg(not(target_arch = "wasm32"))]
         majit_gc::shadow_stack::register_extra_root_walker(signal_handler_root_walker);
         // `GcWeakrefBox` instances are immortal, so the collector never
         // relocates / retains their inline `inner` Weakref pointer. Walk
@@ -2287,6 +2289,7 @@ fn pyre_interpreter_side_table_root_walker(visitor: &mut dyn FnMut(&mut majit_ir
     });
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_interpreter::module::signal::interp_signal::walk_signal_handler_roots(|slot| {
         visit_pyobject_root(slot, visitor);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2060,6 +2060,11 @@ thread_local! {
         // normally traced by the translated GC. Walk its value slots
         // explicitly until the table is folded into the object layout.
         majit_gc::shadow_stack::register_extra_root_walker(pyre_interpreter_side_table_root_walker);
+        // The signal-handler table (`signal.interp_signal::HANDLERS`) is an
+        // immortal dict, so the collector does not trace its heap handler
+        // callables. Walk its value slots as roots so a handler reachable
+        // only through it survives `gc.collect`.
+        majit_gc::shadow_stack::register_extra_root_walker(signal_handler_root_walker);
         // JIT-created callee frames (frame arena + heap fallbacks) hold
         // GC refs in their locals arrays but sit on no
         // `CURRENT_FRAME`/`f_backref` chain while compiled code runs,
@@ -2267,6 +2272,12 @@ fn visit_pyobject_root(
 
 fn pyre_interpreter_side_table_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_interpreter::objspace::std::mapdict::walk_mapdict_roots(|slot| {
+        visit_pyobject_root(slot, visitor);
+    });
+}
+
+fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    pyre_interpreter::module::signal::interp_signal::walk_signal_handler_roots(|slot| {
         visit_pyobject_root(slot, visitor);
     });
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2065,6 +2065,12 @@ thread_local! {
         // callables. Walk its value slots as roots so a handler reachable
         // only through it survives `gc.collect`.
         majit_gc::shadow_stack::register_extra_root_walker(signal_handler_root_walker);
+        // `GcWeakrefBox` instances are immortal, so the collector never
+        // relocates / retains their inline `inner` Weakref pointer. Walk
+        // those slots as roots so a cached weakref's boxed Weakref stays
+        // coherent across collections (otherwise `get_or_make_weakref`'s
+        // cache returns a dangling pointer after a minor cycle).
+        majit_gc::shadow_stack::register_extra_root_walker(weakref_box_inner_root_walker);
         // JIT-created callee frames (frame arena + heap fallbacks) hold
         // GC refs in their locals arrays but sit on no
         // `CURRENT_FRAME`/`f_backref` chain while compiled code runs,
@@ -2278,6 +2284,12 @@ fn pyre_interpreter_side_table_root_walker(visitor: &mut dyn FnMut(&mut majit_ir
 
 fn signal_handler_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     pyre_interpreter::module::signal::interp_signal::walk_signal_handler_roots(|slot| {
+        visit_pyobject_root(slot, visitor);
+    });
+}
+
+fn weakref_box_inner_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    pyre_object::weakref::walk_gc_weakref_box_inner_roots(|slot| {
         visit_pyobject_root(slot, visitor);
     });
 }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3380,6 +3380,7 @@ struct FnPtrIndices {
     call_fn_13: HelperHandle,
     call_fn_14: HelperHandle,
     get_current_exception_fn: HelperHandle,
+    reraise_varargs_zero_fn: HelperHandle,
     set_current_exception_fn: HelperHandle,
     load_attr_fn: HelperHandle,
     load_method_self_fn: HelperHandle,
@@ -3870,6 +3871,16 @@ fn register_helper_fn_pointers(
         cpu.for_iter_next_fn as *const (),
         CallFlavor::MayForce,
     );
+    // `bh_reraise_varargs_zero` reads the TLS current-exception and, when none
+    // is live, allocates a `RuntimeError` (`raise_varargs(0)`, eval.rs:2624):
+    // can `MemoryError`, runs no user code, does not force virtuals →
+    // `CallFlavor::Plain` (symmetric with `newtuple_from_array_fn`).  Appended
+    // last to preserve fn_ptr indices.
+    let reraise_varargs_zero_fn = bind(
+        assembler,
+        cpu.reraise_varargs_zero_fn as *const (),
+        CallFlavor::Plain,
+    );
     FnPtrIndices {
         call_fn,
         load_global_fn,
@@ -3904,6 +3915,7 @@ fn register_helper_fn_pointers(
         call_fn_13,
         call_fn_14,
         get_current_exception_fn,
+        reraise_varargs_zero_fn,
         set_current_exception_fn,
         load_attr_fn,
         load_method_self_fn,
@@ -5238,6 +5250,11 @@ impl CodeWriter {
                 HelperHandle {
                     idx: get_current_exception_fn_idx,
                     flavor: _get_current_exception_fn_flavor,
+                },
+            reraise_varargs_zero_fn:
+                HelperHandle {
+                    idx: reraise_varargs_zero_fn_idx,
+                    flavor: _reraise_varargs_zero_fn_flavor,
                 },
             set_current_exception_fn:
                 HelperHandle {
@@ -8257,17 +8274,52 @@ impl CodeWriter {
                                 // `graph.exceptblock` (no catch adjacency), so a
                                 // covered bare raise escapes the frame.
                                 let covered = catch_for_pc.get(py_pc).copied().flatten().is_some();
-                                if covered && current_state.last_exception.is_some() {
-                                    // Materialize the active exception via
-                                    // `get_current_exception()` — exactly what
-                                    // `raise_varargs(0)` re-raises
-                                    // (eval.rs:2549).  The per-thread current-
-                                    // exception slot is maintained by
-                                    // `PUSH_EXC_INFO` / `POP_EXCEPT` and survives
-                                    // the compiled-trace ↔ blackhole resume
-                                    // boundary, unlike the blackhole-local
-                                    // `exception_last_value` field (only set when
-                                    // the blackhole itself routes a catch).
+                                if current_state.last_exception.is_none() {
+                                    // No statically-live handler exception seeded the
+                                    // FrameState, so the runtime current-exception may
+                                    // be null / None — a bare `raise` reached by normal
+                                    // fall-through (e.g. in a `finally`) rather than by
+                                    // exception propagation.  Materialize the value the
+                                    // interpreter's `raise_varargs(0)` (eval.rs:2624)
+                                    // re-raises: the active exception when live, else a
+                                    // `RuntimeError("No active exception to reraise")`.
+                                    // `bh_reraise_varargs_zero` performs that
+                                    // null/None/non-exception → RuntimeError
+                                    // normalization so the `raise/r` op always receives
+                                    // a non-null value (`blackhole.py:1002` asserts
+                                    // non-null); materializing raw `get_current_exception()`
+                                    // here would pass null and trip that assert.
+                                    // `emit_raise!` consults `catch_for_pc`, routing a
+                                    // covered PC to its catch landing and an uncovered
+                                    // PC to `graph.exceptblock`.
+                                    let reraise_value = residual_call!(
+                                        reraise_varargs_zero_fn_idx,
+                                        CallFlavor::Plain,
+                                        majit_ir::PyreHelperKind::RaiseVarargs,
+                                        vec![],
+                                        vec![],
+                                        vec![],
+                                        vec![],
+                                        ResKind::Ref,
+                                        py_pc as i64,
+                                    )
+                                    .map(super::flow::FlowValue::from)
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph));
+                                    emit_raise!(0u16, reraise_value, py_pc as i64, true);
+                                } else if covered {
+                                    // Catch-covered bare raise with a live
+                                    // `last_exception` pair: the runtime current-
+                                    // exception is non-null (we are inside a handler),
+                                    // so materialize it via `get_current_exception()`
+                                    // — exactly what `raise_varargs(0)` re-raises
+                                    // (eval.rs:2624).  The per-thread current-exception
+                                    // slot is maintained by `PUSH_EXC_INFO` /
+                                    // `POP_EXCEPT` and survives the compiled-trace ↔
+                                    // blackhole resume boundary, unlike the
+                                    // blackhole-local `exception_last_value` field
+                                    // (only set when the blackhole itself routes a
+                                    // catch).  `emit_raise!` consults `catch_for_pc`,
+                                    // so this covered PC routes to its catch landing.
                                     let reraise_value = residual_call!(
                                         get_current_exception_fn_idx,
                                         CallFlavor::PlainCannotRaiseNoHeap,
@@ -8283,8 +8335,12 @@ impl CodeWriter {
                                     .unwrap_or_else(|| fresh_ref_value(&mut graph));
                                     emit_raise!(0u16, reraise_value, py_pc as i64, true);
                                 } else {
-                                    // No enclosing handler (or no active
-                                    // exception): function-level exception exit.
+                                    // No enclosing handler, but the state carries a
+                                    // live `last_exception` pair: function-level
+                                    // exception exit via the orthodox `reraise/`
+                                    // coding (`flatten.py:163-174 make_exception_link`
+                                    // matches `link.args == [last_exception,
+                                    // last_exc_value]`).
                                     emit_reraise!();
                                 }
                             }

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -237,6 +237,10 @@ pub struct Cpu {
     pub normalize_raise_varargs_fn: extern "C" fn(i64, i64, i64) -> i64,
     /// Read per-thread `CURRENT_EXCEPTION` — used by `PUSH_EXC_INFO`.
     pub get_current_exception_fn: extern "C" fn() -> i64,
+    /// `raise_varargs(0)` value — the active exception, or a fresh
+    /// `RuntimeError("No active exception to reraise")` when none is live.
+    /// Used by a bare `RAISE_VARARGS(0)` with no static `last_exception` pair.
+    pub reraise_varargs_zero_fn: extern "C" fn() -> i64,
     /// Write per-thread `CURRENT_EXCEPTION` — used by `PUSH_EXC_INFO`
     /// (set to new exc) and `POP_EXCEPT` (restore saved prev).
     pub set_current_exception_fn: extern "C" fn(i64),
@@ -367,6 +371,7 @@ impl Cpu {
             build_slice_fn: crate::call_jit::bh_build_slice_fn,
             normalize_raise_varargs_fn: crate::call_jit::bh_normalize_raise_varargs_with_frame,
             get_current_exception_fn: crate::call_jit::bh_get_current_exception,
+            reraise_varargs_zero_fn: crate::call_jit::bh_reraise_varargs_zero,
             set_current_exception_fn: crate::call_jit::bh_set_current_exception,
             rtyper,
             lowering_ctx: std::sync::RwLock::new(None),

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -4347,6 +4347,21 @@ impl DictStrategy for EmptyKwargsDictStrategy {
         EMPTY_DICT_STRATEGY.get_empty_storage()
     }
 
+    /// An empty kwargs dict has the `erased(None)` null `dstorage` from
+    /// `w_dict_new_kwargs` and holds no entries — `setitem`/`setitem_str`
+    /// switch to a concrete strategy before storing — so there is nothing
+    /// to trace.  This overrides (rather than inherits `EmptyDictStrategy`'s
+    /// trait-default) walk, which would unerase the null `dstorage` as an
+    /// `IndexMap` and dereference null. EmptyDictStrategy keeps the default
+    /// walk because its proxy-backed dicts (`w_dict_new_with_storage_proxy`)
+    /// carry mirrored entries in a non-null `dstorage`.
+    unsafe fn walk_gc_refs(
+        &self,
+        _w_dict: PyObjectRef,
+        _visitor: &mut dyn FnMut(*mut PyObjectRef),
+    ) {
+    }
+
     unsafe fn getitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> Option<PyObjectRef> {
         EMPTY_DICT_STRATEGY.getitem(w_dict, w_key)
     }

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -40,7 +40,7 @@ impl crate::lltype::GcType for GeneratorIterator {
 }
 
 pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
-    crate::lltype::malloc_typed(GeneratorIterator {
+    let value = GeneratorIterator {
         ob: PyObject {
             ob_type: &GENERATOR_TYPE as *const PyType,
             w_class: get_instantiate(&GENERATOR_TYPE),
@@ -49,7 +49,30 @@ pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
         started: false,
         exhausted: false,
         running: false,
-    }) as PyObjectRef
+    };
+    // A generator must be GC-managed, not immortal `malloc_typed`: the
+    // collector never reaches an immortal object, so the registered
+    // `generator_object_custom_trace` (which walks the SUSPENDED frame's
+    // locals/cells/valuestack via `walk_suspended_generator_frame`) would
+    // never run, and a value live only across a `yield` would be reclaimed by
+    // a major collection — resuming the generator then dereferences freed
+    // memory. Allocate stable (non-moving old-gen) so the many raw
+    // `*GeneratorIterator` / `frame_ptr` readers keep a fixed address, and
+    // fall back to the immortal alloc only when the GC is not installed.
+    if let Some(raw) =
+        crate::gc_hook::try_gc_alloc_stable(W_GENERATOR_GC_TYPE_ID, W_GENERATOR_OBJECT_SIZE)
+            .filter(|p| !p.is_null())
+    {
+        crate::gc_interp::note_alloc();
+        unsafe {
+            std::ptr::write(raw as *mut GeneratorIterator, value);
+        }
+        // The old-gen generator may reference young frame contents (walked via
+        // the custom trace), so remember it for the next minor's tracer.
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as PyObjectRef;
+    }
+    crate::lltype::malloc_typed(value) as PyObjectRef
 }
 
 #[inline]

--- a/pyre/pyre-object/src/interp_sre.rs
+++ b/pyre/pyre-object/src/interp_sre.rs
@@ -30,6 +30,33 @@ pub struct W_SRE_Pattern {
     pub w_indexgroup: PyObjectRef,
 }
 
+thread_local! {
+    /// Every `W_SRE_Pattern` ever allocated. Patterns are `malloc_typed`
+    /// (immortal, off-GC), so the collector never traces into them: their
+    /// GC-heap `w_pattern` / `w_groupindex` / `w_indexgroup` slots would be
+    /// reclaimed (or relocated without updating the slot) by a collection,
+    /// and a later `groupdict()` / `group("name")` would iterate / read a
+    /// dangling dict. Walking these slots as roots (see
+    /// [`walk_sre_pattern_roots`]) keeps them coherent, as the signal
+    /// handler-table and weakref-box walkers do for their immortal storage.
+    static SRE_PATTERNS: std::cell::RefCell<Vec<*mut W_SRE_Pattern>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Visit each immortal pattern's GC-heap `PyObjectRef` slots as roots.
+pub fn walk_sre_pattern_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
+    SRE_PATTERNS.with(|b| {
+        for &p in b.borrow().iter() {
+            if p.is_null() {
+                continue;
+            }
+            visitor(unsafe { &mut (*p).w_pattern });
+            visitor(unsafe { &mut (*p).w_groupindex });
+            visitor(unsafe { &mut (*p).w_indexgroup });
+        }
+    });
+}
+
 /// Allocate a `W_SRE_Pattern` — `SRE_Pattern__new__` field stamping
 /// (interp_sre.py:624-639).
 pub fn w_sre_pattern_new(
@@ -45,7 +72,7 @@ pub fn w_sre_pattern_new(
     crate::gc_roots::pin_root(w_pattern);
     crate::gc_roots::pin_root(w_groupindex);
     crate::gc_roots::pin_root(w_indexgroup);
-    W_SRE_Pattern::allocate(W_SRE_Pattern {
+    let obj = W_SRE_Pattern::allocate(W_SRE_Pattern {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
@@ -57,7 +84,9 @@ pub fn w_sre_pattern_new(
         num_groups,
         w_groupindex,
         w_indexgroup,
-    })
+    });
+    SRE_PATTERNS.with(|b| b.borrow_mut().push(obj as *mut W_SRE_Pattern));
+    obj
 }
 
 /// # Safety

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -209,7 +209,15 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
         ob_type: &LONG_TYPE as *const PyType,
         w_class: get_instantiate(&INT_TYPE),
     };
-    if crate::gc_interp::enabled() {
+    // The wrapper must be GC-managed whenever its `value` payload is: a
+    // `BigInt` routed through the GC (`bigint_gc_type_id() != 0`, the
+    // `alloc_bigint_*` condition) is reclaimed by collections, so an immortal
+    // `malloc_typed` wrapper — which the collector never traces — would let a
+    // major collection run the payload's destructor (freeing the limb `Vec`)
+    // while the wrapper still points at it. Tie the wrapper's GC path to the
+    // same predicate as the payload, not to `gc_interp::enabled()` alone
+    // (unlike int/float, whose payload is inline and carries no destructor).
+    if crate::gc_interp::enabled() || bigint_gc_type_id() != 0 {
         // Pin the (possibly young) `value` payload across the wrapper malloc:
         // a minor collection inside `try_gc_alloc_stable` can move a young
         // bigint, so re-read its address afterwards. The proxy/dictproxy

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -201,6 +201,15 @@ pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> P
                 },
             );
         }
+        // The tuple lives in old-gen (`try_gc_alloc_stable`) but `value0` /
+        // `value1` may still be in the nursery. Without recording the store,
+        // the next minor collection scans only the remembered set, never
+        // visits this tuple, and reclaims a young element reachable solely
+        // through it — leaving an inline slot dangling. Register the tuple so
+        // the collection relocates/marks the young elements, mirroring the
+        // `write_barrier_from_array` an old-gen store emits
+        // (incminimark.py:1495) and `w_tuple_new_array_backed`.
+        crate::gc_hook::try_gc_write_barrier(raw);
         return raw as PyObjectRef;
     }
     Box::into_raw(Box::new(W_SpecialisedTupleObject_oo {

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -359,7 +359,7 @@ pub fn w_type_new_builtin(
     let _roots = crate::gc_roots::push_roots();
     crate::gc_roots::pin_root(bases);
 
-    crate::lltype::malloc_typed(W_TypeObject {
+    let w_type = crate::lltype::malloc_typed(W_TypeObject {
         ob_header: PyObject {
             ob_type: &TYPE_TYPE as *const PyType,
             w_class: std::ptr::null_mut(),
@@ -394,7 +394,15 @@ pub fn w_type_new_builtin(
         // generator / coroutine / frame typedefs flip it via
         // `w_type_set_disallow_instantiation`.
         flag_disallow_instantiation: std::sync::atomic::AtomicBool::new(false),
-    }) as PyObjectRef
+    }) as PyObjectRef;
+    // A builtin type is Box-immortal just like a heap type, so its namespace
+    // values, `bases`, and the lazily-cached `type.__dict__` `mirror_target`
+    // are reachable only through `walk_type_dicts_gc` (`pyre_interpreter
+    // ::eval`).  Register it so that walk forwards them; without this a
+    // collection reclaims the cached `__dict__` wrapper and the next
+    // `cls.__dict__` access reads a dangling pointer.
+    register_heap_type(w_type as usize);
+    w_type
 }
 
 /// `dictmultiobject.py:153 UNKNOWN` — cache miss; recompute via

--- a/pyre/pyre-object/src/weakref.rs
+++ b/pyre/pyre-object/src/weakref.rs
@@ -127,6 +127,20 @@ impl crate::lltype::GcType for GcWeakrefBox {
     const SIZE: usize = GC_WEAKREF_BOX_OBJECT_SIZE;
 }
 
+thread_local! {
+    /// Every `GcWeakrefBox` ever allocated. The box is `malloc_typed`
+    /// (immortal, off-GC) so the collector never traces into it, which
+    /// would leave its `inner` `*mut Weakref` slot un-relocated /
+    /// un-retained across a collection — the boxed Weakref would be swept
+    /// (or moved without updating `inner`) and `w_gc_weakref_box_deref`
+    /// would read a dangling slot. Walking these `inner` slots as roots
+    /// (see [`walk_gc_weakref_box_inner_roots`]) keeps each boxed Weakref
+    /// alive and relocates the slot in place, exactly as the signal
+    /// handler-table walker does for its immortal dict.
+    static WEAKREF_BOXES: std::cell::RefCell<Vec<*mut GcWeakrefBox>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
 /// Allocate a `GcWeakrefBox` wrapping a fresh rweakref to `target`.
 /// Returns null when no GC hook is installed (test environments that
 /// did not wire `pyre-jit`) or when `target` itself is null.
@@ -138,13 +152,33 @@ pub fn w_gc_weakref_box_new(target: PyObjectRef) -> PyObjectRef {
     if inner.is_null() {
         return std::ptr::null_mut();
     }
-    crate::lltype::malloc_typed(GcWeakrefBox {
+    let boxed = crate::lltype::malloc_typed(GcWeakrefBox {
         ob_header: PyObject {
             ob_type: &GC_WEAKREF_BOX_TYPE as *const PyType,
             w_class: get_instantiate(&GC_WEAKREF_BOX_TYPE),
         },
         inner,
-    }) as PyObjectRef
+    });
+    WEAKREF_BOXES.with(|b| b.borrow_mut().push(boxed));
+    boxed as PyObjectRef
+}
+
+/// Visit each immortal box's `inner` Weakref pointer as a strong GC root.
+/// The collector keeps the Weakref alive and rewrites the slot after a
+/// relocation; its `weakptr` is still cleared independently by
+/// `invalidate_young_weakrefs` / `invalidate_old_weakrefs` when the
+/// weakly-referenced target dies, so weak semantics are preserved while
+/// the box's `inner` slot stays coherent.
+pub fn walk_gc_weakref_box_inner_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
+    WEAKREF_BOXES.with(|b| {
+        for &boxed in b.borrow().iter() {
+            if boxed.is_null() {
+                continue;
+            }
+            let inner_slot = unsafe { std::ptr::addr_of_mut!((*boxed).inner) } as *mut PyObjectRef;
+            visitor(unsafe { &mut *inner_slot });
+        }
+    });
 }
 
 /// `isinstance(obj, GcWeakrefBox)` predicate.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -166,6 +166,10 @@ fn real_main(binary_name: &str) {
     // user statement, not only after the first JIT-traced bytecode.
     pyre_jit::eval::init_jit_hooks();
 
+    // Record `-S` before the first `import sys` so `sys.flags.no_site`
+    // reflects whether site initialization was skipped.
+    importing::set_no_site(no_site);
+
     match mode {
         RunMode::Command(cmd) => {
             // Initialize sys.path with CWD for -c mode.

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -471,6 +471,13 @@ fn run_source(source: &str, mode: Mode, filename: &str, no_site: bool) {
         );
     }
 
+    // `sys.path` is created as an empty placeholder; mirror the native search
+    // path into it before `site` and user code read it (run_module does the
+    // same after its importlib bootstrap). `sync_python_sys_path` needs `sys`
+    // loaded, so import it first.
+    let _ = importing::importhook("sys", canonical, pyre_object::PY_NULL, 0, ec_ptr);
+    importing::sync_python_sys_path();
+
     import_site(no_site, canonical, ec_ptr);
 
     match eval_with_jit(&mut frame) {

--- a/pyre/pyrex/src/repl.rs
+++ b/pyre/pyrex/src/repl.rs
@@ -93,6 +93,10 @@ pub fn run_repl(quiet: bool, no_site: bool) {
     };
     configure_sys_for_repl(sys_module);
 
+    // Mirror the native search path into Python `sys.path` (an empty
+    // placeholder until now) before `site` and interactive input read it.
+    importing::sync_python_sys_path();
+
     crate::import_site(no_site, canonical, Rc::as_ptr(&execution_context));
 
     let runtime = ReplRuntime {


### PR DESCRIPTION
post #188

Next round of CPython 3.14 test-suite compatibility work on the `test-infra` branch. Two axes: interpreter/GC correctness fixes surfaced by running the suite, plus a handful of stdlib/builtin gaps. `check.py` is green on both backends (dynasm 166/166 + cranelift 166/166).

## Moving-GC root / use-after-free fixes
Objects reachable only through immortal or off-heap tables were not walked by the collector, so a minor/major collection could move or free a live child and leave a dangling pointer. Each fix registers the missing edge as a GC root or write-barriers the store:

- `majit-gc`: invalidate weakrefs born in the old generation (were never registered → dangling on collect).
- `generator`: GC-manage `GeneratorIterator` so its suspended-frame custom trace runs.
- `longobject`: gate the `W_LongObject` wrapper GC alloc on the bigint payload's GC condition.
- `_sre`: trace immortal `W_SRE_Pattern` `PyObjectRef` fields as GC roots.
- `weakref`: trace `GcWeakrefBox` inner weakref and fresh weakref instances as roots.
- `signal`: trace immortal handler-table values as roots.
- `specialisedtupleobject`: write-barrier the arity-2 object tuple at construction.
- `typeobject`: register builtin types as GC roots for the namespace walk.
- `EmptyKwargsDictStrategy`: no-op `walk_gc_refs` over the null erased storage.
- `function`: allocate `BuiltinCode`-backed functions immortal.

## Exception / trace correctness
- `eval`: route `bytecode_trace` errors through the frame's exception blocks; pass the raised instance in the `exception_trace` `w_type` slot.
- builtin arity mismatch now raises `TypeError` instead of asserting (generic path + `tuple.count`/`index`).
- lone-surrogate str output/source encoded through the codec error handler instead of panicking in `w_str_get_value`.
- `error`: stamp `ImportError`/`ModuleNotFoundError` `.msg` on the raw-message raise path.

## Stdlib / builtin gaps
- `_imp.get_frozen_object`: raise `ImportError` for unknown frozen names (was returning `None`).
- `LOAD_FROM_DICT_OR_DEREF`: resolve the name from the localsplus table (was indexing `code.names` → OOB on nested generic classes).
- `posix.rename`: expose keyword-only `src_dir_fd`/`dst_dir_fd`, routed to `renameat` on unix via `crt_fd::Borrowed`.
- `open()`: back path-based file objects with raw bytes so non-UTF-8 binary content round-trips exactly (was lossy `from_utf8_lossy`).
- `faulthandler.enable`: accept the `c_stack=` keyword (3.14).
- `sys`: reflect the launcher `-S` flag in `sys.flags.no_site`; propagate `getdictscope()` errors out of `_getframe`.
- `_template`: make `Template`/`Interpolation` final and validate `Interpolation` fields.
- `typeobject`: fold `__abc_tpflags__` into the structural-match marker; short-circuit `type.__flags__` in the getattr path.
- `get_awaitable_iter`: reject re-awaiting a suspended native coroutine.
- `baseobjspace`: pin the seq iterator across `getitem` in the generic next path.
- `pyrex`: mirror the native search path into `sys.path` for `-c`, scripts, and the REPL.

## Test infra
- `cpython_tests`: document that the default gate runs only the PASS subset.

## Verification
`python3 ./pyre/check.py` → dynasm 166/166 + cranelift 166/166, both green. `rename` dir_fd and binary `open()` round-trip verified byte-identical against CPython 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `sys.flags.no_site` and improved `sys.path` syncing during startup and REPL launches.
  * Expanded support for `posix.rename` keyword-only directory file descriptor arguments.
  * Added stronger handling for weak references, generators, signal handlers, and traceback display.

* **Bug Fixes**
  * Fixed several runtime crashes by turning bad argument counts into clear `TypeError`s.
  * Improved handling of `print`, `compile`, file/text output, and exception rendering for non-UTF-8 content and lone surrogates.
  * Corrected coroutine re-await, iterator, weakref, and GC-related behavior.

* **Documentation**
  * Clarified CPython test gating and skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->