### PR TITLE
front/descroperation

### DIFF
--- a/majit/majit-translate/src/front/bigint_binop.rs
+++ b/majit/majit-translate/src/front/bigint_binop.rs
@@ -1,0 +1,146 @@
+//! `<BigInt as {BitAnd,BitOr,BitXor,Sub,Mul}>::op()` → `jit_bigint_*` residual.
+//!
+//! ## Positioning
+//!
+//! malachite's operator impls (`impl BitAnd for &BigInt`, …) have Opaque bodies
+//! in the LLBC, so a traced-into caller (`bigint_truediv`, which is `#[elidable]`
+//! and therefore walked) emits a residual `<Impl>` FunctionPath call — an
+//! unregistered callee the rtyper census Skips.  Unlike a method-syntax call
+//! (`num.div_rem(&den)` → `["bigint","BigInt","div_rem"]`, owner resolved), an
+//! operator desugars to `<BigInt as Trait>::op(a, b)` whose path keeps the
+//! unresolved `<Impl>` segment, so the harvester's resolved-owner key never
+//! matches and the call stays unregistered.
+//!
+//! Each such operator returns a single owned `BigInt`, which the front models as
+//! the classdef-less `*mut BigInt` GcRef — ABI-identical to the
+//! `#[dont_look_inside] jit_bigint_*(a: i64, b: i64) -> i64` residuals.  So the
+//! fix is a pure **call-target retarget** (no aggregate, no control flow): swap
+//! the `<Impl>::op` target for the residual path, keep the operand args and the
+//! result var.  `front::mir` performs the swap in place while lowering the Call
+//! op, guarded on **both operands resolving to the opaque `BigInt` ADT**, so a
+//! same-named operator on any other type is never mis-retargeted.  This module
+//! owns the (leaf → residual path) mapping the guard consults.
+//!
+//! Sibling of [`crate::front::bigint_div_rem`]; the retarget is simpler because
+//! the result is a single Ref rather than a `(BigInt, BigInt)` tuple.
+
+/// The `#[dont_look_inside]` residual's module path (in `pyre-interpreter`),
+/// matching its `jit_fnaddr` binding.
+const RESIDUAL_MODULE: [&str; 3] = ["pyre_interpreter", "objspace", "descroperation"];
+
+/// If `segments` is a foreign BigInt binary-operator impl-method path
+/// (`[…, "<Impl>", op]` for one of the retargetable operators), return the
+/// fully-qualified `jit_bigint_*` residual path to retarget it to; otherwise
+/// `None`.  The caller separately confirms the operands are `BigInt` before
+/// applying the retarget — this only classifies the operator leaf.
+pub(crate) fn bigint_binop_residual_path(segments: &[String]) -> Option<Vec<String>> {
+    // The impl-method form is `[…, "<Impl>", <op>]`: the operator leaf preceded
+    // by the unresolved `<Impl>` owner segment.
+    let [.., impl_seg, leaf] = segments else {
+        return None;
+    };
+    if impl_seg != "<Impl>" {
+        return None;
+    }
+    let residual_leaf = match leaf.as_str() {
+        "bitand" => "jit_bigint_and",
+        "bitor" => "jit_bigint_or",
+        "bitxor" => "jit_bigint_xor",
+        "sub" => "jit_bigint_sub",
+        "mul" => "jit_bigint_mul",
+        "add" => "jit_bigint_add",
+        _ => return None,
+    };
+    Some(residual_path(residual_leaf))
+}
+
+/// If `segments` is a foreign BigInt **shift** impl-method path (`[…,
+/// "<Impl>", {"shl"|"shr"}]`), return the `jit_bigint_{shl,shr}` residual
+/// path; otherwise `None`.  Shifts are split from [`bigint_binop_residual_path`]
+/// because the shift amount is a machine integer (`usize`), not a `BigInt`: the
+/// caller confirms the first operand is `BigInt` and the second is an integer
+/// (so the residual reads `b` as the count, not a pointer).
+pub(crate) fn bigint_shift_residual_path(segments: &[String]) -> Option<Vec<String>> {
+    let [.., impl_seg, leaf] = segments else {
+        return None;
+    };
+    if impl_seg != "<Impl>" {
+        return None;
+    }
+    let residual_leaf = match leaf.as_str() {
+        "shl" => "jit_bigint_shl",
+        "shr" => "jit_bigint_shr",
+        _ => return None,
+    };
+    Some(residual_path(residual_leaf))
+}
+
+/// Build the fully-qualified residual path for a `jit_bigint_*` leaf.
+fn residual_path(leaf: &str) -> Vec<String> {
+    let mut path: Vec<String> = RESIDUAL_MODULE.iter().map(|s| s.to_string()).collect();
+    path.push(leaf.to_string());
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segs(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn desc(residual: &str) -> Vec<String> {
+        segs(&["pyre_interpreter", "objspace", "descroperation", residual])
+    }
+
+    #[test]
+    fn maps_each_retargetable_operator_to_its_residual() {
+        for (op, residual) in [
+            ("bitand", "jit_bigint_and"),
+            ("bitor", "jit_bigint_or"),
+            ("bitxor", "jit_bigint_xor"),
+            ("sub", "jit_bigint_sub"),
+            ("mul", "jit_bigint_mul"),
+            ("add", "jit_bigint_add"),
+        ] {
+            let path =
+                bigint_binop_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", op]))
+                    .unwrap_or_else(|| panic!("{op} must map"));
+            assert_eq!(path, desc(residual));
+        }
+    }
+
+    #[test]
+    fn maps_each_shift_operator_to_its_residual() {
+        for (op, residual) in [("shl", "jit_bigint_shl"), ("shr", "jit_bigint_shr")] {
+            let path =
+                bigint_shift_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", op]))
+                    .unwrap_or_else(|| panic!("{op} must map"));
+            assert_eq!(path, desc(residual));
+        }
+        // Shifts are not in the two-BigInt-operand map, and vice versa.
+        assert!(
+            bigint_binop_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", "shr"]))
+                .is_none()
+        );
+        assert!(
+            bigint_shift_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", "sub"]))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn declines_non_impl_and_unlisted_operators() {
+        // Method-syntax (owner resolved, no `<Impl>`) is handled elsewhere.
+        assert!(bigint_binop_residual_path(&segs(&["bigint", "BigInt", "sub"])).is_none());
+        // An operator not in either retarget set (e.g. `rem`).
+        assert!(
+            bigint_binop_residual_path(&segs(&["malachite_bigint", "bigint", "<Impl>", "rem"]))
+                .is_none()
+        );
+        // Too short / no `<Impl>` segment.
+        assert!(bigint_binop_residual_path(&segs(&["sub"])).is_none());
+        assert!(bigint_shift_residual_path(&segs(&["shr"])).is_none());
+    }
+}

--- a/majit/majit-translate/src/front/bigint_div_rem.rs
+++ b/majit/majit-translate/src/front/bigint_div_rem.rs
@@ -1,0 +1,301 @@
+//! `bigint::BigInt::div_rem()` → modeled `(quotient, remainder)` tuple.
+//!
+//! ## Positioning
+//!
+//! malachite's `BigInt::div_rem(&self, &Self) -> (Self, Self)` returns a
+//! `(BigInt, BigInt)` tuple whose body is Opaque in the LLBC, so the caller
+//! emits a residual `div_rem` FunctionPath call — an unregistered callee the
+//! rtyper census Skips.  The value flows into a downstream `let (q, r) = …`
+//! destructure the front lowers as `__pos_0` / `__pos_1` tuple field reads.
+//! This pass supplies that producer, sourcing each half from a
+//! `#[dont_look_inside]` residual and reassembling the pair as the same
+//! synthetic-`Tuple` aggregate `Rvalue::Aggregate` emits:
+//!
+//! ```text
+//!     t = num.div_rem(&den)                  // residual `div_rem` call
+//! becomes
+//!     q = jit_bigint_div(num, den)           // truncated quotient
+//!     r = jit_bigint_rem(num, den)           // truncated remainder
+//!     t = Tuple { __pos_0: q, __pos_1: r }
+//! ```
+//!
+//! `num` / `den` are the raw `*mut BigInt` the front models a `BigInt` value
+//! as (a classdef-less `SomeInstance` GcRef), matching both helpers' i64-over-
+//! `*mut BigInt` ABI; each helper allocates its result in the collecting
+//! nursery.  Sibling of [`crate::front::bigint_to_i64`] — the same branchless
+//! in-place splice, building a two-field `Ref` tuple instead of an `Option`.
+//!
+//! It is **fail-safe**: a site whose producer op is not the expected 2-arg
+//! residual call is left untouched, and the unregistered `div_rem` callee
+//! keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::model::{
+    CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
+
+/// The `#[dont_look_inside]` residuals the synth calls, spelled to match their
+/// `jit_fnaddr` bindings.
+const DIV_PATH: [&str; 4] = [
+    "pyre_interpreter",
+    "objspace",
+    "descroperation",
+    "jit_bigint_div",
+];
+const REM_PATH: [&str; 4] = [
+    "pyre_interpreter",
+    "objspace",
+    "descroperation",
+    "jit_bigint_rem",
+];
+
+/// A recognized `bigint::BigInt::div_rem()` call site captured during body
+/// lowering (`front::mir` `recognize_bigint_div_rem_site`).  The synthetic
+/// `Tuple` owner is a constant, so the site carries only the result var.
+#[derive(Clone)]
+pub(crate) struct BigIntDivRemSite {
+    /// The `div_rem` call result (the `(BigInt, BigInt)` tuple) — locates the
+    /// producer op.
+    pub result_var: Variable,
+}
+
+/// Rewrite every recorded `bigint::BigInt::div_rem()` call site into the
+/// modeled quotient/remainder tuple.  Fail-safe: a site whose producer op is
+/// not the expected 2-arg residual call is left untouched (Skip).  Returns the
+/// number of sites rewritten.
+pub(crate) fn rewire_bigint_div_rem_call_sites(
+    graph: &mut FunctionGraph,
+    sites: &[BigIntDivRemSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_bigint_div_rem_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `div_rem` call; the unregistered callee
+                // keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_bigint_div_rem_site(
+    graph: &mut FunctionGraph,
+    site: &BigIntDivRemSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    let (a, call_idx) = graph
+        .blocks
+        .iter()
+        .enumerate()
+        .find_map(|(bi, b)| {
+            b.operations
+                .iter()
+                .position(|op| op.result.as_ref() == Some(&site.result_var))
+                .map(|oi| (bi, oi))
+        })
+        .ok_or_else(|| format!("{name}: bigint div_rem result var has no producer op"))?;
+
+    // The producer must be the 2-arg residual call (numerator, denominator).
+    let (num, den) = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
+        other => {
+            return Err(format!(
+                "{name}: bigint div_rem producer op is not a 2-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // --- Structural validation passed; splice the producer. ---
+    let q = graph.alloc_value_var();
+    let r = graph.alloc_value_var();
+    let inserts = build_div_rem_tuple(&site.result_var, num, den, q, r);
+
+    let ops = &mut graph.blocks[a].operations;
+    ops.remove(call_idx);
+    for (offset, op) in inserts.into_iter().enumerate() {
+        ops.insert(call_idx + offset, op);
+    }
+    Ok(())
+}
+
+/// A residual `CallTarget::FunctionPath` for a `#[dont_look_inside]` helper.
+fn functionpath(segments: &[&str]) -> CallTarget {
+    CallTarget::FunctionPath {
+        segments: segments.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+/// A synthetic-`Tuple` `__pos_<idx>` `FieldWrite` of a `Ref` element, matching
+/// the `Rvalue::Aggregate` non-Adt tuple chain (owner_root `"Tuple"`, element
+/// ty `Ref(None)`).
+fn tuple_field_write(base: &Variable, idx: usize, value: Variable) -> SpaceOperation {
+    SpaceOperation {
+        result: None,
+        kind: OpKind::FieldWrite {
+            base: base.clone(),
+            field: FieldDescriptor {
+                name: format!("__pos_{idx}"),
+                owner_root: Some("Tuple".to_string()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(value),
+            ty: ValueType::Ref(None),
+        },
+    }
+}
+
+/// Build the modeled quotient/remainder tuple bound to `result_var`: the two
+/// `#[dont_look_inside]` residuals + the synthetic-`Tuple` ctor + `__pos_0` /
+/// `__pos_1` writes, the same transparent-ctor + `FieldWrite` chain
+/// `Rvalue::Aggregate` emits for a non-Adt tuple.
+fn build_div_rem_tuple(
+    result_var: &Variable,
+    num: Variable,
+    den: Variable,
+    q: Variable,
+    r: Variable,
+) -> [SpaceOperation; 5] {
+    [
+        SpaceOperation {
+            result: Some(q.clone()),
+            kind: OpKind::Call {
+                target: functionpath(&DIV_PATH),
+                args: vec![num.clone(), den.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        },
+        SpaceOperation {
+            result: Some(r.clone()),
+            kind: OpKind::Call {
+                target: functionpath(&REM_PATH),
+                args: vec![num, den],
+                result_ty: ValueType::Ref(None),
+            },
+        },
+        SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::synthetic_transparent_ctor("Tuple".to_string()),
+                args: Vec::new(),
+                result_ty: ValueType::Ref(Some("Tuple".to_string())),
+            },
+        },
+        tuple_field_write(result_var, 0, q),
+        tuple_field_write(result_var, 1, r),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn div_rem_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["bigint", "BigInt", "div_rem"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn calls_to<'a>(g: &'a FunctionGraph, leaf: &'a str) -> usize {
+        g.blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some(leaf)
+                )
+            })
+            .count()
+    }
+
+    /// Build `t = num.div_rem(&den)` and assert the rewrite drops the `div_rem`
+    /// call, emits the `jit_bigint_div` / `jit_bigint_rem` residuals, and
+    /// builds the `Tuple { __pos_0, __pos_1 }` aggregate on the original result.
+    #[test]
+    fn rewrite_lifts_div_rem_to_modeled_tuple() {
+        let mut g = FunctionGraph::new("test_bigint_div_rem");
+        let a = g.startblock;
+        let num = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let den = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: div_rem_target(),
+                    args: vec![num.clone(), den.clone()],
+                    result_ty: ValueType::Ref(Some("Tuple".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_bigint_div_rem_call_sites(
+            &mut g,
+            &[BigIntDivRemSite {
+                result_var: result.clone(),
+            }],
+        );
+        assert_eq!(rewritten, 1, "the div_rem site must be rewritten");
+        assert_eq!(calls_to(&g, "div_rem"), 0, "residual div_rem call removed");
+        assert_eq!(calls_to(&g, "jit_bigint_div"), 1, "quotient residual emitted");
+        assert_eq!(calls_to(&g, "jit_bigint_rem"), 1, "remainder residual emitted");
+        // The aggregate: __pos_0 + __pos_1 writes on the result var.
+        let pos_writes: Vec<usize> = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, .. } if field.name.starts_with("__pos_") => {
+                    field.name.strip_prefix("__pos_").and_then(|n| n.parse().ok())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(pos_writes, vec![0, 1], "two positional tuple writes");
+        let ctor_binds_result = g.blocks[a.0].operations.iter().any(|op| {
+            op.result.as_ref() == Some(&result)
+                && matches!(&op.kind, OpKind::Call { args, .. } if args.is_empty())
+        });
+        assert!(ctor_binds_result, "result var re-bound to the Tuple ctor");
+    }
+
+    /// A producer op that is not a 2-arg call declines (fail-safe).
+    #[test]
+    fn rewrite_declines_when_producer_not_binary_call() {
+        let mut g = FunctionGraph::new("test_bigint_div_rem_decline");
+        let a = g.startblock;
+        let num = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: div_rem_target(),
+                    args: vec![num],
+                    result_ty: ValueType::Ref(Some("Tuple".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_bigint_div_rem_call_sites(
+            &mut g,
+            &[BigIntDivRemSite {
+                result_var: result,
+            }],
+        );
+        assert_eq!(rewritten, 0, "a non-binary producer declines");
+        assert_eq!(calls_to(&g, "div_rem"), 1, "residual call survives on decline");
+    }
+}

--- a/majit/majit-translate/src/front/bigint_div_rem.rs
+++ b/majit/majit-translate/src/front/bigint_div_rem.rs
@@ -108,9 +108,12 @@ fn rewire_one_bigint_div_rem_site(
     };
 
     // --- Structural validation passed; splice the producer. ---
+    // Key the rebuilt tuple's `__pos_N` owner off the destructure reads so
+    // the writes land on the same (possibly per-shape-suffixed) classdef.
+    let owner = graph.tuple_owner_for_var(&site.result_var);
     let q = graph.alloc_value_var();
     let r = graph.alloc_value_var();
-    let inserts = build_div_rem_tuple(&site.result_var, num, den, q, r);
+    let inserts = build_div_rem_tuple(&site.result_var, num, den, q, r, &owner);
 
     let ops = &mut graph.blocks[a].operations;
     ops.remove(call_idx);
@@ -130,14 +133,14 @@ fn functionpath(segments: &[&str]) -> CallTarget {
 /// A synthetic-`Tuple` `__pos_<idx>` `FieldWrite` of a `Ref` element, matching
 /// the `Rvalue::Aggregate` non-Adt tuple chain (owner_root `"Tuple"`, element
 /// ty `Ref(None)`).
-fn tuple_field_write(base: &Variable, idx: usize, value: Variable) -> SpaceOperation {
+fn tuple_field_write(base: &Variable, idx: usize, value: Variable, owner: &str) -> SpaceOperation {
     SpaceOperation {
         result: None,
         kind: OpKind::FieldWrite {
             base: base.clone(),
             field: FieldDescriptor {
                 name: format!("__pos_{idx}"),
-                owner_root: Some("Tuple".to_string()),
+                owner_root: Some(owner.to_string()),
                 owner_id: None,
             },
             value: LinkArg::Value(value),
@@ -156,6 +159,7 @@ fn build_div_rem_tuple(
     den: Variable,
     q: Variable,
     r: Variable,
+    owner: &str,
 ) -> [SpaceOperation; 5] {
     [
         SpaceOperation {
@@ -177,13 +181,13 @@ fn build_div_rem_tuple(
         SpaceOperation {
             result: Some(result_var.clone()),
             kind: OpKind::Call {
-                target: CallTarget::synthetic_transparent_ctor("Tuple".to_string()),
+                target: CallTarget::synthetic_transparent_ctor(owner.to_string()),
                 args: Vec::new(),
-                result_ty: ValueType::Ref(Some("Tuple".to_string())),
+                result_ty: ValueType::Ref(Some(owner.to_string())),
             },
         },
-        tuple_field_write(result_var, 0, q),
-        tuple_field_write(result_var, 1, r),
+        tuple_field_write(result_var, 0, q, owner),
+        tuple_field_write(result_var, 1, r, owner),
     ]
 }
 
@@ -248,17 +252,26 @@ mod tests {
         );
         assert_eq!(rewritten, 1, "the div_rem site must be rewritten");
         assert_eq!(calls_to(&g, "div_rem"), 0, "residual div_rem call removed");
-        assert_eq!(calls_to(&g, "jit_bigint_div"), 1, "quotient residual emitted");
-        assert_eq!(calls_to(&g, "jit_bigint_rem"), 1, "remainder residual emitted");
+        assert_eq!(
+            calls_to(&g, "jit_bigint_div"),
+            1,
+            "quotient residual emitted"
+        );
+        assert_eq!(
+            calls_to(&g, "jit_bigint_rem"),
+            1,
+            "remainder residual emitted"
+        );
         // The aggregate: __pos_0 + __pos_1 writes on the result var.
         let pos_writes: Vec<usize> = g
             .blocks
             .iter()
             .flat_map(|blk| &blk.operations)
             .filter_map(|op| match &op.kind {
-                OpKind::FieldWrite { field, .. } if field.name.starts_with("__pos_") => {
-                    field.name.strip_prefix("__pos_").and_then(|n| n.parse().ok())
-                }
+                OpKind::FieldWrite { field, .. } if field.name.starts_with("__pos_") => field
+                    .name
+                    .strip_prefix("__pos_")
+                    .and_then(|n| n.parse().ok()),
                 _ => None,
             })
             .collect();
@@ -289,13 +302,13 @@ mod tests {
             .unwrap();
         g.set_return(a, None);
 
-        let rewritten = rewire_bigint_div_rem_call_sites(
-            &mut g,
-            &[BigIntDivRemSite {
-                result_var: result,
-            }],
-        );
+        let rewritten =
+            rewire_bigint_div_rem_call_sites(&mut g, &[BigIntDivRemSite { result_var: result }]);
         assert_eq!(rewritten, 0, "a non-binary producer declines");
-        assert_eq!(calls_to(&g, "div_rem"), 1, "residual call survives on decline");
+        assert_eq!(
+            calls_to(&g, "div_rem"),
+            1,
+            "residual call survives on decline"
+        );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5985,6 +5985,74 @@ impl<'a> Lowering<'a> {
             op_kind
         };
 
+        // Retarget a foreign BigInt binary-operator call (`<BigInt as
+        // BitAnd>::bitand`, …) to its `#[dont_look_inside]` `jit_bigint_*`
+        // residual.  The malachite operator body is Opaque, and both operands
+        // and the result are the classdef-less `*mut BigInt` GcRef the front
+        // models a `BigInt` as, so the i64-ABI residual is a faithful pointer
+        // pass.  Guarded on both operands resolving to the opaque `BigInt` ADT
+        // so a same-named operator on another type is never mis-retargeted; a
+        // pure target swap (args + result var unchanged), fail-safe by
+        // construction (a non-BigInt / unlisted operator leaves the residual
+        // `<Impl>` call the census Skips).
+        let op_kind = if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_is_opaque_bigint(t, self.llbc))
+            && second_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_is_opaque_bigint(t, self.llbc))
+            && let Some(residual) =
+                crate::front::bigint_binop::bigint_binop_residual_path(segments)
+        {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments: residual },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
+            }
+        } else {
+            op_kind
+        };
+
+        // Retarget a foreign BigInt shift call (`<BigInt as Shl<usize>>::shl`,
+        // …) to its `jit_bigint_{shl,shr}` residual.  Split from the binary
+        // retarget above because the shift amount is a machine integer, not a
+        // `BigInt`: the guard requires the first operand to be the opaque
+        // `BigInt` ADT and the second to be an integer, so the residual reads
+        // `b` as the shift count rather than as a `*mut BigInt` pointer.  Same
+        // pure-target-swap, fail-safe contract.
+        let op_kind = if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && first_arg_ty
+                .as_ref()
+                .is_some_and(|t| tyref_is_opaque_bigint(t, self.llbc))
+            && second_arg_ty.as_ref().is_some_and(|t| {
+                matches!(
+                    tyref_to_value_type(t, self.llbc),
+                    ValueType::Int | ValueType::Unsigned
+                )
+            })
+            && let Some(residual) =
+                crate::front::bigint_binop::bigint_shift_residual_path(segments)
+        {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments: residual },
+                args: args.clone(),
+                result_ty: ValueType::Ref(None),
+            }
+        } else {
+            op_kind
+        };
+
         // Allocate the result Variable and bind it to the destination
         // local before pushing the op, so subsequent reads see the
         // freshly-minted Variable.
@@ -10324,6 +10392,22 @@ fn dont_look_inside_return_token(output: &TyRef, llbc: &Llbc) -> Option<String> 
         ValueType::Void | ValueType::State | ValueType::Unknown => return None,
     };
     Some(token.to_string())
+}
+
+/// True when `ty` (after stripping `&`/`&mut`/`*` wrappers) resolves to the
+/// foreign opaque `malachite_bigint::bigint::BigInt` ADT.  Guards the
+/// BigInt binary-operator retarget (`front::bigint_binop`) so a same-named
+/// operator (`BitAnd`/`Sub`/`Mul`/…) on any other type is never redirected to
+/// a `jit_bigint_*` residual that would misread its non-BigInt pointer.
+fn tyref_is_opaque_bigint(ty: &TyRef, llbc: &Llbc) -> bool {
+    tyref_node(ty, llbc)
+        .and_then(|n| strip_ty_wrappers(n, llbc))
+        .and_then(adt_node_def_id)
+        .and_then(|id| llbc.type_by_id(id))
+        .is_some_and(|td| {
+            matches!(td.kind, TypeDeclKind::Opaque)
+                && td.item_meta.name_path().ends_with("bigint::BigInt")
+        })
 }
 
 /// Classify a struct field [`TyRef`] into the RPython `lltype` register

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1680,6 +1680,19 @@ pub fn lower_fun_decl_with_static_addrs(
                 &lo.closure_select_sites,
             )
         };
+        // The `bigint::BigInt::div_rem()` producer rewrite
+        // (`front::bigint_div_rem`) splices the residual `div_rem` call in
+        // place with `jit_bigint_div` / `jit_bigint_rem` residuals + a
+        // synthetic-`Tuple` `(quotient, remainder)` aggregate.  It touches no
+        // control flow (no fresh blocks, no detached edges), so it does not
+        // gate the reachability sweep; fail-safe, so a structural mismatch
+        // leaves the residual call (rtyper Skip).
+        if !lo.bigint_div_rem_sites.is_empty() {
+            crate::front::bigint_div_rem::rewire_bigint_div_rem_call_sites(
+                &mut lo.graph,
+                &lo.bigint_div_rem_sites,
+            );
+        }
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
@@ -2028,6 +2041,11 @@ struct Lowering<'a> {
     /// resolved ctor/method owners the arms need (see
     /// [`crate::front::bool_then::BoolThenSite`]).
     bool_then_sites: Vec<crate::front::bool_then::BoolThenSite>,
+    /// `bigint::BigInt::div_rem()` call sites recorded for the modeled
+    /// `(quotient, remainder)` tuple producer the `front::bigint_div_rem`
+    /// post-pass synthesizes (see
+    /// [`crate::front::bigint_div_rem::BigIntDivRemSite`]).
+    bigint_div_rem_sites: Vec<crate::front::bigint_div_rem::BigIntDivRemSite>,
     /// `Option::unwrap_or(opt, default)` call sites recorded for the
     /// discriminant value-select the `front::option_unwrap_or` post-pass
     /// synthesizes after the body lowering completes.  Each carries the
@@ -2204,6 +2222,7 @@ impl<'a> Lowering<'a> {
             checked_arith_call_results: Vec::new(),
             option_try_sites: Vec::new(),
             bool_then_sites: Vec::new(),
+            bigint_div_rem_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             map_or_sites: Vec::new(),
             is_none_sites: Vec::new(),
@@ -6050,6 +6069,24 @@ impl<'a> Lowering<'a> {
                 self.recognize_bool_then_site(&call.dest.ty, second_arg_ty.as_ref(), &result_var)
         {
             self.bool_then_sites.push(site);
+        }
+        // Capture `bigint::BigInt::div_rem()` sites for the modeled
+        // `(quotient, remainder)` tuple producer `front::bigint_div_rem`
+        // synthesizes.  Opaque foreign 2-arg FunctionPath (numerator,
+        // denominator); the `(BigInt, BigInt)` tuple owner is the synthetic
+        // `"Tuple"` constant, so only the result var is recorded.
+        if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && fmt_path_ends_with(segments, &["bigint", "BigInt", "div_rem"])
+        {
+            self.bigint_div_rem_sites
+                .push(crate::front::bigint_div_rem::BigIntDivRemSite {
+                    result_var: result_var.clone(),
+                });
         }
         // Capture `Option::unwrap_or(opt, default)` sites for the
         // discriminant value-select `front::option_unwrap_or` synthesizes.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1647,6 +1647,16 @@ pub fn lower_fun_decl_with_static_addrs(
                 &lo.unwrap_or_sites,
             )
         };
+        // The `Option::unwrap` guard rewrite (`front::option_unwrap`) splits the
+        // residual `unwrap` call block into a `__discriminant` guard whose
+        // `Some` arm extracts `__pos_0` and whose `None` arm raises the implicit
+        // `AssertionError`; same fail-safe contract as `unwrap_or`, gate the
+        // reachability sweep on an actual rewrite.
+        let unwrap_rewritten = if lo.unwrap_sites.is_empty() {
+            0
+        } else {
+            crate::front::option_unwrap::rewire_unwrap_call_sites(&mut lo.graph, &lo.unwrap_sites)
+        };
         // The `Option::map_or` closure-select rewrite (`front::option_map_or`)
         // splits the residual `map_or` call block into a `__discriminant`
         // diamond whose `Some` arm calls the closure, same post-lowering shape
@@ -1700,6 +1710,7 @@ pub fn lower_fun_decl_with_static_addrs(
             || option_try_stats.rewritten > 0
             || bool_then_rewritten > 0
             || unwrap_or_rewritten > 0
+            || unwrap_rewritten > 0
             || map_or_rewritten > 0
             || closure_select_rewritten > 0
         {
@@ -2052,6 +2063,10 @@ struct Lowering<'a> {
     /// resolved `Option` owners the arms' field reads need (see
     /// [`crate::front::option_unwrap_or::UnwrapOrSite`]).
     unwrap_or_sites: Vec<crate::front::option_unwrap_or::UnwrapOrSite>,
+    /// `Option::unwrap(opt)` call sites recorded for the discriminant guard the
+    /// `front::option_unwrap` post-pass synthesizes (see
+    /// [`crate::front::option_unwrap::UnwrapSite`]).
+    unwrap_sites: Vec<crate::front::option_unwrap::UnwrapSite>,
     /// `Option::map_or(opt, default, closure)` call sites recorded for the
     /// discriminant closure-select the `front::option_map_or` post-pass
     /// synthesizes (see [`crate::front::option_map_or::MapOrSite`]).
@@ -2224,6 +2239,7 @@ impl<'a> Lowering<'a> {
             bool_then_sites: Vec::new(),
             bigint_div_rem_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
+            unwrap_sites: Vec::new(),
             map_or_sites: Vec::new(),
             is_none_sites: Vec::new(),
             closure_select_sites: Vec::new(),
@@ -6200,6 +6216,24 @@ impl<'a> Lowering<'a> {
         {
             self.unwrap_or_sites.push(site);
         }
+        // Capture `Option::unwrap(opt)` sites for the discriminant guard
+        // `front::option_unwrap` synthesizes.  Like `unwrap_or`, `unwrap`'s body
+        // is Opaque (foreign `core`) and its receiver is the `Option` ADT, so
+        // `first_is_self` routes it to a `CallTarget::Method` (receiver in
+        // `args[0]`, the sole argument).  `recognize_unwrap_site` confirms the
+        // receiver is an `Option` (not `Result`).  A resolution miss leaves the
+        // residual call — an unregistered callee the rtyper census Skips.
+        if let OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 1
+            && name == "unwrap"
+            && let Some(site) = self.recognize_unwrap_site(first_arg_ty.as_ref(), &result_var)
+        {
+            self.unwrap_sites.push(site);
+        }
         // Capture `Option::map_or(opt, default, closure)` sites for the
         // discriminant closure-select `front::option_map_or` synthesizes.
         // Like `unwrap_or`, `map_or`'s body is Opaque (foreign `core`) and its
@@ -7688,6 +7722,35 @@ impl<'a> Lowering<'a> {
             result_var: result_var.clone(),
             option_owner,
             is_some,
+        })
+    }
+
+    /// Resolve a recognized `Option::unwrap(opt)` call into an
+    /// [`crate::front::option_unwrap::UnwrapSite`] — the `Option` enum root +
+    /// `Some` variant owners and the payload type the discriminant-guard
+    /// post-pass needs.  `None` (leaving the residual call) when the receiver
+    /// type is not a resolvable `Option`.  Guards on `Option` specifically —
+    /// `Result::unwrap` shares the method name but its `Ok`/`Err` tags do not
+    /// match `Some`=1/`None`=0.
+    fn recognize_unwrap_site(
+        &self,
+        recv_ty: Option<&TyRef>,
+        result_var: &Variable,
+    ) -> Option<crate::front::option_unwrap::UnwrapSite> {
+        let recv_ty = recv_ty?;
+        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+            return None;
+        }
+        let def_id = self.tyref_adt_def_id(recv_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        let option_owner = td.item_meta.name_path();
+        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+        let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
+        Some(crate::front::option_unwrap::UnwrapSite {
+            result_var: result_var.clone(),
+            option_owner,
+            some_owner,
+            payload_ty,
         })
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -3010,7 +3010,7 @@ impl<'a> Lowering<'a> {
                 // consumes the rvalue, so `.N` reads of the local can
                 // later emit a symmetric `FieldRead __pos_<N>` carrying
                 // the same owner (see `resolve_place`).
-                let positional_owner = self.positional_aggregate_owner(&rvalue);
+                let positional_owner = self.positional_aggregate_owner(&rvalue, &dest_ty);
                 let (op, result_var) = self.build_rvalue(mir_bb, rvalue, &dest_ty)?;
                 // The destination local takes on the freshly-minted
                 // result Variable. Subsequent reads of the local
@@ -3746,10 +3746,27 @@ impl<'a> Lowering<'a> {
                         (owner_path, ctor_name, field_names)
                     }
                     None => {
-                        let leaf = aggregate_ctor_name(&kind);
                         // Synthetic placeholders for non-Adt aggregates
                         // (`Tuple`, `Array`, `Closure`) — they have no
-                        // user-defined class to resolve into.
+                        // user-defined class to resolve into.  A non-empty
+                        // tuple carries its per-shape `<…>` suffix (gate) so
+                        // its `__pos_N` attrs do not collide with other-shape
+                        // tuples on one global class; the suffix matches
+                        // `positional_aggregate_owner` (Site-A reads) and
+                        // `tyref_tuple_suffix` (Site-B reads).
+                        // The per-shape `<…>` suffix is rendered from the
+                        // destination place type, not the `AggregateKind` head:
+                        // Charon's `AggregateKind::Adt(Tuple, …)` carries no
+                        // element `types`, so keying off it would spell a bare
+                        // `Tuple` on the write while the `.N` projection reads
+                        // (which do see `place.ty`'s element types) spell the
+                        // suffixed owner — a write/read owner split.  `dest_ty`
+                        // is that same `place.ty`, so both sides agree.
+                        let leaf = format!(
+                            "{}{}",
+                            aggregate_ctor_name(&kind),
+                            tyref_tuple_suffix(dest_ty, self.llbc)
+                        );
                         let positional =
                             (0..arg_vars.len()).map(|i| format!("__pos_{i}")).collect();
                         (Vec::new(), leaf, positional)
@@ -4194,6 +4211,13 @@ impl<'a> Lowering<'a> {
                         }
                         // idx == 0: fall through to the base-collapse below.
                     } else {
+                        // Same spelling the construction-side FieldWrite
+                        // chain records for builtin tuple aggregates
+                        // (`aggregate_ctor_name` id atom + the per-shape
+                        // `<…>` suffix rendered from this tuple's element
+                        // types), so read and write attrs key under one
+                        // owner.
+                        let owner = format!("Tuple{}", tyref_tuple_suffix(&inner.ty, self.llbc));
                         let base = self.resolve_place(mir_bb, *inner)?;
                         let bb_id = self.block_id[mir_bb];
                         let ty = tyref_to_value_type(&place_ty, self.llbc);
@@ -4204,15 +4228,7 @@ impl<'a> Lowering<'a> {
                             result: Some(res.clone()),
                             kind: OpKind::FieldRead {
                                 base,
-                                field: FieldDescriptor::new(
-                                    format!("__pos_{idx}"),
-                                    // Same spelling the construction-side
-                                    // FieldWrite chain records for builtin
-                                    // tuple aggregates (`aggregate_ctor_name`
-                                    // id atom), so read and write attrs key
-                                    // under one owner.
-                                    Some("Tuple".to_string()),
-                                ),
+                                field: FieldDescriptor::new(format!("__pos_{idx}"), Some(owner)),
                                 ty,
                                 pure: false,
                             },
@@ -4356,10 +4372,18 @@ impl<'a> Lowering<'a> {
     /// Returns `None` for Adt aggregates: their `.field` reads already
     /// take the typed [`Self::resolve_adt_field`] path and never reach
     /// the collapse fallback.
-    fn positional_aggregate_owner(&self, rvalue: &Rvalue) -> Option<String> {
+    fn positional_aggregate_owner(&self, rvalue: &Rvalue, dest_ty: &TyRef) -> Option<String> {
         match rvalue {
             Rvalue::Aggregate(kind, _) if self.resolve_aggregate_adt(kind).is_none() => {
-                Some(aggregate_ctor_name(kind))
+                // Suffix from `dest_ty` (the tuple `place.ty`, element types
+                // present), matching the construction-side `build_rvalue`
+                // owner and the Site-B projection read; the `AggregateKind`
+                // head carries no element `types`.
+                Some(format!(
+                    "{}{}",
+                    aggregate_ctor_name(kind),
+                    tyref_tuple_suffix(dest_ty, self.llbc)
+                ))
             }
             _ => None,
         }
@@ -6007,8 +6031,7 @@ impl<'a> Lowering<'a> {
             && second_arg_ty
                 .as_ref()
                 .is_some_and(|t| tyref_is_opaque_bigint(t, self.llbc))
-            && let Some(residual) =
-                crate::front::bigint_binop::bigint_binop_residual_path(segments)
+            && let Some(residual) = crate::front::bigint_binop::bigint_binop_residual_path(segments)
         {
             OpKind::Call {
                 target: CallTarget::FunctionPath { segments: residual },
@@ -6041,8 +6064,7 @@ impl<'a> Lowering<'a> {
                     ValueType::Int | ValueType::Unsigned
                 )
             })
-            && let Some(residual) =
-                crate::front::bigint_binop::bigint_shift_residual_path(segments)
+            && let Some(residual) = crate::front::bigint_binop::bigint_shift_residual_path(segments)
         {
             OpKind::Call {
                 target: CallTarget::FunctionPath { segments: residual },
@@ -11521,6 +11543,66 @@ fn render_adt_type_args(
                 .filter(|s| s != "Global" && s != "RandomState")
                 .collect()
         })
+        .unwrap_or_default()
+}
+
+/// A non-empty synthetic tuple aggregate's classdef carries a `<T0,T1,…>`
+/// suffix rendered from its element types, so `(BigInt,BigInt)` and `(f64,f64)`
+/// get distinct classdefs instead of colliding on the shared `__pos_N`
+/// attributes of one global `Tuple` class — the `generalize_attr` UnionError
+/// that walls every graph mixing tuple element categories (`bigint_truediv`,
+/// …) off the two-phase rtyper.  On by default; `PYRE_TUPLE_PER_SHAPE_CLASSDEF=0`
+/// is the kill switch that restores the single global `Tuple` classdef.
+fn tuple_per_shape_enabled() -> bool {
+    !matches!(
+        std::env::var("PYRE_TUPLE_PER_SHAPE_CLASSDEF").as_deref(),
+        Ok("0") | Ok("false")
+    )
+}
+
+/// The per-shape `<…>` suffix for a synthetic tuple whose Charon ADT
+/// descriptor is `adt` (`{"id":"Tuple","generics":{"types":[…]}}`), or `""`
+/// when the gate is off, `adt` is not a `"Tuple"`, or the tuple is the unit
+/// `()` (empty type list — kept bare `"Tuple"` so the unit-value special-cases
+/// in `jtransform` / `unit_variant_fold` still match).  Rendered via the same
+/// [`render_adt_type_args`] both the construction and the projection derive
+/// from the tuple's `place.ty` node (NOT the element-type-less `AggregateKind`
+/// head), so the `__pos_N` read and write owners agree.
+fn tuple_shape_suffix(adt: &serde_json::Map<String, serde_json::Value>, llbc: &Llbc) -> String {
+    if !tuple_per_shape_enabled() {
+        return String::new();
+    }
+    if adt.get("id").and_then(serde_json::Value::as_str) != Some("Tuple") {
+        return String::new();
+    }
+    let args = render_adt_type_args(adt, llbc, 0);
+    if args.is_empty() {
+        return String::new();
+    }
+    format!("<{}>", args.join(","))
+}
+
+/// The per-shape tuple suffix for a place/operand [`TyRef`] — used by BOTH the
+/// construction side (the aggregate's destination `place.ty`) and the
+/// projection side (the read place's `.ty`), where the tuple type is `ty`'s
+/// `{"Adt": {"id":"Tuple", …}}` node.  Keying both off the same `place.ty`
+/// source (rather than the element-type-less `AggregateKind` head) makes the
+/// `__pos_N` write and read owners agree.  `""` for non-tuple / gate-off /
+/// unit; see [`tuple_shape_suffix`].
+fn tyref_tuple_suffix(ty: &TyRef, llbc: &Llbc) -> String {
+    let value = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return String::new(),
+        },
+    };
+    value
+        .as_object()
+        .and_then(|m| m.get("Adt"))
+        .and_then(serde_json::Value::as_object)
+        .map(|adt| tuple_shape_suffix(adt, llbc))
         .unwrap_or_default()
 }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -6194,17 +6194,17 @@ impl<'a> Lowering<'a> {
                     result_var: result_var.clone(),
                 });
         }
-        // Capture `Option::unwrap_or(opt, default)` sites for the
-        // discriminant value-select `front::option_unwrap_or` synthesizes.
-        // `unwrap_or`'s body is Opaque (foreign `core`), but its receiver is
-        // the `Option` ADT, so `first_is_self` routes it to a
-        // `CallTarget::Method` (receiver in `args[0]`, default in `args[1]`),
-        // NOT a raw FunctionPath.  Resolving the `Option` field owners needs
-        // the receiver's `Option` type (`first_arg_ty`), in hand here;
-        // `recognize_unwrap_or_site` also confirms the receiver is an `Option`
-        // (not `Result`, whose variant tags differ).  A resolution miss
-        // leaves the residual call — an unregistered callee the rtyper census
-        // Skips, so no graph regresses.
+        // Capture `Option::unwrap_or(opt, default)` /
+        // `Result::unwrap_or(res, default)` sites for the discriminant
+        // value-select `front::option_unwrap_or` synthesizes.  `unwrap_or`'s
+        // body is Opaque (foreign `core`), but its receiver is the enum ADT, so
+        // `first_is_self` routes it to a `CallTarget::Method` (receiver in
+        // `args[0]`, default in `args[1]`), NOT a raw FunctionPath.  Resolving
+        // the enum field owners needs the receiver's type (`first_arg_ty`), in
+        // hand here; `recognize_unwrap_or_site` classifies `Option` vs `Result`
+        // (their `Some`=1 / `Ok`=0 payload tags differ) and records the
+        // polarity.  A resolution miss leaves the residual call — an
+        // unregistered callee the rtyper census Skips, so no graph regresses.
         if let OpKind::Call {
             target: CallTarget::Method { name, .. },
             args,
@@ -7670,33 +7670,51 @@ impl<'a> Lowering<'a> {
         })
     }
 
-    /// Resolve a recognized `Option::unwrap_or(opt, default)` call into an
-    /// [`crate::front::option_unwrap_or::UnwrapOrSite`] — the `Option` enum
-    /// root + `Some` variant owners and the payload type the value-select
-    /// post-pass needs.  `None` (leaving the residual call) when the receiver
-    /// type is not a resolvable `Option`.
+    /// Resolve a recognized `Option::unwrap_or(opt, default)` /
+    /// `Result::unwrap_or(res, default)` call into an
+    /// [`crate::front::option_unwrap_or::UnwrapOrSite`] — the enum root +
+    /// payload-variant owners and the payload type the value-select post-pass
+    /// needs.  `None` (leaving the residual call) when the receiver type is not
+    /// a resolvable `Option` or `Result`.  The payload variant differs by enum:
+    /// `Option::Some = 1` (`None = 0`), `Result::Ok = 0` (`Err = 1`) — recorded
+    /// in `payload_on_disc_true` so the post-pass branches to the right arm.
     fn recognize_unwrap_or_site(
         &self,
         recv_ty: Option<&TyRef>,
         result_var: &Variable,
     ) -> Option<crate::front::option_unwrap_or::UnwrapOrSite> {
-        // Receiver `Option`: enum root + `Some` variant owners + payload.
-        // Guard on `Option` specifically — `Result::unwrap_or` shares the
-        // method name but its `Ok`/`Err` tags do not match `Some`=1/`None`=0.
         let recv_ty = recv_ty?;
-        if !crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
-            return None;
-        }
+        // The payload variant discriminant (`Some`=1 / `Ok`=0) both classifies
+        // the receiver enum and picks the value-select polarity.  `Result<_,
+        // PyError>` is excluded — that instantiation is the exception-transform's
+        // domain (`front::result_exc` rewrites its `Ok`/`Err` into exception
+        // edges, not a switchable discriminant value), so its `unwrap_or` is
+        // left residual (Skip) rather than risk a value-select on an
+        // exception-form value.  Only `Option` and plain-error `Result` (e.g.
+        // `io::Result`) select here.
+        let (payload_disc, payload_on_disc_true) =
+            if crate::front::result_exc::tyref_is_option(recv_ty, self.llbc) {
+                (1, true)
+            } else if crate::front::result_exc::tyref_is_result(recv_ty, self.llbc)
+                && !crate::front::result_exc::tyref_is_result_of_pyerror(recv_ty, self.llbc)
+            {
+                (0, false)
+            } else {
+                return None;
+            };
         let def_id = self.tyref_adt_def_id(recv_ty)?;
         let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
-        let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
+        let enum_owner = td.item_meta.name_path();
+        let payload_owner = Self::tagged_pair_payload_owner(td, &enum_owner, payload_disc)?;
+        // The payload `T` is the first type arg for both `Option<T>` and
+        // `Result<T, E>`.
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
         Some(crate::front::option_unwrap_or::UnwrapOrSite {
             result_var: result_var.clone(),
-            option_owner,
-            some_owner,
+            enum_owner,
+            payload_owner,
             payload_ty,
+            payload_on_disc_true,
         })
     }
 

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -80,6 +80,7 @@ pub(crate) mod option_closure_select;
 pub(crate) mod option_is_none;
 pub(crate) mod option_map_or;
 pub(crate) mod option_try;
+pub(crate) mod option_unwrap;
 pub(crate) mod option_unwrap_or;
 pub(crate) mod result_exc;
 pub mod semantic;

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -67,6 +67,7 @@
 //! the only extraction gap is std `thread_local!` accessor stubs,
 //! treated as opaque ops.
 
+pub(crate) mod bigint_div_rem;
 pub(crate) mod bool_then;
 pub(crate) mod checked_arith;
 pub(crate) mod iter_next;

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -67,6 +67,7 @@
 //! the only extraction gap is std `thread_local!` accessor stubs,
 //! treated as opaque ops.
 
+pub(crate) mod bigint_binop;
 pub(crate) mod bigint_div_rem;
 pub(crate) mod bool_then;
 pub(crate) mod checked_arith;

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -97,7 +97,9 @@ fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Resul
     // pushing it) so removing it leaves the receiver construction as the tail.
     let call_idx = graph.blocks[a].operations.len() - 1;
     if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
-        return Err(format!("{name}: unwrap call is not the last op of block {a}"));
+        return Err(format!(
+            "{name}: unwrap call is not the last op of block {a}"
+        ));
     }
     // Capture the receiver `Option` operand (the sole argument).
     let opt = match &graph.blocks[a].operations[call_idx].kind {
@@ -280,11 +282,7 @@ mod tests {
         let raises = g
             .blocks
             .iter()
-            .filter(|blk| {
-                blk.exits
-                    .iter()
-                    .any(|link| link.target == g.exceptblock)
-            })
+            .filter(|blk| blk.exits.iter().any(|link| link.target == g.exceptblock))
             .count();
         assert_eq!(raises, 1, "the None arm raises to exceptblock");
     }

--- a/majit/majit-translate/src/front/option_unwrap.rs
+++ b/majit/majit-translate/src/front/option_unwrap.rs
@@ -1,0 +1,323 @@
+//! `Option::unwrap(opt)` → discriminant guard + payload extraction.
+//!
+//! ## Positioning
+//!
+//! `core::option::<Impl>::unwrap` is a foreign combinator whose body is Opaque
+//! in the LLBC (Charon cannot extract `core`), so the caller emits a residual
+//! `unwrap` call — an unregistered callee the rtyper census Skips.  Like
+//! [`crate::front::option_unwrap_or`] the combinator's match lives inside the
+//! opaque body: at the call site there is only `result = unwrap(opt)` flowing
+//! on.  This pass creates the guard the combinator's semantics imply:
+//!
+//! ```text
+//!     result = opt.unwrap()               // residual `unwrap` call
+//! becomes
+//!     if opt.__discriminant == 1 { result = opt.__pos_0 } else { <panic> }
+//! ```
+//!
+//! Unlike `unwrap_or` there is no default: `Option::unwrap` panics on `None`.
+//! The `None` arm is therefore not a value path but an implicit-`AssertionError`
+//! raise ([`FunctionGraph::set_raise_implicit`]) — the "shouldn't occur at
+//! run-time" shape [`crate::model::remove_assertion_errors`] prunes, matching
+//! `unwrap`'s never-`None` contract.  The `Some` arm reads `opt.__pos_0` exactly
+//! as `unwrap_or`'s does.  `Option`'s tags are `None = 0` / `Some = 1`, so
+//! branching on `bool(disc)` selects the `Some` arm.
+//!
+//! ## The rewrite (`rewire_one_unwrap_site`)
+//!
+//! Block A holds the residual `unwrap` call producing `result` as its last op,
+//! closed by `lower_call` with a single forwarding exit to block B (the
+//! continuation consuming `result`).  The rewrite:
+//! 1. drops the `unwrap` call, reads `disc = opt.__discriminant`, and closes A
+//!    with a `bool(disc)` branch to two fresh arms;
+//! 2. the `then_bb` (`Some`) arm reads `opt.__pos_0` and forwards it to B as
+//!    the `result` slot, threading every other live value through;
+//! 3. the `else_bb` (`None`) arm raises the implicit `AssertionError` (no edge
+//!    to B — the `None` path never produces a `result`).
+//!
+//! It is **fail-safe**: any structural mismatch returns `Err`, the caller
+//! leaves the residual call untouched, and the unregistered `unwrap` callee
+//! keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
+use crate::model::{FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+
+/// A recognized `Option::unwrap(opt)` call site captured during body lowering
+/// (`front::mir` `recognize_unwrap_site`).  The owner strings are resolved at
+/// the recording site where the receiver `Option` type is in hand; the
+/// post-pass only needs them to spell the `__discriminant` / `__pos_0` field
+/// reads in the synthesized `Some` arm.
+#[derive(Clone)]
+pub(crate) struct UnwrapSite {
+    /// The `unwrap` call result (the payload `T` value) — locates block A.
+    pub result_var: Variable,
+    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
+    pub option_owner: String,
+    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
+    /// owner (matching the variant-qualified `resolve_adt_field` read owner).
+    pub some_owner: String,
+    /// The `Option`'s payload `T` projected to a [`ValueType`] — the
+    /// `Some::__pos_0` field kind and the extracted result kind.
+    pub payload_ty: ValueType,
+}
+
+/// Rewrite every recorded `Option::unwrap` call site into the discriminant
+/// guard.  Fail-safe: a site whose block does not fit the residual-call shape
+/// is left untouched (Skip), so a mismatch never regresses a graph the legacy
+/// walker already handled.  Returns the number of sites rewritten.
+pub(crate) fn rewire_unwrap_call_sites(graph: &mut FunctionGraph, sites: &[UnwrapSite]) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_unwrap_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `unwrap` call; the unregistered callee
+                // keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_unwrap_site(graph: &mut FunctionGraph, site: &UnwrapSite) -> Result<(), String> {
+    let name = graph.name.clone();
+    // Block A: the `unwrap` residual call producing `result_var`.
+    let a = graph
+        .blocks
+        .iter()
+        .position(|b| {
+            b.operations
+                .iter()
+                .any(|op| op.result.as_ref() == Some(&site.result_var))
+        })
+        .ok_or_else(|| format!("{name}: unwrap result var has no producer block"))?;
+
+    // The call must be A's last op (lower_call closes the block right after
+    // pushing it) so removing it leaves the receiver construction as the tail.
+    let call_idx = graph.blocks[a].operations.len() - 1;
+    if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
+        return Err(format!("{name}: unwrap call is not the last op of block {a}"));
+    }
+    // Capture the receiver `Option` operand (the sole argument).
+    let opt = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 1 => args[0].clone(),
+        other => {
+            return Err(format!(
+                "{name}: unwrap producer op is not a 1-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // A's single exit → B (the continuation consuming the payload).  Must be a
+    // plain goto — `lower_call` closes with exactly this shape.
+    let [exit] = graph.blocks[a].exits.as_slice() else {
+        return Err(format!(
+            "{name}: unwrap call block {a} does not have a single exit"
+        ));
+    };
+    if exit.exitcase.is_some() || exit.last_exception.is_some() || exit.last_exc_value.is_some() {
+        return Err(format!(
+            "{name}: unwrap call block {a} exit is not a plain goto"
+        ));
+    }
+    let saved_exit = exit.clone();
+    let b_target = saved_exit.target;
+
+    // `carried` = the distinct live Values A forwards to B other than the
+    // payload itself; each must be threaded through the `Some` arm to reach B.
+    // The `None` arm raises and never reaches B, so it carries nothing.
+    let mut carried: Vec<Variable> = Vec::new();
+    for arg in &saved_exit.args {
+        if let LinkArg::Value(v) = arg
+            && *v != site.result_var
+            && !carried.contains(v)
+        {
+            carried.push(v.clone());
+        }
+    }
+
+    // --- All structural validation passed; mutate the graph. ---
+
+    // `then_bb` (`Some`) carries `carried` plus `opt` (the base for the
+    // `__pos_0` read); `else_bb` (`None`) has no inputs — it raises.  The
+    // source-var lists double as the branch link args.
+    let mut then_sources = carried.clone();
+    if !then_sources.contains(&opt) {
+        then_sources.push(opt.clone());
+    }
+    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
+    let (else_bb, _else_inputs) = graph.create_block_with_arg_vars(0);
+
+    // `then_bb`: payload = opt.__pos_0.
+    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
+        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    let payload = graph.alloc_value_var();
+    graph.block_mut(then_bb).operations.push(SpaceOperation {
+        result: Some(payload.clone()),
+        kind: OpKind::FieldRead {
+            base: opt_in_then,
+            field: FieldDescriptor {
+                name: "__pos_0".to_string(),
+                owner_root: Some(site.some_owner.clone()),
+                owner_id: None,
+            },
+            ty: site.payload_ty.clone(),
+            pure: true,
+        },
+    });
+    let then_link_args = reproduce_exit_args(
+        &saved_exit,
+        &site.result_var,
+        &payload,
+        &then_sources,
+        &then_inputs,
+        &name,
+    )?;
+    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+
+    // `else_bb` (`None`): raise the implicit `AssertionError` — `unwrap` panics
+    // on `None`, and the never-`None` contract makes this the "shouldn't occur"
+    // shape `remove_assertion_errors` prunes.
+    graph.set_raise_implicit(else_bb, "Option::unwrap on None value");
+
+    // A: drop the residual `unwrap` call, read the discriminant, branch on it.
+    // `Option` tags None=0 / Some=1, so `bool(disc)` selects the `Some` (then)
+    // arm.  The receiver construction ops stay as A's tail.
+    let a_id = graph.blocks[a].id;
+    graph.blocks[a].operations.remove(call_idx);
+    let disc = graph.alloc_value_var();
+    graph.block_mut(a_id).operations.push(SpaceOperation {
+        result: Some(disc.clone()),
+        kind: OpKind::FieldRead {
+            base: opt.clone(),
+            field: FieldDescriptor {
+                name: "__discriminant".to_string(),
+                owner_root: Some(site.option_owner.clone()),
+                owner_id: None,
+            },
+            ty: ValueType::Int,
+            pure: true,
+        },
+    });
+    graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, Vec::new());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::CallTarget;
+
+    fn unwrap_target() -> CallTarget {
+        CallTarget::method("unwrap", None)
+    }
+
+    /// Build `result = opt.unwrap()` closed by a goto to a continuation block
+    /// consuming `result`, and assert the rewrite drops the `unwrap` call,
+    /// reads `opt.__discriminant`, branches, extracts `opt.__pos_0` in the
+    /// `Some` arm, and raises in the `None` arm.
+    #[test]
+    fn rewrite_lifts_unwrap_to_discriminant_guard() {
+        let mut g = FunctionGraph::new("test_option_unwrap");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_target(),
+                    args: vec![opt.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_unwrap_call_sites(
+            &mut g,
+            &[UnwrapSite {
+                result_var: result.clone(),
+                option_owner: "core::option::Option".to_string(),
+                some_owner: "core::option::Option::Some".to_string(),
+                payload_ty: ValueType::Int,
+            }],
+        );
+        assert_eq!(rewritten, 1, "the unwrap site must be rewritten");
+
+        // The residual `unwrap` call is gone.
+        let has_unwrap_call = g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call { target: CallTarget::Method { name, .. }, .. } if name == "unwrap"
+            )
+        });
+        assert!(!has_unwrap_call, "residual unwrap call removed");
+
+        // A `__discriminant` read and a `__pos_0` read exist.
+        let field_reads: Vec<String> = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::FieldRead { field, .. } => Some(field.name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            field_reads.iter().any(|n| n == "__discriminant"),
+            "discriminant read emitted"
+        );
+        assert!(
+            field_reads.iter().any(|n| n == "__pos_0"),
+            "Some-arm payload read emitted"
+        );
+
+        // Exactly one arm raises to the exceptblock (the `None` arm).
+        let raises = g
+            .blocks
+            .iter()
+            .filter(|blk| {
+                blk.exits
+                    .iter()
+                    .any(|link| link.target == g.exceptblock)
+            })
+            .count();
+        assert_eq!(raises, 1, "the None arm raises to exceptblock");
+    }
+
+    /// A producer op that is not a 1-arg call declines (fail-safe).
+    #[test]
+    fn rewrite_declines_when_producer_not_unary_call() {
+        let mut g = FunctionGraph::new("test_option_unwrap_decline");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let extra = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_target(),
+                    args: vec![opt, extra],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_unwrap_call_sites(
+            &mut g,
+            &[UnwrapSite {
+                result_var: result,
+                option_owner: "core::option::Option".to_string(),
+                some_owner: "core::option::Option::Some".to_string(),
+                payload_ty: ValueType::Int,
+            }],
+        );
+        assert_eq!(rewritten, 0, "a non-unary producer declines");
+    }
+}

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -1,14 +1,15 @@
-//! `Option::unwrap_or(opt, default)` → discriminant value-select.
+//! `Option::unwrap_or(opt, default)` / `Result::unwrap_or(res, default)` →
+//! discriminant value-select.
 //!
 //! ## Positioning
 //!
-//! `core::option::<Impl>::unwrap_or` is a foreign combinator whose body is
-//! Opaque in the LLBC (Charon cannot extract `core`), so the caller emits a
-//! residual `unwrap_or` call — an unregistered callee the rtyper census
-//! Skips.  Like [`crate::front::bool_then`] and unlike
+//! `core::{option,result}::<Impl>::unwrap_or` is a foreign combinator whose
+//! body is Opaque in the LLBC (Charon cannot extract `core`), so the caller
+//! emits a residual `unwrap_or` call — an unregistered callee the rtyper
+//! census Skips.  Like [`crate::front::bool_then`] and unlike
 //! [`crate::front::checked_arith`], the combinator's match lives inside the
 //! opaque body: at the call site there is no discriminant switch to rewrite,
-//! only `result = unwrap_or(opt, default)` flowing on.  This pass *creates*
+//! only `result = unwrap_or(recv, default)` flowing on.  This pass *creates*
 //! the two-way select the combinator's semantics imply:
 //!
 //! ```text
@@ -20,22 +21,23 @@
 //! Both candidates are already-computed values with no side effects, so a
 //! single-block value-select would be sound — but the graph has no
 //! conditional-move primitive, so the select is spelled as a two-arm diamond
-//! (the `Some` arm reads `opt.__pos_0`, the `None` arm forwards `default`).
-//! `Option`'s tags are `None = 0` / `Some = 1`, and the front models every
-//! `Option<T>` uniformly with an explicit `__discriminant` field (Rust niche
-//! optimisation is a codegen detail below the IR), so branching on the
-//! discriminant read as `bool(disc)` selects the `Some` arm exactly.
+//! (the payload variant reads `recv.__pos_0`, the other arm forwards
+//! `default`).  The front models every enum uniformly with an explicit
+//! `__discriminant` field (Rust niche optimisation is a codegen detail below
+//! the IR).  The payload variant's discriminant differs by enum: `Option::Some
+//! = 1` (`None = 0`), `Result::Ok = 0` (`Err = 1`), so `UnwrapOrSite`'s
+//! `payload_on_disc_true` records which `bool(disc)` arm reads `__pos_0`.
 //!
 //! ## The rewrite (`rewire_one_unwrap_or_site`)
 //!
 //! Block A holds the residual `unwrap_or` call producing `result` as its
 //! last op, closed by `lower_call` with a single forwarding exit to block B
 //! (the continuation consuming `result`).  The rewrite:
-//! 1. drops the `unwrap_or` call, reads `disc = opt.__discriminant`, and
+//! 1. drops the `unwrap_or` call, reads `disc = recv.__discriminant`, and
 //!    closes A with a `bool(disc)` branch to two fresh arms;
-//! 2. the `then_bb` (`Some`) arm reads `opt.__pos_0` as the payload;
-//! 3. the `else_bb` (`None`) arm forwards `default`;
-//! 4. both arms forward to B, reproducing A's original exit args with the
+//! 2. the payload arm reads `recv.__pos_0`, the other arm forwards `default`;
+//!    `payload_on_disc_true` picks which is the `bool(disc)`-true arm;
+//! 3. both arms forward to B, reproducing A's original exit args with the
 //!    `result` slot sourced from the arm's payload / default value and every
 //!    other live value threaded through the arm's inputargs.
 //!
@@ -49,23 +51,30 @@ use crate::model::{
     CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
 };
 
-/// A recognized `Option::unwrap_or(opt, default)` call site captured during
-/// body lowering (`front::mir` `recognize_unwrap_or_site`).  The owner
-/// strings are resolved at the recording site where the receiver `Option`
-/// type is in hand; the post-pass only needs them to spell the
-/// `__discriminant` / `__pos_0` field reads in the synthesized arms.
+/// A recognized `Option::unwrap_or(opt, default)` / `Result::unwrap_or(res,
+/// default)` call site captured during body lowering (`front::mir`
+/// `recognize_unwrap_or_site`).  The owner strings are resolved at the
+/// recording site where the receiver enum type is in hand; the post-pass only
+/// needs them to spell the `__discriminant` / `__pos_0` field reads in the
+/// synthesized arms.
 #[derive(Clone)]
 pub(crate) struct UnwrapOrSite {
     /// The `unwrap_or` call result (the payload `T` value) — locates block A.
     pub result_var: Variable,
-    /// The `Option` enum root `name_path` — the `__discriminant` field owner.
-    pub option_owner: String,
-    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
-    /// owner (matching the variant-qualified `resolve_adt_field` read owner).
-    pub some_owner: String,
-    /// The `Option`'s payload `T` projected to a [`ValueType`] — the
-    /// `Some::__pos_0` field kind and the select result kind.
+    /// The enum root `name_path` (`Option` / `Result`) — the `__discriminant`
+    /// field owner.
+    pub enum_owner: String,
+    /// The payload variant `name_path` (`Option::Some` / `Result::Ok`) — the
+    /// `__pos_0` payload field owner (matching the variant-qualified
+    /// `resolve_adt_field` read owner).
+    pub payload_owner: String,
+    /// The payload `T` projected to a [`ValueType`] — the `__pos_0` field kind
+    /// and the select result kind.
     pub payload_ty: ValueType,
+    /// True when the payload variant sits on discriminant 1 (`Option::Some`),
+    /// false when on discriminant 0 (`Result::Ok`) — selects which `bool(disc)`
+    /// arm reads `__pos_0` versus forwards the `default`.
+    pub payload_on_disc_true: bool,
 }
 
 /// Rewrite every recorded `Option::unwrap_or` call site into the
@@ -186,68 +195,70 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
 
     // --- All structural validation passed; mutate the graph. ---
 
-    // `then_bb` (`Some`) carries `carried` plus `opt` (the base for the
-    // `__pos_0` read); `else_bb` (`None`) carries `carried` plus `default`
-    // (the forwarded fallback).  The source-var lists double as the branch
-    // link args.
-    let mut then_sources = carried.clone();
-    if !then_sources.contains(&opt) {
-        then_sources.push(opt.clone());
+    // The payload arm carries `carried` plus `recv` (the base for the
+    // `__pos_0` read); the default arm carries `carried` plus `default` (the
+    // forwarded fallback).  The source-var lists double as the branch link
+    // args.  Which arm is the `bool(disc)`-true (`then`) target is decided
+    // below from `payload_on_disc_true`.
+    let mut payload_sources = carried.clone();
+    if !payload_sources.contains(&opt) {
+        payload_sources.push(opt.clone());
     }
-    let mut else_sources = carried.clone();
-    if !else_sources.contains(&default) {
-        else_sources.push(default.clone());
+    let mut default_sources = carried.clone();
+    if !default_sources.contains(&default) {
+        default_sources.push(default.clone());
     }
-    let (then_bb, then_inputs) = graph.create_block_with_arg_vars(then_sources.len());
-    let (else_bb, else_inputs) = graph.create_block_with_arg_vars(else_sources.len());
+    let (payload_bb, payload_inputs) = graph.create_block_with_arg_vars(payload_sources.len());
+    let (default_bb, default_inputs) = graph.create_block_with_arg_vars(default_sources.len());
 
-    // `then_bb`: payload = opt.__pos_0.
-    let opt_in_then = map_source(&then_sources, &then_inputs, &opt)
-        .ok_or_else(|| format!("{name}: Option value not threaded into Some arm"))?;
+    // Payload arm: value = recv.__pos_0 (narrowed if the call carried a cast).
+    let recv_in_payload = map_source(&payload_sources, &payload_inputs, &opt)
+        .ok_or_else(|| format!("{name}: receiver not threaded into payload arm"))?;
     let payload = graph.alloc_value_var();
-    graph.block_mut(then_bb).operations.push(SpaceOperation {
+    graph.block_mut(payload_bb).operations.push(SpaceOperation {
         result: Some(payload.clone()),
         kind: OpKind::FieldRead {
-            base: opt_in_then,
+            base: recv_in_payload,
             field: FieldDescriptor {
                 name: "__pos_0".to_string(),
-                owner_root: Some(site.some_owner.clone()),
+                owner_root: Some(site.payload_owner.clone()),
                 owner_id: None,
             },
             ty: site.payload_ty.clone(),
             pure: true,
         },
     });
-    let then_value = emit_narrow(graph, then_bb, &cast, payload);
-    let then_link_args = reproduce_exit_args(
+    let payload_value = emit_narrow(graph, payload_bb, &cast, payload);
+    let payload_link_args = reproduce_exit_args(
         &saved_exit,
         &out_var,
-        &then_value,
-        &then_sources,
-        &then_inputs,
+        &payload_value,
+        &payload_sources,
+        &payload_inputs,
         &name,
     )?;
-    close_goto_mixed(graph, then_bb, b_target, then_link_args);
+    close_goto_mixed(graph, payload_bb, b_target, payload_link_args);
 
-    // `else_bb`: forward `default` as the result.
-    let default_in_else = map_source(&else_sources, &else_inputs, &default)
-        .ok_or_else(|| format!("{name}: default value not threaded into None arm"))?;
-    let else_value = emit_narrow(graph, else_bb, &cast, default_in_else);
-    let else_link_args = reproduce_exit_args(
+    // Default arm: forward `default` (narrowed if the call carried a cast).
+    let default_in_arm = map_source(&default_sources, &default_inputs, &default)
+        .ok_or_else(|| format!("{name}: default value not threaded into default arm"))?;
+    let default_value = emit_narrow(graph, default_bb, &cast, default_in_arm);
+    let default_link_args = reproduce_exit_args(
         &saved_exit,
         &out_var,
-        &else_value,
-        &else_sources,
-        &else_inputs,
+        &default_value,
+        &default_sources,
+        &default_inputs,
         &name,
     )?;
-    close_goto_mixed(graph, else_bb, b_target, else_link_args);
+    close_goto_mixed(graph, default_bb, b_target, default_link_args);
 
     // A: drop the residual `unwrap_or` call, read the discriminant, branch on
     // it.  `set_branch` appends the `bool(disc)` hop and installs the
-    // Bool(false)/Bool(true) arm links; `Option` tags None=0 / Some=1, so
-    // `bool(disc)` selects the `Some` (then) arm.  The receiver/default
-    // construction ops stay as A's tail.
+    // Bool(false)/Bool(true) arm links.  The payload variant's discriminant
+    // differs by enum (`Option::Some = 1`, `Result::Ok = 0`), so
+    // `payload_on_disc_true` picks whether the payload arm is the true (`then`)
+    // target.  The receiver/default construction ops stay as A's tail.
     let a_id = graph.blocks[a].id;
     // Drop the trailing narrowing cast (if any) first so `call_idx` stays valid,
     // then the `unwrap_or` call — both are subsumed by the diamond (the cast is
@@ -263,13 +274,18 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
             base: opt.clone(),
             field: FieldDescriptor {
                 name: "__discriminant".to_string(),
-                owner_root: Some(site.option_owner.clone()),
+                owner_root: Some(site.enum_owner.clone()),
                 owner_id: None,
             },
             ty: ValueType::Int,
             pure: true,
         },
     });
+    let ((then_bb, then_sources), (else_bb, else_sources)) = if site.payload_on_disc_true {
+        ((payload_bb, payload_sources), (default_bb, default_sources))
+    } else {
+        ((default_bb, default_sources), (payload_bb, payload_sources))
+    };
     graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
     Ok(())
 }
@@ -318,9 +334,30 @@ mod tests {
     fn option_site(result_var: Variable) -> UnwrapOrSite {
         UnwrapOrSite {
             result_var,
-            option_owner: "core::option::Option".into(),
-            some_owner: "core::option::Option::Some".into(),
+            enum_owner: "core::option::Option".into(),
+            payload_owner: "core::option::Option::Some".into(),
             payload_ty: ValueType::Int,
+            payload_on_disc_true: true,
+        }
+    }
+
+    fn result_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["core", "result", "<Impl>", "unwrap_or"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn result_site(result_var: Variable) -> UnwrapOrSite {
+        UnwrapOrSite {
+            result_var,
+            enum_owner: "core::result::Result".into(),
+            payload_owner: "core::result::Result::Ok".into(),
+            payload_ty: ValueType::Int,
+            // `Result::Ok = 0`, so the payload arm is the `bool(disc)`-false arm.
+            payload_on_disc_true: false,
         }
     }
 
@@ -445,7 +482,10 @@ mod tests {
         let mut site = option_site(result.clone());
         site.payload_ty = ValueType::Ref(None);
         let rewritten = rewire_unwrap_or_call_sites(&mut g, &[site]);
-        assert_eq!(rewritten, 1, "the trailing-cast unwrap_or site is rewritten");
+        assert_eq!(
+            rewritten, 1,
+            "the trailing-cast unwrap_or site is rewritten"
+        );
 
         // No residual `unwrap_or` call survives (the two arm casts remain).
         assert!(
@@ -469,6 +509,58 @@ mod tests {
             })
             .count();
         assert_eq!(arm_casts, 2, "each diamond arm narrows its payload");
+    }
+
+    /// `Result::unwrap_or` inverts the payload polarity: `Result::Ok = 0`, so
+    /// the payload (`__pos_0`) arm is reached via the `bool(disc)`-false exit
+    /// and the `default` via the `bool(disc)`-true exit — the mirror of the
+    /// `Option` layout.
+    #[test]
+    fn rewrite_lifts_result_unwrap_or_payload_on_disc_false() {
+        use crate::model::ExitCase;
+        let mut g = FunctionGraph::new("test_result_unwrap_or");
+        let a = g.startblock;
+        let res = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: result_target(),
+                    args: vec![res.clone(), default.clone()],
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_unwrap_or_call_sites(&mut g, &[result_site(result.clone())]);
+        assert_eq!(rewritten, 1, "the Result unwrap_or site is rewritten");
+
+        assert_eq!(g.blocks[a.0].exits.len(), 2, "A branches to Ok/Err arms");
+        let reads_pos0 = |bb: usize| {
+            g.blocks[bb].operations.iter().any(
+                |op| matches!(&op.kind, OpKind::FieldRead { field, .. } if field.name == "__pos_0"),
+            )
+        };
+        for link in &g.blocks[a.0].exits {
+            let tgt = link.target.0;
+            match &link.exitcase {
+                Some(ExitCase::Bool(false)) => {
+                    assert!(reads_pos0(tgt), "Ok arm (disc==0) reads __pos_0")
+                }
+                Some(ExitCase::Bool(true)) => {
+                    assert!(
+                        !reads_pos0(tgt),
+                        "Err arm (disc==1) forwards default, no __pos_0"
+                    )
+                }
+                other => panic!("unexpected branch exitcase {other:?}"),
+            }
+        }
     }
 
     /// A call block whose last op is not the recorded result declines

--- a/majit/majit-translate/src/front/option_unwrap_or.rs
+++ b/majit/majit-translate/src/front/option_unwrap_or.rs
@@ -45,7 +45,9 @@
 
 use crate::flowspace::model::Variable;
 use crate::front::bool_then::{close_goto_mixed, map_source, reproduce_exit_args};
-use crate::model::{FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
+use crate::model::{
+    CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
 
 /// A recognized `Option::unwrap_or(opt, default)` call site captured during
 /// body lowering (`front::mir` `recognize_unwrap_or_site`).  The owner
@@ -101,15 +103,49 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
         })
         .ok_or_else(|| format!("{name}: unwrap_or result var has no producer block"))?;
 
-    // The call must be A's last op (lower_call closes the block right after
-    // pushing it) so removing it leaves the receiver/default construction as
-    // the block tail.
-    let call_idx = graph.blocks[a].operations.len() - 1;
-    if graph.blocks[a].operations[call_idx].result.as_ref() != Some(&site.result_var) {
+    // Index of the `unwrap_or` call op within block A.
+    let call_idx = graph.blocks[a]
+        .operations
+        .iter()
+        .position(|op| op.result.as_ref() == Some(&site.result_var))
+        .expect("result var producer resolved to block A above");
+    let last_idx = graph.blocks[a].operations.len() - 1;
+    // The call sits at the block tail, optionally followed by a single
+    // `__pyre_cast_instance(result)` narrowing op.  `lower_call` appends that
+    // cast when the payload is a `*mut <registered ADT>` (a raw-pointer
+    // `Option` payload) and reassigns the destination local to the narrowed
+    // var, so the continuation consumes `narrowed`, not the raw call result.
+    // The cast is jitcode-identity (`cast_pointer` → `same_as`); carry it into
+    // each arm so B keeps receiving a narrowed value.  `out_var` is the value
+    // block B actually consumes for the select result.
+    let (cast, out_var): (Option<(Vec<String>, ValueType)>, Variable) = if call_idx == last_idx {
+        (None, site.result_var.clone())
+    } else if call_idx == last_idx - 1 {
+        let tail = &graph.blocks[a].operations[last_idx];
+        match (&tail.kind, tail.result.clone()) {
+            (
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    result_ty,
+                },
+                Some(narrowed),
+            ) if segments.first().map(String::as_str) == Some("__pyre_cast_instance")
+                && args.as_slice() == std::slice::from_ref(&site.result_var) =>
+            {
+                (Some((segments.clone(), result_ty.clone())), narrowed)
+            }
+            _ => {
+                return Err(format!(
+                    "{name}: unwrap_or call is not the last op of block {a}"
+                ));
+            }
+        }
+    } else {
         return Err(format!(
             "{name}: unwrap_or call is not the last op of block {a}"
         ));
-    }
+    };
     // Capture the receiver `Option` + default operands.
     let (opt, default) = match &graph.blocks[a].operations[call_idx].kind {
         OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
@@ -136,12 +172,12 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     let b_target = saved_exit.target;
 
     // `carried` = the distinct live Values A forwards to B other than the
-    // payload itself; each must be threaded through the diamond arms to reach
-    // B (a fresh block cannot see A-scope Variables directly).
+    // select output itself; each must be threaded through the diamond arms to
+    // reach B (a fresh block cannot see A-scope Variables directly).
     let mut carried: Vec<Variable> = Vec::new();
     for arg in &saved_exit.args {
         if let LinkArg::Value(v) = arg
-            && *v != site.result_var
+            && *v != out_var
             && !carried.contains(v)
         {
             carried.push(v.clone());
@@ -182,10 +218,11 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
             pure: true,
         },
     });
+    let then_value = emit_narrow(graph, then_bb, &cast, payload);
     let then_link_args = reproduce_exit_args(
         &saved_exit,
-        &site.result_var,
-        &payload,
+        &out_var,
+        &then_value,
         &then_sources,
         &then_inputs,
         &name,
@@ -195,10 +232,11 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     // `else_bb`: forward `default` as the result.
     let default_in_else = map_source(&else_sources, &else_inputs, &default)
         .ok_or_else(|| format!("{name}: default value not threaded into None arm"))?;
+    let else_value = emit_narrow(graph, else_bb, &cast, default_in_else);
     let else_link_args = reproduce_exit_args(
         &saved_exit,
-        &site.result_var,
-        &default_in_else,
+        &out_var,
+        &else_value,
         &else_sources,
         &else_inputs,
         &name,
@@ -211,6 +249,12 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     // `bool(disc)` selects the `Some` (then) arm.  The receiver/default
     // construction ops stay as A's tail.
     let a_id = graph.blocks[a].id;
+    // Drop the trailing narrowing cast (if any) first so `call_idx` stays valid,
+    // then the `unwrap_or` call — both are subsumed by the diamond (the cast is
+    // re-emitted per arm).
+    if cast.is_some() {
+        graph.blocks[a].operations.remove(last_idx);
+    }
     graph.blocks[a].operations.remove(call_idx);
     let disc = graph.alloc_value_var();
     graph.block_mut(a_id).operations.push(SpaceOperation {
@@ -228,6 +272,33 @@ fn rewire_one_unwrap_or_site(graph: &mut FunctionGraph, site: &UnwrapOrSite) -> 
     });
     graph.set_branch(a_id, disc, then_bb, then_sources, else_bb, else_sources);
     Ok(())
+}
+
+/// Re-emit the `__pyre_cast_instance` narrowing the residual call carried into
+/// an arm's `raw` payload value.  `None` (no cast on the original result) is a
+/// pass-through: the raw value flows on unchanged.  The cast is jitcode-identity
+/// (`cast_pointer` → `same_as`), so duplicating it per arm is sound.
+fn emit_narrow(
+    graph: &mut FunctionGraph,
+    bb: crate::model::BlockId,
+    cast: &Option<(Vec<String>, ValueType)>,
+    raw: Variable,
+) -> Variable {
+    let Some((segments, result_ty)) = cast else {
+        return raw;
+    };
+    let narrowed = graph.alloc_value_var();
+    graph.block_mut(bb).operations.push(SpaceOperation {
+        result: Some(narrowed.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: segments.clone(),
+            },
+            args: vec![raw],
+            result_ty: result_ty.clone(),
+        },
+    });
+    narrowed
 }
 
 #[cfg(test)]
@@ -325,6 +396,79 @@ mod tests {
             arms_to_b, 2,
             "both diamond arms forward to the continuation"
         );
+    }
+
+    /// A raw-pointer payload (`Option<*mut PyObject>`) makes `lower_call`
+    /// append a `__pyre_cast_instance(result)` narrowing op after the
+    /// `unwrap_or` call, so the call is the block's second-to-last op and the
+    /// continuation consumes the *narrowed* var.  The rewrite must tolerate
+    /// that trailing identity cast: lift to the discriminant select and apply
+    /// the same narrowing to each arm's payload so B still receives a narrowed
+    /// value.
+    #[test]
+    fn rewrite_lifts_unwrap_or_with_trailing_narrowing_cast() {
+        let mut g = FunctionGraph::new("test_unwrap_or_cast");
+        let a = g.startblock;
+        let opt = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let default = g.push_op_var(a, OpKind::ConstInt(42), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: unwrap_or_target(),
+                    args: vec![opt.clone(), default.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        // The narrowing cast `lower_call` appends for a `*mut <registered ADT>`
+        // result; the continuation consumes its `narrowed` var, not `result`.
+        let narrowed = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__pyre_cast_instance".into(), "PyObject".into()],
+                    },
+                    args: vec![result.clone()],
+                    result_ty: ValueType::Ref(Some("PyObject".into())),
+                },
+                true,
+            )
+            .unwrap();
+
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![narrowed.clone()]);
+
+        let mut site = option_site(result.clone());
+        site.payload_ty = ValueType::Ref(None);
+        let rewritten = rewire_unwrap_or_call_sites(&mut g, &[site]);
+        assert_eq!(rewritten, 1, "the trailing-cast unwrap_or site is rewritten");
+
+        // No residual `unwrap_or` call survives (the two arm casts remain).
+        assert!(
+            !g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.last().map(String::as_str) == Some("unwrap_or"))
+            }),
+            "residual unwrap_or call removed"
+        );
+        // Block A branches two ways after reading the discriminant.
+        assert_eq!(g.blocks[a.0].exits.len(), 2, "A branches to Some/None arms");
+        // Each arm applies the narrowing cast to its payload (Some: __pos_0,
+        // None: default), so two casts remain in the arms.
+        let arm_casts = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(&op.kind, OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                    if segments.first().map(String::as_str) == Some("__pyre_cast_instance"))
+            })
+            .count();
+        assert_eq!(arm_casts, 2, "each diamond arm narrows its payload");
     }
 
     /// A call block whose last op is not the recorded result declines

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -140,6 +140,22 @@ pub(crate) fn tyref_is_option(ty: &TyRef, llbc: &Llbc) -> bool {
     adt_path_of(body, llbc).as_deref() == Some("core::option::Option")
 }
 
+/// True when `ty` is any `core::result::Result<T, E>` (error type
+/// unconstrained) — the guard for combinators like `Result::unwrap_or` that
+/// discard the error and so do not care about `E`.  For the `Result<T,
+/// PyError>` exception-transform guard use [`tyref_is_result_of_pyerror`].
+pub(crate) fn tyref_is_result(ty: &TyRef, llbc: &Llbc) -> bool {
+    let body = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return false,
+        },
+    };
+    adt_path_of(body, llbc).as_deref() == Some("core::result::Result")
+}
+
 /// The per-instantiation `<…>` suffix for a scoped callee's
 /// `Result<T, PyError>` return type, or `None` when the instantiation is
 /// not Ref-shaped (bool/int payloads stay on the bare `Result::Ok`

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -4496,6 +4496,31 @@ impl FunctionGraph {
         self.alloc_value_var_with_type(ConcreteType::Unknown)
     }
 
+    /// The `__pos_N` field owner an existing read/write of `result_var`
+    /// already uses — the per-shape tuple classdef the projection side minted
+    /// (`Tuple<…>` under `PYRE_TUPLE_PER_SHAPE_CLASSDEF`, else bare `Tuple`).
+    /// A front synth that rebuilds a tuple bound to `result_var` keys its
+    /// `FieldWrite` owner off this so writes match the destructure reads
+    /// whether the per-shape suffix is on or off. Defaults to `"Tuple"` when
+    /// no positional access of `result_var` is present.
+    pub(crate) fn tuple_owner_for_var(
+        &self,
+        result_var: &crate::flowspace::model::Variable,
+    ) -> String {
+        self.blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .find_map(|op| match &op.kind {
+                OpKind::FieldRead { base, field, .. }
+                    if base == result_var && field.name.starts_with("__pos_") =>
+                {
+                    field.owner_root.clone()
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| "Tuple".to_string())
+    }
+
     /// Mint a fresh value [`crate::flowspace::model::Variable`] with its
     /// [`ConcreteType`] stamped at construction — pyre's analogue of
     /// upstream `Variable(concretetype=...)` (RPython

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1817,7 +1817,21 @@ pub fn translate_op(
                     // convert_from_to has no common base → typer error), and
                     // two `()` values meeting at a join can never union.
                     let host = if owner_path.is_empty() {
-                        if matches!(name.as_str(), "Tuple" | "Array" | "Closure") {
+                        // Match the aggregate-kind placeholder tag by its
+                        // instantiation-stripped root so a per-shape tuple
+                        // (`Tuple<f64,f64>`, `Tuple<BigInt,BigInt>`) interns
+                        // by its full suffixed qualname exactly as bare
+                        // `Tuple` does — `canonical_struct_name` keys the
+                        // cache by the whole `Tuple<…>` string, so every
+                        // construction site of one shape shares one Arc and
+                        // matches the field-projection side's interned class.
+                        // Without this a suffixed tuple falls to the fresh-Arc
+                        // branch below and mints a distinct `Tuple<f64,f64>`
+                        // per site → `commonbase` None → UnionError at a join.
+                        if matches!(
+                            majit_ir::descr::strip_instantiation_suffix(&name),
+                            "Tuple" | "Array" | "Closure"
+                        ) {
                             call_registry.bookkeeper().intern_class_by_qualname(&name)
                         } else {
                             HostObject::new_class(name.clone(), Vec::new())

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -189,14 +189,17 @@ fn lowers_tuple_roundtrip_with_symmetric_positional_field_reads() {
     }
 
     // Exactly one synthetic ctor (the genuine tuple) and its two-field
-    // `__pos_0` / `__pos_1` construction chain.
+    // `__pos_0` / `__pos_1` construction chain.  The per-shape tuple classdef
+    // (default-ON) keys the owner on the tuple's element types, so the owner is
+    // the suffixed `Tuple<i64,i64>` — the construction and projection sides must
+    // agree on that exact spelling (the symmetry asserted below).
     assert_eq!(ctor_count, 1, "expected one tuple SyntheticTransparentCtor");
     field_writes.sort();
     assert_eq!(
         field_writes,
         vec![
-            ("__pos_0".to_string(), Some("Tuple".to_string())),
-            ("__pos_1".to_string(), Some("Tuple".to_string())),
+            ("__pos_0".to_string(), Some("Tuple<i64,i64>".to_string())),
+            ("__pos_1".to_string(), Some("Tuple<i64,i64>".to_string())),
         ],
         "tuple construction must emit a __pos_0 / __pos_1 FieldWrite chain"
     );
@@ -208,8 +211,8 @@ fn lowers_tuple_roundtrip_with_symmetric_positional_field_reads() {
     assert_eq!(
         field_reads,
         vec![
-            ("__pos_0".to_string(), Some("Tuple".to_string())),
-            ("__pos_1".to_string(), Some("Tuple".to_string())),
+            ("__pos_0".to_string(), Some("Tuple<i64,i64>".to_string())),
+            ("__pos_1".to_string(), Some("Tuple<i64,i64>".to_string())),
         ],
         "tuple reads must emit __pos_0 / __pos_1 FieldReads (owner_root \
          matching the FieldWrite chain) and *Checked .0 reads must collapse"

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -502,6 +502,52 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::objspace::descroperation::jit_bigint_rem",
         crate::objspace::descroperation::jit_bigint_rem as *const (),
     );
+    // `jit_bigint_{and,or,xor,sub,mul}` residualize the foreign BigInt binary
+    // operators (`<BigInt as BitAnd>::bitand`, …) the `front::mir` retarget
+    // (`front::bigint_binop`) redirects when both operands are the opaque
+    // `BigInt` ADT.  Each returns a fresh `*mut BigInt` (as i64), bound by path.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_and",
+        crate::objspace::descroperation::jit_bigint_and as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_or",
+        crate::objspace::descroperation::jit_bigint_or as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_xor",
+        crate::objspace::descroperation::jit_bigint_xor as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_sub",
+        crate::objspace::descroperation::jit_bigint_sub as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_mul",
+        crate::objspace::descroperation::jit_bigint_mul as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_add",
+        crate::objspace::descroperation::jit_bigint_add as *const (),
+    );
+    // `jit_bigint_{shl,shr}` residualize the BigInt shift-by-`usize` operators
+    // (`<BigInt as Shl<usize>>::shl`, …); `b` is the machine shift count.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_shl",
+        crate::objspace::descroperation::jit_bigint_shl as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_shr",
+        crate::objspace::descroperation::jit_bigint_shr as *const (),
+    );
 
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {
@@ -581,6 +627,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::longobject::jit_bigint_to_i64_value",
         "pyre_object::jit_bigint_to_i64_value",
         pyre_object::jit_bigint_to_i64_value as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::longobject::jit_bigint_to_u64_fits",
+        "pyre_object::jit_bigint_to_u64_fits",
+        pyre_object::jit_bigint_to_u64_fits as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::longobject::jit_bigint_to_u64_value",
+        "pyre_object::jit_bigint_to_u64_value",
+        pyre_object::jit_bigint_to_u64_value as *const (),
     );
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -488,6 +488,20 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::bigint_gc_type_id",
         pyre_object::longobject::bigint_gc_type_id as *const (),
     );
+    // `jit_bigint_div` / `jit_bigint_rem` residualize the `div_rem()` tuple
+    // synth (`front::bigint_div_rem`): the foreign malachite `div_rem` returns
+    // a `(BigInt, BigInt)` the tracer models as a `__pos_0`/`__pos_1` tuple
+    // sourced from these two `#[dont_look_inside]` calls, bound by path.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_div",
+        crate::objspace::descroperation::jit_bigint_div as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_rem",
+        crate::objspace::descroperation::jit_bigint_rem as *const (),
+    );
 
     for (nargs, (module_path, root_path)) in CALLABLE_HELPER_PATHS.iter().enumerate() {
         if let Some(fnptr) = crate::runtime_ops::callable_call_helper(nargs) {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -99,20 +99,99 @@ fn bigint_to_f64(a: BigInt) -> f64 {
 /// quotient (this) + remainder ([`jit_bigint_rem`]) sourcing a modeled 2-tuple.
 /// Allocates the result via the COLLECTING nursery (a gcmap-rooted residual,
 /// its operand pointers rooted across the alloc), matching the arithmetic
-/// residuals. Returns a freshly heap-allocated `*mut BigInt` (as i64).
+/// residuals. Returns a freshly heap-allocated `*mut BigInt` — a `ref`-token
+/// return so the CodeWriter models the result as a traced GcRef.
 #[majit_macros::dont_look_inside]
-pub extern "C" fn jit_bigint_div(a: i64, b: i64) -> i64 {
+pub extern "C" fn jit_bigint_div(a: i64, b: i64) -> *mut BigInt {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).0) as i64 }
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).0) }
 }
 
 /// `rbigint.divmod`'s truncated remainder — the `.1` of `num_integer::div_rem`.
 /// See [`jit_bigint_div`]; the two share the `(BigInt, BigInt)` semantics the
 /// `front::bigint_div_rem` synth reassembles into a modeled tuple.
 #[majit_macros::dont_look_inside]
-pub extern "C" fn jit_bigint_rem(a: i64, b: i64) -> i64 {
+pub extern "C" fn jit_bigint_rem(a: i64, b: i64) -> *mut BigInt {
     let (a, b) = (a as *const BigInt, b as *const BigInt);
-    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).1) as i64 }
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).1) }
+}
+
+// ── BigInt binary-operator residuals ─────────────────────────────────
+// The foreign malachite operator impls (`<BigInt as BitAnd>::bitand`, …)
+// are Opaque in the LLBC, so a traced-into caller (`bigint_truediv`) emits
+// an unregistered `<Impl>` FunctionPath call the census Skips. `front::mir`
+// retargets each such call — guarded on both operands resolving to the
+// opaque `BigInt` ADT — to the matching residual below. Both operands and
+// the result are the classdef-less `*mut BigInt` GcRef the front models a
+// `BigInt` as: the operands arrive as i64-encoded pointers (a faithful ABI
+// pass) and the result is returned as `*mut BigInt` so the return token is
+// `ref` (a traced GcRef), matching the front's `Ref(None)` result type. Each
+// allocates the fresh result in the collecting nursery, its operand pointers
+// rooted across the alloc. The `#[dont_look_inside]` sibling of the elidable
+// `longobject::jit_bigint_*` opcode-payload helpers (which the front cannot
+// residualize because only `dont_look_inside` callees are registered).
+
+/// `rbigint.and_` payload — `&BigInt & &BigInt`. See the module note above.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_and(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a & &*b) }
+}
+
+/// `rbigint.or_` payload — `&BigInt | &BigInt`. See [`jit_bigint_and`].
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_or(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a | &*b) }
+}
+
+/// `rbigint.xor_` payload — `&BigInt ^ &BigInt`. See [`jit_bigint_and`].
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_xor(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a ^ &*b) }
+}
+
+/// `rbigint.sub` payload — `&BigInt - &BigInt`. See [`jit_bigint_and`].
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_sub(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a - &*b) }
+}
+
+/// `rbigint.mul` payload — `&BigInt * &BigInt`. See [`jit_bigint_and`].
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_mul(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a * &*b) }
+}
+
+/// `rbigint.add` payload — `&BigInt + &BigInt`. See [`jit_bigint_and`].
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_add(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a + &*b) }
+}
+
+// ── BigInt shift-by-`usize` residuals ────────────────────────────────
+// `<BigInt as Shl<usize>>::shl` / `Shr<usize>::shr` — the shift amount is a
+// plain machine integer, NOT a `BigInt`, so `b` is the count value itself
+// (not a pointer). `front::mir` retargets these separately, guarded on the
+// first operand being the opaque `BigInt` ADT and the second being an
+// integer. See the operator-residual module note above.
+
+/// `rbigint.lshift` by a machine `usize` — `&BigInt << (b as usize)`.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_shl(a: i64, b: i64) -> *mut BigInt {
+    let a = a as *const BigInt;
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a << (b as usize)) }
+}
+
+/// `rbigint.rshift` by a machine `usize` — `&BigInt >> (b as usize)`.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_shr(a: i64, b: i64) -> *mut BigInt {
+    let a = a as *const BigInt;
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting(&*a >> (b as usize)) }
 }
 
 #[majit_macros::elidable]
