### PR TITLE
#131 follow-up: closure Fn-family keystone + Option combinator (unwrap_or/map_or) front-synthesis

### DIFF
--- a/majit/majit-translate/src/front/bool_then.rs
+++ b/majit/majit-translate/src/front/bool_then.rs
@@ -232,7 +232,11 @@ fn rewire_one_bool_then_site(graph: &mut FunctionGraph, site: &BoolThenSite) -> 
 }
 
 /// The arm inputarg `v` binds to, by position in the arm's source list.
-fn map_source(sources: &[Variable], inputs: &[Variable], v: &Variable) -> Option<Variable> {
+pub(crate) fn map_source(
+    sources: &[Variable],
+    inputs: &[Variable],
+    v: &Variable,
+) -> Option<Variable> {
     sources
         .iter()
         .position(|s| s == v)
@@ -244,7 +248,7 @@ fn map_source(sources: &[Variable], inputs: &[Variable], v: &Variable) -> Option
 /// Value is re-sourced from the arm's threaded inputarg, and constants
 /// pass through.  `Err` if a forwarded Value was not threaded into the arm
 /// (an unexpected live set) — the caller declines and keeps the residual.
-fn reproduce_exit_args(
+pub(crate) fn reproduce_exit_args(
     saved: &Link,
     result_var: &Variable,
     option_val: &Variable,
@@ -344,7 +348,7 @@ fn emit_option_variant(
 /// through `Link::new_mixed` + `set_control_flow_metadata`.  Arity matches
 /// B's inputargs because the args are derived from A's original B-bound
 /// exit.
-fn close_goto_mixed(
+pub(crate) fn close_goto_mixed(
     graph: &mut FunctionGraph,
     block: BlockId,
     target: BlockId,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1617,11 +1617,25 @@ pub fn lower_fun_decl_with_static_addrs(
         } else {
             crate::front::bool_then::rewire_bool_then_call_sites(&mut lo.graph, &lo.bool_then_sites)
         };
+        // The `Option::unwrap_or` value-select rewrite
+        // (`front::option_unwrap_or`) splits the residual `unwrap_or` call
+        // block into a `__discriminant` diamond, same post-lowering shape and
+        // fail-safe contract as `bool::then`; gate the reachability sweep on
+        // an actual rewrite.
+        let unwrap_or_rewritten = if lo.unwrap_or_sites.is_empty() {
+            0
+        } else {
+            crate::front::option_unwrap_or::rewire_unwrap_or_call_sites(
+                &mut lo.graph,
+                &lo.unwrap_or_sites,
+            )
+        };
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
             || checked_arith_rewritten > 0
             || bool_then_rewritten > 0
+            || unwrap_or_rewritten > 0
         {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
@@ -1957,6 +1971,12 @@ struct Lowering<'a> {
     /// resolved ctor/method owners the arms need (see
     /// [`crate::front::bool_then::BoolThenSite`]).
     bool_then_sites: Vec<crate::front::bool_then::BoolThenSite>,
+    /// `Option::unwrap_or(opt, default)` call sites recorded for the
+    /// discriminant value-select the `front::option_unwrap_or` post-pass
+    /// synthesizes after the body lowering completes.  Each carries the
+    /// resolved `Option` owners the arms' field reads need (see
+    /// [`crate::front::option_unwrap_or::UnwrapOrSite`]).
+    unwrap_or_sites: Vec<crate::front::option_unwrap_or::UnwrapOrSite>,
 }
 
 impl<'a> Lowering<'a> {
@@ -2113,6 +2133,7 @@ impl<'a> Lowering<'a> {
             next_call_results: Vec::new(),
             checked_arith_call_results: Vec::new(),
             bool_then_sites: Vec::new(),
+            unwrap_or_sites: Vec::new(),
         })
     }
 
@@ -5872,6 +5893,28 @@ impl<'a> Lowering<'a> {
         {
             self.bool_then_sites.push(site);
         }
+        // Capture `Option::unwrap_or(opt, default)` sites for the
+        // discriminant value-select `front::option_unwrap_or` synthesizes.
+        // `unwrap_or`'s body is Opaque (foreign `core`), but its receiver is
+        // the `Option` ADT, so `first_is_self` routes it to a
+        // `CallTarget::Method` (receiver in `args[0]`, default in `args[1]`),
+        // NOT a raw FunctionPath.  Resolving the `Option` field owners needs
+        // the receiver's `Option` type (`first_arg_ty`), in hand here;
+        // `recognize_unwrap_or_site` also confirms the receiver is an `Option`
+        // (not `Result`, whose variant tags differ).  A resolution miss
+        // leaves the residual call — an unregistered callee the rtyper census
+        // Skips, so no graph regresses.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && name == "unwrap_or"
+            && let Some(site) = self.recognize_unwrap_or_site(first_arg_ty.as_ref(), &result_var)
+        {
+            self.unwrap_or_sites.push(site);
+        }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var.clone()),
             kind: op_kind,
@@ -7221,6 +7264,36 @@ impl<'a> Lowering<'a> {
         Some(crate::front::bool_then::BoolThenSite {
             result_var: result_var.clone(),
             call_once_owner,
+            option_owner,
+            some_owner,
+            payload_ty,
+        })
+    }
+
+    /// Resolve a recognized `Option::unwrap_or(opt, default)` call into an
+    /// [`crate::front::option_unwrap_or::UnwrapOrSite`] — the `Option` enum
+    /// root + `Some` variant owners and the payload type the value-select
+    /// post-pass needs.  `None` (leaving the residual call) when the receiver
+    /// type is not a resolvable `Option`.
+    fn recognize_unwrap_or_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        result_var: &Variable,
+    ) -> Option<crate::front::option_unwrap_or::UnwrapOrSite> {
+        // Receiver `Option`: enum root + `Some` variant owners + payload.
+        // Guard on `Option` specifically — `Result::unwrap_or` shares the
+        // method name but its `Ok`/`Err` tags do not match `Some`=1/`None`=0.
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+            return None;
+        }
+        let def_id = self.tyref_adt_def_id(recv_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let option_owner = td.item_meta.name_path();
+        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        Some(crate::front::option_unwrap_or::UnwrapOrSite {
+            result_var: result_var.clone(),
             option_owner,
             some_owner,
             payload_ty,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1630,12 +1630,23 @@ pub fn lower_fun_decl_with_static_addrs(
                 &lo.unwrap_or_sites,
             )
         };
+        // The `Option::map_or` closure-select rewrite (`front::option_map_or`)
+        // splits the residual `map_or` call block into a `__discriminant`
+        // diamond whose `Some` arm calls the closure, same post-lowering shape
+        // and fail-safe contract as `unwrap_or`; gate the reachability sweep on
+        // an actual rewrite.
+        let map_or_rewritten = if lo.map_or_sites.is_empty() {
+            0
+        } else {
+            crate::front::option_map_or::rewire_map_or_call_sites(&mut lo.graph, &lo.map_or_sites)
+        };
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
             || checked_arith_rewritten > 0
             || bool_then_rewritten > 0
             || unwrap_or_rewritten > 0
+            || map_or_rewritten > 0
         {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
@@ -1977,6 +1988,10 @@ struct Lowering<'a> {
     /// resolved `Option` owners the arms' field reads need (see
     /// [`crate::front::option_unwrap_or::UnwrapOrSite`]).
     unwrap_or_sites: Vec<crate::front::option_unwrap_or::UnwrapOrSite>,
+    /// `Option::map_or(opt, default, closure)` call sites recorded for the
+    /// discriminant closure-select the `front::option_map_or` post-pass
+    /// synthesizes (see [`crate::front::option_map_or::MapOrSite`]).
+    map_or_sites: Vec<crate::front::option_map_or::MapOrSite>,
 }
 
 impl<'a> Lowering<'a> {
@@ -2134,6 +2149,7 @@ impl<'a> Lowering<'a> {
             checked_arith_call_results: Vec::new(),
             bool_then_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
+            map_or_sites: Vec::new(),
         })
     }
 
@@ -4979,6 +4995,14 @@ impl<'a> Lowering<'a> {
             Operand::Copy(p) | Operand::Move(p) => Some(clone_tyref(&p.ty)),
             Operand::Const(_) => None,
         });
+        // Third argument's MIR-declared type — `Option::map_or`'s closure env
+        // operand.  Captured before the operands are consumed so the
+        // `front::option_map_or` recording can resolve the closure ADT's
+        // `call_once` inherent-method owner.
+        let third_arg_ty: Option<TyRef> = call.args.get(2).and_then(|op| match op {
+            Operand::Copy(p) | Operand::Move(p) => Some(clone_tyref(&p.ty)),
+            Operand::Const(_) => None,
+        });
         for op in call.args {
             args.push(self.resolve_operand(mir_bb, op)?);
         }
@@ -5914,6 +5938,33 @@ impl<'a> Lowering<'a> {
             && let Some(site) = self.recognize_unwrap_or_site(first_arg_ty.as_ref(), &result_var)
         {
             self.unwrap_or_sites.push(site);
+        }
+        // Capture `Option::map_or(opt, default, closure)` sites for the
+        // discriminant closure-select `front::option_map_or` synthesizes.
+        // Like `unwrap_or`, `map_or`'s body is Opaque (foreign `core`) and its
+        // receiver is the `Option` ADT, so `first_is_self` routes it to a
+        // `CallTarget::Method` (receiver `args[0]`, default `args[1]`, closure
+        // env `args[2]`).  Resolving the `Option` field owners + closure
+        // `call_once` owner needs the receiver's `Option` type (`first_arg_ty`)
+        // and the env type (`third_arg_ty`), both in hand here;
+        // `recognize_map_or_site` also confirms the receiver is an `Option`.  A
+        // resolution miss leaves the residual call — an unregistered callee the
+        // rtyper census Skips, so no graph regresses.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 3
+            && name == "map_or"
+            && let Some(site) = self.recognize_map_or_site(
+                first_arg_ty.as_ref(),
+                third_arg_ty.as_ref(),
+                &call.dest.ty,
+                &result_var,
+            )
+        {
+            self.map_or_sites.push(site);
         }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var.clone()),
@@ -7297,6 +7348,47 @@ impl<'a> Lowering<'a> {
             option_owner,
             some_owner,
             payload_ty,
+        })
+    }
+
+    /// Resolve a recognized `Option::map_or(opt, default, closure)` call into a
+    /// [`crate::front::option_map_or::MapOrSite`] — the `Option` enum root +
+    /// `Some` variant owners, the closure env's `call_once` owner, the payload
+    /// type `T` (the `Some::__pos_0` read the closure consumes), and the result
+    /// type `U` (the `call_once` / select result).  `None` (leaving the residual
+    /// call) when the receiver is not a resolvable `Option` — guarding on
+    /// `Option` since `Result::map_or` shares the name but has different tags —
+    /// or the closure env type does not resolve to an ADT.
+    fn recognize_map_or_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        env_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::option_map_or::MapOrSite> {
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+            return None;
+        }
+        let def_id = self.tyref_adt_def_id(recv_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let option_owner = td.item_meta.name_path();
+        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        // Closure env ADT → its `name_path` is the `call_once` inherent method
+        // owner (`resolve_impl_owner_adt_def_id_free` records the same spelling
+        // for the closure's transparent `call_once` body).
+        let env_def_id = self.tyref_ref_adt_def_id(env_ty?)?;
+        let env_td = self.llbc.type_by_id(env_def_id)?;
+        let call_once_owner = env_td.item_meta.name_path();
+        let result_ty = tyref_to_value_type(dest_ty, self.llbc);
+        Some(crate::front::option_map_or::MapOrSite {
+            result_var: result_var.clone(),
+            option_owner,
+            some_owner,
+            call_once_owner,
+            payload_ty,
+            result_ty,
         })
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2028,7 +2028,7 @@ impl<'a> Lowering<'a> {
             // resolves through the unique-impl map
             // (`pyre_trait_unique_impls`, keyed by qualified path).
             let class_root = match &ty {
-                ValueType::Ref(_) => tyref_class_root(&local.ty, llbc)
+                ValueType::Ref(_) => tyref_input_class_root(&local.ty, llbc)
                     // A `&str` / `str` param strips to the `str` builtin
                     // (not an ADT), so `tyref_class_root` answers `None`;
                     // name it `"str"` so `derive_subject_inputcells` seeds
@@ -10084,6 +10084,22 @@ fn adt_path_of_tyref(ty: &TyRef, llbc: &Llbc) -> Option<String> {
     let node = strip_ty_wrappers(node, llbc)?;
     let id = adt_node_def_id(node)?;
     Some(llbc.type_by_id(id)?.item_meta.name_path())
+}
+
+/// The struct-root `class_root` for a `Ref`-typed input param: the bare
+/// ADT leaf (`tyref_class_root`), except for a closure env, whose shared
+/// bare leaf `closure` `harden_duplicate_leaf_metadata` drops from the
+/// field registry — carry its full `::` `name_path` (a surviving
+/// registry key) so `derive_subject_inputcells` projects the captured
+/// fields rather than seeding a classdef-less `SomeInstance(None)` shell
+/// its `self.<capture>` reads would wall on.  RPython forbids closures.
+fn tyref_input_class_root(ty: &TyRef, llbc: &Llbc) -> Option<String> {
+    let leaf = tyref_class_root(ty, llbc);
+    if leaf.as_deref() == Some("closure") {
+        adt_path_of_tyref(ty, llbc).or(leaf)
+    } else {
+        leaf
+    }
 }
 
 /// The inner [`ValueType`] of a `core::sync::atomic` atomic type

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -74,6 +74,7 @@ pub mod llbc_hints;
 pub mod mir;
 pub mod mir_dispatch;
 pub mod opcode_wrapper;
+pub(crate) mod option_unwrap_or;
 pub(crate) mod result_exc;
 pub mod semantic;
 pub mod typestr;

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -74,6 +74,7 @@ pub mod llbc_hints;
 pub mod mir;
 pub mod mir_dispatch;
 pub mod opcode_wrapper;
+pub(crate) mod option_map_or;
 pub(crate) mod option_unwrap_or;
 pub(crate) mod result_exc;
 pub mod semantic;

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -1,0 +1,564 @@
+//! `Option::map_or(opt, default, closure)` → discriminant closure-select.
+//!
+//! ## Positioning
+//!
+//! `core::option::<Impl>::map_or` is a foreign combinator whose body is
+//! Opaque in the LLBC (Charon cannot extract `core`), and whose receiver is
+//! the `Option` ADT, so `first_is_self` routes it to a `CallTarget::Method`
+//! (receiver in `args[0]`, `default` in `args[1]`, closure env in `args[2]`),
+//! NOT a raw FunctionPath — the same routing as [`crate::front::option_unwrap_or`].
+//! Like [`crate::front::bool_then`] and unlike [`crate::front::checked_arith`],
+//! the combinator's match lives inside the opaque body: at the call site there
+//! is no discriminant switch to rewrite, only `result = map_or(opt, default,
+//! closure)` flowing on.  This pass *creates* the two-way select the
+//! combinator's semantics imply:
+//!
+//! ```text
+//!     result = opt.map_or(default, |x| body)     // residual `map_or` call
+//! becomes
+//!     if opt.__discriminant == 1 { result = closure((opt.__pos_0,)) }
+//!     else                       { result = default }
+//! ```
+//!
+//! It is a hybrid of the two prior passes: the discriminant branch and the
+//! `None`-arm `default` forward come from `option_unwrap_or`; the `Some`-arm
+//! `call_once` on the closure env comes from `bool_then`.  The one structural
+//! difference from `bool_then` is the argument tuple: `map_or`'s closure is
+//! unary (it receives the unwrapped payload), so the `Args` tuple is `(x,)`
+//! rather than the niladic `()`, and the `call_once` result flows on directly
+//! (`map_or` returns the closure's `U`, not `Option<U>`).
+//!
+//! The branch is mandatory — the closure must not run when `opt` is `None`
+//! (its `opt.__pos_0` read would be against an absent payload), so a
+//! single-block always-call encoding is unsound.  `Option`'s tags are
+//! `None = 0` / `Some = 1`, and the front models every `Option<T>` uniformly
+//! with an explicit `__discriminant` field, so branching on the discriminant
+//! read as `bool(disc)` selects the `Some` arm exactly.
+//!
+//! ## The rewrite (`rewire_one_map_or_site`)
+//!
+//! Block A holds the residual `map_or` call producing `result` as its last op,
+//! closed by `lower_call` with a single forwarding exit to block B (the
+//! continuation consuming `result`).  The rewrite:
+//! 1. drops the `map_or` call, reads `disc = opt.__discriminant`, and closes A
+//!    with a `bool(disc)` branch to two fresh arms;
+//! 2. the `then_bb` (`Some`) arm reads `payload = opt.__pos_0`, builds the
+//!    `(payload,)` args tuple, calls the closure's `call_once`, and forwards
+//!    the call result;
+//! 3. the `else_bb` (`None`) arm forwards `default`;
+//! 4. both arms forward to B, reproducing A's original exit args with the
+//!    `result` slot sourced from the arm's call result / default value and
+//!    every other live value threaded through the arm's inputargs.
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `map_or` callee
+//! keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
+use crate::model::{
+    BlockId, CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
+
+/// A recognized `Option::map_or(opt, default, closure_env)` call site captured
+/// during body lowering (`front::mir` `recognize_map_or_site`).  The owner
+/// strings are resolved at the recording site where the receiver `Option` type
+/// and the closure env type are in hand; the post-pass only needs them to spell
+/// the field reads, the closure `call_once`, and the args tuple in the
+/// synthesized `Some` arm.
+#[derive(Clone)]
+pub(crate) struct MapOrSite {
+    /// The `map_or` call result (the closure return / `default` value `U`) —
+    /// locates block A.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// owner (matching the variant-qualified `resolve_adt_field` read owner).
+    pub some_owner: String,
+    /// The closure env ADT `name_path` — the inherent-method owner for the
+    /// `call_once` call the `Some` arm emits.
+    pub call_once_owner: String,
+    /// The `Option`'s payload `T` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` field kind (the closure's unwrapped input).
+    pub payload_ty: ValueType,
+    /// The `map_or` result `U` projected to a [`ValueType`] — the `call_once`
+    /// result kind and the select result kind.
+    pub result_ty: ValueType,
+}
+
+/// Rewrite every recorded `Option::map_or` call site into the discriminant
+/// closure-select diamond.  Fail-safe: a site whose block does not fit the
+/// residual-call shape is left untouched (Skip), so a mismatch never regresses
+/// a graph the legacy walker already handled.  Returns the number of sites
+/// rewritten.
+pub(crate) fn rewire_map_or_call_sites(graph: &mut FunctionGraph, sites: &[MapOrSite]) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_map_or_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `map_or` call; the unregistered callee
+                // keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `map_or` residual call producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: map_or result var has no producer block"))?;
+
+    // Locate the `map_or` call op by its result (not assuming it is the block
+    // tail).
+    let ci = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .ok_or_else(|| format!("{name}: map_or call op not found in block {a}"))?;
+    let ops_len = graph.blocks[a].operations.len();
+
+    // `lower_call` closes the call as the block tail, but a `*mut <registered
+    // ADT>` result gains a trailing `__pyre_cast_instance` narrowing op
+    // (`result_narrow_root`) whose output is what the block forwards on.
+    // Absorb that optional cast: `flow_result` is the value B consumes,
+    // `narrow_root` re-applies the narrowing per arm, and `remove_upto` bounds
+    // the ops to drop.  Any other trailing shape declines (fail-safe).
+    let (flow_result, narrow_root, remove_upto) = if ci + 1 == ops_len {
+        (site.result_var.clone(), None, ci)
+    } else if ci + 2 == ops_len {
+        let cast = &graph.blocks[a].operations[ci + 1];
+        match (&cast.kind, cast.result.as_ref()) {
+            (
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                },
+                Some(narrowed),
+            ) if segments.len() == 2
+                && segments[0] == "__pyre_cast_instance"
+                && args.len() == 1
+                && args[0] == site.result_var =>
+            {
+                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+            }
+            _ => {
+                return Err(format!(
+                    "{name}: map_or call is not the last op of block {a}"
+                ));
+            }
+        }
+    } else {
+        return Err(format!(
+            "{name}: map_or call is not the last op of block {a}"
+        ));
+    };
+
+    // Capture the receiver `Option` + default + closure env operands.
+    let (opt, default, env) = match &graph.blocks[a].operations[ci].kind {
+        OpKind::Call { args, .. } if args.len() == 3 => {
+            (args[0].clone(), args[1].clone(), args[2].clone())
+        }
+        other => {
+            return Err(format!(
+                "{name}: map_or producer op is not a 3-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → B (the continuation consuming the result).  Must be a
+    // plain goto — `lower_call` closes with exactly this shape.
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: map_or call block {a} does not have a single exit"
+        ));
+    };
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: map_or call block {a} exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let b_target = saved_exit.target;
+
+    // `carried` = the distinct live Values A forwards to B other than the
+    // result itself (`flow_result`, the narrowed value when a cast was
+    // absorbed); each must be threaded through the diamond arms to reach B (a
+    // fresh block cannot see A-scope Variables directly).
+    let mut carried: Vec<Variable> = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(v) = arg
+            && *v != flow_result
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // `then_bb` (`Some`) carries `carried` plus `opt` (the base for the
+    // `__pos_0` read) and `env` (the `call_once` receiver); `else_bb` (`None`)
+    // carries `carried` plus `default` (the forwarded fallback).  The
+    // source-var lists double as the branch link args.
+    let mut then_sources = carried.clone();
+    if !then_sources.contains(&opt) {
+        then_sources.push(opt.clone());
+    }
+    if !then_sources.contains(&env) {
+        then_sources.push(env.clone());
+    }
+    let mut else_sources = carried.clone();
+    if !else_sources.contains(&default) {
+        else_sources.push(default.clone());
+    }
+    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
+    let (else_bb, else_inputs) = graph.create_block_with_arg_vars(else_sources.len());
+
+    // `then_bb`: payload = opt.__pos_0; result = call_once(env, (payload,)).
+    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
+        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    let env_in_then = map_source(&then_sources, &then_inputs, &env)
+        .ok_or_else(|| format!("{name}: closure env not threaded into Some arm"))?;
+    let payload = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(payload.clone()),
+        kind: OpKind::FieldRead {
+            base: opt_in_then,
+            field: FieldDescriptor {
+                name: "__pos_0".to_string(),
+                owner_root: Some(site.some_owner.clone()),
+                owner_id: None,
+            },
+            ty: site.payload_ty.clone(),
+            pure: true,
+        },
+    });
+    // The closure's `Args` tuple `(payload,)` — the transparent-ctor + a
+    // single `__pos_0` FieldWrite, the same shape `Rvalue::Aggregate` emits for
+    // a tuple (owner_root `"Tuple"`, write ty `Ref(None)`).
+    let args_tuple = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(args_tuple.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::synthetic_transparent_ctor("Tuple"),
+            args: Vec::new(),
+            result_ty: ValueType::Ref(Some("Tuple".to_string())),
+        },
+    });
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: None,
+        kind: OpKind::FieldWrite {
+            base: args_tuple.clone(),
+            field: FieldDescriptor {
+                name: "__pos_0".to_string(),
+                owner_root: Some("Tuple".to_string()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(payload),
+            ty: ValueType::Ref(None),
+        },
+    });
+    let call_result = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(call_result.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::method("call_once", Some(site.call_once_owner.clone())),
+            args: vec![env_in_then, args_tuple],
+            result_ty: site.result_ty.clone(),
+        },
+    });
+    // Re-apply the absorbed `*mut <registered ADT>` narrowing to the closure
+    // result so the value B consumes keeps its pointee class (as the original
+    // single post-call cast did).
+    let then_result = emit_narrow(graph, then_bb, call_result, &narrow_root);
+    let then_link_args = reproduce_exit_args(
+        &saved_exit,
+        &flow_result,
+        &then_result,
+        &then_sources,
+        &then_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+
+    // `else_bb`: forward `default` as the result (narrowed to match the Some
+    // arm when a cast was absorbed).
+    let default_in_else = map_source(&else_sources, &else_inputs, &default)
+        .ok_or_else(|| format!("{name}: default value not threaded into None arm"))?;
+    let else_result = emit_narrow(graph, else_bb, default_in_else, &narrow_root);
+    let else_link_args = reproduce_exit_args(
+        &saved_exit,
+        &flow_result,
+        &else_result,
+        &else_sources,
+        &else_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, else_bb, b_target, else_link_args);
+
+    // A: drop the residual `map_or` call, read the discriminant, branch on it.
+    // `set_branch` appends the `bool(disc)` hop and installs the
+    // Bool(false)/Bool(true) arm links; `Option` tags None=0 / Some=1, so
+    // `bool(disc)` selects the `Some` (then) arm.  The receiver/default/env
+    // construction ops stay as A's tail.
+    let a_id = graph.blocks[a].id;
+    // Drop the `map_or` call and the absorbed narrowing cast (if any); both sit
+    // at index `ci` onward, so removing at `ci` `remove_upto - ci + 1` times
+    // clears exactly that range.
+    for _ in ci..=remove_upto {
+        graph.blocks[a].operations.remove(ci);
+    }
+    let disc = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(disc.clone()),
+        kind: OpKind::FieldRead {
+            base: opt.clone(),
+            field: FieldDescriptor {
+                name: "__discriminant".to_string(),
+                owner_root: Some(site.option_owner.clone()),
+                owner_id: None,
+            },
+            ty: ValueType::Int,
+            pure: true,
+        },
+    });
+    graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
+    Ok(())
+}
+
+/// Re-emit the `__pyre_cast_instance` pointee-class narrowing in `block` on
+/// `value`, returning the narrowed value — the same cast `result_narrow_root`
+/// appends after a `*mut <registered ADT>` call result.  `value` unchanged when
+/// no narrowing was absorbed.
+fn emit_narrow(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    value: Variable,
+    narrow_root: &Option<String>,
+) -> Variable {
+    let Some(root) = narrow_root else {
+        return value;
+    };
+    let narrowed = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(narrowed.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__pyre_cast_instance".to_string(), root.clone()],
+            },
+            args: vec![value],
+            result_ty: ValueType::Ref(Some(root.clone())),
+        },
+    });
+    narrowed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map_or_site(result_var: Variable) -> MapOrSite {
+        MapOrSite {
+            result_var,
+            option_owner: "core::option::Option".into(),
+            some_owner: "core::option::Option::Some".into(),
+            call_once_owner: "test::closure".into(),
+            payload_ty: ValueType::Int,
+            result_ty: ValueType::Int,
+        }
+    }
+
+    /// Build the minimal `result = map_or(opt, default, env)` shape — block A =
+    /// the residual call closed by a single goto to B (which consumes the
+    /// result) — and assert the rewrite drops the call, reads
+    /// `opt.__discriminant`, and branches to a `Some` arm (`opt.__pos_0` →
+    /// `call_once`) and a `None` arm (the `default`), both merging to B.
+    #[test]
+    fn rewrite_lifts_map_or_to_discriminant_closure_select() {
+        let mut g = FunctionGraph::new("test_map_or");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(42), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method("map_or", Some("core::option::Option".into())),
+                    args: vec![opt.clone(), default.clone(), env.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+
+        // B: the continuation consuming the map_or result.
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_map_or_call_sites(&mut g, &[map_or_site(result.clone())]);
+        assert_eq!(rewritten, 1, "the map_or site must be rewritten");
+
+        // The residual `map_or` call is gone; the only surviving Call ops are
+        // the synthesized args-tuple ctor and the closure `call_once`.
+        let call_targets: Vec<&CallTarget> = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::Call { target, .. } => Some(target),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !call_targets
+                .iter()
+                .any(|t| matches!(t, CallTarget::Method { name, .. } if name == "map_or")),
+            "residual map_or call removed"
+        );
+        assert!(
+            call_targets
+                .iter()
+                .any(|t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            "the Some arm calls the closure's call_once"
+        );
+        // Block A reads `opt.__discriminant` exactly once and branches two ways.
+        let disc_reads = g.blocks[a.0]
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__discriminant")
+            })
+            .count();
+        assert_eq!(disc_reads, 1, "A reads the Option discriminant once");
+        assert_eq!(g.blocks[a.0].exits.len(), 2, "A branches to Some/None arms");
+        // Exactly one arm reads `opt.__pos_0` (the Some payload).
+        let pos0_reads = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(
+                |op| matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__pos_0"),
+            )
+            .count();
+        assert_eq!(pos0_reads, 1, "the Some arm reads __pos_0");
+    }
+
+    /// The production shape: a `*mut <registered ADT>` result appends a
+    /// trailing `__pyre_cast_instance` narrowing op, so the call is NOT the
+    /// block tail.  The rewrite absorbs the cast, fires, and re-applies the
+    /// narrowing in both arms (so B still consumes a narrowed value).
+    #[test]
+    fn rewrite_absorbs_trailing_narrow_cast() {
+        let mut g = FunctionGraph::new("test_map_or_narrow");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(42), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method("map_or", Some("core::option::Option".into())),
+                    args: vec![opt.clone(), default.clone(), env.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        // The `result_narrow_root` cast the real lowering appends after the call.
+        let narrowed = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                    },
+                    args: vec![result.clone()],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+
+        // B consumes the NARROWED value (what the block actually forwards).
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![narrowed.clone()]);
+
+        // Site records the CALL result; the rewrite discovers the trailing cast.
+        let rewritten = rewire_map_or_call_sites(&mut g, &[map_or_site(result.clone())]);
+        assert_eq!(rewritten, 1, "the map_or site must be rewritten");
+
+        // Both the residual call and the trailing cast are gone from block A.
+        assert!(
+            !g.blocks[a.0].operations.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, .. } if name == "map_or"
+            )),
+            "residual map_or call removed from A"
+        );
+        // Two arms each re-emit a `__pyre_cast_instance` narrowing.
+        let narrow_casts = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                )
+            })
+            .count();
+        assert_eq!(narrow_casts, 2, "each diamond arm re-applies the narrowing");
+    }
+
+    /// A call block whose last op is not the recorded result declines
+    /// (fail-safe): the residual call survives untouched.
+    #[test]
+    fn rewrite_declines_when_call_not_last_op() {
+        let mut g = FunctionGraph::new("test_map_or_decline");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(2), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method("map_or", Some("core::option::Option".into())),
+                    args: vec![opt, default, env],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        // A trailing op after the call breaks the "call is A's last op" shape.
+        g.push_op_var(a, OpKind::ConstInt(9), true).unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_map_or_call_sites(&mut g, &[map_or_site(result)]);
+        assert_eq!(rewritten, 0, "a non-last-op call declines");
+        assert!(
+            g.blocks[a.0]
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::Call { target: CallTarget::Method { name, .. }, .. } if name == "map_or")),
+            "residual call survives on decline"
+        );
+    }
+}

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -1,0 +1,363 @@
+//! `Option::unwrap_or(opt, default)` → discriminant value-select.
+//!
+//! ## Positioning
+//!
+//! `core::option::<Impl>::unwrap_or` is a foreign combinator whose body is
+//! Opaque in the LLBC (Charon cannot extract `core`), so the caller emits a
+//! residual `unwrap_or` call — an unregistered callee the rtyper census
+//! Skips.  Like [`crate::front::bool_then`] and unlike
+//! [`crate::front::checked_arith`], the combinator's match lives inside the
+//! opaque body: at the call site there is no discriminant switch to rewrite,
+//! only `result = unwrap_or(opt, default)` flowing on.  This pass *creates*
+//! the two-way select the combinator's semantics imply:
+//!
+//! ```text
+//!     result = opt.unwrap_or(default)     // residual `unwrap_or` call
+//! becomes
+//!     if opt.__discriminant == 1 { result = opt.__pos_0 } else { result = default }
+//! ```
+//!
+//! Both candidates are already-computed values with no side effects, so a
+//! single-block value-select would be sound — but the graph has no
+//! conditional-move primitive, so the select is spelled as a two-arm diamond
+//! (the `Some` arm reads `opt.__pos_0`, the `None` arm forwards `default`).
+//! `Option`'s tags are `None = 0` / `Some = 1`, and the front models every
+//! `Option<T>` uniformly with an explicit `__discriminant` field (Rust niche
+//! optimisation is a codegen detail below the IR), so branching on the
+//! discriminant read as `bool(disc)` selects the `Some` arm exactly.
+//!
+//! ## The rewrite (`rewire_one_unwrap_or_site`)
+//!
+//! Block A holds the residual `unwrap_or` call producing `result` as its
+//! last op, closed by `lower_call` with a single forwarding exit to block B
+//! (the continuation consuming `result`).  The rewrite:
+//! 1. drops the `unwrap_or` call, reads `disc = opt.__discriminant`, and
+//!    closes A with a `bool(disc)` branch to two fresh arms;
+//! 2. the `then_bb` (`Some`) arm reads `opt.__pos_0` as the payload;
+//! 3. the `else_bb` (`None`) arm forwards `default`;
+//! 4. both arms forward to B, reproducing A's original exit args with the
+//!    `result` slot sourced from the arm's payload / default value and every
+//!    other live value threaded through the arm's inputargs.
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `unwrap_or`
+//! callee keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
+use crate::model::{FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+
+/// A recognized `Option::unwrap_or(opt, default)` call site captured during
+/// body lowering (`front::mir` `recognize_unwrap_or_site`).  The owner
+/// strings are resolved at the recording site where the receiver `Option`
+/// type is in hand; the post-pass only needs them to spell the
+/// `__discriminant` / `__pos_0` field reads in the synthesized arms.
+#[derive(Clone)]
+pub(crate) struct UnwrapOrSite {
+    /// The `unwrap_or` call result (the payload `T` value) — locates block A.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// owner (matching the variant-qualified `resolve_adt_field` read owner).
+    pub some_owner: String,
+    /// The `Option`'s payload `T` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` field kind and the select result kind.
+    pub payload_ty: ValueType,
+}
+
+/// Rewrite every recorded `Option::unwrap_or` call site into the
+/// discriminant value-select diamond.  Fail-safe: a site whose block does
+/// not fit the residual-call shape is left untouched (Skip), so a mismatch
+/// never regresses a graph the legacy walker already handled.  Returns the
+/// number of sites rewritten.
+pub(crate) fn rewire_unwrap_or_call_sites(
+    graph: &mut FunctionGraph,
+    sites: &[UnwrapOrSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_unwrap_or_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `unwrap_or` call; the unregistered
+                // callee keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `unwrap_or` residual call producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: unwrap_or result var has no producer block"))?;
+
+    // The call must be A's last op (lower_call closes the block right after
+    // pushing it) so removing it leaves the receiver/default construction as
+    // the block tail.
+    let call_idx = graph.blocks[a].operations.len() - 1;
+    if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
+        return Err(format!(
+            "{name}: unwrap_or call is not the last op of block {a}"
+        ));
+    }
+    // Capture the receiver `Option` + default operands.
+    let (opt, default) = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
+        other => {
+            return Err(format!(
+                "{name}: unwrap_or producer op is not a 2-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → B (the continuation consuming the payload).  Must be
+    // a plain goto — `lower_call` closes with exactly this shape.
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: unwrap_or call block {a} does not have a single exit"
+        ));
+    };
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: unwrap_or call block {a} exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let b_target = saved_exit.target;
+
+    // `carried` = the distinct live Values A forwards to B other than the
+    // payload itself; each must be threaded through the diamond arms to reach
+    // B (a fresh block cannot see A-scope Variables directly).
+    let mut carried: Vec<Variable> = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(v) = arg
+            && *v != site.result_var
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // `then_bb` (`Some`) carries `carried` plus `opt` (the base for the
+    // `__pos_0` read); `else_bb` (`None`) carries `carried` plus `default`
+    // (the forwarded fallback).  The source-var lists double as the branch
+    // link args.
+    let mut then_sources = carried.clone();
+    if !then_sources.contains(&opt) {
+        then_sources.push(opt.clone());
+    }
+    let mut else_sources = carried.clone();
+    if !else_sources.contains(&default) {
+        else_sources.push(default.clone());
+    }
+    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
+    let (else_bb, else_inputs) = graph.create_block_with_arg_vars(else_sources.len());
+
+    // `then_bb`: payload = opt.__pos_0.
+    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
+        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    let payload = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(payload.clone()),
+        kind: OpKind::FieldRead {
+            base: opt_in_then,
+            field: FieldDescriptor {
+                name: "__pos_0".to_string(),
+                owner_root: Some(site.some_owner.clone()),
+                owner_id: None,
+            },
+            ty: site.payload_ty.clone(),
+            pure: true,
+        },
+    });
+    let then_link_args = reproduce_exit_args(
+        &saved_exit,
+        &site.result_var,
+        &payload,
+        &then_sources,
+        &then_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+
+    // `else_bb`: forward `default` as the result.
+    let default_in_else = map_source(&else_sources, &else_inputs, &default)
+        .ok_or_else(|| format!("{name}: default value not threaded into None arm"))?;
+    let else_link_args = reproduce_exit_args(
+        &saved_exit,
+        &site.result_var,
+        &default_in_else,
+        &else_sources,
+        &else_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, else_bb, b_target, else_link_args);
+
+    // A: drop the residual `unwrap_or` call, read the discriminant, branch on
+    // it.  `set_branch` appends the `bool(disc)` hop and installs the
+    // Bool(false)/Bool(true) arm links; `Option` tags None=0 / Some=1, so
+    // `bool(disc)` selects the `Some` (then) arm.  The receiver/default
+    // construction ops stay as A's tail.
+    let a_id = graph.blocks[a].id;
+    graph.blocks[a].operations.remove(call_idx);
+    let disc = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(disc.clone()),
+        kind: OpKind::FieldRead {
+            base: opt.clone(),
+            field: FieldDescriptor {
+                name: "__discriminant".to_string(),
+                owner_root: Some(site.option_owner.clone()),
+                owner_id: None,
+            },
+            ty: ValueType::Int,
+            pure: true,
+        },
+    });
+    graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn unwrap_or_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["core", "option", "<Impl>", "unwrap_or"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn option_site(result_var: Variable) -> UnwrapOrSite {
+        UnwrapOrSite {
+            result_var,
+            option_owner: "core::option::Option".into(),
+            some_owner: "core::option::Option::Some".into(),
+            payload_ty: ValueType::Int,
+        }
+    }
+
+    /// Build the minimal `result = unwrap_or(opt, default)` shape — block A =
+    /// the residual call closed by a single goto to B (which consumes the
+    /// result) — and assert the rewrite drops the call, reads
+    /// `opt.__discriminant`, and branches to a `Some` arm (`opt.__pos_0`) and
+    /// a `None` arm (the `default`), both merging to B.
+    #[test]
+    fn rewrite_lifts_unwrap_or_to_discriminant_select() {
+        let mut g = FunctionGraph::new("test_unwrap_or");
+        let a = g.startblock;
+        // `opt` (the receiver Option) and `default`, both defined before the
+        // call; a `ConstInt` placeholder stands in for the Option value.
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(42), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_or_target(),
+                    args: vec![opt.clone(), default.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+
+        // B: the continuation consuming the unwrapped payload.
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_unwrap_or_call_sites(&mut g, &[option_site(result.clone())]);
+        assert_eq!(rewritten, 1, "the unwrap_or site must be rewritten");
+
+        // The residual `unwrap_or` call is gone from the whole graph.
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| matches!(&op.kind, OpKind::Call { .. })),
+            "residual unwrap_or call removed"
+        );
+        // Block A reads `opt.__discriminant` exactly once.
+        let disc_reads = g.blocks[a.0]
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__discriminant")
+            })
+            .count();
+        assert_eq!(disc_reads, 1, "A reads the Option discriminant once");
+        // Block A now branches two ways (Some / None arms).
+        assert_eq!(g.blocks[a.0].exits.len(), 2, "A branches to Some/None arms");
+        // Exactly one arm reads `opt.__pos_0` (the Some payload).
+        let pos0_reads = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(
+                |op| matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__pos_0"),
+            )
+            .count();
+        assert_eq!(pos0_reads, 1, "the Some arm reads __pos_0");
+        // Both arms merge to B.
+        let arms_to_b = g.blocks[a.0]
+            .exits
+            .iter()
+            .filter(|link| g.blocks[link.target.0].exits.iter().any(|l| l.target == b))
+            .count();
+        assert_eq!(
+            arms_to_b, 2,
+            "both diamond arms forward to the continuation"
+        );
+    }
+
+    /// A call block whose last op is not the recorded result declines
+    /// (fail-safe): the residual call survives untouched.
+    #[test]
+    fn rewrite_declines_when_call_not_last_op() {
+        let mut g = FunctionGraph::new("test_unwrap_or_decline");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_or_target(),
+                    args: vec![opt, default],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        // A trailing op after the call breaks the "call is A's last op" shape.
+        g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_unwrap_or_call_sites(&mut g, &[option_site(result)]);
+        assert_eq!(rewritten, 0, "a non-last-op call declines");
+        assert!(
+            g.blocks[a.0]
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::Call { .. })),
+            "residual call survives on decline"
+        );
+    }
+}

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1859,8 +1859,33 @@ pub fn translate_op(
                         if is_enum_variant {
                             bk.intern_enum_variant_host(owner_tail.unwrap(), &name)
                         } else {
-                            let qualname = format!("{}.{}", owner_path.join("."), name);
-                            bk.intern_class_by_qualname(&qualname)
+                            // A closure env ctor.  Normal struct ctors keep the
+                            // dotted qualname (`_init_classdef`'s
+                            // `struct_force_key_from_dotted_qualname` reduces it
+                            // to the `module::Type` FORCE key), but a closure's
+                            // deep `<Impl>::fn::closure` path does not reduce to
+                            // a field-registry key, so the dotted class mints
+                            // fieldless.  When the full `::` `name_path` IS a
+                            // struct-root registry key, intern under it and
+                            // project the captured fields via
+                            // `getuniqueclassdef_for_struct_root`, matching the
+                            // fielded classdef the closure param-typing path
+                            // (`tyref_input_class_root`) derives.  RPython
+                            // forbids closures.
+                            let colon_qual = format!("{owner_qual}::{name}");
+                            let is_closure_root = name == "closure"
+                                && bk
+                                    .pyre_struct_fields
+                                    .borrow()
+                                    .as_ref()
+                                    .is_some_and(|reg| reg.fields.contains_key(&colon_qual));
+                            if is_closure_root {
+                                let _ = bk.getuniqueclassdef_for_struct_root(&colon_qual);
+                                bk.intern_class_by_qualname(&colon_qual)
+                            } else {
+                                let qualname = format!("{}.{}", owner_path.join("."), name);
+                                bk.intern_class_by_qualname(&qualname)
+                            }
                         }
                     };
                     let callable = Hlvalue::Constant(Constant::new(ConstValue::HostObject(host)));

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -326,11 +326,47 @@ impl PyreCallRegistry {
                 *leaf_struct_counts.entry(leaf).or_default() += 1;
             }
         }
