### PR TITLE
pyobject: seqlock the subclass-range restamp vs ll_issubclass reads

### DIFF
--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2070,10 +2070,21 @@ thread_local! {
         // back into the static PyType structs so that ll_issubclass
         // (rclass.py:1133-1137) can read them directly from the typeptr.
         gc.freeze_types();
-        for (&classptr, &_tid) in &pytype_to_tid {
-            if let Some((min, max)) = gc.subclass_range(classptr) {
-                let tp = unsafe { &*(classptr as *const pyre_object::pyobject::PyType) };
-                pyre_object::pyobject::assign_subclass_range(tp, min, max);
+        // This writeback replaces every static `subclassrange_{min,max}`
+        // with the GC-tid numbering, which differs from the preorder
+        // numbering the interpreter seeds via `compute_subclass_ranges_from`.
+        // Publish the whole batch inside one seqlock write section so a
+        // concurrent interpreter `ll_issubclass` observes either the
+        // all-preorder or the all-GC set, never a half-swapped mix — a mixed
+        // read makes `ll_issubclass(TypeError, BaseException)` spuriously
+        // false.
+        {
+            let _range_guard = pyre_object::pyobject::subclass_range_write_guard();
+            for (&classptr, &_tid) in &pytype_to_tid {
+                if let Some((min, max)) = gc.subclass_range(classptr) {
+                    let tp = unsafe { &*(classptr as *const pyre_object::pyobject::PyType) };
+                    pyre_object::pyobject::assign_subclass_range(tp, min, max);
+                }
             }
         }
         d.set_gc_allocator(Box::new(gc));

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1245,6 +1245,8 @@ pub fn standard_exc_instance(kind: ExcKind) -> PyObjectRef {
 #[inline]
 pub unsafe fn is_exception(obj: PyObjectRef) -> bool {
     crate::pyobject::ensure_object_subclass_ranges_initialized();
+    // `ll_issubclass` reads the ranges under the seqlock, so a concurrent
+    // one-time batch re-stamp cannot make this spuriously false.
     unsafe { ll_isinstance(obj, &EXCEPTION_TYPE) }
 }
 

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -4,8 +4,9 @@
 //! Concrete types (W_IntObject, W_BoolObject, etc.) embed this header as their
 //! first field, enabling safe pointer casts between `*mut PyObject` and typed pointers.
 
+use std::sync::Mutex;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicI64, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicU64, Ordering};
 
 /// Type descriptor for Python objects — corresponds to RPython's OBJECT_VTABLE
 /// (rclass.py:167-174).
@@ -262,11 +263,16 @@ pub unsafe fn ll_type(obj: PyObjectRef) -> *const PyType {
 ///   `int_between(cls.subclassrange_min, subcls.subclassrange_min, cls.subclassrange_max)`
 #[inline]
 pub fn ll_issubclass(subcls: &PyType, cls: &PyType) -> bool {
-    let cls_min = cls.subclassrange_min.load(Ordering::Relaxed);
-    let subcls_min = subcls.subclassrange_min.load(Ordering::Relaxed);
-    let cls_max = cls.subclassrange_max.load(Ordering::Relaxed);
-    // int_between(a, b, c) ≡ a <= b < c
-    cls_min <= subcls_min && subcls_min < cls_max
+    // Seqlock read: a concurrent one-time batch re-stamp (interpreter
+    // preorder ids vs JIT GC-tid ids) must not be observed half-applied, or
+    // `cls`/`subcls` could carry mismatched numberings.
+    subclass_range_read(|| {
+        let cls_min = cls.subclassrange_min.load(Ordering::Relaxed);
+        let subcls_min = subcls.subclassrange_min.load(Ordering::Relaxed);
+        let cls_max = cls.subclassrange_max.load(Ordering::Relaxed);
+        // int_between(a, b, c) ≡ a <= b < c
+        cls_min <= subcls_min && subcls_min < cls_max
+    })
 }
 
 /// rclass.py:1139-1140 `ll_issubclass_const(subcls, minid, maxid)`.
@@ -275,9 +281,13 @@ pub fn ll_issubclass(subcls: &PyType, cls: &PyType) -> bool {
 /// constants. Used by the JIT when the target class is constant-folded.
 #[inline]
 pub fn ll_issubclass_const(subcls: &PyType, minid: i64, maxid: i64) -> bool {
-    let subcls_min = subcls.subclassrange_min.load(Ordering::Relaxed);
-    // int_between(a, b, c) ≡ a <= b < c
-    minid <= subcls_min && subcls_min < maxid
+    // Seqlock read: `minid`/`maxid` are baked from one numbering, so
+    // `subcls_min` must be read from a matching (fully-published) batch.
+    subclass_range_read(|| {
+        let subcls_min = subcls.subclassrange_min.load(Ordering::Relaxed);
+        // int_between(a, b, c) ≡ a <= b < c
+        minid <= subcls_min && subcls_min < maxid
+    })
 }
 
 /// rclass.py:1143-1147 `ll_isinstance(obj, cls)`.
@@ -337,6 +347,84 @@ pub fn assign_subclass_range(tp: &PyType, min: i64, max: i64) {
     tp.subclassrange_max.store(max, Ordering::Relaxed);
 }
 
+/// Sequence lock (seqlock) guarding the batch (re)stamping of the static
+/// `subclassrange_{min,max}` fields.  Two independent initializers write
+/// them with *different* numberings: the interpreter's
+/// `compute_subclass_ranges_from` (preorder ids rooted at `INSTANCE_TYPE`)
+/// and the JIT's GC-tid writeback (`eval.rs`, from `assign_inheritance_ids`,
+/// which collapses every per-`ExcKind` PyType onto one tid).  Each set is
+/// internally consistent, but a reader that observes a half-completed swap —
+/// some types already re-stamped, others not — can see a parent/child pair
+/// carrying mismatched numberings and wrongly conclude the child is not a
+/// subclass.
+///
+/// A seqlock, not a mutex/rwlock, because this is free-threaded (`nogil`):
+/// the writes happen once at startup while `ll_issubclass` is a hot,
+/// concurrently-read path.  Optimistic readers touch only `SUBCLASS_RANGE_SEQ`
+/// with plain loads (no read-side atomic RMW), so once both one-time inits
+/// settle and the sequence stops changing, concurrent readers share that
+/// cache line read-only with no cross-core contention.  Even = stable,
+/// odd = a batch write is in flight.
+static SUBCLASS_RANGE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Serializes the (rare, one-time) writers against each other so the seqlock
+/// parity stays well-formed; readers never touch it.
+static SUBCLASS_RANGE_WRITER_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII write section for a batch subclass-range update.  Held by
+/// `compute_subclass_ranges_from` and the JIT GC-tid writeback in `eval.rs`
+/// for the whole batch: entering makes the sequence odd (optimistic readers
+/// retry), dropping publishes the writes and makes it even again.
+pub struct SubclassRangeWriteGuard {
+    _writers: std::sync::MutexGuard<'static, ()>,
+    seq: u64,
+}
+
+/// Enter a subclass-range write section (see [`SubclassRangeWriteGuard`]).
+pub fn subclass_range_write_guard() -> SubclassRangeWriteGuard {
+    let writers = SUBCLASS_RANGE_WRITER_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    // Serialized by the writer lock, so this load/store pair is race-free.
+    let seq = SUBCLASS_RANGE_SEQ.load(Ordering::Relaxed).wrapping_add(1);
+    SUBCLASS_RANGE_SEQ.store(seq, Ordering::Relaxed);
+    std::sync::atomic::fence(Ordering::Release);
+    SubclassRangeWriteGuard {
+        _writers: writers,
+        seq,
+    }
+}
+
+impl Drop for SubclassRangeWriteGuard {
+    fn drop(&mut self) {
+        // Publish the batch, then leave the write section (sequence even).
+        std::sync::atomic::fence(Ordering::Release);
+        SUBCLASS_RANGE_SEQ.store(self.seq.wrapping_add(1), Ordering::Release);
+    }
+}
+
+/// Optimistic seqlock read: run `read` (which loads the relevant
+/// `subclassrange_*` atomics) and retry until it lands in a window with no
+/// concurrent batch write, so the returned value reflects one coherent
+/// numbering.  In steady state (sequence stable) this is two plain loads of
+/// `SUBCLASS_RANGE_SEQ` plus one acquire fence — no read-side RMW.
+#[inline]
+fn subclass_range_read<T>(read: impl Fn() -> T) -> T {
+    loop {
+        let seq1 = SUBCLASS_RANGE_SEQ.load(Ordering::Acquire);
+        if seq1 & 1 != 0 {
+            std::hint::spin_loop();
+            continue;
+        }
+        let value = read();
+        std::sync::atomic::fence(Ordering::Acquire);
+        let seq2 = SUBCLASS_RANGE_SEQ.load(Ordering::Relaxed);
+        if seq1 == seq2 {
+            return value;
+        }
+    }
+}
+
 /// Compute preorder subclass IDs for every PyType reachable from
 /// `INSTANCE_TYPE` through the supplied `(subtype, parent)` pairs and
 /// write them via `assign_subclass_range`. Mirrors
@@ -363,6 +451,10 @@ pub fn compute_subclass_ranges_from(
     for chain in pairs_chains {
         pairs.extend_from_slice(chain);
     }
+    // Serialize against the JIT GC-tid writeback and publish the batch
+    // atomically w.r.t. seqlock readers so none observes a half-renumbered
+    // hierarchy.
+    let _range_guard = subclass_range_write_guard();
     let mut counter: i64 = 1;
     for root in roots {
         visit_preorder(root, &pairs, &mut counter);


### PR DESCRIPTION
## Summary

The static `subclassrange_{min,max}` fields are written by two independent initializers with different numberings:

- the interpreter's `compute_subclass_ranges_from` — preorder ids rooted at `INSTANCE_TYPE`, exceptions nested;
- the JIT GC-tid writeback in `eval.rs` (from `assign_inheritance_ids`), which collapses every per-`ExcKind` `PyType` onto the single `W_BaseException` tid.

Each set is internally consistent, but the two writebacks **race**: an `ll_issubclass` reader observing a half-applied swap can see a parent and child carrying mismatched numberings and wrongly conclude the child is not a subclass. Via `is_exception` that degrades a freshly built `TypeError`'s `message_text` to its object repr — surfacing as a windows-dynasm flake in the `bh_normalize_raise` reject-`len` test.

## Fix

Guard the ranges with a **seqlock** rather than a mutex/rwlock. This runtime is free-threaded (nogil) and `ll_issubclass` is a hot, concurrently-read path while the writes are one-time at startup:

- Optimistic readers touch only the sequence counter with plain loads (**no read-side atomic RMW**), so once both inits settle the counter stops changing and concurrent readers share it read-only with no cross-core contention. An rwlock would instead RMW a reader-count on every hot call → cache-line bouncing across cores.
- Writers (`compute_subclass_ranges_from` internally; the `eval.rs` GC-tid loop explicitly) take a `SubclassRangeWriteGuard` that brackets the batch with odd/even sequence bumps; a short writer mutex keeps parity well-formed against concurrent writers.
- Coherence lives in `ll_issubclass` / `ll_issubclass_const`, so **every** interpreter subclass check is covered, not just `is_exception`. Range fields are `AtomicI64`, so torn reads are UB-free and discarded on retry. JIT machine-code `GUARD_SUBCLASS` reads run post-init (stable) and need no guard.

## Test

- `check.py`: dynasm 171/171, cranelift 171/171, wasm 171/171
- unit: pyre-object 206, pyre-jit(dynasm) 290, pyre-interpreter 375

The windows-dynasm failure is not reproducible on macOS; this is a coherent seqlock fix for the identified race, and the actual windows pass will be confirmed by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)