### PR TITLE
front: Option combinator front-synth (is_none/is_some, map/and_then/unwrap_or_else, const &str)

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4582,6 +4582,19 @@ impl<'a> Lowering<'a> {
             DecodedConst::Int(n) => Some(OpKind::ConstInt(n)),
             DecodedConst::Bool(b) => Some(OpKind::ConstBool(b)),
             DecodedConst::Float(bits) => Some(OpKind::ConstFloat(bits)),
+            // A `const NAME: &str = "..."` global reads as a named-const
+            // fold, not a static address; without this arm the read falls
+            // through to a residual `FunctionPath` Call on the const path
+            // (`ATTR_W_OBJ_WEAK` etc.) the registry cannot bind.  Emit the
+            // same synthetic `__str_const` the `build_rvalue` const path
+            // uses (result kind `Ref` — a `&str` literal is `Ptr(STR)`).
+            DecodedConst::Str(s) => Some(OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__str_const".to_string(), s],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(None),
+            }),
             _ => None,
         }
     }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1662,7 +1662,10 @@ pub fn lower_fun_decl_with_static_addrs(
         // `__discriminant` comparison; no block split, so it needs no
         // reachability sweep.  Same fail-safe contract as the diamonds above.
         if !lo.is_none_sites.is_empty() {
-            crate::front::option_is_none::rewire_is_none_call_sites(&mut lo.graph, &lo.is_none_sites);
+            crate::front::option_is_none::rewire_is_none_call_sites(
+                &mut lo.graph,
+                &lo.is_none_sites,
+            );
         }
         // The `Option::map`/`and_then`/`unwrap_or_else` closure-select rewrite
         // (`front::option_closure_select`) splits the residual call block into a
@@ -5768,6 +5771,53 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
+                // `core::intrinsics::discriminant_value(v)` reads the integer
+                // tag of the enum `*v` — the intrinsic (call) form of
+                // `Rvalue::Discriminant`.  Emit the same synthetic
+                // `__discriminant` `FieldRead` instead of leaving the graph-less
+                // intrinsic extern.  The owner is derived from the arg's enum
+                // type (peeling the `&T` ref), keyed to the enum base identity
+                // so it resolves at the tag's real byte position; an
+                // unresolvable type falls back to the unowned read (offset 0),
+                // matching `Rvalue::Discriminant`'s `None` path.
+                if args.len() == 1
+                    && fmt_path_ends_with(&segments, &["intrinsics", "discriminant_value"])
+                {
+                    let (owner_root, owner_id) = match first_arg_ty
+                        .as_ref()
+                        .and_then(|t| self.tyref_ref_adt_def_id(t))
+                        .and_then(|id| self.llbc.type_by_id(id))
+                        .map(|td| td.item_meta.name_path())
+                    {
+                        Some(name_path) => {
+                            let canon = strip_crate_prefix(&name_path);
+                            let sid = majit_ir::descr::StructId::from_canonical(&canon);
+                            (Some(canon), Some(sid))
+                        }
+                        None => (None, None),
+                    };
+                    let res = self
+                        .graph
+                        .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                        result: Some(res.clone()),
+                        kind: OpKind::FieldRead {
+                            base: args[0].clone(),
+                            field: crate::model::FieldDescriptor {
+                                name: "__discriminant".to_string(),
+                                owner_root,
+                                owner_id,
+                            },
+                            ty: ValueType::Int,
+                            pure: true,
+                        },
+                    });
+                    self.local_var[dest_local] = Some(res);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 let alias =
                     if let Some(payload) = self.expect_on_const_ok(&segments, &args, &arg_locals) {
                         // Identity unwrap: the receiver variable was bound
@@ -6065,11 +6115,8 @@ impl<'a> Lowering<'a> {
         } = &op_kind
             && args.len() == 1
             && (name == "is_none" || name == "is_some")
-            && let Some(site) = self.recognize_is_none_site(
-                first_arg_ty.as_ref(),
-                &result_var,
-                name == "is_some",
-            )
+            && let Some(site) =
+                self.recognize_is_none_site(first_arg_ty.as_ref(), &result_var, name == "is_some")
         {
             self.is_none_sites.push(site);
         }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1664,6 +1664,19 @@ pub fn lower_fun_decl_with_static_addrs(
         if !lo.is_none_sites.is_empty() {
             crate::front::option_is_none::rewire_is_none_call_sites(&mut lo.graph, &lo.is_none_sites);
         }
+        // The `Option::map`/`and_then`/`unwrap_or_else` closure-select rewrite
+        // (`front::option_closure_select`) splits the residual call block into a
+        // `__discriminant` diamond, same post-lowering shape and fail-safe
+        // contract as `map_or`; gate the reachability sweep on an actual
+        // rewrite.
+        let closure_select_rewritten = if lo.closure_select_sites.is_empty() {
+            0
+        } else {
+            crate::front::option_closure_select::rewire_closure_select_call_sites(
+                &mut lo.graph,
+                &lo.closure_select_sites,
+            )
+        };
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
@@ -1672,6 +1685,7 @@ pub fn lower_fun_decl_with_static_addrs(
             || bool_then_rewritten > 0
             || unwrap_or_rewritten > 0
             || map_or_rewritten > 0
+            || closure_select_rewritten > 0
         {
             crate::model::clear_unreachable_blocks(&mut lo.graph);
         }
@@ -2025,6 +2039,11 @@ struct Lowering<'a> {
     /// the discriminant comparison the `front::option_is_none` post-pass
     /// synthesizes in place (see [`crate::front::option_is_none::IsNoneSite`]).
     is_none_sites: Vec<crate::front::option_is_none::IsNoneSite>,
+    /// `Option::map`/`and_then`/`unwrap_or_else(opt, closure)` call sites
+    /// recorded for the discriminant closure-select the
+    /// `front::option_closure_select` post-pass synthesizes (see
+    /// [`crate::front::option_closure_select::ClosureSelectSite`]).
+    closure_select_sites: Vec<crate::front::option_closure_select::ClosureSelectSite>,
 }
 
 impl<'a> Lowering<'a> {
@@ -2185,6 +2204,7 @@ impl<'a> Lowering<'a> {
             unwrap_or_sites: Vec::new(),
             map_or_sites: Vec::new(),
             is_none_sites: Vec::new(),
+            closure_select_sites: Vec::new(),
         })
     }
 
@@ -6053,6 +6073,40 @@ impl<'a> Lowering<'a> {
         {
             self.is_none_sites.push(site);
         }
+        // Capture `Option::map`/`and_then`/`unwrap_or_else(opt, closure)` sites
+        // for the discriminant closure-select `front::option_closure_select`
+        // synthesizes.  All three are Opaque (foreign `core`) with the `Option`
+        // ADT receiver, so `first_is_self` routes them to a two-arg
+        // `CallTarget::Method` (receiver `args[0]`, closure env `args[1]`).
+        // Resolving the `Option` field owners + closure `call_once` owner needs
+        // the receiver type (`first_arg_ty`), the env type (`second_arg_ty`),
+        // and the result type (`call.dest.ty`), all in hand here;
+        // `recognize_closure_select_site` also confirms the receiver is an
+        // `Option`.  A resolution miss leaves the residual call.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && let Some(kind) = match name.as_str() {
+                "map" => Some(crate::front::option_closure_select::ClosureCombinator::Map),
+                "and_then" => Some(crate::front::option_closure_select::ClosureCombinator::AndThen),
+                "unwrap_or_else" => {
+                    Some(crate::front::option_closure_select::ClosureCombinator::UnwrapOrElse)
+                }
+                _ => None,
+            }
+            && let Some(site) = self.recognize_closure_select_site(
+                kind,
+                first_arg_ty.as_ref(),
+                second_arg_ty.as_ref(),
+                &call.dest.ty,
+                &result_var,
+            )
+        {
+            self.closure_select_sites.push(site);
+        }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var.clone()),
             kind: op_kind,
