### PR TITLE
nbody: STORE int cell-fold + len/pow inline + prebuilt-root GC minor-skip

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -986,6 +986,15 @@ impl MiniMarkGC {
         // `PyFrame.locals_cells_stack_w` across the active f_backref chain
         // so nursery refs held only by a Python frame local or operand-stack
         // slot survive collection.
+        //
+        // Announce the collection kind so walkers mirroring incminimark's
+        // prebuilt-object scanning can skip clean prebuilt structures during
+        // a minor collection (incminimark.py:339-344
+        // `old_objects_pointing_to_young`); restored to the conservative
+        // Major default right after.
+        crate::shadow_stack::set_extra_root_walk_kind(
+            crate::shadow_stack::ExtraRootWalkKind::Minor,
+        );
         crate::walk_active_extra_roots(&mut |gcref| {
             self.drag_out_root(gcref);
         });
@@ -994,6 +1003,9 @@ impl MiniMarkGC {
         crate::shadow_stack::walk_extra_roots(|gcref| {
             self.drag_out_root(gcref);
         });
+        crate::shadow_stack::set_extra_root_walk_kind(
+            crate::shadow_stack::ExtraRootWalkKind::Major,
+        );
 
         // incminimark parity: during an active marking cycle, old objects
         // remembered by the write barrier may already be black. Requeue

--- a/majit/majit-gc/src/nursery.rs
+++ b/majit/majit-gc/src/nursery.rs
@@ -114,6 +114,20 @@ impl Nursery {
 
     /// incminimark.py:1946 parity: reset nursery after minor collection.
     ///   self.nursery_free = self.nursery
+    ///
+    /// PRE-EXISTING-ADAPTATION: the full-nursery zeroing below has no
+    /// upstream counterpart — incminimark's reset is `arena_reset(prev,
+    /// ..., 0)` (incminimark.py:1938; llarena.py:334 mode 0 = "don't fill
+    /// with zeroes") with `malloc_zero_filled = False` (incminimark.py:211),
+    /// each allocation initializing its own fields ("fully initialized,
+    /// but not zero-filled", incminimark.py:960).  pyre allocation paths
+    /// (Rust constructors and JIT inline New*) currently assume
+    /// zero-filled nursery memory for fields they do not write, i.e. the
+    /// system behaves as `malloc_zero_filled = True`.  Convergence path:
+    /// audit every alloc site for assumed-zero fields (add explicit field
+    /// init / `zero_gc_pointers_inside` equivalents), then drop this
+    /// `write_bytes` — it costs one full-nursery memset per minor
+    /// collection (~4.5% of nbody).
     pub fn reset(&mut self) {
         unsafe {
             ptr::write_bytes(self.start, 0, self.size);

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -639,6 +639,37 @@ pub fn walk_resume_ref_roots(mut visitor: impl FnMut(&mut GcRef)) {
 /// root if the GC moved the referenced object.
 pub type ExtraRootWalkerFn = fn(&mut dyn FnMut(&mut GcRef));
 
+/// Which collection is currently driving the extra-root walk.
+///
+/// incminimark distinguishes the two: a minor collection scans an
+/// old/prebuilt object only when the write barrier recorded a store into it
+/// (`old_objects_pointing_to_young`, incminimark.py:339-344), while a major
+/// collection always traces `prebuilt_root_objects` (incminimark.py:355).
+/// Walkers that mirror prebuilt-object scanning read this to apply the same
+/// minor-skip; the default is [`ExtraRootWalkKind::Major`] (scan everything)
+/// so an unset call site stays conservative.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ExtraRootWalkKind {
+    Minor,
+    Major,
+}
+
+thread_local! {
+    static EXTRA_ROOT_WALK_KIND: std::cell::Cell<ExtraRootWalkKind> =
+        const { std::cell::Cell::new(ExtraRootWalkKind::Major) };
+}
+
+/// Set by the collector around its root-walk phases; see
+/// [`ExtraRootWalkKind`].
+pub fn set_extra_root_walk_kind(kind: ExtraRootWalkKind) {
+    EXTRA_ROOT_WALK_KIND.with(|k| k.set(kind));
+}
+
+/// The collection kind driving the current extra-root walk.
+pub fn extra_root_walk_kind() -> ExtraRootWalkKind {
+    EXTRA_ROOT_WALK_KIND.with(|k| k.get())
+}
+
 // Walkers registered today: eval.rs registers twelve (rd_consts, partial
 // trace, active trace, compile snapshot, jitcode constants, fbw store
 // journal, fbw finish concrete, pyre interpreter side tables, signal

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -534,6 +534,20 @@ pub enum PyreHelperKind {
     /// `w_globals`) through the same module-dict cell fast path as
     /// [`PyreHelperKind::LoadGlobal`], eliding the per-iteration residual.
     LoadName,
+    /// `bh_store_name_fn(frame, w_name, value)` — the STORE_NAME frame-receiver
+    /// helper (`pyopcode.py:855-859`, delegates to `store_name_value` →
+    /// `setitem_str` → `_setitem_str_cell_known` → `typeobject.py:53-71
+    /// write_cell`).  The full-body walker recognises this tag to fold a
+    /// module-scope int store whose slot holds an `IntMutableCell` (the
+    /// stabilised in-place shape) to a `setfield_gc_i(cell, intvalue)`,
+    /// eliding the boxing + residual dict setitem — the store dual of
+    /// [`PyreHelperKind::LoadName`].
+    StoreName,
+    /// `bh_store_global_fn(frame, w_name, value)` — the STORE_GLOBAL
+    /// frame-receiver helper (`pyopcode.py:567`, delegates to
+    /// `store_global_value`).  Recognised for the same `IntMutableCell`
+    /// in-place store fold as [`PyreHelperKind::StoreName`].
+    StoreGlobal,
     /// `bh_call_fn_N(callable, null_or_self, args...)` — the CALL-family
     /// Python-call helper.  `null_or_self` (arg index 1) is a sentinel
     /// the helper checks before use (a non-null receiver is prepended as

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -3435,12 +3435,23 @@ impl OptContext {
             let _ = result_type;
             // unroll.py:34-37: potential_extra_ops[op] = preamble_op
             if !is_constant {
-                // unroll.py:35-36: invented_name → get_box_replacement(op)
-                let key = if preamble_op.invented_name {
-                    result
-                } else {
-                    preamble_source
-                };
+                // unroll.py:29/37 `op = preamble_op.op; potential_extra_ops[op]
+                // = preamble_op` — upstream keys by the Box the BODY holds:
+                // heap.py's `_getfield` hands `self.res` (== preamble_op.op)
+                // to body ops directly, so `force_box`'s `pop(get_box_
+                // replacement(arg))` lands on that same object. majit's
+                // Cat-2.2 heap production reverses the chain — `produce_heap_
+                // field` forwards `source → result_opref`, so the terminal
+                // body-visible OpRef is `result`, NOT `preamble_source`.
+                // Key by `result` for every kind: non-invented Pure installs
+                // no forwarding (result == preamble_source, behavior
+                // unchanged), invented already used it, and Heap/LoopInvariant
+                // need it — keying those by `preamble_source` left the entry
+                // unreachable from every consumer (force_box resolves body
+                // args forward, never back), silently dropping the short
+                // box from `used_boxes`/`short_preamble_jump` and emitting a
+                // bridge JUMP one arg short of the target label.
+                let key = result;
                 if crate::optimizeopt::majit_log_enabled() {
                     eprintln!(
                         "[jit] potential_extra_ops.insert key={key:?} source={preamble_source:?} result={result:?} invented={}",

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2028,13 +2028,13 @@ impl AbstractShortPreambleBuilderState {
         &mut self,
         op: majit_ir::operand::Operand,
         replay_op: &majit_ir::OpRc,
-        invented_name: bool,
+        needs_alias: bool,
         same_as_source: Option<majit_ir::operand::Operand>,
     ) {
         if !self.recorded_canonical_results.insert(replay_op.pos.get()) {
             return;
         }
-        if invented_name {
+        if needs_alias {
             // shortpreamble.py:436-437: extra_same_as carries the resolved
             // box itself; a producer-bound box sheds to a live operand.
             //
@@ -2047,7 +2047,7 @@ impl AbstractShortPreambleBuilderState {
             // kept as a release safety net.
             debug_assert!(
                 same_as_source.is_some(),
-                "invented_name without same_as_source at {:?}",
+                "needs_alias without same_as_source at {:?}",
                 replay_op.pos.get()
             );
             let source = same_as_source.unwrap_or_else(|| op.clone());
@@ -2428,16 +2428,40 @@ impl ShortPreambleBuilder {
         // threaded through `field_entry::PreambleOp` — so the
         // produced_short_boxes lookup is no longer consulted here (#149/S8f).
         let replay_op = &preamble_op.preamble_op;
+        // shortpreamble.py:435 `op = preamble_op.op.get_box_replacement()`:
+        // for non-invented entries the resolved Box IS the preamble-defined
+        // res, so the `used_boxes` label slot always has a producer at
+        // label fall-through. pyre's Cat-2.2 heap import resolves through
+        // `make_equal_to(source, result)` to a fresh body-visible OpRef with
+        // NO preamble producer — the flat-OpRef analogue of an invented
+        // name. Emit the same defining alias the invented arm uses
+        // (`same_as(resolved) = carried preamble box`) whenever the resolved
+        // slot differs from the carried box, so the extended label slot is
+        // defined in the preamble exactly as upstream's Box identity
+        // guarantees.
+        let (needs_alias, alias_source) = if preamble_op.invented_name {
+            (
+                true,
+                preamble_op
+                    .same_as_source
+                    .as_ref()
+                    .map(majit_ir::operand::Operand::from_boxref),
+            )
+        } else if resolved_op.to_opref() != preamble_op.op.to_opref() {
+            (
+                true,
+                Some(majit_ir::operand::Operand::from_boxref(&preamble_op.op)),
+            )
+        } else {
+            (false, None)
+        };
         // The info-force `PreambleOp` still carries BoxRef; shed its bound
         // producer boxes to operands for the operand-carrying record API.
         self.state.record_imported_preamble_use(
             majit_ir::operand::Operand::from_boxref(&resolved_op),
             replay_op,
-            preamble_op.invented_name,
-            preamble_op
-                .same_as_source
-                .as_ref()
-                .map(majit_ir::operand::Operand::from_boxref),
+            needs_alias,
+            alias_source,
         );
     }
 
@@ -2914,7 +2938,12 @@ impl ExtendedShortPreambleBuilder {
                 return;
             }
             let op = resolved_key;
-            if preamble_op.invented_name {
+            // shortpreamble.py:436-437 plus the Cat-2.2 fresh-slot case: a
+            // non-invented pop whose resolved slot differs from the carried
+            // preamble box has no preamble producer for the label slot (see
+            // ShortPreambleBuilder::add_preamble_op_from_pop); emit the same
+            // defining alias with the carried box as source.
+            let alias_source = if preamble_op.invented_name {
                 // shortpreamble.py:436-437: alias the carried original
                 // (same_as_source), matching `add_tracked_preamble_op`; the
                 // resolved box is the release fallback when none was threaded.
@@ -2923,10 +2952,18 @@ impl ExtendedShortPreambleBuilder {
                     "invented_name without same_as_source at {:?}",
                     replay_op.pos.get()
                 );
-                let source = preamble_op
-                    .same_as_source
-                    .clone()
-                    .unwrap_or_else(|| resolved_op.clone());
+                Some(
+                    preamble_op
+                        .same_as_source
+                        .clone()
+                        .unwrap_or_else(|| resolved_op.clone()),
+                )
+            } else if resolved_key != preamble_op.op.to_opref() {
+                Some(preamble_op.op.clone())
+            } else {
+                None
+            };
+            if let Some(source) = alias_source {
                 let mut same_as = Op::new(
                     OpCode::same_as_for_type(replay_op.result_type()),
                     &[majit_ir::operand::Operand::from_boxref(&source)],

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -6983,11 +6983,19 @@ mod tests {
         // empty until force_box runs add_preamble_op.
         assert!(sp.used_boxes.is_empty());
         assert!(sp.jump_args.is_empty());
-        // `force_op_from_preamble_op` keys potential_extra_ops by
-        // `preamble_source` (non-invented) per `unroll.py:34-37`.
+        // `force_op_from_preamble_op` keys potential_extra_ops by the
+        // body-visible box `get_box_replacement(preamble_source)`
+        // (unroll.py:35-37 `op = get_box_replacement(op)`).  This heap
+        // variant forwarded source 19 -> body-visible 14 (produce_heap_field
+        // installs the `make_equal_to` upstream heap.py omits), so the entry
+        // lands on 14, not on the source 19.
         assert!(
-            ctx.has_potential_extra_op(OpRef::ref_op(19)),
-            "force_op_from_preamble_op must seed potential_extra_ops by source"
+            ctx.has_potential_extra_op(OpRef::ref_op(14)),
+            "force_op_from_preamble_op must seed potential_extra_ops by the body-visible box"
+        );
+        assert!(
+            !ctx.has_potential_extra_op(OpRef::ref_op(19)),
+            "the forwarded source box must not carry the potential_extra_ops entry"
         );
 
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
@@ -7000,8 +7008,10 @@ mod tests {
         // jump_args carries the unresolved Phase 1 source.
         assert_eq!(sp.used_boxes.clone(), vec![OpRef::ref_op(14)]);
         assert_eq!(sp.jump_args.clone(), vec![OpRef::ref_op(19)]);
+        // force_box resolves the body arg forward (19 -> 14) and pops the
+        // entry at the body-visible key 14.
         assert!(
-            !ctx.has_potential_extra_op(OpRef::ref_op(19)),
+            !ctx.has_potential_extra_op(OpRef::ref_op(14)),
             "force_box must consume the potential_extra_ops entry"
         );
     }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3005,6 +3005,9 @@ pub fn dict_storage_to_dict_kind(
         }
     }
     storage.set_mirror_target(dict);
+    // Fresh proxy link: the immortal storage's slots became reachable
+    // through a new path; rescan on the next minor collection.
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     dict
 }
 
@@ -5875,6 +5878,9 @@ unsafe fn _cached_lookup_where(
         return tup;
     }
     let tup = lookup_where(w_type, name).unwrap_or((std::ptr::null_mut(), std::ptr::null_mut()));
+    // Prebuilt-family store: the cache slot is reached only by
+    // `walk_method_cache_gc`, skipped on clean minor collections.
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     METHOD_CACHE.with(|c| {
         let mut cache = c.borrow_mut();
         cache.versions[h] = version_tag;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5541,6 +5541,9 @@ fn exec_or_eval(
             }
             ns.set_mirror_target(backing);
         }
+        // The fresh immortal storage now holds refs copied out of a GC
+        // dict (possibly young); rescan on the next minor collection.
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         ns.fix_ptr();
         let storage_ptr: *mut crate::DictStorage = ns.as_mut() as *mut _;
         unsafe {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2244,6 +2244,23 @@ pub(crate) fn builtin_range(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     }
 }
 
+/// True iff `callable` is the builtin `len` function object — a
+/// builtin-code function whose code wraps [`builtin_len`].  The JIT
+/// walker uses this to recognize a `len(x)` residual it can lower to the
+/// container's inline length read.
+pub fn is_builtin_len_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        crate::gateway::builtin_code_get(code) == builtin_len as crate::gateway::BuiltinCodeFn
+    }
+}
+
 /// `len(obj)` — return the length of an object.
 /// `len(obj)` — PyPy: operation.py len → space.len_w
 fn builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -387,7 +387,30 @@ unsafe fn walk_type_dicts_gc(forward: &mut dyn FnMut(&mut PyObjectRef)) {
     }
 }
 
+/// Whether the incminimark-parity minor-collection skip of clean prebuilt
+/// structures is enabled (`PYRE_GC_PREBUILT_REMEMBER=0` opts out, restoring
+/// the rescan-everything-every-minor behavior).
+fn gc_prebuilt_remember_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("PYRE_GC_PREBUILT_REMEMBER").as_deref() != Ok("0"))
+}
+
 fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    // incminimark.py:339-355 prebuilt-object scanning parity: a minor
+    // collection scans an old/prebuilt object only when the write barrier
+    // recorded a store into it since the previous minor collection
+    // (`old_objects_pointing_to_young`); a major collection always traces
+    // `prebuilt_root_objects`.  The Box-immortal structures walked below
+    // (module dicts / cells, heap-type namespace dicts, method caches,
+    // function fields) are pyre's prebuilt family; their mutation helpers
+    // set `mark_prebuilt_roots_dirty`, so a clean bit during a minor
+    // collection means no young pointer can be inside and the walks are
+    // skipped.  Live-frame slots are real stack roots and are always walked.
+    let is_minor = majit_gc::shadow_stack::extra_root_walk_kind()
+        == majit_gc::shadow_stack::ExtraRootWalkKind::Minor;
+    let scan_prebuilt = !is_minor
+        || pyre_object::gc_roots::prebuilt_roots_dirty()
+        || !gc_prebuilt_remember_enabled();
     CURRENT_FRAME.with(|cf| {
         // Forward `CURRENT_FRAME` itself: when the top frame is a
         // nursery-allocated `PyFrame`
@@ -544,14 +567,20 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                         pyre_object::dictmultiobject::w_dict_get_dict_storage_proxy(live_obj)
                             as *mut crate::DictStorage;
                     if !globals_ptr.is_null() {
-                        let value_slots: Vec<*mut PyObjectRef> = (&mut *globals_ptr)
-                            .values_mut()
-                            .iter_mut()
-                            .map(|value| value as *mut PyObjectRef)
-                            .collect();
-                        for value in value_slots {
-                            visitor(&mut *(value as *mut majit_ir::GcRef));
-                            walk_raw_function_roots(*value, visitor);
+                        // Prebuilt-family value scan (see `scan_prebuilt`
+                        // above); the mirror-target refresh below stays
+                        // unconditional — it re-syncs the (immortal) module
+                        // dict pointer, not a movable value.
+                        if scan_prebuilt {
+                            let value_slots: Vec<*mut PyObjectRef> = (&mut *globals_ptr)
+                                .values_mut()
+                                .iter_mut()
+                                .map(|value| value as *mut PyObjectRef)
+                                .collect();
+                            for value in value_slots {
+                                visitor(&mut *(value as *mut majit_ir::GcRef));
+                                walk_raw_function_roots(*value, visitor);
+                            }
                         }
                         (&mut *globals_ptr).set_mirror_target(live_obj);
                     }
@@ -567,7 +596,7 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                 // No-op for non-module dicts.  The picked builtin Module's
                 // dict is consulted on a globals miss (`_load_global`
                 // fallback), so forward it too.
-                {
+                if scan_prebuilt {
                     let mut forward = |slot: &mut PyObjectRef| {
                         visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
                         walk_raw_function_roots(*slot, visitor);
@@ -622,37 +651,47 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
         // module-scope movable values bound in modules other than the
         // running frame's globals — e.g. `gc.collect` reached through
         // `gc.__dict__` on a fresh `LOAD_METHOD` after a collection.
-        unsafe {
-            let mut forward = |slot: &mut PyObjectRef| {
-                visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
-                walk_raw_function_roots(*slot, visitor);
-                // getset descriptors are Box-immortal (custom trace never
-                // fires), so their collectable `fget`/`fset`/`fdel`
-                // functions must be marked reachable here or the getter
-                // dangles after a collection.
-                walk_raw_getset_roots(*slot, visitor);
-            };
-            crate::importing::walk_module_dicts_gc(&mut forward);
-            // The `sys.modules` dict is cached in a fast-path cell
-            // (`importing::SYS_MODULES_DICT`) that is independent of the
-            // `sys.__dict__["modules"]` slot the walk above forwards; forward
-            // the cell too so a relocated modules dict is not read back stale
-            // on the next import / `check_sys_modules` lookup.
-            crate::importing::walk_sys_modules_dict_gc(&mut forward);
-            // Box-immortal heap types' namespace dicts hold movable
-            // methods / class attributes / descriptor copies that no
-            // custom trace reaches; root them the same way.
-            walk_type_dicts_gc(&mut forward);
-            // The interpreter method cache (`baseobjspace::MethodCache`)
-            // keeps a second pointer to each looked-up method that the
-            // namespace-dict walk above does not reach; forward those so
-            // a cache hit after a moving collection is not stale.
-            crate::baseobjspace::walk_method_cache_gc(&mut forward);
-            // The per-pycode `_mapdict_caches` LOAD_METHOD slots hold a
-            // `w_method` pointer (mapdict.py:1418) that no custom trace
-            // reaches — code objects are Box-immortal — so forward those
-            // the same way.
-            crate::pycode::walk_mapdict_method_cache_gc(&mut forward);
+        if scan_prebuilt {
+            unsafe {
+                let mut forward = |slot: &mut PyObjectRef| {
+                    visitor(&mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef));
+                    walk_raw_function_roots(*slot, visitor);
+                    // getset descriptors are Box-immortal (custom trace never
+                    // fires), so their collectable `fget`/`fset`/`fdel`
+                    // functions must be marked reachable here or the getter
+                    // dangles after a collection.
+                    walk_raw_getset_roots(*slot, visitor);
+                };
+                crate::importing::walk_module_dicts_gc(&mut forward);
+                // The `sys.modules` dict is cached in a fast-path cell
+                // (`importing::SYS_MODULES_DICT`) that is independent of the
+                // `sys.__dict__["modules"]` slot the walk above forwards; forward
+                // the cell too so a relocated modules dict is not read back stale
+                // on the next import / `check_sys_modules` lookup.
+                crate::importing::walk_sys_modules_dict_gc(&mut forward);
+                // Box-immortal heap types' namespace dicts hold movable
+                // methods / class attributes / descriptor copies that no
+                // custom trace reaches; root them the same way.
+                walk_type_dicts_gc(&mut forward);
+                // The interpreter method cache (`baseobjspace::MethodCache`)
+                // keeps a second pointer to each looked-up method that the
+                // namespace-dict walk above does not reach; forward those so
+                // a cache hit after a moving collection is not stale.
+                crate::baseobjspace::walk_method_cache_gc(&mut forward);
+                // The per-pycode `_mapdict_caches` LOAD_METHOD slots hold a
+                // `w_method` pointer (mapdict.py:1418) that no custom trace
+                // reaches — code objects are Box-immortal — so forward those
+                // the same way.
+                crate::pycode::walk_mapdict_method_cache_gc(&mut forward);
+            }
+            // The minor walk above promoted every young value reachable
+            // from the prebuilt family; re-arm the write-tracking bit
+            // (incminimark: the minor collection empties
+            // `old_objects_pointing_to_young`).  A major seeding walk does
+            // not promote, so the bit is left untouched there.
+            if is_minor {
+                pyre_object::gc_roots::clear_prebuilt_roots_dirty();
+            }
         }
     });
 }
@@ -2921,6 +2960,9 @@ impl OpcodeStepExecutor for PyFrame {
                 // requested; stored on the function's typed
                 // `w_annotate` slot (CPython 3.14 `func_annotate`).
                 unsafe { (*(func as *mut crate::function::Function)).w_annotate = attr };
+                // Direct field store bypasses `function_write_barrier`;
+                // record it for the prebuilt-root minor-collection skip.
+                pyre_object::gc_roots::mark_prebuilt_roots_dirty();
             }
             // `MakeFunctionFlag::TypeParams` (oparg.rs:356) carries the
             // tuple of TypeVar / ParamSpec / TypeVarTuple bound by a

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -515,6 +515,10 @@ impl DictStorage {
         if let Some(idx) = self.slot_of(name) {
             return unsafe { self.values_slice()[idx] };
         }
+        // DictStorage backs Box-immortal namespaces (type dicts, module
+        // mirrors) reached only by the prebuilt-family root walk; record
+        // every store (gc_roots.rs prebuilt-root write tracking).
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         let value = make();
         self.names.push(Wtf8Buf::from_string(name.to_string()));
         unsafe { self.push(value) };
@@ -532,6 +536,8 @@ impl DictStorage {
     }
 
     pub fn insert(&mut self, name: String, value: PyObjectRef) -> Option<PyObjectRef> {
+        // Prebuilt-family store (see `get_or_insert_with`).
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         let result = if let Some(idx) = self.slot_of(&name) {
             let slice = unsafe { self.values_slice_mut() };
             let old = slice[idx];
@@ -569,6 +575,8 @@ impl DictStorage {
     /// key reaches the bound `W_DictObject` (which is `ObjectKey`-keyed
     /// and surrogate-safe).
     pub fn insert_wtf8(&mut self, name: Wtf8Buf, value: PyObjectRef) -> Option<PyObjectRef> {
+        // Prebuilt-family store (see `get_or_insert_with`).
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         let result = if let Some(idx) = self.slot_of_wtf8(&name) {
             let slice = unsafe { self.values_slice_mut() };
             let old = slice[idx];
@@ -639,6 +647,8 @@ impl DictStorage {
 
     #[inline]
     pub fn set_slot(&mut self, idx: usize, value: PyObjectRef) -> bool {
+        // Prebuilt-family store (see `get_or_insert_with`).
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         let slice = unsafe { self.values_slice_mut() };
         let Some(slot) = slice.get_mut(idx) else {
             return false;

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -156,6 +156,10 @@ impl Drop for FrameLocalsRoot {
 #[inline]
 fn function_write_barrier(obj: PyObjectRef) {
     pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    // A Box-immortal function's children are reached only through
+    // `walk_raw_function_roots`, which clean minor collections skip;
+    // record every field store (gc_roots.rs prebuilt-root tracking).
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
 }
 
 /// Field offset of `code` within `Function`, for JIT field access.

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -824,6 +824,9 @@ pub fn sys_modules_dict() -> PyObjectRef {
 }
 
 pub fn set_sys_module(name: &str, module: PyObjectRef) {
+    // A new module joins the `walk_module_dicts_gc` root set; its dict
+    // may hold young values — rescan on the next minor collection.
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     SYS_MODULES.with(|m| {
         m.borrow_mut().insert(name.to_string(), module);
     });
@@ -956,6 +959,9 @@ pub fn take_pending_sys_argv() -> pyre_object::PyObjectRef {
 }
 
 pub fn set_sys_modules_dict(dict: PyObjectRef) {
+    // The fast-path cell walked by `walk_sys_modules_dict_gc` now holds
+    // a possibly-young dict; rescan on the next minor collection.
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     SYS_MODULES_DICT.with(|d| d.set(dict));
     // Populate with all modules already in the cache.
     SYS_MODULES.with(|m| {

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -812,6 +812,9 @@ pub unsafe fn w_code_set_w_globals(obj: PyObjectRef, w_globals: PyObjectRef) {
     unsafe {
         (*(obj as *mut PyCode)).w_globals = w_globals;
     }
+    // Box-immortal code slot reached only by `walk_raw_code_roots`,
+    // skipped on clean minor collections; record the store.
+    pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     if !w_globals.is_null() {
         let code_ptr = unsafe { (*(obj as *const PyCode)).code_ptr };
         register_live_code_wrapper(code_ptr, obj);
@@ -827,6 +830,8 @@ pub unsafe fn w_code_frame_stores_global(obj: PyObjectRef, w_globals: PyObjectRe
     let code = unsafe { &mut *(obj as *mut PyCode) };
     if code.w_globals.is_null() {
         code.w_globals = w_globals;
+        // Prebuilt-family store (see `w_code_set_w_globals`).
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         register_live_code_wrapper(code.code_ptr, obj);
         return false;
     }
@@ -1100,6 +1105,9 @@ pub unsafe fn w_code_mapdict_caches_set(
             MAPDICT_METHOD_CACHE_CODES.with(|s| {
                 s.borrow_mut().insert(obj as usize);
             });
+            // Prebuilt-family store: the slot is reached only by
+            // `walk_mapdict_method_cache_gc`, skipped on clean minors.
+            pyre_object::gc_roots::mark_prebuilt_roots_dirty();
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -32,6 +32,20 @@ const FIELD_DESCR_TAG: u32 = 0x1000_0000;
 const ARRAY_DESCR_TAG: u32 = 0x2000_0000;
 const SIZE_DESCR_TAG: u32 = 0x3000_0000;
 
+// Reserved, hand-assigned indices for mutable-cell payload fields. The
+// runtime `HeapCache` keys entries by `descr.index()`; `stable_field_index`
+// derives that key from `(offset, field_size, field_type, signed)` alone, so
+// two distinct structs sharing a field layout collapse onto one `CacheEntry`.
+// `IntMutableCell.intvalue` (offset 16 / 8 / Int) lands on the exact slot of
+// `W_IntObject.intval` (signed) or `W_ListObject.length` (unsigned) — no
+// `signed` value avoids both. The read-only LOAD fold tolerated the collision,
+// but the store fold's `SetfieldGc` plus the const-cell `last_const_box`
+// heuristic thrash the shared `CacheEntry` against colliding list/int reads.
+// A reserved index above the FIELD/ARRAY/SIZE tag ranges gives the cell
+// payload a private `CacheEntry`; no code inspects the tag bits of `index()`.
+const CELL_DESCR_TAG: u32 = 0x4000_0000;
+const INT_MUTABLE_CELL_VALUE_INDEX: u32 = CELL_DESCR_TAG;
+
 fn type_bits(tp: Type) -> u32 {
     match tp {
         Type::Int => 0,
@@ -1755,6 +1769,52 @@ pub fn method_w_self_descr() -> DescrRef {
 /// payload.
 pub fn object_mutable_cell_value_descr() -> DescrRef {
     field_descr_from_group(&W_OBJECT_MUTABLE_CELL_DESCR_GROUP, 0)
+}
+
+/// `typeobject.py:37-45 IntMutableCell.intvalue` — the unboxed `Signed`
+/// payload of a module-global int cell, read LIVE on the cell fast path.
+/// `write_cell` rewrites it in place when a hot int global is reassigned to
+/// another int (no strategy-version bump), so this descriptor is mutable
+/// (not immutable / quasi-immutable); the `version?` guard protects cell
+/// identity, not the payload. Reassigning to a non-int replaces the cell,
+/// bumping the version and invalidating the fold.
+/// Descriptor for `IntMutableCell.intvalue`.  Minted with a reserved unique
+/// [`INT_MUTABLE_CELL_VALUE_INDEX`] rather than `stable_field_index` because
+/// that field's `(offset 16, size 8, Int)` layout collides with
+/// `W_IntObject.intval` / `W_ListObject.length` in the runtime `HeapCache`
+/// key space (which keys by `descr.index()`; see [`CELL_DESCR_TAG`]).
+///
+/// A SINGLETON `Arc`, one descr per field exactly as upstream's codewriter
+/// produces one `FieldDescr` per `IntMutableCell.inst_intvalue`.  The
+/// optimizer's `cached_fields` is keyed by `descr_identity`
+/// (`Arc::as_ptr`), so the LOAD `getfield_gc_i` and the STORE
+/// `setfield_gc_i` MUST share the Arc: with per-call fresh Arcs the store's
+/// lazy `setfield` lives in a `CachedField` the load's lookup never finds,
+/// the load skips heap.py:67-75 `possible_aliasing_two_infos` entirely, and
+/// `force_lazy_sets_for_guard` later flushes the store BELOW the emitted
+/// load — reordering a store past a load of the same location (the nested
+/// module-loop `i = i + 1; while i < n` reads the pre-increment value and
+/// runs one extra iteration).  Distinct cells (`i`/`j`/`k`) do NOT
+/// cross-forward under the shared descr: `CachedField` distinguishes
+/// structs by the obj operand (`same_box` MUST_ALIAS / UNKNOWN_ALIAS →
+/// `force_lazy_set`, heap.py:103-120).  Signed `i64` payload, mutable
+/// (`write_cell` rewrites `intvalue` in place for an int->int reassign with
+/// no version bump).
+pub fn int_mutable_cell_value_descr() -> DescrRef {
+    static DESCR: std::sync::OnceLock<DescrRef> = std::sync::OnceLock::new();
+    DESCR
+        .get_or_init(|| {
+            Arc::new(majit_ir::descr::SimpleFieldDescr::new_with_name(
+                INT_MUTABLE_CELL_VALUE_INDEX,
+                core::mem::offset_of!(pyre_object::celldict::IntMutableCell, intvalue),
+                8,
+                Type::Int,
+                false,
+                majit_ir::descr::ArrayFlag::Signed,
+                "IntMutableCell.intvalue".to_string(),
+            ))
+        })
+        .clone()
 }
 
 /// Size descriptor for `W_ListObject` allocation via NewWithVtable.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7572,6 +7572,21 @@ thread_local! {
     static FBW_APPEND_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
+    /// Undo log for the walked region's eagerly executed module-global
+    /// `IntMutableCell` stores: `(cell, intvalue_before)` pairs pushed by the
+    /// StoreName/StoreGlobal cell fold before it writes `cell.intvalue` in
+    /// place.  Same rationale as [`FBW_STORE_JOURNAL`] — the walker is the
+    /// authoritative executor, so a folded store must apply its concrete
+    /// effect at walk time (the residual it replaces would have run
+    /// `write_cell` via `try_execute_residual_call_via_executor`); a
+    /// non-commit walk restores each cell's prior `intvalue` in reverse push
+    /// order so the legacy replay re-applies the store against the pre-walk
+    /// heap.  Cells are immovable (`malloc_typed`; the fold's `can_move`
+    /// gate) and stay reachable from their module dict slot, so entries need
+    /// no GC-root forwarding.
+    static FBW_CELL_STORE_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+
     /// In-flight FOR_ITER continuation (#57 Option C): `(consumed_item,
     /// body_pc)` stashed when the FOR_ITER `for_iter_next` residual
     /// ([`PyreHelperKind::ForIterNext`]) runs concretely on the
@@ -7668,6 +7683,7 @@ fn fbw_built_exc_take(op: OpRef) -> bool {
 pub(crate) fn fbw_store_journal_reset() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_UNJOURNALED_EFFECT.with(|c| c.set(false));
     // #57 Option C: drop any in-flight FOR_ITER items a prior aborted walk
     // left undelivered (its live frame already consumed the delivery), so a
@@ -7707,11 +7723,26 @@ pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_bef
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
 }
 
+/// Record the `intvalue` a walked eager `IntMutableCell` store displaces,
+/// for the in-place restore when the walk does not commit its end state.
+// Consumed by the StoreName/StoreGlobal cell fold
+// (`emit_namespace_cell_store_fold`).
+pub(crate) fn fbw_cell_store_journal_push(cell: pyre_object::PyObjectRef, intvalue_before: i64) {
+    if fbw_debug_abort_enabled() {
+        eprintln!(
+            "[fbw-cell-journal] push cell=0x{:x} before={intvalue_before}",
+            cell as usize
+        );
+    }
+    FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().push((cell, intvalue_before)));
+}
+
 /// Commit-path epilogue: the walk's eager stores and appends stand; drop
 /// the undo logs.
 pub(crate) fn fbw_store_journal_commit() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     // #57 Option C: a committed walk's end-flush adopts the advanced
     // iterator + the body that consumed it (counted once), so the in-flight
     // items must NOT also be delivered — drop the stash (and with it the
@@ -7857,6 +7888,7 @@ pub fn fbw_foriter_any_body_effect_signal() -> bool {
     fbw_foriter_body_effect_since_consume()
         || fbw_store_journal_len() != 0
         || FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) != 0
+        || FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len()) != 0
         || fbw_has_unjournaled_effect()
 }
 
@@ -7902,8 +7934,9 @@ pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> 
     let body_effect = stash.body_effect_since_consume;
     let store_len = fbw_store_journal_len();
     let append_len = FBW_APPEND_JOURNAL.with(|j| j.borrow().len());
+    let cell_store_len = FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len());
     let unjournaled = fbw_has_unjournaled_effect();
-    if body_effect || store_len != 0 || append_len != 0 || unjournaled {
+    if body_effect || store_len != 0 || append_len != 0 || cell_store_len != 0 || unjournaled {
         if fbw_debug_abort_enabled() {
             eprintln!(
                 "[fbw-foriter] deliver REFUSED (body effect committed since consume) body_pc={} \
@@ -7995,6 +8028,23 @@ pub(crate) fn fbw_store_journal_rollback() {
             }
         }
     });
+    // Restore each eagerly stored `IntMutableCell`'s prior `intvalue` in
+    // reverse push order (raw i64 write; allocation-free, cells immovable).
+    FBW_CELL_STORE_JOURNAL.with(|j| {
+        let mut entries = j.borrow_mut();
+        while let Some((cell, intvalue_before)) = entries.pop() {
+            unsafe {
+                if fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[fbw-cell-journal] rollback cell=0x{:x} {} -> {intvalue_before}",
+                        cell as usize,
+                        (*(cell as *const pyre_object::celldict::IntMutableCell)).intvalue
+                    );
+                }
+                (*(cell as *mut pyre_object::celldict::IntMutableCell)).intvalue = intvalue_before;
+            }
+        }
+    });
 }
 
 /// Current journal length (commit-point diagnostics).
@@ -8062,6 +8112,17 @@ pub fn fbw_store_journal_root_walker(visitor: &mut dyn FnMut(&mut majit_ir::GcRe
             // SAFETY: as above — only the `PyObjectRef` slot is a root; the
             // `usize` length is a plain scalar.
             visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
+        }
+    });
+    // Cell-store journal: the cell is immovable (`malloc_typed`) so no
+    // forwarding happens, but a mid-walk rebind can drop the module dict's
+    // only reference — rooting it keeps the rollback's `intvalue` restore
+    // from writing into a freed block.
+    FBW_CELL_STORE_JOURNAL.with(|j| {
+        for (cell, _intvalue) in j.borrow_mut().iter_mut() {
+            // SAFETY: as above — only the `PyObjectRef` slot is a root; the
+            // `i64` payload is a plain scalar.
+            visitor(unsafe { &mut *(cell as *mut pyre_object::PyObjectRef).cast() });
         }
     });
     // #57 Option C: each captured in-flight FOR_ITER item is nursery-resident
@@ -12520,6 +12581,54 @@ fn dispatch_residual_call_iRd_kind(
         return Ok((outcome, op.next_pc));
     }
 
+    // StoreName/StoreGlobal IntMutableCell in-place store fold: module-scope
+    // dual of the LoadName/LoadGlobal cell fold.  Fires when the target slot
+    // holds a stabilised immovable `IntMutableCell` and the store value is a
+    // provably-plain-int box; emits `QUASIIMMUT_FIELD` + `setfield_gc_i(cell,
+    // intvalue)`, eliding the boxing + residual dict setitem.  Same
+    // handler-free gate as the LoadName fold (the fold elides a can-raise
+    // residual a `catch_exception/L` could resume into).
+    //
+    // Default ON (`PYRE_FBW_STORENAME_FOLD=0` opts out).  Two staleness bugs
+    // fixed before the flip: (1) the fold now eagerly applies the concrete
+    // `cell.intvalue` write (journaled in [`FBW_CELL_STORE_JOURNAL`]) —
+    // without it the walk's remaining concrete execution read the pre-store
+    // global and the next LOAD fold's cache-hit sanity check tripped;
+    // (2) `int_mutable_cell_value_descr` is a singleton `Arc` so the
+    // optimizer's `cached_fields` (keyed by `descr_identity`) connects the
+    // store's lazy `setfield_gc_i` to the LOAD's `getfield_gc_i` —
+    // per-call fresh Arcs let `force_lazy_sets_for_guard` flush the store
+    // BELOW an emitted load of the same cell (the nested module-loop
+    // `i = i + 1; while i < n` read the pre-increment value and ran one
+    // extra iteration).
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && dst_bank == 'v'
+        && r_args.len() == 3
+        && matches!(
+            ei.pyre_helper,
+            majit_ir::PyreHelperKind::StoreName | majit_ir::PyreHelperKind::StoreGlobal
+        )
+        && !jitcode_has_exception_handler(code)
+        && std::env::var("PYRE_FBW_STORENAME_FOLD").as_deref() != Ok("0")
+    {
+        if let (Some(&frame_opref), Some(&name_opref), Some(&value_opref)) =
+            (r_args.first(), r_args.get(1), r_args.get(2))
+        {
+            if let (
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(frame_ptr))),
+                Some(majit_ir::Value::Ref(majit_ir::GcRef(w_name_ptr))),
+            ) = (
+                ctx.trace_ctx.box_value(frame_opref),
+                ctx.trace_ctx.box_value(name_opref),
+            ) {
+                if try_walker_store_name_cell_fold(ctx, frame_ptr, w_name_ptr, value_opref)? {
+                    return Ok((DispatchOutcome::Continue, op.next_pc));
+                }
+            }
+        }
+    }
+
     // pyjitpl.py:2003-2005 OS_NOT_IN_TRACE guard — see helper docstring
     // for the convergence rationale.
     if let Some(outcome) = do_not_in_trace_call_result(ei, op.pc)? {
@@ -12670,6 +12779,23 @@ fn dispatch_residual_call_iRd_kind(
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
         return Err(DispatchError::UnfoldableListAppendResidualUnsupported { pc: op.pc });
+    }
+
+    // `len(x)` on an exact canonical list: inline the strategy-guarded
+    // length read (guard_value callable + guard_class + exact w_class +
+    // guard_value strategy + length getfield + wrapint) instead of the
+    // opaque `bh_call_fn(len_builtin, NULL, x)` residual — the shape the
+    // meta-tracer produces upstream (descroperation.py:294 `_len` →
+    // `W_ListObject.length()`).  Read-only like the SUBSCR fold, so no
+    // sub-walk restriction; any non-matching shape falls through to the
+    // generic residual (SAFE).
+    if ctx.is_authoritative_executor
+        && ctx.is_full_body_walk
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
     // B3 (`PYRE_FBW_RAISE`, default OFF): a `raise Type(args)` of a canonical
@@ -13405,6 +13531,146 @@ fn walker_float_eq_const(
     ctx.trace_ctx
         .set_opref_concrete(r, majit_ir::Value::Int(concrete_truth));
     r
+}
+
+/// ll_math.py:84-86 `VERY_LARGE_FLOAT`: the smallest power of 64 whose
+/// `* 100.0` overflows to infinity.  `ll_math_isinf` (ll_math.py:98-100)
+/// tests `(y + VERY_LARGE_FLOAT) == y` when jitted — one add plus one
+/// compare instead of two ±inf equality checks.
+fn very_large_float() -> f64 {
+    let mut f = 1.0f64;
+    while f * 100.0 != f64::INFINITY {
+        f *= 64.0;
+    }
+    f
+}
+
+/// Record a float comparison with its already-known concrete truth, then
+/// pin the observed direction with `GuardTrue`/`GuardFalse` (walker
+/// snapshot at `op_pc`).
+fn walker_float_cmp_guard(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    opcode: OpCode,
+    args: &[OpRef],
+    truth: bool,
+) -> Result<(), DispatchError> {
+    let c = ctx.trace_ctx.record_op(opcode, args);
+    ctx.trace_ctx
+        .set_opref_concrete(c, majit_ir::Value::Int(truth as i64));
+    let guard = if truth {
+        OpCode::GuardTrue
+    } else {
+        OpCode::GuardFalse
+    };
+    walker_emit_guard_with_snapshot(ctx, op_pc, guard, &[c])
+}
+
+/// Inline trace of `_pow` (floatobject.py:865, ported as
+/// `float_pow_inner`) for its fast paths: `y == 2.0` (`float_mul`),
+/// `y == 0.0` / `bx == 1.0` (constant result), and the mainstream
+/// finite `x >= 0` case.  Each `if` on the way is recorded as a float
+/// comparison pinned by a guard in the concretely-observed direction —
+/// the shape the meta-tracer produces upstream, where the y-dependent
+/// checks const-fold when `y` comes from LOAD_CONST — and only the raw
+/// libm pow remains as a residual `call_f(ccall_pow, x, y)`
+/// (ll_math.py `math_pow`, EF_CANNOT_RAISE: no `guard_no_exception`).
+///
+/// Cold branches return `Ok(None)` before emitting anything and stay on
+/// the opaque `float_pow_jit` leg: taken isnan/isinf arms and the
+/// negative-base arm need fmod/floor/copysign lowerings (lloperation has
+/// no float_mod llop — those are residual calls upstream too).
+///
+/// Guard soundness: pow is pure, so a guard failing even after the
+/// residual call deopts to `op_pc` and re-executes the whole BINARY_OP in
+/// the interpreter.  The raising cases are all behind such guards:
+/// `0.0 ** negative` (ZeroDivisionError) fails the `x == 0.0` or
+/// `y < 0.0` guard, negative-base-fractional (PowDomainError → complex)
+/// fails the `x < 0.0` guard, and overflow (OverflowError,
+/// floatobject.py:872-877 `isinf(z) and not isinf(bx)`) fails the
+/// trailing isfinite guard — `bx` is already pinned finite, so the check
+/// reduces to `isinf(z)`, emitted as `ll_math_isfinite`'s jitted form
+/// `(z - z) == 0.0` (ll_math.py:106-110).
+fn walker_emit_float_pow_inline(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    x: OpRef,
+    y: OpRef,
+    lx: f64,
+    ly: f64,
+    result_val: f64,
+) -> Result<Option<OpRef>, DispatchError> {
+    // Decline the cold paths before any emission so the generic leg
+    // starts from a clean trace.  (`lx >= 0.0` is false for NaN, but the
+    // isnan case is spelled out to mirror the branch list above.)
+    let tame = !lx.is_nan() && !ly.is_nan() && !lx.is_infinite() && !ly.is_infinite() && lx >= 0.0;
+    if ly != 2.0 && ly != 0.0 && !tame {
+        return Ok(None);
+    }
+
+    // floatobject.py:800-801  if y == 2.0: return x * x
+    let two = ctx.trace_ctx.const_float(2.0f64.to_bits() as i64);
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[y, two], ly == 2.0)?;
+    if ly == 2.0 {
+        let r = ctx.trace_ctx.record_op(OpCode::FloatMul, &[x, x]);
+        ctx.trace_ctx
+            .set_opref_concrete(r, majit_ir::Value::Float(result_val));
+        return Ok(Some(r));
+    }
+    // floatobject.py:803-805  if y == 0.0: return 1.0
+    let zero = ctx.trace_ctx.const_float(0.0f64.to_bits() as i64);
+    let one = ctx.trace_ctx.const_float(1.0f64.to_bits() as i64);
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[y, zero], ly == 0.0)?;
+    if ly == 0.0 {
+        return Ok(Some(one));
+    }
+    // floatobject.py:806-808  if isnan(x)  (ll_math_isnan: x != x)
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatNe, &[x, x], false)?;
+    // floatobject.py:809-814  if isnan(y)
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatNe, &[y, y], false)?;
+    // floatobject.py:815-827  if isinf(y)
+    let vlf_val = very_large_float();
+    let vlf = ctx.trace_ctx.const_float(vlf_val.to_bits() as i64);
+    let t = ctx.trace_ctx.record_op(OpCode::FloatAdd, &[y, vlf]);
+    ctx.trace_ctx
+        .set_opref_concrete(t, majit_ir::Value::Float(ly + vlf_val));
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[t, y], false)?;
+    // floatobject.py:828-842  if isinf(x)
+    let t = ctx.trace_ctx.record_op(OpCode::FloatAdd, &[x, vlf]);
+    ctx.trace_ctx
+        .set_opref_concrete(t, majit_ir::Value::Float(lx + vlf_val));
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[t, x], false)?;
+    // floatobject.py:844-847  if x == 0.0 and y < 0.0: ZeroDivisionError
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[x, zero], lx == 0.0)?;
+    if lx == 0.0 {
+        // The raising direction never reaches here: the concrete helper
+        // execution would have raised and declined the specialization.
+        debug_assert!(ly >= 0.0);
+        walker_float_cmp_guard(ctx, op_pc, OpCode::FloatLt, &[y, zero], false)?;
+    }
+    // floatobject.py:849-862  if bx < 0.0  (cold: declined above)
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatLt, &[x, zero], false)?;
+    // floatobject.py:864-869  if bx == 1.0 (negate_result is false here)
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[x, one], lx == 1.0)?;
+    if lx == 1.0 {
+        return Ok(Some(one));
+    }
+    // floatobject.py:871  z = math.pow(bx, y) — the residual raw libm call
+    let z = ctx.trace_ctx.call_float_typed_with_effect(
+        crate::trace_opcode::ccall_pow as *const (),
+        &[x, y],
+        &[majit_ir::Type::Float, majit_ir::Type::Float],
+        majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+    );
+    ctx.trace_ctx
+        .set_opref_concrete(z, majit_ir::Value::Float(result_val));
+    // floatobject.py:872-877  if isinf(z) and not isinf(bx): OverflowError
+    let d = ctx.trace_ctx.record_op(OpCode::FloatSub, &[z, z]);
+    ctx.trace_ctx
+        .set_opref_concrete(d, majit_ir::Value::Float(result_val - result_val));
+    walker_float_cmp_guard(ctx, op_pc, OpCode::FloatEq, &[d, zero], true)?;
+    // floatobject.py:879-881  negate_result is false on this path.
+    Ok(Some(z))
 }
 
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
@@ -14747,25 +15013,35 @@ fn try_walker_specialize_binary_op_float(
             r
         }
         None => {
-            // ll_math_pow (ll_math.py:260) is EF_CAN_RAISE, NOT
-            // force_virtual: pyjitpl.py:2084-2121 execute_varargs(
-            // rop.CALL_F, ..., exc=True, pure=False) records CALL_F and
-            // handle_possible_exception → GUARD_NO_EXCEPTION
-            // (pyjitpl.py:3395).  The raising case never reaches here:
-            // `walker_float_specialization_operands` already executed
-            // the helper concretely and returns `None` on a raise,
-            // falling back to the generic residual leg.
-            let r = ctx.trace_ctx.call_float_typed_with_effect(
-                crate::trace_opcode::float_pow_jit as *const (),
-                &[lhs_raw, rhs_raw],
-                &[majit_ir::Type::Float, majit_ir::Type::Float],
-                majit_metainterp::default_effect_info(),
-            );
-            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
             let result_val = unsafe { pyre_object::w_float_get_value(boxed_result_i64 as _) };
-            ctx.trace_ctx
-                .set_opref_concrete(r, majit_ir::Value::Float(result_val));
-            r
+            // _pow (floatobject.py:865) traced inline for its fast paths:
+            // every special-case `if` becomes a comparison guard and only
+            // the raw libm pow stays residual.
+            if let Some(r) = walker_emit_float_pow_inline(
+                ctx, op_pc, lhs_raw, rhs_raw, lhs_f64, rhs_f64, result_val,
+            )? {
+                r
+            } else {
+                // Cold-path fallback (nan/inf operands, negative base):
+                // the opaque `_pow` helper.  It is EF_CAN_RAISE, NOT
+                // force_virtual: pyjitpl.py:2084-2121 execute_varargs(
+                // rop.CALL_F, ..., exc=True, pure=False) records CALL_F
+                // and handle_possible_exception → GUARD_NO_EXCEPTION
+                // (pyjitpl.py:3395).  The raising case never reaches
+                // here: `walker_float_specialization_operands` already
+                // executed the helper concretely and returns `None` on a
+                // raise, falling back to the generic residual leg.
+                let r = ctx.trace_ctx.call_float_typed_with_effect(
+                    crate::trace_opcode::float_pow_jit as *const (),
+                    &[lhs_raw, rhs_raw],
+                    &[majit_ir::Type::Float, majit_ir::Type::Float],
+                    majit_metainterp::default_effect_info(),
+                );
+                walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
+                ctx.trace_ctx
+                    .set_opref_concrete(r, majit_ir::Value::Float(result_val));
+                r
+            }
         }
     };
     let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw_result);
@@ -15114,6 +15390,148 @@ fn try_walker_specialize_subscr_tuple(
         majit_ir::Value::Ref(majit_ir::GcRef(boxed_result_i64 as usize)),
     );
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// `len(x)` on an exact canonical `W_ListObject`: lower the opaque
+/// `bh_call_fn(len_builtin, PY_NULL, x)` residual to the strategy-guarded
+/// inline length read the meta-tracer produces upstream
+/// (descroperation.py:294 `_len` → `W_ListObject.length()` →
+/// `strategy.length`): `guard_value(callable)` + `guard_class LIST` +
+/// exact `w_class` guard + `guard_value(strategy)` + length
+/// `getfield_gc_i` + `wrapint`.  The exact `w_class` guard is required
+/// because a list SUBCLASS shares `ob_type == &LIST_TYPE` but may
+/// override `__len__` (`baseobjspace::len` dispatches
+/// `subclass_special_override`); it side-exits to the generic residual.
+///
+/// Returns `None` (fall through to the generic residual, SAFE) for any
+/// other shape: non-list arg, list subclass, empty-strategy list, a bound
+/// receiver, or wrong arity.
+fn try_walker_specialize_builtin_len(
+    ctx: &mut WalkContext<'_, '_>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    // Plain `bh_call_fn(callable, PY_NULL, arg)` shape only.
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Ref(null_or_self),
+        ConcreteValue::Ref(list_obj),
+    ) = (arg_concretes[0], arg_concretes[1], arg_concretes[2])
+    else {
+        return Ok(None);
+    };
+    // A non-null `null_or_self` is a bound receiver `bh_call_fn_impl`
+    // prepends as arg0 — not a plain `len(x)` call.
+    if concrete_callable.is_null() || !null_or_self.is_null() || list_obj.is_null() {
+        return Ok(None);
+    }
+    if !pyre_interpreter::builtins::is_builtin_len_function(concrete_callable) {
+        return Ok(None);
+    }
+    // Exact canonical list only (see the doc comment on the subclass
+    // `__len__` hazard).
+    let list_canonical = unsafe {
+        std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::LIST_TYPE)
+            && std::ptr::eq(
+                (*list_obj).w_class,
+                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+            )
+    };
+    if !list_canonical {
+        return Ok(None);
+    }
+    let (sid, concrete_len) = unsafe {
+        let concrete_len = pyre_object::w_list_len(list_obj);
+        let sid = if pyre_object::w_list_uses_int_storage(list_obj) {
+            1i64
+        } else if pyre_object::w_list_uses_float_storage(list_obj) {
+            2i64
+        } else if pyre_object::w_list_uses_object_storage(list_obj) {
+            0i64
+        } else {
+            // Empty-strategy list: no length field to read.
+            return Ok(None);
+        };
+        (sid, concrete_len)
+    };
+
+    // Authentic boxed result, produced on the plain eval loop exactly as
+    // the skipped residual would (len on an exact list is side-effect-free).
+    let boxed_result = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[list_obj])
+    };
+    let Ok(boxed_result) = boxed_result else {
+        return Ok(None);
+    };
+
+    // --- emit the specialized IR (walker-native) ---
+    // Pin the callable identity (LOAD_GLOBAL `len` is usually already a
+    // constant via the namespace cell fold).
+    let callable_op = r_args[0];
+    if !callable_op.is_constant() {
+        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(callable_op, expected);
+    }
+    let list_op = r_args[2];
+    // guard_class LIST (skip when class already known / operand is constant).
+    let list_type_addr = &pyre_object::pyobject::LIST_TYPE as *const _ as i64;
+    if !list_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(list_op) {
+        let type_const = ctx.trace_ctx.const_int(list_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[list_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(list_op, list_type_addr);
+    walker_guard_exact_w_class(
+        ctx,
+        op.pc,
+        list_op,
+        pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
+    )?;
+    // guard_value(strategy == sid).
+    let strategy = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        list_op,
+        crate::descr::list_strategy_descr(),
+    );
+    let sid_const = ctx.trace_ctx.const_int(sid);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[strategy, sid_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(strategy, sid_const);
+    // Length read by strategy (rlist.py:116 inline field for object
+    // storage; typed items-block length for int/float storage).
+    let len_descr = match sid {
+        0 => crate::descr::list_length_descr(),
+        1 => crate::descr::list_int_items_len_descr(),
+        _ => crate::descr::list_float_items_len_descr(),
+    };
+    let raw_len = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr);
+    ctx.trace_ctx
+        .set_opref_concrete(raw_len, majit_ir::Value::Int(concrete_len as i64));
+    let boxed = crate::state::wrapint(ctx.trace_ctx, raw_len);
+    ctx.trace_ctx.set_opref_concrete(
+        boxed,
+        majit_ir::Value::Ref(majit_ir::GcRef(boxed_result as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
     Ok(Some(()))
 }
 
@@ -16439,13 +16857,13 @@ fn emit_module_dict_cell_fold(
     name: &str,
 ) -> Result<bool, DispatchError> {
     // Cell fast path applies only to a module dict still in strategy mode
-    // whose slot holds a raw value or an `ObjectMutableCell`; null/absent
-    // keys and `IntMutableCell` slots fall through to the residual.
+    // whose slot holds a raw value, an `ObjectMutableCell`, or an
+    // `IntMutableCell`; null/absent keys fall through to the residual.
     if let Some(slot) = crate::state::module_dict_cell_slot_direct(w_globals, name) {
         if let Some(stored) = crate::state::module_dict_cell_value_direct(w_globals, slot) {
-            if !stored.is_null() && !unsafe { pyre_object::celldict::is_int_mutable_cell(stored) } {
+            if !stored.is_null() {
                 // The fast path const-folds `stored` (the slot's raw value, or
-                // the `ObjectMutableCell`) as the elidable
+                // the `ObjectMutableCell` / `IntMutableCell`) as the elidable
                 // `jit_namespace_cell_lookup` result.  That bakes its address
                 // into the trace / guard resume data.  The collector is
                 // moving, so a `stored` still in the nursery at trace time
@@ -16453,7 +16871,9 @@ fn emit_module_dict_cell_fold(
                 // dangles (a `memo` dict grown in the loop is the canonical
                 // case).  Fall through to the residual live lookup, which
                 // re-reads the slot each call and follows the relocation, when
-                // `stored` can still move.
+                // `stored` can still move.  Mutable cells are `malloc_typed`
+                // (never nursery), so `can_move` is false and a hot int/object
+                // global folds; a raw movable value does not.
                 if !majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
                     emit_namespace_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, slot, stored)?;
                     return Ok(true);
@@ -16461,9 +16881,9 @@ fn emit_module_dict_cell_fold(
             }
         }
         // The name is present in the module dict but unfoldable
-        // (IntMutableCell / null / movable / strategy-switched); keep the
-        // residual rather than misreaching into the builtins fallback (the
-        // residual reads the live globals slot, which is correct).
+        // (null / movable raw value / strategy-switched); keep the residual
+        // rather than misreaching into the builtins fallback (the residual
+        // reads the live globals slot, which is correct).
         return Ok(false);
     }
     // Name absent from this module dict.
@@ -16471,11 +16891,13 @@ fn emit_module_dict_cell_fold(
 }
 
 /// Emit the `QUASIIMMUT_FIELD(ns, slot)` + elidable `jit_namespace_cell_lookup`
-/// + (for an `ObjectMutableCell`) live `cell.w_value` read that the LOAD_GLOBAL
-/// cell fold lowers to, seeding the dst's concrete with the unwrapped value.
-/// `stored` is the raw value-or-cell at `slot` of `ns` (a module dict in
-/// strategy mode); the caller has already proven it foldable
-/// (non-null, non-`IntMutableCell`, immovable).
+/// + (for a mutable cell) live field read that the LOAD_GLOBAL cell fold lowers
+/// to, seeding the dst's concrete with the unwrapped value.  `stored` is the
+/// raw value-or-cell at `slot` of `ns` (a module dict in strategy mode); the
+/// caller has already proven it foldable (non-null, immovable).  An
+/// `ObjectMutableCell` reads `cell.w_value` (`getfield_gc_r`); an
+/// `IntMutableCell` reads `cell.intvalue` (`getfield_gc_i`) and re-boxes it
+/// (the box is elided by the optimizer when the sole consumer unboxes).
 fn emit_namespace_cell_fold(
     ctx: &mut WalkContext<'_, '_>,
     op_pc: usize,
@@ -16486,42 +16908,44 @@ fn emit_namespace_cell_fold(
     stored: pyre_object::PyObjectRef,
 ) -> Result<(), DispatchError> {
     let is_obj_cell = unsafe { pyre_object::celldict::is_object_mutable_cell(stored) };
+    let is_int_cell = unsafe { pyre_object::celldict::is_int_mutable_cell(stored) };
     let result_obj = unsafe { pyre_object::celldict::unwrap_cell(stored) };
 
     let ns_const = ctx.trace_ctx.const_ref(ns as i64);
     let slot_const = ctx.trace_ctx.const_int(slot as i64);
     ctx.trace_ctx
         .record_op(majit_ir::OpCode::QuasiimmutField, &[ns_const, slot_const]);
-    let lookup_fn = crate::helpers::jit_namespace_cell_lookup as *const ();
-    let lookup_args = [ns_const, slot_const];
-    let lookup_arg_types = [majit_ir::Type::Ref, majit_ir::Type::Int];
-    ctx.trace_ctx.record_known_result_typed(
-        stored as i64,
-        lookup_fn,
-        &lookup_args,
-        &lookup_arg_types,
-        majit_ir::Type::Ref,
-        majit_metainterp::EffectInfoSlot::ElidableCannotRaise,
-    );
-    let concrete_args = crate::helpers::namespace_slot_lookup_values(lookup_fn, ns, slot);
-    let concrete_cell = crate::helpers::namespace_slot_lookup_result(stored);
-    let cell_opref = crate::helpers::emit_trace_call_ref_typed_elidable_cannot_raise(
-        ctx.trace_ctx,
-        lookup_fn,
-        &lookup_args,
-        &lookup_arg_types,
-        &concrete_args,
-        concrete_cell,
-    );
+    // Bake the immovable cell as a `ConstPtr` (pypy `ConstPtr(cell)`).  The
+    // `QuasiimmutField(ns, slot)` guard above invalidates the loop on a
+    // rebind / strategy-version bump (`optimize_QUASIIMMUT_FIELD` watches the
+    // `(dict, slot)` pair, not the cell), and the caller's `can_move` check
+    // guarantees the address is stable — the optimizer already folds the
+    // equivalent elidable `jit_namespace_cell_lookup` down to this same const
+    // ptr.  A genuine constant (not the elidable call's `RefOp` result, which
+    // is not `is_constant()`) is what lets the trace-time heapcache's
+    // `_unique_const_heuristic` canonicalise the LOAD's `getfield_gc_i` and
+    // the STORE fold's `setfield_gc_i` onto one cache slot; without it a hot
+    // int global's cached field goes stale.
+    let cell_opref = ctx.trace_ctx.const_ref(stored as i64);
     // An `ObjectMutableCell` needs `cell.w_value` read LIVE so a same-key
     // reassign (in-place `write_cell`, no version bump) is observed each
-    // iteration; a raw stored value is its own result.
+    // iteration; an `IntMutableCell` reads `cell.intvalue` LIVE for the same
+    // reason (`write_cell` mutates `intvalue` in place for an int->int
+    // reassign) then re-boxes the raw int; a raw stored value is its own
+    // result.
     let result_opref = if is_obj_cell {
         crate::state::opimpl_getfield_gc_r(
             ctx.trace_ctx,
             cell_opref,
             crate::descr::object_mutable_cell_value_descr(),
         )
+    } else if is_int_cell {
+        let raw_int = crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            cell_opref,
+            crate::descr::int_mutable_cell_value_descr(),
+        );
+        crate::state::wrapint(ctx.trace_ctx, raw_int)
     } else {
         cell_opref
     };
@@ -16586,6 +17010,162 @@ fn try_walker_load_name_cell_fold(
         pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)
     };
     emit_module_dict_cell_fold(ctx, op_pc, dst, dst_bank, w_globals, name)
+}
+
+/// STORE dual of [`emit_namespace_cell_fold`]: `QUASIIMMUT_FIELD(ns, slot)` +
+/// elidable `jit_namespace_cell_lookup` (const-fold the cell ptr) +
+/// `setfield_gc_i(cell, raw_int)` writing `IntMutableCell.intvalue` in place.
+/// Mirrors pypy's inlined `write_cell` int arm (`typeobject.py:60-62`, the
+/// `isinstance(w_cell, IntMutableCell) and is_plain_int1(w_value)` branch):
+/// `setfield_gc(ConstPtr(cell), i_new, IntMutableCell.inst_intvalue)`.  No
+/// runtime guard on `raw_int` — the caller recovered it from a
+/// provably-plain-int JIT box (heapcache), so `is_plain_int1` folds away as it
+/// does in the optimized pypy trace.  The version watcher (the
+/// `QUASIIMMUT_FIELD` guard) still protects cell IDENTITY: reassigning the
+/// global to a non-int replaces the cell + bumps the strategy version,
+/// invalidating this loop.
+fn emit_namespace_cell_store_fold(
+    ctx: &mut WalkContext<'_, '_>,
+    ns: pyre_object::PyObjectRef,
+    slot: usize,
+    stored: pyre_object::PyObjectRef,
+    raw_int: OpRef,
+    new_int: i64,
+) -> Result<(), DispatchError> {
+    let ns_const = ctx.trace_ctx.const_ref(ns as i64);
+    let slot_const = ctx.trace_ctx.const_int(slot as i64);
+    ctx.trace_ctx
+        .record_op(majit_ir::OpCode::QuasiimmutField, &[ns_const, slot_const]);
+    // Bake the immovable cell as a `ConstPtr`, identical to the LOAD fold
+    // (`emit_namespace_cell_fold`), so this `setfield_gc_i` and the LOAD's
+    // `getfield_gc_i` canonicalise onto one trace-heapcache slot via
+    // `_unique_const_heuristic` (both `ConstPtr(cell)`, matched by
+    // `same_constant`).  An elidable-call `RefOp` cell would not be
+    // `is_constant()`, leaving the store's cache write unreachable from the
+    // load — the hot int global's cached field would go stale.
+    let cell_opref = ctx.trace_ctx.const_ref(stored as i64);
+    // `setfield_gc(cell, raw_int, IntMutableCell.intvalue)` with the same
+    // heapcache-redundancy skip + write-through as `setfield_gc_via_heapcache`
+    // (`pyjitpl.py:973-988 _opimpl_setfield_gc_any`).
+    let descr = crate::descr::int_mutable_cell_value_descr();
+    let descr_index = descr.index();
+    let is_redundant = ctx
+        .trace_ctx
+        .heapcache_getfield_cached(cell_opref, descr_index)
+        == Some(raw_int);
+    if is_redundant {
+        ctx.trace_ctx.profiler().count_ops(
+            majit_ir::OpCode::SetfieldGc,
+            majit_metainterp::counters::HEAPCACHED_OPS,
+        );
+    } else {
+        ctx.trace_ctx.record_op_with_descr(
+            majit_ir::OpCode::SetfieldGc,
+            &[cell_opref, raw_int],
+            descr,
+        );
+        ctx.trace_ctx
+            .heapcache_setfield_cached(cell_opref, descr_index, raw_int);
+        // Authoritative-executor eager store: the elided residual would have
+        // run `write_cell` concretely (`try_execute_residual_call_via_executor`),
+        // so apply the in-place `cell.intvalue` write now and journal the
+        // displaced value for the non-commit rollback
+        // ([`FBW_CELL_STORE_JOURNAL`]).  Without it the live cell keeps its
+        // pre-store value while the trace heapcache carries the new box —
+        // the next LOAD fold's cache-hit sanity check (pyjitpl.py:934-945)
+        // trips on the divergence, and the walk's remaining concrete
+        // execution reads the stale global.  The redundant arm above skips
+        // the write: `cached == raw_int` means the cell already holds this
+        // box's value (the cache is seeded from — and kept in step with —
+        // the live cell).
+        let cell = stored as *mut pyre_object::celldict::IntMutableCell;
+        fbw_cell_store_journal_push(stored, unsafe { (*cell).intvalue });
+        unsafe { (*cell).intvalue = new_int };
+    }
+    // `store_name_fn` is `CallFlavor::Plain` (can-raise); the fold replaces a
+    // SUCCESSFUL non-raising store, so mirror the residual success arm's
+    // exception clear exactly as [`emit_namespace_cell_fold`] does.
+    ctx.last_exc_value = None;
+    ctx.last_exc_value_concrete = ConcreteValue::Null;
+    Ok(())
+}
+
+/// StoreName/StoreGlobal cell fold — module-scope store dual of
+/// [`try_walker_load_name_cell_fold`].  Folds `i = <int>` on a hot module
+/// global whose slot has stabilised to an `IntMutableCell` (the in-place
+/// shape `write_cell` reaches after the 2nd int store) to a single
+/// `setfield_gc_i(cell, intvalue)`, eliding the value boxing + residual dict
+/// setitem.  Declines (→ residual `bh_store_name_fn`, which runs the full
+/// `write_cell`) when the frame is non-module, the slot is not an immovable
+/// `IntMutableCell`, or the value is not a provably-plain-int box (bool /
+/// int-subclass / long / object all fall through — `write_cell` REPLACES the
+/// cell + bumps the version for those, which the setfield fast path must not).
+fn try_walker_store_name_cell_fold(
+    ctx: &mut WalkContext<'_, '_>,
+    frame_ptr: usize,
+    w_name_ptr: usize,
+    value_opref: OpRef,
+) -> Result<bool, DispatchError> {
+    if frame_ptr == 0 {
+        return Ok(false);
+    }
+    let frame = unsafe { &*(frame_ptr as *const pyre_interpreter::pyframe::PyFrame) };
+    let w_globals = frame.get_w_globals();
+    if w_globals.is_null() {
+        return Ok(false);
+    }
+    // Module scope gate: `w_locals` aliases `w_globals` (same as the LOAD
+    // fold); a distinct `w_locals` routes to the live residual.
+    let w_locals = frame.get_w_locals();
+    if !w_locals.is_null() && !std::ptr::eq(w_locals, w_globals) {
+        return Ok(false);
+    }
+    let name = unsafe {
+        pyre_object::unicodeobject::w_str_get_value(w_name_ptr as pyre_object::PyObjectRef)
+    };
+    // Slot must hold an immovable `IntMutableCell`.  `can_move` gates the same
+    // baked-address relocation hazard as the LOAD fold; mutable cells are
+    // `malloc_typed` (never nursery) so a stabilised int global folds.
+    let Some(slot) = crate::state::module_dict_cell_slot_direct(w_globals, name) else {
+        return Ok(false);
+    };
+    let Some(stored) = crate::state::module_dict_cell_value_direct(w_globals, slot) else {
+        return Ok(false);
+    };
+    if stored.is_null() || !unsafe { pyre_object::celldict::is_int_mutable_cell(stored) } {
+        return Ok(false);
+    }
+    if majit_gc::can_move(majit_ir::GcRef(stored as usize)) {
+        return Ok(false);
+    }
+    // The stored value must be a provably-plain-int box.  `is_plain_int1` on
+    // the trace-time concrete rejects `bool` / int-subclass / `long` (whose
+    // `write_cell` replaces the cell rather than mutating `intvalue`); the
+    // heapcache lookup recovers the box's raw `intvalue` (populated only by
+    // JIT int boxes, `emit_box_int_inline`), so the setfield needs no runtime
+    // class guard — exactly as pypy's optimized trace folds the
+    // `is_plain_int1` check away for an `int_add` result.
+    let is_plain_int = matches!(
+        ctx.trace_ctx.box_value(value_opref),
+        Some(majit_ir::Value::Ref(majit_ir::GcRef(p)))
+            if p != 0 && unsafe { pyre_object::listobject::is_plain_int1(p as pyre_object::PyObjectRef) }
+    );
+    if !is_plain_int {
+        return Ok(false);
+    }
+    let Some(raw_int) = ctx
+        .trace_ctx
+        .heapcache_getfield_cached(value_opref, crate::descr::int_intval_descr().index())
+    else {
+        return Ok(false);
+    };
+    // The eager concrete write needs the raw int the store applies; a
+    // raw-int box with no concrete shadow declines to the residual.
+    let Some(majit_ir::Value::Int(new_int)) = ctx.trace_ctx.box_value(raw_int) else {
+        return Ok(false);
+    };
+    emit_namespace_cell_store_fold(ctx, w_globals, slot, stored, raw_int, new_int)?;
+    Ok(true)
 }
 
 #[allow(non_snake_case)]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7290,6 +7290,28 @@ pub(crate) fn fbw_loop_callee_ca_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_VABLE_SCALAR_CA` (default OFF) — sub-mode of
+/// [`fbw_loop_callee_ca_enabled`]. When on, the gap-10 loop-callee
+/// CALL_ASSEMBLER passes the callee's loop-carried locals as scalar
+/// CALL_ASSEMBLER args plus a `VableExpansion` (`arg_overrides` mapping each
+/// scalar to a callee jitframe slot), so the optimizer can elide the per-call
+/// frame-array build (`NewArrayClear` + per-element `SetarrayitemGc`) instead
+/// of forcing the virtual frame. Mirrors `direct_assembler_call`
+/// (`pyjitpl.py:3613`, raw red boxes) + `handle_call_assembler`
+/// (`rewrite.py:665`, GC_STORE scalars into the callee jitframe). Default OFF
+/// until the callee scalar contract + optimizer array-elision land and the
+/// path is verified fib-safe on both backends.
+pub(crate) fn fbw_vable_scalar_ca_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_VABLE_SCALAR_CA") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
+    })
+}
+
 /// `PYRE_FBW_RAISE` (default ON) — the FBW walker owns the Python raise/except
 /// loop.  The twin NULL-ref guards exempt the trailing `cause` sentinel of a
 /// [`PyreHelperKind::RaiseVarargs`] residual so the walker records the raise.
@@ -11677,11 +11699,21 @@ fn emit_walker_loop_callee_call_assembler(
     // SETFIELD_GC(vable_token) before the assembler call.
     maybe_walker_vable_and_vrefs_before_residual_call(ctx);
 
-    let ca_result = ctx.trace_ctx.call_assembler_red_only_ref(
-        token_number,
-        &[callee_frame, callee_ec],
-        &[Type::Ref, Type::Ref],
-    );
+    let ca_result = if fbw_vable_scalar_ca_enabled() {
+        // S1-S3 (`PYRE_FBW_VABLE_SCALAR_CA`): route through the vable-scalar
+        // emitter so loop-carried locals become scalar CALL_ASSEMBLER args +
+        // `VableExpansion` arg_overrides, letting the optimizer elide the
+        // per-call frame-array build. S0 scaffolding: the emitter currently
+        // produces the identical red-only CA; the vable_expansion routing lands
+        // in S2.
+        emit_loop_callee_ca_vable_scalar(ctx, callee_frame, callee_ec, token_number)
+    } else {
+        ctx.trace_ctx.call_assembler_red_only_ref(
+            token_number,
+            &[callee_frame, callee_ec],
+            &[Type::Ref, Type::Ref],
+        )
+    };
     ctx.trace_ctx.record_op(OpCode::Keepalive, &[callee_frame]);
 
     // Run the call concretely to stamp `ca_result` (same rationale as the
@@ -11743,6 +11775,29 @@ fn emit_walker_loop_callee_call_assembler(
     walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
 
     Ok(Some((DispatchOutcome::Continue, op.next_pc)))
+}
+
+/// `PYRE_FBW_VABLE_SCALAR_CA` emission seam (S0 scaffolding).
+///
+/// Emits the gap-10 loop-callee CALL_ASSEMBLER when the vable-scalar mode is
+/// on. S0: produces the identical red-only `[callee_frame, callee_ec]` CA as
+/// the default path, so flag-ON is byte-identical to flag-OFF. S2 replaces the
+/// body with `call_assembler_with_vable_expansion` — passing the callee's
+/// loop-carried locals as scalar args plus a `VableExpansion` whose
+/// `arg_overrides` map each scalar to a callee jitframe slot
+/// (`rewrite.py:665-695` handle_call_assembler parity) — so the optimizer can
+/// elide the per-call frame-array build.
+fn emit_loop_callee_ca_vable_scalar(
+    ctx: &mut WalkContext<'_, '_>,
+    callee_frame: OpRef,
+    callee_ec: OpRef,
+    token_number: u64,
+) -> OpRef {
+    ctx.trace_ctx.call_assembler_red_only_ref(
+        token_number,
+        &[callee_frame, callee_ec],
+        &[Type::Ref, Type::Ref],
+    )
 }
 
 /// #62 slice (3c): full-body-walk inline of a recognized user-function

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -54,6 +54,19 @@ extern "C" fn trace_dict_lookup_jit(dict: i64, key: i64) -> i64 {
 /// Must match `float_pow_impl` semantics in `baseobjspace.rs`: any
 /// divergence would cause the JIT compiled code to produce a different
 /// result from the interpreter for the same input (correctness bug).
+/// ll_math.py:52 `math_pow = llexternal('pow', [DOUBLE, DOUBLE], DOUBLE)`
+/// — the raw libm pow the inline-traced `_pow` fast path residualizes as
+/// `call_f(ConstClass(ccall_pow), x, y)` with an EF_CANNOT_RAISE descr
+/// (no `guard_no_exception` follows).  Every `_pow` special case
+/// (floatobject.py:865) is pinned by a comparison guard at trace time
+/// (`walker_emit_float_pow_inline`), so this is reached only with finite
+/// operands, `x >= 0`, `x != 1`, `y` not in {0, 2, nan, ±inf}; an
+/// overflowing result deopts on the trailing isfinite guard instead of
+/// raising here.
+pub(crate) extern "C" fn ccall_pow(x: f64, y: f64) -> f64 {
+    x.powf(y)
+}
+
 pub(crate) extern "C" fn float_pow_jit(x: f64, y: f64) -> f64 {
     match pyre_interpreter::float_pow_raw(x, y) {
         Ok(z) => z,

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -4040,7 +4040,11 @@ where
         ctx.store_name_fn_idx,
         vec![frame_operand, name_operand, value_operand],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        // Tag so the full-body walker can try the module-scope IntMutableCell
+        // in-place store fold (`try_walker_store_name_cell_fold`); the fold
+        // falls through to this residual for non-module frames / non-int
+        // values / non-cell slots.
+        majit_ir::PyreHelperKind::StoreName,
     ))
 }
 
@@ -4079,7 +4083,9 @@ where
         ctx.store_global_fn_idx,
         vec![frame_operand, name_operand, value_operand],
         CallFlavor::Plain,
-        majit_ir::PyreHelperKind::None,
+        // Tag for the same module-scope IntMutableCell in-place store fold as
+        // `lower_store_name_hlop_to_insn` (`try_walker_store_name_cell_fold`).
+        majit_ir::PyreHelperKind::StoreGlobal,
     ))
 }
 

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -273,6 +273,10 @@ pub unsafe fn walk_module_value_slot(
 /// `w_cell` must be either `None` or a valid PyObjectRef.  `w_value`
 /// must be a valid non-null PyObjectRef.
 pub unsafe fn write_cell(w_cell: Option<PyObjectRef>, w_value: PyObjectRef) -> Option<PyObjectRef> {
+    // The cell payload lives in a Box-immortal structure reached only by the
+    // prebuilt-family root walk; record the store so the next minor
+    // collection rescans it (gc_roots.rs prebuilt-root write tracking).
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     let Some(w_cell) = w_cell else {
         // attribute does not exist at all, write it without a cell first
         return Some(w_value);
@@ -383,6 +387,9 @@ impl ModuleDictStorage {
     /// `dict[key] = w_value` — insertion-ordered.  Returns the
     /// previous value (or None if this is a fresh slot).
     pub fn set(&mut self, key: &str, w_value: PyObjectRef) -> Option<PyObjectRef> {
+        // Prebuilt-family store (see `write_cell`): the module-dict storage
+        // is Box-immortal, so the write-tracking bit is its write barrier.
+        crate::gc_roots::mark_prebuilt_roots_dirty();
         // `IndexMap::insert` preserves the existing slot's position
         // on overwrite, matching Python `{}`'s assignment semantics
         // (rewriting an existing key does not move it to the end).
@@ -641,6 +648,10 @@ impl ModuleDictStrategy {
         // not space.builtin.w_dict:` …) are skipped because pyre is
         // permanently in `honor__builtins__=True` mode (see method
         // docstring above); builtincache attachment is unreachable.
+        // The fresh cache duplicates the (possibly nursery-young) cell /
+        // value pointer into walker-only storage (`walk_cache_cells`);
+        // record the store like any other prebuilt-family write.
+        crate::gc_roots::mark_prebuilt_roots_dirty();
         let rc = std::rc::Rc::new(std::cell::RefCell::new(GlobalCache::new(cell)));
         caches.insert(key.to_string(), rc.clone());
         rc

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1180,6 +1180,9 @@ pub unsafe fn w_module_dict_switch_to_object_strategy(obj: PyObjectRef) {
     if !raw.object_storage.is_null() {
         return;
     }
+    // The promotion mints young key objects into the fresh object_storage
+    // (prebuilt-family storage; see `w_module_dict_setitem_str_internal`).
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     let strategy = &mut *raw.mstrategy;
     let storage = &mut *raw.dstorage;
     let mut new_storage: indexmap::IndexMap<ObjectKey, PyObjectRef> =
@@ -1323,6 +1326,10 @@ unsafe fn w_module_dict_setitem_str_internal(
     w_value: PyObjectRef,
     fire_proxy: bool,
 ) {
+    // Module-dict storage is Box-immortal, reached only by the
+    // prebuilt-family root walk; record the store (gc_roots.rs
+    // prebuilt-root write tracking).
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     let proxy = if fire_proxy {
         (*(obj as *const W_ModuleDictObject)).dict_storage_proxy
     } else {
@@ -2185,6 +2192,8 @@ pub unsafe fn w_dict_store_object_strategy_checked(
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 pub unsafe fn w_module_dict_store_inner(obj: PyObjectRef, key: PyObjectRef, value: PyObjectRef) {
+    // Prebuilt-family store (see `w_module_dict_setitem_str_internal`).
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     if !w_module_dict_is_object_strategy(obj) {
         if let Some(ks) = key_as_utf8(key) {
             return w_module_dict_setitem_str(obj, ks, value);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -179,6 +179,57 @@ pub fn walk_shadow_stack(mut visitor: impl FnMut(&mut PyObjectRef)) {
     });
 }
 
+// ── Prebuilt-root write tracking ────────────────────────────────────
+//
+// incminimark.py:106-114 `GCFLAG_TRACK_YOUNG_PTRS` / 339-344
+// `old_objects_pointing_to_young` / 355 `prebuilt_root_objects`: an old or
+// prebuilt object is NOT scanned during a minor collection unless the write
+// barrier recorded a store into it since the previous minor collection; a
+// major collection always traces the prebuilt roots.
+//
+// pyre's Box-immortal interpreter structures (module dicts / cells, heap-type
+// namespace dicts, method caches, function fields) bypass the compiled-code
+// write barrier — their stores go through Rust runtime helpers — so the
+// band-aid root walks in `pyre-interpreter::eval::walk_pyframe_roots` rescan
+// them at EVERY minor collection.  This flag is the write-barrier bit for
+// that whole prebuilt family, one global bit instead of a per-object flag
+// (coarser than upstream: any single store rescans everything on the next
+// minor collection — still sound, just less selective).  Every mutation
+// helper that can store a (possibly nursery-young) `PyObjectRef` into one of
+// those walked structures must call [`mark_prebuilt_roots_dirty`]; the minor
+// walk clears the bit after it runs (the walk itself promotes every young
+// value it reaches, so a clean bit again means "no young pointers inside").
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static PREBUILT_ROOTS_DIRTY: AtomicBool = AtomicBool::new(true);
+
+/// Write-barrier hook for the prebuilt/Box-immortal root family
+/// (incminimark `remember_young_pointer` analog).  Call from every helper
+/// that stores a `PyObjectRef` into a structure reached only by the
+/// `walk_pyframe_roots` band-aid walks.
+#[inline]
+pub fn mark_prebuilt_roots_dirty() {
+    PREBUILT_ROOTS_DIRTY.store(true, Ordering::Relaxed);
+}
+
+/// Whether any prebuilt-family store happened since the last completed
+/// minor-collection walk (incminimark: "is this object in
+/// `old_objects_pointing_to_young`?").
+#[inline]
+pub fn prebuilt_roots_dirty() -> bool {
+    PREBUILT_ROOTS_DIRTY.load(Ordering::Relaxed)
+}
+
+/// Clear the write-tracking bit after a minor-collection walk promoted every
+/// young value reachable from the prebuilt family (incminimark: the minor
+/// collection empties `old_objects_pointing_to_young` and re-sets
+/// GCFLAG_TRACK_YOUNG_PTRS).  Must only be called by the walker, after the
+/// walk completed, during a stop-the-world collection.
+#[inline]
+pub fn clear_prebuilt_roots_dirty() {
+    PREBUILT_ROOTS_DIRTY.store(false, Ordering::Relaxed);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-object/src/typedef.rs
+++ b/pyre/pyre-object/src/typedef.rs
@@ -187,6 +187,9 @@ pub unsafe fn w_getset_get_objclass(obj: PyObjectRef) -> PyObjectRef {
 /// `obj` must point to a valid `GetSetProperty`.
 #[inline]
 pub unsafe fn w_getset_set_objclass(obj: PyObjectRef, value: PyObjectRef) {
+    // Immortal-descriptor slot reached only by `walk_raw_getset_roots`,
+    // skipped on clean minor collections; record the store.
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     unsafe { (*(obj as *mut GetSetProperty)).w_objclass = value }
 }
 
@@ -204,6 +207,9 @@ pub unsafe fn w_getset_get_qualname(obj: PyObjectRef) -> PyObjectRef {
 /// `obj` must point to a valid `GetSetProperty`.
 #[inline]
 pub unsafe fn w_getset_set_qualname(obj: PyObjectRef, value: PyObjectRef) {
+    // Immortal-descriptor slot (see `w_getset_set_objclass`); the lazy
+    // qualname cache stores a freshly allocated string.
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     unsafe { (*(obj as *mut GetSetProperty)).w_qualname = value }
 }
 

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -251,6 +251,10 @@ thread_local! {
 
 /// Record a heap type for the collection-time namespace root walk.
 fn register_heap_type(addr: usize) {
+    // A fresh heap type carries young namespace values / bases; record the
+    // prebuilt-family store so the next minor collection scans it
+    // (gc_roots.rs prebuilt-root write tracking).
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     HEAP_TYPE_REGISTRY.with(|reg| reg.borrow_mut().push(addr));
 }
 
@@ -678,6 +682,9 @@ pub unsafe fn w_type_get_bases(obj: PyObjectRef) -> PyObjectRef {
 /// responsible for validating layout compatibility and recomputing the MRO.
 pub unsafe fn w_type_set_bases(obj: PyObjectRef, bases: PyObjectRef) {
     crate::gc_roots::pin_root(bases);
+    // Prebuilt-family store: `bases` lives on the Box-immortal type and is
+    // reached only by the `walk_type_dicts_gc` root walk.
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     (*(obj as *mut W_TypeObject)).bases = bases;
 }
 
@@ -836,6 +843,9 @@ pub unsafe fn w_type_add_subclass(w_parent: PyObjectRef, w_subclass: PyObjectRef
         return;
     }
     let parent = &mut *(w_parent as *mut W_TypeObject);
+    // Prebuilt-family store: the weak_subclasses list is reached only by the
+    // `walk_type_dicts_gc` root walk.
+    crate::gc_roots::mark_prebuilt_roots_dirty();
     if parent.weak_subclasses.is_null() {
         parent.weak_subclasses = Box::into_raw(Box::new(Vec::new()));
     }


### PR DESCRIPTION
#128 

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
