### PR TITLE
#169: BoxRef teardown E4-E7 — ProducedShortOp/ImportedShortAlias/IndexVar.var_box to Operand

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/dependency.rs
+++ b/majit/majit-metainterp/src/optimizeopt/dependency.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use majit_ir::vec_set::VecSet;
 
 use crate::optimizeopt::schedule::Pack;
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{Op, OpCode, OpRef};
 
@@ -905,15 +904,15 @@ pub(crate) fn schedule_operations(graph: &DependencyGraph) -> Vec<usize> {
 pub struct IndexVar {
     /// The base SSA variable.
     pub var: OpRef,
-    /// The BOUND box for `var`, captured from the real op arg at build time so
-    /// `get_operations` can carry `var` as `Operand::Op`/`InputArg` instead of
-    /// minting a position-only box. RPython's IndexVar holds the box object
+    /// The BOUND operand for `var`, captured from the real op arg at build time
+    /// so `get_operations` can carry `var` as `Operand::Op`/`InputArg` instead
+    /// of a position-only box. RPython's IndexVar holds the box object
     /// (`dependency.py:983 self.var`); pyre's flat-OpRef `var` loses the
-    /// producer, so the box is captured alongside. `None` when no bound box was
-    /// available at construction (e.g. a synthetic-result var) — then
-    /// `get_operations` falls back to `from_opref`. Its `to_opref()` always
-    /// equals `var`.
-    pub var_box: Option<BoxRef>,
+    /// producer, so the operand is captured alongside. `None` when no bound
+    /// operand was available at construction (e.g. a synthetic-result var) —
+    /// then `get_operations` binds a synthetic producer via `bound_from_opref`.
+    /// Its `to_opref()` always equals `var`.
+    pub var_box: Option<majit_ir::operand::Operand>,
     /// If `var` is a ConstInt OpRef, the resolved integer value.
     /// dependency.py:1117-1118: isinstance(svar, ConstInt) comparison.
     pub var_const: Option<i64>,
@@ -937,10 +936,10 @@ impl IndexVar {
         }
     }
 
-    /// Like [`IndexVar::new`] but capturing the BOUND box for `var`
+    /// Like [`IndexVar::new`] but capturing the BOUND operand for `var`
     /// (`var_box.to_opref() == var`), used so `get_operations` carries a bound
     /// operand rather than a position-only one.
-    pub fn new_boxed(var_box: BoxRef) -> Self {
+    pub fn new_boxed(var_box: majit_ir::operand::Operand) -> Self {
         let var = var_box.to_opref();
         IndexVar {
             var,
@@ -1046,17 +1045,19 @@ impl IndexVar {
     /// Box-carrying note: the `var` operand of the FIRST emitted op is
     /// `self.var` — the IndexVar's base SSA variable (the loop's index inputarg
     /// or another loop-body producer). RPython carries `self.var` as the live
-    /// index-var box object; pyre's flat-OpRef `var` lost it, so the bound box
-    /// is captured at build time into `self.var_box` (see `get_or_create`) and
-    /// re-installed here, carrying `Operand::Op`/`InputArg` instead of a
-    /// position-only box. The first-var arm falls back to `from_opref` only when
-    /// no box was captured (a synthetic-result var). The CHAINED `var =
-    /// op.pos.get()` references (when `coefficient_mul != 1`, i.e. an `IntAdd` /
-    /// `IntSub` consuming the prior `IntMul`) point at the just-created local
-    /// `Op` value — this fn returns `Vec<Op>`, not `Vec<OpRc>`, so there is no
-    /// producer `Rc` to bind to and the chained `var` stays a position-only
-    /// residual. `to_opref()` is preserved in every case; the constant arg `c`
-    /// always sheds to `Operand::Const`.
+    /// index-var box object; pyre's flat-OpRef `var` lost it, so the bound
+    /// operand is captured at build time into `self.var_box` (see
+    /// `get_or_create`) and
+    /// re-installed here, carrying `Operand::Op`/`InputArg`. The first-var arm
+    /// binds a synthetic producer via `bound_from_opref` only when no operand
+    /// was captured (a synthetic-result var). The CHAINED `var = op.pos.get()`
+    /// references (when `coefficient_mul != 1`, i.e. an `IntAdd` / `IntSub`
+    /// consuming the prior `IntMul`) point at the just-created local `Op`
+    /// value — this fn returns `Vec<Op>`, not `Vec<OpRc>`, so there is no
+    /// producer `Rc` to bind to; the chained `var` binds a synthetic producer
+    /// carrying the same `pos` (`bound_from_opref`, `to_opref()`-identical).
+    /// `to_opref()` is preserved in every case; the constant arg `c` always
+    /// sheds to `Operand::Const`.
     pub fn get_operations(&self, mut next_const: impl FnMut(i64) -> OpRef) -> Vec<majit_ir::Op> {
         use majit_ir::{Op, OpCode};
         // First-var box: the captured bound box when its `to_opref()` still
@@ -1064,20 +1065,20 @@ impl IndexVar {
         // else a position-only box for a box-less (synthetic) var.
         let first_var = match &self.var_box {
             Some(b) if b.to_opref() == self.var => b.clone(),
-            _ => BoxRef::from_opref(self.var),
+            _ => majit_ir::operand::Operand::bound_from_opref(self.var),
         };
         let mut var = self.var;
         let mut first = true;
         let mut tolist = Vec::new();
         // Carry `var` bound for the FIRST emitted op (from `first_var`); the
         // chained references thereafter point at local `Op` values (no `Rc`),
-        // so they fall back to a position-only box.
-        let var_box = |var: OpRef, first: &mut bool| -> BoxRef {
+        // so they bind a synthetic producer carrying the same `pos`.
+        let var_box = |var: OpRef, first: &mut bool| -> majit_ir::operand::Operand {
             if *first {
                 *first = false;
                 first_var.clone()
             } else {
-                BoxRef::from_opref(var)
+                majit_ir::operand::Operand::bound_from_opref(var)
             }
         };
         if self.coefficient_mul != 1 {
@@ -1086,7 +1087,7 @@ impl IndexVar {
             let op = Op::new(
                 OpCode::IntMul,
                 &[
-                    majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)),
+                    var_box(var, &mut first),
                     majit_ir::operand::Operand::from_opref(c),
                 ],
             );
@@ -1104,7 +1105,7 @@ impl IndexVar {
             let op = Op::new(
                 OpCode::IntAdd,
                 &[
-                    majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)),
+                    var_box(var, &mut first),
                     majit_ir::operand::Operand::from_opref(c),
                 ],
             );
@@ -1117,7 +1118,7 @@ impl IndexVar {
             let op = Op::new(
                 OpCode::IntSub,
                 &[
-                    majit_ir::operand::Operand::from_boxref(&var_box(var, &mut first)),
+                    var_box(var, &mut first),
                     majit_ir::operand::Operand::from_opref(c),
                 ],
             );
@@ -1417,9 +1418,7 @@ impl<'a> IntegralForwardModification<'a> {
                 let val = self.const_val(arg).unwrap_or(0);
                 IndexVar::new_const(arg, val)
             } else {
-                // `IndexVar::new_boxed`/`var_box` still hold a `BoxRef` (a later
-                // E7 slice flips them); bridge the bound (non-const) operand.
-                IndexVar::new_boxed(arg_box.to_boxref())
+                IndexVar::new_boxed(arg_box.clone())
             }
         })
     }

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -674,7 +674,10 @@ impl GuardStrengthenOpt {
         for i in 0..op.num_args() {
             let arg = op.arg(i).to_opref();
             if let Some(&replacement) = self.renamer.get(&arg) {
-                op.setarg(i, majit_ir::operand::Operand::from_opref(replacement));
+                // `renamer.py` carries box objects; the replacement is a
+                // producer position, so bind a synthetic producer carrying
+                // the same `pos` rather than minting a position-only operand.
+                op.setarg(i, majit_ir::operand::Operand::bound_from_opref(replacement));
             }
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4072,10 +4072,7 @@ mod tests {
         preamble_op.pos.set(source);
         ctx.initialize_imported_short_preamble_builder(
             &[object, resolved],
-            &[
-                bound_arg(object).to_boxref(),
-                bound_arg(resolved).to_boxref(),
-            ],
+            &[object, resolved],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
                 res: bound_arg(source).to_boxref(),

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4075,7 +4075,7 @@ mod tests {
             &[object, resolved],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
-                res: bound_arg(source).to_boxref(),
+                res: bound_arg(source),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -651,21 +651,17 @@ pub struct OptContext {
     /// the exported loop-header inputargs.
     pub exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
     /// unroll.py:480 `short_inputargs = sb.create_short_inputargs(label_args
-    /// + virtuals)` — the ShortBoxes-stored renamed inputarg boxes
+    /// + virtuals)` — the ShortBoxes-stored renamed inputarg positions
     /// themselves, carried from the preview pass (optimizer.rs, where the
     /// ShortBoxes object lives) to `export_state_with_bounds` through the
-    /// same channel as `exported_short_boxes`. Position projection equals
-    /// the export-site `label_args + virtuals` recompute (measured
-    /// identical across the corpus, 2026-06-11).
-    pub exported_short_inputargs: Vec<majit_ir::box_ref::BoxRef>,
+    /// same channel as `exported_short_boxes` (measured identical to the
+    /// export-site `label_args + virtuals` recompute across the corpus,
+    /// 2026-06-11).
+    pub exported_short_inputargs: Vec<OpRef>,
     /// Rooted `InputArgRc` carriers for `exported_short_inputargs`, index-
-    /// aligned with that vector. Each renamed short-preamble input box
-    /// (`exported_short_inputargs[i]`) holds a WEAK handle to
-    /// `exported_short_inputarg_refs[i]`; keeping the strong Rc alive here
-    /// lets the box resolve to a real bound `InputArg` (so the operand binds
-    /// to `Operand::InputArg` instead of an unbound position-only box, which
-    /// `from_boxref` now rejects). Carried alongside `exported_short_inputargs`
-    /// through the same export channel.
+    /// aligned with that vector. Keeping the strong Rc alive here preserves
+    /// the renamed inputarg producer across the export boundary; consumers
+    /// that need an operand bind the stored position directly.
     pub exported_short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// optimizer.py: `can_replace_guards` — disable guard replacement during
     /// bridge compilation. Defaults to true for preamble.
@@ -2919,7 +2915,7 @@ impl OptContext {
     pub fn initialize_imported_short_preamble_builder(
         &mut self,
         label_args: &[OpRef],
-        short_inputargs: &[majit_ir::box_ref::BoxRef],
+        short_inputargs: &[OpRef],
         exported_short_boxes: &[crate::optimizeopt::shortpreamble::PreambleOp],
     ) {
         let produced: Vec<(
@@ -2987,7 +2983,7 @@ impl OptContext {
     pub fn initialize_imported_short_preamble_builder_from_short_boxes(
         &mut self,
         short_args: &[OpRef],
-        short_inputargs: &[majit_ir::box_ref::BoxRef],
+        short_inputargs: &[OpRef],
         short_boxes: &[(OpRef, crate::optimizeopt::shortpreamble::ProducedShortOp)],
         short_box_const_values: &majit_ir::VecMap<OpRef, majit_ir::Value>,
         result_map: &majit_ir::VecMap<OpRef, OpRef>,
@@ -10455,10 +10451,7 @@ mod imported_short_preamble_fallback_tests {
             OptContext::with_inputarg_types(16, &[majit_ir::Type::Ref, majit_ir::Type::Ref]);
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
-            &[
-                majit_ir::box_ref::BoxRef::from_opref(OpRef::int_op(7)),
-                majit_ir::box_ref::BoxRef::from_opref(OpRef::int_op(8)),
-            ],
+            &[OpRef::int_op(7), OpRef::int_op(8)],
             &[],
         );
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -500,10 +500,10 @@ impl PartialEq for ImportedShortPureOp {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ImportedShortAlias {
     pub result: OpRef,
-    /// MIGRATION (#9): the canonical box of the SameAs source operand,
-    /// carried directly off `extra_same_as` instead of a positional
-    /// round-trip.
-    pub same_as_source: majit_ir::box_ref::BoxRef,
+    /// The canonical operand of the SameAs source, carried directly off
+    /// `extra_same_as` (already an `Operand` op-arg) instead of round-tripping
+    /// through a positional box.
+    pub same_as_source: majit_ir::operand::Operand,
     pub same_as_opcode: OpCode,
 }
 
@@ -4183,7 +4183,7 @@ impl OptContext {
                     .iter()
                     .map(|op| ImportedShortAlias {
                         result: op.pos.get(),
-                        same_as_source: op.arg(0).to_boxref(),
+                        same_as_source: op.arg(0),
                         same_as_opcode: op.opcode,
                     })
                     .collect()

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2923,7 +2923,7 @@ impl OptContext {
         exported_short_boxes: &[crate::optimizeopt::shortpreamble::PreambleOp],
     ) {
         let produced: Vec<(
-            majit_ir::box_ref::BoxRef,
+            majit_ir::operand::Operand,
             crate::optimizeopt::shortpreamble::ProducedShortOp,
         )> = exported_short_boxes
             .iter()
@@ -2942,7 +2942,7 @@ impl OptContext {
                 // synthetic and the second (stable) box is the real key.
                 let pos = entry.op.pos.get();
                 let _ = self.materialize_box_at(pos);
-                let res = self.materialize_box_at(pos);
+                let res = self.materialize_operand_at(pos);
                 (
                     res.clone(),
                     crate::optimizeopt::shortpreamble::ProducedShortOp {
@@ -3084,7 +3084,7 @@ impl OptContext {
             if produced_op.res.to_opref().is_constant() {
                 continue;
             }
-            if let Some(info) = exported_infos.get(&produced_op.res) {
+            if let Some(info) = exported_infos.get(&produced_op.res.to_boxref()) {
                 self.set_preamble_forwarded_info(replay_pos(*source, produced_op), info);
             }
         }
@@ -3098,7 +3098,7 @@ impl OptContext {
         // invented-name replay-position aliasing the dual key compensates for,
         // so the builder map collapses to a single box-identity key.
         let mut produced: Vec<(OpRef, ProducedShortOp)> = Vec::with_capacity(short_boxes.len());
-        let mut builder_entries: Vec<(majit_ir::box_ref::BoxRef, ProducedShortOp)> =
+        let mut builder_entries: Vec<(majit_ir::operand::Operand, ProducedShortOp)> =
             Vec::with_capacity(short_boxes.len());
         let mut produced_results: majit_ir::VecMap<OpRef, OpRef> = majit_ir::VecMap::new();
         // shortpreamble.py:PreambleOp.add_op_to_short — Pure ops whose
@@ -3209,7 +3209,7 @@ impl OptContext {
                     if let Some(d) = produced_op.preamble_op.getdescr() {
                         op.setdescr(d);
                     }
-                    let res = self.materialize_box_at(op.pos.get());
+                    let res = self.materialize_operand_at(op.pos.get());
                     let new_pop = ProducedShortOp {
                         kind: PreambleOpKind::Pure,
                         res,
@@ -3252,7 +3252,7 @@ impl OptContext {
                             let mut op = Op::new(opcode, &[obj_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
-                            let res = self.materialize_box_at(op.pos.get());
+                            let res = self.materialize_operand_at(op.pos.get());
                             ProducedShortOp {
                                 kind: PreambleOpKind::Heap,
                                 res,
@@ -3293,7 +3293,7 @@ impl OptContext {
                             let mut op = Op::new(opcode, &[obj_b, index_b]);
                             op.pos.set(replay_pos(*source, produced_op));
                             op.setdescr(descr);
-                            let res = self.materialize_box_at(op.pos.get());
+                            let res = self.materialize_operand_at(op.pos.get());
                             ProducedShortOp {
                                 kind: PreambleOpKind::Heap,
                                 res,
@@ -3332,7 +3332,7 @@ impl OptContext {
                     let func_b = dep_or_materialize(self, &produced, func_opref);
                     let mut op = Op::new(loop_invariant_opcode(result_type), &[func_b]);
                     op.pos.set(replay_pos(*source, produced_op));
-                    let res = self.materialize_box_at(op.pos.get());
+                    let res = self.materialize_operand_at(op.pos.get());
                     let new_pop = ProducedShortOp {
                         kind: PreambleOpKind::LoopInvariant,
                         res,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -6959,20 +6959,8 @@ mod tests {
         let sp = ctx
             .build_imported_short_preamble()
             .expect("forcing imported short guard arg should build short preamble");
-        assert_eq!(
-            sp.used_boxes
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(14)]
-        );
-        assert_eq!(
-            sp.jump_args
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(14)]
-        );
+        assert_eq!(sp.used_boxes, vec![OpRef::int_op(14)]);
+        assert_eq!(sp.jump_args, vec![OpRef::int_op(14)]);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3703,10 +3703,10 @@ impl Optimizer {
                     arg.set_position(opref.raw());
                 }
                 for arg in &mut state.end_args {
-                    remap_boxref(arg);
+                    remap_opref(arg);
                 }
                 for arg in &mut state.renamed_inputargs {
-                    remap_boxref(arg);
+                    remap_opref(arg);
                 }
                 for arg in &mut state.short_inputargs {
                     remap_opref(arg);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3709,17 +3709,8 @@ impl Optimizer {
                 for arg in &mut state.renamed_inputargs {
                     remap_boxref(arg);
                 }
-                for arg in &state.short_inputargs {
-                    // A bound short inputarg live-tracks its producer's
-                    // `op.pos`, already remapped by the main loop, so it needs
-                    // no rewrite. Only position-only boxes (test fixtures) carry
-                    // a pre-remap position the table must rewrite.
-                    if arg.bound_op().is_some() || arg.bound_inputarg().is_some() {
-                        continue;
-                    }
-                    let mut opref = arg.to_opref();
-                    remap_opref(&mut opref);
-                    arg.set_position(opref.raw());
+                for arg in &mut state.short_inputargs {
+                    remap_opref(arg);
                 }
                 // exported_infos is keyed by box identity (Rc::ptr_eq), so its keys
                 // need NO position remap — the lookup matches by Rc, not OpRef. The
@@ -6922,7 +6913,7 @@ mod tests {
         ctx.make_constant_box(&b, majit_ir::Value::Int(0));
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::int_op(0)],
-            &[rooted_resop_box(Type::Int, 0)],
+            &[OpRef::int_op(0)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
                 res: rooted_resop_box(Type::Int, 14),

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3326,11 +3326,10 @@ impl Optimizer {
                         Some(crate::optimizeopt::shortpreamble::PreambleOp {
                             op: preamble_op,
                             // short_op.res travels with the entry as the
-                            // exported `PreambleOp.res` box (the potential-op
-                            // res channel stays BoxRef); the preview
-                            // ProducedShortOp carries a bound producer operand,
-                            // so `to_boxref` re-mints a ptr_eq-stable box.
-                            res: produced.res.to_boxref(),
+                            // exported `PreambleOp.res` operand; the preview
+                            // ProducedShortOp already carries the bound producer
+                            // / const operand, so it moves across unchanged.
+                            res: produced.res.clone(),
                             kind: produced.kind,
                             label_arg_idx,
                             invented_name: produced.invented_name,
@@ -3777,19 +3776,10 @@ impl Optimizer {
                     // position Cell to rewrite. The former bound-box refresh
                     // copied that same `op.pos`; the position-only else-branch
                     // was dead since #173 roots the producer.
-                    // res: a bound box live-tracks its producer through the
-                    // op handle — the producer's `Op.pos` was already
-                    // remapped above, so refreshing the position Cell from
-                    // it is idempotent (no double-map). Position-only mints
-                    // (test fixtures) go through the remap table instead;
-                    // `set_position` is a no-op for InputArg/Const kinds.
-                    if let Some(op) = entry.res.bound_op() {
-                        entry.res.set_position(op.pos.get().raw());
-                    } else {
-                        let mut res_opref = entry.res.to_opref();
-                        remap_opref(&mut res_opref);
-                        entry.res.set_position(res_opref.raw());
-                    }
+                    // res: a producer-bound / const operand live-tracks its
+                    // producer through the carried handle — the producer's
+                    // `Op.pos` was already remapped above, so there is no
+                    // separate position to rewrite (same as `same_as_source`).
                 }
             }
         }
@@ -6916,7 +6906,7 @@ mod tests {
             &[OpRef::int_op(0)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op.clone()),
-                res: rooted_resop_box(Type::Int, 14),
+                res: rooted_resop_operand(Type::Int, 14),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3325,11 +3325,12 @@ impl Optimizer {
                         };
                         Some(crate::optimizeopt::shortpreamble::PreambleOp {
                             op: preamble_op,
-                            // short_op.res travels with the entry — the SAME
-                            // box object the preview ProducedShortOp carries,
-                            // so the export/re-import round trip preserves
-                            // upstream Box identity.
-                            res: produced.res.clone(),
+                            // short_op.res travels with the entry as the
+                            // exported `PreambleOp.res` box (the potential-op
+                            // res channel stays BoxRef); the preview
+                            // ProducedShortOp carries a bound producer operand,
+                            // so `to_boxref` re-mints a ptr_eq-stable box.
+                            res: produced.res.to_boxref(),
                             kind: produced.kind,
                             label_arg_idx,
                             invented_name: produced.invented_name,
@@ -3779,19 +3780,12 @@ impl Optimizer {
                             );
                         }
                     }
-                    // same_as_source: same rule as res below — the stored
-                    // box object is shared with the preview ProducedShortOp,
-                    // so rewrite its position Cell in place instead of
-                    // replacing it with a fresh position-only mint.
-                    if let Some(ref src) = entry.same_as_source {
-                        if let Some(op) = src.bound_op() {
-                            src.set_position(op.pos.get().raw());
-                        } else {
-                            let mut src_opref = src.to_opref();
-                            remap_opref(&mut src_opref);
-                            src.set_position(src_opref.raw());
-                        }
-                    }
+                    // same_as_source is a producer-bound operand (or None):
+                    // it live-tracks its producer's already-remapped `Op.pos`
+                    // through the carried `Rc<Op>`, so there is no separate
+                    // position Cell to rewrite. The former bound-box refresh
+                    // copied that same `op.pos`; the position-only else-branch
+                    // was dead since #173 roots the producer.
                     // res: a bound box live-tracks its producer through the
                     // op handle — the producer's `Op.pos` was already
                     // remapped above, so refreshing the position Cell from

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1316,16 +1316,10 @@ mod tests {
             Some(idx) => (0..=idx as u32).map(OpRef::int_op).collect(),
             None => vec![OpRef::int_op(0)],
         };
-        // Materialize the canonical ctx boxes for the short inputargs and the
-        // entry res position, rather than minting position-only boxes.
-        let short_inputarg_boxes: Vec<majit_ir::box_ref::BoxRef> = short_inputargs
-            .iter()
-            .map(|&a| ctx.materialize_box_at(a))
-            .collect();
         let res = ctx.materialize_box_at(source);
         ctx.initialize_imported_short_preamble_builder(
             &short_inputargs,
-            &short_inputarg_boxes,
+            &short_inputargs,
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: std::rc::Rc::new(preamble_op),
                 res,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1316,7 +1316,7 @@ mod tests {
             Some(idx) => (0..=idx as u32).map(OpRef::int_op).collect(),
             None => vec![OpRef::int_op(0)],
         };
-        let res = ctx.materialize_box_at(source);
+        let res = ctx.materialize_operand_at(source);
         ctx.initialize_imported_short_preamble_builder(
             &short_inputargs,
             &short_inputargs,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -339,11 +339,11 @@ pub struct PreambleOp {
     /// object across the export/import boundary (upstream `preamble_op` is
     /// one ResOperation object, shortpreamble.py:283-296).
     pub op: majit_ir::OpRc,
-    /// `short_op.res` — the result box this entry produces. Identity-
-    /// bearing on exported entries (threaded from the preview
-    /// `ProducedShortOp.res`); on potential-op entries it is a
-    /// position-only mint that `add_op_to_short` re-resolves via ctx.
-    pub res: majit_ir::box_ref::BoxRef,
+    /// `short_op.res` — the result operand this entry produces. Carried as a
+    /// producer-bound / const [`Operand`] so the canonical operand travels
+    /// with the struct and its `to_boxref()` re-mint at the export boundary
+    /// (`ProducedShortOp.res`) is `Rc::ptr_eq`-stable on the producer.
+    pub res: majit_ir::operand::Operand,
     /// Classification of this operation.
     pub kind: PreambleOpKind,
     /// Index of the argument in the label (None if not a label arg).
@@ -671,7 +671,7 @@ impl ShortBoxes {
             // shortpreamble.py:371-373: const_short_boxes.append(HeapOp(...))
             let label_arg_idx = self.lookup_label_arg(result);
             self.const_short_boxes.push(PreambleOp {
-                res: BoxRef::from_opref(op.pos.get()),
+                res: ctx.materialize_operand_at(op.pos.get()),
                 op: std::rc::Rc::new(op),
                 kind: PreambleOpKind::Heap,
                 label_arg_idx,
@@ -765,6 +765,7 @@ impl ShortBoxes {
         // returns (ptr_eq), keeping the BoxRef-keyed map ptr-stable.
         let _ = ctx.materialize_box_at(arg);
         let arg_box = ctx.materialize_box_at(arg);
+        let arg_res = majit_ir::operand::Operand::from_boxref(&arg_box);
         let mut same_as = Op::new(
             OpCode::same_as_for_type(arg_type),
             &[majit_ir::operand::Operand::from_boxref(&arg_box.clone())],
@@ -776,7 +777,7 @@ impl ShortBoxes {
         self.potential_ops.insert(
             majit_ir::operand::Operand::from_boxref(&arg_box),
             PotentialShortOp::Preamble(PreambleOp {
-                res: arg_box,
+                res: arg_res,
                 op: std::rc::Rc::new(same_as),
                 kind: PreambleOpKind::InputArg,
                 label_arg_idx: Some(live_slot),
@@ -1064,7 +1065,7 @@ impl ShortBoxes {
         let _ = ctx.materialize_box_at(result);
         let key = ctx.materialize_box_at(result);
         let pop = PotentialShortOp::Preamble(PreambleOp {
-            res: BoxRef::from_opref(result),
+            res: majit_ir::operand::Operand::from_boxref(&key),
             op: std::rc::Rc::new(op),
             kind,
             label_arg_idx,
@@ -1132,7 +1133,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_guard(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.guards.push(PreambleOp {
-            res: BoxRef::from_opref(op.pos.get()),
+            res: majit_ir::operand::Operand::bound_from_opref(op.pos.get()),
             op: std::rc::Rc::new(op),
             kind: PreambleOpKind::Guard,
             label_arg_idx,
@@ -1145,7 +1146,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_pure_op(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.pure_ops.push(PreambleOp {
-            res: BoxRef::from_opref(op.pos.get()),
+            res: majit_ir::operand::Operand::bound_from_opref(op.pos.get()),
             op: std::rc::Rc::new(op),
             kind: PreambleOpKind::Pure,
             label_arg_idx,
@@ -1158,7 +1159,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_heap_op(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.heap_ops.push(PreambleOp {
-            res: BoxRef::from_opref(op.pos.get()),
+            res: majit_ir::operand::Operand::bound_from_opref(op.pos.get()),
             op: std::rc::Rc::new(op),
             kind: PreambleOpKind::Heap,
             label_arg_idx,
@@ -1171,7 +1172,7 @@ impl CollectedExtendedShortPreambleBuilder {
     pub fn add_loopinvariant_op(&mut self, op: Op) {
         let label_arg_idx = self.lookup_label_arg(op.pos.get());
         self.loopinvariant_ops.push(PreambleOp {
-            res: BoxRef::from_opref(op.pos.get()),
+            res: majit_ir::operand::Operand::bound_from_opref(op.pos.get()),
             op: std::rc::Rc::new(op),
             kind: PreambleOpKind::LoopInvariant,
             label_arg_idx,
@@ -3295,10 +3296,10 @@ pub(crate) fn produced_short_boxes_from_exported_boxes(
                 ProducedShortOp {
                     kind: entry.kind.clone(),
                     // shortpreamble.py:58/110 short_op.res — the exported
-                    // entry carries the Phase-1 res box across the boundary;
-                    // shed the bound producer box to its live operand (#173
-                    // roots the producer, so this is never position-only).
-                    res: majit_ir::operand::Operand::from_boxref(&entry.res),
+                    // entry carries the Phase-1 res operand across the
+                    // boundary; it already holds the live producer / const
+                    // operand (#173 roots the producer, never position-only).
+                    res: entry.res.clone(),
                     preamble_op: std::rc::Rc::new(preamble_op),
                     invented_name: entry.invented_name,
                     same_as_source: entry.same_as_source.clone(),
@@ -3595,7 +3596,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(7));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 7),
+                res: rooted_resop_operand(Type::Int, 7),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3607,7 +3608,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(8));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 8),
+                res: rooted_resop_operand(Type::Int, 8),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3639,7 +3640,7 @@ mod tests {
         let exported = vec![
             PreambleOp {
                 op: std::rc::Rc::new(ovf),
-                res: rooted_resop_box(Type::Int, 20),
+                res: rooted_resop_operand(Type::Int, 20),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -3647,7 +3648,7 @@ mod tests {
             },
             PreambleOp {
                 op: std::rc::Rc::new(guard),
-                res: BoxRef::none(),
+                res: majit_ir::operand::Operand::None,
                 kind: PreambleOpKind::Guard,
                 label_arg_idx: None,
                 invented_name: false,

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -72,18 +72,18 @@ pub struct ShortPreamble {
     pub ops: Vec<ShortPreambleOp>,
     /// Input args of the short preamble Label.
     /// RPython stores the full short preamble as [Label(short_inputargs), ...].
-    /// Stored as [`BoxRef`] so a `Const` ref is GC-walked through
-    /// `BoxRef::walk_const_ptr_refs`; consumers read via `to_opref`.
-    pub inputargs: Vec<BoxRef>,
+    /// Stored as flat [`OpRef`] positions; an inline `OpRef::ConstPtr`
+    /// ref is GC-walked directly by `walk_const_ptr_refs_mut`.
+    pub inputargs: Vec<OpRef>,
     /// Extra loop-header values carried by the short preamble Jump.
     /// RPython appends `sb.used_boxes` to the loop label and jumps with
     /// `args + extra`, where `extra` is the remapped version of these boxes.
-    pub used_boxes: Vec<BoxRef>,
+    pub used_boxes: Vec<OpRef>,
     /// Preamble producer results used by the short preamble's own trailing JUMP.
     /// RPython keeps this separate from `used_boxes`: the loop contract carries
     /// body boxes, while the short preamble JUMP reuses the corresponding
     /// preamble-produced values.
-    pub jump_args: Vec<BoxRef>,
+    pub jump_args: Vec<OpRef>,
     /// The exported virtual state at the loop header (from the preamble's exit).
     /// Used to check bridge compatibility and generate additional guards.
     pub exported_state: Option<VirtualState>,
@@ -104,7 +104,7 @@ pub struct ShortPreamble {
     /// inputargs (Phase 2 label_args), ops may reference Phase 1 OpRefs
     /// that aren't in the new inputargs. This field stores the original
     /// Phase 1 inputargs so inline_short_preamble can map them to jump_args.
-    pub phase1_inputargs: Option<Vec<BoxRef>>,
+    pub phase1_inputargs: Option<Vec<OpRef>>,
 }
 
 impl ShortPreamble {
@@ -133,20 +133,22 @@ impl ShortPreamble {
     }
 
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
-        fn visit_boxrefs(boxes: &[BoxRef], visitor: &mut dyn FnMut(&mut GcRef)) {
-            for b in boxes {
-                b.walk_const_ptr_refs(visitor);
+        fn visit_oprefs(refs: &mut [OpRef], visitor: &mut dyn FnMut(&mut GcRef)) {
+            for r in refs {
+                if let OpRef::ConstPtr(gcref) = r {
+                    visitor(gcref);
+                }
             }
         }
 
         for entry in &mut self.ops {
             entry.op.walk_const_ptr_refs_mut(visitor);
         }
-        visit_boxrefs(&self.inputargs, visitor);
-        visit_boxrefs(&self.used_boxes, visitor);
-        visit_boxrefs(&self.jump_args, visitor);
-        if let Some(phase1_inputargs) = self.phase1_inputargs.as_ref() {
-            visit_boxrefs(phase1_inputargs, visitor);
+        visit_oprefs(&mut self.inputargs, visitor);
+        visit_oprefs(&mut self.used_boxes, visitor);
+        visit_oprefs(&mut self.jump_args, visitor);
+        if let Some(phase1_inputargs) = self.phase1_inputargs.as_mut() {
+            visit_oprefs(phase1_inputargs, visitor);
         }
         if let Some(exported_state) = self.exported_state.as_mut() {
             exported_state.walk_const_ptr_refs_mut(visitor);
@@ -284,7 +286,7 @@ impl CollectedShortPreambleBuilder {
 
         ShortPreamble {
             ops: entries,
-            inputargs: label_args.into_iter().map(BoxRef::from_opref).collect(),
+            inputargs: label_args,
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state,
@@ -2221,13 +2223,9 @@ fn build_short_preamble_struct_from_ops(
     let constants: majit_ir::VecMap<u32, majit_ir::Const> = majit_ir::VecMap::new();
     ShortPreamble {
         ops: entries,
-        inputargs: short_inputargs
-            .iter()
-            .copied()
-            .map(BoxRef::from_opref)
-            .collect(),
-        used_boxes: used_boxes.iter().copied().map(BoxRef::from_opref).collect(),
-        jump_args: jump_args.iter().copied().map(BoxRef::from_opref).collect(),
+        inputargs: short_inputargs.to_vec(),
+        used_boxes: used_boxes.to_vec(),
+        jump_args: jump_args.to_vec(),
         exported_state: None,
         constants,
         phase1_inputargs: None,
@@ -2731,7 +2729,7 @@ impl ExtendedShortPreambleBuilder {
             .iter()
             .map(|arg| {
                 self.phase1_to_inputarg
-                    .get(&arg.to_opref())
+                    .get(arg)
                     .cloned()
                     .unwrap_or_else(|| {
                         // Unmapped Phase 1 jump arg (no rename): resolve the
@@ -2741,9 +2739,9 @@ impl ExtendedShortPreambleBuilder {
                         // producer-less position-only box. Mirrors the mapped
                         // arm, which binds via `materialize_box_at`; falls back
                         // to a position-only box only if no producer exists.
-                        ctx.get_box_replacement_operand_opt(arg.to_opref())
+                        ctx.get_box_replacement_operand_opt(*arg)
                             .map(|o| o.to_boxref())
-                            .unwrap_or_else(|| BoxRef::from_opref(arg.to_opref()))
+                            .unwrap_or_else(|| BoxRef::from_opref(*arg))
                     })
             })
             .collect();
@@ -2757,7 +2755,14 @@ impl ExtendedShortPreambleBuilder {
         self.extra_same_as = self.base_extra_same_as.clone();
         self.short_preamble_jump.clear();
         self.label_args = label_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
-        self.used_boxes = short_preamble.used_boxes.clone();
+        // The struct carries flat OpRef positions; the builder field is
+        // still BoxRef, so re-mint the positions at this boundary.
+        self.used_boxes = short_preamble
+            .used_boxes
+            .iter()
+            .copied()
+            .map(BoxRef::from_opref)
+            .collect();
         self.short_jump_args = jump_args_box;
         true
     }
@@ -3112,12 +3117,7 @@ impl ExtendedShortPreambleBuilder {
         let mut sp =
             build_short_preamble_struct_from_ops(inputargs, &ops, &used_boxes, &short_jump_args);
         if inputargs != &short_inputargs {
-            sp.phase1_inputargs = Some(
-                short_inputargs
-                    .into_iter()
-                    .map(BoxRef::from_opref)
-                    .collect(),
-            );
+            sp.phase1_inputargs = Some(short_inputargs);
         }
         sp
     }
@@ -3648,13 +3648,7 @@ mod tests {
         assert_eq!(sp.ops[0].op.opcode, OpCode::IntAdd);
         assert_eq!(sp.ops[1].op.opcode, OpCode::IntSub);
         assert_eq!(sp.ops[1].arg_mapping, vec![(1, 1)]);
-        assert_eq!(
-            sp.inputargs
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(10), OpRef::int_op(11)]
-        );
+        assert_eq!(sp.inputargs, vec![OpRef::int_op(10), OpRef::int_op(11)]);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -582,8 +582,7 @@ impl PotentialShortOp {
                         alt.same_as_source = Some(ctx.materialize_operand_at(compound.res));
                         // shortpreamble.py:333 `self.produced_short_boxes[
                         // new_name] = lst[i]` — keyed by the alias box.
-                        sb.produced_short_boxes
-                            .insert(alt.res.clone(), alt.clone());
+                        sb.produced_short_boxes.insert(alt.res.clone(), alt.clone());
                     }
                     Some(chosen)
                 }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -486,21 +486,19 @@ pub struct ShortBoxes {
     ///
     /// shortpreamble.py:256 `renamed = OpHelpers.inputarg_from_tp(box.type)`
     /// mints a fresh producer-less InputArg box per label slot; the stored
-    /// boxes ARE the short preamble's Label args (shortpreamble.py:443).
-    /// Each entry is a fresh InputArg box whose position is allocated from
+    /// positions ARE the short preamble's Label args (shortpreamble.py:443).
+    /// Each entry is a fresh InputArg position allocated from
     /// the op-position counter (`alloc_op_position_typed`), so its identity
     /// is DISTINCT from the original label arg (`shortpreamble.py:257`
     /// `ShortInputArg(box, renamed)` — `box` and `renamed` are two objects).
     /// `short_inputargs[i]` corresponds to `label_args[i]` positionally.
-    short_inputargs: Vec<BoxRef>,
-    /// Strong-`Rc` rooting pool for the renamed `InputArg` objects whose
-    /// `Weak` the `short_inputargs[i]` boxes hold (`from_bound_inputarg`
-    /// downgrades the `Rc`, box_ref.rs:293). Index-aligned 1:1 with
-    /// `short_inputargs`. Keeps each renamed `AbstractInputArg` alive so the
-    /// box stays bound (`bound_inputarg()` upgrades) until the operand it
-    /// sheds to (`Operand::InputArg`, a strong `Rc::clone`) self-roots it —
-    /// the analog of `TraceIterator.inputargs` rooting the outer-trace
-    /// inputargs (opencoder.py:250-273).
+    short_inputargs: Vec<OpRef>,
+    /// Strong-`Rc` rooting pool for the renamed `InputArg` objects behind
+    /// `short_inputargs[i]`. Index-aligned 1:1 with `short_inputargs`. Keeps
+    /// each renamed `AbstractInputArg` alive so producer-shaped consumers can
+    /// bind that position to `Operand::InputArg` / a bound BoxRef view — the
+    /// analog of `TraceIterator.inputargs` rooting the outer-trace inputargs
+    /// (opencoder.py:250-273).
     short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// shortpreamble.py:256 `box = label_args[i]` — the ORIGINAL label-arg
     /// references, kept so `potential_ops`/lookups resolve a label arg by
@@ -743,7 +741,7 @@ impl ShortBoxes {
         // (reads only `(type, position)`).
         let pos = ctx.alloc_op_position_typed(arg_type).raw();
         let renamed_ia = majit_ir::InputArg::from_type_rc(arg_type, pos);
-        let renamed = majit_ir::box_ref::BoxRef::from_bound_inputarg(&renamed_ia);
+        let renamed = renamed_ia.opref();
         // shortpreamble.py:259 `self.potential_ops[box] = ShortInputArg(...)`
         // is a plain dict assignment, so for a box duplicated across the
         // combined list it OVERWRITES: the LAST slot's `ShortInputArg`
@@ -800,7 +798,7 @@ impl ShortBoxes {
     fn renamed_short_inputarg(&self, label_arg_idx: Option<usize>) -> BoxRef {
         let idx = label_arg_idx
             .expect("InputArg short box missing label_arg_idx (set by add_short_input_arg)");
-        self.short_inputargs[idx].clone()
+        majit_ir::box_ref::BoxRef::from_bound_inputarg(&self.short_inputarg_refs[idx])
     }
 
     fn produce_arg(
@@ -1031,7 +1029,7 @@ impl ShortBoxes {
     /// Unconditionally returns `self.short_inputargs`. The pyre fallback
     /// to `label_args.to_vec()` on empty was a TODO — empty
     /// short_inputargs is the legitimate empty-loop case in upstream.
-    pub fn create_short_inputargs(&self, _label_args: &[OpRef]) -> Vec<BoxRef> {
+    pub fn create_short_inputargs(&self, _label_args: &[OpRef]) -> Vec<OpRef> {
         self.short_inputargs.clone()
     }
 
@@ -1375,13 +1373,13 @@ fn imported_const_opref(
 pub(crate) fn classify_short_arg(
     ctx: &mut crate::optimizeopt::OptContext,
     arg: OpRef,
-    short_inputargs: &[BoxRef],
+    short_inputargs: &[OpRef],
     short_args: &[OpRef],
     produced_results: &majit_ir::VecMap<OpRef, OpRef>,
     imported_constants: &mut majit_ir::VecMap<OpRef, OpRef>,
     short_box_const_values: &majit_ir::VecMap<OpRef, majit_ir::Value>,
 ) -> Option<crate::optimizeopt::ImportedShortPureArg> {
-    if let Some(slot) = short_inputargs.iter().position(|i| i.to_opref() == arg) {
+    if let Some(slot) = short_inputargs.iter().position(|i| *i == arg) {
         return short_args
             .get(slot)
             .copied()
@@ -1434,7 +1432,7 @@ impl ProducedShortOp {
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
         exported_infos: &majit_ir::VecMap<BoxRef, crate::optimizeopt::info::OpInfo>,
-        short_inputargs: &[BoxRef],
+        short_inputargs: &[OpRef],
         short_args: &[OpRef],
         result_map: &majit_ir::VecMap<OpRef, OpRef>,
         produced_results: &mut majit_ir::VecMap<OpRef, OpRef>,
@@ -1505,7 +1503,7 @@ impl ProducedShortOp {
     fn produce_pure(
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
-        short_inputargs: &[BoxRef],
+        short_inputargs: &[OpRef],
         short_args: &[OpRef],
         result_map: &majit_ir::VecMap<OpRef, OpRef>,
         produced_results: &mut majit_ir::VecMap<OpRef, OpRef>,
@@ -1657,7 +1655,7 @@ impl ProducedShortOp {
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
         exported_infos: &majit_ir::VecMap<BoxRef, crate::optimizeopt::info::OpInfo>,
-        short_inputargs: &[BoxRef],
+        short_inputargs: &[OpRef],
         short_args: &[OpRef],
         result_map: &majit_ir::VecMap<OpRef, OpRef>,
         produced_results: &majit_ir::VecMap<OpRef, OpRef>,
@@ -1780,7 +1778,7 @@ impl ProducedShortOp {
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
         exported_infos: &majit_ir::VecMap<BoxRef, crate::optimizeopt::info::OpInfo>,
-        short_inputargs: &[BoxRef],
+        short_inputargs: &[OpRef],
         short_args: &[OpRef],
         result_map: &majit_ir::VecMap<OpRef, OpRef>,
         produced_results: &majit_ir::VecMap<OpRef, OpRef>,
@@ -1924,7 +1922,7 @@ impl ProducedShortOp {
     fn produce_loop_invariant(
         &self,
         ctx: &mut crate::optimizeopt::OptContext,
-        short_inputargs: &[BoxRef],
+        short_inputargs: &[OpRef],
         short_args: &[OpRef],
         result_map: &majit_ir::VecMap<OpRef, OpRef>,
         produced_results: &majit_ir::VecMap<OpRef, OpRef>,
@@ -1996,9 +1994,9 @@ struct AbstractShortPreambleBuilderState {
     short_preamble_jump: Vec<majit_ir::OpRc>,
     extra_same_as: Vec<Op>,
     /// shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
-    /// the renamed InputArg boxes; reused verbatim as the Label args
+    /// the renamed InputArg positions; reused verbatim as the Label args
     /// (shortpreamble.py:443 `ResOperation(rop.LABEL, self.short_inputargs[:])`).
-    short_inputargs: Vec<BoxRef>,
+    short_inputargs: Vec<OpRef>,
     /// Known constant OpRefs. In RPython, isinstance(box, Const) is a type
     /// check. In majit, constant OpRefs must be explicitly tracked.
     known_constants: VecSet<OpRef>,
@@ -2121,10 +2119,7 @@ impl AbstractShortPreambleBuilderState {
             let arg_opref = arg.to_opref();
             if self.short_results.contains(&arg_opref)
                 || already_in_short.contains(&arg_opref)
-                || self
-                    .short_inputargs
-                    .iter()
-                    .any(|a| a.to_opref() == arg_opref)
+                || self.short_inputargs.iter().any(|a| *a == arg_opref)
                 || self.known_constants.contains(&arg_opref)
             {
                 continue;
@@ -2257,7 +2252,7 @@ impl ShortPreambleBuilder {
     pub fn new(
         label_args: &[OpRef],
         short_boxes: &[(majit_ir::operand::Operand, ProducedShortOp)],
-        short_inputargs: &[BoxRef],
+        short_inputargs: &[OpRef],
     ) -> Self {
         let mut produced_short_boxes = VecMap::new();
         for (k, v) in short_boxes {
@@ -2286,11 +2281,11 @@ impl ShortPreambleBuilder {
             produced_short_boxes.insert(k.clone(), v.clone());
         }
         // shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
-        // store the caller's renamed-box objects themselves. The empty
+        // store the caller's renamed positions themselves. The empty
         // fallback (test paths without an exported preview list) mints
-        // position-only boxes from the label args once.
+        // position refs from the label args once.
         let short_inputargs = if short_inputargs.is_empty() {
-            label_args.iter().map(|&a| BoxRef::from_opref(a)).collect()
+            label_args.to_vec()
         } else {
             short_inputargs.to_vec()
         };
@@ -2465,7 +2460,8 @@ impl ShortPreambleBuilder {
             .state
             .short_inputargs
             .iter()
-            .map(majit_ir::operand::Operand::from_boxref)
+            .copied()
+            .map(majit_ir::operand::Operand::bound_from_opref)
             .collect();
         result.push(Op::new(OpCode::Label, &short_inputargs_operand));
         result.extend(self.state.short.iter().map(|op| (**op).clone()));
@@ -2490,16 +2486,8 @@ impl ShortPreambleBuilder {
             .iter()
             .map(|op| op.pos.get())
             .collect();
-        // ShortPreamble is the cross-phase (position-domain) export;
-        // shed the boxes to their positions at this boundary.
-        let short_inputargs: Vec<OpRef> = self
-            .state
-            .short_inputargs
-            .iter()
-            .map(|a| a.to_opref())
-            .collect();
         build_short_preamble_struct_from_ops(
-            &short_inputargs,
+            &self.state.short_inputargs,
             &self.state.short,
             &self.state.used_boxes,
             &jump_args,
@@ -2518,7 +2506,7 @@ impl ShortPreambleBuilder {
         &self.state.extra_same_as
     }
 
-    pub fn short_inputargs(&self) -> &[BoxRef] {
+    pub fn short_inputargs(&self) -> &[OpRef] {
         &self.state.short_inputargs
     }
 }
@@ -2537,19 +2525,19 @@ pub struct ExtendedShortPreambleBuilder {
     /// therefore unverifiable (the gate cannot exercise the silent-miss
     /// surface), like the deferred vectorizer maps.
     produced_short_boxes: VecMap<OpRef, ProducedShortOp>,
-    short_inputargs: Vec<BoxRef>,
+    short_inputargs: Vec<OpRef>,
     /// shortpreamble.py:460: self.short = short — single ops list (base + JUMP sentinel)
     short: Vec<Op>,
     /// Tracks which OpRefs are already in `short` (for dedup).
     short_results: VecSet<OpRef>,
     /// Constants tracked for RPython isinstance(arg, Const) checks.
-    known_constants: VecSet<BoxRef>,
+    known_constants: VecSet<OpRef>,
     extra_same_as: Vec<Op>,
     short_preamble_jump: Vec<majit_ir::OpRc>,
     base_extra_same_as: Vec<Op>,
-    label_args: Vec<BoxRef>,
-    used_boxes: Vec<BoxRef>,
-    short_jump_args: Vec<BoxRef>,
+    label_args: Vec<OpRef>,
+    used_boxes: Vec<OpRef>,
+    short_jump_args: Vec<OpRef>,
     pub target_token: u64,
     /// RPython parity: remap Phase 1 preamble OpRefs → current inputargs.
     /// Values are the current-namespace boxes, bound to their producers at
@@ -2574,6 +2562,25 @@ impl ExtendedShortPreambleBuilder {
             }
         }
 
+        fn visit_oprefs(refs: &mut [OpRef], visitor: &mut dyn FnMut(&mut GcRef)) {
+            for r in refs {
+                if let OpRef::ConstPtr(gcref) = r {
+                    visitor(gcref);
+                }
+            }
+        }
+
+        fn visit_opref_set(set: &mut VecSet<OpRef>, visitor: &mut dyn FnMut(&mut GcRef)) {
+            let refs: Vec<OpRef> = set.iter().copied().collect();
+            set.clear();
+            for mut r in refs {
+                if let OpRef::ConstPtr(gcref) = &mut r {
+                    visitor(gcref);
+                }
+                set.insert(r);
+            }
+        }
+
         fn visit_produced(produced: &mut ProducedShortOp, visitor: &mut dyn FnMut(&mut GcRef)) {
             produced.preamble_op.walk_const_ptr_refs_mut(visitor);
             if let Some(source) = produced.same_as_source.as_ref() {
@@ -2584,13 +2591,11 @@ impl ExtendedShortPreambleBuilder {
         for (_, produced) in self.produced_short_boxes.iter_mut() {
             visit_produced(produced, visitor);
         }
-        visit_boxrefs(&self.short_inputargs, visitor);
+        visit_oprefs(&mut self.short_inputargs, visitor);
         for op in &mut self.short {
             op.walk_const_ptr_refs_mut(visitor);
         }
-        for b in self.known_constants.iter() {
-            b.walk_const_ptr_refs(visitor);
-        }
+        visit_opref_set(&mut self.known_constants, visitor);
         for op in &mut self.extra_same_as {
             op.walk_const_ptr_refs_mut(visitor);
         }
@@ -2600,9 +2605,9 @@ impl ExtendedShortPreambleBuilder {
         for op in &mut self.base_extra_same_as {
             op.walk_const_ptr_refs_mut(visitor);
         }
-        visit_boxrefs(&self.label_args, visitor);
-        visit_boxrefs(&self.used_boxes, visitor);
-        visit_boxrefs(&self.short_jump_args, visitor);
+        visit_oprefs(&mut self.label_args, visitor);
+        visit_oprefs(&mut self.used_boxes, visitor);
+        visit_oprefs(&mut self.short_jump_args, visitor);
         // phase1_to_inputarg keys are Phase 1 preamble OpRefs (op result
         // positions, never Const); only the bound values carry const GcRefs.
         for (_, target) in self.phase1_to_inputarg.iter() {
@@ -2716,7 +2721,7 @@ impl ExtendedShortPreambleBuilder {
                     }
                     self.short.clear();
                     self.short_results.clear();
-                    self.label_args = label_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
+                    self.label_args = label_args.to_vec();
                     return false;
                 }
             }
@@ -2724,46 +2729,31 @@ impl ExtendedShortPreambleBuilder {
             self.short.push(op);
         }
         // JUMP sentinel at end (RPython: short[-1] is always JUMP)
-        let jump_args_box: Vec<BoxRef> = short_preamble
-            .jump_args
-            .iter()
-            .map(|arg| {
-                self.phase1_to_inputarg
-                    .get(arg)
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        // Unmapped Phase 1 jump arg (no rename): resolve the
-                        // Phase-2 producer registered at this position — the
-                        // inlined short box op or the label inputarg — so the
-                        // JUMP arg carries the producer object instead of a
-                        // producer-less position-only box. Mirrors the mapped
-                        // arm, which binds via `materialize_box_at`; falls back
-                        // to a position-only box only if no producer exists.
-                        ctx.get_box_replacement_operand_opt(*arg)
-                            .map(|o| o.to_boxref())
-                            .unwrap_or_else(|| BoxRef::from_opref(*arg))
-                    })
-            })
-            .collect();
-        let jump_args_box_operand: Vec<majit_ir::operand::Operand> = jump_args_box
-            .iter()
-            .map(majit_ir::operand::Operand::from_boxref)
-            .collect();
-        self.short
-            .push(Op::new(OpCode::Jump, &jump_args_box_operand));
+        let mut jump_args = Vec::with_capacity(short_preamble.jump_args.len());
+        let mut jump_args_operand = Vec::with_capacity(short_preamble.jump_args.len());
+        for arg in &short_preamble.jump_args {
+            if let Some(target) = self.phase1_to_inputarg.get(arg) {
+                jump_args.push(target.to_opref());
+                jump_args_operand.push(majit_ir::operand::Operand::from_boxref(target));
+            } else {
+                // Unmapped Phase 1 jump arg (no rename): resolve the Phase-2
+                // producer registered at this position — the inlined short box
+                // op or the label inputarg — so the emitted JUMP keeps the
+                // producer binding while `short_jump_args` stores only positions.
+                let operand = ctx
+                    .get_box_replacement_operand_opt(*arg)
+                    .unwrap_or_else(|| ctx.materialize_operand_at(*arg));
+                jump_args.push(operand.to_opref());
+                jump_args_operand.push(operand);
+            }
+        }
+        self.short.push(Op::new(OpCode::Jump, &jump_args_operand));
         // Reset state
         self.extra_same_as = self.base_extra_same_as.clone();
         self.short_preamble_jump.clear();
-        self.label_args = label_args.iter().map(|a| BoxRef::from_opref(*a)).collect();
-        // The struct carries flat OpRef positions; the builder field is
-        // still BoxRef, so re-mint the positions at this boundary.
-        self.used_boxes = short_preamble
-            .used_boxes
-            .iter()
-            .copied()
-            .map(BoxRef::from_opref)
-            .collect();
-        self.short_jump_args = jump_args_box;
+        self.label_args = label_args.to_vec();
+        self.used_boxes = short_preamble.used_boxes.clone();
+        self.short_jump_args = jump_args;
         true
     }
 
@@ -2791,7 +2781,7 @@ impl ExtendedShortPreambleBuilder {
         }
         if self.short_results.contains(&arg)
             || inputargs_set.contains(&arg)
-            || self.known_constants.contains(&BoxRef::from_opref(arg))
+            || self.known_constants.contains(&arg)
             || constants_set.contains(&arg.raw())
         {
             return true;
@@ -2943,11 +2933,10 @@ impl ExtendedShortPreambleBuilder {
                 same_as.pos.set(op);
                 self.extra_same_as.push(same_as);
             }
-            self.label_args.push(resolved_op.clone());
-            // Bind the live preamble producer: `to_opref` is unchanged
-            // (replay_op.pos), and the box now roots replay_op (already held
-            // by short_preamble_jump), so the flattened struct is identical.
-            self.short_jump_args.push(BoxRef::from_bound_op(replay_op));
+            self.label_args.push(resolved_key);
+            // The flattened struct only needs the replay position; the replay
+            // op itself is rooted by short_preamble_jump.
+            self.short_jump_args.push(replay_op.pos.get());
             self.short_preamble_jump.push(replay_op.clone());
         }
     }
@@ -2976,15 +2965,9 @@ impl ExtendedShortPreambleBuilder {
             op.pos.set(current_result);
             self.extra_same_as.push(op);
         }
-        self.label_args.push(result.to_boxref());
-        // Bind the live preamble producer (current_result == preamble_op.pos):
-        // `to_opref` is unchanged and the box roots produced.preamble_op
-        // (already held by short_preamble_jump), so the flattened struct is
-        // identical.
-        self.used_boxes
-            .push(BoxRef::from_bound_op(&produced.preamble_op));
-        self.short_jump_args
-            .push(BoxRef::from_bound_op(&produced.preamble_op));
+        self.label_args.push(result.to_opref());
+        self.used_boxes.push(produced.preamble_op.pos.get());
+        self.short_jump_args.push(produced.preamble_op.pos.get());
         self.short_preamble_jump.push(produced.preamble_op.clone());
     }
 
@@ -3056,8 +3039,8 @@ impl ExtendedShortPreambleBuilder {
             for arg in preamble_op.getarglist().iter() {
                 let arg = arg.to_opref();
                 if self.short_results.contains(&arg)
-                    || self.short_inputargs.iter().any(|a| a.to_opref() == arg)
-                    || self.known_constants.contains(&BoxRef::from_opref(arg))
+                    || self.short_inputargs.iter().any(|a| *a == arg)
+                    || self.known_constants.contains(&arg)
                 {
                     continue;
                 }
@@ -3091,7 +3074,7 @@ impl ExtendedShortPreambleBuilder {
         self.produced_short_boxes.get(&result).cloned()
     }
 
-    pub fn short_inputargs(&self) -> &[BoxRef] {
+    pub fn short_inputargs(&self) -> &[OpRef] {
         &self.short_inputargs
     }
 
@@ -3101,23 +3084,19 @@ impl ExtendedShortPreambleBuilder {
             .iter()
             .map(|op| std::rc::Rc::new(op.clone()))
             .collect();
-        // ShortPreamble is the cross-phase (position-domain) export;
-        // shed the boxes to their positions at this boundary.
-        let short_inputargs: Vec<OpRef> =
-            self.short_inputargs.iter().map(|a| a.to_opref()).collect();
-        let label_args: Vec<OpRef> = self.label_args.iter().map(|b| b.to_opref()).collect();
-        let used_boxes: Vec<OpRef> = self.used_boxes.iter().map(|b| b.to_opref()).collect();
-        let short_jump_args: Vec<OpRef> =
-            self.short_jump_args.iter().map(|b| b.to_opref()).collect();
-        let inputargs = if label_args.is_empty() {
-            &short_inputargs
+        let inputargs = if self.label_args.is_empty() {
+            &self.short_inputargs
         } else {
-            &label_args
+            &self.label_args
         };
-        let mut sp =
-            build_short_preamble_struct_from_ops(inputargs, &ops, &used_boxes, &short_jump_args);
-        if inputargs != &short_inputargs {
-            sp.phase1_inputargs = Some(short_inputargs);
+        let mut sp = build_short_preamble_struct_from_ops(
+            inputargs,
+            &ops,
+            &self.used_boxes,
+            &self.short_jump_args,
+        );
+        if inputargs != self.short_inputargs.as_slice() {
+            sp.phase1_inputargs = Some(self.short_inputargs.clone());
         }
         sp
     }
@@ -3126,11 +3105,11 @@ impl ExtendedShortPreambleBuilder {
         &self.extra_same_as
     }
 
-    pub fn label_args(&self) -> &[BoxRef] {
+    pub fn label_args(&self) -> &[OpRef] {
         &self.label_args
     }
 
-    pub fn jump_args(&self) -> &[BoxRef] {
+    pub fn jump_args(&self) -> &[OpRef] {
         &self.short_jump_args
     }
 
@@ -3340,7 +3319,7 @@ pub(crate) fn produced_short_boxes_from_exported_boxes(
 /// re-running the rename + filter pass.
 pub(crate) fn build_short_preamble_from_produced_boxes(
     label_args: &[OpRef],
-    short_inputargs: &[BoxRef],
+    short_inputargs: &[OpRef],
     produced: &[(OpRef, ProducedShortOp)],
 ) -> ShortPreamble {
     // #146/S8: the builder map keys by the entry res Box (`p.res`, the carried
@@ -3378,7 +3357,7 @@ pub(crate) fn build_short_preamble_from_produced_boxes(
 #[cfg(test)]
 fn build_short_preamble_from_exported_boxes(
     label_args: &[OpRef],
-    short_inputargs: &[BoxRef],
+    short_inputargs: &[OpRef],
     exported_short_boxes: &[PreambleOp],
 ) -> ShortPreamble {
     let produced = produced_short_boxes_from_exported_boxes(exported_short_boxes);
@@ -3638,10 +3617,7 @@ mod tests {
 
         let sp = build_short_preamble_from_exported_boxes(
             &[OpRef::int_op(0), OpRef::int_op(1)],
-            &[
-                rooted_resop_box(Type::Int, 10),
-                rooted_resop_box(Type::Int, 11),
-            ],
+            &[OpRef::int_op(10), OpRef::int_op(11)],
             &exported,
         );
         assert_eq!(sp.ops.len(), 2);
@@ -3654,10 +3630,7 @@ mod tests {
     #[test]
     fn test_build_short_preamble_from_exported_boxes_skips_standalone_overflow_guards() {
         let label_args = vec![OpRef::int_op(10), OpRef::int_op(11)];
-        let short_inputargs = vec![
-            rooted_resop_box(Type::Int, 100),
-            rooted_resop_box(Type::Int, 101),
-        ];
+        let short_inputargs = vec![OpRef::int_op(100), OpRef::int_op(101)];
 
         let mut ovf = Op::new(OpCode::IntAddOvf, &[rop(Type::Int, 10), rop(Type::Int, 11)]);
         ovf.pos.set(OpRef::int_op(20));
@@ -3744,7 +3717,7 @@ mod tests {
         let mut builder = ShortPreambleBuilder::new(
             &[OpRef::int_op(0), OpRef::int_op(1)],
             &produced,
-            &[in0.clone(), in1.clone()],
+            &[OpRef::int_op(0), OpRef::int_op(1)],
         );
 
         let used = builder
@@ -3853,7 +3826,7 @@ mod tests {
         sb.add_pure_op(&mut __ctx, pure);
 
         let produced = sb.produced_ops(&mut __ctx);
-        let renamed10 = sb.create_short_inputargs(&[OpRef::int_op(10)])[0].to_opref();
+        let renamed10 = sb.create_short_inputargs(&[OpRef::int_op(10)])[0];
         // 1 ShortInputArg (label arg 10) + the accepted pure op.
         let non_input: Vec<_> = produced
             .iter()
@@ -4091,15 +4064,15 @@ mod tests {
         assert_eq!(si.len(), 2);
 
         // (A) DISTINCT identity: the renamed box is not the original label arg.
-        assert_ne!(si[0].to_opref(), OpRef::int_op(10));
-        assert_ne!(si[1].to_opref(), OpRef::ref_op(11));
+        assert_ne!(si[0], OpRef::int_op(10));
+        assert_ne!(si[1], OpRef::ref_op(11));
 
         // (B) the renamed boxes are InputArg-kind of the matching type
         // (inputarg_from_tp(box.type)).
-        assert!(matches!(si[0].to_opref(), OpRef::InputArgInt(_)));
-        assert!(matches!(si[1].to_opref(), OpRef::InputArgRef(_)));
-        assert_eq!(si[0].to_opref().ty(), Some(majit_ir::Type::Int));
-        assert_eq!(si[1].to_opref().ty(), Some(majit_ir::Type::Ref));
+        assert!(matches!(si[0], OpRef::InputArgInt(_)));
+        assert!(matches!(si[1], OpRef::InputArgRef(_)));
+        assert_eq!(si[0].ty(), Some(majit_ir::Type::Int));
+        assert_eq!(si[1].ty(), Some(majit_ir::Type::Ref));
 
         // (C) lookups still resolve a label arg by its ORIGINAL opref
         // (shortpreamble.py:259 potential_ops[box]).
@@ -4132,7 +4105,7 @@ mod tests {
         // Two FRESH distinct renamed boxes, one per slot (shortpreamble.py:258).
         let si = sb.create_short_inputargs(&label_args);
         assert_eq!(si.len(), 2);
-        assert_ne!(si[0].to_opref(), si[1].to_opref());
+        assert_ne!(si[0], si[1]);
 
         // The duplicate collapses to ONE produced InputArg entry, keyed at the
         // LAST slot (label_arg_idx == Some(1)), not the first (Some(0)).
@@ -4148,8 +4121,8 @@ mod tests {
 
         // produce_arg returns the LAST slot's renamed box.
         let produced_arg = sb.produce_arg(&mut ctx, OpRef::ref_op(50)).unwrap();
-        assert_eq!(produced_arg.to_opref(), si[1].to_opref());
-        assert_ne!(produced_arg.to_opref(), si[0].to_opref());
+        assert_eq!(produced_arg.to_opref(), si[1]);
+        assert_ne!(produced_arg.to_opref(), si[0]);
 
         // `lookup_label_arg` mirrors `potential_ops[box]`'s last-wins overwrite,
         // resolving the duplicated box to the LAST/live slot. This keeps the
@@ -4175,7 +4148,7 @@ mod tests {
 
         let produced = sb.produced_ops(&mut __ctx);
         let short_inputargs = sb.create_short_inputargs(&[OpRef::int_op(30), OpRef::int_op(31)]);
-        let label_arg_oprefs: Vec<OpRef> = short_inputargs.iter().map(|b| b.to_opref()).collect();
+        let label_arg_oprefs: Vec<OpRef> = short_inputargs.clone();
         // #146/S8: the builder map keys by the entry res Box; re-key the
         // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
         // look up by the res box of the int_op(10) entry.
@@ -4247,11 +4220,8 @@ mod tests {
             .iter()
             .map(|(_, p)| (p.res.clone(), p.clone()))
             .collect();
-        let mut builder = ShortPreambleBuilder::new(
-            &[OpRef::int_op(20)],
-            &entries,
-            &[rooted_resop_box(Type::Int, 20)],
-        );
+        let mut builder =
+            ShortPreambleBuilder::new(&[OpRef::int_op(20)], &entries, &[OpRef::int_op(20)]);
         assert!(builder.add_preamble_op(&alias_res));
         let extra = builder.extra_same_as();
         assert_eq!(extra.len(), 1);
@@ -4269,8 +4239,7 @@ mod tests {
 
     #[test]
     fn test_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
-        let mut builder =
-            ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[rooted_resop_box(Type::Int, 7)]);
+        let mut builder = ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[OpRef::int_op(7)]);
         let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rop(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
@@ -4306,8 +4275,7 @@ mod tests {
 
     #[test]
     fn test_extended_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
-        let sb =
-            ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[rooted_resop_box(Type::Int, 7)]);
+        let sb = ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[OpRef::int_op(7)]);
         let mut builder = ExtendedShortPreambleBuilder::new(0, &sb);
         let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rop(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
@@ -4322,22 +4290,8 @@ mod tests {
 
         builder.add_preamble_op_from_pop(&pop, rooted_resop_box(Type::Int, 41));
 
-        assert_eq!(
-            builder
-                .label_args()
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(41)]
-        );
-        assert_eq!(
-            builder
-                .jump_args()
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(14)]
-        );
+        assert_eq!(builder.label_args(), &[OpRef::int_op(41)]);
+        assert_eq!(builder.jump_args(), &[OpRef::int_op(14)]);
         let extra = builder.extra_same_as();
         assert_eq!(extra.len(), 1);
         assert_eq!(extra[0].opcode, OpCode::SameAsI);

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -811,8 +811,7 @@ impl ShortBoxes {
         // canonical box once for both identity-keyed checks. Const args
         // never key either set (they route to the Const arm below).
         if !opref.is_constant() {
-            let key = ctx.materialize_box_at(opref);
-            let okey = majit_ir::operand::Operand::from_boxref(&key);
+            let okey = ctx.materialize_operand_at(opref);
             if let Some(existing) = self.produced_short_boxes.get(&okey) {
                 // shortpreamble.py:285 `return ...preamble_op` — the
                 // dependency's replay op object itself, so preamble-op
@@ -897,8 +896,7 @@ impl ShortBoxes {
     ) -> Option<ProducedShortOp> {
         // shortpreamble.py:311-339 add_op_to_short — guard, cycle set,
         // and final insert all key on `shortop.res` Box identity.
-        let key = ctx.materialize_box_at(result);
-        let okey = majit_ir::operand::Operand::from_boxref(&key);
+        let okey = ctx.materialize_operand_at(result);
         if let Some(existing) = self.produced_short_boxes.get(&okey) {
             return Some(existing.clone());
         }

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -350,10 +350,10 @@ pub struct PreambleOp {
     /// invented SameAs name because another producer won the original slot.
     pub invented_name: bool,
     /// Original result box this invented name aliases, if any.
-    /// MIGRATION (#9): carried as a [`BoxRef`] so the canonical
-    /// (possibly producer-bound) box travels with the struct instead
-    /// of being re-minted positionally at each use site.
-    pub same_as_source: Option<majit_ir::box_ref::BoxRef>,
+    /// Carried as an [`Operand`] so the canonical (producer-bound) operand
+    /// travels with the struct instead of being re-minted positionally at
+    /// each use site.
+    pub same_as_source: Option<majit_ir::operand::Operand>,
 }
 
 impl PreambleOp {
@@ -446,7 +446,7 @@ impl PreambleOp {
             kind: self.kind.clone(),
             // shortpreamble.py:120/85/170 `ProducedShortOp(self, ...)` —
             // short_op.res is the original result box; resolve canonical.
-            res: ctx.materialize_box_at(self.op.pos.get()),
+            res: ctx.materialize_operand_at(self.op.pos.get()),
             preamble_op: std::rc::Rc::new(preamble_op),
             invented_name: self.invented_name,
             same_as_source: self.same_as_source.clone(),
@@ -563,7 +563,7 @@ impl PotentialShortOp {
                         // shortpreamble.py:329 `lst[i].short_op.res =
                         // new_name` — the alias entry's res becomes the
                         // freshly invented name.
-                        alt.res = ctx.materialize_box_at(alias);
+                        alt.res = ctx.materialize_operand_at(alias);
                         alt.invented_name = true;
                         // shortpreamble.py:330 `lst[i].short_op.res = new_name`:
                         // the alias result is now the freshly invented SameAs box,
@@ -579,13 +579,11 @@ impl PotentialShortOp {
                         // shortpreamble.py:328 `ResOperation(opnum, [shortop.res])`
                         // — the alias source is the Box itself; resolve to
                         // the canonical (possibly producer-bound) box.
-                        alt.same_as_source = Some(ctx.materialize_box_at(compound.res));
+                        alt.same_as_source = Some(ctx.materialize_operand_at(compound.res));
                         // shortpreamble.py:333 `self.produced_short_boxes[
                         // new_name] = lst[i]` — keyed by the alias box.
-                        sb.produced_short_boxes.insert(
-                            majit_ir::operand::Operand::from_boxref(&alt.res),
-                            alt.clone(),
-                        );
+                        sb.produced_short_boxes
+                            .insert(alt.res.clone(), alt.clone());
                     }
                     Some(chosen)
                 }
@@ -1012,7 +1010,7 @@ impl ShortBoxes {
             new_op.pos.set(getfield_op.pos.get());
             // shortpreamble.py:279: ProducedShortOp(short_op, preamble_op)
             short_boxes.push(ProducedShortOp {
-                res: ctx.materialize_box_at(getfield_op.pos.get()),
+                res: ctx.materialize_operand_at(getfield_op.pos.get()),
                 preamble_op: std::rc::Rc::new(new_op),
                 kind: PreambleOpKind::Heap,
                 invented_name: false,
@@ -1311,17 +1309,22 @@ impl CompoundOp {
 pub struct ProducedShortOp {
     /// The short op classification.
     pub kind: PreambleOpKind,
-    /// `short_op.res` (shortpreamble.py:58/110/151/224) — the result box
+    /// `short_op.res` (shortpreamble.py:58/110/151/224) — the result operand
     /// this short op produces. `add_preamble_op` reads it back as the
-    /// `PreambleOp.op` box (upstream `produce_op` passes `self.res`).
-    pub res: majit_ir::box_ref::BoxRef,
+    /// `PreambleOp.op` operand (upstream `produce_op` passes `self.res`).
+    /// Always a producer-bound / const operand (`materialize_operand_at` on
+    /// the preview, `res.bound_op()`-rooted exported entries per #173), never
+    /// position-only — so its `to_boxref()` re-mint at the `expand_info`
+    /// boundary is `Rc::ptr_eq`-stable on the producer.
+    pub res: majit_ir::operand::Operand,
     /// The preamble operation to replay.
     pub preamble_op: majit_ir::OpRc,
     /// Whether this short op uses an invented SameAs result.
     pub invented_name: bool,
     /// Original result this invented name aliases.
-    /// MIGRATION (#9): carried as a [`BoxRef`]; see [`PreambleOp::same_as_source`].
-    pub same_as_source: Option<majit_ir::box_ref::BoxRef>,
+    /// Carried as an [`Operand`] so the canonical producer-bound operand
+    /// travels with the struct; see [`PreambleOp::same_as_source`].
+    pub same_as_source: Option<majit_ir::operand::Operand>,
     /// Slot of this short box's result within the original
     /// `label_args + virtuals`, i.e. `lookup_label_arg(canonical_result)`
     /// carried over from [`PreambleOp::label_arg_idx`] across the export
@@ -1591,7 +1594,7 @@ impl ProducedShortOp {
         let builder_pop = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(&majit_ir::operand::Operand::from_boxref(&self.res)));
+            .and_then(|b| b.produced_short_op(&self.res));
         let imported = match builder_pop {
             Some(p) => {
                 debug_assert_eq!(
@@ -1612,7 +1615,9 @@ impl ProducedShortOp {
                         op: ctx.materialize_box_at(source),
                         invented_name: self.invented_name,
                         preamble_op: p.preamble_op.clone(),
-                        same_as_source: self.same_as_source.clone(),
+                        // info-force channel stays BoxRef-carried; the bound
+                        // producer operand re-mints a ptr_eq-stable box.
+                        same_as_source: self.same_as_source.as_ref().map(|o| o.to_boxref()),
                     },
                 }
             }
@@ -1624,7 +1629,7 @@ impl ProducedShortOp {
                 result_opref,
                 source,
                 self.invented_name,
-                self.same_as_source.clone(),
+                self.same_as_source.as_ref().map(|o| o.to_boxref()),
             ),
         };
         ctx.imported_short_pure_ops.push(imported);
@@ -1722,7 +1727,7 @@ impl ProducedShortOp {
         let replay_rc = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(&majit_ir::operand::Operand::from_boxref(&self.res)))
+            .and_then(|b| b.produced_short_op(&self.res))
             .map(|p| {
                 debug_assert_eq!(
                     p.preamble_op.pos.get(),
@@ -1737,7 +1742,7 @@ impl ProducedShortOp {
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
             preamble_op: replay_rc,
-            same_as_source: self.same_as_source.clone(),
+            same_as_source: self.same_as_source.as_ref().map(|o| o.to_boxref()),
         };
         let parent_descr = getfield_op
             .with_field_descr(|fd| fd.get_parent_descr())
@@ -1853,7 +1858,7 @@ impl ProducedShortOp {
         let replay_rc = ctx
             .imported_short_preamble_builder
             .as_ref()
-            .and_then(|b| b.produced_short_op(&majit_ir::operand::Operand::from_boxref(&self.res)))
+            .and_then(|b| b.produced_short_op(&self.res))
             .map(|p| {
                 debug_assert_eq!(
                     p.preamble_op.pos.get(),
@@ -1868,7 +1873,7 @@ impl ProducedShortOp {
             op: ctx.materialize_box_at(source),
             invented_name: self.invented_name,
             preamble_op: replay_rc,
-            same_as_source: self.same_as_source.clone(),
+            same_as_source: self.same_as_source.as_ref().map(|o| o.to_boxref()),
         };
         let obj_box = ctx.get_box_replacement_operand_opt(obj_resolved);
         if obj_resolved.is_constant()
@@ -2023,10 +2028,10 @@ impl AbstractShortPreambleBuilderState {
     /// `same_as_source`: the original OpRef this invented name aliases.
     fn record_imported_preamble_use(
         &mut self,
-        op: majit_ir::box_ref::BoxRef,
+        op: majit_ir::operand::Operand,
         replay_op: &majit_ir::OpRc,
         invented_name: bool,
-        same_as_source: Option<majit_ir::box_ref::BoxRef>,
+        same_as_source: Option<majit_ir::operand::Operand>,
     ) {
         if !self.recorded_canonical_results.insert(replay_op.pos.get()) {
             return;
@@ -2050,7 +2055,7 @@ impl AbstractShortPreambleBuilderState {
             let source = same_as_source.unwrap_or_else(|| op.clone());
             let mut same_as = Op::new(
                 OpCode::same_as_for_type(replay_op.result_type()),
-                &[majit_ir::operand::Operand::from_boxref(&source)],
+                &[source.clone()],
             );
             same_as.pos.set(op.to_opref());
             self.extra_same_as.push(same_as);
@@ -2061,7 +2066,7 @@ impl AbstractShortPreambleBuilderState {
 
     fn record_preamble_use(
         &mut self,
-        result: majit_ir::box_ref::BoxRef,
+        result: majit_ir::operand::Operand,
         produced: &ProducedShortOp,
     ) {
         self.record_imported_preamble_use(
@@ -2256,7 +2261,7 @@ pub struct ShortPreambleBuilder {
 impl ShortPreambleBuilder {
     pub fn new(
         label_args: &[OpRef],
-        short_boxes: &[(BoxRef, ProducedShortOp)],
+        short_boxes: &[(majit_ir::operand::Operand, ProducedShortOp)],
         short_inputargs: &[BoxRef],
     ) -> Self {
         let mut produced_short_boxes = VecMap::new();
@@ -2283,7 +2288,7 @@ impl ShortPreambleBuilder {
             if k.to_opref().is_constant() {
                 continue;
             }
-            produced_short_boxes.insert(majit_ir::operand::Operand::from_boxref(k), v.clone());
+            produced_short_boxes.insert(k.clone(), v.clone());
         }
         // shortpreamble.py:430 `self.short_inputargs = short_inputargs` —
         // store the caller's renamed-box objects themselves. The empty
@@ -2432,11 +2437,16 @@ impl ShortPreambleBuilder {
         // threaded through `field_entry::PreambleOp` — so the
         // produced_short_boxes lookup is no longer consulted here (#149/S8f).
         let replay_op = &preamble_op.preamble_op;
+        // The info-force `PreambleOp` still carries BoxRef; shed its bound
+        // producer boxes to operands for the operand-carrying record API.
         self.state.record_imported_preamble_use(
-            resolved_op,
+            majit_ir::operand::Operand::from_boxref(&resolved_op),
             replay_op,
             preamble_op.invented_name,
-            preamble_op.same_as_source.clone(),
+            preamble_op
+                .same_as_source
+                .as_ref()
+                .map(majit_ir::operand::Operand::from_boxref),
         );
     }
 
@@ -2900,7 +2910,10 @@ impl ExtendedShortPreambleBuilder {
             preamble_op.op.to_opref()
         };
         if let Some(produced) = self.produced_short_boxes.get(&lookup_key).cloned() {
-            self.add_tracked_preamble_op(resolved_op, &produced);
+            self.add_tracked_preamble_op(
+                majit_ir::operand::Operand::from_boxref(&resolved_op),
+                &produced,
+            );
         } else {
             // shortpreamble.py:465-476: same pattern via replay_op.
             let replay_op = &preamble_op.preamble_op;
@@ -2940,7 +2953,7 @@ impl ExtendedShortPreambleBuilder {
     /// shortpreamble.py:471-477: add_preamble_op (internal)
     pub fn add_tracked_preamble_op(
         &mut self,
-        result: majit_ir::box_ref::BoxRef,
+        result: majit_ir::operand::Operand,
         produced: &ProducedShortOp,
     ) {
         let current_result = produced.preamble_op.pos.get();
@@ -2956,12 +2969,12 @@ impl ExtendedShortPreambleBuilder {
                 .unwrap_or_else(|| result.clone());
             let mut op = Op::new(
                 OpCode::same_as_for_type(produced.preamble_op.result_type()),
-                &[majit_ir::operand::Operand::from_boxref(&source)],
+                &[source.clone()],
             );
             op.pos.set(current_result);
             self.extra_same_as.push(op);
         }
-        self.label_args.push(result.clone());
+        self.label_args.push(result.to_boxref());
         // Bind the live preamble producer (current_result == preamble_op.pos):
         // `to_opref` is unchanged and the box roots produced.preamble_op
         // (already held by short_preamble_jump), so the flattened struct is
@@ -3306,9 +3319,10 @@ pub(crate) fn produced_short_boxes_from_exported_boxes(
                 ProducedShortOp {
                     kind: entry.kind.clone(),
                     // shortpreamble.py:58/110 short_op.res — the exported
-                    // entry carries the Phase-1 res box across the
-                    // boundary; reuse the SAME object.
-                    res: entry.res.clone(),
+                    // entry carries the Phase-1 res box across the boundary;
+                    // shed the bound producer box to its live operand (#173
+                    // roots the producer, so this is never position-only).
+                    res: majit_ir::operand::Operand::from_boxref(&entry.res),
                     preamble_op: std::rc::Rc::new(preamble_op),
                     invented_name: entry.invented_name,
                     same_as_source: entry.same_as_source.clone(),
@@ -3345,7 +3359,7 @@ pub(crate) fn build_short_preamble_from_produced_boxes(
     // box), but a miss only drops the redundant recursive append — the outer
     // loop still emits every entry in valid def-before-use order. This path is
     // a corpus-dead fallback (rebuilt preamble is Some in the measured corpus).
-    let entries: Vec<(BoxRef, ProducedShortOp)> = produced
+    let entries: Vec<(majit_ir::operand::Operand, ProducedShortOp)> = produced
         .iter()
         .filter(|(_, p)| !p.res.to_opref().is_constant())
         .map(|(_, p)| (p.res.clone(), p.clone()))
@@ -3358,9 +3372,8 @@ pub(crate) fn build_short_preamble_from_produced_boxes(
     // to seed into `known_constants` and the `loop_constants`
     // parameter has been retired.
     for (res, _) in &entries {
-        let res = majit_ir::operand::Operand::from_boxref(res);
-        let _ = builder.add_op_to_short(&res);
-        let _ = builder.add_preamble_op(&res);
+        let _ = builder.add_op_to_short(res);
+        let _ = builder.add_preamble_op(res);
     }
     builder.build_short_preamble_struct()
 }
@@ -3715,10 +3728,10 @@ mod tests {
         let res8 = BoxRef::from_bound_op(&producer8);
         let produced = vec![
             (
-                res7.clone(),
+                Operand::from_boxref(&res7),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
-                    res: res7.clone(),
+                    res: Operand::from_boxref(&res7),
                     preamble_op: producer7,
                     invented_name: false,
                     same_as_source: None,
@@ -3726,10 +3739,10 @@ mod tests {
                 },
             ),
             (
-                res8.clone(),
+                Operand::from_boxref(&res8),
                 ProducedShortOp {
                     kind: PreambleOpKind::Pure,
-                    res: res8.clone(),
+                    res: Operand::from_boxref(&res8),
                     preamble_op: producer8,
                     invented_name: false,
                     same_as_source: None,
@@ -4175,18 +4188,17 @@ mod tests {
         // #146/S8: the builder map keys by the entry res Box; re-key the
         // produced_ops list (keyed by `preamble_op.pos`) to res for new() and
         // look up by the res box of the int_op(10) entry.
-        let entries: Vec<(BoxRef, ProducedShortOp)> = produced
+        let entries: Vec<(majit_ir::operand::Operand, ProducedShortOp)> = produced
             .iter()
             .map(|(_, p)| (p.res.clone(), p.clone()))
             .collect();
-        let res10 = Operand::from_boxref(
-            &produced
-                .iter()
-                .find(|(r, _)| *r == OpRef::int_op(10))
-                .unwrap()
-                .1
-                .res,
-        );
+        let res10 = produced
+            .iter()
+            .find(|(r, _)| *r == OpRef::int_op(10))
+            .unwrap()
+            .1
+            .res
+            .clone();
         let mut builder = ShortPreambleBuilder::new(&label_arg_oprefs, &entries, &short_inputargs);
         let used = builder.add_op_to_short(&res10).unwrap();
         assert!(builder.add_preamble_op(&res10));
@@ -4235,12 +4247,12 @@ mod tests {
         let (alias_result, alias_res) = produced
             .iter()
             .find(|(result, pop)| *result != OpRef::int_op(20) && pop.invented_name)
-            .map(|(result, pop)| (*result, Operand::from_boxref(&pop.res)))
+            .map(|(result, pop)| (*result, pop.res.clone()))
             .unwrap();
 
         // #146/S8: re-key the produced_ops list to res for new() + look up the
         // invented-name alias entry by its res box.
-        let entries: Vec<(BoxRef, ProducedShortOp)> = produced
+        let entries: Vec<(majit_ir::operand::Operand, ProducedShortOp)> = produced
             .iter()
             .map(|(_, p)| (p.res.clone(), p.clone()))
             .collect();

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -5796,7 +5796,7 @@ mod tests {
             exported_infos,
             vec![PreambleOp {
                 op: std::rc::Rc::new(Op::new(OpCode::SameAsR, &[Operand::from_opref(old_ref)])),
-                res: BoxRef::from_opref(old_ref),
+                res: Operand::bound_from_opref(old_ref),
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -6614,7 +6614,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 11),
+                res: rooted_resop_operand(Type::Int, 11),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6683,7 +6683,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 11),
+                res: rooted_resop_operand(Type::Int, 11),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6748,7 +6748,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(11));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 11),
+                res: rooted_resop_operand(Type::Int, 11),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
                 label_arg_idx: Some(1),
                 invented_name: false,
@@ -6813,7 +6813,7 @@ mod tests {
                     op.pos.set(source);
                     std::rc::Rc::new(op)
                 },
-                res: source_box.clone(),
+                res: Operand::from_boxref(&source_box),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::LoopInvariant,
                 label_arg_idx: Some(0),
                 invented_name: false,
@@ -6872,7 +6872,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(20));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 20),
+                res: rooted_resop_operand(Type::Int, 20),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
@@ -6962,7 +6962,7 @@ mod tests {
                     op.pos.set(OpRef::ref_op(19));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Ref, 19),
+                res: rooted_resop_operand(Type::Ref, 19),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Heap,
                 label_arg_idx: None,
                 invented_name: false,
@@ -7062,7 +7062,7 @@ mod tests {
                     op.pos.set(OpRef::int_op(30));
                     std::rc::Rc::new(op)
                 },
-                res: rooted_resop_box(Type::Int, 30),
+                res: rooted_resop_operand(Type::Int, 30),
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: true,

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1347,7 +1347,7 @@ impl UnrollOptimizer {
                 let original = slot_to_original[i];
                 let info = original
                     .and_then(|o| final_ctx.get_box_replacement_operand_opt(o))
-                    .or_else(|| final_ctx.get_box_replacement_operand_opt(inputarg.to_opref()))
+                    .or_else(|| final_ctx.get_box_replacement_operand_opt(*inputarg))
                     .as_ref()
                     .and_then(|o| final_ctx.peek_ptr_info(o));
                 infos.push(info);
@@ -1371,20 +1371,16 @@ impl UnrollOptimizer {
         // (no insert at the consumer). No-op when the Label already IS the
         // originals (the two box sets coincide).
         if initial_sp.phase1_inputargs.is_none() {
-            let phase1: Vec<BoxRef> = initial_sp
+            let phase1: Vec<OpRef> = initial_sp
                 .inputargs
                 .iter()
                 .enumerate()
-                .map(|(i, label)| {
-                    slot_to_original[i]
-                        .map(BoxRef::from_opref)
-                        .unwrap_or_else(|| label.clone())
-                })
+                .map(|(i, label)| slot_to_original[i].unwrap_or(*label))
                 .collect();
             let differs = phase1
                 .iter()
                 .zip(initial_sp.inputargs.iter())
-                .any(|(orig, label)| orig.to_opref() != label.to_opref());
+                .any(|(orig, label)| orig != label);
             if differs {
                 initial_sp.phase1_inputargs = Some(phase1);
             }
@@ -1454,14 +1450,14 @@ impl UnrollOptimizer {
                 let mut next_fresh = current_label_args
                     .iter()
                     .copied()
-                    .chain(initial_sp.used_boxes.iter().map(|b| b.to_opref()))
+                    .chain(initial_sp.used_boxes.iter().copied())
                     .map(|a| a.raw())
                     .max()
                     .unwrap_or(0)
                     .saturating_add(1)
                     .max(body_num_inputs as u32 + 100);
                 for ub in &initial_sp.used_boxes {
-                    let ub = ub.to_opref();
+                    let ub = *ub;
                     if !seen_used.contains(&ub) {
                         seen_used.insert(ub);
                         current_label_args.push(ub);
@@ -1774,8 +1770,8 @@ impl UnrollOptimizer {
         }
 
         // ── Assembly (compile.py:310-338) ──
-        let sp_used_boxes: Vec<OpRef> = sp.used_boxes.iter().map(|b| b.to_opref()).collect();
-        let sp_jump_args: Vec<OpRef> = sp.jump_args.iter().map(|b| b.to_opref()).collect();
+        let sp_used_boxes: Vec<OpRef> = sp.used_boxes.clone();
+        let sp_jump_args: Vec<OpRef> = sp.jump_args.clone();
         let mut combined = assemble_peeled_trace_with_jump_args(
             &p1_ops,
             &body_ops,
@@ -2321,17 +2317,17 @@ impl ExportedState {
         }
 
         if let Some(short_preamble) = &self.short_preamble {
-            for boxref in short_preamble
+            for r in short_preamble
                 .inputargs
                 .iter()
                 .chain(short_preamble.used_boxes.iter())
                 .chain(short_preamble.jump_args.iter())
             {
-                visit(boxref.to_opref());
+                visit(*r);
             }
             if let Some(phase1_inputargs) = &short_preamble.phase1_inputargs {
-                for boxref in phase1_inputargs {
-                    visit(boxref.to_opref());
+                for r in phase1_inputargs {
+                    visit(*r);
                 }
             }
             for short_op in &short_preamble.ops {
@@ -3592,7 +3588,7 @@ impl OptUnroll {
             return Vec::new();
         }
         for (i, short_inputarg) in short_preamble.inputargs.iter().enumerate() {
-            let short_inputarg = short_inputarg.to_opref();
+            let short_inputarg = *short_inputarg;
             if let Some(&jump_arg) = jump_args.get(i) {
                 mapping.insert(short_inputarg, jump_arg);
                 // RPython: jump_arg Box inherits info via identity.
@@ -3657,7 +3653,7 @@ impl OptUnroll {
         // this leg plus the phase1_inputargs field can be removed.
         if let Some(ref phase1) = short_preamble.phase1_inputargs {
             for (i, phase1_inputarg) in phase1.iter().enumerate() {
-                let phase1_inputarg = phase1_inputarg.to_opref();
+                let phase1_inputarg = *phase1_inputarg;
                 if let Some(&jump_arg) = jump_args.get(i) {
                     if !mapping.contains_key(&phase1_inputarg) {
                         mapping.insert(phase1_inputarg, jump_arg);
@@ -3697,13 +3693,7 @@ impl OptUnroll {
             ctx.active_short_preamble_producer
                 .as_ref()
                 .map(|builder| builder.jump_args().iter().map(|b| b.to_opref()).collect())
-                .unwrap_or_else(|| {
-                    short_preamble
-                        .jump_args
-                        .iter()
-                        .map(|b| b.to_opref())
-                        .collect()
-                })
+                .unwrap_or_else(|| short_preamble.jump_args.clone())
         }
 
         // unroll.py:398-427: fix-point loop, runs only once in almost all cases.
@@ -5847,15 +5837,15 @@ mod tests {
                 arg_mapping: Vec::new(),
                 fail_arg_mapping: Vec::new(),
             }],
-            inputargs: vec![BoxRef::from_opref(old_ref)],
-            used_boxes: vec![BoxRef::from_opref(old_ref)],
-            jump_args: vec![BoxRef::from_opref(old_ref)],
+            inputargs: vec![old_ref],
+            used_boxes: vec![old_ref],
+            jump_args: vec![old_ref],
             exported_state: Some(VirtualState::new(vec![VirtualStateInfo::KnownClass {
                 class_ptr: old.as_usize() as i64,
             }])),
             constants,
             inputarg_infos: vec![Some(PtrInfo::Constant(old))],
-            phase1_inputargs: Some(vec![BoxRef::from_opref(old_ref)]),
+            phase1_inputargs: Some(vec![old_ref]),
         });
         state.runtime_boxes.push(BoxRef::from_opref(old_ref));
         state.patchguardop = Some(Op::new(
@@ -5907,13 +5897,10 @@ mod tests {
         }
         let short = state.short_preamble.as_ref().unwrap();
         assert_eq!(short.ops[0].op.arg(0).to_opref(), new_ref);
-        assert_eq!(short.inputargs[0].to_opref(), new_ref);
-        assert_eq!(short.used_boxes[0].to_opref(), new_ref);
-        assert_eq!(short.jump_args[0].to_opref(), new_ref);
-        assert_eq!(
-            short.phase1_inputargs.as_ref().unwrap()[0].to_opref(),
-            new_ref
-        );
+        assert_eq!(short.inputargs[0], new_ref);
+        assert_eq!(short.used_boxes[0], new_ref);
+        assert_eq!(short.jump_args[0], new_ref);
+        assert_eq!(short.phase1_inputargs.as_ref().unwrap()[0], new_ref);
         assert_eq!(short.constants.get(&0), Some(&majit_ir::Const::Ref(new)));
     }
 
@@ -6944,20 +6931,8 @@ mod tests {
         let sp = ctx.build_imported_short_preamble().unwrap();
         // After force_box: orthodox `add_preamble_op` (shortpreamble.py:432-440)
         // populated all three lists in lock-step.
-        assert_eq!(
-            sp.used_boxes
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(20)]
-        );
-        assert_eq!(
-            sp.jump_args
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(20)]
-        );
+        assert_eq!(sp.used_boxes.clone(), vec![OpRef::int_op(20)]);
+        assert_eq!(sp.jump_args.clone(), vec![OpRef::int_op(20)]);
         assert!(
             !ctx.has_potential_extra_op(OpRef::int_op(20)),
             "force_box must consume the potential_extra_ops entry"
@@ -7056,20 +7031,8 @@ mod tests {
         // pop.op=19 forwards to body-visible 14 via the producer's make_equal_to,
         // so used_boxes carries the resolved body-visible OpRef while
         // jump_args carries the unresolved Phase 1 source.
-        assert_eq!(
-            sp.used_boxes
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::ref_op(14)]
-        );
-        assert_eq!(
-            sp.jump_args
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::ref_op(19)]
-        );
+        assert_eq!(sp.used_boxes.clone(), vec![OpRef::ref_op(14)]);
+        assert_eq!(sp.jump_args.clone(), vec![OpRef::ref_op(19)]);
         assert!(
             !ctx.has_potential_extra_op(OpRef::ref_op(19)),
             "force_box must consume the potential_extra_ops entry"

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4497,9 +4497,7 @@ fn emit_alias_same_as_for_imports(
     for alias in imported_short_aliases {
         let mut op = Op::new(
             alias.same_as_opcode,
-            &[majit_ir::operand::Operand::from_boxref(
-                &alias.same_as_source.clone(),
-            )],
+            &[alias.same_as_source.clone()],
         );
         op.pos.set(alias.result);
         result.push(std::rc::Rc::new(op));
@@ -7207,7 +7205,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: rooted_resop_box(Type::Int, 10),
+                same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecMap::new(),
@@ -7425,7 +7423,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: rooted_resop_box(Type::Int, 10),
+                same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecMap::new(),
@@ -7594,7 +7592,7 @@ mod tests {
             true,
             &[crate::optimizeopt::ImportedShortAlias {
                 result: OpRef::int_op(50),
-                same_as_source: rooted_resop_box(Type::Int, 10),
+                same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
             &majit_ir::VecMap::new(),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -4495,10 +4495,7 @@ fn emit_alias_same_as_for_imports(
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
 ) {
     for alias in imported_short_aliases {
-        let mut op = Op::new(
-            alias.same_as_opcode,
-            &[alias.same_as_source.clone()],
-        );
+        let mut op = Op::new(alias.same_as_opcode, &[alias.same_as_source.clone()]);
         op.pos.set(alias.result);
         result.push(std::rc::Rc::new(op));
     }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2879,7 +2879,17 @@ impl OptUnroll {
         for (_, produced_op) in &short_boxes_for_info {
             let op = produced_op.res.to_opref();
             if !op.is_constant() {
-                self.expand_info(op, &produced_op.res, ctx, exported_int_bounds, &mut infos);
+                // `expand_info` keys the BoxRef-keyed `exported_infos`
+                // (#158) on the producer-bound `res`; re-mint its box
+                // (`to_boxref` is `Rc::ptr_eq`-stable on the producer, so
+                // the import lookup still hits).
+                self.expand_info(
+                    op,
+                    &produced_op.res.to_boxref(),
+                    ctx,
+                    exported_int_bounds,
+                    &mut infos,
+                );
             }
         }
 
@@ -5813,7 +5823,7 @@ mod tests {
                 kind: PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: false,
-                same_as_source: Some(BoxRef::from_opref(old_ref)),
+                same_as_source: Some(Operand::from_opref(old_ref)),
             }],
             vec![old_ref],
             vec![BoxRef::from_opref(old_ref)],
@@ -5825,13 +5835,13 @@ mod tests {
             old_ref,
             ProducedShortOp {
                 kind: PreambleOpKind::Pure,
-                res: BoxRef::from_opref(old_ref),
+                res: Operand::from_opref(old_ref),
                 preamble_op: std::rc::Rc::new(Op::new(
                     OpCode::SameAsR,
                     &[Operand::from_opref(old_ref)],
                 )),
                 invented_name: false,
-                same_as_source: Some(BoxRef::from_opref(old_ref)),
+                same_as_source: Some(Operand::from_opref(old_ref)),
                 label_arg_idx: None,
             },
         ));
@@ -6912,7 +6922,7 @@ mod tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: rooted_resop_box(Type::Int, 20),
             invented_name: produced.invented_name,
-            same_as_source: produced.same_as_source.clone(),
+            same_as_source: produced.same_as_source.as_ref().map(|o| o.to_boxref()),
             preamble_op: produced.preamble_op,
         };
         let forced = ctx.force_op_from_preamble_op(&pop);
@@ -7022,7 +7032,7 @@ mod tests {
         let pop = crate::optimizeopt::info::PreambleOp {
             op: b_src.clone(),
             invented_name: produced.invented_name,
-            same_as_source: produced.same_as_source.clone(),
+            same_as_source: produced.same_as_source.as_ref().map(|o| o.to_boxref()),
             preamble_op: produced.preamble_op,
         };
         let forced = ctx.force_op_from_preamble_op(&pop);
@@ -7112,7 +7122,7 @@ mod tests {
                 kind: crate::optimizeopt::shortpreamble::PreambleOpKind::Pure,
                 label_arg_idx: None,
                 invented_name: true,
-                same_as_source: Some(rooted_resop_box(Type::Int, 14)),
+                same_as_source: Some(rooted_resop_operand(Type::Int, 14)),
             });
         // Bind export-input positions at their source (IntAdd operands /
         // same-as alias are bound boxes in production); virtualstate.py:711-720

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -642,10 +642,7 @@ impl UnrollOptimizer {
                     // carry the recorded JUMP args into ExportedState so the
                     // peeled-loop close passes them to generate_guards as
                     // `state.runtime_boxes` (unroll.py:153/166).
-                    state.runtime_boxes = recorded_jump_args
-                        .iter()
-                        .map(|&a| BoxRef::from_opref(a))
-                        .collect();
+                    state.runtime_boxes = recorded_jump_args.clone();
                     // end_arg_types is already populated by
                     // `Optimizer::optimize_with_constants_and_inputs_at`
                     // using the optimizer-visible `ctx.opref_type()` (see
@@ -1140,17 +1137,11 @@ impl UnrollOptimizer {
                 .expect("imported_loop_state must survive Phase 2");
             (
                 es.virtual_state.clone(),
-                es.end_args.iter().map(|b| b.to_opref()).collect::<Vec<_>>(),
+                es.end_args.clone(),
                 es.short_inputargs.clone(),
                 es.short_boxes.clone(),
-                es.renamed_inputargs
-                    .iter()
-                    .map(|b| b.to_opref())
-                    .collect::<Vec<_>>(),
-                es.runtime_boxes
-                    .iter()
-                    .map(|b| b.to_opref())
-                    .collect::<Vec<_>>(),
+                es.renamed_inputargs.clone(),
+                es.runtime_boxes.clone(),
             )
         };
         // RPython unroll.py:124-141 performs an extra end-of-preamble forcing
@@ -1907,7 +1898,7 @@ impl Default for UnrollOptimizer {
 #[derive(Debug)]
 pub struct ExportedState {
     /// Label args at the end of the preamble (after forcing).
-    pub end_args: Vec<BoxRef>,
+    pub end_args: Vec<OpRef>,
     /// Args for the next iteration (before forcing).
     pub next_iteration_args: Vec<BoxRef>,
     /// Types of end_args as determined by Phase 1 optimization.
@@ -1962,7 +1953,7 @@ pub struct ExportedState {
     /// `InputArg{Int,Float,Ref}` variant carrying its `.type` intrinsically
     /// (history.py:220), so consumers read the type via `OpRef::ty()` —
     /// RPython `info.renamed_inputargs` Box parity, no parallel type array.
-    pub renamed_inputargs: Vec<BoxRef>,
+    pub renamed_inputargs: Vec<OpRef>,
     /// Short inputargs for the short preamble — the renamed inputarg
     /// positions (shortpreamble.py:430 / unroll.py:480), shared with the
     /// renamed operands inside `short_boxes`.
@@ -1976,7 +1967,7 @@ pub struct ExportedState {
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
     /// Default `Vec::new()` until the export site populates it; callers
     /// that need it write the field directly after `ExportedState::new`.
-    pub runtime_boxes: Vec<BoxRef>,
+    pub runtime_boxes: Vec<OpRef>,
     /// RPython parity: patchguardop from Phase 1's GuardFutureCondition.
     /// Phase 2's extra_guards (from virtualstate) need rd_resume_position
     /// from this patchguardop (unroll.py:333-336).
@@ -2084,7 +2075,7 @@ impl ExportedState {
                 &exported_short_boxes,
             );
         ExportedState {
-            end_args: end_args.iter().map(|&a| BoxRef::from_opref(a)).collect(),
+            end_args,
             // unroll.py:467 `next_iteration_args = end_args` — carry the literal
             // Phase-1 boxes (the same Rcs used as `exported_infos` keys) so the
             // import-state lookup is a ptr_eq hit. NOT `from_opref` (which would
@@ -2097,10 +2088,7 @@ impl ExportedState {
             short_boxes,
             short_box_const_values: majit_ir::VecMap::new(),
             short_preamble: None,
-            renamed_inputargs: renamed_inputargs
-                .iter()
-                .map(|&a| BoxRef::from_opref(a))
-                .collect(),
+            renamed_inputargs,
             short_inputargs,
             short_inputarg_refs,
             runtime_boxes: Vec::new(),
@@ -2201,7 +2189,7 @@ impl ExportedState {
             }
         }
 
-        visit_boxrefs(&self.end_args, visitor);
+        visit_oprefs(&mut self.end_args, visitor);
         visit_boxrefs(&self.next_iteration_args, visitor);
         self.virtual_state.walk_const_ptr_refs_mut(visitor);
         for (key, info) in self.exported_infos.iter_entries_mut() {
@@ -2229,9 +2217,9 @@ impl ExportedState {
         if let Some(short_preamble) = self.short_preamble.as_mut() {
             short_preamble.walk_const_ptr_refs_mut(visitor);
         }
-        visit_boxrefs(&self.renamed_inputargs, visitor);
+        visit_oprefs(&mut self.renamed_inputargs, visitor);
         visit_oprefs(&mut self.short_inputargs, visitor);
-        visit_boxrefs(&self.runtime_boxes, visitor);
+        visit_oprefs(&mut self.runtime_boxes, visitor);
         if let Some(patchguardop) = self.patchguardop.as_ref() {
             visit_op(patchguardop, visitor);
         }
@@ -2274,13 +2262,13 @@ impl ExportedState {
             }
         };
         for arg in &self.end_args {
-            visit(arg.to_opref());
+            visit(*arg);
         }
         for arg in &self.next_iteration_args {
             visit(arg.to_opref());
         }
         for arg in &self.renamed_inputargs {
-            visit(arg.to_opref());
+            visit(*arg);
         }
         for arg in &self.short_inputargs {
             visit(*arg);
@@ -2291,7 +2279,7 @@ impl ExportedState {
         // as the `SameAs*` op's `pos` (visited via `visit_op`). Const-folded
         // slots never survive into Phase 2, so they need no high-water cover.
         for arg in &self.runtime_boxes {
-            visit(arg.to_opref());
+            visit(*arg);
         }
 
         for (key, info) in &self.exported_infos {
@@ -5838,7 +5826,7 @@ mod tests {
             inputarg_infos: vec![Some(PtrInfo::Constant(old))],
             phase1_inputargs: Some(vec![old_ref]),
         });
-        state.runtime_boxes.push(BoxRef::from_opref(old_ref));
+        state.runtime_boxes.push(old_ref);
         state.patchguardop = Some(Op::new(
             OpCode::GuardNonnull,
             &[Operand::from_opref(old_ref)],
@@ -5850,11 +5838,11 @@ mod tests {
             }
         });
 
-        assert_eq!(state.end_args[0].to_opref(), new_ref);
+        assert_eq!(state.end_args[0], new_ref);
         assert_eq!(state.next_iteration_args[0].to_opref(), new_ref);
-        assert_eq!(state.renamed_inputargs[0].to_opref(), new_ref);
+        assert_eq!(state.renamed_inputargs[0], new_ref);
         assert_eq!(state.short_inputargs[0], new_ref);
-        assert_eq!(state.runtime_boxes[0].to_opref(), new_ref);
+        assert_eq!(state.runtime_boxes[0], new_ref);
         assert!(state.exported_infos.keys().any(|k| k.to_opref() == new_ref));
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
         assert_eq!(
@@ -6558,14 +6546,7 @@ mod tests {
 
         let exported = export_state(&[OpRef::int_op(0)], &[], &mut optimizer, &mut ctx, None);
 
-        assert_eq!(
-            exported
-                .end_args
-                .iter()
-                .map(|b| b.to_opref())
-                .collect::<Vec<_>>(),
-            vec![OpRef::int_op(21)]
-        );
+        assert_eq!(exported.end_args.clone(), vec![OpRef::int_op(21)]);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1963,17 +1963,14 @@ pub struct ExportedState {
     /// (history.py:220), so consumers read the type via `OpRef::ty()` —
     /// RPython `info.renamed_inputargs` Box parity, no parallel type array.
     pub renamed_inputargs: Vec<BoxRef>,
-    /// Short inputargs for the short preamble — the renamed inputarg box
-    /// objects themselves (shortpreamble.py:430 / unroll.py:480), shared
-    /// with the renamed operands inside `short_boxes`.
-    pub short_inputargs: Vec<majit_ir::box_ref::BoxRef>,
+    /// Short inputargs for the short preamble — the renamed inputarg
+    /// positions (shortpreamble.py:430 / unroll.py:480), shared with the
+    /// renamed operands inside `short_boxes`.
+    pub short_inputargs: Vec<OpRef>,
     /// Rooted `InputArgRc` carriers for `short_inputargs`, index-aligned.
-    /// Each `short_inputargs[i]` box holds a WEAK handle to
-    /// `short_inputarg_refs[i]`; keeping the strong Rc alive across the
-    /// cross-peel export boundary lets the box resolve to a real bound
-    /// `InputArg` in the rebuilt Phase-2 OptContext, so dependent operands
-    /// bind to `Operand::InputArg` rather than an unbound position-only box
-    /// (which `from_boxref` rejects).
+    /// Keeping the strong Rc alive across the cross-peel export boundary
+    /// preserves the renamed inputarg producers for consumers that need a
+    /// bound operand view.
     pub short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// unroll.py: runtime_boxes — live values at the original jump point.
     /// Threaded into Phase 2 import as `runtime_boxes` for guard generation.
@@ -2073,7 +2070,7 @@ impl ExportedState {
         exported_infos: majit_ir::VecMap<BoxRef, crate::optimizeopt::info::OpInfo>,
         exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
         renamed_inputargs: Vec<OpRef>,
-        short_inputargs: Vec<majit_ir::box_ref::BoxRef>,
+        short_inputargs: Vec<OpRef>,
         short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     ) -> Self {
         // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
@@ -2131,14 +2128,15 @@ impl ExportedState {
     /// expose their actual mutable storage.
     pub fn walk_const_ptr_refs_mut(&mut self, visitor: &mut dyn FnMut(&mut GcRef)) {
         fn visit_opref(opref: &mut OpRef, visitor: &mut dyn FnMut(&mut GcRef)) {
-            // Forward an inline const gcref through the canonical BoxRef-Const
-            // walk; a no-op for non-const positions (they carry no gcref).
-            // short_box_const_values keys are genuine const OpRefs; the other
-            // call sites (op.pos, exported_infos / short_boxes keys) are op
-            // result positions, where this resolves to nothing.
-            let b = BoxRef::from_opref(*opref);
-            b.walk_const_ptr_refs(visitor);
-            *opref = b.to_opref();
+            if let OpRef::ConstPtr(gcref) = opref {
+                visitor(gcref);
+            }
+        }
+
+        fn visit_oprefs(refs: &mut [OpRef], visitor: &mut dyn FnMut(&mut GcRef)) {
+            for r in refs {
+                visit_opref(r, visitor);
+            }
         }
 
         fn visit_boxrefs(boxes: &[BoxRef], visitor: &mut dyn FnMut(&mut GcRef)) {
@@ -2232,9 +2230,7 @@ impl ExportedState {
             short_preamble.walk_const_ptr_refs_mut(visitor);
         }
         visit_boxrefs(&self.renamed_inputargs, visitor);
-        for arg in &self.short_inputargs {
-            arg.walk_const_ptr_refs(visitor);
-        }
+        visit_oprefs(&mut self.short_inputargs, visitor);
         visit_boxrefs(&self.runtime_boxes, visitor);
         if let Some(patchguardop) = self.patchguardop.as_ref() {
             visit_op(patchguardop, visitor);
@@ -2287,7 +2283,7 @@ impl ExportedState {
             visit(arg.to_opref());
         }
         for arg in &self.short_inputargs {
-            visit(arg.to_opref());
+            visit(*arg);
         }
         // The original label/virtual positions that `short_inputargs` rename
         // are reached through the `exported_short_boxes` walk below: every
@@ -2787,48 +2783,44 @@ impl OptUnroll {
         // `label_args + virtuals` (measured identical across the corpus);
         // paths that never ran the preview (test ExportedState setups) fall
         // back to the local recompute.
-        let (short_inputargs, short_inputarg_refs): (
-            Vec<majit_ir::box_ref::BoxRef>,
-            Vec<majit_ir::InputArgRc>,
-        ) = if ctx.exported_short_inputargs.is_empty() {
-            // No preview pass ran (test ExportedState setups): mint the fresh
-            // renamed InputArg boxes directly, mirroring `add_short_input_arg`
-            // (shortpreamble.py:257 `OpHelpers.inputarg_from_tp(box.type)`).
-            // Each is DISTINCT from its `short_args[i]` original so the rename
-            // is a real rename, not an identity no-op. Build the rooted
-            // `InputArgRc` pool alongside (same shape as the preview pass) so
-            // the boxes stay bound to live `InputArg`s instead of an unbound
-            // position-only box (which `from_boxref` rejects).
-            let mut boxes = Vec::with_capacity(short_args.len());
-            let mut refs = Vec::with_capacity(short_args.len());
-            for &a in &short_args {
-                let ty = a
-                    .ty()
-                    .unwrap_or_else(|| panic!("short preamble inputarg {a:?} has no value type"));
-                let pos = ctx.alloc_op_position_typed(ty).raw();
-                let ia = majit_ir::InputArg::from_type_rc(ty, pos);
-                boxes.push(majit_ir::box_ref::BoxRef::from_bound_inputarg(&ia));
-                refs.push(ia);
-            }
-            (boxes, refs)
-        } else {
-            debug_assert_eq!(
-                ctx.exported_short_inputargs.len(),
-                short_args.len(),
-                "preview-pass create_short_inputargs length diverged from the \
+        let (short_inputargs, short_inputarg_refs): (Vec<OpRef>, Vec<majit_ir::InputArgRc>) =
+            if ctx.exported_short_inputargs.is_empty() {
+                // No preview pass ran (test ExportedState setups): mint the fresh
+                // renamed InputArg positions directly, mirroring `add_short_input_arg`
+                // (shortpreamble.py:257 `OpHelpers.inputarg_from_tp(box.type)`).
+                // Each is DISTINCT from its `short_args[i]` original so the
+                // rename is a real rename, not an identity no-op. Build the
+                // rooted `InputArgRc` pool alongside, matching the preview pass.
+                let mut inputargs = Vec::with_capacity(short_args.len());
+                let mut refs = Vec::with_capacity(short_args.len());
+                for &a in &short_args {
+                    let ty = a.ty().unwrap_or_else(|| {
+                        panic!("short preamble inputarg {a:?} has no value type")
+                    });
+                    let pos = ctx.alloc_op_position_typed(ty).raw();
+                    let ia = majit_ir::InputArg::from_type_rc(ty, pos);
+                    inputargs.push(ia.opref());
+                    refs.push(ia);
+                }
+                (inputargs, refs)
+            } else {
+                debug_assert_eq!(
+                    ctx.exported_short_inputargs.len(),
+                    short_args.len(),
+                    "preview-pass create_short_inputargs length diverged from the \
                      export-site label_args + virtuals recompute"
-            );
-            debug_assert_eq!(
-                ctx.exported_short_inputarg_refs.len(),
-                ctx.exported_short_inputargs.len(),
-                "exported_short_inputarg_refs must stay index-aligned with \
+                );
+                debug_assert_eq!(
+                    ctx.exported_short_inputarg_refs.len(),
+                    ctx.exported_short_inputargs.len(),
+                    "exported_short_inputarg_refs must stay index-aligned with \
                      exported_short_inputargs"
-            );
-            (
-                ctx.exported_short_inputargs.clone(),
-                ctx.exported_short_inputarg_refs.clone(),
-            )
-        };
+                );
+                (
+                    ctx.exported_short_inputargs.clone(),
+                    ctx.exported_short_inputarg_refs.clone(),
+                )
+            };
         let exported_short_boxes = ctx.exported_short_boxes.clone();
         // #173 producer-rooting: capture each exported short-box's Phase-1
         // producer Op (`res.bound_op()`) while the Phase-1 ctx still owns the
@@ -3692,7 +3684,7 @@ impl OptUnroll {
         ) -> Vec<OpRef> {
             ctx.active_short_preamble_producer
                 .as_ref()
-                .map(|builder| builder.jump_args().iter().map(|b| b.to_opref()).collect())
+                .map(|builder| builder.jump_args().to_vec())
                 .unwrap_or_else(|| short_preamble.jump_args.clone())
         }
 
@@ -5566,9 +5558,9 @@ mod tests {
             majit_ir::VecMap::new(),
             Vec::new(),
             vec![OpRef::int_op(14)],
-            vec![rooted_resop_box(Type::Int, 23)],
-            // short_inputarg_refs: the renamed_inputargs boxes are rooted
-            // resop boxes, so no parallel InputArgRc pool is needed here.
+            vec![OpRef::int_op(23)],
+            // short_inputarg_refs: this fixture stores plain OpRef positions,
+            // so no parallel InputArgRc pool is needed here.
             Vec::new(),
         );
 
@@ -5811,9 +5803,8 @@ mod tests {
                 same_as_source: Some(Operand::from_opref(old_ref)),
             }],
             vec![old_ref],
-            vec![BoxRef::from_opref(old_ref)],
-            // short_inputarg_refs: `old_ref` is a ConstPtr, so this box sheds
-            // to `Operand::Const` (no position-only mint).
+            vec![old_ref],
+            // short_inputarg_refs: `old_ref` is a ConstPtr inline position.
             Vec::new(),
         );
         state.short_boxes.push((
@@ -5862,7 +5853,7 @@ mod tests {
         assert_eq!(state.end_args[0].to_opref(), new_ref);
         assert_eq!(state.next_iteration_args[0].to_opref(), new_ref);
         assert_eq!(state.renamed_inputargs[0].to_opref(), new_ref);
-        assert_eq!(state.short_inputargs[0].to_opref(), new_ref);
+        assert_eq!(state.short_inputargs[0], new_ref);
         assert_eq!(state.runtime_boxes[0].to_opref(), new_ref);
         assert!(state.exported_infos.keys().any(|k| k.to_opref() == new_ref));
         assert_eq!(state.exported_short_boxes[0].op.arg(0).to_opref(), new_ref);
@@ -6597,11 +6588,11 @@ mod tests {
         // ops carry the renamed box in their args (not the original label
         // arg). Seed the two slot boxes and use slot 0 — the GETFIELD
         // receiver, whose original is int_op(10).
-        // Bound (not position-only) short_inputarg boxes rooted by an
-        // index-aligned `InputArgRc` pool, mirroring production
+        // Bound short_inputarg boxes rooted by an index-aligned `InputArgRc`
+        // pool, mirroring production
         // (optimizer.rs:2937/2942 set `exported_short_inputargs` and
-        // `exported_short_inputarg_refs` in lockstep); the boxes shed to
-        // `Operand::InputArg` instead of the position-only `Operand::Box`.
+        // `exported_short_inputarg_refs` in lockstep); the context channel
+        // stores their positions.
         let (si0, ia0) = crate::history::test_support::bound_inputarg_box(
             Type::Int,
             ctx.alloc_op_position_typed(Type::Int).raw(),
@@ -6610,7 +6601,7 @@ mod tests {
             Type::Int,
             ctx.alloc_op_position_typed(Type::Int).raw(),
         );
-        ctx.exported_short_inputargs = vec![si0.clone(), si1];
+        ctx.exported_short_inputargs = vec![si0.to_opref(), si1.to_opref()];
         ctx.exported_short_inputarg_refs = vec![ia0, ia1];
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {
@@ -6829,9 +6820,8 @@ mod tests {
                 same_as_source: None,
             }],
             Vec::new(),
-            vec![source_box],
-            // short_inputarg_refs: bound resop box rooted in the thread-local
-            // pool; sheds to `Operand::Op` instead of position-only `Operand::Box`.
+            vec![source_box.to_opref()],
+            // short_inputarg_refs: this fixture stores plain OpRef positions.
             Vec::new(),
         );
         let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(
@@ -6869,11 +6859,7 @@ mod tests {
         );
         ctx.initialize_imported_short_preamble_builder(
             &[OpRef::int_op(0), OpRef::int_op(1), OpRef::int_op(2)],
-            &[
-                rooted_resop_box(Type::Int, 10),
-                rooted_resop_box(Type::Int, 11),
-                rooted_resop_box(Type::Int, 12),
-            ],
+            &[OpRef::int_op(10), OpRef::int_op(11), OpRef::int_op(12)],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
                     let mut op = Op::new(
@@ -6961,10 +6947,10 @@ mod tests {
                 OpRef::ref_op(3),
             ],
             &[
-                rooted_resop_box(Type::Ref, 10),
-                rooted_resop_box(Type::Ref, 11),
-                rooted_resop_box(Type::Ref, 12),
-                rooted_resop_box(Type::Ref, 13),
+                OpRef::ref_op(10),
+                OpRef::ref_op(11),
+                OpRef::ref_op(12),
+                OpRef::ref_op(13),
             ],
             &[crate::optimizeopt::shortpreamble::PreambleOp {
                 op: {
@@ -7051,7 +7037,7 @@ mod tests {
         // Bound short_inputarg boxes rooted by an index-aligned `InputArgRc`
         // pool, matching production (optimizer.rs:2937/2942 set
         // `exported_short_inputargs` / `exported_short_inputarg_refs` in
-        // lockstep); the IntAdd operands then shed to `Operand::InputArg`.
+        // lockstep); the context channel stores their positions.
         let (si0, ia0) = crate::history::test_support::bound_inputarg_box(
             Type::Int,
             ctx.alloc_op_position_typed(Type::Int).raw(),
@@ -7064,7 +7050,7 @@ mod tests {
             Type::Int,
             ctx.alloc_op_position_typed(Type::Int).raw(),
         );
-        ctx.exported_short_inputargs = vec![si0.clone(), si1.clone(), si2];
+        ctx.exported_short_inputargs = vec![si0.to_opref(), si1.to_opref(), si2.to_opref()];
         ctx.exported_short_inputarg_refs = vec![ia0, ia1, ia2];
         ctx.exported_short_boxes
             .push(crate::optimizeopt::shortpreamble::PreambleOp {

--- a/majit/majit-metainterp/src/optimizeopt/util.rs
+++ b/majit/majit-metainterp/src/optimizeopt/util.rs
@@ -8,13 +8,13 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-use majit_ir::box_ref::BoxRef;
+use majit_ir::operand::Operand;
 
 /// util.py:100-111 `args_eq`.
 ///
 /// Uses `same_box`, so constants compare by value while regular boxes compare
 /// by object identity.
-pub fn args_eq(args1: &[Option<BoxRef>], args2: &[Option<BoxRef>]) -> bool {
+pub fn args_eq(args1: &[Option<Operand>], args2: &[Option<Operand>]) -> bool {
     args1.len() == args2.len()
         && args1
             .iter()
@@ -32,7 +32,7 @@ pub fn args_eq(args1: &[Option<BoxRef>], args2: &[Option<BoxRef>]) -> bool {
 /// preserves the load-bearing contract with `args_eq`: equal argument lists
 /// produce equal hashes, with constants hashed by value and other boxes by
 /// identity.
-pub fn args_hash(args: &[Option<BoxRef>]) -> u64 {
+pub fn args_hash(args: &[Option<Operand>]) -> u64 {
     let mut state = DefaultHasher::new();
     0x345678_u64.hash(&mut state);
     for arg in args {
@@ -44,7 +44,7 @@ pub fn args_hash(args: &[Option<BoxRef>]) -> u64 {
     state.finish()
 }
 
-fn hash_arg<H: Hasher>(arg: &BoxRef, state: &mut H) {
+fn hash_arg<H: Hasher>(arg: &Operand, state: &mut H) {
     if let Some(value) = arg.const_value() {
         value.hash(state);
     } else {
@@ -55,21 +55,22 @@ fn hash_arg<H: Hasher>(arg: &BoxRef, state: &mut H) {
 #[cfg(test)]
 mod tests {
     use super::{args_eq, args_hash};
-    use majit_ir::Value;
-    use majit_ir::box_ref::BoxRef;
+    use majit_ir::OpRef;
+    use majit_ir::operand::Operand;
+    use majit_ir::value::Const;
 
     #[test]
     fn args_eq_uses_same_box_const_value_semantics() {
-        let a = Some(BoxRef::new_const(Value::Int(5)));
-        let b = Some(BoxRef::new_const(Value::Int(5)));
+        let a = Some(Operand::const_(Const::Int(5)));
+        let b = Some(Operand::const_(Const::Int(5)));
         assert!(args_eq(&[a.clone()], &[b.clone()]));
         assert_eq!(args_hash(&[a]), args_hash(&[b]));
     }
 
     #[test]
     fn args_eq_distinguishes_non_const_box_identity() {
-        let a = Some(BoxRef::new_resop(majit_ir::Type::Int, 0));
-        let b = Some(BoxRef::new_resop(majit_ir::Type::Int, 0));
+        let a = Some(Operand::bound_from_opref(OpRef::int_op(0)));
+        let b = Some(Operand::bound_from_opref(OpRef::int_op(0)));
         assert!(!args_eq(&[a], &[b]));
     }
 }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5411,7 +5411,7 @@ impl<M: Clone> MetaInterp<M> {
                     .iter()
                     .enumerate()
                     .map(|(i, arg)| {
-                        let opref = arg.to_opref();
+                        let opref = *arg;
                         let tp = opref.ty().unwrap_or_else(|| {
                             panic!(
                                 "renamed inputarg {:?} has no intrinsic type \
@@ -9438,7 +9438,7 @@ impl<M: Clone> MetaInterp<M> {
                         // RPython retrace passes the original typed Box list
                         // directly; each renamed inputarg OpRef carries its
                         // `.type` intrinsically (history.py:220).
-                        let opref = arg.to_opref();
+                        let opref = *arg;
                         let tp = opref.ty().unwrap_or_else(|| {
                             panic!(
                                 "renamed inputarg {:?} has no intrinsic type \
@@ -10054,7 +10054,7 @@ impl<M: Clone> MetaInterp<M> {
                     .renamed_inputargs
                     .iter()
                     .map(|arg| {
-                        let opref = arg.to_opref();
+                        let opref = *arg;
                         let tp = opref.ty().unwrap_or_else(|| {
                             panic!(
                                 "renamed inputarg {:?} has no intrinsic type \


### PR DESCRIPTION
Continues the `Box`/`BoxKind`/`BoxRef` wrapper teardown (#169 / #9 / #47), flipping three more channels off `BoxRef` onto `Operand`. Refs #47.

## Commits
- **ProducedShortOp res/same_as_source to Operand** — `ProducedShortOp.res` + `ProducedShortOp.same_as_source` + coupled `PreambleOp(AbstractShortOp).same_as_source` flipped `BoxRef` → `Operand`; retyped the record/add channel (`record_imported_preamble_use`/`record_preamble_use`/`add_tracked_preamble_op` + `ShortPreambleBuilder::new`); 5 `materialize_box_at` → `materialize_operand_at` at construction sites; contained at principled BoxRef boundaries via `to_boxref`; deleted the optimizer same_as_source position-remap block (Operand live-tracks the producer's `Op.pos`).
- **ImportedShortAlias.same_as_source to Operand** — stores `op.arg(0)` directly instead of `op.arg(0).to_boxref()`, dropping the `Operand::from_boxref` reconstruction round-trip in `emit_alias_same_as_for_imports`.
- **bind IndexVar.var_box + rename_op to producers** — `IndexVar.var_box: Option<BoxRef>` → `Option<Operand>`; `get_operations` carries `var` as a producer-bound Operand via `Operand::bound_from_opref` (synthetic producer, `to_opref`-identical) instead of `BoxRef::from_opref`, dropping the three `Operand::from_boxref(&var_box(..))` wraps and the BoxRef import (`dependency.rs` is now BoxRef-free). `guard.rs` `rename_op` `Operand::from_opref(replacement)` → `bound_from_opref` (the renamer replacement is a producer position; `from_opref` would panic on it). Closes the E5b dormant-vectorizer producer-binding residual (#175).

## Gate (each slice, both backends, sequential)
- `cargo test -p majit-ir --lib` 333
- `cargo test -p majit-metainterp --features dynasm --lib` 1370
- `cargo test -p majit-metainterp --features cranelift --lib` 1368
- `python ./pyre/check.py --backend dynasm` 167/167
- `python ./pyre/check.py --backend cranelift` 167/167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when optimizing traces, especially around loop handling and short-preamble replay.
  * Fixed several cases where exported values could be remapped incorrectly after trace compaction.
  * Corrected how repeated or renamed inputs are tracked, reducing mismatches during replay.
  * Improved consistency for imported preambles so replayed operations keep the right references and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->