### PR TITLE
lease wasm timeout

### DIFF
--- a/pyre/bench/synth/print_stdout_redirect.py
+++ b/pyre/bench/synth/print_stdout_redirect.py
@@ -1,0 +1,34 @@
+# bltinmodule.c builtin_print / app_io.py print_ resolve a `file is None`
+# default to the live `sys.stdout` each call, so rebinding `sys.stdout` from
+# Python redirects `print()`. A `None` sys.stdout emits nothing.
+import io
+import sys
+
+
+def main():
+    # Default: prints to the real stdout.
+    print('before')
+
+    # Rebinding sys.stdout redirects print() into the new sink.
+    buf = io.StringIO()
+    saved = sys.stdout
+    sys.stdout = buf
+    print('captured', 1, 2, sep='-', end='!\n')
+    sys.stdout = saved
+    print('captured =', repr(buf.getvalue()))
+
+    # A None sys.stdout drops the output silently, then restores.
+    sys.stdout = None
+    print('dropped while stdout is None')
+    sys.stdout = saved
+    print('after None')
+
+    # flush=True routes through the sink's flush() too.
+    buf2 = io.StringIO()
+    sys.stdout = buf2
+    print('flushed', flush=True)
+    sys.stdout = saved
+    print('flushed =', repr(buf2.getvalue()))
+
+
+main()

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -71,6 +71,13 @@ FBW_INLINE_MULTIFRAME_OFF = False
 # by the dynasm/cranelift backends.
 WASM_ENGINE = "wasmtime"
 
+# The wasm backend has no perf-ratio gate (its run_bench vs_cpython/vs_pypy are
+# None) — its per-bench timeout is only a hang guard. wasm legitimately runs a
+# few× slower than the native backends the base timeouts were tuned for, and
+# slower still on loaded CI runners, so give it extra headroom by default to
+# avoid flaky timeouts. Overridable with --wasm-timeout-scale.
+WASM_TIMEOUT_SCALE = 4.0
+
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
 SNAP_DIR = "pyre/check.snap"
@@ -465,6 +472,11 @@ class Check:
             return self.args.dynasm_timeout_scale
         if backend == "cranelift" and self.args.cranelift_timeout_scale is not None:
             return self.args.cranelift_timeout_scale
+        if backend == "wasm":
+            if self.args.wasm_timeout_scale is not None:
+                return self.args.wasm_timeout_scale
+            # Default wasm headroom composes with --timeout-scale.
+            return WASM_TIMEOUT_SCALE * self.args.timeout_scale
         return self.args.timeout_scale
 
     def _set_pyre(self, backend, path):
@@ -1138,6 +1150,7 @@ def parse_args():
     parser.add_argument("--timeout-scale", type=float, default=1.0)
     parser.add_argument("--dynasm-timeout-scale", type=float, default=None)
     parser.add_argument("--cranelift-timeout-scale", type=float, default=None)
+    parser.add_argument("--wasm-timeout-scale", type=float, default=None)
     parser.add_argument("--snapshot", dest="snapshot_mode", action="store_const", const="record")
     parser.add_argument("--snapshot-diff", dest="snapshot_mode", action="store_const", const="diff")
     parser.add_argument("--threshold", type=float, default=None)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2162,6 +2162,50 @@ unsafe fn stream_encoding_errors(stream: PyObjectRef) -> (String, String) {
 }
 
 /// `print(*args)` — write space-separated str representations to stdout.
+/// The sink `print()` uses when no explicit `file=` is given, resolved from
+/// the live `sys.stdout` on each call — `bltinmodule.c builtin_print` /
+/// `app_io.py print_` map `file is None` to `sys.stdout`, so a Python-level
+/// `sys.stdout = ...` redirects `print()`.
+enum DefaultPrintTarget {
+    /// Unmodified default stdout (`sys.stdout is sys.__stdout__`): keep pyre's
+    /// native `print_output` path (its strict-utf-8 `print_render` render and
+    /// direct write), leaving default output and surrogate handling unchanged.
+    Native,
+    /// A rebound `sys.stdout`; write through its `write` / `flush` methods.
+    Rebound(PyObjectRef),
+    /// `sys.stdout` is `None`; emit nothing (builtin_print returns `None`).
+    Silent,
+}
+
+/// Resolve `print()`'s default sink from the live `sys` module.
+///
+/// Only a user redirect (`sys.stdout` rebound to some object other than the
+/// saved `sys.__stdout__`) is routed through Python `write` / `flush`; the
+/// unmodified default keeps the native path. A missing `sys.stdout` attribute
+/// raises `RuntimeError("lost sys.stdout")` as builtin_print does.
+fn resolve_default_print_target() -> Result<DefaultPrintTarget, crate::PyError> {
+    let Some(sys_mod) = crate::importing::get_sys_module("sys") else {
+        // No `sys` yet (very early bootstrap) — native path.
+        return Ok(DefaultPrintTarget::Native);
+    };
+    let stdout = match crate::baseobjspace::getattr_str(sys_mod, "stdout") {
+        Ok(w) => w,
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+            return Err(crate::PyError::runtime_error("lost sys.stdout"));
+        }
+        Err(e) => return Err(e),
+    };
+    if unsafe { pyre_object::is_none(stdout) } {
+        return Ok(DefaultPrintTarget::Silent);
+    }
+    if let Ok(orig) = crate::baseobjspace::getattr_str(sys_mod, "__stdout__") {
+        if std::ptr::eq(orig, stdout) {
+            return Ok(DefaultPrintTarget::Native);
+        }
+    }
+    Ok(DefaultPrintTarget::Rebound(stdout))
+}
+
 fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // Check if last arg is a kwargs dict (from CALL_KW builtin dispatch).
     // Distinguished from regular dict args by __pyre_kw__ marker key.
@@ -2191,6 +2235,18 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         (&args[..args.len() - 1], end_obj, sep_obj, file_obj, flush)
     } else {
         (args, None, None, None, false)
+    };
+
+    // With no explicit `file` (absent or `file=None`), the sink is the live
+    // `sys.stdout`, resolved per call so a Python-level rebinding redirects
+    // `print()`.  The unmodified default keeps the native path (`file = None`).
+    let file = match file {
+        Some(f) => Some(f),
+        None => match resolve_default_print_target()? {
+            DefaultPrintTarget::Native => None,
+            DefaultPrintTarget::Rebound(fp) => Some(fp),
+            DefaultPrintTarget::Silent => return Ok(w_none()),
+        },
     };
 
     // `bltinmodule.c print_impl` writes incrementally: `str(arg)`, then the


### PR DESCRIPTION
#262

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
