### PR TITLE
Replace misplaced VecMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,7 @@ dependencies = [
 name = "majit-ir"
 version = "0.0.2"
 dependencies = [
+ "indexmap",
  "serde",
  "smallvec",
  "vecmap-rs",

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4303,7 +4303,7 @@ fn op_dereferences_first_arg(opcode: majit_ir::OpCode) -> bool {
 fn validate_oprefs_for_compile(
     inputargs: &[InputArg],
     ops: &[Op],
-    constants: &majit_ir::VecMap<u32, majit_ir::Const>,
+    constants: &majit_ir::ConstMap<majit_ir::Const>,
 ) -> Result<(), BackendError> {
     let num_inputs = inputargs.len();
     // RPython rewrite.py:397 + regalloc invariant: at the current op,
@@ -7447,7 +7447,7 @@ pub struct CraneliftBackend {
     /// the raw `i64` via `as_raw_i64()` and the GC rewriter reads the
     /// `v.type == 'r'` discriminant via `get_type()` — no separate
     /// type side-table.
-    constants: majit_ir::VecMap<u32, majit_ir::Const>,
+    constants: majit_ir::ConstMap<majit_ir::Const>,
     /// compile.py: self.metainterp_sd.callinfocollection — used by
     /// recovery_layout building for VStr/VUni Concat/Slice func ptr
     /// lookups (resume.py:1143-1188).
@@ -7661,7 +7661,7 @@ impl CraneliftBackend {
             cpu_tracker: Arc::new(majit_backend::CpuTotalTracker::default()),
             module,
             func_ctx,
-            constants: majit_ir::VecMap::new(),
+            constants: majit_ir::ConstMap::new(),
             callinfocollection: None,
             func_counter: 0,
             trace_counter: 1,
@@ -7938,7 +7938,7 @@ impl CraneliftBackend {
         &mut self,
         inputargs: &[InputArg],
         ops: &[Op],
-        constants: &majit_ir::VecMap<u32, majit_ir::Const>,
+        constants: &majit_ir::ConstMap<majit_ir::Const>,
     ) -> (Vec<Op>, Vec<GcRef>) {
         let mut normalized = normalize_ops_for_codegen_simple(inputargs, ops);
         inject_builtin_string_descrs(&mut normalized);
@@ -14900,7 +14900,7 @@ impl majit_backend::Backend for CraneliftBackend {
         Ok(info)
     }
 
-    fn set_constants_pool(&mut self, constants: majit_ir::VecMap<u32, majit_ir::Const>) {
+    fn set_constants_pool(&mut self, constants: majit_ir::ConstMap<majit_ir::Const>) {
         self.constants = constants;
     }
 

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -247,7 +247,7 @@ pub struct AssemblerARM64<'a> {
     /// Constants: OpRef index (>= 10000) → typed `Const` value. The box
     /// variant carries its own type (`Const::get_type`), so no separate
     /// constant-type map is needed.
-    constants: majit_ir::VecMap<u32, majit_ir::Const>,
+    constants: majit_ir::ConstMap<majit_ir::Const>,
     /// Next available frame slot index.
     next_slot: usize,
     /// Condition code from the most recent CMP/TEST instruction,
@@ -409,7 +409,7 @@ impl<'a> AssemblerARM64<'a> {
     pub(crate) fn new(
         trace_id: u64,
         header_pc: u64,
-        constants: majit_ir::VecMap<u32, majit_ir::Const>,
+        constants: majit_ir::ConstMap<majit_ir::Const>,
         vtable_offset: Option<usize>,
         classptr_to_typeid: VecMap<i64, u32>,
         guard_gc_type_info: Option<GuardGcTypeInfo>,

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -835,7 +835,7 @@ pub struct DynasmBackend {
     /// Each `Const` carries its value (read via `as_raw_i64()`) and type
     /// (read via `get_type()` for the GC rewriter's `v.type` check), so
     /// there is no separate type side-table.
-    constants: majit_ir::VecMap<u32, majit_ir::Const>,
+    constants: majit_ir::ConstMap<majit_ir::Const>,
     /// llmodel.py:64-69 self.vtable_offset — byte offset of the typeptr
     /// field inside instance objects. None when gcremovetypeptr is enabled.
     vtable_offset: Option<usize>,
@@ -934,7 +934,7 @@ impl DynasmBackend {
             cpu_tracker: Arc::new(majit_backend::CpuTotalTracker::default()),
             next_trace_id: 1,
             next_header_pc: 0,
-            constants: majit_ir::VecMap::new(),
+            constants: majit_ir::ConstMap::new(),
             vtable_offset: None,
             descr_attachments: Arc::new(std::sync::RwLock::new(
                 crate::guard::CpuDescrAttachments::default(),
@@ -1343,7 +1343,7 @@ impl DynasmBackend {
     fn collect_classptr_typeid_table(
         &self,
         ops: &[Op],
-        const_pool: &majit_ir::VecMap<u32, majit_ir::Const>,
+        const_pool: &majit_ir::ConstMap<majit_ir::Const>,
     ) -> majit_ir::VecMap<i64, u32> {
         let mut table = majit_ir::VecMap::new();
         if self.vtable_offset.is_some() || DYNASM_ACTIVE_GC.with(|cell| cell.borrow().is_none()) {
@@ -1969,7 +1969,7 @@ impl Backend for DynasmBackend {
         })
     }
 
-    fn set_constants_pool(&mut self, constants: majit_ir::VecMap<u32, majit_ir::Const>) {
+    fn set_constants_pool(&mut self, constants: majit_ir::ConstMap<majit_ir::Const>) {
         self.constants = constants;
     }
 

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -672,7 +672,7 @@ pub struct Assembler386<'a> {
     /// Constants: OpRef index (>= 10000) → typed `Const` value. The box
     /// variant carries its own type (`Const::get_type`), so no separate
     /// constant-type map is needed.
-    constants: majit_ir::VecMap<u32, majit_ir::Const>,
+    constants: majit_ir::ConstMap<majit_ir::Const>,
     /// Next available frame slot index.
     next_slot: usize,
     /// Condition code from the most recent CMP/TEST instruction,
@@ -865,7 +865,7 @@ impl<'a> Assembler386<'a> {
     pub(crate) fn new(
         trace_id: u64,
         header_pc: u64,
-        constants: majit_ir::VecMap<u32, majit_ir::Const>,
+        constants: majit_ir::ConstMap<majit_ir::Const>,
         vtable_offset: Option<usize>,
         classptr_to_typeid: VecMap<i64, u32>,
         guard_gc_type_info: Option<GuardGcTypeInfo>,

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1390,7 +1390,7 @@ impl majit_backend::Backend for WasmBackend {
         })
     }
 
-    fn set_constants_pool(&mut self, constants: majit_ir::VecMap<u32, majit_ir::Const>) {
+    fn set_constants_pool(&mut self, constants: majit_ir::ConstMap<majit_ir::Const>) {
         self.constants.clear();
         for (&k, c) in constants.iter() {
             self.constants.insert(k, c.as_raw_i64());

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1614,7 +1614,7 @@ pub trait Backend: Send {
     ///
     /// Default is a no-op — only backends that honour constants at emit
     /// time override.
-    fn set_constants_pool(&mut self, _constants: majit_ir::VecMap<u32, Const>) {}
+    fn set_constants_pool(&mut self, _constants: majit_ir::ConstMap<Const>) {}
 
     /// Force the next `compile_loop` / `compile_bridge` call to stamp
     /// this trace id on exits.

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -8,7 +8,7 @@ pub use gcreftracer::{GcTable, install_gc_table_walker};
 /// 4. Stack maps for compiled code
 ///
 /// Reference: rpython/memory/gc/incminimark.py, rpython/jit/backend/llsupport/gc.py
-use majit_ir::{Const, GcRef, Op, VecMap};
+use majit_ir::{Const, ConstMap, GcRef, Op};
 pub use trace::{ClassTypeLayout, TypeEntry, TypeInfo, TypeInfoLayout};
 
 pub mod collector;
@@ -605,8 +605,8 @@ pub trait GcRewriter: Send {
     fn rewrite_for_gc_with_constants(
         &self,
         ops: &[Op],
-        constants: &VecMap<u32, Const>,
-    ) -> (Vec<Op>, VecMap<u32, Const>, Vec<GcRef>) {
+        constants: &ConstMap<Const>,
+    ) -> (Vec<Op>, ConstMap<Const>, Vec<GcRef>) {
         (self.rewrite_for_gc(ops), constants.clone(), Vec::new())
     }
 }

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -15,7 +15,7 @@ use majit_ir::Type;
 use majit_ir::descr::{DescrRef, FieldDescr, SizeDescr};
 use majit_ir::operand::Operand;
 use majit_ir::resoperation::{Op, OpCode, OpRef};
-use majit_ir::{Const, GcRef, Value, VecMap, VecSet};
+use majit_ir::{Const, ConstMap, GcRef, Value, VecMap, VecSet};
 
 use crate::{GcRewriter, WriteBarrierDescr};
 
@@ -331,7 +331,7 @@ struct RewriteState {
     next_pos: u32,
     /// Constant pool (from optimizer) — maps OpRef key → typed `Const`
     /// value. Each box variant carries its own type (`Const::get_type`).
-    constants: VecMap<u32, Const>,
+    constants: ConstMap<Const>,
 
     // ── Nursery batching ──
     /// The index in `out` of the current CALL_MALLOC_NURSERY op, if any.
@@ -447,7 +447,7 @@ impl RewriteState {
         RewriteState {
             out: Vec::with_capacity(hint + hint / 4),
             next_pos,
-            constants: VecMap::new(),
+            constants: ConstMap::new(),
             pending_malloc_idx: None,
             pending_malloc_total: 0,
             previous_size: 0,
@@ -469,7 +469,7 @@ impl RewriteState {
         }
     }
 
-    fn with_constants(hint: usize, next_pos: u32, constants: VecMap<u32, Const>) -> Self {
+    fn with_constants(hint: usize, next_pos: u32, constants: ConstMap<Const>) -> Self {
         // P3 category E — `constants` is an index-keyed constant pool
         // (raw u32 key), not a Box-identity dict.  Bit-helpers replace
         // the `OpRef::from_raw(k).is_constant()` round-trip that would
@@ -2818,7 +2818,7 @@ impl GcRewriterImpl {
 impl GcRewriter for GcRewriterImpl {
     fn rewrite_for_gc(&self, ops: &[Op]) -> Vec<Op> {
         let (rewritten, _constants, gcrefs) =
-            self.rewrite_for_gc_with_constants(ops, &VecMap::new());
+            self.rewrite_for_gc_with_constants(ops, &ConstMap::new());
         // This wrapper drops the gc_table output list. A non-null ConstPtr
         // operand is rewritten to LoadFromGcTable, which needs that list to
         // build the table; callers carrying one must use the
@@ -2834,8 +2834,8 @@ impl GcRewriter for GcRewriterImpl {
     fn rewrite_for_gc_with_constants(
         &self,
         ops: &[Op],
-        constants: &VecMap<u32, Const>,
-    ) -> (Vec<Op>, VecMap<u32, Const>, Vec<GcRef>) {
+        constants: &ConstMap<Const>,
+    ) -> (Vec<Op>, ConstMap<Const>, Vec<GcRef>) {
         // rewrite.py:988-1001 remove_bridge_exception: strip a
         // SaveExcClass+SaveException+RestoreException prefix that is
         // a no-op (common in bridges).
@@ -3357,7 +3357,7 @@ mod tests {
         let rw = make_rewriter();
         let ops = vec![Op::with_descr(OpCode::New, &[], size_descr(32, 7))];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Expect: CallMallocNursery, GcStore (tid)
         assert_eq!(result.len(), 2);
@@ -3442,7 +3442,7 @@ mod tests {
         // array_descr_ref: base_size=8, item_size=8 →
         //   total = 8 + 8*512 = 4104; gen_malloc_nursery sees
         //   round_up(GcHeader::SIZE + 4104) = 4112 > 4096 → returns None.
-        let mut constants: VecMap<u32, Const> = VecMap::new();
+        let mut constants: ConstMap<Const> = ConstMap::new();
         constants.insert(10_000, Const::Int(512));
         let new_array = Op::with_descr(OpCode::NewArray, &[ro(len_ref)], array_descr_ref());
         new_array.pos.set(OpRef::ref_op(0));
@@ -3629,7 +3629,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Allocation header stores only (CallMallocNursery + tid GcStore) + Jump.
         // No delayed-zero NULL-pointer stores must be emitted because
@@ -3661,7 +3661,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Collect the NULL-pointer stores emitted by the pending-zero flush.
         let mut seen_offsets: Vec<i64> = result
@@ -3704,7 +3704,7 @@ mod tests {
             Op::new(OpCode::Jump, &[]),
         ];
 
-        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         let null_offsets: Vec<i64> = result
             .iter()
@@ -3756,7 +3756,7 @@ mod tests {
             Op::with_descr(OpCode::New, &[], size_descr(32, 2)),
         ];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         assert!(result.iter().any(|o| o.opcode == OpCode::CallMallocNursery));
         assert!(
@@ -3917,7 +3917,7 @@ mod tests {
             vtable_descr(48, 3, 0xDEAD),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // CallMallocNursery + GcStore(tid) + GcStore(vtable)
         assert_eq!(result.len(), 3);
@@ -4154,7 +4154,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(2))]);
         let ops = vec![int_eq, guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         let same = result
             .iter()
@@ -4181,7 +4181,7 @@ mod tests {
         guard.store_final_boxes(vec![ro(OpRef::int_op(10)), ro(OpRef::int_op(11))]);
         let ops = vec![guard, Op::new(OpCode::Finish, &[])];
 
-        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, consts, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         assert!(
             result.iter().all(|o| o.opcode != OpCode::GuardAlwaysFails),
@@ -4242,7 +4242,7 @@ mod tests {
 
     /// Helper: build a constants map mapping `key` → `value` for tests
     /// that need the rewriter's resolve_constant to find a length.
-    fn const_pool(entries: &[(u32, i64)]) -> VecMap<u32, Const> {
+    fn const_pool(entries: &[(u32, i64)]) -> ConstMap<Const> {
         entries.iter().map(|&(k, v)| (k, Const::Int(v))).collect()
     }
 
@@ -4622,7 +4622,7 @@ mod tests {
         for &num_elem in &[10_i64, 200_i64] {
             let rw = make_rewriter_with_cards();
             let len_ref = OpRef::int_op(10_000);
-            let mut constants: VecMap<u32, Const> = VecMap::new();
+            let mut constants: ConstMap<Const> = ConstMap::new();
             constants.insert(10_000, Const::Int(num_elem));
             let new_array =
                 Op::with_descr(OpCode::NewArrayClear, &[ro(len_ref)], array_descr_ref());
@@ -4773,7 +4773,7 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         assert_eq!(
             result.len(),
@@ -4844,7 +4844,7 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Expect: LEA, LEA, INT_LSHIFT(i_len, 2), CALL_N
         assert_eq!(result.len(), 4);
@@ -4900,7 +4900,7 @@ mod tests {
             str_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Expect (itemscale=0 so no INT_LSHIFT):
         //   i2b = int_add(p0, i0)
@@ -4961,7 +4961,7 @@ mod tests {
             unicode_array_descr(),
         )];
 
-        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, constants, _gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Expect (itemscale=2):
         //   i0s = int_lshift(i0, 2)
@@ -5094,7 +5094,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // The reference constant is collected at index 0.
         assert_eq!(gcrefs, vec![r]);
@@ -5122,7 +5122,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Same ref ⇒ one gcref entry (dedup) and one LoadFromGcTable (block CSE).
         assert_eq!(gcrefs, vec![r]);
@@ -5159,7 +5159,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Distinct refs occupy distinct, stable indices.
         assert_eq!(gcrefs, vec![r0, r1]);
@@ -5183,7 +5183,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(null))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // rewrite.py:109 `bool(arg.value)` — a null ConstPtr stays inline.
         assert!(
@@ -5211,7 +5211,7 @@ mod tests {
             ),
         ];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // Dedup persists across the block boundary (one gcref) ...
         assert_eq!(gcrefs, vec![r]);
@@ -5232,7 +5232,7 @@ mod tests {
             &[Operand::const_from_value(Value::Ref(r))],
         )];
 
-        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &VecMap::new());
+        let (result, _consts, gcrefs) = rw.rewrite_for_gc_with_constants(&ops, &ConstMap::new());
 
         // rewrite.py:105 `keep` — JIT_DEBUG keeps its constants inline.
         assert!(gcrefs.is_empty(), "JIT_DEBUG keeps its constants inline");

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -352,7 +352,9 @@ struct RewriteState {
     /// we emit an operation that can trigger a collection or on LABEL.
     wb_applied: VecSet<OpRef>,
     /// Forwarding map from original result OpRefs to rewritten result boxes.
-    forwarding: VecMap<OpRef, Operand>,
+    /// Keyed lookup only (`resolve`/`record_result_mapping`), never iterated
+    /// in order, so a hash map keeps the per-op resolve O(1) on long traces.
+    forwarding: std::collections::HashMap<OpRef, Operand>,
 
     // ── Array length tracking (rewrite.py:59 _known_lengths) ──
     /// Maps array OpRef → known length. Populated when NEW_ARRAY has a
@@ -453,7 +455,7 @@ impl RewriteState {
             previous_size: 0,
             last_malloced_ref: Operand::none(),
             wb_applied: VecSet::new(),
-            forwarding: VecMap::new(),
+            forwarding: std::collections::HashMap::new(),
             known_lengths: VecMap::new(),
             pending_zeros: Vec::new(),
             initialized_indices: VecMap::new(),

--- a/majit/majit-ir/Cargo.toml
+++ b/majit/majit-ir/Cargo.toml
@@ -17,3 +17,4 @@ test-support = []
 smallvec = { workspace = true }
 serde = { workspace = true }
 vecmap_rs = { workspace = true }
+indexmap = { workspace = true }

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -47,5 +47,5 @@ pub use value::{
     JitDriverVar, StrEqFn, StrHashFn, Type, Value, VarKind, green_type_to_ir, make_str_slot,
     pypyjit_greenkey_uhash, set_str_resolver, set_unicode_resolver,
 };
-pub use vec_map::{VecMap, VecMapExt};
+pub use vec_map::{ConstMap, VecMap, VecMapExt};
 pub use vec_set::VecSet;

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1709,6 +1709,12 @@ impl<V> ConstLookup<V> for std::collections::HashMap<u32, V> {
     }
 }
 
+impl<V> ConstLookup<V> for indexmap::IndexMap<u32, V> {
+    fn lookup(&self, key: u32) -> Option<&V> {
+        self.get(&key)
+    }
+}
+
 /// Format a trace (list of ops) with optional constants for debugging.
 ///
 /// Generic over the constants value type so both the optimizer-side

--- a/majit/majit-ir/src/vec_map.rs
+++ b/majit/majit-ir/src/vec_map.rs
@@ -10,6 +10,17 @@
 
 pub use vecmap_rs::VecMap;
 
+/// The compiled-trace constant pool: position → constant value.
+///
+/// Backed by [`indexmap::IndexMap`] rather than [`VecMap`] because the pool is
+/// built by inserting one entry per const-folded position (up to the full
+/// trace length) and read back by keyed lookup and in-order iteration.
+/// `VecMap`'s `entry`/`get`/`insert` are linear scans (`iter().position`), so a
+/// large trace's pool made those O(n²); `IndexMap` gives O(1) keyed access
+/// while preserving insertion order, so codegen that iterates the pool is
+/// unaffected.
+pub type ConstMap<V> = indexmap::IndexMap<u32, V>;
+
 impl<V> crate::resoperation::ConstLookup<V> for VecMap<u32, V> {
     fn lookup(&self, key: u32) -> Option<&V> {
         self.get(&key)

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1692,7 +1692,7 @@ pub(crate) fn decode_values_with_layout(
 
 pub(crate) fn normalize_closing_jump_args(
     ops: Vec<majit_ir::OpRc>,
-    constants: &majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &majit_ir::ConstMap<majit_ir::Value>,
     num_inputs: usize,
 ) -> Vec<majit_ir::OpRc> {
     let Some(label_args) = ops
@@ -1800,7 +1800,7 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     vable_array_lengths: &[usize],
     num_red_args: usize,
     index_of_virtualizable: usize,
-    constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &mut majit_ir::ConstMap<majit_ir::Value>,
 ) {
     // TODO (Rust language constraint, not a logic
     // divergence): RPython `compile.py:425-461` calls
@@ -2570,7 +2570,7 @@ pub fn compile_tmp_callback(
     // Inline-Const carries each Const value directly on its OpRef
     // variant (history.py:227/268/314), so the backend pool is left
     // empty for `compile_tmp_callback`.
-    backend.set_constants_pool(majit_ir::VecMap::new());
+    backend.set_constants_pool(majit_ir::ConstMap::new());
     // The backend boundary takes `&[InputArg]` by value (the flat OpRef
     // encoding survives past this point); identity ends here.
     let backend_inputargs: Vec<InputArg> =
@@ -2747,7 +2747,7 @@ mod tests {
         };
         let mut ops: Vec<majit_ir::OpRc> = vec![op0, op1, op2];
         let mut inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         patch_new_loop_to_load_virtualizable_fields(
             &mut ops,
@@ -2824,7 +2824,7 @@ mod tests {
             InputArg::new_ref(1),
             InputArg::new_ref(2),
         ];
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
         patch_new_loop_to_load_virtualizable_fields(

--- a/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
+++ b/majit/majit-metainterp/src/optimizeopt/earlyforce.rs
@@ -171,7 +171,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallMayForceN);
@@ -191,7 +191,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
@@ -208,7 +208,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::CallAssemblerI);
@@ -227,7 +227,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::GuardNotForced);
@@ -248,7 +248,7 @@ mod tests {
             let mut opt = Optimizer::new();
             opt.add_pass(Box::new(OptEarlyForce::new()));
             let result =
-                opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+                opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
             assert_eq!(result.len(), 1, "{opcode:?} should be handled");
         }
     }
@@ -268,7 +268,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(OptEarlyForce::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::SetfieldGc);

--- a/majit/majit-metainterp/src/optimizeopt/guard.rs
+++ b/majit/majit-metainterp/src/optimizeopt/guard.rs
@@ -872,7 +872,7 @@ mod tests {
         }
         opt.snapshot_boxes = snapshots;
         let result: Vec<Op> = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecMap::new(), 1024)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), 1024)
             .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())
@@ -935,7 +935,7 @@ mod tests {
         }
         opt.snapshot_boxes = snapshots;
         let result: Vec<Op> = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecMap::new(), 2)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), 2)
             .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -4206,7 +4206,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
     }
 
     // ── Test 1: SETFIELD then GETFIELD → read from cache ──
@@ -6949,7 +6949,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(crate::optimizeopt::pure::OptPure::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
         let len_count = result
             .iter()
             .filter(|o| o.opcode == OpCode::ArraylenGc)

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -3281,7 +3281,7 @@ mod tests {
         // IntLt/IntAddOvf operate on Int-typed inputs — override the
         // test default (Ref) used by `optimize_with_constants_and_inputs_at`.
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 1024]);
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(200u32, majit_ir::Value::Int(1));
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -212,7 +212,7 @@ mod tests {
 
     fn drain_extra_ops(ctx: &mut OptContext) {
         while let Some((_, op)) = ctx.extra_operations_after.pop_front() {
-            ctx.new_operations.push(op);
+            ctx.push_new_operation(op);
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -528,6 +528,16 @@ use crate::optimizeopt::info::PtrInfoExt;
 pub struct OptContext {
     /// The output operation list being built.
     pub new_operations: Vec<majit_ir::OpRc>,
+    /// O(1) `OpRef → OpRc` index mirroring `new_operations`, keyed by each
+    /// op's result position. `find_producer_op`'s highest-priority lookup
+    /// otherwise scans `new_operations` with `iter().rfind(...)`, which is
+    /// O(n) per call and O(n²) over a whole trace — the dominant cost when
+    /// optimizing a large loop (e.g. aheui's ~64k-op whole-program trace).
+    /// Maintained incrementally by `push_new_operation` (insert overwrites,
+    /// so the last push at a position wins, matching the `rfind`
+    /// last-occurrence semantics); rebuilt by `rebuild_new_operations_index`
+    /// after the rare structural mutations, and cleared with the context.
+    pub(crate) new_operations_index: std::collections::HashMap<OpRef, majit_ir::OpRc>,
     /// optimizer.py:246 `self._emittedoperations = {}` — the result boxes
     /// of ops emitted by THIS optimizer run, keyed by box identity
     /// (`Rc::ptr_eq`) to mirror the upstream dict keyed by the `op` object.
@@ -1622,6 +1632,7 @@ impl OptContext {
     pub fn new(estimated_ops: usize) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
+            new_operations_index: std::collections::HashMap::with_capacity(estimated_ops),
             emitted_operations: majit_ir::vec_set::VecSet::new(),
             num_inputs: 0,
             inputarg_base: 0,
@@ -1824,8 +1835,8 @@ impl OptContext {
         if opref.is_none() || opref.is_constant() {
             return None;
         }
-        if let Some(op) = self.new_operations.iter().rfind(|op| op.pos.get() == opref) {
-            return Some(op.clone());
+        if let Some(op) = self.new_operations_index.get(&opref).cloned() {
+            return Some(op);
         }
         if let Some(op) = self.phase1_emit_ops_index.get(&opref).cloned() {
             return Some(op);
@@ -1853,6 +1864,27 @@ impl OptContext {
         self.input_ops_index.reserve(self.input_ops.len());
         for op in &self.input_ops {
             self.input_ops_index.insert(op.pos.get(), op.clone());
+        }
+    }
+
+    /// Append an emitted op and mirror it into `new_operations_index` so
+    /// `find_producer_op`'s highest-priority lookup stays O(1). Insert
+    /// overwrites, so the last push at a given position wins — matching the
+    /// `iter().rfind(...)` (last-occurrence) scan the index replaces.
+    pub(crate) fn push_new_operation(&mut self, op: majit_ir::OpRc) {
+        self.new_operations_index.insert(op.pos.get(), op.clone());
+        self.new_operations.push(op);
+    }
+
+    /// Rebuild `new_operations_index` from the current `new_operations`.
+    /// Called after the rare structural mutations (tail truncate, jump
+    /// reorder) that the incremental `push_new_operation` maintenance cannot
+    /// track by itself.
+    pub(crate) fn rebuild_new_operations_index(&mut self) {
+        self.new_operations_index.clear();
+        self.new_operations_index.reserve(self.new_operations.len());
+        for op in &self.new_operations {
+            self.new_operations_index.insert(op.pos.get(), op.clone());
         }
     }
 
@@ -2159,6 +2191,7 @@ impl OptContext {
     ) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
+            new_operations_index: std::collections::HashMap::with_capacity(estimated_ops),
             emitted_operations: majit_ir::vec_set::VecSet::new(),
             num_inputs: num_inputs as u32,
             inputarg_base,
@@ -2790,7 +2823,7 @@ impl OptContext {
                 // marked emitted or it stays invisible to producer matching.
                 self.emitted_operations
                     .insert(majit_ir::operand::Operand::from_bound_op(&reused));
-                self.new_operations.push(reused);
+                self.push_new_operation(reused);
                 return op_pos;
             }
         }
@@ -2835,7 +2868,7 @@ impl OptContext {
         // optimizer.py:674 `self._emittedoperations[op] = None`.
         self.emitted_operations
             .insert(majit_ir::operand::Operand::from_bound_op(&op_rc));
-        self.new_operations.push(op_rc);
+        self.push_new_operation(op_rc);
         pos_ref
     }
 
@@ -6775,6 +6808,7 @@ impl OptContext {
     /// Clear the output operation list (used when restarting optimization).
     pub fn clear_newoperations(&mut self) {
         self.new_operations.clear();
+        self.new_operations_index.clear();
         // Reset next_pos to the iteration's first fresh OpRef position
         // (right after the inputarg slice in the OpRef namespace), but
         // never below the prior iteration's watermark. The context

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -503,9 +503,9 @@ pub struct Optimizer {
 /// constant classes — `Value::Void` panics rather than fabricate a
 /// nonexistent `ConstVoid`.
 pub(crate) fn lower_typed_constants_to_const_pool(
-    constants: &majit_ir::VecMap<u32, majit_ir::Value>,
-) -> majit_ir::VecMap<u32, majit_ir::Const> {
-    let mut pool = majit_ir::VecMap::new();
+    constants: &majit_ir::ConstMap<majit_ir::Value>,
+) -> majit_ir::ConstMap<majit_ir::Const> {
+    let mut pool = majit_ir::ConstMap::new();
     for (&k, v) in constants {
         pool.insert(k, v.to_const());
     }
@@ -533,7 +533,7 @@ fn live_runtime_positions<'a>(ops: impl IntoIterator<Item = &'a Op>) -> Vec<bool
 
 pub(crate) fn sanitize_backend_constants_for_ops<'a>(
     ops: impl IntoIterator<Item = &'a Op>,
-    constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &mut majit_ir::ConstMap<majit_ir::Value>,
 ) {
     let live_positions = live_runtime_positions(ops);
     constants
@@ -553,7 +553,7 @@ pub(crate) fn sanitize_backend_constants_for_ops<'a>(
 /// `constant_types` side table.
 pub(crate) fn merge_backend_constants_from_ctx(
     ctx: &OptContext,
-    constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &mut majit_ir::ConstMap<majit_ir::Value>,
 ) {
     let live_positions = live_runtime_positions(ctx.new_operations.iter().map(|rc| rc.as_ref()));
 
@@ -2187,7 +2187,7 @@ impl Optimizer {
     /// Returns the optimized operation list.
     /// optimizer.py:517: propagate_all_forward(trace, call_pure_results, flush)
     pub fn propagate_all_forward(&mut self, ops: &[Op]) -> Vec<Op> {
-        self.optimize_with_constants(ops, &mut majit_ir::VecMap::new())
+        self.optimize_with_constants(ops, &mut majit_ir::ConstMap::new())
     }
 
     /// Run all optimization passes, with known constants pre-populated.
@@ -2203,7 +2203,7 @@ impl Optimizer {
     pub fn optimize_with_constants(
         &mut self,
         ops: &[Op],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
     ) -> Vec<Op> {
         self.optimize_with_constants_and_inputs(ops, constants, 0)
     }
@@ -2219,7 +2219,7 @@ impl Optimizer {
     pub fn optimize_with_constants_and_inputs(
         &mut self,
         ops: &[Op],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
     ) -> Vec<Op> {
         // `_at` traffics in `OpRc`; this `&[Op]` overload wraps each op in a
@@ -2251,7 +2251,7 @@ impl Optimizer {
     pub fn optimize_with_constants_and_inputs_oprc(
         &mut self,
         ops: &[majit_ir::OpRc],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
     ) -> Result<Vec<majit_ir::OpRc>, crate::optimize::InvalidLoop> {
         self.run_optimize_from_inputs(ops, constants, num_inputs, true)
@@ -2260,7 +2260,7 @@ impl Optimizer {
     pub(crate) fn run_optimize_from_inputs(
         &mut self,
         ops: &[majit_ir::OpRc],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
         input_ops_from_ops: bool,
     ) -> Result<Vec<majit_ir::OpRc>, crate::optimize::InvalidLoop> {
@@ -2296,7 +2296,7 @@ impl Optimizer {
     pub fn optimize_with_constants_and_inputs_at(
         &mut self,
         ops: &[majit_ir::OpRc],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
         inputarg_base: u32,
         start_next_pos: u32,
@@ -3847,7 +3847,7 @@ impl Optimizer {
     pub(crate) fn optimize_bridge(
         &mut self,
         ops: &[majit_ir::OpRc],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
         front_target_tokens: &mut Vec<crate::history::TargetToken>,
         runtime_boxes: &[OpRef],
@@ -5743,7 +5743,7 @@ mod tests {
             ],
         )];
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].opcode, OpCode::IntAdd);
     }
@@ -5765,7 +5765,7 @@ mod tests {
             ],
         )];
         ops[0].pos.set(OpRef::int_op(2));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 2);
+        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 2);
 
         assert_eq!(
             hits.get(),
@@ -5829,7 +5829,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 3);
+        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
 
         let call_count = result
             .iter()
@@ -6002,7 +6002,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 3);
+        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
 
         let call_positions: majit_ir::vec_set::VecSet<_> = result
             .iter()
@@ -6049,7 +6049,7 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         let num_inputs = inputs.len();
         let result = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecMap::new(), num_inputs)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
             .expect("test: unexpected InvalidLoop");
         // The duplicate INT_ADD should be eliminated by CSE (OptPure).
         let add_count = result.iter().filter(|o| o.opcode == OpCode::IntAdd).count();
@@ -6079,7 +6079,7 @@ mod tests {
         ops[1].pos.set(OpRef::int_op(4));
         ops[2].pos.set(OpRef::int_op(5));
         ops[3].pos.set(OpRef::int_op(6));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(1u32, majit_ir::Value::Int(27));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 3);
 
@@ -6122,7 +6122,7 @@ mod tests {
         ops[1].pos.set(OpRef::int_op(4));
         ops[2].pos.set(OpRef::int_op(5));
         ops[3].pos.set(OpRef::int_op(6));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(1u32, majit_ir::Value::Int(27));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 3);
 
@@ -6150,7 +6150,7 @@ mod tests {
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(0u32, majit_ir::Value::Int(40));
         constants.insert(1u32, majit_ir::Value::Int(5));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 3);
@@ -6172,7 +6172,7 @@ mod tests {
             ],
         )];
         ops[0].pos.set(OpRef::int_op(3));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(0u32, majit_ir::Value::Int(40));
         constants.insert(1u32, majit_ir::Value::Int(5));
         constants.insert(3u32, majit_ir::Value::Int(1));
@@ -6202,7 +6202,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         assert_eq!(result.len(), 1);
@@ -6248,7 +6248,7 @@ mod tests {
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_empty_guard_snapshots_oprc(&ops);
         let result = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecMap::new(), num_inputs)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
             .expect("test: unexpected InvalidLoop");
         let ctx = OptContext::new(result.len());
         // Just verify the counting methods work
@@ -6273,7 +6273,7 @@ mod tests {
 
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 0);
+        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 0);
 
         assert!(
             result.iter().any(|op| op.opcode == OpCode::GuardValue),
@@ -6329,7 +6329,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         // force_all_lazy_setfields emits lazy SetfieldGc before JUMP.
@@ -6416,7 +6416,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         for set_op in result.iter().filter(|op| op.opcode == OpCode::SetfieldGc) {
@@ -6476,7 +6476,7 @@ mod tests {
         ops[0].pos.set(OpRef::int_op(2));
         ops[1].pos.set(OpRef::void_op(3));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
 
         let new_positions: majit_ir::vec_set::VecSet<_> = result
@@ -6547,7 +6547,7 @@ mod tests {
         }
 
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
         let guard = result
             .iter()
             .find(|op| op.opcode == OpCode::GuardTrue)
@@ -6613,7 +6613,7 @@ mod tests {
             &[rooted_resop_operand(Type::Int, 50)],
         )));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt
             .optimize_with_constants_and_inputs_at(&[], &mut constants, 3, 0, 0, false)
             .expect("empty trace must not produce InvalidLoop");
@@ -6966,7 +6966,7 @@ mod tests {
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_guard_snapshots_with_oprc(&ops, |_| vec![x_ref, y_ref]);
         let result = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecMap::new(), num_inputs)
+            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
             .expect("test: unexpected InvalidLoop");
 
         let guard = result

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1059,7 +1059,7 @@ impl Optimizer {
             let op_rc = std::rc::Rc::new(op);
             ctx.emitted_operations
                 .insert(majit_ir::operand::Operand::from_bound_op(&op_rc));
-            ctx.new_operations.push(op_rc);
+            ctx.push_new_operation(op_rc);
             // Update the field to reference the SameAs result.
             entries[*entry_idx].fields[*field_idx].1 = fresh;
         }
@@ -3502,6 +3502,12 @@ impl Optimizer {
             let jump_op = ctx.new_operations.remove(jump_idx);
             ctx.new_operations.push(jump_op);
         }
+        // `new_operations_index` intentionally not maintained across this
+        // finalization tail (jump reorder + the position remap below): it
+        // feeds `find_producer_op`, which is only queried during the forward
+        // propagate/emit phase that precedes this point. The context is
+        // cleared (`clear_newoperations`) before any reuse re-enters that
+        // phase.
 
         // Remap ALL positions: virtual inputs go to num_inputs..final_num_inputs,
         // This ensures no position collisions between input block params and ops.
@@ -4098,6 +4104,10 @@ impl Optimizer {
             Err(()) => {
                 if !front_target_tokens.is_empty() {
                     ctx.new_operations.truncate(post_force_len);
+                    // The rolled-back attempt left stale entries for the
+                    // truncated ops; `send_extra_operation` below queries
+                    // `find_producer_op`, so resync the index to the survivors.
+                    ctx.rebuild_new_operations_index();
                     // unroll.py:196,238-242 jump_to_preamble parity: the jump-to
                     // jitcell is `jump_op.getdescr()` = terminal_jump's own
                     // recorded descr (the preamble of the loop the trace closed
@@ -4146,6 +4156,9 @@ impl Optimizer {
         // VS is recomputed inside that call from the current (post-force)
         // jump_op.getarglist() — no pre-snapshot is reused.
         ctx.new_operations.truncate(post_force_len);
+        // `try_jump_to_existing_trace` below queries `find_producer_op`;
+        // resync the index to the post-truncate survivors first.
+        ctx.rebuild_new_operations_index();
         let vs2 = match Self::try_jump_to_existing_trace(
             &opt_unroll,
             &jump_args,
@@ -4181,6 +4194,9 @@ impl Optimizer {
         }
         if !front_target_tokens.is_empty() {
             ctx.new_operations.truncate(post_force_len);
+            // Resync the index to the survivors before `send_extra_operation`
+            // queries `find_producer_op` (drops the rolled-back attempt's ops).
+            ctx.rebuild_new_operations_index();
             // unroll.py:196,238-242 jump_to_preamble parity: keep jump_op's own
             // (forced) args so send_extra_operation's Virtualize pass forces the
             // still-virtual ref args, AND keep its recorded descr. That descr is

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5765,7 +5765,8 @@ mod tests {
             ],
         )];
         ops[0].pos.set(OpRef::int_op(2));
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 2);
+        let result =
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 2);
 
         assert_eq!(
             hits.get(),
@@ -5829,7 +5830,8 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
+        let result =
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
 
         let call_count = result
             .iter()
@@ -6002,7 +6004,8 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
+        let result =
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 3);
 
         let call_positions: majit_ir::vec_set::VecSet<_> = result
             .iter()
@@ -6049,7 +6052,11 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         let num_inputs = inputs.len();
         let result = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::ConstMap::new(),
+                num_inputs,
+            )
             .expect("test: unexpected InvalidLoop");
         // The duplicate INT_ADD should be eliminated by CSE (OptPure).
         let add_count = result.iter().filter(|o| o.opcode == OpCode::IntAdd).count();
@@ -6248,7 +6255,11 @@ mod tests {
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_empty_guard_snapshots_oprc(&ops);
         let result = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::ConstMap::new(),
+                num_inputs,
+            )
             .expect("test: unexpected InvalidLoop");
         let ctx = OptContext::new(result.len());
         // Just verify the counting methods work
@@ -6273,7 +6284,8 @@ mod tests {
 
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let result = opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 0);
+        let result =
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 0);
 
         assert!(
             result.iter().any(|op| op.opcode == OpCode::GuardValue),
@@ -6966,7 +6978,11 @@ mod tests {
         let num_inputs = inputs.len();
         opt.snapshot_boxes = seed_guard_snapshots_with_oprc(&ops, |_| vec![x_ref, y_ref]);
         let result = opt
-            .optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
+            .optimize_with_constants_and_inputs_oprc(
+                &ops,
+                &mut majit_ir::ConstMap::new(),
+                num_inputs,
+            )
             .expect("test: unexpected InvalidLoop");
 
         let guard = result

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -1473,7 +1473,7 @@ mod tests {
     fn run_pure(
         num_inputs: u32,
         specs: &[OpSpec],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         extra_passes: &[fn() -> Box<dyn crate::optimizeopt::Optimization>],
         seed_guard_snapshots: bool,
     ) -> Vec<Op> {
@@ -1517,7 +1517,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1537,7 +1537,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(2)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1555,7 +1555,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1573,7 +1573,7 @@ mod tests {
                 op_spec(OpCode::IntSub, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntSub, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1591,7 +1591,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntMul, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1611,7 +1611,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1625,7 +1625,7 @@ mod tests {
         let result = run_pure(
             2,
             &[op_spec(OpCode::CallPureI, &[Arg::In(0), Arg::In(1)])],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1659,7 +1659,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::VecMap::new(),
+                &mut majit_ir::ConstMap::new(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1685,7 +1685,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::VecMap::new(),
+                &mut majit_ir::ConstMap::new(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1718,7 +1718,7 @@ mod tests {
                     arr_descr.clone(),
                 ),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1747,7 +1747,7 @@ mod tests {
                     arr_descr.clone(),
                 ),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1765,7 +1765,7 @@ mod tests {
                 op_spec(OpCode::IntNeg, &[Arg::In(0)]),
                 op_spec(OpCode::IntNeg, &[Arg::In(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1790,7 +1790,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::VecMap::new(),
+                &mut majit_ir::ConstMap::new(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1829,7 +1829,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::VecMap::new(),
+                &mut majit_ir::ConstMap::new(),
                 num_inputs as usize,
             )
             .expect("test: unexpected InvalidLoop");
@@ -1895,7 +1895,7 @@ mod tests {
                 op_spec(OpCode::IntXor, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntXor, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1911,7 +1911,7 @@ mod tests {
                 op_spec(OpCode::IntAnd, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntAnd, &[Arg::In(1), Arg::In(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1929,7 +1929,7 @@ mod tests {
                 op_spec(OpCode::IntLt, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::IntLt, &[Arg::In(0), Arg::In(1)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -1956,7 +1956,7 @@ mod tests {
         let result = opt
             .optimize_with_constants_and_inputs_oprc(
                 &ops,
-                &mut majit_ir::VecMap::new(),
+                &mut majit_ir::ConstMap::new(),
                 inputs.len(),
             )
             .expect("test: unexpected InvalidLoop");
@@ -1978,7 +1978,7 @@ mod tests {
                 op_spec(OpCode::SetfieldGc, &[Arg::In(0), Arg::In(1)]), // not pure, kept
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure dup, eliminated
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -2003,7 +2003,7 @@ mod tests {
                 op_spec(OpCode::CallLoopinvariantI, &[func.clone(), Arg::In(0)]),
                 op_spec(OpCode::CallLoopinvariantI, &[func, Arg::In(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[rewrite_pass],
             false,
         );
@@ -2024,7 +2024,7 @@ mod tests {
                 op_spec(OpCode::CallLoopinvariantI, &[Arg::In(0), Arg::In(1)]),
                 op_spec(OpCode::CallLoopinvariantI, &[Arg::In(0), Arg::In(2)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[rewrite_pass],
             false,
         );
@@ -2045,7 +2045,7 @@ mod tests {
             let result = run_pure(
                 1,
                 &[op_spec(loopinv_op, &[Arg::In(0)])],
-                &mut majit_ir::VecMap::new(),
+                &mut majit_ir::ConstMap::new(),
                 &[rewrite_pass],
                 false,
             );
@@ -2076,7 +2076,7 @@ mod tests {
         let result = run_pure(
             1,
             &specs,
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[rewrite_pass],
             false,
         );
@@ -2099,7 +2099,7 @@ mod tests {
                 op_spec(OpCode::IntAdd, &[Arg::In(0), Arg::In(1)]), // pure dup → removed
                 op_spec(OpCode::CallLoopinvariantI, &[func, Arg::In(2)]), // loopinv dup → removed
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[rewrite_pass],
             false,
         );
@@ -2123,7 +2123,7 @@ mod tests {
                 // Use the result in a finish to prevent dead code elimination
                 op_spec(OpCode::Finish, &[Arg::Prod(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -2145,7 +2145,7 @@ mod tests {
                 ),
                 op_spec(OpCode::Finish, &[Arg::Prod(0)]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -2166,7 +2166,7 @@ mod tests {
                 op_spec(OpCode::GuardNoOverflow, &[]),
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             true,
         );
@@ -2192,7 +2192,7 @@ mod tests {
                 op_spec(OpCode::GuardNoOverflow, &[]),
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             true,
         );
@@ -2370,7 +2370,7 @@ mod tests {
                 op_spec(OpCode::GuardNoException, &[]), // should be removed
                 op_spec(OpCode::Finish, &[]),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             true,
         );
@@ -2940,7 +2940,7 @@ mod tests {
                     &[Arg::In(1), Arg::In(2), Arg::In(3)],
                 ),
             ],
-            &mut majit_ir::VecMap::new(),
+            &mut majit_ir::ConstMap::new(),
             &[],
             false,
         );
@@ -2971,7 +2971,7 @@ mod tests {
         opt.record_call_pure_result(vec![Value::Int(0xCAFE), Value::Int(7)], Value::Int(42));
         opt.add_pass(Box::new(OptPure::new()));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len())
             .expect("test: unexpected InvalidLoop");
@@ -3044,7 +3044,7 @@ mod tests {
         );
         opt.add_pass(Box::new(OptPure::new()));
 
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, inputs.len())
             .expect("test: unexpected InvalidLoop");

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -3514,7 +3514,7 @@ mod tests {
         opt.add_pass(Box::new(crate::optimizeopt::intbounds::OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![majit_ir::Type::Int; 2]);
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);
@@ -3540,7 +3540,7 @@ mod tests {
         // mul_minus_one lives in OptIntBounds (autogenintrules.py).
         opt.add_pass(Box::new(crate::optimizeopt::intbounds::OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
@@ -3565,7 +3565,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
@@ -3586,7 +3586,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)
@@ -3610,7 +3610,7 @@ mod tests {
         let mut opt = crate::optimizeopt::optimizer::Optimizer::new();
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.add_pass(Box::new(OptRewrite::new()));
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let num_inputs = inputs.len();
         let result = opt
             .optimize_with_constants_and_inputs_oprc(&ops, &mut constants, num_inputs)

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -89,7 +89,7 @@ pub struct ShortPreamble {
     /// Production short preamble ops embed inline `Const*` OpRefs
     /// directly, matching RPython where `_map_args` passes Const boxes
     /// through unchanged. This map is therefore empty on production paths.
-    pub constants: majit_ir::VecMap<u32, majit_ir::Const>,
+    pub constants: majit_ir::ConstMap<majit_ir::Const>,
     /// RPython parity: PtrInfo for each inputarg, from Phase 1 export.
     /// shortpreamble.py:414-425: preamble_op.set_forwarded(info)
     /// Used by inline_short_preamble to propagate PtrInfo to jump_args
@@ -114,7 +114,7 @@ impl ShortPreamble {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state: None,
-            constants: majit_ir::VecMap::new(),
+            constants: majit_ir::ConstMap::new(),
             phase1_inputargs: None,
             inputarg_infos: Vec::new(),
         }
@@ -288,7 +288,7 @@ impl CollectedShortPreambleBuilder {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state,
-            constants: majit_ir::VecMap::new(),
+            constants: majit_ir::ConstMap::new(),
             phase1_inputargs: None,
             inputarg_infos: Vec::new(),
         }
@@ -1217,7 +1217,7 @@ impl CollectedExtendedShortPreambleBuilder {
             used_boxes: Vec::new(),
             jump_args: Vec::new(),
             exported_state,
-            constants: majit_ir::VecMap::new(),
+            constants: majit_ir::ConstMap::new(),
             phase1_inputargs: None,
             inputarg_infos: Vec::new(),
         }
@@ -2198,7 +2198,7 @@ fn build_short_preamble_struct_from_ops(
     // RPython parity: `shortpreamble.py` keeps no `loop_constants` side
     // table — `arg` IS the `Const` box, so `_map_args(mapping, args)`
     // (`unroll.py:364`) passes it through unchanged.
-    let constants: majit_ir::VecMap<u32, majit_ir::Const> = majit_ir::VecMap::new();
+    let constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
     ShortPreamble {
         ops: entries,
         inputargs: short_inputargs.to_vec(),
@@ -3234,7 +3234,7 @@ pub(crate) fn extract_short_preamble(peeled_ops: &[Op]) -> ShortPreamble {
         used_boxes: Vec::new(),
         jump_args: Vec::new(),
         exported_state: None,
-        constants: majit_ir::VecMap::new(),
+        constants: majit_ir::ConstMap::new(),
         phase1_inputargs: None,
         inputarg_infos: Vec::new(),
     }

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -124,7 +124,7 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.snapshot_boxes = seed_oprc(&ops);
         let num_inputs = inputs.len();
-        opt.optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::VecMap::new(), num_inputs)
+        opt.optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
             .expect("test: unexpected InvalidLoop")
             .into_iter()
             .map(|rc| (*rc).clone())

--- a/majit/majit-metainterp/src/optimizeopt/simplify.rs
+++ b/majit/majit-metainterp/src/optimizeopt/simplify.rs
@@ -124,11 +124,15 @@ mod tests {
         opt.trace_inputargs = OpRef::inputarg_refs(&inputs);
         opt.snapshot_boxes = seed_oprc(&ops);
         let num_inputs = inputs.len();
-        opt.optimize_with_constants_and_inputs_oprc(&ops, &mut majit_ir::ConstMap::new(), num_inputs)
-            .expect("test: unexpected InvalidLoop")
-            .into_iter()
-            .map(|rc| (*rc).clone())
-            .collect()
+        opt.optimize_with_constants_and_inputs_oprc(
+            &ops,
+            &mut majit_ir::ConstMap::new(),
+            num_inputs,
+        )
+        .expect("test: unexpected InvalidLoop")
+        .into_iter()
+        .map(|rc| (*rc).clone())
+        .collect()
     }
 
     /// The `OpRef`s a header-input slice of `n` `Type::Int` inputargs resolves

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -55,7 +55,7 @@ where
     f()
 }
 
-fn is_trace_constant_ref(opref: OpRef, constants: &majit_ir::VecMap<u32, majit_ir::Value>) -> bool {
+fn is_trace_constant_ref(opref: OpRef, constants: &majit_ir::ConstMap<majit_ir::Value>) -> bool {
     if opref.is_none() {
         return false;
     }
@@ -72,7 +72,7 @@ fn is_trace_constant_ref(opref: OpRef, constants: &majit_ir::VecMap<u32, majit_i
     constants.contains_key(&opref.raw())
 }
 
-fn is_trace_runtime_ref(opref: OpRef, constants: &majit_ir::VecMap<u32, majit_ir::Value>) -> bool {
+fn is_trace_runtime_ref(opref: OpRef, constants: &majit_ir::ConstMap<majit_ir::Value>) -> bool {
     !opref.is_none() && !is_trace_constant_ref(opref, constants)
 }
 
@@ -407,7 +407,7 @@ impl UnrollOptimizer {
     pub fn optimize_trace_with_constants(
         &mut self,
         ops: &[Op],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
     ) -> Vec<Op> {
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::default_pipeline();
         optimizer.add_pass(Box::new(OptUnroll::new()));
@@ -424,7 +424,7 @@ impl UnrollOptimizer {
     pub fn optimize_trace_with_constants_and_inputs(
         &mut self,
         ops: &[Op],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
     ) -> (Vec<majit_ir::OpRc>, usize) {
         self.optimize_trace_with_constants_and_inputs_vable(ops, constants, num_inputs, None)
@@ -441,7 +441,7 @@ impl UnrollOptimizer {
     pub(crate) fn optimize_trace_with_constants_and_inputs_vable(
         &mut self,
         ops: &[Op],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
         vable_config: Option<crate::optimizeopt::virtualize::VirtualizableConfig>,
     ) -> Result<(Vec<majit_ir::OpRc>, usize), crate::optimize::InvalidLoop> {
@@ -462,7 +462,7 @@ impl UnrollOptimizer {
     pub(crate) fn optimize_trace_with_constants_and_inputs_vable_out(
         &mut self,
         ops: &[Op],
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         num_inputs: usize,
         vable_config: Option<crate::optimizeopt::virtualize::VirtualizableConfig>,
         phase1_out: Option<&mut Option<(Vec<majit_ir::OpRc>, ExportedState)>>,
@@ -4412,7 +4412,7 @@ fn assemble_peeled_trace(
     body_num_inputs: usize,
     jump_to_self: bool,
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
-    constants: &majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &majit_ir::ConstMap<majit_ir::Value>,
     start_label_descr: Option<DescrRef>,
     loop_label_descr: Option<DescrRef>,
 ) -> Vec<majit_ir::OpRc> {
@@ -4486,7 +4486,7 @@ fn assemble_peeled_trace_with_jump_args(
     inputarg_base: u32,
     jump_to_self: bool,
     imported_short_aliases: &[crate::optimizeopt::ImportedShortAlias],
-    constants: &majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &majit_ir::ConstMap<majit_ir::Value>,
     start_label_descr: Option<DescrRef>,
     loop_label_descr: Option<DescrRef>,
     _p1_end_args: &[OpRef],
@@ -5578,7 +5578,7 @@ mod tests {
                 .unwrap_or_default()
         });
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
     }
 
     // ── Basic peeling ─────────────────────────────────────────────────
@@ -5776,7 +5776,7 @@ mod tests {
         );
         let mut short_box_const_values = majit_ir::VecMap::new();
         short_box_const_values.insert(old_ref, Value::Ref(old));
-        let mut constants = majit_ir::VecMap::new();
+        let mut constants = majit_ir::ConstMap::new();
         constants.insert(0, majit_ir::Const::Ref(old));
 
         let mut state = ExportedState::new(
@@ -6276,7 +6276,7 @@ mod tests {
         let (ops, snapshots) = super::super::seed_empty_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         // Expect: peeled_add, peeled_guard, Label, body_add, body_guard, Jump = 6
         assert_eq!(result.len(), 6);
@@ -6447,7 +6447,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_inputarg_operand(Type::Int, 0)]),
         ];
         assign_positions(&mut ops, 2);
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let (result, _) =
             unroll_opt.optimize_trace_with_constants_and_inputs(&ops, &mut constants, 2);
         // The optimizer processes the trace; result should not be empty
@@ -7141,7 +7141,7 @@ mod tests {
                 same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
-            &majit_ir::VecMap::new(),
+            &majit_ir::ConstMap::new(),
             None,
             None,
         );
@@ -7202,7 +7202,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 11)]),
         ];
 
-        let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let combined = assemble_peeled_trace(
             &p1_ops,
@@ -7282,7 +7282,7 @@ mod tests {
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 19)]),
         ];
 
-        let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let combined = assemble_peeled_trace(
             &p1_ops,
@@ -7359,7 +7359,7 @@ mod tests {
                 same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
-            &majit_ir::VecMap::new(),
+            &majit_ir::ConstMap::new(),
             None,
             None,
         );
@@ -7418,7 +7418,7 @@ mod tests {
             ),
         ];
         let constants =
-            majit_ir::VecMap::from([(OpRef::void_op(857).raw(), majit_ir::Value::Int(2))]);
+            majit_ir::ConstMap::from([(OpRef::void_op(857).raw(), majit_ir::Value::Int(2))]);
 
         let mut ctx = assemble_test_context(&p1_ops, &p2_ops, 1);
         let p1_ops_rc: Vec<majit_ir::OpRc> = p1_ops
@@ -7528,7 +7528,7 @@ mod tests {
                 same_as_source: rooted_resop_operand(Type::Int, 10),
                 same_as_opcode: OpCode::SameAsI,
             }],
-            &majit_ir::VecMap::new(),
+            &majit_ir::ConstMap::new(),
             None,
             None,
         );
@@ -7585,7 +7585,7 @@ mod tests {
             },
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 64)]),
         ];
-        let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let combined = assemble_peeled_trace(
             &[],
@@ -7665,7 +7665,7 @@ mod tests {
             5,
             false,
             &[],
-            &majit_ir::VecMap::new(),
+            &majit_ir::ConstMap::new(),
             Some(start_descr),
             None,
         );
@@ -7731,7 +7731,7 @@ mod tests {
             2,
             false,
             &[],
-            &majit_ir::VecMap::new(),
+            &majit_ir::ConstMap::new(),
             Some(start_descr),
             Some(loop_descr),
         );
@@ -7776,7 +7776,7 @@ mod tests {
                 jump
             },
         ];
-        let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let combined = assemble_peeled_trace(
             &[],
@@ -7837,7 +7837,7 @@ mod tests {
             ),
             Op::new(OpCode::Jump, &[rooted_resop_operand(Type::Int, 0)]),
         ];
-        let constants = majit_ir::VecMap::from([
+        let constants = majit_ir::ConstMap::from([
             (2_u32, majit_ir::Value::Int(606)),
             (4_u32, majit_ir::Value::Int(611)),
         ]);
@@ -7880,7 +7880,7 @@ mod tests {
             OpCode::Jump,
             &[rooted_resop_operand(Type::Int, 10)],
         )];
-        let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let combined = assemble_peeled_trace(
             &[],
@@ -7915,7 +7915,7 @@ mod tests {
         // The assembler is therefore a passthrough for inputarg references
         // — no source_slot input_remap needed. This test verifies that
         // pre-resolved body args survive intact.
-        let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let p2_ops = vec![
             {
                 let mut op = Op::new(

--- a/majit/majit-metainterp/src/optimizeopt/vector.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vector.rs
@@ -2966,7 +2966,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         let labels = result
             .iter()
@@ -3350,7 +3350,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
 
         assert!(
             result.iter().any(|op| op.opcode == OpCode::Label),
@@ -3607,7 +3607,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
         assert!(!result.is_empty());
     }
 
@@ -3635,7 +3635,7 @@ mod tests {
         let mut opt = Optimizer::new();
         opt.add_pass(Box::new(VectorizingOptimizer::new()));
         let result =
-            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024);
+            opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024);
         assert!(result.iter().any(|op| op.opcode == OpCode::Label));
         assert!(result.iter().any(|op| op.opcode == OpCode::Jump));
     }

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -2908,7 +2908,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
     }
 
     fn run_default_pipeline(ops: &[Op]) -> Vec<Op> {
@@ -2916,7 +2916,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&vec![Type::Ref; 1024]);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
     }
 
     fn run_default_pipeline_typed(ops: &[Op], int_slots: &[u32], float_slots: &[u32]) -> Vec<Op> {
@@ -2931,7 +2931,7 @@ mod tests {
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         let (ops, snapshots) = seed_virtualize_guard_snapshots(ops);
         opt.snapshot_boxes = snapshots;
-        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::VecMap::new(), 1024)
+        opt.optimize_with_constants_and_inputs(&ops, &mut majit_ir::ConstMap::new(), 1024)
     }
 
     fn run_pass_with_constants(ops: &[Op], constants: &[(OpRef, Value)]) -> Vec<Op> {
@@ -3619,7 +3619,7 @@ mod tests {
             vable_input_offset: 0,
             track_array_elements: true,
         });
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let mut ops = vec![
             Op::new(
                 OpCode::Label,
@@ -4081,7 +4081,7 @@ mod tests {
         types[61] = Type::Float;
         opt.trace_inputargs = majit_ir::OpRef::inputarg_refs(&types);
         opt.snapshot_boxes = snapshots;
-        let mut constants = majit_ir::VecMap::new();
+        let mut constants = majit_ir::ConstMap::new();
         constants.insert(50u32, Value::Int(1));
         constants.insert(51u32, Value::Int(0));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
@@ -4177,7 +4177,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = seed_virtualize_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(200u32, majit_ir::Value::Int(42)); // expected class ptr matches vtable
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
         // Both NEW_WITH_VTABLE (virtual) and GuardClass (redundant) removed
@@ -4770,7 +4770,7 @@ mod tests {
         let mut opt = Optimizer::default_pipeline();
         let (ops, snapshots) = seed_virtualize_guard_snapshots(&ops);
         opt.snapshot_boxes = snapshots;
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(200u32, majit_ir::Value::Int(42)); // class ptr constant
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
         assert_eq!(
@@ -5485,7 +5485,7 @@ mod tests {
         ops[1].pos.set(OpRef::void_op(2));
         ops[2].pos.set(OpRef::void_op(3));
         let mut opt = Optimizer::default_pipeline();
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 1024);
 
         let opcodes: Vec<_> = result.iter().map(|op| op.opcode).collect();
@@ -5606,7 +5606,7 @@ mod tests {
         }
 
         let mut opt = Optimizer::default_pipeline();
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         constants.insert(100u32, majit_ir::Value::Int(7));
         constants.insert(101u32, majit_ir::Value::Int(11));
         let result = opt.optimize_with_constants_and_inputs(&ops, &mut constants, 2);

--- a/majit/majit-metainterp/src/optimizeopt/vstring.rs
+++ b/majit/majit-metainterp/src/optimizeopt/vstring.rs
@@ -1810,7 +1810,7 @@ mod tests {
         // Drain extra_operations_after (from emit_extra during force_box)
         // into new_operations so the test can see all emitted ops.
         while let Some((_pass_idx, extra_op)) = ctx.extra_operations_after.pop_front() {
-            ctx.new_operations.push(extra_op);
+            ctx.push_new_operation(extra_op);
         }
         ctx.new_operations
             .into_iter()
@@ -2856,7 +2856,7 @@ mod tests {
 
         // emit_for_force routes to extra_operations_after; drain it.
         while let Some((_pass_idx, extra_op)) = ctx.extra_operations_after.pop_front() {
-            ctx.new_operations.push(extra_op);
+            ctx.push_new_operation(extra_op);
         }
 
         // Check that STRGETITEM ops were emitted (inline path) instead of

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -261,7 +261,7 @@ pub(crate) struct CompiledTrace {
     /// type with value, so `Const` carries both — the legacy
     /// `(constants: HashMap<u32, i64>, constant_types: HashMap<u32, Type>)`
     /// parallel pair has been collapsed.
-    pub(crate) constants: majit_ir::VecMap<u32, majit_ir::Const>,
+    pub(crate) constants: majit_ir::ConstMap<majit_ir::Const>,
     /// Static exit metadata for each guard/finish in this trace.
     pub(crate) exit_layouts: majit_ir::VecMap<u32, StoredExitLayout>,
     /// Static exit metadata for terminal FINISH/JUMP ops, keyed by op index.
@@ -490,7 +490,7 @@ impl Drop for CompileSnapshotRootsGuard {
 
 fn snapshot_map_from_trace_snapshots(
     trace_snapshots: &[crate::recorder::Snapshot],
-    constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+    constants: &mut majit_ir::ConstMap<majit_ir::Value>,
 ) -> (
     SnapshotBoxes,
     SnapshotFrameSizes,
@@ -4778,7 +4778,7 @@ impl<M: Clone> MetaInterp<M> {
         &self,
         inputargs: &mut Vec<InputArg>,
         ops: &mut Vec<majit_ir::OpRc>,
-        constants: &mut majit_ir::VecMap<u32, majit_ir::Value>,
+        constants: &mut majit_ir::ConstMap<majit_ir::Value>,
         driver_descriptor: Option<&crate::jitdriver::JitDriverStaticData>,
         orig_vable_ptr: *const u8,
     ) {
@@ -5168,7 +5168,7 @@ impl<M: Clone> MetaInterp<M> {
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to drain — this backend typed-constant egress map
         // starts fresh.
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         // Materialize Vec<Op> from the trace's `Vec<OpRc>` so the
         // optimizer's `&[Op]` surface gets owned data. The deep-clone
@@ -6165,7 +6165,7 @@ impl<M: Clone> MetaInterp<M> {
         // The recorder carries Const values inline on the OpRef variants
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to snapshot — this typed-constant map starts fresh.
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
         let call_pure_results = ctx.call_pure_results.clone();
         let trace_snapshots = ctx.snapshots().to_vec();
         let (
@@ -6413,7 +6413,7 @@ impl<M: Clone> MetaInterp<M> {
             // The recorder carries Const values inline on the OpRef variants
             // (history.py:227/268/314), so there is no legacy TraceCtx
             // ConstantPool to snapshot — this typed-constant map starts fresh.
-            let constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+            let constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
             let initial_inputarg_consts = ctx.initial_inputarg_consts.clone();
             let call_pure_results = ctx.take_call_pure_results();
 
@@ -6985,7 +6985,7 @@ impl<M: Clone> MetaInterp<M> {
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to drain — this backend typed-constant egress map
         // starts fresh.
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         let num_ops_before = trace_ops.len();
         let mut optimizer = if let Some(config) = vable_config {
@@ -7396,7 +7396,7 @@ impl<M: Clone> MetaInterp<M> {
         // (history.py:227/268/314), so there is no legacy TraceCtx
         // ConstantPool to drain — this backend typed-constant egress map
         // starts fresh.
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
 
         if crate::majit_log_enabled() {
             eprintln!("--- simple loop trace (before opt) ---");
@@ -9350,7 +9350,7 @@ impl<M: Clone> MetaInterp<M> {
         meta: M,
         bridge_ops: &[majit_ir::Op],
         bridge_inputargs: &[majit_ir::InputArg],
-        bridge_constants: majit_ir::VecMap<u32, majit_ir::Const>,
+        bridge_constants: majit_ir::ConstMap<majit_ir::Const>,
         snapshot_boxes: SnapshotBoxes,
         snapshot_frame_sizes: SnapshotFrameSizes,
         snapshot_vable_boxes: SnapshotBoxes,
@@ -9416,7 +9416,7 @@ impl<M: Clone> MetaInterp<M> {
         // history.py:220 box.type parity: promote the legacy `i64` pool
         // to a typed `Value` map for the optimizer's intrinsic Const
         // class identity.
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = bridge_constants
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = bridge_constants
             .iter()
             .map(|(&k, c)| (k, c.to_value()))
             .collect();
@@ -9796,7 +9796,7 @@ impl<M: Clone> MetaInterp<M> {
         fail_descr: &dyn majit_ir::FailDescr,
         bridge_ops: &[majit_ir::Op],
         bridge_inputargs: &[majit_ir::InputArg],
-        bridge_constants: majit_ir::VecMap<u32, majit_ir::Const>,
+        bridge_constants: majit_ir::ConstMap<majit_ir::Const>,
         snapshot_boxes: SnapshotBoxes,
         snapshot_frame_sizes: SnapshotFrameSizes,
         snapshot_vable_boxes: SnapshotBoxes,
@@ -10032,7 +10032,7 @@ impl<M: Clone> MetaInterp<M> {
         }
         // history.py:220 box.type parity: promote the legacy `i64` pool
         // to a typed `Value` map.
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Value> = bridge_constants
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = bridge_constants
             .iter()
             .map(|(&k, c)| (k, c.to_value()))
             .collect();
@@ -18726,7 +18726,7 @@ mod tests {
                 start_descr,
             ),
         ];
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Const> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
         constants.insert(100, majit_ir::Const::Int(1));
         constants.insert(101, majit_ir::Const::Int(2));
         let mut traces = majit_ir::VecMap::new();
@@ -18909,7 +18909,7 @@ mod tests {
             CompiledTrace {
                 inputargs: vec![],
                 ops: vec![],
-                constants: majit_ir::VecMap::new(),
+                constants: majit_ir::ConstMap::new(),
                 exit_layouts,
                 terminal_exit_layouts: majit_ir::VecMap::new(),
             },
@@ -19005,7 +19005,7 @@ mod tests {
             CompiledTrace {
                 inputargs: vec![],
                 ops: vec![],
-                constants: majit_ir::VecMap::new(),
+                constants: majit_ir::ConstMap::new(),
                 exit_layouts,
                 terminal_exit_layouts: majit_ir::VecMap::new(),
             },
@@ -19124,7 +19124,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::VecMap::new(),
+            majit_ir::ConstMap::new(),
         );
 
         let (trace_id, fail_index) = {
@@ -19257,7 +19257,7 @@ mod tests {
         green_key: u64,
         inputargs: &[InputArg],
         ops: Vec<Op>,
-        constants_typed: majit_ir::VecMap<u32, majit_ir::Const>,
+        constants_typed: majit_ir::ConstMap<majit_ir::Const>,
     ) {
         meta.backend.set_constants_pool(constants_typed.clone());
         let mut token = JitCellToken::new(green_key + 1000);
@@ -19367,7 +19367,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::VecMap::new(),
+            majit_ir::ConstMap::new(),
         );
 
         let (trace_id, fail_index) = {
@@ -19445,7 +19445,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::VecMap::new(),
+            majit_ir::ConstMap::new(),
         );
 
         let (trace_id, fail_index, expected_source_op_index, expected_rd_numb, expected_exit_types) = {
@@ -19543,7 +19543,7 @@ mod tests {
             green_key,
             &inputargs,
             ops,
-            majit_ir::VecMap::new(),
+            majit_ir::ConstMap::new(),
         );
 
         let (trace_id, fail_index, descr_arc) = {
@@ -19648,7 +19648,7 @@ mod tests {
             guard_op,
             mk_op(OpCode::Finish, &[OpRef::int_op(0)], OpRef::NONE.raw()),
         ];
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Const> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
         constants.insert(
             100,
             majit_ir::Const::Int(maybe_force_and_return_void as *const () as usize as i64),
@@ -20748,7 +20748,7 @@ mod tests {
                 OpRef::NONE.raw(),
             ),
         ];
-        let mut constants: majit_ir::VecMap<u32, majit_ir::Const> = majit_ir::VecMap::new();
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
         constants.insert(100, majit_ir::Const::Int(1));
         constants.insert(101, majit_ir::Const::Int(0));
         attach_procedure_to_interp_entry(&mut meta, green_key, &inputargs, ops, constants);

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -471,6 +471,27 @@ pub fn inner_close_enabled() -> bool {
     *FLAG.get_or_init(|| single_pass_enabled() || std::env::var_os("PYRE_INNER_CLOSE").is_some())
 }
 
+/// pyjitpl.py:3021 `same_greenkey` parity for the header-close gate: close the
+/// loop only when EVERY green matches the trace-start header, not just the pc
+/// green.  The dispatch model's `header_matches` compares only `mp_green_pc`; a
+/// jitdriver with extra scalar greens (e.g. aheui's `stackok` / `is_queue`) can
+/// revisit the header pc under a *different* full green key, which RPython keeps
+/// tracing past.
+///
+/// DORMANT scaffolding (default-off preserves the pc-only close).  Enabling it
+/// in isolation HANGS aheui logo: the stricter close correctly declines the
+/// header pc when `stackok`/`is_queue` differ from trace-start, but the dispatch
+/// model lacks RPython's rest of `reached_loop_header` (pyjitpl.py:2974-3060) —
+/// the unconditional `GUARD_FUTURE_CONDITION`, `live_arg_boxes = greens + reds`,
+/// and the reverse scan of `current_merge_points` with `append` on no match — so
+/// the trace never finds an outer match and spins.  Landing same_greenkey
+/// therefore requires those pieces together (Codex §2 cluster), not this gate
+/// alone; kept as the entry point + comparison primitive for that rework.
+pub fn same_greenkey_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("PYRE_SAME_GREENKEY").is_some())
+}
+
 /// Walker-as-tracer (`PYRE_AUTHORITATIVE`): when set, the `run_to_end` walk is
 /// the SOLE authoritative executor for a trace — residual calls execute exactly
 /// once during the walk and the outer mainloop must neither replay them nor
@@ -4415,8 +4436,30 @@ where
                     } else {
                         ctx.header_pc
                     };
-                    let header_matches =
-                        mp_green_pc.map_or(true, |pc| pc == close_target_pc as i64);
+                    let pc_matches = mp_green_pc.map_or(true, |pc| pc == close_target_pc as i64);
+                    // pyjitpl.py:3021 same_greenkey: beyond the pc, require every
+                    // int green (aheui's stackok / is_queue, …) to equal the
+                    // trace-start header's.  A primary trace's header is
+                    // current_merge_points[0]; a bridge closes into its parent
+                    // loop, whose full greens are not tracked here, so restrict
+                    // the extra check to primary traces.  Gated (default keeps the
+                    // pc-only close) until verified byte-neutral.
+                    let same_greenkey = if same_greenkey_enabled() && !ctx.is_bridge_trace {
+                        ctx.current_merge_points.first().map_or(true, |hdr| {
+                            let hdr_ints: Vec<i64> = hdr
+                                .green_boxes
+                                .iter()
+                                .filter_map(|b| match b.opref {
+                                    majit_ir::OpRef::ConstInt(v) => Some(v),
+                                    _ => None,
+                                })
+                                .collect();
+                            hdr_ints == mp_green_ints
+                        })
+                    } else {
+                        true
+                    };
+                    let header_matches = pc_matches && same_greenkey;
                     if std::env::var_os("MAJIT_MPTRACE").is_some() {
                         eprintln!(
                             "@@@MPTRACE visit pc={mp_green_pc:?} header_pc={} close_target={close_target_pc} matches={header_matches} num_ops={}",

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -6964,6 +6964,14 @@ where
             }
         }
         let value = eval_binop_i(opcode, lhs_value, rhs_value);
+        // pyjitpl.py `_record_helper_pure`: a pure op whose args are all
+        // constants folds to its constant result at trace time and records
+        // nothing.  Every opcode routed here is a pure int/uint arithmetic or
+        // comparison, so an all-constant pair yields a constant destination.
+        if lhs.is_constant() && rhs.is_constant() {
+            self.set_int_reg(dst, Some(ctx.const_int(value)), Some(value));
+            return;
+        }
         let opref = ctx.record_op(opcode, &[lhs, rhs]);
         // `Box(value)` parity: stamp the result OpRef with its
         // runtime concrete so downstream `box_value(opref)` consumers
@@ -6985,6 +6993,11 @@ where
         };
         let (src, src_value) = self.read_int_reg(src_idx);
         let value = eval_unary_i(opcode, src_value);
+        // `_record_helper_pure`: a constant source folds to a constant result.
+        if src.is_constant() {
+            self.set_int_reg(dst, Some(ctx.const_int(value)), Some(value));
+            return;
+        }
         let opref = ctx.record_op(opcode, &[src]);
         ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
         self.set_int_reg(dst, Some(opref), Some(value));


### PR DESCRIPTION
follow-up #231 
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