@@ -7526,6 +7580,57 @@ impl<'a> Lowering<'a> {
             call_once_owner,
             payload_ty,
             result_ty,
+        })
+    }
+
+    /// Resolve a recognized `Option::map`/`and_then`/`unwrap_or_else(opt,
+    /// closure)` call into a
+    /// [`crate::front::option_closure_select::ClosureSelectSite`] — the `Option`
+    /// enum root + `Some` variant owners, the closure env's `call_once` owner,
+    /// the payload type `T`, and the closure's `call_once` result type (`U` for
+    /// `map`, `Option<U>` for `and_then`, `T` for `unwrap_or_else`).  `None`
+    /// (leaving the residual call) when the receiver is not a resolvable
+    /// `Option`, the closure env does not resolve to an ADT, or (for `map`) the
+    /// result is not an `Option`.
+    fn recognize_closure_select_site(
+        &self,
+        kind: crate::front::option_closure_select::ClosureCombinator,
+        recv_ty: Option<&TyRef>,
+        env_ty: Option<&TyRef>,
+        dest_ty: &TyRef,
+        result_var: &Variable,
+    ) -> Option<crate::front::option_closure_select::ClosureSelectSite> {
+        use crate::front::option_closure_select::ClosureCombinator;
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+            return None;
+        }
+        let def_id = self.tyref_adt_def_id(recv_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let option_owner = td.item_meta.name_path();
+        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        let env_def_id = self.tyref_ref_adt_def_id(env_ty?)?;
+        let env_td = self.llbc.type_by_id(env_def_id)?;
+        let call_once_owner = env_td.item_meta.name_path();
+        // The type the closure's `call_once` returns: `map`'s dest is
+        // `Option<U>` and its closure returns `U` (the dest payload);
+        // `and_then`'s dest is `Option<U>` returned directly; `unwrap_or_else`'s
+        // dest is the bare `T`.
+        let call_result_ty = match kind {
+            ClosureCombinator::Map => self.tyref_option_payload_value_type(dest_ty)?,
+            ClosureCombinator::AndThen | ClosureCombinator::UnwrapOrElse => {
+                tyref_to_value_type(dest_ty, self.llbc)
+            }
+        };
+        Some(crate::front::option_closure_select::ClosureSelectSite {
+            kind,
+            result_var: result_var.clone(),
+            option_owner,
+            some_owner,
+            call_once_owner,
+            payload_ty,
+            call_result_ty,
         })
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1657,6 +1657,13 @@ pub fn lower_fun_decl_with_static_addrs(
         } else {
             crate::front::option_map_or::rewire_map_or_call_sites(&mut lo.graph, &lo.map_or_sites)
         };
+        // The `Option::is_none`/`is_some` rewrite (`front::option_is_none`)
+        // replaces the residual predicate call in place with a
+        // `__discriminant` comparison; no block split, so it needs no
+        // reachability sweep.  Same fail-safe contract as the diamonds above.
+        if !lo.is_none_sites.is_empty() {
+            crate::front::option_is_none::rewire_is_none_call_sites(&mut lo.graph, &lo.is_none_sites);
+        }
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
@@ -2014,6 +2021,10 @@ struct Lowering<'a> {
     /// discriminant closure-select the `front::option_map_or` post-pass
     /// synthesizes (see [`crate::front::option_map_or::MapOrSite`]).
     map_or_sites: Vec<crate::front::option_map_or::MapOrSite>,
+    /// `Option::is_none(opt)` / `Option::is_some(opt)` call sites recorded for
+    /// the discriminant comparison the `front::option_is_none` post-pass
+    /// synthesizes in place (see [`crate::front::option_is_none::IsNoneSite`]).
+    is_none_sites: Vec<crate::front::option_is_none::IsNoneSite>,
 }
 
 impl<'a> Lowering<'a> {
@@ -2173,6 +2184,7 @@ impl<'a> Lowering<'a> {
             bool_then_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             map_or_sites: Vec::new(),
+            is_none_sites: Vec::new(),
         })
     }
 