+        // Reverse index: crate-stripped impl path → full-crate
+        // field-registry key.  Closure Fn-family methods register under
+        // the crate-stripped `self_ty_root` (`for_impl_method`), but the
+        // field registry and the closure receiver classdef both carry the
+        // full-crate spelling, so the closure seed recovers it by keying
+        // each registry root on its post-crate suffix.
+        let mut full_by_stripped: std::collections::HashMap<&str, &str> =
+            std::collections::HashMap::new();
+        for key in reg.fields.keys() {
+            if let Some((_, rest)) = key.split_once("::") {
+                full_by_stripped.entry(rest).or_insert(key.as_str());
+            }
+        }
         for (key, entry) in self.entries.borrow().iter() {
             let segs = key.segments();
             let [.., owner, method] = segs else {
                 continue;
             };
+            // Closure `Fn`/`FnMut`/`FnOnce` impl method.  Every closure
+            // type shares the bare leaf `closure`, so the leaf-ambiguity
+            // guard below would skip it (and duplicate-leaf hardening
+            // already dropped the `closure` field alias).  A closure IS
+            // unambiguous at its full path; recover the full-crate key and
+            // seed the method onto both the `::` struct-root class and the
+            // `.`-joined class the receiver getattr resolves to.  RPython
+            // forbids closures (`_assert_rpythonic`), so there is no
+            // upstream analogue.
+            if owner == "closure" && matches!(method.as_str(), "call_once" | "call" | "call_mut") {
+                let stripped = segs[..segs.len() - 1].join("::");
+                let Some(&reg_key) = full_by_stripped.get(stripped.as_str()) else {
+                    continue;
+                };
+                for qual in [reg_key.to_string(), reg_key.replace("::", ".")] {
+                    let class_host = self.bookkeeper.intern_class_by_qualname(&qual);
+                    class_host.class_set(
+                        method.clone(),
+                        ConstValue::HostObject(entry.host_object.clone()),
+                    );
+                }
+                continue;
+            }
             if !reg.fields.contains_key(owner) {
                 continue;
             }


### PR DESCRIPTION
#131 follow-up: closure Fn-family keystone + Option combinator front-synthesis.

Four commits on top of `main` (rebased onto `261c258c9c`):

- **`front: synthesize Option::unwrap_or into discriminant value-select`** — new `front/option_unwrap_or.rs` rewrites the residual `unwrap_or` call block into a `__discriminant` diamond (Some → payload, None → default). Fail-safe: a structural mismatch leaves the residual call (rtyper census Skip). Shares `bool_then::map_source`/exit helpers (promoted to `pub(crate)`).
- **`rtyper: seed closure Fn-family methods onto per-closure classdef`** (L1 keystone) — the annotator resolves closure `call_once`/`call`/`call_mut` to an inlinable inherent-method PBC by seeding them onto the per-closure classdef.
- **`front/rtyper: resolve closure env to its fielded struct-root classdef`** (L2) — gives the closure env `self` a fielded `::` struct-root classdef so captured-field reads resolve.
- **`front: synthesize Option::map_or into discriminant closure-select`** (L3) — new `front/option_map_or.rs` lifts `opt.map_or(default, closure)` into a `__discriminant` diamond (Some → `(payload,)` tuple → `call_once(env, args)`; None → default), absorbing the optional trailing `__pyre_cast_instance` narrowing cast and re-applying it per arm. Fail-safe.

All passes run before annotation and decline on any shape mismatch, so no graph regresses.

## Verification
- `cargo test -p majit-translate` — 0 failed (incl. `test_mir_frontend`, `test_result_exc_lowering`, and the new `option_map_or`/`option_unwrap_or` unit tests)
- `pyre/check.py` — dynasm 169/169, cranelift 169/169 (2/2 backends)

Assisted-by: Claude
