### PR TITLE
jit: #73 flip direct-pc kept-stack branch-guard resume to default; remove PYRE_M3_JITCODE_PC gate

### DIFF
--- a/pyre/bench/synth/short_circuit_value_local_kept.py
+++ b/pyre/bench/synth/short_circuit_value_local_kept.py
@@ -6,8 +6,8 @@
 # (`flag` -> CONST), so a guard failure on the not-taken arm must restore
 # `flag`, not the taken-path CONST.  Reading the guard-pc register file
 # directly restores the stale CONST and silently miscompiles `kept_and`
-# (over-counting toward `11 * N`: 2197063 instead of 1466663); the positional
-# `kept_stack_subst` recovery restores the kept `flag` correctly.
+# (over-counting toward `11 * N`: 2197063 instead of 1466663); the walk-level
+# box mirror restores the kept `flag` correctly.
 #
 # `kept_stack_branch_depths.py` uses composite `(i % k)` left operands that
 # const-fold differently and side-step this defect; each loop here pins the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -9914,12 +9914,9 @@ fn walker_capture_snapshot_for_last_guard_impl(
             // `setposition`, and the cranelift bridge re-trace entry all agree
             // — the kept operand stack is naturally live at the guard pc, so
             // the positional `kept_stack_subst` recovery (gpc == entry_py_pc)
-            // is skipped.  Flag-off, `resume_py_pc` stays `py_pc`.
-            let liveness_py_pc = if crate::pyjitcode::m3_jitcode_pc_enabled() {
-                guard_py_pc.unwrap_or(py_pc)
-            } else {
-                py_pc
-            };
+            // is skipped.  A non-branch guard carries no guard pc, so it keeps
+            // the merge `py_pc` and its exact `pc_map` translation.
+            let liveness_py_pc = guard_py_pc.unwrap_or(py_pc);
             // The snapshot resume pc folds in the bit-14 marker for a try-block
             // residual call so the decode routes through
             // `after_residual_call_resume_pc_for` (the call's OWN post-call

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -1124,8 +1124,8 @@ pub enum DispatchError {
     /// tested value on the value stack across the branch (`COPY` / `TO_BOOL`
     /// / `POP_JUMP_IF_*`). The full-body walk's single-frame guard snapshot
     /// rebuilds locals + the post-opcode operand stack from the live register
-    /// banks; a single depth-1 kept temp is recovered positionally
-    /// (`kept_stack_subst` in `collect_outer_active_boxes`).  Depth > 1 is
+    /// banks; a single depth-1 kept temp is recovered from the walk-level box
+    /// mirror (`vstack`) in `collect_outer_active_boxes`.  Depth > 1 is
     /// supported only when the not-taken edge's decoded `ref_copy` moves
     /// (`#420`) cover every distinct kept resume color AND each move's source
     /// resolves to a live register value; that resolved set then drives the
@@ -6463,116 +6463,8 @@ fn collect_outer_active_boxes(
         }
         active.push(v);
     }