@@ -6018,6 +6030,29 @@ impl<'a> Lowering<'a> {
         {
             self.map_or_sites.push(site);
         }
+        // Capture `Option::is_none(opt)` / `Option::is_some(opt)` sites for the
+        // discriminant comparison `front::option_is_none` synthesizes in place.
+        // Both are Opaque (foreign `core`) with the `Option` ADT receiver, so
+        // `first_is_self` routes them to a one-arg `CallTarget::Method`.  The
+        // `Option` enum root owning `__discriminant` comes from the receiver
+        // type (`first_arg_ty`), in hand here; `recognize_is_none_site` also
+        // confirms the receiver is an `Option`.  A resolution miss leaves the
+        // residual call — an unregistered callee the rtyper census Skips.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && (name == "is_none" || name == "is_some")
+            && let Some(site) = self.recognize_is_none_site(
+                first_arg_ty.as_ref(),
+                &result_var,
+                name == "is_some",
+            )
+        {
+            self.is_none_sites.push(site);
+        }
         self.graph.block_mut(bb_id).operations.push(SpaceOperation {
             result: Some(result_var.clone()),
             kind: op_kind,
@@ -7400,6 +7435,31 @@ impl<'a> Lowering<'a> {
             option_owner,
             some_owner,
             payload_ty,
+        })
+    }
+
+    /// Resolve a recognized `Option::is_none(opt)` / `Option::is_some(opt)`
+    /// call into an [`crate::front::option_is_none::IsNoneSite`] — the
+    /// `Option` enum root owning `__discriminant`.  `None` (leaving the
+    /// residual call) when the receiver is not a resolvable `Option`; guarding
+    /// on `Option` since a custom type could share the method name.
+    fn recognize_is_none_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        result_var: &Variable,
+        is_some: bool,
+    ) -> Option<crate::front::option_is_none::IsNoneSite> {
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+            return None;
+        }
+        let def_id = self.tyref_adt_def_id(recv_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let option_owner = td.item_meta.name_path();
+        Some(crate::front::option_is_none::IsNoneSite {
+            result_var: result_var.clone(),
+            option_owner,
+            is_some,
         })
     }
 

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -74,6 +74,7 @@ pub mod llbc_hints;
 pub mod mir;
 pub mod mir_dispatch;
 pub mod opcode_wrapper;
+pub(crate) mod option_closure_select;
 pub(crate) mod option_is_none;
 pub(crate) mod option_map_or;
 pub(crate) mod option_try;

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -74,6 +74,7 @@ pub mod llbc_hints;
 pub mod mir;
 pub mod mir_dispatch;
 pub mod opcode_wrapper;
