### PR TITLE
CPython suite: _struct faithful port, code.replace, print file=/flush=, builtin arity caps, surrogate-safe repr/str, posix.rename dir_fd

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9210,6 +9210,10 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         if pyre_object::interp_sre::is_sre_scanner(obj) {
             return Ok(obj);
         }
+        // `interp_struct.py:192 W_UnpackIter.descr_iter` — `return self`.
+        if crate::module::r#struct::is_unpack_iter(obj) {
+            return Ok(obj);
+        }
         // `iter(callable, sentinel)` product — its own iterator.
         if pyre_object::operation::is_callable_iterator(obj) {
             return Ok(obj);
@@ -9943,6 +9947,15 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         // search from the current position, yielding the match object.
         if pyre_object::interp_sre::is_sre_scanner(obj) {
             return crate::module::_sre::interp_sre::sre_scanner_next(obj);
+        }
+        // `interp_struct.py:195 W_UnpackIter.descr_next` — dispatch the
+        // iterator's own `__next__` from its type.
+        if crate::module::r#struct::is_unpack_iter(obj) {
+            if let Some(w_type) = crate::typedef::r#type(obj) {
+                if let Some(method) = lookup_in_type_where(w_type, "__next__") {
+                    return crate::call::call_function_impl_result(method, &[obj]);
+                }
+            }
         }
         // Instance __next__
         if is_instance(obj) {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4425,8 +4425,12 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // Python class in `w_class`; honor its `__str__` override before
             // returning the raw value.
             let tp = (*obj).ob_type;
-            if let Some(s) = crate::display::builtin_subclass_dunder(obj, tp, "__str__")? {
-                return Ok(w_str_new(&s));
+            // WTF-8-preserving so a `__str__` override returning a lone
+            // surrogate yields that str rather than panicking.
+            if let Some(r) = crate::display::builtin_subclass_dunder_obj(obj, tp, "__str__")? {
+                return Ok(pyre_object::w_str_from_wtf8(
+                    pyre_object::w_str_get_wtf8(r).to_owned(),
+                ));
             }
             // `str(s) is s` only for an exact `str`; a subclass with no
             // `__str__` override is copied to a fresh base `str`.
@@ -4450,8 +4454,10 @@ fn builtin_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let s = unsafe { crate::py_repr(args[0])? };
-    Ok(w_str_new(&s))
+    // WTF-8-preserving so a `__repr__` override returning a lone surrogate
+    // yields that str rather than panicking in the `String` path.
+    let w = unsafe { crate::py_repr_wtf8(args[0])? };
+    Ok(pyre_object::w_str_from_wtf8(w))
 }
 
 /// `unicodeobject.c:unicode_repr` post-pass — take the repr of `obj`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2109,36 +2109,76 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             let last = *args.last().unwrap();
             is_dict(last) && pyre_object::w_dict_lookup(last, w_str_new("__pyre_kw__")).is_some()
         };
-    let (positional, end, sep) = if is_kwargs {
+    let (positional, end, sep, file, flush) = if is_kwargs {
         let kwargs = *args.last().unwrap();
-        let end_key = w_str_new("end");
-        let sep_key = w_str_new("sep");
-        let end_val = unsafe { pyre_object::w_dict_lookup(kwargs, end_key) };
-        let sep_val = unsafe { pyre_object::w_dict_lookup(kwargs, sep_key) };
+        let end_val = unsafe { pyre_object::w_dict_lookup(kwargs, w_str_new("end")) };
+        let sep_val = unsafe { pyre_object::w_dict_lookup(kwargs, w_str_new("sep")) };
         // The type check is up front; the str() rendering happens at write
         // time so a raising `__str__` leaves the preceding output in place.
         let end_obj = print_sep_check(end_val, "end")?;
         let sep_obj = print_sep_check(sep_val, "sep")?;
-        (&args[..args.len() - 1], end_obj, sep_obj)
+        // `file=None` (or absent) uses the native stdout path; any other
+        // object is written through its `write` / `flush` methods.
+        let file_obj = match unsafe { pyre_object::w_dict_lookup(kwargs, w_str_new("file")) } {
+            Some(f) if !unsafe { pyre_object::is_none(f) } => Some(f),
+            _ => None,
+        };
+        let flush = match unsafe { pyre_object::w_dict_lookup(kwargs, w_str_new("flush")) } {
+            Some(f) => crate::baseobjspace::is_true(f)?,
+            None => false,
+        };
+        (&args[..args.len() - 1], end_obj, sep_obj, file_obj, flush)
     } else {
-        (args, None, None)
+        (args, None, None, None, false)
     };
 
     // `bltinmodule.c print_impl` writes incrementally: `str(arg)`, then the
     // separator before each following arg, then `end`.  Each `str()` may
-    // raise, leaving the bytes already emitted on the stream.
+    // raise, leaving the bytes already emitted on the stream.  With a `file`
+    // argument every piece is routed through its `write` method; otherwise
+    // the native stdout path is used.
+    let emit = |piece: &str| -> Result<(), crate::PyError> {
+        let Some(fp) = file else {
+            crate::print_output(piece);
+            return Ok(());
+        };
+        let r = crate::baseobjspace::call_method(fp, "write", &[w_str_new(piece)]);
+        if r.is_null() {
+            return Err(crate::call::take_call_error()
+                .unwrap_or_else(|| crate::PyError::runtime_error("print: file.write() failed")));
+        }
+        Ok(())
+    };
     for (i, &obj) in positional.iter().enumerate() {
         if i > 0 {
-            match sep {
-                Some(s) => crate::print_output(&unsafe { print_render(s)? }),
-                None => crate::print_output(" "),
+            let s = match sep {
+                Some(s) => unsafe { print_render(s)? },
+                None => " ".to_string(),
+            };
+            emit(&s)?;
+        }
+        emit(&unsafe { print_render(obj)? })?;
+    }
+    let e = match end {
+        Some(e) => unsafe { print_render(e)? },
+        None => "\n".to_string(),
+    };
+    emit(&e)?;
+    if flush {
+        match file {
+            None => {
+                use std::io::Write;
+                let _ = std::io::stdout().flush();
+            }
+            Some(fp) => {
+                let r = crate::baseobjspace::call_method(fp, "flush", &[]);
+                if r.is_null() {
+                    return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                        crate::PyError::runtime_error("print: file.flush() failed")
+                    }));
+                }
             }
         }
-        crate::print_output(&unsafe { print_render(obj)? });
-    }
-    match end {
-        Some(e) => crate::print_output(&unsafe { print_render(e)? }),
-        None => crate::print_output("\n"),
     }
     Ok(w_none())
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2133,16 +2133,21 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     };
 
     // `bltinmodule.c print_impl` writes incrementally: `str(arg)`, then the