@@ -240,15 +319,13 @@ fn bigint_truediv(a: BigInt, b: BigInt) -> Result<f64, PyError> {
         dropped
     };
 
-    let mantissa = match mantissa_big.to_u64() {
-        Some(v) => v,
-        None => {
-            return Err(PyError::new(
-                PyErrorKind::OverflowError,
-                "integer division result too large for a float",
-            ));
-        }
-    };
+    if pyre_object::longobject::jit_bigint_to_u64_fits(&mantissa_big) == 0 {
+        return Err(PyError::new(
+            PyErrorKind::OverflowError,
+            "integer division result too large for a float",
+        ));
+    }
+    let mantissa = pyre_object::longobject::jit_bigint_to_u64_value(&mantissa_big);
 
     // `mantissa` has at most DBL_MANT_DIG bits, so it is exact in `f64`; scale it
     // by 2^exponent with a non-raising ldexp that preserves subnormal results.

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -92,6 +92,29 @@ fn bigint_to_f64(a: BigInt) -> f64 {
     jit_bigint_to_f64_or_inf(&a)
 }
 
+/// `rbigint.divmod`'s truncated quotient — the `.0` of `num_integer::div_rem`
+/// on two bare `*const BigInt` payloads. The foreign malachite `div_rem`
+/// returns a `(BigInt, BigInt)` tuple the tracer cannot model, so the front
+/// `div_rem` synth (`front::bigint_div_rem`) replaces the call with the
+/// quotient (this) + remainder ([`jit_bigint_rem`]) sourcing a modeled 2-tuple.
+/// Allocates the result via the COLLECTING nursery (a gcmap-rooted residual,
+/// its operand pointers rooted across the alloc), matching the arithmetic
+/// residuals. Returns a freshly heap-allocated `*mut BigInt` (as i64).
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_div(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).0) as i64 }
+}
+
+/// `rbigint.divmod`'s truncated remainder — the `.1` of `num_integer::div_rem`.
+/// See [`jit_bigint_div`]; the two share the `(BigInt, BigInt)` semantics the
+/// `front::bigint_div_rem` synth reassembles into a modeled tuple.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_rem(a: i64, b: i64) -> i64 {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).1) as i64 }
+}
+
 #[majit_macros::elidable]
 fn float_copysign(mag: f64, sign: f64) -> f64 {
     if sign.is_sign_negative() {

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -361,6 +361,25 @@ pub fn jit_bigint_to_i64_value(num: &BigInt) -> i64 {
     })
 }
 
