### PR TITLE
issue62 P2 multiframe bridge: safe-ON + continuous cross-frame walk (depth-1)

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -608,7 +608,7 @@ impl MiniMarkGC {
             .oldgen
             .alloc_with_card_header(total_size, card_header_bytes);
         let hdr = unsafe { &mut *(ptr as *mut GcHeader) };
-        *hdr = GcHeader::with_flags(type_id, extra_flags);
+        *hdr = GcHeader::with_flags(type_id, self.oldgen_birth_flags(extra_flags));
         self.bytes_made_old_since_cycle = self
             .bytes_made_old_since_cycle
             .saturating_add(card_header_bytes + total_size);
@@ -837,12 +837,36 @@ impl MiniMarkGC {
         *hdr = GcHeader::new(type_id);
     }
 
+    /// Flags for an object born directly into the old generation, adding
+    /// `flags::VISITED` while a major marking cycle is in progress.
+    ///
+    /// pyre's [`OldGen::sweep`] is a flat mark-sweep that frees every object
+    /// lacking `flags::VISITED` — a deliberate simplification of incminimark's
+    /// incremental, position-based arena sweep. Under that flat sweep, an object
+    /// allocated straight into the old generation during marking (a large object
+    /// or a nursery-full fallback) would be white at cycle end and freed while
+    /// still reachable: the one-shot major root scan (`seed_major_roots`) already
+    /// ran, and no minor-collection drag-out re-reaches a non-promoted object.
+    /// Allocating it black preserves the snapshot-at-the-beginning invariant that
+    /// incminimark upholds structurally. Any young pointer later stored into it
+    /// re-enters marking through the write barrier's remembered-set rescan.
+    #[inline]
+    fn oldgen_birth_flags(&self, base: u64) -> u64 {
+        if self.incr_state.marking_in_progress {
+            base | flags::VISITED
+        } else {
+            base
+        }
+    }
+
     /// Allocate directly in old gen (for large objects or post-collection fallback).
     fn alloc_in_oldgen(&mut self, type_id: u32, total_size: usize) -> GcRef {
         let ptr = self.oldgen.alloc(total_size);
         let hdr = unsafe { &mut *(ptr as *mut GcHeader) };
         // Old objects start with TRACK_YOUNG_PTRS set (they need write barrier).
-        *hdr = GcHeader::with_flags(type_id, flags::TRACK_YOUNG_PTRS);
+        // An object born into the old generation while a major marking cycle is
+        // in progress must also be allocated black (see `oldgen_birth_flags`).
+        *hdr = GcHeader::with_flags(type_id, self.oldgen_birth_flags(flags::TRACK_YOUNG_PTRS));
         self.bytes_made_old_since_cycle =
             self.bytes_made_old_since_cycle.saturating_add(total_size);
         let obj_addr = (ptr as usize) + GcHeader::SIZE;
@@ -894,29 +918,16 @@ impl MiniMarkGC {
         // copy_nursery_object mutates oldgen/nursery.
         // Pinned objects are left in place (not copied to old gen).
         let roots: Vec<*mut GcRef> = self.roots.roots.iter().copied().collect();
-        for (_root_idx, root_ptr) in roots.iter().enumerate() {
-            let root_ptr = *root_ptr;
-            let gcref = unsafe { *root_ptr };
-            if !gcref.is_null() && self.is_nursery_object_start(gcref.0) {
-                if self.pinned_objects.contains(&gcref.0) {
-                    continue;
-                }
-                let new_ref = self.copy_nursery_object(gcref.0);
-                unsafe {
-                    *root_ptr = new_ref;
-                }
-            }
+        for root_ptr in roots {
+            let gcref = unsafe { &mut *root_ptr };
+            self.drag_out_root(gcref);
         }
 
         // Phase 1b: Process shadow stack roots.
         // RPython gc.py: GcRootMap_shadowstack — walk the thread-local
         // shadow stack to find GC refs pushed by compiled JIT code.
         crate::shadow_stack::walk_roots(|gcref| {
-            if self.is_nursery_object_start(gcref.0) {
-                if !self.pinned_objects.contains(&gcref.0) {
-                    *gcref = self.copy_nursery_object(gcref.0);
-                }
-            }
+            self.drag_out_root(gcref);
         });
 
         // Phase 1c: Process jitframe shadow stack roots.
@@ -930,9 +941,7 @@ impl MiniMarkGC {
         let mut libc_jf_slots: Vec<*mut majit_ir::GcRef> = Vec::new();
         crate::shadow_stack::walk_jf_roots(|gcref| {
             if self.is_nursery_object_start(gcref.0) {
-                if !self.pinned_objects.contains(&gcref.0) {
-                    *gcref = self.copy_nursery_object(gcref.0);
-                }
+                self.drag_out_root(gcref);
             } else if !gcref.is_null() && self.oldgen.contains(gcref.0) {
                 // RPython parity: old-gen jitframes need their interior
                 // nursery refs traced directly. The custom_trace hook
@@ -949,15 +958,8 @@ impl MiniMarkGC {
             }
         });
         for slot_ptr in libc_jf_slots {
-            let field_ref = unsafe { *slot_ptr };
-            if !field_ref.is_null() && self.is_nursery_object_start(field_ref.0) {
-                if !self.pinned_objects.contains(&field_ref.0) {
-                    let new_ref = self.copy_nursery_object(field_ref.0);
-                    unsafe {
-                        *slot_ptr = new_ref;
-                    }
-                }
-            }
+            let field_ref = unsafe { &mut *slot_ptr };
+            self.drag_out_root(field_ref);
         }
 
         // Phase 1d: Process blackhole interpreter register banks.
@@ -967,11 +969,7 @@ impl MiniMarkGC {
         // (Box arrays); pyre stores raw i64 in Vec<i64> so we walk the
         // explicit thread-local stack of register banks.
         crate::shadow_stack::walk_bh_regs(|gcref| {
-            if self.is_nursery_object_start(gcref.0) {
-                if !self.pinned_objects.contains(&gcref.0) {
-                    *gcref = self.copy_nursery_object(gcref.0);
-                }
-            }
+            self.drag_out_root(gcref);
         });
 
         // blackhole resume construction roots (`resume.py:1312`): the
@@ -980,11 +978,7 @@ impl MiniMarkGC {
         // `push_bh_regs`; forward any already-materialized nursery refs so a
         // later materialization's collection does not strand them.
         crate::shadow_stack::walk_resume_ref_roots(|gcref| {
-            if self.is_nursery_object_start(gcref.0) {
-                if !self.pinned_objects.contains(&gcref.0) {
-                    *gcref = self.copy_nursery_object(gcref.0);
-                }
-            }
+            self.drag_out_root(gcref);
         });
 
         // Phase 1e: framework.py `root_walker.walk_roots` parity — the
@@ -993,20 +987,12 @@ impl MiniMarkGC {
         // so nursery refs held only by a Python frame local or operand-stack
         // slot survive collection.
         crate::walk_active_extra_roots(&mut |gcref| {
-            if self.is_nursery_object_start(gcref.0) {
-                if !self.pinned_objects.contains(&gcref.0) {
-                    *gcref = self.copy_nursery_object(gcref.0);
-                }
-            }
+            self.drag_out_root(gcref);
         });
 
         // Multi-registrar walker fan-out (rd_consts const-pool, etc.).
         crate::shadow_stack::walk_extra_roots(|gcref| {
-            if self.is_nursery_object_start(gcref.0) {
-                if !self.pinned_objects.contains(&gcref.0) {
-                    *gcref = self.copy_nursery_object(gcref.0);
-                }
-            }
+            self.drag_out_root(gcref);
         });
 
         // incminimark parity: during an active marking cycle, old objects
@@ -1253,6 +1239,14 @@ impl MiniMarkGC {
             // that flag. (The source header was copied from the nursery object,
             // which does not carry it.)
             (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::TRACK_YOUNG_PTRS);
+            // A shadow reserved during marking is an old-gen object subject to
+            // the flat sweep; keep it black so the in-progress cycle does not
+            // reclaim the reserved identity home before the object is copied in
+            // (incminimark.py:1747 record_pinned_object_with_shadow). See
+            // `oldgen_birth_flags`.
+            if self.incr_state.marking_in_progress {
+                (*(shadow_hdr_ptr as *mut GcHeader)).set_flag(flags::VISITED);
+            }
             if type_info.item_size > 0 {
                 let len_ofs = type_info.length_offset;
                 *((shadow_obj + len_ofs) as *mut usize) = *((obj_addr + len_ofs) as *const usize);
@@ -1417,6 +1411,40 @@ impl MiniMarkGC {
         }
 
         GcRef(new_obj_addr)
+    }
+
+    /// incminimark.py:2145-2263 `_trace_drag_out` + :2128-2143
+    /// `_trace_drag_out1_marking_phase`, for a nursery object reached
+    /// through a *root* slot during minor collection.
+    ///
+    /// Copies the object out of the nursery (updating `*gcref` to the new
+    /// address) and, when a major marking cycle is in progress, greys the
+    /// promoted copy. The marking phase scans roots only once at cycle
+    /// start (`seed_major_roots`), so an object first made reachable from a
+    /// root *after* that scan — but before the sweep — would otherwise never
+    /// receive `GCFLAG_VISITED` and be freed while still live. Old objects
+    /// reached through `collect_oldrefs_to_nursery` use plain
+    /// `copy_nursery_object` instead: their reachability is re-established by
+    /// tracing the (already-grey/black) parent, so they must not be greyed
+    /// here (matching `_trace_drag_out1` vs `_trace_drag_out1_marking_phase`).
+    #[inline]
+    fn drag_out_root(&mut self, gcref: &mut GcRef) {
+        if !self.is_nursery_object_start(gcref.0) || self.pinned_objects.contains(&gcref.0) {
+            return;
+        }
+        let new_ref = self.copy_nursery_object(gcref.0);
+        *gcref = new_ref;
+        // incminimark.py:2140-2143: append iff (VISITED | PINNED) == 0. pyre's
+        // marking convention sets VISITED at push time (see `seed_major_root`
+        // / `mark_object`), so set it here rather than at pop.
+        if self.incr_state.marking_in_progress {
+            let hdr = unsafe { header_of(new_ref.0) };
+            if unsafe { !(*hdr).has_flag(flags::VISITED) } {
+                unsafe { (*hdr).set_flag(flags::VISITED) };
+                self.incr_state.gray_stack.push(new_ref.0);
+                self.note_nonmoving_nursery_mark(new_ref.0);
+            }
+        }
     }
 
     /// Trace an object's GC pointer fields and update any that point
@@ -1765,9 +1793,40 @@ impl MiniMarkGC {
         self.incr_state.mark_scratch = scratch;
     }
 
+    /// incminimark.py:1793-1799 + :2461-2470 — final snapshot-at-the-beginning
+    /// re-scan before the sweep completes.
+    ///
+    /// Every old object modified since the last minor collection is recorded in
+    /// `remembered_set` (the write barrier's `old_objects_pointing_to_young`) with
+    /// its `TRACK_YOUNG_PTRS` cleared. Such a store may install an `old -> old`
+    /// edge to a still-white object. The per-minor black re-grey in
+    /// `do_collect_nursery` only re-scans modifications up to the last minor; a
+    /// cycle finished at a safepoint *between* minors (`do_collect_oldgen_nonmoving`
+    /// branch A, `gc_step`) leaves the trailing delta unscanned. Under pyre's flat
+    /// [`OldGen::sweep`], those white-but-reachable children would then be freed.
+    /// Re-grey every already-marked modified object and trace transitively so the
+    /// delta is marked before the retain/sweep below. (pyre's marking convention
+    /// sets VISITED at push time, so a black object is simply re-pushed; white
+    /// entries are left for the normal frontier / retain to drop.)
+    fn rescan_remembered_black_and_drain(&mut self) {
+        let snapshot: Vec<usize> = self.remembered_set.iter().copied().collect();
+        for addr in snapshot {
+            if unsafe { (*header_of(addr)).has_flag(flags::VISITED) } {
+                self.incr_state.gray_stack.push(addr);
+            }
+        }
+        while let Some(obj_addr) = self.incr_state.gray_stack.pop() {
+            self.mark_object(obj_addr);
+        }
+    }
+
     /// Complete the sweep phase after incremental marking finishes.
     fn finish_incremental_cycle(&mut self) {
         self.major_collections += 1;
+        // Re-scan the trailing snapshot-at-the-beginning delta (old objects
+        // modified since the last minor) before the sweep, or a cycle finished
+        // between minors frees reachable old->old targets.
+        self.rescan_remembered_black_and_drain();
         // incminimark.py:2961-2965 (and :2495-2499) — clear weak
         // pointers to dying objects before the sweep frees them. The
         // VISITED bit on every old-gen object is still meaningful at
@@ -2268,9 +2327,17 @@ impl MiniMarkGC {
                 }
             }
 
-            // incminimark.py:2079-2083: if incremental marking, re-add.
+            // incminimark.py:2079-2083: if incremental marking, re-add so the
+            // object's outgoing references are (re)scanned before the sweep.
+            // incminimark clears GCFLAG_VISITED here because its trace-list
+            // drain re-marks on visit; pyre's `mark_object` does not set VISITED
+            // on the popped object (the marking convention sets it at *push*
+            // time — see `seed_major_root` and the remembered-set rescan above),
+            // so keep the object black across the re-push. Clearing it would
+            // leave the still-reachable card object white and let `OldGen::sweep`
+            // reclaim it.
             if self.incr_state.marking_in_progress {
-                unsafe { (*hdr).clear_flag(flags::VISITED) };
+                unsafe { (*hdr).set_flag(flags::VISITED) };
                 self.incr_state.gray_stack.push(obj);
             }
         }

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -299,9 +299,21 @@ def _jit_panic_reason(stderr):
     if not stderr:
         return None
     if "panicked" in stderr:
-        for line in stderr.splitlines():
+        lines = stderr.splitlines()
+        for idx, line in enumerate(lines):
             if "panicked" in line:
-                return f"rust panic: {line.strip()[:80]}"
+                reason = f"rust panic: {line.strip()[:80]}"
+                # Rust's default hook prints the panic MESSAGE on the line(s)
+                # after 'panicked at file:line:col:'. That body carries the
+                # actionable detail (e.g. a GC 'invalid type_id ... site=...'
+                # diagnostic); the location line alone is not enough to triage
+                # a flaky crash from CI logs, so append the first message line.
+                for follow in lines[idx + 1 :]:
+                    follow = follow.strip()
+                    if follow:
+                        reason += f" | {follow[:200]}"
+                        break
+                return reason
         return "rust panic"
     for line in stderr.splitlines():
         if line.startswith("[jit-stats]") and "internal_compile_panics=" in line:

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6947,12 +6947,21 @@ impl Drop for CarrierResumeGuard {
 /// `DEFAULT_MAX_UNROLL_RECURSION`).
 const FBW_MAX_INLINE_RECURSION: usize = 7;
 
-/// Maximum self-recursive inline depth the multiframe guard-snapshot path
-/// (`walker_capture_multi_frame_inline_snapshot`) currently supports.  The
-/// bounded unroll keeps every inlined recursion level within this so each level
-/// has a valid multi-frame resume snapshot; deeper recursion folds to the
-/// `CALL_ASSEMBLER` tail.
-const FBW_MAX_MULTIFRAME_DEPTH: usize = 4;
+/// Maximum inline depth the multiframe guard-snapshot path
+/// (`walker_capture_multi_frame_inline_snapshot`) SOUNDLY supports.  Only a
+/// single paused caller frame (depth-1, one parent) resumes correctly: on
+/// guard-failure blackhole resume the one caller frame's virtualizable is
+/// rematerialized and its `portal_frame_reg` decodes to a live vable.  A
+/// depth-≥2 snapshot has a MIDDLE inlined-callee frame whose `NewWithVtable`
+/// virtual `PyFrame` (`emit_new_pyframe_inline_with_params`) is NOT
+/// rematerialized by the resume decoder — its `portal_frame_reg` decodes to a
+/// raw `TAGVIRTUAL` value and `handler_setarrayitem_vable_r` dereferences it
+/// (`EXC_BAD_ACCESS`).  Bounded to 1 so `try_multiframe` (`inline_depth <
+/// FBW_MAX_MULTIFRAME_DEPTH`) only fires at the top inline level; deeper
+/// recursion folds to the `CALL_ASSEMBLER` tail.  Restoring deeper unroll
+/// needs middle-frame virtual rematerialization in the optimizer
+/// `store_final_boxes_in_guard` / resume decoder (the walker-arch rework).
+const FBW_MAX_MULTIFRAME_DEPTH: usize = 1;
 
 /// Recursion depth of `w_code` on the FBW inline stack.
 fn fbw_inline_recursion_count(w_code: usize) -> usize {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -6626,20 +6626,38 @@ fn collect_outer_active_boxes(
                 .copied()
                 .unwrap_or_else(|| panic!("{}", dump_ctx("ref", idx)))
         };
-        let value = if color as u16 == portal_frame_reg && portal_frame_reg != u16::MAX {
-            sym.frame
-        } else if color as u16 == portal_ec_reg && portal_ec_reg != u16::MAX {
-            sym.execution_context
+        let semantic_idx = crate::state::semantic_ref_slot_for_reg_color(
+            nlocals,
+            valid_stack_only,
+            &local_color_map,
+            &portal_stack_color_map,
+            &portal_live_locals,
+            pcdep_opt,
+            color,
+        );
+        // Portal-red routing applies only to the force-alived SCRATCH case
+        // (`filter_liveness_in_place` keeps `portal_frame_reg`/`portal_ec_reg`
+        // in every `-live-` R-bank even where the color carries no value).
+        // The jitcode register allocator ALSO assigns these colors to real
+        // frame slots at other PCs (e.g. a call-result register live across a
+        // later call), where `pcdep_color_slots` maps the color to a semantic
+        // slot.  Routing such a colliding color to `sym.frame`/
+        // `sym.execution_context` encodes the wrong box: the blackhole then
+        // resumes the slot's register with the EC and feeds it to the slot's
+        // consumer (`fib(n-1) + fib(n-2)` resumed the left operand as the EC
+        // → SIGSEGV).  A color that names a live semantic slot takes the
+        // normal slot-value paths below; the EC stays recoverable from the
+        // frame (`ensure_execution_context` getfield).
+        let is_portal_red_scratch = semantic_idx.is_none()
+            && ((color as u16 == portal_frame_reg && portal_frame_reg != u16::MAX)
+                || (color as u16 == portal_ec_reg && portal_ec_reg != u16::MAX));
+        let value = if is_portal_red_scratch {
+            if color as u16 == portal_frame_reg {
+                sym.frame
+            } else {
+                sym.execution_context
+            }
         } else if owns_vable {
-            let semantic_idx = crate::state::semantic_ref_slot_for_reg_color(
-                nlocals,
-                valid_stack_only,
-                &local_color_map,
-                &portal_stack_color_map,
-                &portal_live_locals,
-                pcdep_opt,
-                color,
-            );
             match semantic_idx {
                 Some(s_idx) if s_idx < nlocals + valid_stack_only => {
                     let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -8159,35 +8159,50 @@ impl JitState for PyreJitState {
                 resume_data.frames.len()
             );
         }
-        if (p2_drain_enabled() || p2_framestack_enabled())
-            && resume_data.frames.len() > 1
-            && resume_data.frames[0].pc >= 0
-        {
-            let root_pc = resume_data.frames[0].pc as usize;
+        if (p2_drain_enabled() || p2_framestack_enabled()) && resume_data.frames.len() > 1 {
+            let root_pc_valid = resume_data.frames[0].pc >= 0;
+            let root_pc = if root_pc_valid {
+                resume_data.frames[0].pc as usize
+            } else {
+                0
+            };
             let mut recipes: Vec<ReconstructRecipe> =
                 Vec::with_capacity(resume_data.frames.len() - 1);
-            let mut ok = true;
-            for frame in &resume_data.frames[1..] {
-                match reconstruct_inline_recipe(
-                    ctx,
-                    frame,
-                    rd_virtuals,
-                    resume_data,
-                    fail_values,
-                    fail_types,
-                    backend,
-                    &mut virtuals_cache,
-                ) {
-                    Some(recipe) => recipes.push(recipe),
-                    None => {
-                        ok = false;
-                        break;
+            let mut ok = root_pc_valid;
+            if root_pc_valid {
+                for frame in &resume_data.frames[1..] {
+                    match reconstruct_inline_recipe(
+                        ctx,
+                        frame,
+                        rd_virtuals,
+                        resume_data,
+                        fail_values,
+                        fail_types,
+                        backend,
+                        &mut virtuals_cache,
+                    ) {
+                        Some(recipe) => recipes.push(recipe),
+                        None => {
+                            ok = false;
+                            break;
+                        }
                     }
                 }
             }
-            if ok && !recipes.is_empty() {
-                ctx.set_bridge_inline_carrier(BridgeInlineCarrier { root_pc, recipes });
+            if !ok {
+                // A multi-frame resume whose callee chain cannot be
+                // reconstructed must still be MARKED as multi-frame: without a
+                // carrier the trace-start routing treats the resume as a
+                // single-frame bridge and walks the ROOT frame's code at the
+                // INNERMOST frame's pc, compiling a degenerate bridge that
+                // finishes with a root resume slot as the call result
+                // (dropping the whole in-flight callee continuation — wrong
+                // values, or a SEGV when the slot is not an int box).  An
+                // empty-recipe carrier routes the walk to its NoRecipes abort
+                // instead, degrading to the blackhole re-interpret.
+                recipes.clear();
             }
+            ctx.set_bridge_inline_carrier(BridgeInlineCarrier { root_pc, recipes });
         }
     }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -234,6 +234,15 @@ impl MetaInterpStaticData {
         if code.is_null() {
             return None;
         }
+        // A raw `CodeObject*` IS the canonical key (jitcodes compare
+        // `raw_code()` identity).  Post-#16 callers pass the raw code
+        // identity directly (`ReconstructRecipe.code_ptr`); recognize it via
+        // the live-wrapper registry — keyed by raw code identity — before
+        // dereferencing `code` as a `PyCode` wrapper, which would read a
+        // garbage field out of a raw `CodeObject`.
+        if !pyre_interpreter::live_code_wrapper(code).is_null() {
+            return Some(code as usize);
+        }
         let raw = unsafe { pyre_interpreter::w_code_get_ptr(code as pyre_object::PyObjectRef) };
         if raw.is_null() {
             None

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1378,6 +1378,22 @@ pub fn result_color_at_pc_at(jitcode_index: i32, pc: usize) -> Option<usize> {
     })
 }
 
+/// Whether `pcdep_color_slots[pc]` maps register color `color` to a semantic
+/// frame slot — i.e. the register allocator assigned this color to a real
+/// local/stack value at `pc`, so the color does NOT carry its force-alived
+/// portal-red meaning there (`collect_outer_active_boxes` scratch gate /
+/// `setup_bridge_sym` ec-seed gate).
+pub fn pcdep_color_names_frame_slot_at(jitcode_index: i32, pc: usize, color: u16) -> bool {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        sd.jitcodes
+            .get(jitcode_index as usize)
+            .and_then(|jc| jc.payload.metadata.pcdep_color_slots.get(pc))
+            .is_some_and(|entries| entries.iter().any(|&(c, _)| c == color))
+    })
+}
+
 /// Depth-based `valuestackdepth` for `w_code` at `py_pc`:
 /// `nlocals + ncells + depth_at_py_pc[py_pc]`.  Mirrors the encoder's
 /// published vsd (the `jitcode_dispatch` valuestackdepth publish).  The
@@ -7872,16 +7888,32 @@ impl JitState for PyreJitState {
         // value), so read it from the color-indexed decode `bridge_registers_r`
         // — `sym.registers_r` is now the slot-indexed mirror and does not carry
         // portal-red colors.
+        //
+        // At PCs where the register allocator reuses the ec color for a real
+        // frame slot (a call result live across a later call), the snapshot
+        // encoder recorded the SLOT value in this register, not the ec
+        // (`collect_outer_active_boxes` portal-red scratch gate); seeding
+        // `sym.execution_context` from it would hand a frame value to every
+        // downstream ec consumer.  Detect the collision through the same
+        // per-PC color→slot table the encoder consulted and leave ec to the
+        // `ensure_execution_context` frame-field recovery instead.
         let (_pfr, portal_ec_reg) = crate::state::portal_red_regs_at(frame0.jitcode_index);
         if portal_ec_reg != u16::MAX {
-            let slot = portal_ec_reg as usize;
-            assert!(
-                slot < bridge_registers_r.len(),
-                "setup_bridge_sym: portal_ec_reg={} out of bridge_registers_r range (len={})",
-                slot,
-                bridge_registers_r.len(),
+            let ec_color_names_frame_slot = crate::state::pcdep_color_names_frame_slot_at(
+                frame0.jitcode_index,
+                frame0.pc as usize,
+                portal_ec_reg,
             );
-            sym.execution_context = bridge_registers_r[slot];
+            if !ec_color_names_frame_slot {
+                let slot = portal_ec_reg as usize;
+                assert!(
+                    slot < bridge_registers_r.len(),
+                    "setup_bridge_sym: portal_ec_reg={} out of bridge_registers_r range (len={})",
+                    slot,
+                    bridge_registers_r.len(),
+                );
+                sym.execution_context = bridge_registers_r[slot];
+            }
         }
         // pyjitpl.py:3400-3430 rebuild_state_after_failure parity: after
         // a guard failure the tracing-time `virtualizable_boxes` mirror

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -2053,11 +2053,38 @@ impl MIFrame {
             let sym_ec = self.ensure_execution_context(ctx);
             let mut it = LivenessIterator::new(cursor, length_r, &all_liveness);
             while let Some(reg_idx) = it.next() {
-                let opref = if reg_idx == portal_frame_reg {
-                    sym_frame
-                } else if reg_idx == portal_ec_reg {
-                    sym_ec
+                // Portal-red substitution applies only to the force-alived
+                // SCRATCH case. The register allocator reuses these low
+                // colors for real frame slots (a call result live across a
+                // later call); at such PCs the bank materialization above
+                // already wrote the slot's box at this color, and
+                // substituting sym frame/ec would clobber it in the snapshot
+                // (same scratch gate as `collect_outer_active_boxes`).
+                let is_portal_red = reg_idx == portal_frame_reg || reg_idx == portal_ec_reg;
+                let is_portal_red_scratch = is_portal_red
+                    && crate::state::semantic_ref_slot_for_reg_color(
+                        nlocals,
+                        valid_stack_only,
+                        &local_color_map,
+                        &stack_slot_color_map,
+                        &live_local_indices,
+                        pcdep_opt,
+                        reg_idx as usize,
+                    )
+                    .is_none();
+                let opref = if is_portal_red_scratch {
+                    if reg_idx == portal_frame_reg {
+                        sym_frame
+                    } else {
+                        sym_ec
+                    }
                 } else {
+                    if is_portal_red && std::env::var_os("PYRE_P2_DIAG").is_some() {
+                        eprintln!(
+                            "[p2-trait-scratch] live_pc={} color={} owned by frame slot; keeping bank box",
+                            live_pc, reg_idx
+                        );
+                    }
                     registers_r_bank[reg_idx as usize]
                 };
                 boxes.push(opref);


### PR DESCRIPTION
## issue #62 / #215 item2 — P2 multiframe bridge resume: safe-ON + continuous cross-frame walk (depth-1)

Compiles a correct JIT **multiframe bridge** for the gate-ON path: when a deopt fires deep in a recursive callee, rebuild the framestack and resume forward keeping the callee recursion as a **general live `CALL_ASSEMBLER`**, instead of the old vable-reconstruction that read arg slots as results.

All new behavior is behind default-**OFF** env gates; the OFF path is byte-identical and `pyre/check.py` is **167/167 dynasm + 167/167 cranelift** green.

### What lands

- **Safe-ON (`PYRE_P2_FRAMESTACK`)** — `drive_bridge_framestack_walk` reconstructs the deepest callee frame, sub-walks it, then aborts cleanly rather than compiling a malformed reconstruction bridge (no SEGV; multiframe resumes degrade to the interpreter with correct results).
- **Continuous cross-frame walk (`PYRE_P2_FS_COMPILE`)** — `drive_outer_frame_continuation` + `drive_outer_continuation_and_map`: after the callee sub-walk returns its result, walk the outer root portal frame forward from its resume pc via `walk()`, **appending to the same trace** (no cut) so the sub-walk's live `CALL_ASSEMBLER` continuation stays in the compiled bridge. The callee result is delivered into the outer's call-dst register — the physical `make_result_of_lastop` slot decoded from the residual-call op whose `next_pc` is the resume entry — not a resume color, dissolving the earlier color-vs-register mismatch. `is_top_level=true` so the outer's return surfaces the portal `Terminate` → `TraceAction::Finish`.
- **Supporting fixes**: reserved-red-color skip in the bridge argbox seed; old-generation allocation of resume-materialized GC structs; non-finite GC env value treated as unset; bounded-unroll gating of the self-recursive `CALL_ASSEMBLER` side-door.
- **Diagnostics** (all env-gated, OFF-safe): `PYRE_MFRAME_DIAG`, `PYRE_P2_DIAG` (`[p2-ca]`/`[p2-fs]` phase logs), `TraceCtx::dump_trace_ops_diag`.

### Result on `fib`

Under `PYRE_P2_FRAMESTACK=1 PYRE_P2_AUTHORITATIVE=1 PYRE_P2_FS_COMPILE=1 PYRE_FBW_REC_UNROLL=7`, the continuous walk compiles a bridge with three live `CALL_ASSEMBLER` (callee `fib(n-1)` inner pair + outer `fib(n-2)`) whose `IntAddOvf` reads the call results and ends in `Finish`. `fib(16..27)` all correct; the compile path also **shields the pre-existing unroll depth SEGV** (`PYRE_FBW_REC_UNROLL=7` alone SEGVs `fib27+`, the compile path returns correct results).

### Not yet in scope

- `fib28+`: depth>1 carriers (`n_recipes=2/3`) are not yet handled (depth-1 only; deeper carriers clean-abort), and the depth region is entangled with a pre-existing unroll depth SEGV. N-frame generalization is the follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JIT panic diagnostics now include more context from error output, making failures easier to understand and act on.

* **Bug Fixes**
  * Fixed incorrect register/frame handling during JIT trace resume, improving stability in edge cases.
  * Improved multi-frame resume behavior so valid snapshots are handled more reliably, even when some reconstruction details are missing.
  * Prevented incorrect substitution of runtime values in active box lists when a register is actually holding a real frame slot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->