### PR TITLE
trace_ctx OpRef→Operand bridge; PR#350 review fixes

### DIFF
--- a/majit/majit-backend/src/model.rs
+++ b/majit/majit-backend/src/model.rs
@@ -336,8 +336,12 @@ pub struct DefaultCpu;
 
 impl Cpu for DefaultCpu {
     fn cls_of_box(&self, box_: &Operand) -> i64 {
-        // resoperation.py:57-68 walker to the terminal Const.
-        match box_.get_box_replacement(false).const_value() {
+        // resoperation.py:57-68 walker, then read the concrete ref off the
+        // resolved operand. model.py:199-201 `box.getref_base().typeptr`
+        // reads any ref-carrying box, so a bound `Op` / `InputArg` with a
+        // stamped `Value::Ref` must resolve too — `get_value()`, not the
+        // const-only `const_value()`.
+        match box_.get_box_replacement(false).get_value() {
             Some(Value::Ref(gcref)) if !gcref.is_null() => self.cls_of_gcref(gcref),
             _ => 0,
         }
@@ -401,7 +405,9 @@ pub fn cpu_from_cls_of_box_fn(f: fn(i64) -> i64) -> Arc<dyn Cpu> {
     struct ClosureCpu(fn(i64) -> i64);
     impl Cpu for ClosureCpu {
         fn cls_of_box(&self, box_: &Operand) -> i64 {
-            let raw = match box_.get_box_replacement(false).const_value() {
+            // `get_value()` (not const-only `const_value()`) so a bound
+            // producer carrying a stamped `Value::Ref` yields its payload.
+            let raw = match box_.get_box_replacement(false).get_value() {
                 Some(Value::Ref(gcref)) => gcref.0 as i64,
                 _ => 0,
             };

--- a/majit/majit-ir/Cargo.toml
+++ b/majit/majit-ir/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 description = "Intermediate representation for majit JIT compiler"
 
 [features]
-# Exposes `box_ref::test_support` cross-crate so downstream test suites
-# (backends / gc / jit-trace) can build bound BoxRefs from a single helper
+# Exposes `forwarding::test_support` cross-crate so downstream test suites
+# (backends / gc / jit-trace) can build bound Operands from a single helper
 # instead of duplicating it. Enabled only from `[dev-dependencies]`, so it
 # never reaches a production build (resolver = "2").
 test-support = []

--- a/majit/majit-ir/src/forwarding.rs
+++ b/majit/majit-ir/src/forwarding.rs
@@ -15,13 +15,13 @@
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
+#[cfg(feature = "test-support")]
+use crate::OpRef;
 use crate::intbound::IntBound;
 use crate::op_info::OpInfo;
 use crate::ptr_info::PtrInfo;
 use crate::resoperation::Op;
 use crate::value::{Const, InputArg};
-#[cfg(feature = "test-support")]
-use crate::OpRef;
 
 /// Variant of the `_forwarded` slot.
 ///
@@ -326,8 +326,8 @@ pub fn bound_operand_from_opref(a: OpRef) -> crate::operand::Operand {
 #[cfg(test)]
 pub(crate) mod test_support {
     use crate::operand::Operand;
-    use crate::{OpRef, Type};
     use crate::resoperation::{Op, OpCode};
+    use crate::{OpRef, Type};
 
     /// A self-rooting bound `Operand::Op` at `position`: the returned operand
     /// holds a strong `Rc` to the synthetic `SameAs*` / `Jump` producer, so it

--- a/majit/majit-ir/src/forwarding.rs
+++ b/majit/majit-ir/src/forwarding.rs
@@ -20,7 +20,8 @@ use crate::op_info::OpInfo;
 use crate::ptr_info::PtrInfo;
 use crate::resoperation::Op;
 use crate::value::{Const, InputArg};
-use crate::{OpRef, Type};
+#[cfg(feature = "test-support")]
+use crate::OpRef;
 
 /// Variant of the `_forwarded` slot.
 ///
@@ -231,118 +232,80 @@ impl ForwardingHost for InputArg {
     }
 }
 
-pub struct PtrInfoBorrow {
-    inner: std::cell::Ref<'static, PtrInfo>,
-    _rc: Rc<std::cell::RefCell<PtrInfo>>,
+/// Owning borrow guard: a shared `Ref<T>` transmuted to `'static`, kept
+/// sound by holding the source `Rc<RefCell<T>>` alongside it.
+///
+/// SAFETY invariant (centralised here for all guard types): `_rc` keeps
+/// the `RefCell` allocation alive for at least as long as `Self` exists,
+/// so the `'static` `Ref` never dangles. Struct fields drop in
+/// declaration order, so `inner` (the borrow) is released before `_rc`
+/// drops the allocation.
+pub struct BorrowGuard<T: 'static> {
+    inner: std::cell::Ref<'static, T>,
+    _rc: Rc<std::cell::RefCell<T>>,
 }
 
-impl PtrInfoBorrow {
-    pub(crate) fn new(rc: Rc<std::cell::RefCell<PtrInfo>>) -> Self {
-        // SAFETY: see struct doc — _rc keeps the RefCell allocation
-        // alive for at least as long as Self exists.
-        let r: std::cell::Ref<'_, PtrInfo> = rc.borrow();
-        let r: std::cell::Ref<'static, PtrInfo> = unsafe { std::mem::transmute(r) };
+impl<T> BorrowGuard<T> {
+    pub(crate) fn new(rc: Rc<std::cell::RefCell<T>>) -> Self {
+        // SAFETY: see the type-level invariant above.
+        let r: std::cell::Ref<'_, T> = rc.borrow();
+        let r: std::cell::Ref<'static, T> = unsafe { std::mem::transmute(r) };
         Self { inner: r, _rc: rc }
     }
 }
 
-impl std::ops::Deref for PtrInfoBorrow {
-    type Target = PtrInfo;
-    fn deref(&self) -> &PtrInfo {
+impl<T> std::ops::Deref for BorrowGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
         &self.inner
     }
 }
 
-impl std::fmt::Debug for PtrInfoBorrow {
+impl<T: std::fmt::Debug> std::fmt::Debug for BorrowGuard<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&*self.inner, f)
     }
 }
 
-/// Mutable counterpart of `PtrInfoBorrow`.  Holds the inner `RefCell`
-/// exclusive borrow; conflicts with concurrent `PtrInfoBorrow` /
-/// `PtrInfoBorrowMut` on the same handle panic at runtime per
-/// `RefCell` semantics.
-pub struct PtrInfoBorrowMut {
-    inner: std::cell::RefMut<'static, PtrInfo>,
-    _rc: Rc<std::cell::RefCell<PtrInfo>>,
+/// Mutable counterpart of [`BorrowGuard`]. Holds the inner `RefCell`
+/// exclusive borrow; a concurrent shared or exclusive borrow on the same
+/// handle panics at runtime per `RefCell` semantics. Same `'static`
+/// transmute + drop-order invariant as [`BorrowGuard`].
+pub struct BorrowGuardMut<T: 'static> {
+    inner: std::cell::RefMut<'static, T>,
+    _rc: Rc<std::cell::RefCell<T>>,
 }
 
-impl PtrInfoBorrowMut {
-    pub(crate) fn new(rc: Rc<std::cell::RefCell<PtrInfo>>) -> Self {
-        // SAFETY: see `PtrInfoBorrow::new`.
-        let r: std::cell::RefMut<'_, PtrInfo> = rc.borrow_mut();
-        let r: std::cell::RefMut<'static, PtrInfo> = unsafe { std::mem::transmute(r) };
+impl<T> BorrowGuardMut<T> {
+    pub(crate) fn new(rc: Rc<std::cell::RefCell<T>>) -> Self {
+        // SAFETY: see the [`BorrowGuard`] type-level invariant.
+        let r: std::cell::RefMut<'_, T> = rc.borrow_mut();
+        let r: std::cell::RefMut<'static, T> = unsafe { std::mem::transmute(r) };
         Self { inner: r, _rc: rc }
     }
 }
 
-impl std::ops::Deref for PtrInfoBorrowMut {
-    type Target = PtrInfo;
-    fn deref(&self) -> &PtrInfo {
+impl<T> std::ops::Deref for BorrowGuardMut<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
         &self.inner
     }
 }
 
-impl std::ops::DerefMut for PtrInfoBorrowMut {
-    fn deref_mut(&mut self) -> &mut PtrInfo {
+impl<T> std::ops::DerefMut for BorrowGuardMut<T> {
+    fn deref_mut(&mut self) -> &mut T {
         &mut self.inner
     }
 }
 
-/// Owning borrow guard for `int_bound()`.  Same shape as
-/// `PtrInfoBorrow` but parameterised on `IntBound`.
-pub struct IntBoundBorrow {
-    inner: std::cell::Ref<'static, IntBound>,
-    _rc: Rc<std::cell::RefCell<IntBound>>,
-}
-
-impl IntBoundBorrow {
-    pub(crate) fn new(rc: Rc<std::cell::RefCell<IntBound>>) -> Self {
-        let r: std::cell::Ref<'_, IntBound> = rc.borrow();
-        let r: std::cell::Ref<'static, IntBound> = unsafe { std::mem::transmute(r) };
-        Self { inner: r, _rc: rc }
-    }
-}
-
-impl std::ops::Deref for IntBoundBorrow {
-    type Target = IntBound;
-    fn deref(&self) -> &IntBound {
-        &self.inner
-    }
-}
-
-impl std::fmt::Debug for IntBoundBorrow {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&*self.inner, f)
-    }
-}
-
-pub struct IntBoundBorrowMut {
-    inner: std::cell::RefMut<'static, IntBound>,
-    _rc: Rc<std::cell::RefCell<IntBound>>,
-}
-
-impl IntBoundBorrowMut {
-    pub(crate) fn new(rc: Rc<std::cell::RefCell<IntBound>>) -> Self {
-        let r: std::cell::RefMut<'_, IntBound> = rc.borrow_mut();
-        let r: std::cell::RefMut<'static, IntBound> = unsafe { std::mem::transmute(r) };
-        Self { inner: r, _rc: rc }
-    }
-}
-
-impl std::ops::Deref for IntBoundBorrowMut {
-    type Target = IntBound;
-    fn deref(&self) -> &IntBound {
-        &self.inner
-    }
-}
-
-impl std::ops::DerefMut for IntBoundBorrowMut {
-    fn deref_mut(&mut self) -> &mut IntBound {
-        &mut self.inner
-    }
-}
+/// Owning shared borrow guard for `ptr_info()`.
+pub type PtrInfoBorrow = BorrowGuard<PtrInfo>;
+/// Owning exclusive borrow guard for `ptr_info_mut()`.
+pub type PtrInfoBorrowMut = BorrowGuardMut<PtrInfo>;
+/// Owning shared borrow guard for `int_bound()`.
+pub type IntBoundBorrow = BorrowGuard<IntBound>;
+/// Owning exclusive borrow guard for `int_bound_mut()`.
+pub type IntBoundBorrowMut = BorrowGuardMut<IntBound>;
 
 /// Turn an `OpRef` into a **bound** [`Operand`](crate::operand::Operand) for
 /// op-argument / fail-arg fixtures: `None` / `Const` shed inline, an
@@ -362,8 +325,8 @@ pub fn bound_operand_from_opref(a: OpRef) -> crate::operand::Operand {
 /// operands directly must do the same.
 #[cfg(test)]
 pub(crate) mod test_support {
-    use super::{OpRef, Type};
     use crate::operand::Operand;
+    use crate::{OpRef, Type};
     use crate::resoperation::{Op, OpCode};
 
     /// A self-rooting bound `Operand::Op` at `position`: the returned operand

--- a/majit/majit-ir/src/operand.rs
+++ b/majit/majit-ir/src/operand.rs
@@ -55,8 +55,8 @@ pub enum Operand {
     /// shares the same const object (`getarglist_copy` reuses the same
     /// `Const`). Value equality is the opt-in `same_constant` (history.py:211),
     /// surfaced as [`same_box`](Self::same_box). This is the same shared-cell
-    /// in-place-forward contract the const-kind `Forwarded::Const { value:
-    /// Cell<Value> }` carrier provided. The forwarding visitor is
+    /// in-place-forward contract the const-kind `Forwarded::Const(Const)`
+    /// carrier provided. The forwarding visitor is
     /// idempotent on an already-forwarded object (collector.rs:1133), so a
     /// const cell reachable from two slots forwards safely.
     Const(Rc<Cell<Value>>),

--- a/majit/majit-ir/src/ptr_info.rs
+++ b/majit/majit-ir/src/ptr_info.rs
@@ -1431,7 +1431,11 @@ impl PtrInfo {
                 .map(|fd| fd.field_type())
                 .unwrap_or(Type::Int);
             let opcode = OpCode::getfield_for_type(tp);
-            result.push(Op::with_descr(opcode, &[structbox.clone()], descr));
+            result.push(Op::with_descr(
+                opcode,
+                std::slice::from_ref(&structbox),
+                descr,
+            ));
         };
         if let PtrInfo::Virtual(v) = self {
             for (field_idx, value) in &v.fields {

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -1055,10 +1055,10 @@ mod tests {
     }
 
     // Bound-box drop-ins for op-arg / fail-arg sites. Each binds a rooted
-    // synthetic producer (forwarding.rs `test_support`) so the arg sheds to
-    // `Operand::InputArg` / `Operand::Op` (never the position-only
-    // `Operand::Box`); `to_opref()` is preserved, so position-keyed
-    // assertions still hold.
+    // synthetic producer (local `rooted_*_operand` helpers) so the arg sheds
+    // to `Operand::InputArg` / `Operand::Op` (never a bare position-only
+    // `OpRef`); `to_opref()` is preserved, so position-keyed assertions
+    // still hold.
     fn iarg_box(pos: u32) -> Operand {
         rooted_inputarg_operand(Type::Int, pos)
     }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -252,6 +252,13 @@ pub struct UnrollOptimizer {
     /// because the unroll optimizer owns the inner phase optimizers while the
     /// registered GC walker enters through MetaInterp.
     pub compile_snapshot_root_slots: Option<usize>,
+    /// Snapshot-root slots that must stay rooted across every phase's
+    /// `replace_compile_snapshot_roots`. pyjitpl installs the caller-owned
+    /// original snapshot maps here so a moving GC during unroll forwards their
+    /// inline `ConstPtr`s in place — the `InvalidLoop` retry re-clones those
+    /// originals and would otherwise read a stale pre-move gcref. Prepended to
+    /// each phase's slot list rather than overwritten.
+    pub persistent_snapshot_root_slots: Vec<usize>,
 }
 
 impl UnrollOptimizer {
@@ -289,6 +296,7 @@ impl UnrollOptimizer {
             cpu: crate::cpu::default_cpu(),
             phase2_input_ops_seed: None,
             compile_snapshot_root_slots: None,
+            persistent_snapshot_root_slots: Vec::new(),
         }
     }
 
@@ -316,8 +324,10 @@ impl UnrollOptimizer {
             // `MetaInterp.compile_snapshot_refs` for the duration of one
             // compile. Unroll phases run on the same thread as the registered
             // root walker.
+            let mut all = self.persistent_snapshot_root_slots.clone();
+            all.extend(slots);
             unsafe {
-                *(addr as *mut Vec<usize>) = slots;
+                *(addr as *mut Vec<usize>) = all;
             }
         }
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5242,10 +5242,10 @@ impl<M: Clone> MetaInterp<M> {
         // vectors so the optimizer can rebuild fail_args from snapshot in
         // store_final_boxes_in_guard (RPython ResumeDataVirtualAdder.finish).
         let (
-            snapshot_map,
+            mut snapshot_map,
             snapshot_frame_size_map,
-            snapshot_vable_map,
-            snapshot_vref_map,
+            mut snapshot_vable_map,
+            mut snapshot_vref_map,
             snapshot_pc_map,
         ) = snapshot_map_from_trace_snapshots(&trace_snapshots, &mut constants);
         // history.py:220/261/307 — `Const{Int,Float,Ptr}.type` is an
@@ -5257,10 +5257,19 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
         unroll_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
         unroll_opt.snapshot_frame_pcs = snapshot_pc_map.clone();
+        // Root BOTH the phase-1 clones (read during optimization) AND the
+        // originals (re-cloned into `simple_opt` on the InvalidLoop retry
+        // below). A moving GC during phase 1 forwards each inline `ConstPtr`
+        // in place; without rooting the originals the retry clone would carry
+        // a stale pre-move gcref. `snapshot_frame_sizes` / `snapshot_frame_pcs`
+        // hold no gcrefs, so they need no roots.
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
             &mut unroll_opt.snapshot_boxes,
             &mut unroll_opt.snapshot_vable_boxes,
             &mut unroll_opt.snapshot_vref_boxes,
+            &mut snapshot_map,
+            &mut snapshot_vable_map,
+            &mut snapshot_vref_map,
         ]);
 
         // RPython compile.py:278-294 parity: Phase 1 results must survive

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5257,12 +5257,20 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
         unroll_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
         unroll_opt.snapshot_frame_pcs = snapshot_pc_map.clone();
-        // Root BOTH the phase-1 clones (read during optimization) AND the
-        // originals (re-cloned into `simple_opt` on the InvalidLoop retry
-        // below). A moving GC during phase 1 forwards each inline `ConstPtr`
-        // in place; without rooting the originals the retry clone would carry
-        // a stale pre-move gcref. `snapshot_frame_sizes` / `snapshot_frame_pcs`
-        // hold no gcrefs, so they need no roots.
+        // The original snapshot maps are re-cloned into `simple_opt` on the
+        // InvalidLoop retry below, so they must stay rooted across the WHOLE
+        // unroll. Each phase's `replace_compile_snapshot_roots` overwrites the
+        // root list, so register the originals as the persistent base (prepended
+        // to every phase's slots) rather than only up front — otherwise a moving
+        // GC after the first phase replace leaves them with stale pre-move
+        // gcrefs. `snapshot_frame_sizes` / `snapshot_frame_pcs` hold no gcrefs.
+        unroll_opt.persistent_snapshot_root_slots = collect_snapshot_const_ptr_slots(&mut [
+            &mut snapshot_map,
+            &mut snapshot_vable_map,
+            &mut snapshot_vref_map,
+        ]);
+        // Until the first phase replace, also root unroll_opt's own clones (the
+        // phase-1 source) alongside the persistent originals.
         self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
             &mut unroll_opt.snapshot_boxes,
             &mut unroll_opt.snapshot_vable_boxes,
@@ -5317,6 +5325,16 @@ impl<M: Clone> MetaInterp<M> {
                         return CompileOutcome::Cancelled;
                     }
                     {
+                        // Unroll's last `replace_compile_snapshot_roots` may
+                        // have left dangling phase slots (its inner optimizer
+                        // dropped on the InvalidLoop return). Re-root just the
+                        // live originals before the clones below allocate and
+                        // can move the GC.
+                        self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
+                            &mut snapshot_map,
+                            &mut snapshot_vable_map,
+                            &mut snapshot_vref_map,
+                        ]);
                         let mut retry_constants = constants_snapshot;
                         let mut simple_opt = Optimizer::default_pipeline();
                         // history.py:220/261/307: `Const.type` /
@@ -5332,6 +5350,16 @@ impl<M: Clone> MetaInterp<M> {
                         simple_opt.snapshot_vable_boxes = snapshot_vable_map.clone();
                         simple_opt.snapshot_vref_boxes = snapshot_vref_map.clone();
                         simple_opt.snapshot_frame_pcs = snapshot_pc_map.clone();
+                        // `run_optimize_from_inputs` (and the `.to_vec()` /
+                        // `Rc::new` allocations before it) can move the GC via
+                        // constant_fold_alloc. Root simple_opt's own snapshot
+                        // copies so their inline ConstPtrs are forwarded in
+                        // place; the originals are no longer read past this point.
+                        self.compile_snapshot_refs = collect_snapshot_const_ptr_slots(&mut [
+                            &mut simple_opt.snapshot_boxes,
+                            &mut simple_opt.snapshot_vable_boxes,
+                            &mut simple_opt.snapshot_vref_boxes,
+                        ]);
                         simple_opt.call_pure_results = call_pure_results.clone();
                         // Forward the recorder's operand pool — the retry path
                         // uses the same upstream `Rc<Box>` allocations from

--- a/majit/majit-metainterp/src/recorder.rs
+++ b/majit/majit-metainterp/src/recorder.rs
@@ -213,7 +213,13 @@ impl Trace {
     /// measured 0 hits across the corpus. `#[cfg(test)]` fixtures that build
     /// position-only synthetic operands bind a synthetic producer via
     /// `bound_from_opref` (`to_opref`-identical) rather than panicking.
-    fn box_for_operand(&self, r: OpRef) -> Operand {
+    /// Deterministic per recorded position: a ResOp / InputArg operand always
+    /// binds to the SAME producer `Rc` (`self.ops` / `self.inputargs` are dense
+    /// and immutable once recorded), so two calls for the same `OpRef` return
+    /// `Operand`s that compare equal under `Operand::eq` (`Rc::ptr_eq`). This is
+    /// the real box object — `MIFrame.registers_r` holds these in `pyjitpl.py` —
+    /// so consumers can key by box identity instead of flat `OpRef`.
+    pub(crate) fn box_for_operand(&self, r: OpRef) -> Operand {
         if r.is_none() || r.is_constant() {
             return Operand::from_opref(r);
         }
@@ -667,6 +673,33 @@ mod tests {
         rec.cut(saved);
         assert_eq!(rec.num_ops(), 0);
         assert_eq!(rec.num_inputargs(), 1);
+    }
+
+    #[test]
+    fn box_for_operand_is_deterministic_per_position() {
+        // The canonical Operand bridge must be stable per recorded position: the
+        // same OpRef always binds to the same producer Rc, so a consumer can key
+        // by box identity (Operand::eq = Rc::ptr_eq) instead of flat OpRef and
+        // still get the "same value -> same key" behaviour, matching the
+        // box-object-keyed dicts in heapcache.py / registers_r in pyjitpl.py.
+        let mut rec = Trace::new();
+        let i0 = rec.record_input_arg(Type::Int);
+        let i1 = rec.record_op(OpCode::IntAdd, &[i0, i0]);
+
+        // ResOp position: two calls resolve to the SAME producer box.
+        let a = rec.box_for_operand(i1);
+        let b = rec.box_for_operand(i1);
+        assert_eq!(a, b, "same position must yield ptr_eq-equal Operands");
+        assert_eq!(a.to_opref(), i1, "Operand round-trips to its OpRef");
+
+        // InputArg position: same invariant.
+        let ia_a = rec.box_for_operand(i0);
+        let ia_b = rec.box_for_operand(i0);
+        assert_eq!(ia_a, ia_b);
+        assert_eq!(ia_a.to_opref(), i0);
+
+        // Distinct positions are distinct boxes.
+        assert_ne!(rec.box_for_operand(i0), rec.box_for_operand(i1));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1389,6 +1389,18 @@ impl TraceCtx {
     /// fields (history.py:680,696). The standard-virtualizable shadow
     /// restores the value of the portal's red-virtualizable inputarg
     /// whose Box identity is recycled across loop iterations.
+    /// Canonical `Operand` (box object) for a value `OpRef`. The trace-record
+    /// analogue of the box objects RPython holds in `MIFrame.registers_r`
+    /// (`pyjitpl.py`): it surfaces the recorder's real per-op `Rc<Op>` /
+    /// `Rc<InputArg>` identity so consumers can key by box identity
+    /// (`Operand::eq` = `Rc::ptr_eq`) rather than flat `OpRef` position, matching
+    /// the box-keyed dicts upstream (e.g. `heapcache.py` `cache_anything[ref_box]`).
+    /// Deterministic: the same recorded position always yields an `Operand`
+    /// wrapping the same producer `Rc`.
+    pub fn operand_for(&self, opref: OpRef) -> majit_ir::operand::Operand {
+        self.recorder.box_for_operand(opref)
+    }
+
     pub fn box_value(&self, opref: OpRef) -> Option<Value> {
         if let Some(v) = opref.inline_const_to_value() {
             return Some(v);


### PR DESCRIPTION
close #47 

Follow-up to #350 (squash-merged). Four commits on `box-pool` beyond the
merge point.

## Commits

- **`trace_ctx: expose canonical OpRef->Operand box bridge`** — makes
  `Trace::box_for_operand` `pub(crate)` and adds a public
  `TraceCtx::operand_for(OpRef) -> Operand` wrapper + determinism test.
  Foundational primitive for retiring `OpRef` as a box-identity carrier;
  no consumer yet.

## PR #350 bot-review fixes (verified against code)

- **`Fix cls_of_box ref read and root retry snapshot clones`** (correctness)
  - **Codex P1** — a latent GC use-after-move introduced by #350's
    `SnapshotBox.opref_box → flat OpRef` flip. `compile_loop` rooted only
    the phase-1 `unroll_opt` snapshot clones, not the original locals that
    the `InvalidLoop` retry re-clones; a moving GC during phase-1
    optimization left the retry clone with a stale pre-move `ConstPtr`.
    Now roots the originals too (matching the bridge/simple-trace paths).
  - **`cls_of_box`** — read the resolved operand via `get_value()` not the
    const-only `const_value()`, so a bound `Op`/`InputArg` carrying a
    stamped `Value::Ref` resolves to its class instead of `0`
    (model.py:199-201 `getref_base` reads any ref-carrying box).
- **`Consolidate borrow guards; fix imports and stale doc refs`** (hygiene)
  - Collapse the four duplicated unsafe borrow-guard structs into generic
    `BorrowGuard<T>` / `BorrowGuardMut<T>` (SAFETY invariant documented
    once; old names kept as type aliases).
  - Gate the `OpRef` import to `feature = "test-support"` (clears the
    unused-import warning); fix stale `Forwarded::Const` doc shape; use
    `slice::from_ref` instead of a redundant clone; correct a doc comment's
    file reference and drop a mention of the deleted `Operand::Box`.

## #47 census closeout

- **`Reword test-support feature comment to forwarding/Operand`** — the
  last `BoxRef` token in `majit/` was a stale Cargo.toml comment. With it
  gone, `rg 'BoxRef|BoxKind' majit/` → **0**. The `Box`/`BoxKind`/`BoxRef`
  wrapper is fully deleted; the optimizer carries producer identity as
  `Operand` + flat `OpRef`. (The remaining `pyre/` hits are comments naming
  RPython's `BoxInt`/`BoxRef` upstream classes, not the deleted type.)

## Verification

- `majit-ir` lib 292 · `majit-metainterp` dynasm-lib 1384 · cranelift-lib 1382
- `check.py` dynasm **170/170** + cranelift **170/170**
- clippy: no unused-import warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a helper to fetch a canonical operand for a given operation reference.
  * Strengthened deterministic mapping from traced positions to operands, ensuring consistent round-trips.

* **Bug Fixes**
  * Fixed snapshot rooting across optimization retry paths to prevent stale GC references.
  * Improved runtime class/type resolution when boxed operands carry reference payloads.

* **Tests**
  * Added coverage to verify deterministic operand selection by position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->