+pub(crate) mod option_is_none;
 pub(crate) mod option_map_or;
 pub(crate) mod option_try;
 pub(crate) mod option_unwrap_or;

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -422,31 +422,42 @@ mod tests {
         let (g, a) = build_and_rewrite(ClosureCombinator::Map, "map");
         assert!(residual_gone(&g, "map"), "residual map call removed");
         assert_eq!(
-            count_calls(&g, |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            count_calls(
+                &g,
+                |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")
+            ),
             1,
             "the Some arm calls the closure once"
         );
         assert_eq!(g.blocks[a].exits.len(), 2, "A branches to Some/None arms");
         // Two `Option` ctors: Some(f(x)) in the then arm, None in the else arm.
-        let ctors = count_calls(&g, |t| {
-            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option")
-        });
+        let ctors = count_calls(
+            &g,
+            |t| matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option"),
+        );
         assert_eq!(ctors, 2, "map builds Some(U) and None");
     }
 
     #[test]
     fn and_then_forwards_some_call_and_builds_none() {
         let (g, a) = build_and_rewrite(ClosureCombinator::AndThen, "and_then");
-        assert!(residual_gone(&g, "and_then"), "residual and_then call removed");
+        assert!(
+            residual_gone(&g, "and_then"),
+            "residual and_then call removed"
+        );
         assert_eq!(
-            count_calls(&g, |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            count_calls(
+                &g,
+                |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")
+            ),
             1,
             "the Some arm calls the closure once"
         );
         // Only the None arm builds an Option; the Some arm forwards the call.
-        let ctors = count_calls(&g, |t| {
-            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option")
-        });
+        let ctors = count_calls(
+            &g,
+            |t| matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option"),
+        );
         assert_eq!(ctors, 1, "and_then builds only None");
         assert_eq!(g.blocks[a].exits.len(), 2);
     }
@@ -459,14 +470,18 @@ mod tests {
             "residual unwrap_or_else call removed"
         );
         assert_eq!(
-            count_calls(&g, |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            count_calls(
+                &g,
+                |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")
+            ),
             1,
             "the None arm calls the niladic closure once"
         );
         // No Option is built — result is a bare T.
-        let ctors = count_calls(&g, |t| {
-            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option")
-        });
+        let ctors = count_calls(
+            &g,
+            |t| matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option"),
+        );
         assert_eq!(ctors, 0, "unwrap_or_else returns a bare value");
         assert_eq!(g.blocks[a].exits.len(), 2);
     }
@@ -490,8 +505,12 @@ mod tests {
             .unwrap();
         g.push_op_var(a, OpKind::ConstInt(9), true).unwrap();
         g.set_return(a, None);
-        let rewritten = rewire_closure_select_call_sites(&mut g, &[site(ClosureCombinator::Map, result)]);
+        let rewritten =
+            rewire_closure_select_call_sites(&mut g, &[site(ClosureCombinator::Map, result)]);
         assert_eq!(rewritten, 0, "a non-last-op call declines");
-        assert!(!residual_gone(&g, "map"), "residual call survives on decline");
+        assert!(
+            !residual_gone(&g, "map"),
+            "residual call survives on decline"
+        );
     }
 }

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -1,0 +1,497 @@
+//! `Option::map` / `Option::and_then` / `Option::unwrap_or_else` →
+//! discriminant closure-select.
+//!
+//! ## Positioning
+//!
+//! These three `core::option::<Impl>` combinators are foreign (Opaque body in
+//! the LLBC) with the `Option` ADT receiver, so `first_is_self` routes each to
+//! a two-arg `CallTarget::Method` (receiver in `args[0]`, closure env in
+//! `args[1]`).  Like [`crate::front::option_map_or`] they carry a single closure
+//! and imply a two-way select on the receiver's tag, which this pass *creates*.
+//! They differ only in how each arm produces its result:
+//!
+//! ```text
+//!     map(opt, f):            Some(x) => Some(f(x))   None => None
+//!     and_then(opt, f):       Some(x) => f(x)         None => None
+//!     unwrap_or_else(opt, f): Some(x) => x            None => f()
+//! ```
+//!
+//! `map`/`and_then` run the closure on the `Some` payload; `unwrap_or_else` runs
+//! its niladic closure on the `None` arm instead and forwards the payload
+//! directly on `Some`.  `map` wraps the closure result back into `Some`, and
+//! both `map`/`and_then` build a fresh `None` on the empty arm; `unwrap_or_else`
+//! returns a bare `T`.  Everything else — locating the residual call, absorbing
+//! the trailing `*mut <registered ADT>` narrowing cast, threading the live
+//! values through the arms, and closing the `bool(disc)` branch — is the
+//! [`crate::front::option_map_or`] skeleton.
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller leaves
+//! the residual call untouched, and the unregistered callee keeps the rtyper
+//! census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{
+    close_goto_mixed, emit_option_variant, map_source, reproduce_exit_args,
+};
+use crate::front::option_map_or::emit_narrow;
+use crate::model::{
+    BlockId, CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
+
+/// Which `Option` closure combinator a recorded site is.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ClosureCombinator {
+    /// `Some(x) => Some(f(x))`, `None => None`.
+    Map,
+    /// `Some(x) => f(x)`, `None => None`.
+    AndThen,
+    /// `Some(x) => x`, `None => f()`.
+    UnwrapOrElse,
+}
+
+/// A recognized `Option::map`/`and_then`/`unwrap_or_else(opt, closure_env)`
+/// call site captured during body lowering (`front::mir`
+/// `recognize_closure_select_site`).  The owner strings are resolved at the
+/// recording site where the receiver `Option` and the closure env type are in
+/// hand; the post-pass only needs them to spell the field reads, the closure
+/// `call_once`, and any `Some`/`None` it builds.
+#[derive(Clone)]
+pub(crate) struct ClosureSelectSite {
+    /// Which combinator — selects the per-arm result construction.
+    pub kind: ClosureCombinator,
+    /// The combinator call result — locates block A.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner
+    /// (both the receiver read and any built `Some`/`None`).
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// owner (the receiver read and any built `Some`).
+    pub some_owner: String,
+    /// The closure env ADT `name_path` — the `call_once` inherent-method owner.
+    pub call_once_owner: String,
+    /// The receiver `Option`'s payload `T` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` read kind and the `(x,)` args-tuple element.
+    pub payload_ty: ValueType,
+    /// The type the closure's `call_once` returns, projected to a
+    /// [`ValueType`]: `U` for `map`, `Option<U>` for `and_then`, `T` for
+    /// `unwrap_or_else`.
+    pub call_result_ty: ValueType,
+}
+
+/// Rewrite every recorded closure-select call site into the discriminant
+/// diamond.  Fail-safe: a site whose block does not fit the residual-call shape
+/// is left untouched (Skip).  Returns the number of sites rewritten.
+pub(crate) fn rewire_closure_select_call_sites(
+    graph: &mut FunctionGraph,
+    sites: &[ClosureSelectSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        if rewire_one_closure_select_site(graph, site).is_ok() {
+            rewritten += 1;
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_closure_select_site(
+    graph: &mut FunctionGraph,
+    site: &ClosureSelectSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the residual call producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: closure-select result var has no producer block"))?;
+    let ci = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .ok_or_else(|| format!("{name}: closure-select call op not found in block {a}"))?;
+    let ops_len = graph.blocks[a].operations.len();
+
+    // Absorb the optional trailing `__pyre_cast_instance` narrowing cast a
+    // `*mut <registered ADT>` result gains (see `option_map_or`).
+    let (flow_result, narrow_root, remove_upto) = if ci + 1 == ops_len {
+        (site.result_var.clone(), None, ci)
+    } else if ci + 2 == ops_len {
+        let cast = &graph.blocks[a].operations[ci + 1];
+        match (&cast.kind, cast.result.as_ref()) {
+            (
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                },
+                Some(narrowed),
+            ) if segments.len() == 2
+                && segments[0] == "__pyre_cast_instance"
+                && args.len() == 1
+                && args[0] == site.result_var =>
+            {
+                (narrowed.clone(), Some(segments[1].clone()), ci + 1)
+            }
+            _ => {
+                return Err(format!(
+                    "{name}: closure-select call is not the last op of block {a}"
+                ));
+            }
+        }
+    } else {
+        return Err(format!(
+            "{name}: closure-select call is not the last op of block {a}"
+        ));
+    };
+
+    // Capture the receiver `Option` + closure env operands.
+    let (opt, env) = match &graph.blocks[a].operations[ci].kind {
+        OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
+        other => {
+            return Err(format!(
+                "{name}: closure-select producer op is not a 2-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → B.  Must be a plain goto.
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: closure-select call block {a} does not have a single exit"
+        ));
+    };
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: closure-select call block {a} exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let b_target = saved_exit.target;
+
+    // Distinct live Values A forwards to B other than the result.
+    let mut carried: Vec<Variable> = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(v) = arg
+            && *v != flow_result
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+
+    // The `Some` arm always reads `opt.__pos_0`; `map`/`and_then` also run the
+    // closure there (so need `env`), while `unwrap_or_else` runs its closure on
+    // the `None` arm instead.  Thread each arm exactly the sources it consumes.
+    let closure_on_some = site.kind != ClosureCombinator::UnwrapOrElse;
+    let mut then_sources = carried.clone();
+    if !then_sources.contains(&opt) {
+        then_sources.push(opt.clone());
+    }
+    if closure_on_some && !then_sources.contains(&env) {
+        then_sources.push(env.clone());
+    }
+    let mut else_sources = carried.clone();
+    if !closure_on_some && !else_sources.contains(&env) {
+        else_sources.push(env.clone());
+    }
+    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
+    let (else_bb, else_inputs) = graph.create_block_with_arg_vars(else_sources.len());
+
+    // --- `then_bb` (`Some`) ---
+    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
+        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    let payload = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(payload.clone()),
+        kind: OpKind::FieldRead {
+            base: opt_in_then,
+            field: FieldDescriptor {
+                name: "__pos_0".to_string(),
+                owner_root: Some(site.some_owner.clone()),
+                owner_id: None,
+            },
+            ty: site.payload_ty.clone(),
+            pure: true,
+        },
+    });
+    let then_value = match site.kind {
+        ClosureCombinator::UnwrapOrElse => payload,
+        ClosureCombinator::Map | ClosureCombinator::AndThen => {
+            let env_in_then = map_source(&then_sources, &then_inputs, &env)
+                .ok_or_else(|| format!("{name}: closure env not threaded into Some arm"))?;
+            let call_result = emit_call_once(
+                graph,
+                then_bb,
+                env_in_then,
+                Some((payload, site.payload_ty.clone())),
+                &site.call_once_owner,
+                site.call_result_ty.clone(),
+            );
+            match site.kind {
+                // `map` wraps the closure result back into `Some(U)`.
+                ClosureCombinator::Map => emit_option_variant(
+                    graph,
+                    then_bb,
+                    &site.option_owner,
+                    1,
+                    Some((&site.some_owner, call_result, site.call_result_ty.clone())),
+                ),
+                // `and_then`'s closure already returns `Option<U>`.
+                _ => call_result,
+            }
+        }
+    };
+    let then_result = emit_narrow(graph, then_bb, then_value, &narrow_root);
+    let then_link_args = reproduce_exit_args(
+        &saved_exit,
+        &flow_result,
+        &then_result,
+        &then_sources,
+        &then_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+
+    // --- `else_bb` (`None`) ---
+    let else_value = match site.kind {
+        // `map`/`and_then` build a fresh `None`.
+        ClosureCombinator::Map | ClosureCombinator::AndThen => {
+            emit_option_variant(graph, else_bb, &site.option_owner, 0, None)
+        }
+        // `unwrap_or_else` runs its niladic closure.
+        ClosureCombinator::UnwrapOrElse => {
+            let env_in_else = map_source(&else_sources, &else_inputs, &env)
+                .ok_or_else(|| format!("{name}: closure env not threaded into None arm"))?;
+            emit_call_once(
+                graph,
+                else_bb,
+                env_in_else,
+                None,
+                &site.call_once_owner,
+                site.call_result_ty.clone(),
+            )
+        }
+    };
+    let else_result = emit_narrow(graph, else_bb, else_value, &narrow_root);
+    let else_link_args = reproduce_exit_args(
+        &saved_exit,
+        &flow_result,
+        &else_result,
+        &else_sources,
+        &else_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, else_bb, b_target, else_link_args);
+
+    // A: drop the residual call (+ absorbed cast), read the discriminant, branch
+    // on `bool(disc)` (Option tags None=0 / Some=1 → the Some arm is `then`).
+    let a_id = graph.blocks[a].id;
+    for _ in ci..=remove_upto {
+        graph.blocks[a].operations.remove(ci);
+    }
+    let disc = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(disc.clone()),
+        kind: OpKind::FieldRead {
+            base: opt.clone(),
+            field: FieldDescriptor {
+                name: "__discriminant".to_string(),
+                owner_root: Some(site.option_owner.clone()),
+                owner_id: None,
+            },
+            ty: ValueType::Int,
+            pure: true,
+        },
+    });
+    graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
+    Ok(())
+}
+
+/// Emit `call_once(env, args)` in `block`, returning the call result.  `arg` is
+/// the single closure argument (a `(x,)` tuple) or `None` for a niladic closure
+/// (an empty tuple the opaque body ignores) — the same `Args`-tuple shape
+/// `Rvalue::Aggregate` emits.
+fn emit_call_once(
+    graph: &mut FunctionGraph,
+    block: BlockId,
+    env: Variable,
+    arg: Option<(Variable, ValueType)>,
+    call_once_owner: &str,
+    result_ty: ValueType,
+) -> Variable {
+    let args_tuple = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(args_tuple.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::synthetic_transparent_ctor("Tuple"),
+            args: Vec::new(),
+            result_ty: ValueType::Ref(Some("Tuple".to_string())),
+        },
+    });
+    if let Some((value, _value_ty)) = arg {
+        graph.block_mut(block).operations.push(SpaceOperation {
+            result: None,
+            kind: OpKind::FieldWrite {
+                base: args_tuple.clone(),
+                field: FieldDescriptor {
+                    name: "__pos_0".to_string(),
+                    owner_root: Some("Tuple".to_string()),
+                    owner_id: None,
+                },
+                value: LinkArg::Value(value),
+                ty: ValueType::Ref(None),
+            },
+        });
+    }
+    let call_result = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(call_result.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::method("call_once", Some(call_once_owner.to_string())),
+            args: vec![env, args_tuple],
+            result_ty,
+        },
+    });
+    call_result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn site(kind: ClosureCombinator, result_var: Variable) -> ClosureSelectSite {
+        ClosureSelectSite {
+            kind,
+            result_var,
+            option_owner: "core::option::Option".into(),
+            some_owner: "core::option::Option::Some".into(),
+            call_once_owner: "test::closure".into(),
+            payload_ty: ValueType::Int,
+            call_result_ty: ValueType::Int,
+        }
+    }
+
+    /// Build `result = <combinator>(opt, env)` — block A = the residual call
+    /// closed by a single goto to B — and rewrite it.
+    fn build_and_rewrite(kind: ClosureCombinator, method: &str) -> (FunctionGraph, usize) {
+        let mut g = FunctionGraph::new("test_closure_select");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method(method, Some("core::option::Option".into())),
+                    args: vec![opt, env],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+        let rewritten = rewire_closure_select_call_sites(&mut g, &[site(kind, result)]);
+        assert_eq!(rewritten, 1, "the {method} site must be rewritten");
+        (g, a.0)
+    }
+
+    fn count_calls(g: &FunctionGraph, pred: impl Fn(&CallTarget) -> bool) -> usize {
+        g.blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| matches!(&op.kind, OpKind::Call { target, .. } if pred(target)))
+            .count()
+    }
+
+    fn residual_gone(g: &FunctionGraph, method: &str) -> bool {
+        count_calls(
+            g,
+            |t| matches!(t, CallTarget::Method { name, .. } if name == method),
+        ) == 0
+    }
+
+    #[test]
+    fn map_selects_some_call_wrapped_and_none() {
+        let (g, a) = build_and_rewrite(ClosureCombinator::Map, "map");
+        assert!(residual_gone(&g, "map"), "residual map call removed");
+        assert_eq!(
+            count_calls(&g, |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            1,
+            "the Some arm calls the closure once"
+        );
+        assert_eq!(g.blocks[a].exits.len(), 2, "A branches to Some/None arms");
+        // Two `Option` ctors: Some(f(x)) in the then arm, None in the else arm.
+        let ctors = count_calls(&g, |t| {
+            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option")
+        });
+        assert_eq!(ctors, 2, "map builds Some(U) and None");
+    }
+
+    #[test]
+    fn and_then_forwards_some_call_and_builds_none() {
+        let (g, a) = build_and_rewrite(ClosureCombinator::AndThen, "and_then");
+        assert!(residual_gone(&g, "and_then"), "residual and_then call removed");
+        assert_eq!(
+            count_calls(&g, |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            1,
+            "the Some arm calls the closure once"
+        );
+        // Only the None arm builds an Option; the Some arm forwards the call.
+        let ctors = count_calls(&g, |t| {
+            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option")
+        });
+        assert_eq!(ctors, 1, "and_then builds only None");
+        assert_eq!(g.blocks[a].exits.len(), 2);
+    }
+
+    #[test]
+    fn unwrap_or_else_forwards_payload_and_calls_on_none() {
+        let (g, a) = build_and_rewrite(ClosureCombinator::UnwrapOrElse, "unwrap_or_else");
+        assert!(
+            residual_gone(&g, "unwrap_or_else"),
+            "residual unwrap_or_else call removed"
+        );
+        assert_eq!(
+            count_calls(&g, |t| matches!(t, CallTarget::Method { name, .. } if name == "call_once")),
+            1,
+            "the None arm calls the niladic closure once"
+        );
+        // No Option is built — result is a bare T.
+        let ctors = count_calls(&g, |t| {
+            matches!(t, CallTarget::SyntheticTransparentCtor { name, .. } if name == "Option")
+        });
+        assert_eq!(ctors, 0, "unwrap_or_else returns a bare value");
+        assert_eq!(g.blocks[a].exits.len(), 2);
+    }
+
+    #[test]
+    fn declines_when_call_not_last_op() {
+        let mut g = FunctionGraph::new("test_closure_select_decline");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let env = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::method("map", Some("core::option::Option".into())),
+                    args: vec![opt, env],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.push_op_var(a, OpKind::ConstInt(9), true).unwrap();
+        g.set_return(a, None);
+        let rewritten = rewire_closure_select_call_sites(&mut g, &[site(ClosureCombinator::Map, result)]);
+        assert_eq!(rewritten, 0, "a non-last-op call declines");
+        assert!(!residual_gone(&g, "map"), "residual call survives on decline");
+    }
+}

--- a/majit/majit-translate/src/front/option_is_none.rs
+++ b/majit/majit-translate/src/front/option_is_none.rs
@@ -1,0 +1,240 @@
+//! `Option::is_none` / `Option::is_some` → discriminant comparison (#131).
+//!
+//! `is_none`/`is_some` are pure predicates on the receiver's tag: `is_none`
+//! is `opt.__discriminant == 0` and `is_some` is `opt.__discriminant != 0`
+//! (`None`=0, `Some`=1).  Unlike `unwrap_or`/`map_or` they read no payload
+//! and take no default, so there is no diamond and no block split — the
+//! residual one-arg `Method` call is replaced **in place** by a
+//! `__discriminant` `FieldRead` + `ConstInt(0)` + `BinOp` producing the same
+//! result `Variable`.
+//!
+//! `is_none`/`is_some` bodies are Opaque (foreign `core`), so the receiver is
+//! the `Option` ADT and `first_is_self` routes the call to a
+//! `CallTarget::Method` (receiver in `args[0]`).  The `Option` enum root
+//! owning `__discriminant` is resolved at the recording site
+//! (`front::mir` `recognize_is_none_site`) where the receiver type is in hand.
+//!
+//! It is **fail-safe**: any structural mismatch leaves the residual call
+//! untouched, so the unregistered callee keeps the rtyper census Skip and no
+//! graph the legacy walker already handled regresses.
+
+use crate::flowspace::model::Variable;
+use crate::model::{FieldDescriptor, FunctionGraph, OpKind, SpaceOperation, ValueType};
+
+/// A recognized `Option::is_none(opt)` / `Option::is_some(opt)` call site
+/// captured during body lowering (`front::mir` `recognize_is_none_site`).
+#[derive(Clone)]
+pub(crate) struct IsNoneSite {
+    /// The predicate call result (the `bool`) — locates the producer op.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
+    pub option_owner: String,
+    /// `true` for `is_some` (`__discriminant != 0`), `false` for `is_none`
+    /// (`__discriminant == 0`).
+    pub is_some: bool,
+}
+
+/// Rewrite every recorded `is_none`/`is_some` call into the discriminant
+/// comparison.  Fail-safe: a site whose producer op does not fit the residual
+/// one-arg-call shape is left untouched (Skip).  Returns the number of sites
+/// rewritten.
+pub(crate) fn rewire_is_none_call_sites(graph: &mut FunctionGraph, sites: &[IsNoneSite]) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        if rewire_one_is_none_site(graph, site).is_ok() {
+            rewritten += 1;
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_is_none_site(graph: &mut FunctionGraph, site: &IsNoneSite) -> Result<(), String> {
+    let name = graph.name.clone();
+    // The block + op index producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: is_none result var has no producer block"))?;
+    let call_idx = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .expect("producer op located above");
+
+    // The producer must be the one-arg residual call; capture the receiver.
+    let opt = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+        other => {
+            return Err(format!(
+                "{name}: is_none producer op is not a 1-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // --- Structural validation passed; mutate the graph. ---
+    let disc = graph.alloc_value_var();
+    let zero = graph.alloc_value_var();
+    let op = if site.is_some { "ne" } else { "eq" };
+    let new_ops = vec![
+        SpaceOperation {
+            result: Some(disc.clone()),
+            kind: OpKind::FieldRead {
+                base: opt,
+                field: FieldDescriptor {
+                    name: "__discriminant".to_string(),
+                    owner_root: Some(site.option_owner.clone()),
+                    owner_id: None,
+                },
+                ty: ValueType::Int,
+                pure: true,
+            },
+        },
+        SpaceOperation {
+            result: Some(zero.clone()),
+            kind: OpKind::ConstInt(0),
+        },
+        SpaceOperation {
+            result: Some(site.result_var.clone()),
+            kind: OpKind::BinOp {
+                op: op.to_string(),
+                lhs: disc,
+                rhs: zero,
+                result_ty: ValueType::Int,
+            },
+        },
+    ];
+    graph.blocks[a]
+        .operations
+        .splice(call_idx..=call_idx, new_ops);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn is_none_target(name: &str) -> CallTarget {
+        CallTarget::method(name, Some("core::option::Option".to_string()))
+    }
+
+    fn site(result_var: Variable, is_some: bool) -> IsNoneSite {
+        IsNoneSite {
+            result_var,
+            option_owner: "core::option::Option".into(),
+            is_some,
+        }
+    }
+
+    /// Build `result = is_none(opt)` — a one-arg residual call — and assert the
+    /// rewrite drops the call and replaces it with `opt.__discriminant == 0`
+    /// bound to the same result var.
+    fn build_and_rewrite(method: &str, is_some: bool) -> (FunctionGraph, Variable, Variable) {
+        let mut g = FunctionGraph::new("test_is_none");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: is_none_target(method),
+                    args: vec![opt.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+        let rewritten = rewire_is_none_call_sites(&mut g, &[site(result.clone(), is_some)]);
+        assert_eq!(rewritten, 1, "the is_none/is_some site must be rewritten");
+        (g, opt, result)
+    }
+
+    #[test]
+    fn rewrite_lifts_is_none_to_discriminant_eq_zero() {
+        let (g, opt, result) = build_and_rewrite("is_none", false);
+        let a = g.startblock.0;
+        // Residual call is gone.
+        assert!(
+            !g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| matches!(&op.kind, OpKind::Call { .. })),
+            "residual is_none call removed"
+        );
+        // The discriminant is read off `opt` exactly once.
+        let disc = g.blocks[a]
+            .operations
+            .iter()
+            .find(|op| {
+                matches!(&op.kind, OpKind::FieldRead { field, base, .. }
+                    if field.name == "__discriminant" && base == &opt)
+            })
+            .expect("reads opt.__discriminant");
+        let disc_var = disc.result.clone().unwrap();
+        // The result var is a `BinOp("eq", disc, 0)`.
+        let binop = g.blocks[a]
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&result))
+            .expect("result var has a producer");
+        match &binop.kind {
+            OpKind::BinOp { op, lhs, .. } => {
+                assert_eq!(op, "eq", "is_none compares == 0");
+                assert_eq!(lhs, &disc_var, "compares the discriminant read");
+            }
+            other => panic!("result is not a BinOp: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rewrite_lifts_is_some_to_discriminant_ne_zero() {
+        let (g, _opt, result) = build_and_rewrite("is_some", true);
+        let a = g.startblock.0;
+        let binop = g.blocks[a]
+            .operations
+            .iter()
+            .find(|op| op.result.as_ref() == Some(&result))
+            .expect("result var has a producer");
+        match &binop.kind {
+            OpKind::BinOp { op, .. } => assert_eq!(op, "ne", "is_some compares != 0"),
+            other => panic!("result is not a BinOp: {other:?}"),
+        }
+    }
+
+    /// A producer op that is not a 1-arg call declines (fail-safe): the residual
+    /// op survives untouched.
+    #[test]
+    fn rewrite_declines_on_wrong_arity() {
+        let mut g = FunctionGraph::new("test_is_none_decline");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: is_none_target("is_none"),
+                    args: vec![opt, default],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+        let rewritten = rewire_is_none_call_sites(&mut g, &[site(result, false)]);
+        assert_eq!(rewritten, 0, "a 2-arg call declines");
+        assert!(
+            g.blocks[a.0]
+                .operations
+                .iter()
+                .any(|op| matches!(&op.kind, OpKind::Call { .. })),
+            "residual call survives on decline"
+        );
+    }
+}

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -342,7 +342,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
 /// `value`, returning the narrowed value — the same cast `result_narrow_root`
 /// appends after a `*mut <registered ADT>` call result.  `value` unchanged when
 /// no narrowing was absorbed.
-fn emit_narrow(
+pub(crate) fn emit_narrow(
     graph: &mut FunctionGraph,
     block: BlockId,
     value: Variable,


### PR DESCRIPTION
Grows two-phase rtyper coverage (#131) by front-synthesizing more foreign
`Option` combinators, whose Opaque `core` bodies otherwise block the
annotator's `compute_at_fixpoint` inside inlined callees.

## Commits

- **fold named const &str global read to `__str_const`** — the
  `fold_named_const_global` path gains a `DecodedConst::Str` arm, emitting a
  `__str_const` op for a `const &str` global read (fixes `ATTR_W_OBJ_WEAK`).

- **`Option::is_none`/`is_some` → discriminant compare** — new
  `front/option_is_none.rs` post-pass replaces each one-arg predicate call in
  place with `__discriminant` FieldRead + `ConstInt(0)` + `BinOp(eq|ne)`. No
  block split. Census: is_none blocked-getattr 5→0.

- **`Option::map`/`and_then`/`unwrap_or_else` → closure-select** — new unified
  `front/option_closure_select.rs` reuses the `option_map_or` diamond skeleton
  (block location, trailing-cast absorption, live-value threading, `bool(disc)`
  branch) and varies only the two arm-builders per combinator:

  ```
  map:            Some(x) => Some(f(x))   None => None
  and_then:       Some(x) => f(x)         None => None
  unwrap_or_else: Some(x) => x            None => f()
  ```

  `option_map_or::emit_narrow` is made `pub(crate)` for reuse. Census:
  and_then/unwrap_or_else/map blocked-getattrs all cleared.

Every pass is fail-safe: a non-`Option` receiver, unresolved closure env, or
non-tail residual call leaves the call untouched, so a graph the legacy walker
already handled never regresses.

## Verification

- `cargo test -p majit-translate` (7 new unit tests) green.
- `python ./pyre/check.py` — dynasm 170/170, cranelift 170/170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)