-    // separator before each following arg, then `end`.  Each `str()` may
-    // raise, leaving the bytes already emitted on the stream.  With a `file`
-    // argument every piece is routed through its `write` method; otherwise
-    // the native stdout path is used.
-    let emit = |piece: &str| -> Result<(), crate::PyError> {
+    // separator before each following arg, then `end`.  Each source is rendered
+    // at emit time so a raising `__str__` leaves the bytes already emitted on
+    // the stream.  With a `file`, `str(source)` is handed to `file.write` as a
+    // str object untouched (`PyFile_WriteObject`), so a lone surrogate is the
+    // sink's concern — a `StringIO` or custom writer accepts it.  The native
+    // stdout path renders through the strict utf-8 error handler in
+    // `print_render`.
+    let emit = |source: PyObjectRef| -> Result<(), crate::PyError> {
         let Some(fp) = file else {
-            crate::print_output(piece);
+            let s = unsafe { print_render(source)? };
+            crate::print_output(&s);
             return Ok(());
         };
-        let r = crate::baseobjspace::call_method(fp, "write", &[w_str_new(piece)]);
+        let s_obj = pyre_object::w_str_from_wtf8(unsafe { crate::py_str_wtf8(source)? });
+        let r = crate::baseobjspace::call_method(fp, "write", &[s_obj]);
         if r.is_null() {
             return Err(crate::call::take_call_error()
                 .unwrap_or_else(|| crate::PyError::runtime_error("print: file.write() failed")));
@@ -2151,19 +2156,11 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     };
     for (i, &obj) in positional.iter().enumerate() {
         if i > 0 {
-            let s = match sep {
-                Some(s) => unsafe { print_render(s)? },
-                None => " ".to_string(),
-            };
-            emit(&s)?;
+            emit(sep.unwrap_or_else(|| w_str_new(" ")))?;
         }
-        emit(&unsafe { print_render(obj)? })?;
+        emit(obj)?;
     }
-    let e = match end {
-        Some(e) => unsafe { print_render(e)? },
-        None => "\n".to_string(),
-    };
-    emit(&e)?;
+    emit(end.unwrap_or_else(|| w_str_new("\n")))?;
     if flush {
         match file {
             None => {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5977,7 +5977,7 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// `id(obj)` — PyPy: baseobjspace.py id → object identity as int
 fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.is_empty() {
+    if args.len() != 1 {
         return Err(crate::PyError::type_error(format!(
             "id() takes exactly one argument ({} given)",
             args.len()
@@ -6004,7 +6004,7 @@ fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// unhashables, recurses through tuple/frozenset contents, and
 /// propagates user `__hash__` errors.
 pub(crate) fn builtin_hash(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.is_empty() {
+    if args.len() != 1 {
         return Err(crate::PyError::type_error(format!(
             "hash() takes exactly one argument ({} given)",
             args.len()
@@ -8384,6 +8384,12 @@ fn builtin_pow(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() < 2 {
         return Err(crate::PyError::type_error(format!(
             "pow() takes at least two arguments ({} given)",
+            args.len()
+        )));
+    }
+    if args.len() > 3 {
+        return Err(crate::PyError::type_error(format!(
+            "pow() takes at most 3 arguments ({} given)",
             args.len()
         )));
     }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -776,6 +776,24 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
             let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {obj:?}>")
         } else {
+            // A builtin type carrying its own `__repr__` dict entry (e.g.
+            // `_struct.Struct`) — dispatch it before the generic
+            // `<name object at 0x...>` fallback.  Mirrors the tuple-subclass
+            // path above.
+            let w_class = (*obj).w_class;
+            if !w_class.is_null() {
+                if let Some((src, method)) =
+                    crate::baseobjspace::lookup_where_with_method_cache(w_class, "__repr__")
+                {
+                    if !std::ptr::eq(src, crate::typedef::w_object()) && !method.is_null() {
+                        let r = crate::builtins::call_and_check(method, &[obj])?;
+                        if pyre_object::is_str(r) {
+                            return Ok(pyre_object::w_str_get_value(r).to_string());
+                        }
+                        return Err(dunder_returned_non_string("__repr__", r));
+                    }
+                }
+            }
             let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {obj:?}>")
         };

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -278,8 +278,25 @@ pub(crate) unsafe fn builtin_subclass_dunder(
     name: &str,
 ) -> Result<Option<String>, crate::PyError> {
     unsafe {
-        Ok(builtin_subclass_dunder_obj(obj, tp, name)?
-            .map(|r| pyre_object::w_str_get_value(r).to_string()))
+        let Some(r) = builtin_subclass_dunder_obj(obj, tp, name)? else {
+            return Ok(None);
+        };
+        let w = pyre_object::w_str_get_wtf8(r).to_wtf8_buf();
+        // A surrogate-bearing override cannot fold into a Rust `String`; the
+        // WTF-8 callers (`py_str_wtf8` / `py_repr_wtf8`) preserve it, while
+        // this `String` path (used for container elements) degrades through
+        // the codec's `backslashreplace` handler rather than panicking.
+        let valid = w.as_str().map(str::to_owned).ok();
+        Ok(Some(match valid {
+            Some(s) => s,
+            None => {
+                let s_obj = pyre_object::w_str_from_wtf8(w);
+                crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
+                    .ok()
+                    .and_then(|b| String::from_utf8(b).ok())
+                    .unwrap_or_default()
+            }
+        }))
     }
 }
 
@@ -322,6 +339,41 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
             return Ok(Some(r));
         }
         Err(dunder_returned_non_string(name, r))
+    }
+}
+
+/// `repr(obj)` preserving a lone-surrogate result, the WTF-8 dual of
+/// [`py_repr`] (as [`py_str_wtf8`] is to [`py_str`]).  A builtin leaf
+/// subclass or plain instance whose `__repr__` returns a surrogate-bearing
+/// str is read through `w_str_get_wtf8` instead of the panicking
+/// `w_str_get_value`; every other object's `repr` is plain and delegates to
+/// `py_repr`.
+///
+/// # Safety
+/// `obj` must point to a valid `PyObject`.
+pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
+    unsafe {
+        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+            return Ok(Wtf8Buf::from_string(format!(
+                "{}",
+                pyre_object::tagged_int::untag_int(obj)
+            )));
+        }
+        let obj = crate::baseobjspace::unwrap_cell(obj);
+        if !obj.is_null() {
+            let tp = (*obj).ob_type;
+            // A builtin leaf subclass's `__repr__` override may return a
+            // lone surrogate; read it as WTF-8 rather than folding to `&str`.
+            if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+                return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
+            }
+            if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
+                if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
+                    return Ok(w);
+                }
+            }
+        }
+        Ok(Wtf8Buf::from_string(py_repr(obj)?))
     }
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1890,6 +1890,7 @@ impl IterOpcodeHandler for PyFrame {
                 || pyre_object::functional::is_zip(iter)
                 || pyre_object::operation::is_callable_iterator(iter)
                 || pyre_object::interp_sre::is_sre_scanner(iter)
+                || crate::module::r#struct::is_unpack_iter(iter)
             {
                 return Ok(());
             }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -661,6 +661,17 @@ pub fn register_module(ns: &mut DictStorage) {
             if pos.len() < 2 {
                 return Err(crate::PyError::type_error("rename() requires 2 arguments"));
             }
+            if pos.len() > 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "rename() takes exactly 2 positional arguments ({} given)",
+                    pos.len()
+                )));
+            }
+            crate::builtins::kwarg_reject_unknown(
+                kwargs,
+                &["src_dir_fd", "dst_dir_fd"],
+                "rename",
+            )?;
             let src = extract_path(pos[0])?;
             let dst = extract_path(pos[1])?;
             let dir_fd = |name: &str| -> Result<Option<i32>, crate::PyError> {
@@ -691,7 +702,11 @@ pub fn register_module(ns: &mut DictStorage) {
             };
             #[cfg(not(unix))]
             let (src_b, dst_b) = {
-                let _ = (src_fd, dst_fd);
+                if src_fd.is_some() || dst_fd.is_some() {
+                    return Err(crate::PyError::not_implemented(
+                        "dir_fd unavailable on this platform",
+                    ));
+                }
                 (None, None)
             };
             host_os::rename(&src, src_b, &dst, dst_b).map_err(|e| io_err(e, &src))?;

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -343,9 +343,16 @@ unsafe fn accept_float(arg: PyObjectRef) -> Result<f64, crate::PyError> {
             return Ok(w_int_get_value(arg) as f64);
         }
         if is_long(arg) {
-            return Ok(longobject::w_long_get_value(arg)
+            // A value that does not fit a C double fails the conversion;
+            // `np_float` / `np_double` reformat any such failure to
+            // "required argument is not a float".
+            let f = longobject::w_long_get_value(arg)
                 .to_f64()
-                .unwrap_or(f64::INFINITY));
+                .unwrap_or(f64::INFINITY);
+            if !f.is_finite() {
+                return Err(struct_error("required argument is not a float"));
+            }
+            return Ok(f);
         }
         if is_bool(arg) {
             return Ok(if w_bool_get_value(arg) { 1.0 } else { 0.0 });
@@ -386,30 +393,29 @@ unsafe fn pack_int(
     bigendian: bool,
 ) -> Result<(), crate::PyError> {
     let value = unsafe { accept_int(arg)? };
-    let bits = 8 * size;
-    let (min_i128, max_i128): (i128, i128) = if signed {
-        (-(1i128 << (bits - 1)), (1i128 << (bits - 1)) - 1)
-    } else {
-        (0, (1i128 << bits) - 1)
-    };
+    // Largest unsigned value representable in `size` bytes (`ulargest` in
+    // `_range_error`); the signed bounds are `ulargest >> 1` and its
+    // bitwise complement.
+    let ulargest = u64::MAX >> ((8 - size) * 8);
 
     // The valid range always fits i64 (signed) or u64 (unsigned, 8-byte),
-    // so `to_i64` / `to_u64` double as the in-range test — the `to_i128`
-    // default would spuriously reject u64 values above i64::MAX.
+    // so `to_i64` / `to_u64` double as the in-range test.
     let le8: [u8; 8] = if signed {
+        let max = (ulargest >> 1) as i64;
+        let min = !max;
         match value.to_i64() {
-            Some(v) if (v as i128) >= min_i128 && (v as i128) <= max_i128 => v.to_le_bytes(),
-            _ => return Err(range_error(fmtchar, min_i128, max_i128)),
+            Some(v) if v >= min && v <= max => v.to_le_bytes(),
+            _ => return Err(range_error(fmtchar, size, signed)),
         }
     } else if size < 8 {
         match value.to_i64() {
-            Some(v) if v >= 0 && (v as i128) <= max_i128 => (v as u64).to_le_bytes(),
-            _ => return Err(range_error(fmtchar, min_i128, max_i128)),
+            Some(v) if v >= 0 && (v as u64) <= ulargest => (v as u64).to_le_bytes(),
+            _ => return Err(range_error(fmtchar, size, signed)),
         }
     } else {
         match value.to_u64() {
             Some(u) => u.to_le_bytes(),
-            None => return Err(range_error(fmtchar, min_i128, max_i128)),
+            None => return Err(range_error(fmtchar, size, signed)),
         }
     };
 
@@ -423,10 +429,16 @@ unsafe fn pack_int(
     Ok(())
 }
 
-fn range_error(fmtchar: char, min: i128, max: i128) -> crate::PyError {
-    struct_error(format!(
-        "'{fmtchar}' format requires {min} <= number <= {max}"
-    ))
+fn range_error(fmtchar: char, size: usize, signed: bool) -> crate::PyError {
+    let ulargest = u64::MAX >> ((8 - size) * 8);
+    let msg = if signed {
+        let max = (ulargest >> 1) as i64;
+        let min = !max;
+        format!("'{fmtchar}' format requires {min} <= number <= {max}")
+    } else {
+        format!("'{fmtchar}' format requires 0 <= number <= {ulargest}")
+    };
+    struct_error(msg)
 }
 
 unsafe fn pack_float_code(
@@ -549,7 +561,11 @@ fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate
                 for _ in 0..rep {
                     let arg = values[ai];
                     ai += 1;
-                    out.push(if crate::baseobjspace::is_true(arg)? { 1 } else { 0 });
+                    out.push(if crate::baseobjspace::is_true(arg)? {
+                        1
+                    } else {
+                        0
+                    });
                 }
             }
             Code::Int { signed } => {
@@ -557,7 +573,14 @@ fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate
                     let arg = values[ai];
                     ai += 1;
                     unsafe {
-                        pack_int(&mut out, arg, fmt.size, signed, fmt.fmtchar, parsed.bigendian)?
+                        pack_int(
+                            &mut out,
+                            arg,
+                            fmt.size,
+                            signed,
+                            fmt.fmtchar,
+                            parsed.bigendian,
+                        )?
                     };
                 }
             }
@@ -779,11 +802,7 @@ fn unpack_units(parsed: &Parsed, buf: &[u8]) -> Result<PyObjectRef, crate::PyErr
 
 /// `do_unpack_from` — unpack `calcsize(format)` bytes of `buf` starting at
 /// `offset`, resolving a negative offset against the buffer end.
-fn do_unpack_from(
-    format: &str,
-    buf: &[u8],
-    offset: i64,
-) -> Result<PyObjectRef, crate::PyError> {
+fn do_unpack_from(format: &str, buf: &[u8], offset: i64) -> Result<PyObjectRef, crate::PyError> {
     let parsed = parse_format(format)?;
     let size = parsed.calcsize()? as usize;
     let buflen = buf.len() as i64;
@@ -903,11 +922,7 @@ fn unpack_half(bits: u16) -> f64 {
     let e = ((bits >> 10) & 0x1f) as i32;
     let f = (bits & 0x3ff) as u32;
     let val = if e == 0x1f {
-        if f == 0 {
-            f64::INFINITY
-        } else {
-            f64::NAN
-        }
+        if f == 0 { f64::INFINITY } else { f64::NAN }
     } else {
         let mut x = f as f64 / 1024.0;
         let ee = if e == 0 {
@@ -918,11 +933,7 @@ fn unpack_half(bits: u16) -> f64 {
         };
         ldexp(x, ee)
     };
-    if sign {
-        -val
-    } else {
-        val
-    }
+    if sign { -val } else { val }
 }
 
 // ── W_Struct ─────────────────────────────────────────────────────────
@@ -1046,7 +1057,11 @@ fn resolve_buffer_offset(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), cra
         .ok_or_else(|| {
             crate::PyError::type_error("unpack_from() missing required argument 'buffer'")
         })?;
-    let offset = match pos.get(1).copied().or_else(|| crate::builtins::kwarg_get(kwargs, "offset")) {
+    let offset = match pos
+        .get(1)
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs, "offset"))
+    {
         Some(o) => unsafe { crate::builtins::space_index_w(o)? },
         None => 0,
     };
@@ -1152,7 +1167,9 @@ unsafe fn readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
         if bytesobject::is_bytes_like(obj) {
             Ok(bytesobject::bytes_like_data(obj))
         } else {
-            Err(crate::PyError::type_error("a bytes-like object is required"))
+            Err(crate::PyError::type_error(
+                "a bytes-like object is required",
+            ))
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -38,7 +38,16 @@ fn code_size(c: char) -> usize {
 fn format_to_string(obj: PyObjectRef) -> Result<String, crate::PyError> {
     unsafe {
         if is_str(obj) {
-            Ok(w_str_get_value(obj).to_string())
+            // A lone surrogate is never a valid format character; read via
+            // WTF-8 and degrade through the codec's `backslashreplace`
+            // handler rather than panicking in `w_str_get_value`.
+            let w = w_str_get_wtf8(obj).to_wtf8_buf();
+            if let Ok(s) = w.as_str() {
+                return Ok(s.to_string());
+            }
+            let s_obj = w_str_from_wtf8(w);
+            let bytes = crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")?;
+            Ok(String::from_utf8(bytes).unwrap_or_default())
         } else if bytesobject::is_bytes_like(obj) {
             Ok(String::from_utf8_lossy(bytesobject::bytes_like_data(obj)).into_owned())
         } else {

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1,46 +1,50 @@
 //! _struct module — PyPy: `pypy/module/struct/`.
 //!
-//! Implements just enough of `pack` / `unpack` / `calcsize` /
-//! `_clearcache` plus the `error` type alias to let `struct.py` load,
-//! and the `W_Struct` class (`interp_struct.py:213 W_Struct`) whose
-//! `pack` / `unpack` promote the format string by value before each
-//! call (`jit.promote_string(self.format)`).  Each packer handles the
-//! format codes pyre actually uses during import (`<q`, `<d`, etc.).
+//! Ports the format interpreter (`rpython/rlib/rstruct/formatiterator.py`
+//! `FormatIterator.interpret`) plus the standard and native format tables
+//! (`standardfmttable.py`, `nativefmttable.py`): byte-order/size/alignment
+//! decoding from the leading char, repetition counts, `needcount` codes
+//! (`x`/`s`/`p`), per-code range checks, and the `s`/`c`/`x`/`p`/`?`/`e`
+//! string, char, pad, pascal, bool and half-float codes.  `struct.error`
+//! is `space.new_exception_class("struct.error", space.w_Exception)`
+//! (`interp_struct.py:20 Cache`).
 
+use malachite_bigint::BigInt;
+use num_traits::ToPrimitive;
 use pyre_object::*;
 
-fn parse_format(fmt: &str) -> (char, Vec<char>) {
-    let chars = fmt.chars();
-    let first = chars.clone().next().unwrap_or('@');
-    let (endian, rest) = if matches!(first, '<' | '>' | '!' | '=' | '@') {
-        (first, chars.skip(1).collect::<String>())
-    } else {
-        ('@', fmt.to_string())
-    };
-    (
-        endian,
-        rest.chars().filter(|c| !c.is_ascii_whitespace()).collect(),
-    )
+/// True on a big-endian build; the native (`@` / no-prefix) byte order.
+const fn native_is_bigendian() -> bool {
+    cfg!(target_endian = "big")
 }
 
-fn code_size(c: char) -> usize {
-    match c {
-        'b' | 'B' | 'c' | '?' | 'x' => 1,
-        'h' | 'H' | 'e' => 2,
-        'i' | 'I' | 'l' | 'L' | 'f' => 4,
-        'q' | 'Q' | 'd' | 'n' | 'N' => 8,
-        _ => 0,
-    }
+/// `interp_struct.py:23 get_error` — raise an instance of `struct.error`
+/// (registered in the exc-class registry under its qualified name) carrying
+/// `msg`.
+fn struct_error(msg: impl Into<String>) -> crate::PyError {
+    let msg = msg.into();
+    let cls = crate::builtins::lookup_exc_class("struct.error")
+        .or_else(|| crate::builtins::lookup_exc_class("Exception"))
+        .expect("Exception must be installed before _struct is used");
+    let exc = crate::builtins::exc_exception_new(&[cls, w_str_new(&msg)])
+        .expect("exc_exception_new is infallible for str args");
+    let mut err = crate::PyError::new(crate::PyErrorKind::ValueError, msg);
+    err.exc_object = exc;
+    err
 }
 
-/// Accept str or bytes-like format spec (PyPy `calcsize` /
-/// `_clearcache` parity) and surface as `String`.
+/// `StructOverflowError` → `space.w_OverflowError` (`interp_struct.py:58`).
+fn struct_overflow(msg: &str) -> crate::PyError {
+    crate::PyError::new(crate::PyErrorKind::OverflowError, msg.to_string())
+}
+
+/// Accept a str or bytes-like format spec (`interp_struct.py:38
+/// text_or_bytes_w`).  A lone surrogate is never a valid format character;
+/// read a str via WTF-8 and degrade through the codec's `backslashreplace`
+/// handler rather than panicking in `w_str_get_value`.
 fn format_to_string(obj: PyObjectRef) -> Result<String, crate::PyError> {
     unsafe {
         if is_str(obj) {
-            // A lone surrogate is never a valid format character; read via
-            // WTF-8 and degrade through the codec's `backslashreplace`
-            // handler rather than panicking in `w_str_get_value`.
             let w = w_str_get_wtf8(obj).to_wtf8_buf();
             if let Ok(s) = w.as_str() {
                 return Ok(s.to_string());
@@ -51,168 +55,877 @@ fn format_to_string(obj: PyObjectRef) -> Result<String, crate::PyError> {
         } else if bytesobject::is_bytes_like(obj) {
             Ok(String::from_utf8_lossy(bytesobject::bytes_like_data(obj)).into_owned())
         } else {
-            Err(crate::PyError::type_error("format must be str or bytes"))
+            Err(crate::PyError::type_error(
+                "Struct() argument 1 must be str or bytes, not object",
+            ))
         }
     }
 }
 
-/// Low 64 bits (two's-complement) of a Python int, whether it arrives as a
-/// small `W_IntObject` or a `W_LongObject`.  Narrower codes truncate this via
-/// `as u8`/`as u16`/`as u32`, which keeps the correct low bytes for both
-/// signed and unsigned formats.  Unsigned `Q`/`N` above `i64::MAX` reach here
-/// as a `W_LongObject`, so a plain `w_int_get_value` would be wrong.
-unsafe fn int_pack_bits(arg: PyObjectRef) -> u64 {
-    use num_traits::ToPrimitive;
-    unsafe {
-        if is_long(arg) {
-            let big = longobject::w_long_get_value(arg);
-            big.to_u64()
-                .or_else(|| big.to_i64().map(|v| v as u64))
-                .unwrap_or(0)
-        } else {
-            w_int_get_value(arg) as u64
-        }
-    }
+// ── format table ─────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+enum Code {
+    Pad,
+    Char,
+    Str,
+    Pascal,
+    Bool,
+    HalfFloat,
+    Float,
+    Double,
+    Int { signed: bool },
 }
 
-fn pack_into(out: &mut Vec<u8>, code: char, little: bool, arg: PyObjectRef) {
-    match code {
-        'b' | 'B' => {
-            out.push(unsafe { int_pack_bits(arg) } as u8);
-        }
-        'h' | 'H' => {
-            let v = unsafe { int_pack_bits(arg) } as u16;
-            out.extend_from_slice(&if little {
-                v.to_le_bytes()
-            } else {
-                v.to_be_bytes()
+/// One entry of the standard/native format table (`FmtDesc`).
+#[derive(Clone, Copy)]
+struct Fmt {
+    code: Code,
+    /// Element size in bytes (int/float width; 1 for `x`/`c`/`s`/`p`).
+    size: usize,
+    /// Native alignment (`FmtDesc.alignment`); always 1 in standard mode.
+    alignment: usize,
+    /// `x`/`s`/`p` consume the repetition as a byte count, not a repeat.
+    needcount: bool,
+    fmtchar: char,
+}
+
+/// `standard_fmttable` / `native_fmttable` lookup.  `native` selects the
+/// native table (`@` or no prefix), where `l`/`L`/`n`/`N`/`P` take C
+/// `long`/`ssize_t`/`size_t`/pointer sizes and every scalar is naturally
+/// aligned; the standard table has no `n`/`N`/`P` and no alignment.
+fn lookup_fmt(c: char, native: bool) -> Option<Fmt> {
+    // Shared string / pad / char / pascal rows (both tables, size 1).
+    match c {
+        'x' => {
+            return Some(Fmt {
+                code: Code::Pad,
+                size: 1,
+                alignment: 1,
+                needcount: true,
+                fmtchar: c,
             });
         }
-        'i' | 'I' | 'l' | 'L' => {
-            let v = unsafe { int_pack_bits(arg) } as u32;
-            out.extend_from_slice(&if little {
-                v.to_le_bytes()
-            } else {
-                v.to_be_bytes()
+        'c' => {
+            return Some(Fmt {
+                code: Code::Char,
+                size: 1,
+                alignment: 1,
+                needcount: false,
+                fmtchar: c,
             });
         }
-        'q' | 'Q' | 'n' | 'N' => {
-            let v = unsafe { int_pack_bits(arg) };
-            out.extend_from_slice(&if little {
-                v.to_le_bytes()
-            } else {
-                v.to_be_bytes()
+        's' => {
+            return Some(Fmt {
+                code: Code::Str,
+                size: 1,
+                alignment: 1,
+                needcount: true,
+                fmtchar: c,
             });
         }
-        'f' => {
-            let v = unsafe {
-                if is_float(arg) {
-                    w_float_get_value(arg) as f32
-                } else {
-                    w_int_get_value(arg) as f32
-                }
-            };
-            out.extend_from_slice(&if little {
-                v.to_le_bytes()
-            } else {
-                v.to_be_bytes()
-            });
-        }
-        'd' => {
-            let v = unsafe {
-                if is_float(arg) {
-                    w_float_get_value(arg)
-                } else {
-                    w_int_get_value(arg) as f64
-                }
-            };
-            out.extend_from_slice(&if little {
-                v.to_le_bytes()
-            } else {
-                v.to_be_bytes()
+        'p' => {
+            return Some(Fmt {
+                code: Code::Pascal,
+                size: 1,
+                alignment: 1,
+                needcount: true,
+                fmtchar: c,
             });
         }
         _ => {}
     }
+
+    let (code, size) = if native {
+        let c_long = std::mem::size_of::<std::os::raw::c_long>();
+        let sz_t = std::mem::size_of::<usize>();
+        match c {
+            'b' => (Code::Int { signed: true }, 1),
+            'B' => (Code::Int { signed: false }, 1),
+            'h' => (Code::Int { signed: true }, 2),
+            'H' => (Code::Int { signed: false }, 2),
+            'i' => (Code::Int { signed: true }, 4),
+            'I' => (Code::Int { signed: false }, 4),
+            'l' => (Code::Int { signed: true }, c_long),
+            'L' => (Code::Int { signed: false }, c_long),
+            'q' => (Code::Int { signed: true }, 8),
+            'Q' => (Code::Int { signed: false }, 8),
+            'n' => (Code::Int { signed: true }, sz_t),
+            'N' => (Code::Int { signed: false }, sz_t),
+            'P' => (Code::Int { signed: false }, sz_t),
+            '?' => (Code::Bool, 1),
+            'e' => (Code::HalfFloat, 2),
+            'f' => (Code::Float, 4),
+            'd' => (Code::Double, 8),
+            _ => return None,
+        }
+    } else {
+        match c {
+            'b' => (Code::Int { signed: true }, 1),
+            'B' => (Code::Int { signed: false }, 1),
+            'h' => (Code::Int { signed: true }, 2),
+            'H' => (Code::Int { signed: false }, 2),
+            'i' | 'l' => (Code::Int { signed: true }, 4),
+            'I' | 'L' => (Code::Int { signed: false }, 4),
+            'q' => (Code::Int { signed: true }, 8),
+            'Q' => (Code::Int { signed: false }, 8),
+            '?' => (Code::Bool, 1),
+            'e' => (Code::HalfFloat, 2),
+            'f' => (Code::Float, 4),
+            'd' => (Code::Double, 8),
+            // `n`/`N`/`P` do not exist in standard sizes.
+            _ => return None,
+        }
+    };
+    // Scalar types are naturally aligned on the targets pyre builds for;
+    // in standard mode all alignments collapse to 1.
+    let alignment = if native { size.max(1) } else { 1 };
+    Some(Fmt {
+        code,
+        size,
+        alignment,
+        needcount: false,
+        fmtchar: c,
+    })
 }
 
-fn unpack_one(buf: &[u8], pos: &mut usize, code: char, little: bool) -> Option<PyObjectRef> {
-    macro_rules! take {
-        ($n:expr) => {
-            if *pos + $n > buf.len() {
-                return None;
-            } else {
-                let slice = &buf[*pos..*pos + $n];
-                *pos += $n;
-                slice
+/// A fully parsed format string: byte order plus the sequence of
+/// `(descriptor, repetitions)` units.
+struct Parsed {
+    bigendian: bool,
+    units: Vec<(Fmt, usize)>,
+}
+
+impl Parsed {
+    /// Number of values a `pack` call must supply: pad consumes none, the
+    /// `needcount` codes consume one, every other code consumes one per
+    /// repetition.
+    fn expected_args(&self) -> usize {
+        self.units
+            .iter()
+            .map(|(fmt, rep)| match fmt.code {
+                Code::Pad => 0,
+                _ if fmt.needcount => 1,
+                _ => *rep,
+            })
+            .sum()
+    }
+
+    /// `CalcSizeFormatIterator` — total packed size including native
+    /// alignment padding.
+    fn calcsize(&self) -> Result<i64, crate::PyError> {
+        let mut total: usize = 0;
+        for (fmt, rep) in &self.units {
+            if fmt.alignment > 1 {
+                total = align_up(total, fmt.alignment);
+            }
+            let unit = fmt
+                .size
+                .checked_mul(*rep)
+                .ok_or_else(|| struct_error("total struct size too long"))?;
+            total = total
+                .checked_add(unit)
+                .ok_or_else(|| struct_error("total struct size too long"))?;
+        }
+        i64::try_from(total).map_err(|_| struct_error("total struct size too long"))
+    }
+}
+
+fn align_up(pos: usize, alignment: usize) -> usize {
+    (pos + alignment - 1) & !(alignment - 1)
+}
+
+/// `FormatIterator.interpret` — decode the leading byte-order char then
+/// each format unit, validating repetition counts and codes.
+fn parse_format(format: &str) -> Result<Parsed, crate::PyError> {
+    let chars: Vec<char> = format.chars().collect();
+    let mut native = true;
+    let mut bigendian = native_is_bigendian();
+    let mut index = 0;
+    if let Some(&first) = chars.first() {
+        match first {
+            '@' => index = 1,
+            '=' => {
+                native = false;
+                index = 1;
+            }
+            '<' => {
+                native = false;
+                bigendian = false;
+                index = 1;
+            }
+            '>' | '!' => {
+                native = false;
+                bigendian = true;
+                index = 1;
+            }
+            _ => index = 0,
+        }
+    }
+
+    let mut units = Vec::new();
+    while index < chars.len() {
+        let mut c = chars[index];
+        index += 1;
+        if c.is_whitespace() {
+            continue;
+        }
+        let repetitions = if c.is_ascii_digit() {
+            let mut rep: i64 = (c as i64) - ('0' as i64);
+            loop {
+                if index == chars.len() {
+                    return Err(struct_error("repeat count given without format specifier"));
+                }
+                c = chars[index];
+                index += 1;
+                if !c.is_ascii_digit() {
+                    break;
+                }
+                rep = rep
+                    .checked_mul(10)
+                    .and_then(|v| v.checked_add((c as i64) - ('0' as i64)))
+                    .ok_or_else(|| struct_error("overflow in item count"))?;
+            }
+            rep as usize
+        } else {
+            1
+        };
+
+        let fmt = match lookup_fmt(c, native) {
+            Some(f) => f,
+            None => {
+                if c == '\0' {
+                    return Err(struct_error("embedded null character"));
+                }
+                return Err(struct_error("bad char in struct format"));
             }
         };
+        units.push((fmt, repetitions));
     }
-    // Endian-aware fixed-width read: `<T>::from_le_bytes` / `from_be_bytes`.
-    macro_rules! rd {
-        ($ty:ty, $n:expr) => {{
-            let b: [u8; $n] = take!($n).try_into().unwrap();
-            if little {
-                <$ty>::from_le_bytes(b)
-            } else {
-                <$ty>::from_be_bytes(b)
+    Ok(Parsed { bigendian, units })
+}
+
+// ── argument acceptance ──────────────────────────────────────────────
+
+/// `PackFormatIterator._accept_integral` — an int / bool / `__index__`
+/// object as a `BigInt` for range checking.
+unsafe fn accept_int(arg: PyObjectRef) -> Result<BigInt, crate::PyError> {
+    unsafe {
+        if is_int(arg) || is_long(arg) {
+            return Ok(crate::builtins::obj_to_bigint(arg));
+        }
+        if is_bool(arg) {
+            return Ok(BigInt::from(if w_bool_get_value(arg) { 1 } else { 0 }));
+        }
+        if let Some(tp) = crate::typedef::r#type(arg) {
+            if let Some(index_fn) = crate::baseobjspace::lookup_in_type(tp, "__index__") {
+                let r = crate::call::call_function_impl_result(index_fn, &[arg])?;
+                if is_int(r) || is_long(r) {
+                    return Ok(crate::builtins::obj_to_bigint(r));
+                }
+                if is_bool(r) {
+                    return Ok(BigInt::from(if w_bool_get_value(r) { 1 } else { 0 }));
+                }
             }
-        }};
+        }
+        Err(struct_error("required argument is not an integer"))
     }
-    // Uppercase codes are unsigned, lowercase signed
-    // (`interp_array.py unpack_value` — the `b'B'`/`b'H'`/`b'I'`/`b'Q'`
-    // rows box unsigned values, boxing `Q`/`N` above `i64::MAX` into a
-    // `W_LongObject`).
+}
+
+/// `PackFormatIterator.accept_float_arg` — a float / int / `__float__`
+/// object as an `f64`.
+unsafe fn accept_float(arg: PyObjectRef) -> Result<f64, crate::PyError> {
+    unsafe {
+        if is_float(arg) {
+            return Ok(w_float_get_value(arg));
+        }
+        if is_int(arg) {
+            return Ok(w_int_get_value(arg) as f64);
+        }
+        if is_long(arg) {
+            return Ok(longobject::w_long_get_value(arg)
+                .to_f64()
+                .unwrap_or(f64::INFINITY));
+        }
+        if is_bool(arg) {
+            return Ok(if w_bool_get_value(arg) { 1.0 } else { 0.0 });
+        }
+        if let Some(tp) = crate::typedef::r#type(arg) {
+            if let Some(float_fn) = crate::baseobjspace::lookup_in_type(tp, "__float__") {
+                let r = crate::call::call_function_impl_result(float_fn, &[arg])?;
+                if is_float(r) {
+                    return Ok(w_float_get_value(r));
+                }
+            }
+        }
+        Err(struct_error("required argument is not a float"))
+    }
+}
+
+/// A bytes / bytearray argument's raw bytes (`accept_str_arg` =
+/// `space.bytes_w`).  `role` names the code for the error message.
+unsafe fn accept_bytes<'a>(arg: PyObjectRef, msg: &str) -> Result<&'a [u8], crate::PyError> {
+    unsafe {
+        if bytesobject::is_bytes_like(arg) {
+            Ok(bytesobject::bytes_like_data(arg))
+        } else {
+            Err(struct_error(msg.to_string()))
+        }
+    }
+}
+
+// ── per-code packing ─────────────────────────────────────────────────
+
+/// `make_int_packer.pack_int` — range-check then write `size` low bytes.
+unsafe fn pack_int(
+    out: &mut Vec<u8>,
+    arg: PyObjectRef,
+    size: usize,
+    signed: bool,
+    fmtchar: char,
+    bigendian: bool,
+) -> Result<(), crate::PyError> {
+    let value = unsafe { accept_int(arg)? };
+    let bits = 8 * size;
+    let (min_i128, max_i128): (i128, i128) = if signed {
+        (-(1i128 << (bits - 1)), (1i128 << (bits - 1)) - 1)
+    } else {
+        (0, (1i128 << bits) - 1)
+    };
+
+    // The valid range always fits i64 (signed) or u64 (unsigned, 8-byte),
+    // so `to_i64` / `to_u64` double as the in-range test — the `to_i128`
+    // default would spuriously reject u64 values above i64::MAX.
+    let le8: [u8; 8] = if signed {
+        match value.to_i64() {
+            Some(v) if (v as i128) >= min_i128 && (v as i128) <= max_i128 => v.to_le_bytes(),
+            _ => return Err(range_error(fmtchar, min_i128, max_i128)),
+        }
+    } else if size < 8 {
+        match value.to_i64() {
+            Some(v) if v >= 0 && (v as i128) <= max_i128 => (v as u64).to_le_bytes(),
+            _ => return Err(range_error(fmtchar, min_i128, max_i128)),
+        }
+    } else {
+        match value.to_u64() {
+            Some(u) => u.to_le_bytes(),
+            None => return Err(range_error(fmtchar, min_i128, max_i128)),
+        }
+    };
+
+    if bigendian {
+        for i in (0..size).rev() {
+            out.push(le8[i]);
+        }
+    } else {
+        out.extend_from_slice(&le8[0..size]);
+    }
+    Ok(())
+}
+
+fn range_error(fmtchar: char, min: i128, max: i128) -> crate::PyError {
+    struct_error(format!(
+        "'{fmtchar}' format requires {min} <= number <= {max}"
+    ))
+}
+
+unsafe fn pack_float_code(
+    out: &mut Vec<u8>,
+    arg: PyObjectRef,
+    code: Code,
+    bigendian: bool,
+) -> Result<(), crate::PyError> {
+    let d = unsafe { accept_float(arg)? };
     match code {
-        'b' => Some(w_int_new(take!(1)[0] as i8 as i64)),
-        'B' => Some(w_int_new(take!(1)[0] as i64)),
-        'h' => Some(w_int_new(rd!(i16, 2) as i64)),
-        'H' => Some(w_int_new(rd!(u16, 2) as i64)),
-        'i' | 'l' => Some(w_int_new(rd!(i32, 4) as i64)),
-        'I' | 'L' => Some(w_int_new(rd!(u32, 4) as i64)),
-        'q' | 'n' => Some(w_int_new(rd!(i64, 8))),
-        'Q' | 'N' => {
-            let v = rd!(u64, 8);
-            if v <= i64::MAX as u64 {
-                Some(w_int_new(v as i64))
-            } else {
-                Some(pyre_object::longobject::w_long_new(
-                    malachite_bigint::BigInt::from(v),
-                ))
+        Code::Float => {
+            let f = d as f32;
+            if d.is_finite() && f.is_infinite() {
+                return Err(struct_overflow("float too large to pack with f format"));
+            }
+            let b = f.to_bits().to_le_bytes();
+            push_endian(out, &b, bigendian);
+        }
+        Code::Double => {
+            let b = d.to_bits().to_le_bytes();
+            push_endian(out, &b, bigendian);
+        }
+        Code::HalfFloat => {
+            let bits = pack_half(d)?;
+            push_endian(out, &bits.to_le_bytes(), bigendian);
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
+}
+
+fn push_endian(out: &mut Vec<u8>, le: &[u8], bigendian: bool) {
+    if bigendian {
+        out.extend(le.iter().rev());
+    } else {
+        out.extend_from_slice(le);
+    }
+}
+
+/// `_pack_string` — write `min(len, count)` bytes then zero-pad to `count`.
+fn pack_string_bytes(out: &mut Vec<u8>, data: &[u8], count: usize) {
+    if data.len() < count {
+        out.extend_from_slice(data);
+        out.extend(std::iter::repeat_n(0u8, count - data.len()));
+    } else {
+        out.extend_from_slice(&data[..count]);
+    }
+}
+
+// ── packing driver ───────────────────────────────────────────────────
+
+/// `do_pack` — pack `values` according to `format`.
+fn do_pack(format: &str, values: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let parsed = parse_format(format)?;
+    Ok(w_bytes_from_bytes(&pack_values(&parsed, values)?))
+}
+
+/// `_pack` — the packed bytes of `values` according to a parsed format.
+fn pack_values(parsed: &Parsed, values: &[PyObjectRef]) -> Result<Vec<u8>, crate::PyError> {
+    let expected = parsed.expected_args();
+    if values.len() != expected {
+        return Err(struct_error(format!(
+            "pack expected {expected} items for packing (got {})",
+            values.len()
+        )));
+    }
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut ai = 0usize;
+    for (fmt, rep) in &parsed.units {
+        if fmt.alignment > 1 {
+            let pad = align_up(out.len(), fmt.alignment) - out.len();
+            out.extend(std::iter::repeat_n(0u8, pad));
+        }
+        let rep = *rep;
+        match fmt.code {
+            Code::Pad => out.extend(std::iter::repeat_n(0u8, rep)),
+            Code::Char => {
+                for _ in 0..rep {
+                    let arg = values[ai];
+                    ai += 1;
+                    let data = unsafe {
+                        accept_bytes(arg, "char format requires a bytes object of length 1")?
+                    };
+                    if data.len() != 1 {
+                        return Err(struct_error(
+                            "char format requires a bytes object of length 1",
+                        ));
+                    }
+                    out.push(data[0]);
+                }
+            }
+            Code::Str => {
+                let arg = values[ai];
+                ai += 1;
+                let data = unsafe { accept_bytes(arg, "argument for 's' must be a bytes object")? };
+                pack_string_bytes(&mut out, data, rep);
+            }
+            Code::Pascal => {
+                let arg = values[ai];
+                ai += 1;
+                let data = unsafe { accept_bytes(arg, "argument for 'p' must be a bytes object")? };
+                // `pack_pascal` — length prefix byte (clamped to count-1 and
+                // 255) then the string, padded to `count` bytes total.  A
+                // `0p` field has no room for even the length byte.
+                let mut prefix = data.len();
+                if prefix >= rep {
+                    if rep == 0 {
+                        return Err(struct_error("bad '0p' in struct format"));
+                    }
+                    prefix = rep - 1;
+                }
+                if prefix > 255 {
+                    prefix = 255;
+                }
+                out.push(prefix as u8);
+                pack_string_bytes(&mut out, &data[..prefix], rep - 1);
+            }
+            Code::Bool => {
+                for _ in 0..rep {
+                    let arg = values[ai];
+                    ai += 1;
+                    out.push(if crate::baseobjspace::is_true(arg)? { 1 } else { 0 });
+                }
+            }
+            Code::Int { signed } => {
+                for _ in 0..rep {
+                    let arg = values[ai];
+                    ai += 1;
+                    unsafe {
+                        pack_int(&mut out, arg, fmt.size, signed, fmt.fmtchar, parsed.bigendian)?
+                    };
+                }
+            }
+            Code::Float | Code::Double | Code::HalfFloat => {
+                for _ in 0..rep {
+                    let arg = values[ai];
+                    ai += 1;
+                    unsafe { pack_float_code(&mut out, arg, fmt.code, parsed.bigendian)? };
+                }
             }
         }
-        'f' => Some(w_float_new(rd!(f32, 4) as f64)),
-        'd' => Some(w_float_new(rd!(f64, 8))),
-        _ => None,
+    }
+    Ok(out)
+}
+
+/// `space.writebuf_w` — a writable byte slice from a `bytearray` or a
+/// contiguous read-write `memoryview` over one.
+unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError> {
+    unsafe {
+        if bytearrayobject::is_bytearray(obj) {
+            return Ok(bytearrayobject::w_bytearray_data_mut(obj));
+        }
+        if memoryview::is_w_memoryview(obj) {
+            crate::builtins::memoryview_check_released(obj)?;
+            if memoryview::w_memoryview_readonly(obj) {
+                return Err(crate::PyError::type_error(
+                    "a read-write bytes-like object is required",
+                ));
+            }
+            let backing = memoryview::w_memoryview_backing(obj);
+            if bytearrayobject::is_bytearray(backing)
+                && memoryview::w_memoryview_stride0(obj) == memoryview::w_memoryview_itemsize(obj)
+            {
+                let off = memoryview::w_memoryview_offset(obj) as usize;
+                let len = memoryview::w_memoryview_length(obj) as usize;
+                let full = bytearrayobject::w_bytearray_data_mut(backing);
+                return Ok(&mut full[off..off + len]);
+            }
+        }
+        Err(crate::PyError::type_error(
+            "argument must be read-write bytes-like object",
+        ))
     }
 }
 
-/// `interp_struct.py:71 do_pack` — pack `values` according to `format`.
-fn do_pack(format: &str, values: &[PyObjectRef]) -> PyObjectRef {
-    let (endian, codes) = parse_format(format);
-    let little = matches!(endian, '<' | '=' | '@');
-    let mut out = Vec::new();
-    for (i, code) in codes.iter().enumerate() {
-        let arg = values.get(i).copied().unwrap_or(w_none());
-        pack_into(&mut out, *code, little, arg);
+/// `do_pack_into` — pack `values` into `buffer` starting at `offset`,
+/// resolving a negative offset against the buffer end.
+fn do_pack_into(
+    format: &str,
+    buffer: PyObjectRef,
+    offset: i64,
+    values: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let parsed = parse_format(format)?;
+    let size = parsed.calcsize()?;
+    let buf = unsafe { writebuf(buffer)? };
+    let buflen = buf.len() as i64;
+    let mut offset = offset;
+    if offset < 0 {
+        if offset + size > 0 {
+            return Err(struct_error(format!(
+                "no space to pack {size} bytes at offset {offset}"
+            )));
+        }
+        if offset + buflen < 0 {
+            return Err(struct_error(format!(
+                "offset {offset} out of range for {buflen}-byte buffer"
+            )));
+        }
+        offset += buflen;
     }
-    w_bytes_from_bytes(&out)
+    if buflen - offset < size {
+        return Err(struct_error(format!(
+            "pack_into requires a buffer of at least {} bytes for packing {} bytes at offset {} (actual buffer size is {})",
+            size + offset,
+            size,
+            offset,
+            buflen
+        )));
+    }
+    let packed = pack_values(&parsed, values)?;
+    let start = offset as usize;
+    buf[start..start + packed.len()].copy_from_slice(&packed);
+    Ok(w_none())
 }
 
-/// `interp_struct.py:139 do_unpack` — unpack `buf` according to `format`.
-fn do_unpack(format: &str, buf: &[u8]) -> PyObjectRef {
-    let (endian, codes) = parse_format(format);
-    let little = matches!(endian, '<' | '=' | '@');
-    let mut out = Vec::new();
-    let mut pos = 0usize;
-    for code in codes {
-        match unpack_one(buf, &mut pos, code, little) {
-            Some(v) => out.push(v),
-            None => break,
+// ── per-code unpacking ───────────────────────────────────────────────
+
+/// `make_int_unpacker.unpack_int` — read `size` bytes and box the value,
+/// promoting an unsigned value above `i64::MAX` to a `W_LongObject`.
+fn unpack_int(raw: &[u8], size: usize, signed: bool, bigendian: bool) -> PyObjectRef {
+    // Normalise to little-endian ordering.
+    let mut le = [0u8; 8];
+    for i in 0..size {
+        le[i] = if bigendian { raw[size - 1 - i] } else { raw[i] };
+    }
+    if signed {
+        // Sign-extend from the top byte of the field.
+        let fill = if le[size - 1] & 0x80 != 0 { 0xff } else { 0x00 };
+        for b in le.iter_mut().skip(size) {
+            *b = fill;
+        }
+        w_int_new(i64::from_le_bytes(le))
+    } else {
+        let u = u64::from_le_bytes(le);
+        if u <= i64::MAX as u64 {
+            w_int_new(u as i64)
+        } else {
+            longobject::w_long_new(BigInt::from(u))
         }
     }
-    w_tuple_new(out)
 }
+
+fn unpack_float(raw: &[u8], code: Code, bigendian: bool) -> PyObjectRef {
+    match code {
+        Code::Float => {
+            let mut b = [0u8; 4];
+            copy_endian(raw, &mut b, bigendian);
+            w_float_new(f32::from_bits(u32::from_le_bytes(b)) as f64)
+        }
+        Code::Double => {
+            let mut b = [0u8; 8];
+            copy_endian(raw, &mut b, bigendian);
+            w_float_new(f64::from_bits(u64::from_le_bytes(b)))
+        }
+        Code::HalfFloat => {
+            let mut b = [0u8; 2];
+            copy_endian(raw, &mut b, bigendian);
+            w_float_new(unpack_half(u16::from_le_bytes(b)))
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn copy_endian(raw: &[u8], out: &mut [u8], bigendian: bool) {
+    let n = out.len();
+    for i in 0..n {
+        out[i] = if bigendian { raw[n - 1 - i] } else { raw[i] };
+    }
+}
+
+// ── unpacking driver ─────────────────────────────────────────────────
+
+/// `do_unpack` / `_unpack` — unpack the whole of `buf` (which must be
+/// exactly `calcsize(format)` bytes) according to `format`.
+fn do_unpack(format: &str, buf: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+    let parsed = parse_format(format)?;
+    let size = parsed.calcsize()? as usize;
+    if buf.len() != size {
+        return Err(struct_error(format!(
+            "unpack requires a buffer of {size} bytes"
+        )));
+    }
+    unpack_units(&parsed, buf)
+}
+
+fn unpack_units(parsed: &Parsed, buf: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+    let mut out: Vec<PyObjectRef> = Vec::new();
+    let mut pos = 0usize;
+    for (fmt, rep) in &parsed.units {
+        if fmt.alignment > 1 {
+            pos = align_up(pos, fmt.alignment);
+        }
+        let rep = *rep;
+        match fmt.code {
+            Code::Pad => pos += rep,
+            Code::Char => {
+                for _ in 0..rep {
+                    out.push(w_bytes_from_bytes(&buf[pos..pos + 1]));
+                    pos += 1;
+                }
+            }
+            Code::Str => {
+                out.push(w_bytes_from_bytes(&buf[pos..pos + rep]));
+                pos += rep;
+            }
+            Code::Pascal => {
+                // `unpack_pascal` — first byte is the length, clamped to the
+                // field width; the value is the following bytes.
+                if rep == 0 {
+                    return Err(struct_error("bad '0p' in struct format"));
+                }
+                let data = &buf[pos..pos + rep];
+                let end = (1 + data[0] as usize).min(rep);
+                out.push(w_bytes_from_bytes(&data[1..end]));
+                pos += rep;
+            }
+            Code::Bool => {
+                for _ in 0..rep {
+                    out.push(boolobject::w_bool_from(buf[pos] != 0));
+                    pos += 1;
+                }
+            }
+            Code::Int { signed } => {
+                for _ in 0..rep {
+                    out.push(unpack_int(
+                        &buf[pos..pos + fmt.size],
+                        fmt.size,
+                        signed,
+                        parsed.bigendian,
+                    ));
+                    pos += fmt.size;
+                }
+            }
+            Code::Float | Code::Double | Code::HalfFloat => {
+                for _ in 0..rep {
+                    out.push(unpack_float(
+                        &buf[pos..pos + fmt.size],
+                        fmt.code,
+                        parsed.bigendian,
+                    ));
+                    pos += fmt.size;
+                }
+            }
+        }
+    }
+    Ok(w_tuple_new(out))
+}
+
+/// `do_unpack_from` — unpack `calcsize(format)` bytes of `buf` starting at
+/// `offset`, resolving a negative offset against the buffer end.
+fn do_unpack_from(
+    format: &str,
+    buf: &[u8],
+    offset: i64,
+) -> Result<PyObjectRef, crate::PyError> {
+    let parsed = parse_format(format)?;
+    let size = parsed.calcsize()? as usize;
+    let buflen = buf.len() as i64;
+    let mut offset = offset;
+    if offset < 0 {
+        if offset + size as i64 > 0 {
+            return Err(struct_error(format!(
+                "not enough data to unpack {size} bytes at offset {offset}"
+            )));
+        }
+        if offset + buflen < 0 {
+            return Err(struct_error(format!(
+                "offset {offset} out of range for {buflen}-byte buffer"
+            )));
+        }
+        offset += buflen;
+    }
+    if buflen - offset < size as i64 {
+        return Err(struct_error(format!(
+            "unpack_from requires a buffer of at least {} bytes for unpacking {} bytes at offset {} (actual buffer size is {})",
+            size as i64 + offset,
+            size,
+            offset,
+            buflen
+        )));
+    }
+    let start = offset as usize;
+    unpack_units(&parsed, &buf[start..start + size])
+}
+
+// ── half-float (IEEE 754 binary16) ───────────────────────────────────
+
+/// `frexp` for a finite non-zero positive `x`: returns `(m, e)` with
+/// `x == m * 2**e` and `m` in `[0.5, 1.0)`.
+fn frexp(x: f64) -> (f64, i32) {
+    let bits = x.to_bits();
+    let biased = ((bits >> 52) & 0x7ff) as i32;
+    if biased == 0 {
+        // Subnormal: scale up by 2**53 to normalise, then correct exponent.
+        let norm = x * 9007199254740992.0; // 2**53
+        let nbits = norm.to_bits();
+        let e = (((nbits >> 52) & 0x7ff) as i32) - 1022 - 53;
+        let m = f64::from_bits((nbits & !(0x7ffu64 << 52)) | (1022u64 << 52));
+        return (m, e);
+    }
+    let e = biased - 1022;
+    let m = f64::from_bits((bits & !(0x7ffu64 << 52)) | (1022u64 << 52));
+    (m, e)
+}
+
+fn ldexp(x: f64, e: i32) -> f64 {
+    x * (2.0f64).powi(e)
+}
+
+/// `_PyFloat_Pack2` — round `x` to IEEE binary16, raising `OverflowError`
+/// for a finite value too large to represent.
+fn pack_half(x: f64) -> Result<u16, crate::PyError> {
+    let sign: u16;
+    let e: i32;
+    let bits: u16;
+    if x == 0.0 {
+        sign = if x.is_sign_negative() { 1 } else { 0 };
+        e = 0;
+        bits = 0;
+    } else if x.is_infinite() {
+        sign = if x < 0.0 { 1 } else { 0 };
+        e = 0x1f;
+        bits = 0;
+    } else if x.is_nan() {
+        sign = if x.is_sign_negative() { 1 } else { 0 };
+        e = 0x1f;
+        bits = 512;
+    } else {
+        sign = if x < 0.0 { 1 } else { 0 };
+        let ax = x.abs();
+        let (mut f, mut ex) = frexp(ax);
+        // Normalize f to [1.0, 2.0).
+        f *= 2.0;
+        ex -= 1;
+        if ex >= 16 {
+            return Err(struct_overflow("float too large to pack with e format"));
+        } else if ex < -25 {
+            // |x| < 2**-25: underflow to zero.
+            f = 0.0;
+            ex = 0;
+        } else if ex < -14 {
+            // Gradual underflow.
+            f = ldexp(f, 14 + ex);
+            ex = 0;
+        } else {
+            ex += 15;
+            f -= 1.0; // Discard the leading 1.
+        }
+        f *= 1024.0; // 2**10
+        let mut b = f as u16; // truncation
+        let frac = f - (b as f64);
+        if frac > 0.5 || (frac == 0.5 && (b & 1) == 1) {
+            b += 1;
+            if b == 1024 {
+                // Carry propagated out of ten 1 bits.
+                b = 0;
+                ex += 1;
+                if ex == 31 {
+                    return Err(struct_overflow("float too large to pack with e format"));
+                }
+            }
+        }
+        e = ex;
+        bits = b;
+    }
+    Ok(bits | ((e as u16) << 10) | (sign << 15))
+}
+
+/// `_PyFloat_Unpack2` — decode an IEEE binary16 to a double.
+fn unpack_half(bits: u16) -> f64 {
+    let sign = (bits >> 15) & 1 == 1;
+    let e = ((bits >> 10) & 0x1f) as i32;
+    let f = (bits & 0x3ff) as u32;
+    let val = if e == 0x1f {
+        if f == 0 {
+            f64::INFINITY
+        } else {
+            f64::NAN
+        }
+    } else {
+        let mut x = f as f64 / 1024.0;
+        let ee = if e == 0 {
+            -14
+        } else {
+            x += 1.0;
+            e - 15
+        };
+        ldexp(x, ee)
+    };
+    if sign {
+        -val
+    } else {
+        val
+    }
+}
+
+// ── W_Struct ─────────────────────────────────────────────────────────
 
 /// `interp_struct.py:213 W_Struct` — a compiled struct object holding its
 /// format string and precomputed size.
@@ -243,8 +956,7 @@ impl W_Struct {
     /// format string and its `_calcsize`.
     fn __init__(&mut self, w_format: PyObjectRef) -> Result<(), crate::PyError> {
         let format = format_to_string(w_format)?;
-        let (_, codes) = parse_format(&format);
-        self.size = codes.iter().copied().map(code_size).sum::<usize>() as i64;
+        self.size = parse_format(&format)?.calcsize()?;
         self.format = w_str_new(&format);
         Ok(())
     }
@@ -266,7 +978,7 @@ impl W_Struct {
     fn pack(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let format = majit_metainterp::jit::promote_string(self.format);
         let fmt = unsafe { w_str_get_value(format) };
-        Ok(do_pack(fmt, &args[1..]))
+        do_pack(fmt, &args[1..])
     }
 
     /// `interp_struct.py:234 descr_unpack` —
@@ -274,53 +986,250 @@ impl W_Struct {
     fn unpack(&self, w_str: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
         let format = majit_metainterp::jit::promote_string(self.format);
         let fmt = unsafe { w_str_get_value(format) };
-        let buf = unsafe {
-            if bytesobject::is_bytes_like(w_str) {
-                bytesobject::bytes_like_data(w_str)
-            } else {
-                return Err(crate::PyError::type_error(
-                    "a bytes-like object is required",
-                ));
+        let buf = unsafe { readbuf(w_str)? };
+        do_unpack(fmt, buf)
+    }
+
+    /// `interp_struct.py:231 descr_pack_into` —
+    /// `do_pack_into(space, jit.promote_string(self.format), buffer, offset, args_w)`.
+    /// Whole-args ABI: `args[0]` = self, `args[1]` = buffer, `args[2]` =
+    /// offset, `args[3..]` = the packed values.
+    fn pack_into(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let format = majit_metainterp::jit::promote_string(self.format);
+        let fmt = unsafe { w_str_get_value(format) };
+        let (pos, _) = crate::builtins::split_builtin_kwargs(&args[1..]);
+        if pos.len() < 2 {
+            return Err(crate::PyError::type_error(
+                "pack_into() missing buffer or offset argument",
+            ));
+        }
+        let offset = unsafe { crate::builtins::space_index_w(pos[1])? };
+        do_pack_into(fmt, pos[0], offset, &pos[2..])
+    }
+
+    /// `interp_struct.py:238 descr_unpack_from` —
+    /// `do_unpack_from(space, jit.promote_string(self.format), buffer, offset)`.
+    /// `buffer` / `offset` are accepted positionally or by keyword.
+    fn unpack_from(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let format = majit_metainterp::jit::promote_string(self.format);
+        let fmt = unsafe { w_str_get_value(format) };
+        let (buffer, offset) = resolve_buffer_offset(&args[1..])?;
+        let buf = unsafe { readbuf(buffer)? };
+        do_unpack_from(fmt, buf, offset)
+    }
+
+    /// `interp_struct.py:241 descr_iter_unpack` — a `W_UnpackIter` over
+    /// `buffer`.  Whole-args ABI: `args[0]` = self, `args[1]` = buffer.
+    fn iter_unpack(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let buffer = args
+            .get(1)
+            .copied()
+            .ok_or_else(|| crate::PyError::type_error("iter_unpack() missing buffer argument"))?;
+        make_unpack_iter(self.format, self.size, buffer)
+    }
+
+    /// `_struct.Struct.__repr__` — `Struct('<format>')`.
+    fn __repr__(&self) -> PyObjectRef {
+        let fmt = unsafe { w_str_get_value(self.format) };
+        w_str_new(&format!("Struct('{fmt}')"))
+    }
+}
+
+/// Resolve `(buffer, offset=0)` from a positional/keyword argument slice
+/// (`unpack_from` accepts both `buffer=` and `offset=`).
+fn resolve_buffer_offset(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let buffer = pos
+        .first()
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs, "buffer"))
+        .ok_or_else(|| {
+            crate::PyError::type_error("unpack_from() missing required argument 'buffer'")
+        })?;
+    let offset = match pos.get(1).copied().or_else(|| crate::builtins::kwarg_get(kwargs, "offset")) {
+        Some(o) => unsafe { crate::builtins::space_index_w(o)? },
+        None => 0,
+    };
+    Ok((buffer, offset))
+}
+
+// ── W_UnpackIter ─────────────────────────────────────────────────────
+
+/// `interp_struct.py:177 W_UnpackIter` — an iterator yielding the
+/// successive fixed-size records of a buffer.  Kept in its own module
+/// because each `#[pyre_class]` emits a module-scoped `type_object()`.
+mod unpack_iter {
+    use super::{do_unpack, readbuf, struct_error};
+    use pyre_object::*;
+
+    #[crate::pyre_class("_struct.unpack_iterator")]
+    pub struct W_UnpackIter {
+        format: PyObjectRef,
+        buffer: PyObjectRef,
+        size: i64,
+        index: i64,
+    }
+
+    #[crate::pyre_methods]
+    impl W_UnpackIter {
+        fn __iter__(&self, args: &[PyObjectRef]) -> PyObjectRef {
+            args[0]
+        }
+
+        /// `descr_next` — unpack the next record, raising `StopIteration`
+        /// at the end of the buffer.
+        fn __next__(&mut self) -> Result<PyObjectRef, crate::PyError> {
+            let buf = unsafe { readbuf(self.buffer)? };
+            if self.index >= buf.len() as i64 {
+                return Err(crate::PyError::new(crate::PyErrorKind::StopIteration, ""));
             }
-        };
-        Ok(do_unpack(fmt, buf))
+            let start = self.index as usize;
+            let end = start + self.size as usize;
+            let fmt = unsafe { w_str_get_value(self.format) };
+            let res = do_unpack(fmt, &buf[start..end])?;
+            self.index += self.size;
+            Ok(res)
+        }
+
+        /// `descr_length_hint` — records remaining.
+        fn __length_hint__(&self) -> PyObjectRef {
+            let remaining = match unsafe { readbuf(self.buffer) } {
+                Ok(buf) => (buf.len() as i64 - self.index) / self.size,
+                Err(_) => 0,
+            };
+            w_int_new(remaining)
+        }
+    }
+
+    /// `interp_struct.py:178 W_UnpackIter.__init__` — build an unpack
+    /// iterator, rejecting a zero-length struct or a buffer whose length is
+    /// not a whole multiple of the record size.
+    pub fn make_unpack_iter(
+        format: PyObjectRef,
+        size: i64,
+        buffer: PyObjectRef,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        // Force the type's method table to be built before allocating (the
+        // `unpack_iterator` type is not exposed as a module attribute, so
+        // nothing else triggers `type_object()`).
+        let _ = type_object();
+        let buf = unsafe { readbuf(buffer)? };
+        if size <= 0 {
+            return Err(struct_error(format!(
+                "cannot iteratively unpack with a struct of length {size}"
+            )));
+        }
+        if buf.len() as i64 % size != 0 {
+            return Err(struct_error(format!(
+                "iterative unpacking requires a buffer of a multiple of {size} bytes"
+            )));
+        }
+        Ok(W_UnpackIter::allocate(W_UnpackIter {
+            ob: pyre_object::PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
+            format,
+            buffer,
+            size,
+            index: 0,
+        }))
+    }
+}
+
+use unpack_iter::make_unpack_iter;
+
+/// True if `obj` is an `unpack_iterator` (the `iter_unpack` result).  Used
+/// by the `iter()` / `next()` dispatch to route the iteration protocol,
+/// mirroring the other builtin iterators (`is_sre_scanner`, …).
+pub fn is_unpack_iter(obj: PyObjectRef) -> bool {
+    unpack_iter::W_UnpackIter::from_obj(obj).is_some()
+}
+
+/// `space.readbuf_w` — a read-only byte slice from a bytes-like object.
+unsafe fn readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
+    unsafe {
+        if bytesobject::is_bytes_like(obj) {
+            Ok(bytesobject::bytes_like_data(obj))
+        } else {
+            Err(crate::PyError::type_error("a bytes-like object is required"))
+        }
     }
 }
 
 crate::py_module! {
     "_struct",
     interpleveldefs: {
-        "error" => crate::typedef::w_object(),
         "Struct" => type_object(),
     },
     inline_functions: {
         fn _clearcache() {}
         fn calcsize(fmt_obj: PyObjectRef) -> Result<i64, crate::PyError> {
             let fmt = format_to_string(fmt_obj)?;
-            let (_, codes) = parse_format(&fmt);
-            Ok(codes.iter().copied().map(code_size).sum::<usize>() as i64)
+            parse_format(&fmt)?.calcsize()
         }
-        fn unpack(fmt: &str, buf: &[u8]) -> PyObjectRef {
-            do_unpack(fmt, buf)
+        fn unpack(fmt_obj: PyObjectRef, buf: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+            let fmt = format_to_string(fmt_obj)?;
+            do_unpack(&fmt, buf)
         }
     },
     functions: {
         // `pack(fmt, *args)` — variadic positional after fmt; route
-        // through the args slice for now (typed varargs not supported
-        // by inline_functions arity inference).
+        // through the args slice (typed varargs are not supported by
+        // inline_functions arity inference).
         "pack" / * = |args| {
             if args.is_empty() {
-                return Ok(w_bytes_from_bytes(&[]));
+                return Err(crate::PyError::type_error(
+                    "pack() missing 1 required positional argument: 'fmt'",
+                ));
             }
-            let fmt = unsafe {
-                if !is_str(args[0]) {
-                    return Err(crate::PyError::type_error("pack: format must be str"));
-                }
-                w_str_get_value(args[0])
-            };
-            Ok(do_pack(fmt, &args[1..]))
+            let fmt = format_to_string(args[0])?;
+            do_pack(&fmt, &args[1..])
         },
-        "unpack_from" / * = |_| Ok(w_tuple_new(vec![])),
-        "iter_unpack" / 2 = |_| Ok(w_list_new(vec![])),
+        // `pack_into(fmt, buffer, offset, *args)` — write the packed bytes
+        // into a writable buffer at `offset`.
+        "pack_into" / * = |args| {
+            let (pos, _) = crate::builtins::split_builtin_kwargs(args);
+            if pos.len() < 3 {
+                return Err(crate::PyError::type_error(
+                    "pack_into() missing format, buffer or offset argument",
+                ));
+            }
+            let fmt = format_to_string(pos[0])?;
+            let offset = unsafe { crate::builtins::space_index_w(pos[2])? };
+            do_pack_into(&fmt, pos[1], offset, &pos[3..])
+        },
+        // `unpack_from(fmt, /, buffer, offset=0)` — `buffer` / `offset`
+        // are accepted positionally or by keyword.
+        "unpack_from" / * = |args| {
+            let (pos, _) = crate::builtins::split_builtin_kwargs(args);
+            if pos.is_empty() {
+                return Err(crate::PyError::type_error(
+                    "unpack_from() missing required argument 'format'",
+                ));
+            }
+            let fmt = format_to_string(pos[0])?;
+            let (buffer, offset) = resolve_buffer_offset(&args[1..])?;
+            let buf = unsafe { readbuf(buffer)? };
+            do_unpack_from(&fmt, buf, offset)
+        },
+        // `iter_unpack(fmt, buffer)` — an iterator over the records.
+        "iter_unpack" / 2 = |args| {
+            let fmt = format_to_string(args[0])?;
+            let size = parse_format(&fmt)?.calcsize()?;
+            make_unpack_iter(w_str_new(&fmt), size, args[1])
+        },
+    },
+    extra_init: |ns| {
+        // `interp_struct.py:20 Cache` —
+        // `space.new_exception_class("struct.error", space.w_Exception)`.
+        let base = crate::builtins::lookup_exc_class("Exception")
+            .expect("Exception must be installed before _struct init");
+        let error = crate::builtins::make_exc_type(
+            "struct.error",
+            crate::builtins::exc_exception_new,
+            base,
+        );
+        crate::dict_storage_store(ns, "error", error);
     },
 }

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -47,13 +47,32 @@ fn format_to_string(obj: PyObjectRef) -> Result<String, crate::PyError> {
     }
 }
 
+/// Low 64 bits (two's-complement) of a Python int, whether it arrives as a
+/// small `W_IntObject` or a `W_LongObject`.  Narrower codes truncate this via
+/// `as u8`/`as u16`/`as u32`, which keeps the correct low bytes for both
+/// signed and unsigned formats.  Unsigned `Q`/`N` above `i64::MAX` reach here
+/// as a `W_LongObject`, so a plain `w_int_get_value` would be wrong.
+unsafe fn int_pack_bits(arg: PyObjectRef) -> u64 {
+    use num_traits::ToPrimitive;
+    unsafe {
+        if is_long(arg) {
+            let big = longobject::w_long_get_value(arg);
+            big.to_u64()
+                .or_else(|| big.to_i64().map(|v| v as u64))
+                .unwrap_or(0)
+        } else {
+            w_int_get_value(arg) as u64
+        }
+    }
+}
+
 fn pack_into(out: &mut Vec<u8>, code: char, little: bool, arg: PyObjectRef) {
     match code {
         'b' | 'B' => {
-            out.push(unsafe { w_int_get_value(arg) } as i8 as u8);
+            out.push(unsafe { int_pack_bits(arg) } as u8);
         }
         'h' | 'H' => {
-            let v = unsafe { w_int_get_value(arg) } as i16;
+            let v = unsafe { int_pack_bits(arg) } as u16;
             out.extend_from_slice(&if little {
                 v.to_le_bytes()
             } else {
@@ -61,7 +80,7 @@ fn pack_into(out: &mut Vec<u8>, code: char, little: bool, arg: PyObjectRef) {
             });
         }
         'i' | 'I' | 'l' | 'L' => {
-            let v = unsafe { w_int_get_value(arg) } as i32;
+            let v = unsafe { int_pack_bits(arg) } as u32;
             out.extend_from_slice(&if little {
                 v.to_le_bytes()
             } else {
@@ -69,7 +88,7 @@ fn pack_into(out: &mut Vec<u8>, code: char, little: bool, arg: PyObjectRef) {
             });
         }
         'q' | 'Q' | 'n' | 'N' => {
-            let v = unsafe { w_int_get_value(arg) };
+            let v = unsafe { int_pack_bits(arg) };
             out.extend_from_slice(&if little {
                 v.to_le_bytes()
             } else {
@@ -120,56 +139,41 @@ fn unpack_one(buf: &[u8], pos: &mut usize, code: char, little: bool) -> Option<P
             }
         };
     }
+    // Endian-aware fixed-width read: `<T>::from_le_bytes` / `from_be_bytes`.
+    macro_rules! rd {
+        ($ty:ty, $n:expr) => {{
+            let b: [u8; $n] = take!($n).try_into().unwrap();
+            if little {
+                <$ty>::from_le_bytes(b)
+            } else {
+                <$ty>::from_be_bytes(b)
+            }
+        }};
+    }
+    // Uppercase codes are unsigned, lowercase signed
+    // (`interp_array.py unpack_value` — the `b'B'`/`b'H'`/`b'I'`/`b'Q'`
+    // rows box unsigned values, boxing `Q`/`N` above `i64::MAX` into a
+    // `W_LongObject`).
     match code {
-        'b' | 'B' => {
-            let b = take!(1);
-            Some(w_int_new(b[0] as i8 as i64))
-        }
-        'h' | 'H' => {
-            let b: [u8; 2] = take!(2).try_into().unwrap();
-            let v = if little {
-                i16::from_le_bytes(b)
+        'b' => Some(w_int_new(take!(1)[0] as i8 as i64)),
+        'B' => Some(w_int_new(take!(1)[0] as i64)),
+        'h' => Some(w_int_new(rd!(i16, 2) as i64)),
+        'H' => Some(w_int_new(rd!(u16, 2) as i64)),
+        'i' | 'l' => Some(w_int_new(rd!(i32, 4) as i64)),
+        'I' | 'L' => Some(w_int_new(rd!(u32, 4) as i64)),
+        'q' | 'n' => Some(w_int_new(rd!(i64, 8))),
+        'Q' | 'N' => {
+            let v = rd!(u64, 8);
+            if v <= i64::MAX as u64 {
+                Some(w_int_new(v as i64))
             } else {
-                i16::from_be_bytes(b)
-            };
-            Some(w_int_new(v as i64))
+                Some(pyre_object::longobject::w_long_new(
+                    malachite_bigint::BigInt::from(v),
+                ))
+            }
         }
-        'i' | 'I' | 'l' | 'L' => {
-            let b: [u8; 4] = take!(4).try_into().unwrap();
-            let v = if little {
-                i32::from_le_bytes(b)
-            } else {
-                i32::from_be_bytes(b)
-            };
-            Some(w_int_new(v as i64))
-        }
-        'q' | 'Q' | 'n' | 'N' => {
-            let b: [u8; 8] = take!(8).try_into().unwrap();
-            let v = if little {
-                i64::from_le_bytes(b)
-            } else {
-                i64::from_be_bytes(b)
-            };
-            Some(w_int_new(v))
-        }
-        'f' => {
-            let b: [u8; 4] = take!(4).try_into().unwrap();
-            let v = if little {
-                f32::from_le_bytes(b)
-            } else {
-                f32::from_be_bytes(b)
-            };
-            Some(w_float_new(v as f64))
-        }
-        'd' => {
-            let b: [u8; 8] = take!(8).try_into().unwrap();
-            let v = if little {
-                f64::from_le_bytes(b)
-            } else {
-                f64::from_be_bytes(b)
-            };
-            Some(w_float_new(v))
-        }
+        'f' => Some(w_float_new(rd!(f32, 4) as f64)),
+        'd' => Some(w_float_new(rd!(f64, 8))),
         _ => None,
     }
 }

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -548,9 +548,7 @@ unsafe fn read_code_u32(v: PyObjectRef, field: &str) -> Result<u32, crate::PyErr
 /// A `str` `co_*` field as an owned `String` (the compiler `Name` type).
 unsafe fn read_code_str(v: PyObjectRef, field: &str) -> Result<String, crate::PyError> {
     if !unsafe { pyre_object::is_str(v) } {
-        return Err(crate::PyError::type_error(format!(
-            "{field} must be a str"
-        )));
+        return Err(crate::PyError::type_error(format!("{field} must be a str")));
     }
     Ok(unsafe { pyre_object::w_str_get_value(v) }.to_string())
 }
@@ -675,7 +673,8 @@ unsafe fn obj_to_constant_data(
             let n = pyre_object::w_tuple_len(obj);
             let mut elements = Vec::with_capacity(n);
             for i in 0..n {
-                let e = pyre_object::w_tuple_getitem(obj, i as i64).unwrap_or_else(pyre_object::w_none);
+                let e =
+                    pyre_object::w_tuple_getitem(obj, i as i64).unwrap_or_else(pyre_object::w_none);
                 elements.push(obj_to_constant_data(e)?);
             }
             return Ok(ConstantData::Tuple { elements });

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -398,6 +398,302 @@ pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     w_code_new(code_ptr)
 }
 
+/// The keyword-only fields `code.replace` accepts, in the order
+/// `pypy/interpreter/pycode.py:77-81` reconstructs the code object.
+const REPLACE_KWARGS: [&str; 18] = [
+    "co_argcount",
+    "co_posonlyargcount",
+    "co_kwonlyargcount",
+    "co_nlocals",
+    "co_stacksize",
+    "co_flags",
+    "co_firstlineno",
+    "co_code",
+    "co_consts",
+    "co_names",
+    "co_varnames",
+    "co_freevars",
+    "co_cellvars",
+    "co_filename",
+    "co_name",
+    "co_qualname",
+    "co_linetable",
+    "co_exceptiontable",
+];
+
+/// `code.replace(**kwds)` — `pypy/interpreter/pycode.py:74-91` applevel
+/// `replace`, which gathers every `co_*` attribute (taking the keyword
+/// override where present) and reconstructs the code object through the
+/// `CodeType` constructor.  pyre stores a compiler `CodeObject`, so the
+/// equivalent is to clone it, override each supplied field, and re-box it.
+///
+/// # Safety
+/// `args[0]` must be the receiver `code` object (verified).
+pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    let w_self = pos.first().copied().unwrap_or(PY_NULL);
+    if w_self.is_null() || !unsafe { is_code(w_self) } {
+        return Err(crate::PyError::type_error(
+            "descriptor 'replace' requires a 'code' object",
+        ));
+    }
+    // `replace` is keyword-only (`__args__.topacked()` asserts no positional
+    // args at pycode.py:548-549).
+    if pos.len() > 1 {
+        return Err(crate::PyError::type_error(
+            "replace() takes no positional arguments",
+        ));
+    }
+    // pycode.py:86-87 `raise TypeError(f"{kwds.popitem()[0]!r} is an invalid
+    // keyword argument for replace()")`.
+    if let Some(dict) = kwargs {
+        for (key, _) in unsafe { pyre_object::w_dict_str_entries(dict) } {
+            if key == "__pyre_kw__" {
+                continue;
+            }
+            if !REPLACE_KWARGS.contains(&key.as_str()) {
+                return Err(crate::PyError::type_error(format!(
+                    "'{key}' is an invalid keyword argument for replace()"
+                )));
+            }
+        }
+    }
+
+    let code_ptr = unsafe { w_code_get_ptr(w_self) } as *const crate::CodeObject;
+    if code_ptr.is_null() {
+        return Err(crate::PyError::type_error(
+            "cannot replace fields of a code object with no code body",
+        ));
+    }
+    let mut code = unsafe { (*code_ptr).clone() };
+    let get = |name: &str| crate::builtins::kwarg_get(kwargs, name);
+
+    if let Some(v) = get("co_argcount") {
+        code.arg_count = unsafe { read_code_u32(v, "co_argcount")? };
+    }
+    if let Some(v) = get("co_posonlyargcount") {
+        code.posonlyarg_count = unsafe { read_code_u32(v, "co_posonlyargcount")? };
+    }
+    if let Some(v) = get("co_kwonlyargcount") {
+        code.kwonlyarg_count = unsafe { read_code_u32(v, "co_kwonlyargcount")? };
+    }
+    // co_nlocals is derived from the varnames length; it is accepted for
+    // constructor-signature compatibility but carries no independent field.
+    if let Some(v) = get("co_nlocals") {
+        let _ = unsafe { read_code_u32(v, "co_nlocals")? };
+    }
+    if let Some(v) = get("co_stacksize") {
+        code.max_stackdepth = unsafe { read_code_u32(v, "co_stacksize")? };
+    }
+    if let Some(v) = get("co_flags") {
+        let bits = unsafe { crate::builtins::space_index_w(v)? } as u32;
+        code.flags = crate::bytecode::CodeFlags::from_bits_retain(bits);
+    }
+    if let Some(v) = get("co_firstlineno") {
+        let n = unsafe { crate::builtins::space_index_w(v)? };
+        code.first_line_number = if n <= 0 {
+            None
+        } else {
+            rustpython_compiler_core::OneIndexed::new(n as usize)
+        };
+    }
+    if let Some(v) = get("co_name") {
+        code.obj_name = unsafe { read_code_str(v, "co_name")? };
+    }
+    if let Some(v) = get("co_qualname") {
+        code.qualname = unsafe { read_code_str(v, "co_qualname")? };
+    }
+    if let Some(v) = get("co_filename") {
+        code.source_path = unsafe { read_code_str(v, "co_filename")? };
+    }
+    if let Some(v) = get("co_names") {
+        code.names = unsafe { read_code_names(v, "co_names")? };
+    }
+    if let Some(v) = get("co_varnames") {
+        code.varnames = unsafe { read_code_names(v, "co_varnames")? };
+    }
+    if let Some(v) = get("co_freevars") {
+        code.freevars = unsafe { read_code_names(v, "co_freevars")? };
+    }
+    if let Some(v) = get("co_cellvars") {
+        code.cellvars = unsafe { read_code_names(v, "co_cellvars")? };
+    }
+    if let Some(v) = get("co_linetable") {
+        code.linetable = unsafe { read_code_bytes(v, "co_linetable")? };
+    }
+    if let Some(v) = get("co_exceptiontable") {
+        code.exceptiontable = unsafe { read_code_bytes(v, "co_exceptiontable")? };
+    }
+    if let Some(v) = get("co_consts") {
+        code.constants = unsafe { read_code_consts(v)? };
+    }
+    if let Some(v) = get("co_code") {
+        code.instructions = unsafe { read_code_units(v)? };
+    }
+
+    Ok(box_code_constant(&code))
+}
+
+/// A non-negative `co_*` count argument as `u32`.
+unsafe fn read_code_u32(v: PyObjectRef, field: &str) -> Result<u32, crate::PyError> {
+    let n = unsafe { crate::builtins::space_index_w(v)? };
+    if n < 0 {
+        return Err(crate::PyError::value_error(format!(
+            "{field} must be a non-negative integer"
+        )));
+    }
+    Ok(n as u32)
+}
+
+/// A `str` `co_*` field as an owned `String` (the compiler `Name` type).
+unsafe fn read_code_str(v: PyObjectRef, field: &str) -> Result<String, crate::PyError> {
+    if !unsafe { pyre_object::is_str(v) } {
+        return Err(crate::PyError::type_error(format!(
+            "{field} must be a str"
+        )));
+    }
+    Ok(unsafe { pyre_object::w_str_get_value(v) }.to_string())
+}
+
+/// A `tuple[str]` `co_*` field (names / varnames / freevars / cellvars).
+unsafe fn read_code_names(v: PyObjectRef, field: &str) -> Result<Box<[String]>, crate::PyError> {
+    if !unsafe { is_tuple(v) } {
+        return Err(crate::PyError::type_error(format!(
+            "{field} must be a tuple of strings"
+        )));
+    }
+    let n = pyre_object::w_tuple_len(v);
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let e = pyre_object::w_tuple_getitem(v, i as i64).unwrap_or_else(pyre_object::w_none);
+        if !unsafe { pyre_object::is_str(e) } {
+            return Err(crate::PyError::type_error(format!(
+                "{field} must be a tuple of strings"
+            )));
+        }
+        out.push(unsafe { pyre_object::w_str_get_value(e) }.to_string());
+    }
+    Ok(out.into_boxed_slice())
+}
+
+/// A `bytes` `co_*` field (linetable / exceptiontable) as raw bytes.
+unsafe fn read_code_bytes(v: PyObjectRef, field: &str) -> Result<Box<[u8]>, crate::PyError> {
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(v) } {
+        return Err(crate::PyError::type_error(format!(
+            "{field} must be a bytes object"
+        )));
+    }
+    Ok(unsafe { pyre_object::bytesobject::bytes_like_data(v) }
+        .to_vec()
+        .into_boxed_slice())
+}
+
+/// `co_code` bytes → the decoded `CodeUnits` instruction stream.  The byte
+/// form is the `original_bytes` layout: one `(opcode, arg)` pair per unit.
+unsafe fn read_code_units(v: PyObjectRef) -> Result<crate::bytecode::CodeUnits, crate::PyError> {
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(v) } {
+        return Err(crate::PyError::type_error("co_code must be a bytes object"));
+    }
+    let bytes = unsafe { pyre_object::bytesobject::bytes_like_data(v) };
+    if bytes.len() % 2 != 0 {
+        return Err(crate::PyError::value_error(
+            "co_code length must be a multiple of 2",
+        ));
+    }
+    let mut units = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        let op = crate::bytecode::Instruction::try_from(pair[0]).map_err(|_| {
+            crate::PyError::value_error(format!("co_code contains unknown opcode {}", pair[0]))
+        })?;
+        units.push(crate::bytecode::CodeUnit::new(
+            op,
+            crate::bytecode::OpArgByte::from(pair[1]),
+        ));
+    }
+    Ok(crate::bytecode::CodeUnits::from(units))
+}
+
+/// A `tuple` `co_consts` field → the compiler `Constants` table.
+unsafe fn read_code_consts(
+    v: PyObjectRef,
+) -> Result<crate::bytecode::Constants<crate::bytecode::ConstantData>, crate::PyError> {
+    if !unsafe { is_tuple(v) } {
+        return Err(crate::PyError::type_error("co_consts must be a tuple"));
+    }
+    let n = pyre_object::w_tuple_len(v);
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let e = pyre_object::w_tuple_getitem(v, i as i64).unwrap_or_else(pyre_object::w_none);
+        out.push(unsafe { obj_to_constant_data(e)? });
+    }
+    Ok(out.into_iter().collect())
+}
+
+/// Convert a Python object into the compiler `ConstantData` a code object
+/// stores.  Covers None/Ellipsis/bool/int/float/str/bytes/tuple and nested
+/// code; `complex` and `frozenset` constants (rare in a replaced
+/// `co_consts`) and any object that is not a valid code constant raise
+/// `ValueError` (pyre's constant table cannot hold an arbitrary object the
+/// way a CPython `co_consts` tuple can).
+unsafe fn obj_to_constant_data(
+    obj: PyObjectRef,
+) -> Result<crate::bytecode::ConstantData, crate::PyError> {
+    use crate::bytecode::ConstantData;
+    unsafe {
+        if is_none(obj) {
+            return Ok(ConstantData::None);
+        }
+        if is_ellipsis(obj) {
+            return Ok(ConstantData::Ellipsis);
+        }
+        // bool is a subclass of int, so test it first.
+        if is_bool(obj) {
+            let value = crate::builtins::space_index_w(obj)? != 0;
+            return Ok(ConstantData::Boolean { value });
+        }
+        if is_int_or_long(obj) {
+            return Ok(ConstantData::Integer {
+                value: crate::builtins::obj_to_bigint(obj),
+            });
+        }
+        if is_float(obj) {
+            return Ok(ConstantData::Float {
+                value: pyre_object::w_float_get_value(obj),
+            });
+        }
+        if pyre_object::is_str(obj) {
+            return Ok(ConstantData::Str {
+                value: pyre_object::w_str_get_wtf8(obj).to_owned(),
+            });
+        }
+        if pyre_object::bytesobject::is_bytes_like(obj) {
+            return Ok(ConstantData::Bytes {
+                value: pyre_object::bytesobject::bytes_like_data(obj).to_vec(),
+            });
+        }
+        if is_tuple(obj) {
+            let n = pyre_object::w_tuple_len(obj);
+            let mut elements = Vec::with_capacity(n);
+            for i in 0..n {
+                let e = pyre_object::w_tuple_getitem(obj, i as i64).unwrap_or_else(pyre_object::w_none);
+                elements.push(obj_to_constant_data(e)?);
+            }
+            return Ok(ConstantData::Tuple { elements });
+        }
+        if is_code(obj) {
+            let ptr = w_code_get_ptr(obj) as *const crate::CodeObject;
+            if !ptr.is_null() {
+                return Ok(ConstantData::Code {
+                    code: Box::new((*ptr).clone()),
+                });
+            }
+        }
+        Err(crate::PyError::value_error(
+            "co_consts contains a value that is not a valid code constant",
+        ))
+    }
+}
+
 /// `pyopcode.py:498-499 getconstant_w(index) -> co_consts_w[index]` for a code
 /// constant: return the one shared `PyCode` the enclosing code holds at
 /// `index`, realizing it into the slot on first access (`pycode.py:126` builds

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1380,6 +1380,7 @@ pub fn via_space_next(iter: PyObjectRef) -> bool {
             || pyre_object::operation::is_callable_iterator(iter)
             || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
             || pyre_object::interp_sre::is_sre_scanner(iter)
+            || crate::module::r#struct::is_unpack_iter(iter)
     }
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -58,6 +58,24 @@ pub(crate) fn arity_at_least(
     Ok(())
 }
 
+/// TypeError for a method accepting at most `max` positional arguments after
+/// the receiver, called with more — the METH_VARARGS "X expected at most N
+/// arguments, got M" form (`list.index`, `dict.pop`).
+pub(crate) fn arity_at_most(
+    args: &[PyObjectRef],
+    name: &str,
+    max: usize,
+) -> Result<(), crate::PyError> {
+    if args.len() > max + 1 {
+        return Err(crate::PyError::type_error(format!(
+            "{name} expected at most {max} argument{}, got {}",
+            if max == 1 { "" } else { "s" },
+            args.len().saturating_sub(1),
+        )));
+    }
+    Ok(())
+}
+
 /// TypeError for an unbound method descriptor invoked with no receiver
 /// (`list.append()` with zero arguments) — `args` is empty.
 pub(crate) fn require_receiver(args: &[PyObjectRef], name: &str) -> Result<(), crate::PyError> {
@@ -198,6 +216,7 @@ pub fn list_method_sort(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// listobject.py:795 `descr_index` — list.index(value[, start[, stop]]).
 pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "index", 1)?;
+    arity_at_most(args, "index", 3)?;
     let list = args[0];
     let value = args[1];
     // listobject.py:799 unwrap_spec defaults: w_start=0 / w_stop=sys.maxint.
@@ -237,7 +256,7 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// listobject.py:744 `descr_count` — list.count(value)
 pub fn list_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    arity_at_least(args, "count", 1)?;
+    arity_exact(args, "list.count", 1)?;
     let list = args[0];
     let value = args[1];
     match crate::listobject::w_list_find_or_count(list, value, 0, i64::MAX, true)? {
@@ -251,7 +270,7 @@ pub fn list_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// listobject.py:782 `descr_remove` — list.remove(value).
 pub fn list_method_remove(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    arity_at_least(args, "remove", 1)?;
+    arity_exact(args, "list.remove", 1)?;
     crate::listobject::w_list_remove(args[0], args[1])?;
     Ok(w_none())
 }
@@ -3631,6 +3650,7 @@ fn dict_sync_dict_storage_proxy(dict: PyObjectRef) {
 /// via strategy dispatch (one hash).
 pub fn dict_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "pop", 1)?;
+    arity_at_most(args, "pop", 2)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
     let default = args.get(2).copied();

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6407,15 +6407,13 @@ fn init_method_type(ns: &mut DictStorage) {
 }
 
 fn init_code_type(ns: &mut DictStorage) {
-    // code.replace(**kwargs) — PyPy: interpreter/pycode.py W_PyCode.descr_replace.
-    // The full method creates a new code object with the given fields
-    // replaced; pyre's code objects are immutable, so replace() with no
-    // kwargs returns the code itself (enough for reset_code / tests).
+    // code.replace(**kwargs) — pycode.py:543-550 W_PyCode.descr_replace →
+    // reconstruct the code object with the given co_* fields overridden.
     dict_storage_store(
         ns,
         "replace",
-        make_builtin_function("replace", |args| {
-            Ok(args.first().copied().unwrap_or(pyre_object::w_none()))
+        make_builtin_function("replace", |args| unsafe {
+            crate::pycode::code_replace(args)
         }),
     );
     // `pypy/interpreter/typedef.py:720`


### PR DESCRIPTION
Post-#188 CPython test-infra fixes on `test-infra` (8 commits).

## Interpreter / stdlib
- **`_struct` faithful port** — format validation, integer range checks, the `s`/`c`/`x`/`p` string codes, the `e` half-float code, native-mode `l`/`L`/`n`/`N`/`P` sizes with natural alignment, `struct.error` as a real `Exception` subclass, and the `Struct` type (`pack`/`unpack`/`pack_into`/`unpack_from`/`iter_unpack`/`__repr__`) plus the module `pack_into`/`unpack_from`/`iter_unpack` and the `unpack_iterator` type. `baseobjspace` `iter()`/`next()` route the `unpack_iterator`; `display` `py_repr` consults a builtin type's own `__repr__` before the generic fallback.
- **`_struct` unsigned/bignum** — read unsigned formats as unsigned and pack bignum `Q`/`N`.
- **`_struct` surrogate format** — don't panic on a surrogate-bearing format string.
- **`code.replace`** — reconstruct the code object with overridden `co_*` fields (was a total stub); `co_code` decodes back to instructions, `co_consts` converts to the constant table; `@types.coroutine` can now flip `CO_ITERABLE_COROUTINE`.
- **`print()`** — honor `file=` and `flush=` keywords.
- **builtin arity caps** — `id`/`hash`/`pow` and several `list`/`dict` methods reject extra positional arguments.
- **surrogate-safe `repr()`/`str()`** — preserve lone surrogates in `__repr__`/`__str__` overrides instead of panicking.
- **`posix.rename`** — reject extra positionals / unknown kwargs and report an unavailable `dir_fd`.

## Verification
`python3 ./pyre/check.py` — **dynasm 169/169, cranelift 169/169** (both backends green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)