-    // #124 kept-stack recovery (gated by `guard_py_pc`, set on the
-    // branch-guard snapshot path).  A branch guard's not-taken arm
-    // resumes at a merge point whose live Ref colors are filled by the
-    // not-taken edge's register move — colors the walk has NOT written at
-    // the guard point, because that move executes only when the branch is
-    // taken at runtime.  Reading `registers_r[merge_color]` there yields a
-    // stale/color-reused box (the #124 corruption: it decodes to a wrong
-    // or null value on the odd-path iteration).  The kept operand-stack
-    // value lives instead in the guard-pc-only color the edge move reads
-    // from.  Recover `{resume merge color -> guard-pc kept value}`
-    // positionally: the not-taken arm preserves the bottom of the operand
-    // stack, so guard-only Ref colors (live at the guard, dead at resume),
-    // taken in ascending color order (the splice colors operand-stack
-    // slots in push order), supply the values for resume-only Ref colors
-    // that name a stack slot, in ascending semantic-slot order.
-    let kept_stack_subst: std::collections::HashMap<u32, OpRef> = match guard_py_pc {
-        Some(gpc) if gpc != entry_py_pc && owns_vable => {
-            let guard_banks = crate::state::frame_liveness_reg_indices_by_bank_at(
-                outer_jitcode_index as i32,
-                gpc as i32,
-            );
-            let resume_set: std::collections::HashSet<u32> = banks.ref_.iter().copied().collect();
-            let guard_set: std::collections::HashSet<u32> =
-                guard_banks.ref_.iter().copied().collect();
-            // Guard-only Ref colors carrying a real walk value.
-            let mut guard_only: Vec<u32> = guard_banks
-                .ref_
-                .iter()
-                .copied()
-                .filter(|c| !resume_set.contains(c))
-                .filter(|&c| {
-                    regs_r
-                        .get(c as usize)
-                        .copied()
-                        .is_some_and(|v| v != OpRef::NONE)
-                })
-                .collect();
-            guard_only.sort_unstable();
-            // Resume-only Ref colors naming an operand-stack slot.
-            let mut resume_only_stack: Vec<(usize, u32)> = banks
-                .ref_
-                .iter()
-                .copied()
-                .filter(|c| !guard_set.contains(c))
-                .filter_map(|c| {
-                    let s = crate::state::semantic_ref_slot_for_reg_color(
-                        nlocals,
-                        valid_stack_only,
-                        pcdep_opt.unwrap_or(&[]),
-                        c as usize,
-                    )?;
-                    (s >= nlocals).then_some((s, c))
-                })
-                .collect();
-            resume_only_stack.sort_unstable();
-            if std::env::var_os("PYRE_DIAG124C").is_some() {
-                eprintln!(
-                    "[diag124c] guard_py_pc={gpc} entry_py_pc={entry_py_pc} \
-                     guard_live_r={:?} resume_live_r={:?} guard_only={guard_only:?} \
-                     resume_only_stack={resume_only_stack:?}",
-                    guard_banks.ref_, banks.ref_,
-                );
-            }
-            let mut subst: std::collections::HashMap<u32, OpRef> = resume_only_stack
-                .into_iter()
-                .zip(guard_only)
-                .map(|((_, resume_color), guard_color)| {
-                    (resume_color, regs_r[guard_color as usize])
-                })
-                .collect();
-            // Live-across kept stack slot: a Ref color live at BOTH the
-            // guard and the resume point (same color) names an operand-
-            // stack slot the not-taken arm preserves.  The walker wrote
-            // its value into the color-indexed `registers_r` bank, but the
-            // `virtualizable_boxes` shadow the owns_vable read sources from
-            // is never updated on the walker path (only the retired trait
-            // `write_stack_slot` writes it), so the shadow returns a stale
-            // trace-seed box.  Supply the walker bank value directly.  Only
-            // genuinely live-across colors qualify (a guard-pc-only scratch
-            // reusing the color is excluded by the `guard_set` membership
-            // test), so a speculatively const-folded kept value absent from
-            // the guard register state still falls through unchanged.
-            for &c in &banks.ref_ {
-                if !guard_set.contains(&c) || subst.contains_key(&c) {
-                    continue;
-                }
-                let Some(s) = crate::state::semantic_ref_slot_for_reg_color(
-                    nlocals,
-                    valid_stack_only,
-                    pcdep_opt.unwrap_or(&[]),
-                    c as usize,
-                ) else {
-                    continue;
-                };
-                if s < nlocals {
-                    continue;
-                }
-                if let Some(v) = regs_r.get(c as usize).copied() {
-                    if v != OpRef::NONE {
-                        subst.insert(c, v);
-                    }
-                }
-            }
-            subst
-        }
-        _ => std::collections::HashMap::new(),
-    };
     // #420: exact not-taken edge-move recovery, keyed by resume-merge color.
-    // Takes precedence over the positional `kept_stack_subst` heuristic — the
-    // guard trampoline's `ref_copy(dst <- src)` gave this kept slot's live
+    // The guard trampoline's `ref_copy(dst <- src)` gave this kept slot's live
     // guard-pc source value directly, exact for any kept-stack depth.
     let kept_recovered: std::collections::HashMap<u32, OpRef> = BRANCH_GUARD_KEPT_RECOVERED
         .with(|c| c.borrow().iter().map(|&(dst, v)| (dst as u32, v)).collect());
