### PR TITLE
rbuilder: ll_getlength/ll_bool/ll_new helper graphs

### DIFF
--- a/majit/examples/braininterp/src/jit_interp.rs
+++ b/majit/examples/braininterp/src/jit_interp.rs
@@ -11,6 +11,10 @@
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -43,7 +47,7 @@ fn mainloop(program: &Bytecode, threshold: u32) -> String {
     let mut driver: majit_metainterp::JitDriver<BfState> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let _stacksize: i32 = 0;
     let mut state = BfState {
         pointer: 0,
         tape: vec![0i64; TAPE_SIZE],

--- a/majit/examples/braininterp/src/main.rs
+++ b/majit/examples/braininterp/src/main.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 /// Mandelbrot set in Brainfuck (compact version).
 /// Source: https://github.com/erikdubbelboer/brainfuck-jit
+#[expect(dead_code, reason = "kept as the benchmark corpus fixture")]
 const MANDELBROT: &[u8] = b"+++++++++++++[->++>>>+++++>++>+<<<<<<]>>>>>++++++>--->>>>>>>\
 ++++++++[->+++++++++<]>[->+>+>+>+<<<<]+++>>+>+>+++++[>++>++++++<<-]+>>+>+>>>>>++>++>++>+\
 +>++>++>++>++>++>++<<<<<<<<<<<<<<<[>[->+<]>[-<+>>>>+<<<]>>>>>[->>>>>>>>>+<<<<<<<<<]>>>>>>\

--- a/majit/examples/calc/src/interp.rs
+++ b/majit/examples/calc/src/interp.rs
@@ -137,7 +137,7 @@ mod tests {
     fn test_loop_sum() {
         // sum = 0; i = 10; while i > 0: sum += i; i -= 1
         // Exercises: Jump, JumpIfFalse, StoreVar, LoadVar, Sub, Add, Gt
-        let prog = vec![
+        let _prog = vec![
             ByteCode::LoadConst(0),  //  0: push 0
             ByteCode::StoreVar(0),   //  1: sum = 0     (var a)
             ByteCode::LoadConst(10), //  2: push 10
@@ -159,7 +159,7 @@ mod tests {
                                        // Re-layout with correct targets:
         ];
         // Correct layout:
-        let prog = vec![
+        let _prog = vec![
             ByteCode::LoadConst(0),  //  0
             ByteCode::StoreVar(0),   //  1: sum = 0
             ByteCode::LoadConst(10), //  2

--- a/majit/examples/i64env/src/main.rs
+++ b/majit/examples/i64env/src/main.rs
@@ -46,7 +46,7 @@ fn mainloop(program: &Code, num_regs: usize, threshold: u32) -> i64 {
         COMPILES.fetch_add(1, Ordering::Relaxed);
     });
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let _stacksize: i32 = 0;
     let mut state = VmState {
         regs: vec![0; num_regs],
     };

--- a/majit/examples/tiny2/src/jit_interp.rs
+++ b/majit/examples/tiny2/src/jit_interp.rs
@@ -78,6 +78,10 @@ struct Tiny2State {
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -103,7 +107,7 @@ fn mainloop(program: &Bytecode, num_args: usize, args_out: &mut [i64], threshold
     let mut driver: majit_metainterp::JitDriver<Tiny2State> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let stacksize: i32 = 0;
     let mut state = Tiny2State {
         stackpos: num_args as i64,
         stack: vec![0i64; program.len()],

--- a/majit/examples/tiny3/src/jit_interp.rs
+++ b/majit/examples/tiny3/src/jit_interp.rs
@@ -81,6 +81,10 @@ struct Tiny3State {
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -106,7 +110,7 @@ fn mainloop(program: &Bytecode, num_args: usize, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<Tiny3State> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let stacksize: i32 = 0;
     let mut state = Tiny3State {
         stackpos: num_args as i64,
         stack: vec![0i64; program.len()],

--- a/majit/examples/tinyframe/src/jit_interp.rs
+++ b/majit/examples/tinyframe/src/jit_interp.rs
@@ -6,6 +6,10 @@ use crate::interp::{ADD, JUMP_IF_ABOVE, LOAD, RETURN};
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -45,7 +49,7 @@ fn mainloop(
     let mut driver: majit_metainterp::JitDriver<TinyFrameState> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let _stacksize: i32 = 0;
     let mut state = TinyFrameState {
         regs: vec![0; num_regs],
     };

--- a/majit/examples/tl/src/jit_interp.rs
+++ b/majit/examples/tl/src/jit_interp.rs
@@ -48,6 +48,10 @@ extern "C" fn storage_roll(stack_ptr: usize, stackpos: i64, r: i64) {
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -113,7 +117,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
         SPIKE_COMPILES.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     });
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let stacksize: i32 = 0;
     let mut state = TlState {
         stackpos: 0,
         stack: vec![0i64; program.len()],

--- a/majit/examples/tla/src/jit_interp.rs
+++ b/majit/examples/tla/src/jit_interp.rs
@@ -8,6 +8,10 @@
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -52,7 +56,7 @@ pub fn mainloop(program: &Bytecode, initial_value: i64, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<TlaState> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let stacksize: i32 = 0;
     let mut state = TlaState {
         stackpos: 1,
         stack: {

--- a/majit/examples/tlc/src/jit_interp.rs
+++ b/majit/examples/tlc/src/jit_interp.rs
@@ -17,6 +17,10 @@ use crate::interp::{self, ConstantPool};
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -115,7 +119,7 @@ pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<TlcState> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let stacksize: i32 = 0;
     // tlc.py:223 `self.stack = []` is a plain dynamic Python list (no
     // virtualizable). pyre's `state_fields = [int; virt]` requires a fixed
     // size; use `program.len()` as a safe upper bound (no sequence of

--- a/majit/examples/tlr/src/jit_interp.rs
+++ b/majit/examples/tlr/src/jit_interp.rs
@@ -7,6 +7,10 @@
 
 pub type Bytecode = [u8];
 
+#[expect(
+    dead_code,
+    reason = "the jit_interp macro resolves bytecode reads through this trait surface"
+)]
 trait BytecodeExt {
     fn get_op(&self, pc: usize) -> u8;
 }
@@ -53,7 +57,7 @@ fn mainloop(program: &Bytecode, initial_a: i64, threshold: u32) -> i64 {
     let mut driver: majit_metainterp::JitDriver<TlrState> =
         majit_metainterp::JitDriver::new(threshold);
     let mut pc: usize = 0;
-    let mut stacksize: i32 = 0;
+    let _stacksize: i32 = 0;
     let mut state = TlrState {
         a: initial_a,
         regs: Vec::new(),

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -5,7 +5,7 @@
 use majit_ir::{VecMap, VecMapExt, VecSet};
 use std::cell::{Cell, RefCell, UnsafeCell};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use cranelift_codegen::Context;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
@@ -505,6 +505,10 @@ struct RegisteredLoopTarget {
     /// 0 for FINISH traces (no JUMP/Label).
     header_pc: u64,
     /// RPython greenkey hash: function identifier for guard lookup.
+    #[expect(
+        dead_code,
+        reason = "registered loop targets retain green-key identity for bridge metadata"
+    )]
     green_key: u64,
     caller_prefix_layout: Option<ExitRecoveryLayout>,
     code_ptr: *const u8,
@@ -567,7 +571,15 @@ struct LoopTargetEntry {
     /// contract (compile.py:183-203 record_loop_or_bridge).
     fail_descrs: Box<[DescrRef]>,
     /// Position-aligned `FailDescrCell` wrappers — see `CompiledLoop`.
+    #[expect(
+        dead_code,
+        reason = "keeps baked fail-descr cells alive for parity with loop-code entries"
+    )]
     fail_descr_cells: Box<[Arc<majit_ir::FailDescrCell>]>,
+    #[expect(
+        dead_code,
+        reason = "loop-code entries retain input arity for the external-JUMP path"
+    )]
     num_inputs: usize,
     num_ref_roots: usize,
     max_output_slots: usize,
@@ -1086,6 +1098,10 @@ fn var(idx: u32) -> Variable {
 }
 
 /// Convert a slice of Values to a Vec of BlockArgs for Cranelift 0.130 branch instructions.
+#[expect(
+    dead_code,
+    reason = "kept as the Cranelift BlockArg adapter while typed branch lowering uses block_args_to"
+)]
 fn block_args(vals: &[CValue]) -> Vec<BlockArg> {
     vals.iter().copied().map(BlockArg::from).collect()
 }
@@ -1576,6 +1592,10 @@ struct GcRootSlotGuard {
 }
 
 impl GcRootSlotGuard {
+    #[expect(
+        dead_code,
+        reason = "constructor is paired with GcRootSlotGuard's retained RAII path"
+    )]
     fn new(slots: Vec<*mut GcRef>) -> Self {
         if slots.is_empty() {
             return Self {
@@ -3148,7 +3168,7 @@ fn call_assembler_guard_failure_inner(
         return handle as i64;
     }
 
-    let target = unsafe { &*fast_lookup_ca_target(token_number) };
+    let _target = unsafe { &*fast_lookup_ca_target(token_number) };
 
     // `history.py:109-114` `AbstractDescr.show(cpu, descr_gcref)`
     // parity.  `fail_descr_ptr` is the JIT-baked
@@ -6616,6 +6636,10 @@ pub(crate) fn fail_descr_set_trace_info(fd: &dyn FailDescr, trace_info: Compiled
 /// `ResumeGuardDescr::external_jump_target` slot.  Returns `None` for
 /// descrs without a `ResumeGuardDescr` meta AND for regular guard
 /// descrs (the common case).
+#[expect(
+    dead_code,
+    reason = "external-JUMP descr query is retained for bridge dispatch parity"
+)]
 pub(crate) fn fail_descr_external_jump_target(descr: &DescrRef) -> Option<DescrRef> {
     descr
         .as_any()
@@ -6826,6 +6850,10 @@ struct JitExecResult {
 }
 
 impl JitExecResult {
+    #[expect(
+        dead_code,
+        reason = "documents the JitFrame header layout for direct frame access"
+    )]
     const HEADER_WORDS: usize = (JF_FRAME_ITEM0_OFS as usize) / 8;
 
     /// Read jf_frame[index] as i64.
@@ -7177,6 +7205,10 @@ fn run_compiled_code_inner(
 }
 
 struct GuardInfo {
+    #[expect(
+        dead_code,
+        reason = "guard metadata keeps the assigned fail index alongside emitted layouts"
+    )]
     fail_index: u32,
     can_have_bridge: bool,
     fail_arg_refs: Vec<OpRef>,
@@ -7719,6 +7751,10 @@ impl CraneliftBackend {
     /// Delegates to the installed `GcAllocator`. RPython resolves the
     /// typeid through `cpu.gc_ll_descr`; in majit the gc_ll_descr role
     /// is filled by the active GC runtime registered via set_gc_allocator.
+    #[expect(
+        dead_code,
+        reason = "GC type-id lookup hook is retained for gcremovetypeptr parity"
+    )]
     fn lookup_typeid_from_classptr(&self, classptr: usize) -> Option<u32> {
         with_cranelift_gc(|gc| gc.get_typeid_from_classptr_if_gcremovetypeptr(classptr)).flatten()
     }
@@ -13889,7 +13925,7 @@ fn collect_guards(
     header_pc: u64,
     source_guard: Option<(u64, u32)>,
     caller_layout: Option<&ExitRecoveryLayout>,
-    constants: &majit_ir::VecMap<u32, i64>,
+    _constants: &majit_ir::VecMap<u32, i64>,
     attached_descrs: majit_backend::AttachedDescrPtrs,
 ) -> Result<(), BackendError> {
     let type_index = OpTypeIndex::new(inputargs, ops);
@@ -16380,9 +16416,9 @@ mod tests {
     use majit_gc::flags;
     use majit_gc::header::{GcHeader, header_of};
     use majit_gc::trace::TypeInfo;
-    use majit_ir::box_ref::BoxRef;
     use majit_ir::descr::{Descr, EffectInfo, ExtraEffect, SizeDescr};
     use majit_ir::operand::Operand;
+    use std::sync::Mutex;
 
     fn mk_op(opcode: OpCode, args: &[OpRef], pos: u32) -> majit_ir::OpRc {
         let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
@@ -16655,6 +16691,10 @@ mod tests {
         12.5
     }
 
+    #[expect(
+        dead_code,
+        reason = "ref-forcing residual-call test fixture retained for parity"
+    )]
     extern "C" fn maybe_force_and_return_ref(
         force_token: i64,
         flag: i64,
@@ -17300,7 +17340,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
 
         let inputargs = vec![InputArg::new_int(0), InputArg::new_ref(1)];
-        let mut guard = mk_op(
+        let guard = mk_op(
             OpCode::GuardTrue,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -17508,7 +17548,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(
+        let guard = mk_op(
             OpCode::GuardFalse,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -17603,7 +17643,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(
+        let guard = mk_op(
             OpCode::GuardFalse,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -17672,7 +17712,7 @@ mod tests {
 
         let bridge_fail_descr_arc = mk_test_resume_guard_descr(190, vec![Type::Int]);
         let bridge_fail_descr = bridge_fail_descr_arc.as_fail_descr().unwrap();
-        let mut bridge_guard = mk_op(
+        let bridge_guard = mk_op(
             OpCode::GuardFalse,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -17742,7 +17782,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut root_guard = mk_op(
+        let root_guard = mk_op(
             OpCode::GuardFalse,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -17808,7 +17848,7 @@ mod tests {
 
         let bridge_fail_descr_arc = mk_test_resume_guard_descr(290, vec![Type::Int]);
         let bridge_fail_descr = bridge_fail_descr_arc.as_fail_descr().unwrap();
-        let mut bridge_guard = mk_op(
+        let bridge_guard = mk_op(
             OpCode::GuardFalse,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -18331,7 +18371,7 @@ mod tests {
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 1);
+        let guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 1);
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -18379,7 +18419,7 @@ mod tests {
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 1);
+        let guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 1);
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -18420,7 +18460,7 @@ mod tests {
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -18471,7 +18511,7 @@ mod tests {
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -18526,7 +18566,7 @@ mod tests {
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 3);
+        let guard = mk_op(OpCode::GuardException, &[OpRef::int_op(101)], 3);
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -18598,7 +18638,7 @@ mod tests {
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardNoException, &[], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -20568,7 +20608,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
 
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard_op = mk_op(
+        let guard_op = mk_op(
             OpCode::GuardTrue,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -20664,7 +20704,7 @@ mod tests {
             InputArg::new_float(1),
             InputArg::new_ref(2),
         ];
-        let mut guard_op = mk_op(
+        let guard_op = mk_op(
             OpCode::GuardTrue,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -20714,7 +20754,7 @@ mod tests {
             InputArg::new_float(2),
             InputArg::new_ref(3),
         ];
-        let mut guard_op = mk_op(
+        let guard_op = mk_op(
             OpCode::GuardTrue,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -20914,7 +20954,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Void);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
+        let guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
             rb(OpRef::input_arg_int(1)),
             rb(OpRef::input_arg_int(0)),
@@ -20990,7 +21030,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Void);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
+        let guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
             rb(OpRef::input_arg_int(1)),
             rb(OpRef::input_arg_int(0)),
@@ -21065,7 +21105,7 @@ mod tests {
         // and its guard) must be rejected at compile time.
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Int);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
+        let guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
             rb(OpRef::input_arg_int(1)),
             rb(OpRef::int_op(3)),
@@ -21124,7 +21164,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Int);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
+        let guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
             rb(OpRef::input_arg_int(1)),
             rb(OpRef::int_op(3)),
@@ -21195,7 +21235,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
         let descr = make_call_descr(vec![Type::Ref, Type::Int], Type::Float);
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
+        let guard_op = mk_op(OpCode::GuardNotForced, &[], OpRef::NONE.raw());
         guard_op.setfailargs(smallvec::smallvec![
             rb(OpRef::input_arg_int(1)),
             rb(OpRef::float_op(3)),
@@ -21638,7 +21678,7 @@ mod tests {
         let loop_descr = make_label_descr(1500_260);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
@@ -21712,7 +21752,7 @@ mod tests {
         let loop_descr = make_label_descr(1500_259);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
@@ -21789,7 +21829,7 @@ mod tests {
             InputArg::new_int(1),
             InputArg::new_ref(2),
         ];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(4)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(4)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![
             rb(OpRef::input_arg_ref(0)),
             rb(OpRef::input_arg_int(1)),
@@ -21889,7 +21929,7 @@ mod tests {
         let body_descr = make_label_descr(1500_266);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
@@ -21974,7 +22014,7 @@ mod tests {
         let final_descr = make_label_descr(1500_270);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
@@ -22087,7 +22127,7 @@ mod tests {
         let final_descr = make_label_descr(1500_282);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
         let root_ops = vec![
             mk_op_with_descr(
@@ -22205,7 +22245,7 @@ mod tests {
         let final_descr = make_label_descr(1500_291);
 
         let inputargs = vec![InputArg::new_int(0)];
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![rb(OpRef::int_op(1))]);
         let root_ops = vec![
             // Peeled preamble: runs once on the initial host entry, before the
@@ -22695,7 +22735,7 @@ mod tests {
         backend.set_constants(consts);
         let size_arg = OpRef::int_op(10000);
         let inputargs = vec![];
-        let mut guard = mk_op(OpCode::GuardNonnull, &[OpRef::ref_op(2)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardNonnull, &[OpRef::ref_op(2)], OpRef::NONE.raw());
         guard.setfailargs(smallvec::smallvec![
             rb(OpRef::ref_op(0)),
             rb(OpRef::ref_op(1)),
@@ -23468,7 +23508,7 @@ mod tests {
         let mut backend = CraneliftBackend::new();
 
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
-        let mut guard1 = mk_op(
+        let guard1 = mk_op(
             OpCode::GuardTrue,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -23482,7 +23522,7 @@ mod tests {
             &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
             2,
         );
-        let mut guard2 = mk_op(OpCode::GuardFalse, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        let guard2 = mk_op(OpCode::GuardFalse, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard2.setfailargs(smallvec::smallvec![rb(OpRef::int_op(2))]);
         let ops = vec![
             mk_op(
@@ -23537,7 +23577,7 @@ mod tests {
             InputArg::new_ref(1),
             InputArg::new_float(2),
         ];
-        let mut guard = mk_op(
+        let guard = mk_op(
             OpCode::GuardTrue,
             &[OpRef::input_arg_int(0)],
             OpRef::NONE.raw(),
@@ -23609,7 +23649,7 @@ mod tests {
             ),
             mk_op(OpCode::IntGt, &[OpRef::int_op(1), OpRef::int_op(101)], 2),
             {
-                let mut g = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+                let g = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
                 g.setfailargs(smallvec::smallvec![rb(OpRef::input_arg_int(0))]);
                 g
             },

--- a/majit/majit-backend-cranelift/tests/integration.rs
+++ b/majit/majit-backend-cranelift/tests/integration.rs
@@ -8,7 +8,6 @@ use majit_backend::{
     Backend, ExitFrameLayout, ExitRecoveryLayout, ExitValueSourceLayout, JitCellToken,
 };
 use majit_backend_cranelift::{CraneliftBackend, force_token_to_dead_frame, jit_exc_raise};
-use majit_ir::box_ref::BoxRef;
 use majit_ir::operand::Operand;
 use majit_ir::{
     ArrayDescr, Descr, DescrRef, FieldDescr, GcRef, InputArg, Op, OpCode, OpRef, Type, Value,
@@ -1022,6 +1021,10 @@ impl majit_ir::CallDescr for TestCallDescr {
     }
 }
 
+#[expect(
+    dead_code,
+    reason = "optimizer descriptor fixture helper retained for coverage parity"
+)]
 fn field_descr(idx: u32) -> DescrRef {
     Arc::new(TestFieldDescr {
         idx,
@@ -1029,6 +1032,10 @@ fn field_descr(idx: u32) -> DescrRef {
     })
 }
 
+#[expect(
+    dead_code,
+    reason = "optimizer descriptor fixture helper retained for coverage parity"
+)]
 fn immutable_field_descr(idx: u32) -> DescrRef {
     Arc::new(TestFieldDescr {
         idx,
@@ -1036,6 +1043,10 @@ fn immutable_field_descr(idx: u32) -> DescrRef {
     })
 }
 
+#[expect(
+    dead_code,
+    reason = "optimizer descriptor fixture helper retained for coverage parity"
+)]
 fn call_descr_can_raise(idx: u32) -> DescrRef {
     Arc::new(TestCallDescr {
         idx,

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -632,7 +632,7 @@ fn add_refs(live: &mut Vec<OpRef>, args: &[OpRef]) {
 
 #[cfg(test)]
 mod tests {
-    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
+    use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
 
     use super::{GuardKind, IntBinKind, IntCmpKind, LirOp, TracePlan};
 
@@ -644,19 +644,19 @@ mod tests {
         let c1 = OpRef::const_int(1);
         let c10 = OpRef::const_int(10);
 
-        let mut label = Op::new(OpCode::Label, &[rb(i0)]);
+        let label = Op::new(OpCode::Label, &[rb(i0)]);
         label.pos.set(OpRef::int_op(10));
 
-        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
+        let add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(OpRef::int_op(1));
 
-        let mut lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(1)), rb(c10)]);
+        let lt = Op::new(OpCode::IntLt, &[rb(OpRef::int_op(1)), rb(c10)]);
         lt.pos.set(OpRef::int_op(2));
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
         guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
-        let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
+        let jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
         let plan = TracePlan::build(
@@ -694,16 +694,16 @@ mod tests {
         let i0 = OpRef::int_op(0);
         let c1 = OpRef::const_int(1);
 
-        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
+        let add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(OpRef::int_op(1));
 
-        let mut is_true = Op::new(OpCode::IntIsTrue, &[rb(OpRef::int_op(1))]);
+        let is_true = Op::new(OpCode::IntIsTrue, &[rb(OpRef::int_op(1))]);
         is_true.pos.set(OpRef::int_op(2));
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
         guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
-        let mut finish = Op::new(OpCode::Finish, &[]);
+        let finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
 
         let plan = TracePlan::build(
@@ -733,16 +733,16 @@ mod tests {
         let i0 = OpRef::int_op(0);
         let c1 = OpRef::const_int(1);
 
-        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
+        let add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(OpRef::int_op(1));
 
-        let mut is_true = Op::new(OpCode::IntIsTrue, &[rb(OpRef::int_op(1))]);
+        let is_true = Op::new(OpCode::IntIsTrue, &[rb(OpRef::int_op(1))]);
         is_true.pos.set(OpRef::int_op(2));
 
-        let mut guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
+        let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::int_op(2))]);
         guard.pos.set(OpRef::int_op(3));
         guard.setfailargs(vec![rb(OpRef::int_op(1))].into());
-        let mut jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
+        let jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
         let plan = TracePlan::build(
@@ -762,7 +762,7 @@ mod tests {
         let offset = OpRef::const_int(16);
         let size = OpRef::const_int(8);
 
-        let mut load = Op::new(
+        let load = Op::new(
             OpCode::GcLoadIndexedI,
             &[rb(base), rb(index), rb(scale), rb(offset), rb(size)],
         );
@@ -816,7 +816,7 @@ mod tests {
     #[test]
     fn lowers_misc_opcode_without_fallback() {
         let i0 = OpRef::int_op(0);
-        let mut same_as = Op::new(OpCode::SameAsI, &[rb(i0)]);
+        let same_as = Op::new(OpCode::SameAsI, &[rb(i0)]);
         same_as.pos.set(OpRef::int_op(1));
         let debug = Op::new(OpCode::JitDebug, &[]);
 
@@ -846,10 +846,10 @@ mod tests {
     #[test]
     fn lowers_remaining_guard_kinds_without_fallback() {
         let i0 = OpRef::int_op(0);
-        let mut is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
+        let is_object = Op::new(OpCode::GuardIsObject, &[rb(i0)]);
         is_object.pos.set(OpRef::int_op(1));
         is_object.setfailargs(vec![rb(i0)].into());
-        let mut future = Op::new(OpCode::GuardFutureCondition, &[]);
+        let future = Op::new(OpCode::GuardFutureCondition, &[]);
         future.pos.set(OpRef::int_op(2));
         future.setfailargs(vec![rb(i0)].into());
         let plan = TracePlan::build(

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -6032,21 +6032,21 @@ fn loc_eq(a: &Loc, b: &Loc) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use majit_ir::VecMap;
+
     use majit_ir::operand::Operand;
-    use majit_ir::{InputArg, Op, OpCode, OpRc, OpRef, Type};
+    use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
 
     use majit_ir::box_ref::bound_operand_from_opref as rb;
 
     fn make_op(opcode: OpCode, pos: u32, args: &[OpRef]) -> Op {
         let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
-        let mut op = Op::new(opcode, &bx);
+        let op = Op::new(opcode, &bx);
         op.pos.set(OpRef::int_op(pos));
         op
     }
 
     fn make_guard(opcode: OpCode, pos: u32, args: &[OpRef], fail_args: &[OpRef]) -> Op {
-        let mut op = make_op(opcode, pos, args);
+        let op = make_op(opcode, pos, args);
         op.setfailargs(fail_args.iter().map(|a| rb(*a)).collect());
         op
     }
@@ -6204,14 +6204,14 @@ mod tests {
 
         let inputargs = vec![InputArg::from_type(Type::Int, i0.raw())];
 
-        let mut add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
+        let add = Op::new(OpCode::IntAdd, &[rb(i0), rb(c1)]);
         add.pos.set(i1);
-        let mut is_true = Op::new(OpCode::IntIsTrue, &[rb(i1)]);
+        let is_true = Op::new(OpCode::IntIsTrue, &[rb(i1)]);
         is_true.pos.set(i2);
-        let mut guard = Op::new(OpCode::GuardTrue, &[rb(i2)]);
+        let guard = Op::new(OpCode::GuardTrue, &[rb(i2)]);
         guard.pos.set(OpRef::int_op(3));
         guard.setfailargs(vec![rb(i1)].into());
-        let mut finish = Op::new(OpCode::Finish, &[]);
+        let finish = Op::new(OpCode::Finish, &[]);
         finish.pos.set(OpRef::int_op(4));
         finish.setfailargs(vec![].into());
         finish.set_fail_arg_types(vec![]);
@@ -6298,9 +6298,9 @@ mod tests {
             InputArg::from_type(Type::Int, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::IntIsTrue, &[rb(i0)]);
+        let raw = Op::new(OpCode::IntIsTrue, &[rb(i0)]);
         raw.pos.set(i2);
-        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
+        let finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6342,10 +6342,10 @@ mod tests {
             InputArg::from_type(Type::Int, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::GuardTrue, &[rb(i0)]);
+        let raw = Op::new(OpCode::GuardTrue, &[rb(i0)]);
         raw.pos.set(OpRef::int_op(2));
         raw.setfailargs(vec![].into());
-        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
+        let finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6379,9 +6379,9 @@ mod tests {
             InputArg::from_type(Type::Ref, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::GcLoadI, &[rb(i0), rb(c0), rb(c8)]);
+        let raw = Op::new(OpCode::GcLoadI, &[rb(i0), rb(c0), rb(c8)]);
         raw.pos.set(i2);
-        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
+        let finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6424,7 +6424,7 @@ mod tests {
         ];
 
         let raw = Op::new(OpCode::GcStore, &[rb(i0), rb(c0), rb(i2), rb(c8)]);
-        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
+        let finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 
@@ -6460,9 +6460,9 @@ mod tests {
             InputArg::from_type(Type::Int, i1.raw()),
         ];
 
-        let mut raw = Op::new(OpCode::SameAsI, &[rb(i0)]);
+        let raw = Op::new(OpCode::SameAsI, &[rb(i0)]);
         raw.pos.set(i2);
-        let mut finish = Op::new(OpCode::Finish, &[rb(i1)]);
+        let finish = Op::new(OpCode::Finish, &[rb(i1)]);
         finish.pos.set(OpRef::int_op(3));
         let ops = vec![raw, finish];
 

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -4103,7 +4103,7 @@ mod tests {
         let direct = backend.execute_token(&callee_token, &[Value::Ref(payload)]);
         assert_eq!(backend.get_ref_value(&direct, 0), payload);
 
-        let mut call = mk_op(OpCode::CallAssemblerR, &[OpRef::input_arg_ref(0)], 1);
+        let call = mk_op(OpCode::CallAssemblerR, &[OpRef::input_arg_ref(0)], 1);
         call.setdescr(make_call_assembler_descr(
             &callee_token,
             vec![Type::Ref],
@@ -4139,7 +4139,7 @@ mod tests {
         // resoperation.py:719 InputArgInt — slot 0 is `InputArg::new_int(0)`,
         // referenced via `OpRef::input_arg_int(0)`. Variant-aware Eq/Hash
         // treats `IntOp(0)` and `InputArgInt(0)` as disjoint Box classes.
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(1)], OpRef::NONE.raw());
         guard.setfailargs(vec![rb(OpRef::input_arg_int(0))].into());
         let ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_int(0)], OpRef::NONE.raw()),
@@ -4155,7 +4155,7 @@ mod tests {
                 2,
             ),
             {
-                let mut call = mk_op(OpCode::CallAssemblerI, &[OpRef::int_op(2)], 3);
+                let call = mk_op(OpCode::CallAssemblerI, &[OpRef::int_op(2)], 3);
                 call.setdescr(make_call_assembler_descr(
                     &token,
                     vec![Type::Int],
@@ -4226,7 +4226,7 @@ mod tests {
 
         let mut token = JitCellToken::new(1603);
         backend.register_pending_target(token.number, vec![Type::Int, Type::Ref], 2, 2, -1);
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard.setfailargs(vec![rb(OpRef::input_arg_int(0)), rb(OpRef::input_arg_ref(1))].into());
         let ops = vec![
             mk_op(
@@ -4246,7 +4246,7 @@ mod tests {
                 3,
             ),
             {
-                let mut call = mk_op(
+                let call = mk_op(
                     OpCode::CallAssemblerR,
                     &[OpRef::int_op(3), OpRef::input_arg_ref(1)],
                     4,
@@ -4326,7 +4326,7 @@ mod tests {
         token.virtualizable_arg_index = Some(0);
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(
@@ -4346,7 +4346,7 @@ mod tests {
                 3,
             ),
             {
-                let mut call = mk_op(
+                let call = mk_op(
                     OpCode::CallAssemblerR,
                     &[OpRef::input_arg_ref(0), OpRef::int_op(3)],
                     4,
@@ -4419,7 +4419,7 @@ mod tests {
         let callee_inputargs = vec![InputArg::new_ref(0), InputArg::new_int(1)];
         let field_descr: DescrRef =
             Arc::new(majit_ir::SimpleFieldDescr::new(0, 16, 8, Type::Int, false));
-        let mut entry_getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 2);
+        let entry_getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 2);
         entry_getfield.setdescr(field_descr);
         let callee_ops = vec![
             mk_op(
@@ -4449,7 +4449,7 @@ mod tests {
             const_overrides: vec![],
             arg_overrides: vec![],
         };
-        let mut call = mk_op(
+        let call = mk_op(
             OpCode::CallAssemblerI,
             &[OpRef::input_arg_ref(0), OpRef::input_arg_int(1)],
             2,
@@ -4511,7 +4511,7 @@ mod tests {
         token.virtualizable_arg_index = Some(0);
         backend.register_pending_target(token.number, vec![Type::Ref, Type::Int], 2, 2, 0);
 
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(2)], OpRef::NONE.raw());
         guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
         let ops = vec![
             mk_op(
@@ -4531,7 +4531,7 @@ mod tests {
                 3,
             ),
             {
-                let mut call = mk_op(
+                let call = mk_op(
                     OpCode::CallAssemblerR,
                     &[OpRef::input_arg_ref(0), OpRef::int_op(3)],
                     4,
@@ -4554,7 +4554,7 @@ mod tests {
         backend.set_constants(majit_ir::VecMap::new());
         let field_descr: DescrRef =
             Arc::new(majit_ir::SimpleFieldDescr::new(0, 16, 8, Type::Int, false));
-        let mut getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 1);
+        let getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 1);
         getfield.setdescr(field_descr);
         let bridge_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
@@ -4613,12 +4613,12 @@ mod tests {
 
         let field_descr: DescrRef =
             Arc::new(majit_ir::SimpleFieldDescr::new(0, 16, 8, Type::Int, false));
-        let mut entry_getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 2);
+        let entry_getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 2);
         entry_getfield.setdescr(field_descr.clone());
 
-        let mut guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
+        let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(3)], OpRef::NONE.raw());
         guard.setfailargs(vec![rb(OpRef::input_arg_ref(0))].into());
-        let mut call1 = mk_op(
+        let call1 = mk_op(
             OpCode::CallAssemblerI,
             &[OpRef::input_arg_ref(0), OpRef::int_op(4)],
             6,
@@ -4628,7 +4628,7 @@ mod tests {
             vec![Type::Ref, Type::Int],
             Type::Int,
         ));
-        let mut call2 = mk_op(
+        let call2 = mk_op(
             OpCode::CallAssemblerI,
             &[OpRef::input_arg_ref(0), OpRef::int_op(5)],
             7,
@@ -4674,7 +4674,7 @@ mod tests {
         let guard_trace_id = backend.get_latest_descr(&failed).trace_id();
         let guard_descr = DynasmBackend::find_descr(&token, guard_trace_id, guard_fail_index);
         backend.set_constants(majit_ir::VecMap::new());
-        let mut bridge_getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 1);
+        let bridge_getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 1);
         bridge_getfield.setdescr(field_descr);
         let bridge_ops = vec![
             mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
@@ -4728,7 +4728,7 @@ mod tests {
         backend.set_constants(constants);
 
         let mut token = JitCellToken::new(1604);
-        let mut guard = mk_op(
+        let guard = mk_op(
             OpCode::GuardClass,
             &[OpRef::input_arg_ref(0), OpRef::int_op(100)],
             OpRef::NONE.raw(),
@@ -4753,7 +4753,7 @@ mod tests {
         let mut bridge_constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
         bridge_constants.insert(200, return_ref_passthrough as *const () as usize as i64);
         backend.set_constants(bridge_constants);
-        let mut bridge_value = mk_op(
+        let bridge_value = mk_op(
             OpCode::CondCallValueR,
             &[OpRef::input_arg_ref(0), OpRef::int_op(200)],
             1,
@@ -4818,7 +4818,7 @@ mod tests {
         backend.set_constants(constants);
 
         let mut token = JitCellToken::new(1618);
-        let mut guard = mk_op(
+        let guard = mk_op(
             OpCode::GuardClass,
             &[OpRef::input_arg_ref(1), OpRef::int_op(100)],
             OpRef::NONE.raw(),
@@ -4850,7 +4850,7 @@ mod tests {
         backend.set_constants(majit_ir::VecMap::new());
         let field_descr: DescrRef =
             Arc::new(majit_ir::SimpleFieldDescr::new(0, 16, 8, Type::Int, false));
-        let mut getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 2);
+        let getfield = mk_op(OpCode::GetfieldRawI, &[OpRef::input_arg_ref(0)], 2);
         getfield.setdescr(field_descr);
         let bridge_ops = vec![
             mk_op(
@@ -4910,7 +4910,7 @@ mod tests {
         backend.set_constants(constants);
 
         let mut token = JitCellToken::new(1605);
-        let mut passthrough = mk_op(
+        let passthrough = mk_op(
             OpCode::CondCallValueR,
             &[OpRef::input_arg_ref(0), OpRef::int_op(200)],
             1,
@@ -4961,16 +4961,16 @@ mod tests {
             .unwrap();
 
         let mut constants: majit_ir::VecMap<u32, i64> = majit_ir::VecMap::new();
-        constants.insert(200, return_ref_passthrough as usize as i64);
+        constants.insert(200, return_ref_passthrough as *const () as usize as i64);
         backend.set_constants(constants);
 
-        let mut plain_call = mk_op(
+        let plain_call = mk_op(
             OpCode::CallR,
             &[OpRef::int_op(200), OpRef::input_arg_ref(0)],
             1,
         );
         plain_call.setdescr(make_plain_call_descr(vec![Type::Ref], Type::Ref));
-        let mut call_asm = mk_op(OpCode::CallAssemblerR, &[OpRef::ref_op(1)], 2);
+        let call_asm = mk_op(OpCode::CallAssemblerR, &[OpRef::ref_op(1)], 2);
         call_asm.setdescr(make_call_assembler_descr(
             &callee_token,
             vec![Type::Ref],
@@ -5029,13 +5029,13 @@ mod tests {
         constants.insert(201, return_ref_passthrough as *const () as usize as i64);
         backend.set_constants(constants);
 
-        let mut plain_call = mk_op(
+        let plain_call = mk_op(
             OpCode::CallR,
             &[OpRef::int_op(201), OpRef::input_arg_ref(0)],
             2,
         );
         plain_call.setdescr(make_plain_call_descr(vec![Type::Ref], Type::Ref));
-        let mut call_asm = mk_op(
+        let call_asm = mk_op(
             OpCode::CallAssemblerR,
             &[OpRef::ref_op(2), OpRef::input_arg_ref(1)],
             3,
@@ -5104,9 +5104,9 @@ mod tests {
             .compile_loop(&callee_inputargs, &callee_ops, &mut callee_token)
             .unwrap();
 
-        let mut plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(203)], 1);
+        let plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(203)], 1);
         plain_call.setdescr(make_plain_call_descr(vec![], Type::Ref));
-        let mut call_asm = mk_op(
+        let call_asm = mk_op(
             OpCode::CallAssemblerR,
             &[OpRef::ref_op(1), OpRef::input_arg_ref(0)],
             2,
@@ -5185,7 +5185,7 @@ mod tests {
             .compile_loop(&callee_inputargs, &callee_ops, &mut callee_token)
             .unwrap();
 
-        let mut call_asm = mk_op(
+        let call_asm = mk_op(
             OpCode::CallAssemblerR,
             &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
             2,
@@ -5254,7 +5254,7 @@ mod tests {
         assert!(backend.get_latest_descr(&direct).is_finish());
         assert_eq!(backend.get_ref_value(&direct, 0), payload);
 
-        let mut call = mk_op(OpCode::CallAssemblerR, &[OpRef::input_arg_ref(0)], 1);
+        let call = mk_op(OpCode::CallAssemblerR, &[OpRef::input_arg_ref(0)], 1);
         call.setdescr(make_call_assembler_descr(
             &callee_token,
             vec![Type::Ref],
@@ -5313,9 +5313,9 @@ mod tests {
         consts.insert(203, alloc_marked_ref as *const () as usize as i64);
         backend.set_constants(consts);
 
-        let mut plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(203)], 1);
+        let plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(203)], 1);
         plain_call.setdescr(make_plain_call_descr(vec![], Type::Ref));
-        let mut call = mk_op(OpCode::CallAssemblerR, &[OpRef::ref_op(1)], 2);
+        let call = mk_op(OpCode::CallAssemblerR, &[OpRef::ref_op(1)], 2);
         call.setdescr(make_call_assembler_descr(
             &callee_token,
             vec![Type::Ref],
@@ -5363,7 +5363,7 @@ mod tests {
         backend.set_constants(consts);
         backend.set_gc_allocator(Box::new(gc));
 
-        let mut plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(205)], 0);
+        let plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(205)], 0);
         plain_call.setdescr(make_plain_call_descr(vec![], Type::Ref));
         let ops = vec![
             plain_call,
@@ -5407,7 +5407,7 @@ mod tests {
         backend.set_constants(consts);
         backend.set_gc_allocator(Box::new(gc));
 
-        let mut plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(206)], 0);
+        let plain_call = mk_op(OpCode::CallR, &[OpRef::int_op(206)], 0);
         plain_call.setdescr(make_plain_call_descr(vec![], Type::Ref));
         let ops = vec![
             plain_call,

--- a/majit/majit-backend-wasm/src/glue.rs
+++ b/majit/majit-backend-wasm/src/glue.rs
@@ -64,15 +64,40 @@ mod imports {
 pub fn compile_module(wasm_bytes: &[u8]) -> u32 {
     let ptr = wasm_bytes.as_ptr() as u32;
     let len = wasm_bytes.len() as u32;
-    unsafe { imports::jit_compile_wasm(ptr, len) }
+    #[cfg(feature = "web")]
+    {
+        imports::jit_compile_wasm(ptr, len)
+    }
+    #[cfg(not(feature = "web"))]
+    {
+        unsafe { imports::jit_compile_wasm(ptr, len) }
+    }
 }
 
 /// Execute a compiled JIT function with the given frame pointer.
 pub fn execute(func_id: u32, frame_ptr: u32) -> u32 {
-    unsafe { imports::jit_execute_wasm(func_id, frame_ptr) }
+    #[cfg(feature = "web")]
+    {
+        imports::jit_execute_wasm(func_id, frame_ptr)
+    }
+    #[cfg(not(feature = "web"))]
+    {
+        unsafe { imports::jit_execute_wasm(func_id, frame_ptr) }
+    }
 }
 
 /// Free a compiled JIT function.
+#[expect(
+    dead_code,
+    reason = "host bindings expose free for embedder parity even though the backend does not call it yet"
+)]
 pub fn free(func_id: u32) {
-    unsafe { imports::jit_free_wasm(func_id) }
+    #[cfg(feature = "web")]
+    {
+        imports::jit_free_wasm(func_id)
+    }
+    #[cfg(not(feature = "web"))]
+    {
+        unsafe { imports::jit_free_wasm(func_id) }
+    }
 }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -526,6 +526,13 @@ fn wasm_jitframe_tid() -> u32 {
 /// marked bit, so marking those indices exposes each home's `GcRef` (the high
 /// word stays unmarked). Returns `[data_word_count, word0, ...]` in `usize`
 /// words (GCMAP array layout: `gcmap[0]` = number of data words).
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        dead_code,
+        reason = "native test builds compile the wasm backend without running wasm frame entry"
+    )
+)]
 fn build_home_gcmap(home_count: usize) -> Box<[usize]> {
     let sign = std::mem::size_of::<isize>();
     let bits_per_word = std::mem::size_of::<usize>() * 8;

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -14,7 +14,7 @@ fn validate_wasm(bytes: &[u8]) {
 
 fn make_op(opcode: OpCode, args: &[OpRef], pos: OpRef) -> Op {
     let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
-    let mut op = Op::new(opcode, &bx);
+    let op = Op::new(opcode, &bx);
     op.pos.set(pos);
     op
 }
@@ -23,7 +23,7 @@ use majit_ir::box_ref::bound_operand_from_opref as rb;
 
 fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
     let bx: Vec<Operand> = args.iter().map(|a| rb(*a)).collect();
-    let mut op = Op::new(opcode, &bx);
+    let op = Op::new(opcode, &bx);
     op.setfailargs(smallvec![rb(fail_args[0]); 0]);
     let mut fa: smallvec::SmallVec<[Operand; 3]> = smallvec::SmallVec::new();
     for &a in fail_args {
@@ -37,7 +37,7 @@ fn make_guard(opcode: OpCode, args: &[OpRef], fail_args: &[OpRef]) -> Op {
 fn test_empty_trace() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let ops = vec![{
-        let mut op = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
+        let op = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
         op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
         op
     }];
@@ -159,7 +159,7 @@ fn test_float_ops() {
             OpRef::int_op(8),
         ),
         {
-            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(7))]);
+            let op = Op::new(OpCode::Finish, &[rb(OpRef::float_op(7))]);
             op.setfailargs(smallvec![rb(OpRef::float_op(7))]);
             op
         },
@@ -199,7 +199,7 @@ fn test_call_generates_import() {
             OpRef::int_op(1),
         ),
         {
-            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
+            let op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]);
             op.setfailargs(smallvec![rb(OpRef::int_op(1))]);
             op
         },
@@ -284,13 +284,13 @@ fn test_guard_types() {
         ),
         // GuardNoOverflow (0 args)
         {
-            let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
+            let op = Op::new(OpCode::GuardNoOverflow, &[]);
             op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         // GuardNotInvalidated (0 args, always pass)
         {
-            let mut op = Op::new(OpCode::GuardNotInvalidated, &[]);
+            let op = Op::new(OpCode::GuardNotInvalidated, &[]);
             op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
@@ -332,13 +332,13 @@ fn test_exception_guards() {
         Op::new(OpCode::Label, &[rb(OpRef::input_arg_int(0))]),
         // GuardNoException — 0 args, fails when an exception is pending.
         {
-            let mut op = Op::new(OpCode::GuardNoException, &[]);
+            let op = Op::new(OpCode::GuardNoException, &[]);
             op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
         },
         // GuardException(expected_type) — caught value bound to int_op(1).
         {
-            let mut op = Op::new(OpCode::GuardException, &[rb(OpRef::input_arg_int(0))]);
+            let op = Op::new(OpCode::GuardException, &[rb(OpRef::input_arg_int(0))]);
             op.pos.set(OpRef::int_op(1));
             op.setfailargs(smallvec![rb(OpRef::input_arg_int(0))]);
             op
@@ -585,7 +585,7 @@ fn test_sameas_and_conversions() {
             OpRef::int_op(9),
         ),
         {
-            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(9))]);
+            let op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(9))]);
             op.setfailargs(smallvec![rb(OpRef::int_op(9))]);
             op
         },
@@ -624,7 +624,7 @@ fn test_overflow_ops() {
             OpRef::int_op(2),
         ),
         {
-            let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
+            let op = Op::new(OpCode::GuardNoOverflow, &[]);
             op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
             op
         },
@@ -634,12 +634,12 @@ fn test_overflow_ops() {
             OpRef::int_op(3),
         ),
         {
-            let mut op = Op::new(OpCode::GuardNoOverflow, &[]);
+            let op = Op::new(OpCode::GuardNoOverflow, &[]);
             op.setfailargs(smallvec![rb(OpRef::int_op(3))]);
             op
         },
         {
-            let mut op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]);
+            let op = Op::new(OpCode::Finish, &[rb(OpRef::int_op(2))]);
             op.setfailargs(smallvec![rb(OpRef::int_op(2))]);
             op
         },

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -160,6 +160,7 @@ const ADDRESSABLE_SIZE: f64 = 9_223_372_036_854_775_808.0; // 2**63
 /// env.py:100-110 `get_total_memory_darwin`. Clamp the probed total memory:
 /// fall back to the addressable size when the probe failed (`<= 0`) and cap it
 /// at the addressable size otherwise.
+#[cfg(target_os = "macos")]
 fn get_total_memory_darwin(result: i64) -> f64 {
     if result <= 0 {
         ADDRESSABLE_SIZE

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(unused_variables))]
+
 /// GC rewriter — transforms high-level allocation and store operations
 /// into GC-aware lower-level IR before code generation.
 ///

--- a/majit/majit-ir/src/box_ref.rs
+++ b/majit/majit-ir/src/box_ref.rs
@@ -1275,6 +1275,10 @@ pub(crate) mod test_support {
 
     /// InputArg counterpart of [`bound_resop_operand`]: a self-rooting
     /// `Operand::InputArg` at `index`.
+    #[expect(
+        dead_code,
+        reason = "test-support helper retained for external fixture builders"
+    )]
     pub(crate) fn bound_inputarg_operand(tp: Type, index: u32) -> crate::operand::Operand {
         let (b, _ia) = bound_inputarg_box(tp, index);
         crate::operand::Operand::from_boxref(&b)
@@ -1372,6 +1376,7 @@ mod tests {
     /// InputArg counterpart of `bound_resop` — binds a fresh `BoxRef::new_inputarg`
     /// to a fresh `InputArgRc` so writes land on `inputarg.forwarded`
     /// (resoperation.py:700).
+    #[expect(dead_code, reason = "test helper retained for bound inputarg coverage")]
     fn bound_inputarg(tp: Type, index: u32) -> (BoxRef, InputArgRc) {
         let b = BoxRef::new_inputarg(tp, index);
         let ia = std::rc::Rc::new(InputArg::from_type(tp, index));

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -324,6 +324,7 @@ fn emit_helper_call_target_fn(
     let wrapper = match helper_call_kind_for_return(&func.sig.output) {
         HelperCallKind::Void => quote! {
             #[doc(hidden)]
+            #[allow(non_snake_case)]
             #vis extern "C" fn #trace_target_name(#(#wrapper_params),*) {
                 #helper_name(#(#converted_args),*);
             }
@@ -342,6 +343,7 @@ fn emit_helper_call_target_fn(
             };
             quote! {
                 #[doc(hidden)]
+                #[allow(non_snake_case)]
                 #vis extern "C" fn #trace_target_name(#(#wrapper_params),*) -> i64 {
                     #converted_return
                 }
@@ -353,6 +355,7 @@ fn emit_helper_call_target_fn(
             };
             let float_wrapper = quote! {
                 #[doc(hidden)]
+                #[allow(non_snake_case)]
                 #vis extern "C" fn #trace_target_name(#(#wrapper_params),*) -> f64 {
                     #helper_name(#(#converted_args),*)
                 }
@@ -367,6 +370,7 @@ fn emit_helper_call_target_fn(
             };
             let concrete_wrapper = quote! {
                 #[doc(hidden)]
+                #[allow(non_snake_case)]
                 #vis extern "C" fn #concrete_target_name(#(#wrapper_params),*) -> i64 {
                     #concrete_return
                 }
@@ -578,6 +582,7 @@ fn emit_helper_policy_fn(
     // (`RFFI_ERR_NONE`, `rffi.py:80`).
     Ok(quote! {
         #[doc(hidden)]
+        #[allow(non_snake_case)]
         #vis fn #helper_name() -> (u8, *const (), *const (), *const (), *const (), i32) {
             #body
         }
@@ -1903,6 +1908,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[doc(hidden)]
+        #[allow(non_snake_case)]
         pub(crate) fn #policy_name() -> (u8, *const (), *const (), *const (), *const (), i32) {
             (
                 #inferred_policy_code,

--- a/majit/majit-macros/tests/jit_module_test.rs
+++ b/majit/majit-macros/tests/jit_module_test.rs
@@ -60,6 +60,10 @@ fn test_functions_still_callable() {
 
 #[jit_module]
 mod empty_module {
+    #[expect(
+        dead_code,
+        reason = "plain function is intentionally skipped by jit_module discovery"
+    )]
     pub fn plain_fn() -> i64 {
         42
     }
@@ -176,6 +180,10 @@ mod impl_walk_module {
         }
 
         // No JIT attribute — must be skipped by discovery.
+        #[expect(
+            dead_code,
+            reason = "plain method is intentionally skipped by jit_module discovery"
+        )]
         pub fn ignore_me(_x: i64) -> i64 {
             0
         }

--- a/majit/majit-macros/tests/jit_struct_test.rs
+++ b/majit/majit-macros/tests/jit_struct_test.rs
@@ -1,6 +1,6 @@
 //! Smoke tests for `#[jit_struct]` — descr.py:105-127 / :218-239 auto-discovery.
 
-use majit_ir::descr::{Descr, FieldDescr, GcCache, LLType};
+use majit_ir::descr::{Descr, GcCache, LLType};
 use majit_ir::value::Type;
 use majit_macros::jit_struct;
 
@@ -12,7 +12,15 @@ struct Node {
 
 #[jit_struct]
 struct Stack {
+    #[expect(
+        dead_code,
+        reason = "field is inspected by jit_struct descriptor generation"
+    )]
     head: Option<Box<Node>>,
+    #[expect(
+        dead_code,
+        reason = "field is inspected by jit_struct descriptor generation"
+    )]
     size: usize,
 }
 

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -6887,7 +6887,7 @@ mod tests {
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&op));
         ctx.snapshot_boxes = snapshots;
-        opt.emit_operation(seeded_ops.pop().unwrap(), &mut ctx, false);
+        let _ = opt.emit_operation(seeded_ops.pop().unwrap(), &mut ctx, false);
 
         assert!(!ctx.in_final_emission);
         assert!(ctx.new_operations.iter().any(|op| op.opcode == OpCode::New));
@@ -6953,7 +6953,7 @@ mod tests {
         let (mut seeded_ops, snapshots) =
             super::super::seed_empty_guard_snapshots(std::slice::from_ref(&guard));
         ctx.snapshot_boxes = snapshots;
-        opt.emit_operation(seeded_ops.pop().unwrap(), &mut ctx, false);
+        let _ = opt.emit_operation(seeded_ops.pop().unwrap(), &mut ctx, false);
 
         let sp = ctx
             .build_imported_short_preamble()

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -8129,8 +8129,8 @@ mod tests {
 
         fn recursive_fresh_alloc_free_targets(&self) -> Option<(*const (), *const ())> {
             Some((
-                test_recursive_fresh_alloc as usize as *const (),
-                test_recursive_fresh_free as usize as *const (),
+                test_recursive_fresh_alloc as *const () as usize as *const (),
+                test_recursive_fresh_free as *const () as usize as *const (),
             ))
         }
     }

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -1339,29 +1339,31 @@ impl VableArrayInfo {
 /// layout described by `info`.
 #[cfg(test)]
 unsafe fn read_virtualizable_boxes(info: &VirtualizableInfo, obj_ptr: *const u8) -> Vec<i64> {
-    let mut boxes = Vec::with_capacity(info.num_static_extra_boxes);
+    unsafe {
+        let mut boxes = Vec::with_capacity(info.num_static_extra_boxes);
 
-    // Read static fields
-    for field in &info.static_fields {
-        let val = match field.field_type {
-            Type::Int => {
-                let ptr = obj_ptr.add(field.offset) as *const i64;
-                *ptr
-            }
-            Type::Float => {
-                let ptr = obj_ptr.add(field.offset) as *const f64;
-                f64::to_bits(*ptr) as i64
-            }
-            Type::Ref => {
-                let ptr = obj_ptr.add(field.offset) as *const i64;
-                *ptr
-            }
-            Type::Void => 0,
-        };
-        boxes.push(val);
+        // Read static fields
+        for field in &info.static_fields {
+            let val = match field.field_type {
+                Type::Int => {
+                    let ptr = obj_ptr.add(field.offset) as *const i64;
+                    *ptr
+                }
+                Type::Float => {
+                    let ptr = obj_ptr.add(field.offset) as *const f64;
+                    f64::to_bits(*ptr) as i64
+                }
+                Type::Ref => {
+                    let ptr = obj_ptr.add(field.offset) as *const i64;
+                    *ptr
+                }
+                Type::Void => 0,
+            };
+            boxes.push(val);
+        }
+
+        boxes
     }
-
-    boxes
 }
 
 /// Writes values back from JIT representation to a virtualizable heap object.
@@ -1373,20 +1375,22 @@ unsafe fn read_virtualizable_boxes(info: &VirtualizableInfo, obj_ptr: *const u8)
 /// layout described by `info`.
 #[cfg(test)]
 unsafe fn write_virtualizable_boxes(info: &VirtualizableInfo, obj_ptr: *mut u8, boxes: &[i64]) {
-    for (i, field) in info.static_fields.iter().enumerate() {
-        if i >= boxes.len() {
-            break;
-        }
-        match field.field_type {
-            Type::Int | Type::Ref => {
-                let ptr = obj_ptr.add(field.offset) as *mut i64;
-                *ptr = boxes[i];
+    unsafe {
+        for (i, field) in info.static_fields.iter().enumerate() {
+            if i >= boxes.len() {
+                break;
             }
-            Type::Float => {
-                let ptr = obj_ptr.add(field.offset) as *mut f64;
-                *ptr = f64::from_bits(boxes[i] as u64);
+            match field.field_type {
+                Type::Int | Type::Ref => {
+                    let ptr = obj_ptr.add(field.offset) as *mut i64;
+                    *ptr = boxes[i];
+                }
+                Type::Float => {
+                    let ptr = obj_ptr.add(field.offset) as *mut f64;
+                    *ptr = f64::from_bits(boxes[i] as u64);
+                }
+                Type::Void => {}
             }
-            Type::Void => {}
         }
     }
 }
@@ -1400,8 +1404,10 @@ unsafe fn write_virtualizable_boxes(info: &VirtualizableInfo, obj_ptr: *mut u8, 
 /// The caller must ensure `obj_ptr` points to a valid object.
 #[cfg(test)]
 unsafe fn reset_vable_token(info: &VirtualizableInfo, obj_ptr: *mut u8) {
-    let token_ptr = obj_ptr.add(info.token_offset) as *mut usize;
-    *token_ptr = 0;
+    unsafe {
+        let token_ptr = obj_ptr.add(info.token_offset) as *mut usize;
+        *token_ptr = 0;
+    }
 }
 
 /// Check if the vable_token is non-null (JIT code may be active).
@@ -1431,7 +1437,9 @@ unsafe fn force_virtualizable(
     obj_ptr: *mut u8,
     force_fn: impl FnOnce(u64),
 ) {
-    info.force_now(obj_ptr, force_fn);
+    unsafe {
+        info.force_now(obj_ptr, force_fn);
+    }
 }
 
 /// Read array lengths from a virtualizable heap object.
@@ -1443,7 +1451,7 @@ unsafe fn force_virtualizable(
 /// The caller must ensure `obj_ptr` points to a valid virtualizable object.
 #[cfg(test)]
 unsafe fn read_array_lengths(info: &VirtualizableInfo, obj_ptr: *const u8) -> Vec<usize> {
-    info.read_array_lengths_from_heap(obj_ptr)
+    unsafe { info.read_array_lengths_from_heap(obj_ptr) }
 }
 
 /// Read a virtualizable's array field contents from the heap.
@@ -1459,18 +1467,20 @@ unsafe fn read_virtualizable_array(
     obj_ptr: *const u8,
     length: usize,
 ) -> Vec<i64> {
-    let mut values = Vec::with_capacity(length);
-    for i in 0..length {
-        let array_ptr = array_info.data_ptr(obj_ptr);
-        let item_offset = array_info.items_offset + i * array_info.item_size;
-        let val = match array_info.item_type {
-            Type::Int | Type::Ref => *(array_ptr.add(item_offset) as *const i64),
-            Type::Float => f64::to_bits(*(array_ptr.add(item_offset) as *const f64)) as i64,
-            Type::Void => 0,
-        };
-        values.push(val);
+    unsafe {
+        let mut values = Vec::with_capacity(length);
+        for i in 0..length {
+            let array_ptr = array_info.data_ptr(obj_ptr);
+            let item_offset = array_info.items_offset + i * array_info.item_size;
+            let val = match array_info.item_type {
+                Type::Int | Type::Ref => *(array_ptr.add(item_offset) as *const i64),
+                Type::Float => f64::to_bits(*(array_ptr.add(item_offset) as *const f64)) as i64,
+                Type::Void => 0,
+            };
+            values.push(val);
+        }
+        values
     }
-    values
 }
 
 /// symbolic.py:get_array_token → itemsize = sizeof(ARRAY.OF).
@@ -1512,19 +1522,21 @@ pub fn item_size_for_type(ty: Type) -> usize {
 /// The caller must ensure `obj_ptr` is valid and the array has sufficient space.
 #[cfg(test)]
 unsafe fn write_virtualizable_array(array_info: &VableArrayInfo, obj_ptr: *mut u8, values: &[i64]) {
-    for (i, &val) in values.iter().enumerate() {
-        let array_ptr = array_info.data_ptr(obj_ptr.cast_const()) as *mut u8;
-        let item_offset = array_info.items_offset + i * array_info.item_size;
-        match array_info.item_type {
-            Type::Int | Type::Ref => {
-                let ptr = array_ptr.add(item_offset) as *mut i64;
-                *ptr = val;
+    unsafe {
+        for (i, &val) in values.iter().enumerate() {
+            let array_ptr = array_info.data_ptr(obj_ptr.cast_const()) as *mut u8;
+            let item_offset = array_info.items_offset + i * array_info.item_size;
+            match array_info.item_type {
+                Type::Int | Type::Ref => {
+                    let ptr = array_ptr.add(item_offset) as *mut i64;
+                    *ptr = val;
+                }
+                Type::Float => {
+                    let ptr = array_ptr.add(item_offset) as *mut f64;
+                    *ptr = f64::from_bits(val as u64);
+                }
+                Type::Void => {}
             }
-            Type::Float => {
-                let ptr = array_ptr.add(item_offset) as *mut f64;
-                *ptr = f64::from_bits(val as u64);
-            }
-            Type::Void => {}
         }
     }
 }

--- a/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
+++ b/majit/majit-metainterp/tests/jit_driver_runtime_parity.rs
@@ -248,6 +248,7 @@ struct MismatchedTypedState {
     acc: f64,
 }
 
+#[expect(dead_code, reason = "fixture type used by trait impl parity coverage")]
 struct TypedRestoreOnlyState {
     frame: usize,
     acc: f64,
@@ -417,6 +418,7 @@ impl JitState for VirtualizableSyncState {
     }
 }
 
+#[expect(dead_code, reason = "fixture type used by trait impl parity coverage")]
 struct NamedVirtualizableSyncState {
     frame: usize,
     stack: i64,
@@ -427,12 +429,17 @@ struct NamedVirtualizableSyncState {
 }
 
 #[repr(C)]
+#[expect(
+    dead_code,
+    reason = "heap-layout fixture for auto-virtualizable parity"
+)]
 struct AutoVirtualizableFrame {
     token: u64,
     stackpos: i64,
     stack_ptr: *mut u8,
 }
 
+#[expect(dead_code, reason = "fixture type used by trait impl parity coverage")]
 struct AutoVirtualizableState {
     frame: usize,
     stackpos: i64,

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -8,8 +8,7 @@
 
 use majit_metainterp::jitcode::insns::{
     BC_ABORT, BC_GETARRAYITEM_GC_I, BC_GOTO_IF_NOT_INT_EQ, BC_INLINE_CALL, BC_INT_ADD,
-    BC_INT_GUARD_VALUE, BC_INT_RETURN, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C, BC_LIVE,
-    BC_STORE_STATE_FIELD,
+    BC_INT_RETURN, BC_JIT_MERGE_POINT, BC_JIT_MERGE_POINT_C, BC_LIVE, BC_STORE_STATE_FIELD,
 };
 use majit_metainterp::{Assembler, BC_GOTO, JitCode, JitDriver};
 
@@ -144,9 +143,9 @@ fn dispatch_arm_subjitcode_lowers_state_field_write() {
 }
 
 mod or_pattern {
-    use super::{Bytecode, BytecodeExt, OP_INC_A, OP_NOP};
+    use super::{Bytecode, OP_INC_A, OP_NOP};
     use majit_metainterp::jitcode::insns::BC_INLINE_CALL;
-    use majit_metainterp::{Assembler, BC_GOTO, JitCode, JitDriver};
+    use majit_metainterp::{Assembler, BC_GOTO, JitDriver};
 
     struct OrDispatchState {
         a: i64,
@@ -401,7 +400,7 @@ fn dispatch_jitcode_emits_typed_return_for_default_arm() {
 }
 
 mod pre_promote {
-    use crate::BytecodeExt;
+
     use majit_metainterp::{Assembler, JitDriver};
 
     struct PromoteState {
@@ -538,7 +537,7 @@ fn register_dispatch_jitcode_stores_singleton() {
 /// non-empty. A.2.2-A.2.4 add lower-side recognition for the new surfaces
 /// (oparg fetch, last_instr store position) and pin shape via dedicated tests.
 mod oparg_minimal {
-    use crate::BytecodeExt;
+
     use majit_metainterp::{Assembler, JitDriver};
 
     struct OpargState {
@@ -597,7 +596,7 @@ mod oparg_minimal {
         // `#stacksize_expr = 0i32;`).  All examples that wire
         // `can_enter_jit!()` declare `let mut stacksize: i32 = 0;` in the
         // function scope; the OP_JUMP_BACK arm below requires the same.
-        let mut stacksize: i32 = 0;
+        let stacksize: i32 = 0;
         let mut state = OpargState {
             last_instr: 0,
             acc: 0,
@@ -1181,7 +1180,7 @@ mod oparg_minimal {
 /// `while opcode == EXTENDED_ARG` form, so the test asserts the body
 /// is non-empty.
 mod oparg_extended {
-    use crate::BytecodeExt;
+
     use majit_metainterp::jitcode::insns::{
         BC_ABORT, BC_GETARRAYITEM_GC_I, BC_INT_MUL, BC_INT_OR, BC_JIT_MERGE_POINT,
         BC_JIT_MERGE_POINT_C,
@@ -1398,7 +1397,7 @@ mod oparg_extended {
 /// `resolve_greens` must resolve the `pc` ident to register `i0` and emit
 /// `greens_i = [0]` in the `jit_merge_point` payload.
 mod oparg_with_pc_green {
-    use crate::BytecodeExt;
+
     use majit_metainterp::{Assembler, JitDriver};
 
     struct PcGreenState {
@@ -1647,7 +1646,7 @@ mod oparg_with_pc_green {
 ///   greens_base + 6: reds_r_len   = 0  (program is green)
 ///   greens_base + 7: reds_f_len   = 0
 mod oparg_with_pypy_parity_greens {
-    use crate::BytecodeExt;
+
     use majit_metainterp::{Assembler, JitDriver};
 
     struct ParityState {
@@ -1791,7 +1790,7 @@ mod oparg_with_pypy_parity_greens {
 /// `lower_value_expr` already handles `BinOp::Le` on int state fields, so
 /// no extension to the expression vocabulary is required by this fixture.
 mod oparg_with_body_local_state_le_green {
-    use crate::BytecodeExt;
+
     use majit_metainterp::{Assembler, JitDriver};
 
     struct LeGreenState {
@@ -2000,6 +1999,10 @@ mod oparg_with_body_local_method_call_green {
             0
         }
 
+        #[expect(
+            dead_code,
+            reason = "shape-test fixture mirrors the interpreter program API"
+        )]
         fn len(&self) -> usize {
             self.bytes.len()
         }
@@ -2277,7 +2280,7 @@ mod oparg_with_body_local_method_call_green {
 /// or shifts the merge-point payload trips this fixture rather than
 /// silently regressing rpaheui parity.
 mod oparg_with_full_4_green_parity {
-    use crate::BytecodeExt;
+
     use majit_metainterp::{Assembler, JitDriver};
 
     struct FullParityState {

--- a/majit/majit-translate/src/codewriter/longlong.rs
+++ b/majit/majit-translate/src/codewriter/longlong.rs
@@ -105,6 +105,7 @@ pub fn singlefloat2int(x: f32) -> i64 {
     x.to_bits() as i32 as i64
 }
 
+#[cfg(target_pointer_width = "64")]
 fn compute_hash_float(f: f64) -> i64 {
     if !f.is_finite() {
         if f.is_infinite() {
@@ -142,6 +143,7 @@ fn signed_intmask(x: i64) -> i64 {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
 fn frexp(f: f64) -> (f64, i32) {
     debug_assert!(f.is_finite());
     debug_assert_ne!(f, 0.0);

--- a/majit/majit-translate/src/translator/goal/unixcheckpoint.rs
+++ b/majit/majit-translate/src/translator/goal/unixcheckpoint.rs
@@ -12,6 +12,7 @@
 //! line-by-line control flow through a small runtime trait so the test process
 //! is not actually forked.
 
+#[cfg(unix)]
 use std::ffi::CString;
 use std::io::{self, BufRead, Write};
 
@@ -89,14 +90,30 @@ type Pid = i32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ForkResult {
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "fork parent result is only constructed on Unix")
+    )]
     Parent(Pid),
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "fork child result is only constructed on Unix")
+    )]
     Child,
     NotSupported,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WaitStatus {
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "wait exit status is only constructed on Unix")
+    )]
     Exited(i32),
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "wait signal status is only constructed on Unix")
+    )]
     Signaled(i32),
     Other(i32),
 }
@@ -109,7 +126,15 @@ trait CheckpointRuntime {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum WaitError {
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "EINTR wait retry is only constructed on Unix")
+    )]
     Interrupted,
+    #[cfg_attr(
+        not(unix),
+        expect(dead_code, reason = "wait errno is only constructed on Unix")
+    )]
     Other(i32),
 }
 
@@ -360,6 +385,13 @@ fn restart_process_real() -> Result<(), TaskError> {
     })
 }
 
+#[cfg_attr(
+    not(unix),
+    expect(
+        dead_code,
+        reason = "OS-error formatting is only used by Unix syscalls"
+    )
+)]
 fn last_os_task_error(context: &str) -> TaskError {
     TaskError {
         message: format!("{context} failed: {}", io::Error::last_os_error()),

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -11,11 +11,19 @@
 
 use std::sync::LazyLock;
 
+use crate::flowspace::model::{
+    Block, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
+    SpaceOperation,
+};
+use crate::flowspace::pygraph::PyGraph;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{
     ForwardReference, LowLevelType, Ptr, PtrTarget, Struct,
 };
 use crate::translator::rtyper::lltypesystem::rstr::{STRPTR, UNICODEPTR};
+use crate::translator::rtyper::rtyper::{
+    helper_pygraph_from_graph, variable_with_lltype, void_field_const,
+};
 
 fn ptr_to_lowlevel(target: LowLevelType) -> LowLevelType {
     match target {
@@ -205,6 +213,88 @@ pub fn ll_getlength() -> Result<(), TyperError> {
     Err(builder_runtime_deferred("ll_getlength"))
 }
 
+/// Synthesise `ll_getlength(ll_builder)` (`rbuilder.py:347-350`):
+/// `ll_builder.total_size - (ll_builder.current_end - ll_builder.current_pos)`.
+pub fn build_ll_getlength_helper_graph(
+    name: &str,
+    builder_ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let ll_builder = variable_with_lltype("ll_builder", builder_ptr_lltype);
+    let startblock = Block::shared(vec![Hlvalue::Variable(ll_builder.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Signed);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let current_end = variable_with_lltype("current_end", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(ll_builder.clone()),
+            void_field_const("current_end"),
+        ],
+        Hlvalue::Variable(current_end.clone()),
+    ));
+    let current_pos = variable_with_lltype("current_pos", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(ll_builder.clone()),
+            void_field_const("current_pos"),
+        ],
+        Hlvalue::Variable(current_pos.clone()),
+    ));
+    let num_chars_missing_from_last_piece =
+        variable_with_lltype("num_chars_missing_from_last_piece", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![
+            Hlvalue::Variable(current_end),
+            Hlvalue::Variable(current_pos),
+        ],
+        Hlvalue::Variable(num_chars_missing_from_last_piece.clone()),
+    ));
+    let total_size = variable_with_lltype("total_size", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(ll_builder),
+            void_field_const("total_size"),
+        ],
+        Hlvalue::Variable(total_size.clone()),
+    ));
+    let result = variable_with_lltype("result", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![
+            Hlvalue::Variable(total_size),
+            Hlvalue::Variable(num_chars_missing_from_last_piece),
+        ],
+        Hlvalue::Variable(result.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["ll_builder".to_string()],
+        func,
+    ))
+}
+
 pub fn ll_build() -> Result<(), TyperError> {
     Err(builder_runtime_deferred("ll_build"))
 }
@@ -343,6 +433,35 @@ mod tests {
         let err = super::ll_append_multiple_char().expect_err("multiple-char helper is deferred");
         assert!(err.is_missing_rtype_operation());
         assert!(err.to_string().contains("ll_append_multiple_char"));
+    }
+
+    #[test]
+    fn build_ll_getlength_reads_fields_and_returns_signed_length() {
+        use super::Hlvalue;
+        let helper =
+            super::build_ll_getlength_helper_graph("ll_getlength", super::STRINGBUILDERPTR.clone())
+                .expect("build_ll_getlength_helper_graph");
+        assert_eq!(helper.func.name, "ll_getlength");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        // total_size - (current_end - current_pos)
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(
+            ops,
+            vec!["getfield", "getfield", "int_sub", "getfield", "int_sub"]
+        );
+        assert_eq!(startblock.inputargs.len(), 1);
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(
+            ret.concretetype.borrow().clone(),
+            Some(LowLevelType::Signed)
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -22,7 +22,7 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 };
 use crate::translator::rtyper::lltypesystem::rstr::{STRPTR, UNICODEPTR};
 use crate::translator::rtyper::rtyper::{
-    helper_pygraph_from_graph, variable_with_lltype, void_field_const,
+    constant_with_lltype, helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
 
 fn ptr_to_lowlevel(target: LowLevelType) -> LowLevelType {
@@ -358,6 +358,142 @@ pub fn build_ll_bool_helper_graph(
     ))
 }
 
+/// Synthesise `ll_new(init_size)` (`rbuilder.py:446-455` / `469-478`):
+///
+/// ```python
+/// init_size = intmask(min(r_uint(init_size), r_uint(1280)))
+/// ll_builder = lltype.malloc(STRINGBUILDER)
+/// ll_builder.current_buf = ll_builder.mallocfn(init_size)
+/// ll_builder.current_pos = 0
+/// ll_builder.current_end = init_size
+/// ll_builder.total_size = init_size
+/// return ll_builder
+/// ```
+///
+/// `min` is `rbuiltin.ll_min` (`rbuiltin.py:238`) and `mallocfn` is the
+/// specialization's `staticAdtMethod(rstr.mallocstr / mallocunicode)`
+/// (`rbuilder.py:54`/`72`) — both baked in as `direct_call` callee consts,
+/// mirroring [`build_ll_call_lookup_function_helper_graph`]. `buf_lltype`
+/// is `STRPTR`/`UNICODEPTR` (the `current_buf` field and `mallocfn` result).
+pub fn build_ll_new_helper_graph(
+    name: &str,
+    builder_ptr_lltype: LowLevelType,
+    builder_struct: LowLevelType,
+    buf_lltype: LowLevelType,
+    min_fn: Constant,
+    mallocfn: Constant,
+) -> Result<PyGraph, TyperError> {
+    use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
+
+    let init_size = variable_with_lltype("init_size", LowLevelType::Signed);
+    let startblock = Block::shared(vec![Hlvalue::Variable(init_size.clone())]);
+    let return_var = variable_with_lltype("result", builder_ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+    let void_result = || variable_with_lltype("v", LowLevelType::Void);
+
+    // init_size = intmask(min(r_uint(init_size), r_uint(1280)))
+    let uint_size = variable_with_lltype("uint_size", LowLevelType::Unsigned);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "cast_int_to_uint",
+        vec![Hlvalue::Variable(init_size)],
+        Hlvalue::Variable(uint_size.clone()),
+    ));
+    let uint_min = variable_with_lltype("uint_min", LowLevelType::Unsigned);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(min_fn),
+            Hlvalue::Variable(uint_size),
+            constant_with_lltype(ConstValue::Int(1280), LowLevelType::Unsigned),
+        ],
+        Hlvalue::Variable(uint_min.clone()),
+    ));
+    let size = variable_with_lltype("size", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "cast_uint_to_int",
+        vec![Hlvalue::Variable(uint_min)],
+        Hlvalue::Variable(size.clone()),
+    ));
+
+    // ll_builder = lltype.malloc(STRINGBUILDER)
+    let ll_builder = variable_with_lltype("ll_builder", builder_ptr_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "malloc",
+        vec![lowlevel_type_const(builder_struct), gc_flavor_const()?],
+        Hlvalue::Variable(ll_builder.clone()),
+    ));
+
+    // ll_builder.current_buf = ll_builder.mallocfn(init_size)
+    let current_buf = variable_with_lltype("current_buf", buf_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![Hlvalue::Constant(mallocfn), Hlvalue::Variable(size.clone())],
+        Hlvalue::Variable(current_buf.clone()),
+    ));
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(ll_builder.clone()),
+            void_field_const("current_buf"),
+            Hlvalue::Variable(current_buf),
+        ],
+        Hlvalue::Variable(void_result()),
+    ));
+    // ll_builder.current_pos = 0
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(ll_builder.clone()),
+            void_field_const("current_pos"),
+            constant_with_lltype(ConstValue::Int(0), LowLevelType::Signed),
+        ],
+        Hlvalue::Variable(void_result()),
+    ));
+    // ll_builder.current_end = init_size
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(ll_builder.clone()),
+            void_field_const("current_end"),
+            Hlvalue::Variable(size.clone()),
+        ],
+        Hlvalue::Variable(void_result()),
+    ));
+    // ll_builder.total_size = init_size
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(ll_builder.clone()),
+            void_field_const("total_size"),
+            Hlvalue::Variable(size),
+        ],
+        Hlvalue::Variable(void_result()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(ll_builder)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["init_size".to_string()],
+        func,
+    ))
+}
+
 /// RPython `class BaseStringBuilderRepr(AbstractStringBuilderRepr)`.
 #[derive(Debug, Default)]
 pub struct BaseStringBuilderRepr;
@@ -536,6 +672,55 @@ mod tests {
             panic!("returnblock inputarg must be a Variable");
         };
         assert_eq!(ret.concretetype.borrow().clone(), Some(LowLevelType::Bool));
+    }
+
+    fn dummy_funcptr_const() -> super::Constant {
+        super::Constant::with_concretetype(super::ConstValue::None, LowLevelType::Void)
+    }
+
+    #[test]
+    fn build_ll_new_clamps_size_mallocs_builder_and_inits_fields() {
+        use super::Hlvalue;
+        let helper = super::build_ll_new_helper_graph(
+            "ll_new",
+            super::STRINGBUILDERPTR.clone(),
+            super::STRINGBUILDER.clone(),
+            super::STRPTR.clone(),
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_new_helper_graph");
+        assert_eq!(helper.func.name, "ll_new");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        // intmask(min(r_uint(init_size), 1280)); malloc; mallocfn; 4 setfields
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(
+            ops,
+            vec![
+                "cast_int_to_uint",
+                "direct_call",
+                "cast_uint_to_int",
+                "malloc",
+                "direct_call",
+                "setfield",
+                "setfield",
+                "setfield",
+                "setfield",
+            ]
+        );
+        assert_eq!(startblock.inputargs.len(), 1);
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(
+            ret.concretetype.borrow().clone(),
+            Some(super::STRINGBUILDERPTR.clone())
+        );
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -311,6 +311,53 @@ pub fn ll_bool() -> Result<(), TyperError> {
     Err(builder_runtime_deferred("ll_bool"))
 }
 
+/// Synthesise `ll_bool(ll_builder)` (`rbuilder.py:417-418`):
+/// `ll_builder != nullptr(lltype.typeOf(ll_builder).TO)`.
+pub fn build_ll_bool_helper_graph(
+    name: &str,
+    builder_ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let ll_builder = variable_with_lltype("ll_builder", builder_ptr_lltype.clone());
+    let startblock = Block::shared(vec![Hlvalue::Variable(ll_builder.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Bool);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // result = ptr_ne(ll_builder, nullptr(TO))
+    let null_builder = Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::None,
+        builder_ptr_lltype,
+    ));
+    let result = variable_with_lltype("result", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "ptr_ne",
+        vec![Hlvalue::Variable(ll_builder), null_builder],
+        Hlvalue::Variable(result.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["ll_builder".to_string()],
+        func,
+    ))
+}
+
 /// RPython `class BaseStringBuilderRepr(AbstractStringBuilderRepr)`.
 #[derive(Debug, Default)]
 pub struct BaseStringBuilderRepr;
@@ -462,6 +509,33 @@ mod tests {
             ret.concretetype.borrow().clone(),
             Some(LowLevelType::Signed)
         );
+    }
+
+    #[test]
+    fn build_ll_bool_compares_pointer_against_null_and_returns_bool() {
+        use super::Hlvalue;
+        let helper = super::build_ll_bool_helper_graph("ll_bool", super::STRINGBUILDERPTR.clone())
+            .expect("build_ll_bool_helper_graph");
+        assert_eq!(helper.func.name, "ll_bool");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        // ll_builder != nullptr(TO)
+        let ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(ops, vec!["ptr_ne"]);
+        assert_eq!(startblock.inputargs.len(), 1);
+        // second arg is the null pointer constant of the builder's own type.
+        let Hlvalue::Constant(null_arg) = &startblock.operations[0].args[1] else {
+            panic!("ptr_ne second arg must be a null Constant");
+        };
+        assert_eq!(null_arg.value, super::ConstValue::None);
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(ret.concretetype.borrow().clone(), Some(LowLevelType::Bool));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -18,6 +18,7 @@
 //! `jtransform` only sees `OpKind::IndirectCall` for indirect dispatch.
 
 #![allow(private_interfaces)]
+#![cfg_attr(test, allow(non_snake_case))]
 
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(
     dead_code,
     non_snake_case,
+    private_interfaces,
     unsafe_op_in_unsafe_fn,
     unused_doc_comments,
     unused_imports,

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -10,7 +10,8 @@
     unused_assignments,
     unused_doc_comments,
     unused_imports,
-    unused_macros
+    unused_macros,
+    unused_mut
 )]
 
 //! pyre-jit: Auto-generated JIT for pyre.

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -46,9 +46,12 @@ mod custom_getrandom {
     }
 }
 
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 use pyre_interpreter::*;
 
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 use std::cell::RefCell;
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 use std::sync::Once;
 
 // Diagnostic counting allocator (feature `heap-prof`): wraps the platform
@@ -334,8 +337,10 @@ pub extern "C" fn pyre_jit_set_wasm_ca(enabled: u32) {
     majit_backend_wasm::set_wasm_ca_enabled(enabled != 0);
 }
 
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 static PANIC_HOOK: Once = Once::new();
 
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 fn install_panic_hook() {
     PANIC_HOOK.call_once(|| {
         std::panic::set_hook(Box::new(|info| {
@@ -350,10 +355,12 @@ fn install_panic_hook() {
     });
 }
 
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 thread_local! {
     static OUTPUT_BUF: RefCell<String> = RefCell::new(String::new());
 }
 
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 fn install_wasm_print_hook() {
     pyre_interpreter::set_print_hook(|s| {
         OUTPUT_BUF.with(|buf| buf.borrow_mut().push_str(s));
@@ -364,6 +371,7 @@ fn install_wasm_print_hook() {
 ///
 /// Host-agnostic core shared by the `web` (wasm-bindgen) and `wasm-host`
 /// (C-ABI) entry points below.
+#[cfg(any(feature = "web", feature = "wasm-host"))]
 fn run_python_impl(source: &str) -> String {
     install_panic_hook();
     #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]


### PR DESCRIPTION
## Summary
Ports three low-level `StringBuilder` runtime helper graphs into `majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs`, mirroring `rpython/rtyper/lltypesystem/rbuilder.py`, plus a build-warnings cleanup.

- `build_ll_getlength_helper_graph` — `rbuilder.py:347-350`: `total_size - (current_end - current_pos)`.
- `build_ll_bool_helper_graph` — `rbuilder.py:417-418`: single `ptr_ne(ll_builder, nullptr(TO))` → `Bool`.
- `build_ll_new_helper_graph` — `rbuilder.py:446-478`: clamp `intmask(min(r_uint(init_size), 1280))` (via `cast_int_to_uint` / `direct_call(ll_min)` / `cast_uint_to_int`), `malloc` the builder struct, `direct_call(mallocfn)` for `current_buf`, then set `current_buf`/`current_pos`/`current_end`/`total_size`.
- `Fix build warnings without broad dead-code allows`.

Each helper graph carries a structural unit test; the `build_ll_*` rtyper tests are green (110 passed / 0 failed).

— *commented by Claude*