+/// `BigInt::to_u64().is_some()` on a borrowed BigInt payload. Scalar half of
+/// the `BigInt::to_u64()` split so the two-phase rtyper never has to model an
+/// `Option<u64>` ABI. Companion of [`jit_bigint_to_u64_value`].
+#[majit_macros::dont_look_inside]
+pub fn jit_bigint_to_u64_fits(num: &BigInt) -> i64 {
+    use num_traits::ToPrimitive;
+    num.to_u64().is_some() as i64
+}
+
+/// `BigInt::to_u64()` on a borrowed BigInt payload. Callers must first check
+/// [`jit_bigint_to_u64_fits`]; a `None` here means that guard was violated.
+#[majit_macros::dont_look_inside]
+pub fn jit_bigint_to_u64_value(num: &BigInt) -> u64 {
+    use num_traits::ToPrimitive;
+    num.to_u64().unwrap_or_else(|| {
+        panic!("jit_bigint_to_u64_value: BigInt exceeds u64 range - fits guard violated")
+    })
+}
+
 /// `rbigint.sign` / sign-digit use (`rpython/rlib/rbigint.py`) on a borrowed
 /// BigInt payload. Returns the scalar signum (-1, 0, +1) so the two-phase
 /// rtyper never has to model malachite's `Sign` enum ABI.


### PR DESCRIPTION
#131

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