@@ -6615,15 +6507,6 @@ fn collect_outer_active_boxes(
             // Edge-move-resolved kept operand; overrides the unwritten
             // merge-color read for this not-taken-arm operand-stack slot.
             active.push(rv);
-            continue;
-        }
-        if let Some(&subst) = kept_stack_subst.get(&idx) {
-            // The guard-pc kept value overrides the (unwritten) merge-color
-            // read for this not-taken-arm operand-stack slot.
-            if subst == OpRef::NONE {
-                panic!("{}", dump_ctx("ref", idx));
-            }
-            active.push(subst);
             continue;
         }
         let fallback = || {
@@ -9912,10 +9795,10 @@ fn walker_capture_snapshot_for_last_guard_impl(
             // snapshot's resume pc on the guard coordinate makes the encoder
             // liveness window (`collect_outer_active_boxes`), the blackhole
             // `setposition`, and the cranelift bridge re-trace entry all agree
-            // — the kept operand stack is naturally live at the guard pc, so
-            // the positional `kept_stack_subst` recovery (gpc == entry_py_pc)
-            // is skipped.  A non-branch guard carries no guard pc, so it keeps
-            // the merge `py_pc` and its exact `pc_map` translation.
+            // — the kept operand stack is naturally live at the guard pc and is
+            // recovered from the walk-level box mirror in
+            // `collect_outer_active_boxes`.  A non-branch guard carries no guard
+            // pc, so it keeps the merge `py_pc` and its exact `pc_map` translation.
             let liveness_py_pc = guard_py_pc.unwrap_or(py_pc);
             // The snapshot resume pc folds in the bit-14 marker for a try-block
             // residual call so the decode routes through

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -279,35 +279,6 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
     (portal_frame_reg, portal_ec_reg)
 }
 
-/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default on).
-///
-/// A kept-stack branch guard resumes at its carried direct JitCode pc and the
-/// encoder collects the guard-pc live box set directly — the faithful
-/// per-bytecode resume that retires the lossy `pc_map` (`#73`).  The opt-out
-/// `PYRE_M3_JITCODE_PC=0` restores the legacy positional kept-stack heuristic,
-/// which resumes past the pop through `pc_map` and recovers the not-taken kept
-/// value out of band: depth 1 via `kept_stack_subst`, depth > 1 via the
-/// not-taken edge's decoded `ref_copy` parallel moves
-/// (`decode_branch_trampoline_ref_moves`, `#420`).
-///
-/// The direct-pc path once miscompiled a depth-1 leading-`and` short-circuit
-/// (`x = local and CONST`): the symbolic bridge seeded the kept operand
-/// concrete, its residual compare const-folded, and `generate_guard` skipped
-/// the now-`Const` condition, so the not-taken arm restored the taken-path
-/// value (`flag and 11`: 2197063 vs 1466663).  `setup_bridge_sym` now withholds
-/// that concrete seed on the guard-pc kept-stack resume, so the kept operand
-/// stays a symbolic input arg and its guard fires per iteration.
-pub(crate) fn m3_jitcode_pc_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M3_JITCODE_PC") {
-        Some(v) => {
-            let v = v.to_string_lossy();
-            v != "0" && !v.eq_ignore_ascii_case("false")
-        }
-        None => true,
-    })
-}
-
 impl PyJitCode {
     pub fn new(payload: PyJitCodePayload) -> Self {
         Self {
@@ -471,23 +442,21 @@ impl PyJitCode {
     /// The encoder (box collection) and decoder (box count + setposition)
     /// both funnel through this with identical `(raw_pc, carried, op_live)`,
     /// so the chosen offset — and hence the live-box layout — is symmetric
-    /// by construction.  Gated by [`m3_jitcode_pc_enabled`]: with the flag
-    /// off the carried word is ignored and behaviour is identical to
-    /// [`Self::resolve_resume_pc`].
+    /// by construction.
     ///
     /// The carried word is preferred only when it is a `-live-`-anchored
-    /// coordinate ([`JitCode::can_decode_live_vars`]); a startpoint that is
-    /// not so anchored (a synthesized specialization guard's `may_force`
-    /// CALL op) falls through to the `pc_map` translation so
-    /// `get_live_vars_info` never hits `_missing_liveness`.
+    /// coordinate ([`JitCode::can_decode_live_vars`]).  A guard with no
+    /// carried coordinate (`NO_JITCODE_PC`, set by every non-branch guard)
+    /// or a startpoint that is not so anchored (a synthesized specialization
+    /// guard's `may_force` CALL op) falls through to the `pc_map` translation
+    /// so `get_live_vars_info` never hits `_missing_liveness`.
     pub fn resolve_resume_pc_with_jitcode_pc(
         &self,
         raw_pc: i32,
         carried: i32,
         op_live: u8,
     ) -> Option<usize> {
-        if m3_jitcode_pc_enabled() && carried != majit_ir::resumedata::NO_JITCODE_PC && carried >= 0
-        {
+        if carried != majit_ir::resumedata::NO_JITCODE_PC && carried >= 0 {
             let jp = carried as usize;
             if self.jitcode.can_decode_live_vars(jp, op_live) {
                 return Some(jp);

--- a/pyre/pyre-jit-trace/src/pyjitcode.rs
+++ b/pyre/pyre-jit-trace/src/pyjitcode.rs
@@ -279,22 +279,24 @@ pub fn portal_red_pre_regalloc_slots(nlocals: usize, max_stackdepth: usize) -> (
     (portal_frame_reg, portal_ec_reg)
 }
 
-/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default off).
+/// `#124` Approach B master switch (`PYRE_M3_JITCODE_PC`, default on).
 ///
-/// When enabled, a kept-stack branch guard resumes at its carried direct
-/// JitCode pc and the encoder collects the guard-pc live box set directly
-/// rather than the resume-pc set patched by the positional kept-stack
-/// heuristic.  Default off: for a depth-1 leading-`and` short-circuit
-/// (`x = local and CONST`) the guard-pc box set holds the *taken*-path value
-/// for the kept operand-stack slot, so the direct-pc path restores that value
-/// on the not-taken arm and silently miscompiles (`flag and 11`: 2197063 vs
-/// 1466663).  The positional heuristic recovers the not-taken kept value
-/// correctly — depth-1 via `kept_stack_subst` and depth > 1 via the not-taken
-/// edge's decoded `ref_copy` parallel moves (`#420`,
-/// `jitcode_dispatch.rs decode_branch_trampoline_ref_moves`), the authoritative
-/// kept-value source while M3 is off.  Set `PYRE_M3_JITCODE_PC=1` to opt back
-/// into the direct-pc path for validating the future snapshot-before-guard fix
-/// (#124/#281).
+/// A kept-stack branch guard resumes at its carried direct JitCode pc and the
+/// encoder collects the guard-pc live box set directly — the faithful
+/// per-bytecode resume that retires the lossy `pc_map` (`#73`).  The opt-out
+/// `PYRE_M3_JITCODE_PC=0` restores the legacy positional kept-stack heuristic,
+/// which resumes past the pop through `pc_map` and recovers the not-taken kept
+/// value out of band: depth 1 via `kept_stack_subst`, depth > 1 via the
+/// not-taken edge's decoded `ref_copy` parallel moves
+/// (`decode_branch_trampoline_ref_moves`, `#420`).
+///
+/// The direct-pc path once miscompiled a depth-1 leading-`and` short-circuit
+/// (`x = local and CONST`): the symbolic bridge seeded the kept operand
+/// concrete, its residual compare const-folded, and `generate_guard` skipped
+/// the now-`Const` condition, so the not-taken arm restored the taken-path
+/// value (`flag and 11`: 2197063 vs 1466663).  `setup_bridge_sym` now withholds
+/// that concrete seed on the guard-pc kept-stack resume, so the kept operand
+/// stays a symbolic input arg and its guard fires per iteration.
 pub(crate) fn m3_jitcode_pc_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M3_JITCODE_PC") {
@@ -302,7 +304,7 @@ pub(crate) fn m3_jitcode_pc_enabled() -> bool {
             let v = v.to_string_lossy();
             v != "0" && !v.eq_ignore_ascii_case("false")
         }
-        None => false,
+        None => true,
     })
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7618,7 +7618,30 @@ impl JitState for PyreJitState {
         // out) once validated, mirroring the LoadGlobal-fold / multiframe
         // gap-10 flips; the opt-out keeps the prior symbolic-bridge
         // behavior available for A/B.
-        let seed_bridge_locals = std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
+        let mut seed_bridge_locals =
+            std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
+        // A branch-guard kept-stack resume (`frame0.jitcode_pc` carries the
+        // guard's own jitcode pc; only kept-stack branch guards set it) resumes
+        // AT the guard pc with the not-taken arm's operand-stack temps still
+        // live (`lo <= x <= hi` keeps `x` below the compare truth; short-circuit
+        // `and`/`or` and the conditional expression keep their left operand).
+        // Stamping a concrete on such a kept operand freezes a downstream branch
+        // that consumes it: `x <= hi`'s residual compare const-folds against the
+        // seeded `x` to a `Const` bool, and `generate_guard` skips the guard for
+        // a `Const` condition (`isinstance(box, Const): return`) — so the second
+        // branch direction is pinned to the resuming iteration's `x` and the
+        // loop over/under-counts.  The kept operand must stay a symbolic input
+        // arg here (the guard fires, the value is guarded, not folded); the seed
+        // stays on the non-kept-stack resumes (guard_value / guard_class / plain
+        // short resumes) it was added for.  Only reachable with the guard-pc
+        // resume coordinate live (the `pc_map` baseline resumes past the pop, so
+        // the kept temp is absent from its frame and never seeded).
+        if seed_bridge_locals
+            && crate::pyjitcode::m3_jitcode_pc_enabled()
+            && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC
+        {
+            seed_bridge_locals = false;
+        }
         let mut value_cursor = 0usize;
         for &reg_idx in &reg_indices.int {
             let value = &frame0.values[value_cursor];

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7636,10 +7636,7 @@ impl JitState for PyreJitState {
         // short resumes) it was added for.  Only reachable with the guard-pc
         // resume coordinate live (the `pc_map` baseline resumes past the pop, so
         // the kept temp is absent from its frame and never seeded).
-        if seed_bridge_locals
-            && crate::pyjitcode::m3_jitcode_pc_enabled()
-            && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC
-        {
+        if seed_bridge_locals && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC {
             seed_bridge_locals = false;
         }
         let mut value_cursor = 0usize;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9042,41 +9042,40 @@ impl CodeWriter {
                         // interpreter on side-exit; the trace only records the
                         // continuing iteration (the loop closes at the back-edge).
                         Instruction::ForIter { delta } => {
-                            // Read the iterator from its value-stack slot via a
-                            // loop-carried `getarrayitem_vable_r` rather than the
-                            // pre-trace register holding the GET_ITER result: the
-                            // FOR_ITER pc sits just past the loop-header
-                            // `jit_merge_point`, so a register written before the
-                            // merge is stale (the merge rebinds the slot's
-                            // loop-input).  Reading the vable slot binds the
-                            // operand from the merge-point reds.  TOS is the
-                            // iterator (`current_depth - 1`).
+                            // Source `next()`'s iterator argument from the
+                            // loop-carried operand Variable at TOS
+                            // (`current_state.stack.last()`, the merge-rebound
+                            // loop-input the runtime vstack mirror holds as an
+                            // InputArgRef), mirroring RPython `space.next(
+                            // peekvalue())`.  Feeding a real operand Variable
+                            // gives the loop-carried iterator a genuine SSA
+                            // reader, so the graph allocator assigns it a
+                            // DISTINCT live color and `compute_liveness` marks it
+                            // live at the FOR_ITER `-live-` marker; both cascades
+                            // let `build_pcdep_color_slots` keep the
+                            // `(iter_color -> nlocals+0)` operand entry at this
+                            // guard pc.  Without a reader (the prior portal-only
+                            // `getarrayitem_vable_r` reload was defined-and-
+                            // consumed inside the opcode) the loop-carried
+                            // iterator color is dropped from both `pcdep` and the
+                            // `-live-` R-bank, so a guard-pc resume (M3) cannot
+                            // reconstruct the kept iterator operand slot and
+                            // re-executes FOR_ITER on a non-iterator.  GET_ITER's
+                            // `setarrayitem_vable_r` still populates the vable
+                            // image (blackhole/interp read), so dropping the
+                            // reload is safe; DCE removes it.  TOS is the iterator
+                            // (`current_depth - 1`).
                             let iter_slot_depth = current_depth.saturating_sub(1);
-                            let iter_value: super::flow::FlowValue = if is_portal {
-                                let stack_slot =
-                                    (stack_base_absolute + iter_slot_depth as usize) as i64;
-                                let v_slot: super::flow::FlowValue =
-                                    super::flow::Constant::signed(stack_slot).into();
-                                let v_iter = emit_graph_op_with_result(
-                                    &mut graph,
-                                    &current_block.block(),
-                                    "getarrayitem_vable_r",
-                                    vable_getarrayitem_ref_graph_args(
-                                        frame_var.into(),
-                                        v_slot.into(),
-                                    ),
-                                    Kind::Ref,
-                                    py_pc as i64,
-                                );
-                                pin!(Some(v_iter), stack_base + iter_slot_depth);
-                                v_iter.into()
-                            } else {
-                                current_state
-                                    .stack
-                                    .last()
-                                    .cloned()
-                                    .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
-                            };
+                            let iter_value: super::flow::FlowValue = current_state
+                                .stack
+                                .last()
+                                .cloned()
+                                .unwrap_or_else(|| fresh_ref_value(&mut graph).into());
+                            if is_portal {
+                                if let super::flow::FlowValue::Variable(v) = &iter_value {
+                                    pin!(Some(*v), stack_base + iter_slot_depth);
+                                }
+                            }
                             let next_var = residual_call!(
                                 for_iter_next_fn_idx,
                                 CallFlavor::MayForce,


### PR DESCRIPTION
Fix #73

## Summary

Makes the faithful **direct-JitCode-pc** resume the unconditional production path for kept-stack branch guards, retiring the lossy `py_pc → pc_map` collapse from that role (#73).

A kept-stack `goto_if_not` guard used to resume *past* the pop at the merge `py_pc` and recover the not-taken-arm operand-stack temps out of band (the positional `kept_stack_subst` / `#420` edge-move heuristics). The direct-pc path — formerly gated behind `PYRE_M3_JITCODE_PC` (default-off) — instead resumes AT the guard's own JitCode pc, where the kept operand stack is naturally live, matching the upstream `opimpl_goto_if_not(resumepc=orgpc)` + `capture_resumedata` shape.

Commits:

- **source FOR_ITER `next()` iterator from the loop-carried operand Variable** — gives the loop-carried iterator a live SSA reader so it stays live at the FOR_ITER guard pc (was the last direct-pc synth blocker: `for x in <iter>` inside a JIT-hot loop crashed `not an iterator`).
- **skip the bridge concrete-seed for a guard-pc kept-stack resume** — the symbolic bridge no longer stamps the kept operand concrete, so a `lo <= x <= hi` middle operand / short-circuit `and`·`or` / conditional-expression left operand stays symbolic and its guard fires instead of const-folding to an unguarded `Const` branch (fixed the chained-compare and leading-`and` over-counts).
- **flip `PYRE_M3_JITCODE_PC` default on** — direct-pc resume becomes the production default.
- **remove flip mechanism** — deletes the `m3_jitcode_pc_enabled()` gate and the `PYRE_M3_JITCODE_PC` env opt-out now that the direct-pc path is unconditional.

`pc_map` itself is retained: it stays the exact resume translation for every non-branch guard (which carry no direct pc → `NO_JITCODE_PC`) and for non-`-live-`-anchored startpoints (e.g. a synthesized specialization guard's `may_force` CALL op), which fall through to it by design.

### Validation

- `pyre/check.py` on the new default: dynasm **171/171**, cranelift **171/171**, wasm **171/171**.
- Differential direct-pc-on ↔ pc_map-baseline (address-normalized) across `extra_tests` snippets + intro + parity = **262 identical × dynasm+cranelift, 0 divergence**.
- `cpython_tests` gated suite: **39/39 baseline-PASS modules, no regressions**.
- `short_circuit_value_local_kept` (`flag and 11`): **1466663** both backends (was 2197063); chained-compare repro **6399** (was 6841).

## Self-review

This patch is AI-assisted (`Assisted-by: Claude` on the code commits). The description above was drafted by Claude; the author's own assessment is pending and is not represented by the checklist below.

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - Code commits carry `Assisted-by`.

— *drafted by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of loop iteration and branch-resume cases to reduce incorrect value recovery during execution.
  * Fixed resume behavior so carried execution coordinates are used more reliably, with safer fallback handling when needed.
  * Prevented certain concrete values from being incorrectly stamped onto recovered stack values in kept-stack resume scenarios.
* **Style**
  * Updated benchmark and internal notes to better reflect the current recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->