### PR TITLE
rbuilder: StringBuilder repr wiring + string-copy/shrink codewriter lowering

### DIFF
--- a/majit/majit-translate/src/annotator/description.rs
+++ b/majit/majit-translate/src/annotator/description.rs
@@ -1165,6 +1165,8 @@ impl FunctionDesc {
                 SomeValueTag::BuiltinMethod => "SomeBuiltinMethod",
                 SomeValueTag::WeakRef => "SomeWeakRef",
                 SomeValueTag::TypeOf => "SomeTypeOf",
+                SomeValueTag::StringBuilder => "SomeStringBuilder",
+                SomeValueTag::UnicodeBuilder => "SomeUnicodeBuilder",
             }
         }
 

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -761,7 +761,7 @@ impl SomeStringBuilder {
 
     /// `method_append(self, s_str)` (rstring.py:891-894) → `s_None`.
     pub fn method_append(&self, s_str: &SomeValue) -> SomeValue {
-        debug_assert!(
+        assert!(
             matches!(
                 s_str,
                 SomeValue::None_(_) | SomeValue::String(_) | SomeValue::Char(_)
@@ -779,9 +779,9 @@ impl SomeStringBuilder {
         s_start: &SomeValue,
         s_end: &SomeValue,
     ) -> SomeValue {
-        debug_assert!(matches!(s_str, SomeValue::None_(_) | SomeValue::String(_)));
-        debug_assert!(matches!(s_start, SomeValue::Integer(_)));
-        debug_assert!(matches!(s_end, SomeValue::Integer(_)));
+        assert!(matches!(s_str, SomeValue::None_(_) | SomeValue::String(_)));
+        assert!(matches!(s_start, SomeValue::Integer(_)));
+        assert!(matches!(s_end, SomeValue::Integer(_)));
         s_none()
     }
 
@@ -792,16 +792,16 @@ impl SomeStringBuilder {
         s_char: &SomeValue,
         s_times: &SomeValue,
     ) -> SomeValue {
-        debug_assert!(matches!(s_char, SomeValue::String(_) | SomeValue::Char(_)));
-        debug_assert!(matches!(s_times, SomeValue::Integer(_)));
+        assert!(matches!(s_char, SomeValue::String(_) | SomeValue::Char(_)));
+        assert!(matches!(s_times, SomeValue::Integer(_)));
         s_none()
     }
 
     /// `method_append_charpsize(self, s_ptr, s_size)`
     /// (rstring.py:908-911) → `s_None`.
     pub fn method_append_charpsize(&self, s_ptr: &SomeValue, s_size: &SomeValue) -> SomeValue {
-        debug_assert!(matches!(s_ptr, SomeValue::Ptr(_)));
-        debug_assert!(matches!(s_size, SomeValue::Integer(_)));
+        assert!(matches!(s_ptr, SomeValue::Ptr(_)));
+        assert!(matches!(s_size, SomeValue::Integer(_)));
         s_none()
     }
 
@@ -841,7 +841,7 @@ impl SomeUnicodeBuilder {
 
     /// `method_append(self, s_str)` (rstring.py:931-934) → `s_None`.
     pub fn method_append(&self, s_str: &SomeValue) -> SomeValue {
-        debug_assert!(
+        assert!(
             matches!(
                 s_str,
                 SomeValue::None_(_) | SomeValue::UnicodeCodePoint(_) | SomeValue::UnicodeString(_)
@@ -859,12 +859,12 @@ impl SomeUnicodeBuilder {
         s_start: &SomeValue,
         s_end: &SomeValue,
     ) -> SomeValue {
-        debug_assert!(matches!(
+        assert!(matches!(
             s_str,
             SomeValue::None_(_) | SomeValue::UnicodeString(_)
         ));
-        debug_assert!(matches!(s_start, SomeValue::Integer(_)));
-        debug_assert!(matches!(s_end, SomeValue::Integer(_)));
+        assert!(matches!(s_start, SomeValue::Integer(_)));
+        assert!(matches!(s_end, SomeValue::Integer(_)));
         s_none()
     }
 
@@ -875,16 +875,16 @@ impl SomeUnicodeBuilder {
         s_char: &SomeValue,
         s_times: &SomeValue,
     ) -> SomeValue {
-        debug_assert!(matches!(s_char, SomeValue::UnicodeCodePoint(_)));
-        debug_assert!(matches!(s_times, SomeValue::Integer(_)));
+        assert!(matches!(s_char, SomeValue::UnicodeCodePoint(_)));
+        assert!(matches!(s_times, SomeValue::Integer(_)));
         s_none()
     }
 
     /// `method_append_charpsize(self, s_ptr, s_size)`
     /// (rstring.py:948-951) → `s_None`.
     pub fn method_append_charpsize(&self, s_ptr: &SomeValue, s_size: &SomeValue) -> SomeValue {
-        debug_assert!(matches!(s_ptr, SomeValue::Ptr(_)));
-        debug_assert!(matches!(s_size, SomeValue::Integer(_)));
+        assert!(matches!(s_ptr, SomeValue::Ptr(_)));
+        assert!(matches!(s_size, SomeValue::Integer(_)));
         s_none()
     }
 
@@ -2354,6 +2354,9 @@ impl SomeValue {
                 s.subset_of.clone(),
             ))),
             SomeValue::WeakRef(s) => Ok(SomeValue::WeakRef(SomeWeakRef::new(s.classdef.clone()))),
+            // rstring.py:1231/1271 — SomeStringBuilder / SomeUnicodeBuilder
+            // `noneify(self)` returns `self`.
+            SomeValue::StringBuilder(_) | SomeValue::UnicodeBuilder(_) => Ok(self.clone()),
             _ => Err(UnionError {
                 lhs: self.clone(),
                 rhs: s_none(),

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -902,6 +902,40 @@ impl Default for SomeUnicodeBuilder {
     }
 }
 
+impl SomeObjectTrait for SomeStringBuilder {
+    fn knowntype(&self) -> KnownType {
+        KnownType::Object
+    }
+    fn immutable(&self) -> bool {
+        false
+    }
+    fn is_constant(&self) -> bool {
+        self.base.const_box.is_some()
+    }
+    fn can_be_none(&self) -> bool {
+        // upstream: default `SomeObject.can_be_none()` = True, no
+        // override on SomeStringBuilder.
+        true
+    }
+}
+
+impl SomeObjectTrait for SomeUnicodeBuilder {
+    fn knowntype(&self) -> KnownType {
+        KnownType::Object
+    }
+    fn immutable(&self) -> bool {
+        false
+    }
+    fn is_constant(&self) -> bool {
+        self.base.const_box.is_some()
+    }
+    fn can_be_none(&self) -> bool {
+        // upstream: default `SomeObject.can_be_none()` = True, no
+        // override on SomeUnicodeBuilder.
+        true
+    }
+}
+
 /// RPython `class SomeByteArray(SomeStringOrUnicode)`
 /// (model.py:304-306). Differs from its siblings in `immutable = False`.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -2116,6 +2150,8 @@ pub enum SomeValue {
     BuiltinMethod(SomeBuiltinMethod),
     WeakRef(SomeWeakRef),
     TypeOf(SomeTypeOf),
+    StringBuilder(SomeStringBuilder),
+    UnicodeBuilder(SomeUnicodeBuilder),
 }
 
 /// Discriminant-only view of [`SomeValue`]. Parity mirror of RPython's
@@ -2159,6 +2195,8 @@ pub enum SomeValueTag {
     BuiltinMethod,
     WeakRef,
     TypeOf,
+    StringBuilder,
+    UnicodeBuilder,
 }
 
 impl SomeValueTag {
@@ -2204,6 +2242,11 @@ impl SomeValueTag {
             T::Builtin => &[T::Builtin, T::Object],
             T::BuiltinMethod => &[T::BuiltinMethod, T::Object],
             T::WeakRef => &[T::WeakRef, T::Object],
+            // rlib/rstring.py SomeStringBuilder / SomeUnicodeBuilder are
+            // flat SomeObject subclasses; dispatch resolves to self then
+            // Object.
+            T::StringBuilder => &[T::StringBuilder, T::Object],
+            T::UnicodeBuilder => &[T::UnicodeBuilder, T::Object],
             // SomeImpossibleValue is the lattice bottom; it still
             // deserves an Object fallback so registries can bind
             // catch-all defaults keyed on Object.
@@ -2266,6 +2309,8 @@ impl SomeValue {
             SomeValue::BuiltinMethod(_) => T::BuiltinMethod,
             SomeValue::WeakRef(_) => T::WeakRef,
             SomeValue::TypeOf(_) => T::TypeOf,
+            SomeValue::StringBuilder(_) => T::StringBuilder,
+            SomeValue::UnicodeBuilder(_) => T::UnicodeBuilder,
         }
     }
 
@@ -2399,6 +2444,8 @@ impl SomeValue {
             SomeValue::BuiltinMethod(s) => s.base.const_box.as_ref(),
             SomeValue::WeakRef(s) => s.base.const_box.as_ref(),
             SomeValue::TypeOf(s) => s.base.const_box.as_ref(),
+            SomeValue::StringBuilder(s) => s.base.const_box.as_ref(),
+            SomeValue::UnicodeBuilder(s) => s.base.const_box.as_ref(),
         };
         cb.map(|c| &c.value)
     }
@@ -2446,6 +2493,8 @@ impl SomeValue {
             SomeValue::BuiltinMethod(s) => s.base.const_box = Some(c),
             SomeValue::WeakRef(s) => s.base.const_box = Some(c),
             SomeValue::TypeOf(s) => s.base.const_box = Some(c),
+            SomeValue::StringBuilder(s) => s.base.const_box = Some(c),
+            SomeValue::UnicodeBuilder(s) => s.base.const_box = Some(c),
         }
     }
 
@@ -2586,6 +2635,8 @@ impl SomeObjectTrait for SomeValue {
             SomeValue::BuiltinMethod(s) => s.knowntype(),
             SomeValue::WeakRef(s) => s.knowntype(),
             SomeValue::TypeOf(s) => s.knowntype(),
+            SomeValue::StringBuilder(s) => s.knowntype(),
+            SomeValue::UnicodeBuilder(s) => s.knowntype(),
         }
     }
 
@@ -2623,6 +2674,8 @@ impl SomeObjectTrait for SomeValue {
             SomeValue::BuiltinMethod(s) => s.immutable(),
             SomeValue::WeakRef(s) => s.immutable(),
             SomeValue::TypeOf(s) => s.immutable(),
+            SomeValue::StringBuilder(s) => s.immutable(),
+            SomeValue::UnicodeBuilder(s) => s.immutable(),
         }
     }
 
@@ -2660,6 +2713,8 @@ impl SomeObjectTrait for SomeValue {
             SomeValue::BuiltinMethod(s) => s.is_constant(),
             SomeValue::WeakRef(s) => s.is_constant(),
             SomeValue::TypeOf(s) => s.is_constant(),
+            SomeValue::StringBuilder(s) => s.is_constant(),
+            SomeValue::UnicodeBuilder(s) => s.is_constant(),
         }
     }
 
@@ -2702,6 +2757,8 @@ impl SomeObjectTrait for SomeValue {
             SomeValue::BuiltinMethod(s) => s.can_be_none(),
             SomeValue::WeakRef(s) => s.can_be_none(),
             SomeValue::TypeOf(s) => s.can_be_none(),
+            SomeValue::StringBuilder(s) => s.can_be_none(),
+            SomeValue::UnicodeBuilder(s) => s.can_be_none(),
         }
     }
 }
@@ -3420,6 +3477,8 @@ pub fn not_const(s: &SomeValue) -> SomeValue {
         SomeValue::BuiltinMethod(v) => v.base.const_box = None,
         SomeValue::WeakRef(v) => v.base.const_box = None,
         SomeValue::TypeOf(v) => v.base.const_box = None,
+        SomeValue::StringBuilder(v) => v.base.const_box = None,
+        SomeValue::UnicodeBuilder(v) => v.base.const_box = None,
         // Impossible / PBC / None_ handled above (early-return).
         SomeValue::Impossible | SomeValue::PBC(_) | SomeValue::None_(_) => unreachable!(),
     }

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -741,6 +741,167 @@ impl SomeObjectTrait for SomeUnicodeString {
     }
 }
 
+/// RPython `class SomeStringBuilder(SomeObject)` (`rlib/rstring.py:890`).
+///
+/// The annotator shape for a `StringBuilder()` value.  It carries no
+/// payload; its `method_*` annotations describe the builder call surface,
+/// and (once wired) the rtyper binds it to `StringBuilderRepr` via
+/// `rtyper_makerepr` (`rlib/rstring.py:919-921`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SomeStringBuilder {
+    pub base: SomeObject,
+}
+
+impl SomeStringBuilder {
+    pub fn new() -> Self {
+        SomeStringBuilder {
+            base: SomeObject::new(KnownType::Object, false),
+        }
+    }
+
+    /// `method_append(self, s_str)` (rstring.py:891-894) → `s_None`.
+    pub fn method_append(&self, s_str: &SomeValue) -> SomeValue {
+        debug_assert!(
+            matches!(
+                s_str,
+                SomeValue::None_(_) | SomeValue::String(_) | SomeValue::Char(_)
+            ),
+            "StringBuilder.append expects str / char"
+        );
+        s_none()
+    }
+
+    /// `method_append_slice(self, s_str, s_start, s_end)`
+    /// (rstring.py:896-901) → `s_None`.
+    pub fn method_append_slice(
+        &self,
+        s_str: &SomeValue,
+        s_start: &SomeValue,
+        s_end: &SomeValue,
+    ) -> SomeValue {
+        debug_assert!(matches!(s_str, SomeValue::None_(_) | SomeValue::String(_)));
+        debug_assert!(matches!(s_start, SomeValue::Integer(_)));
+        debug_assert!(matches!(s_end, SomeValue::Integer(_)));
+        s_none()
+    }
+
+    /// `method_append_multiple_char(self, s_char, s_times)`
+    /// (rstring.py:903-906) → `s_None`.
+    pub fn method_append_multiple_char(&self, s_char: &SomeValue, s_times: &SomeValue) -> SomeValue {
+        debug_assert!(matches!(
+            s_char,
+            SomeValue::String(_) | SomeValue::Char(_)
+        ));
+        debug_assert!(matches!(s_times, SomeValue::Integer(_)));
+        s_none()
+    }
+
+    /// `method_append_charpsize(self, s_ptr, s_size)`
+    /// (rstring.py:908-911) → `s_None`.
+    pub fn method_append_charpsize(&self, s_ptr: &SomeValue, s_size: &SomeValue) -> SomeValue {
+        debug_assert!(matches!(s_ptr, SomeValue::Ptr(_)));
+        debug_assert!(matches!(s_size, SomeValue::Integer(_)));
+        s_none()
+    }
+
+    /// `method_getlength(self)` (rstring.py:913-914) →
+    /// `SomeInteger(nonneg=True)`.
+    pub fn method_getlength(&self) -> SomeValue {
+        SomeValue::Integer(SomeInteger::new(true, false))
+    }
+
+    /// `method_build(self)` (rstring.py:916-917) →
+    /// `SomeString(can_be_None=False)`.
+    pub fn method_build(&self) -> SomeValue {
+        SomeValue::String(SomeString::new(false, false))
+    }
+}
+
+impl Default for SomeStringBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RPython `class SomeUnicodeBuilder(SomeObject)` (`rlib/rstring.py:930`).
+/// The `UnicodeBuilder()` mirror of [`SomeStringBuilder`]; the char /
+/// string arguments and `method_build` result are the unicode variants.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SomeUnicodeBuilder {
+    pub base: SomeObject,
+}
+
+impl SomeUnicodeBuilder {
+    pub fn new() -> Self {
+        SomeUnicodeBuilder {
+            base: SomeObject::new(KnownType::Object, false),
+        }
+    }
+
+    /// `method_append(self, s_str)` (rstring.py:931-934) → `s_None`.
+    pub fn method_append(&self, s_str: &SomeValue) -> SomeValue {
+        debug_assert!(
+            matches!(
+                s_str,
+                SomeValue::None_(_) | SomeValue::UnicodeCodePoint(_) | SomeValue::UnicodeString(_)
+            ),
+            "UnicodeBuilder.append expects unicode / unichar"
+        );
+        s_none()
+    }
+
+    /// `method_append_slice(self, s_str, s_start, s_end)`
+    /// (rstring.py:936-941) → `s_None`.
+    pub fn method_append_slice(
+        &self,
+        s_str: &SomeValue,
+        s_start: &SomeValue,
+        s_end: &SomeValue,
+    ) -> SomeValue {
+        debug_assert!(matches!(
+            s_str,
+            SomeValue::None_(_) | SomeValue::UnicodeString(_)
+        ));
+        debug_assert!(matches!(s_start, SomeValue::Integer(_)));
+        debug_assert!(matches!(s_end, SomeValue::Integer(_)));
+        s_none()
+    }
+
+    /// `method_append_multiple_char(self, s_char, s_times)`
+    /// (rstring.py:943-946) → `s_None`.
+    pub fn method_append_multiple_char(&self, s_char: &SomeValue, s_times: &SomeValue) -> SomeValue {
+        debug_assert!(matches!(s_char, SomeValue::UnicodeCodePoint(_)));
+        debug_assert!(matches!(s_times, SomeValue::Integer(_)));
+        s_none()
+    }
+
+    /// `method_append_charpsize(self, s_ptr, s_size)`
+    /// (rstring.py:948-951) → `s_None`.
+    pub fn method_append_charpsize(&self, s_ptr: &SomeValue, s_size: &SomeValue) -> SomeValue {
+        debug_assert!(matches!(s_ptr, SomeValue::Ptr(_)));
+        debug_assert!(matches!(s_size, SomeValue::Integer(_)));
+        s_none()
+    }
+
+    /// `method_getlength(self)` (rstring.py:953-954) →
+    /// `SomeInteger(nonneg=True)`.
+    pub fn method_getlength(&self) -> SomeValue {
+        SomeValue::Integer(SomeInteger::new(true, false))
+    }
+
+    /// `method_build(self)` (rstring.py:956-957) →
+    /// `SomeUnicodeString(can_be_None=False)`.
+    pub fn method_build(&self) -> SomeValue {
+        SomeValue::UnicodeString(SomeUnicodeString::new(false, false))
+    }
+}
+
+impl Default for SomeUnicodeBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// RPython `class SomeByteArray(SomeStringOrUnicode)`
 /// (model.py:304-306). Differs from its siblings in `immutable = False`.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -5069,5 +5230,48 @@ mod tests {
         v.annotation.replace(Some(Rc::new(s.clone())));
         let got = v.annotation.borrow().as_ref().map(|rc| (**rc).clone());
         assert_eq!(got, Some(s));
+    }
+
+    /// rstring.py:913-917 — `SomeStringBuilder` getlength/build annotate to
+    /// `SomeInteger(nonneg=True)` and `SomeString(can_be_None=False)`.
+    #[test]
+    fn some_string_builder_method_annotations() {
+        let b = SomeStringBuilder::new();
+        match b.method_getlength() {
+            SomeValue::Integer(i) => assert!(i.nonneg),
+            other => panic!("getlength must be SomeInteger(nonneg), got {other:?}"),
+        }
+        match b.method_build() {
+            SomeValue::String(s) => assert!(!s.can_be_none()),
+            other => panic!("build must be SomeString(can_be_None=False), got {other:?}"),
+        }
+        assert!(matches!(
+            b.method_append(&SomeValue::String(SomeString::new(false, false))),
+            SomeValue::None_(_)
+        ));
+        assert!(matches!(
+            b.method_getlength(),
+            SomeValue::Integer(_)
+        ));
+    }
+
+    /// rstring.py:953-957 — `SomeUnicodeBuilder.build` annotates to
+    /// `SomeUnicodeString(can_be_None=False)`; getlength stays the nonneg
+    /// integer.
+    #[test]
+    fn some_unicode_builder_method_annotations() {
+        let b = SomeUnicodeBuilder::new();
+        match b.method_getlength() {
+            SomeValue::Integer(i) => assert!(i.nonneg),
+            other => panic!("getlength must be SomeInteger(nonneg), got {other:?}"),
+        }
+        match b.method_build() {
+            SomeValue::UnicodeString(s) => assert!(!s.can_be_none()),
+            other => panic!("build must be SomeUnicodeString(can_be_None=False), got {other:?}"),
+        }
+        assert!(matches!(
+            b.method_append(&SomeValue::UnicodeString(SomeUnicodeString::new(false, false))),
+            SomeValue::None_(_)
+        ));
     }
 }

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -787,11 +787,12 @@ impl SomeStringBuilder {
 
     /// `method_append_multiple_char(self, s_char, s_times)`
     /// (rstring.py:903-906) → `s_None`.
-    pub fn method_append_multiple_char(&self, s_char: &SomeValue, s_times: &SomeValue) -> SomeValue {
-        debug_assert!(matches!(
-            s_char,
-            SomeValue::String(_) | SomeValue::Char(_)
-        ));
+    pub fn method_append_multiple_char(
+        &self,
+        s_char: &SomeValue,
+        s_times: &SomeValue,
+    ) -> SomeValue {
+        debug_assert!(matches!(s_char, SomeValue::String(_) | SomeValue::Char(_)));
         debug_assert!(matches!(s_times, SomeValue::Integer(_)));
         s_none()
     }
@@ -869,7 +870,11 @@ impl SomeUnicodeBuilder {
 
     /// `method_append_multiple_char(self, s_char, s_times)`
     /// (rstring.py:943-946) → `s_None`.
-    pub fn method_append_multiple_char(&self, s_char: &SomeValue, s_times: &SomeValue) -> SomeValue {
+    pub fn method_append_multiple_char(
+        &self,
+        s_char: &SomeValue,
+        s_times: &SomeValue,
+    ) -> SomeValue {
         debug_assert!(matches!(s_char, SomeValue::UnicodeCodePoint(_)));
         debug_assert!(matches!(s_times, SomeValue::Integer(_)));
         s_none()
@@ -5308,10 +5313,7 @@ mod tests {
             b.method_append(&SomeValue::String(SomeString::new(false, false))),
             SomeValue::None_(_)
         ));
-        assert!(matches!(
-            b.method_getlength(),
-            SomeValue::Integer(_)
-        ));
+        assert!(matches!(b.method_getlength(), SomeValue::Integer(_)));
     }
 
     /// rstring.py:953-957 — `SomeUnicodeBuilder.build` annotates to
@@ -5329,7 +5331,9 @@ mod tests {
             other => panic!("build must be SomeUnicodeString(can_be_None=False), got {other:?}"),
         }
         assert!(matches!(
-            b.method_append(&SomeValue::UnicodeString(SomeUnicodeString::new(false, false))),
+            b.method_append(&SomeValue::UnicodeString(SomeUnicodeString::new(
+                false, false
+            ))),
             SomeValue::None_(_)
         ));
     }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2956,6 +2956,14 @@ impl<'a> Transformer<'a> {
                     return prepend_const_prefix(&mut const_prefix_ops, result);
                 }
             }
+            // jtransform.py:491-492 — stroruni.* oopspecs → _handle_stroruni_call.
+            // Unhandled spellings return `None` and fall through to the
+            // residual-call path (RPython raises `NotSupported`).
+            if base.starts_with("stroruni.") {
+                if let Some(result) = self._handle_stroruni_call(base, op, args) {
+                    return prepend_const_prefix(&mut const_prefix_ops, result);
+                }
+            }
             // NOTE: conditional_call!/conditional_call_elidable!/record_known_result!
             // are handled by jitcode_lower (proc-macro level), NOT here.
             // The codewriter AST parser does not expand macro_rules!, so these
@@ -3046,6 +3054,53 @@ impl<'a> Transformer<'a> {
         let result =
             self.handle_residual_call(graph, op, target, descriptor, args, result_ty, graph_name);
         prepend_const_prefix(&mut const_prefix_ops, result)
+    }
+
+    /// Port of `jtransform.py:2049 _handle_stroruni_call`, `copy_contents`
+    /// arm only (jtransform.py:2079-2086):
+    ///
+    /// ```python
+    /// if oopspec_name == 'stroruni.copy_contents':
+    ///     if SoU.TO == rstr.STR:      new_op = 'copystrcontent'
+    ///     elif SoU.TO == rstr.UNICODE: new_op = 'copyunicodecontent'
+    ///     return SpaceOperation(new_op, args, op.result)
+    /// ```
+    ///
+    /// `SoU = args[0].concretetype` selects the STR vs UNICODE spelling;
+    /// pyre reads it from the flowspace `Variable::concretetype()`
+    /// (`Ptr(STR)` / `Ptr(UNICODE)`), matching the `Array(UniChar)`
+    /// detection `jtransform_opname.rs::is_unichar_array_ptr` uses on the
+    /// Spine-B path.  The resulting `copystrcontent` / `copyunicodecontent`
+    /// op is emitted as [`OpKind::LoweredBlackholeOp`], the same
+    /// representation the Spine-B string transducer produces, so flatten /
+    /// assembly already lower it to the matching jitcode bytecode.
+    ///
+    /// The `concat` / `slice` / `equal` / `cmp` / `copy_string_to_raw` arms
+    /// are not ported yet; those spellings return `None` and fall through to
+    /// the residual-call path.
+    fn _handle_stroruni_call(
+        &self,
+        oopspec_name: &str,
+        op: &SpaceOperation,
+        args: &[crate::flowspace::model::Variable],
+    ) -> Option<RewriteResult> {
+        match oopspec_name {
+            "stroruni.copy_contents" => {
+                let opname = if stroruni_first_arg_is_unicode(args.first()?) {
+                    "copyunicodecontent"
+                } else {
+                    "copystrcontent"
+                };
+                Some(RewriteResult::Replace(vec![SpaceOperation {
+                    result: op.result.clone(),
+                    kind: OpKind::LoweredBlackholeOp {
+                        opname: opname.to_string(),
+                        args: args.to_vec(),
+                    },
+                }]))
+            }
+            _ => None,
+        }
     }
 
     /// Port of `jtransform.py:1762 _handle_list_call` for pyre's
@@ -5616,6 +5671,36 @@ fn call_target_matches_loose(pattern: &CallTarget, target: &CallTarget) -> bool 
 /// distinct names (e.g. `jit_debug`, `int_isconstant`); for list/dict/str
 /// specs RPython uses dedicated OS_* indices. This helper currently maps
 /// the cases that have a direct OopSpecIndex equivalent.
+/// Whether a `stroruni.*` oopspec call's first argument is a `Ptr(UNICODE)`
+/// (chars array of `UniChar`) rather than `Ptr(STR)` (chars array of `Char`).
+///
+/// Mirrors `_handle_stroruni_call`'s `SoU.TO == rstr.STR / rstr.UNICODE`
+/// discriminator (`jtransform.py:2058-2073`), reading the operand's
+/// `Ptr(STR/UNICODE)` concretetype and inspecting the pointee struct's inline
+/// `chars` array element type — the same `Array(UniChar)` test
+/// `jtransform_opname.rs::is_unichar_array_ptr` applies on the Spine-B path.
+/// Non-string / untyped operands return `false`.
+fn stroruni_first_arg_is_unicode(var: &crate::flowspace::model::Variable) -> bool {
+    use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, PtrTarget};
+    let Some(LowLevelType::Ptr(ptr)) = var.concretetype() else {
+        return false;
+    };
+    let pointee = match ptr.TO {
+        PtrTarget::ForwardReference(fwd) => match fwd.resolved() {
+            Some(resolved) => resolved,
+            None => return false,
+        },
+        other => LowLevelType::from(other),
+    };
+    let LowLevelType::Struct(s) = pointee else {
+        return false;
+    };
+    matches!(
+        s.getattr_field_type("chars"),
+        Some(LowLevelType::Array(arr)) if matches!(arr.OF, LowLevelType::UniChar)
+    )
+}
+
 fn map_user_oopspec_to_index(spec: &str) -> majit_ir::descr::OopSpecIndex {
     use majit_ir::descr::OopSpecIndex;
     // Normalize: `jit.isconstant(value)` → `jit.isconstant`
@@ -8079,6 +8164,92 @@ mod tests {
         assert_eq!(
             super::map_user_oopspec_to_index("dict.setitem"),
             OopSpecIndex::None
+        );
+    }
+
+    fn stroruni_copy_contents_args(
+        ptr_lltype: crate::translator::rtyper::lltypesystem::lltype::LowLevelType,
+    ) -> Vec<crate::flowspace::model::Variable> {
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+        use crate::translator::rtyper::rtyper::variable_with_lltype;
+        vec![
+            variable_with_lltype("src", ptr_lltype.clone()),
+            variable_with_lltype("dst", ptr_lltype),
+            variable_with_lltype("srcstart", LowLevelType::Signed),
+            variable_with_lltype("dststart", LowLevelType::Signed),
+            variable_with_lltype("length", LowLevelType::Signed),
+        ]
+    }
+
+    /// jtransform.py:2079-2086 — `stroruni.copy_contents` with a `Ptr(STR)`
+    /// first argument lowers to a single `copystrcontent` blackhole op
+    /// carrying the five call args and a void result.
+    #[test]
+    fn stroruni_copy_contents_str_lowers_to_copystrcontent() {
+        use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
+        let config = GraphTransformConfig::default();
+        let transformer = Transformer::new(&config);
+        let args = stroruni_copy_contents_args(STRPTR.clone());
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::Live,
+        };
+        let result = transformer
+            ._handle_stroruni_call("stroruni.copy_contents", &op, &args)
+            .expect("copy_contents must be handled");
+        let RewriteResult::Replace(ops) = result else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        let OpKind::LoweredBlackholeOp { opname, args: bh_args } = &ops[0].kind else {
+            panic!("expected LoweredBlackholeOp, got {:?}", ops[0].kind);
+        };
+        assert_eq!(opname, "copystrcontent");
+        assert_eq!(bh_args.len(), 5);
+        assert!(ops[0].result.is_none());
+    }
+
+    /// jtransform.py:2082-2083 — the `Ptr(UNICODE)` first argument selects
+    /// the `copyunicodecontent` spelling instead.
+    #[test]
+    fn stroruni_copy_contents_unicode_lowers_to_copyunicodecontent() {
+        use crate::translator::rtyper::lltypesystem::rstr::UNICODEPTR;
+        let config = GraphTransformConfig::default();
+        let transformer = Transformer::new(&config);
+        let args = stroruni_copy_contents_args(UNICODEPTR.clone());
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::Live,
+        };
+        let result = transformer
+            ._handle_stroruni_call("stroruni.copy_contents", &op, &args)
+            .expect("copy_contents must be handled");
+        let RewriteResult::Replace(ops) = result else {
+            panic!("expected Replace");
+        };
+        let OpKind::LoweredBlackholeOp { opname, .. } = &ops[0].kind else {
+            panic!("expected LoweredBlackholeOp");
+        };
+        assert_eq!(opname, "copyunicodecontent");
+    }
+
+    /// The not-yet-ported `stroruni.*` spellings (concat / slice / equal /
+    /// cmp / copy_string_to_raw) return `None` so `handle_builtin_call`
+    /// falls through to the residual-call path.
+    #[test]
+    fn stroruni_unported_spellings_fall_through() {
+        use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
+        let config = GraphTransformConfig::default();
+        let transformer = Transformer::new(&config);
+        let args = stroruni_copy_contents_args(STRPTR.clone());
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::Live,
+        };
+        assert!(
+            transformer
+                ._handle_stroruni_call("stroruni.concat", &op, &args)
+                .is_none()
         );
     }
 

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3073,17 +3073,20 @@ impl<'a> Transformer<'a> {
     /// if oopspec_name == 'stroruni.copy_contents':
     ///     if SoU.TO == rstr.STR:      new_op = 'copystrcontent'
     ///     elif SoU.TO == rstr.UNICODE: new_op = 'copyunicodecontent'
+    ///     else: assert 0
     ///     return SpaceOperation(new_op, args, op.result)
     /// ```
     ///
     /// `SoU = args[0].concretetype` selects the STR vs UNICODE spelling;
-    /// pyre reads it from the flowspace `Variable::concretetype()`
-    /// (`Ptr(STR)` / `Ptr(UNICODE)`), matching the `Array(UniChar)`
-    /// detection `jtransform_opname.rs::is_unichar_array_ptr` uses on the
-    /// Spine-B path.  The resulting `copystrcontent` / `copyunicodecontent`
-    /// op is emitted as [`OpKind::LoweredBlackholeOp`], the same
-    /// representation the Spine-B string transducer produces, so flatten /
-    /// assembly already lower it to the matching jitcode bytecode.
+    /// pyre reads it from the flowspace `Variable::concretetype()` via
+    /// [`stroruni_first_arg_kind`]. Only `Ptr(STR)` maps to `copystrcontent`
+    /// and only `Ptr(UNICODE)` maps to `copyunicodecontent`; `Ptr(BYTEARRAY)`
+    /// (upstream `raise NotSupported`, `jtransform.py:2074`) and any other
+    /// operand shape (`else: assert 0`) return `None`, falling through to the
+    /// residual-call path — pyre's `NotSupported` analogue. The resulting op
+    /// is emitted as [`OpKind::LoweredBlackholeOp`], the same representation
+    /// the Spine-B string transducer produces, so flatten / assembly already
+    /// lower it to the matching jitcode bytecode.
     ///
     /// The `concat` / `slice` / `equal` / `cmp` / `copy_string_to_raw` arms
     /// are not ported yet; those spellings return `None` and fall through to
@@ -3096,10 +3099,12 @@ impl<'a> Transformer<'a> {
     ) -> Option<RewriteResult> {
         match oopspec_name {
             "stroruni.copy_contents" => {
-                let opname = if stroruni_first_arg_is_unicode(args.first()?) {
-                    "copyunicodecontent"
-                } else {
-                    "copystrcontent"
+                let opname = match stroruni_first_arg_kind(args.first()?) {
+                    StrOrUniKind::Str => "copystrcontent",
+                    StrOrUniKind::Unicode => "copyunicodecontent",
+                    // BYTEARRAY → NotSupported; any other shape → assert 0.
+                    // Both fall through to the residual-call path.
+                    StrOrUniKind::ByteArray | StrOrUniKind::Other => return None,
                 };
                 Some(RewriteResult::Replace(vec![SpaceOperation {
                     result: op.result.clone(),
@@ -5720,34 +5725,45 @@ fn call_target_matches_loose(pattern: &CallTarget, target: &CallTarget) -> bool 
 /// distinct names (e.g. `jit_debug`, `int_isconstant`); for list/dict/str
 /// specs RPython uses dedicated OS_* indices. This helper currently maps
 /// the cases that have a direct OopSpecIndex equivalent.
-/// Whether a `stroruni.*` oopspec call's first argument is a `Ptr(UNICODE)`
-/// (chars array of `UniChar`) rather than `Ptr(STR)` (chars array of `Char`).
-///
-/// Mirrors `_handle_stroruni_call`'s `SoU.TO == rstr.STR / rstr.UNICODE`
-/// discriminator (`jtransform.py:2058-2073`), reading the operand's
-/// `Ptr(STR/UNICODE)` concretetype and inspecting the pointee struct's inline
-/// `chars` array element type — the same `Array(UniChar)` test
-/// `jtransform_opname.rs::is_unichar_array_ptr` applies on the Spine-B path.
-/// Non-string / untyped operands return `false`.
-fn stroruni_first_arg_is_unicode(var: &crate::flowspace::model::Variable) -> bool {
+/// The `SoU.TO` discriminant of a `stroruni.*` oopspec's first argument:
+/// `Ptr(STR)` (`rpy_string`), `Ptr(UNICODE)` (`rpy_unicode`), or
+/// `Ptr(BYTEARRAY)` (`rpy_bytearray`). `Other` covers any non-string /
+/// untyped operand.
+enum StrOrUniKind {
+    Str,
+    Unicode,
+    ByteArray,
+    Other,
+}
+
+/// Classify a `stroruni.*` oopspec call's first argument by its pointee
+/// struct, mirroring `_handle_stroruni_call`'s
+/// `SoU.TO == rstr.STR / rstr.UNICODE / rbytearray.BYTEARRAY` chain
+/// (`jtransform.py:2058-2076`). `STR` and `BYTEARRAY` both carry a `chars`
+/// array of `Char`, so the struct name (`rpy_string` / `rpy_unicode` /
+/// `rpy_bytearray`) is the discriminant, matching upstream's `SoU.TO`
+/// identity comparison against the module-global structs.
+fn stroruni_first_arg_kind(var: &crate::flowspace::model::Variable) -> StrOrUniKind {
     use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, PtrTarget};
     let Some(LowLevelType::Ptr(ptr)) = var.concretetype() else {
-        return false;
+        return StrOrUniKind::Other;
     };
     let pointee = match ptr.TO {
         PtrTarget::ForwardReference(fwd) => match fwd.resolved() {
             Some(resolved) => resolved,
-            None => return false,
+            None => return StrOrUniKind::Other,
         },
         other => LowLevelType::from(other),
     };
     let LowLevelType::Struct(s) = pointee else {
-        return false;
+        return StrOrUniKind::Other;
     };
-    matches!(
-        s.getattr_field_type("chars"),
-        Some(LowLevelType::Array(arr)) if matches!(arr.OF, LowLevelType::UniChar)
-    )
+    match s._name.as_str() {
+        "rpy_string" => StrOrUniKind::Str,
+        "rpy_unicode" => StrOrUniKind::Unicode,
+        "rpy_bytearray" => StrOrUniKind::ByteArray,
+        _ => StrOrUniKind::Other,
+    }
 }
 
 fn map_user_oopspec_to_index(spec: &str) -> majit_ir::descr::OopSpecIndex {
@@ -8284,6 +8300,26 @@ mod tests {
             panic!("expected LoweredBlackholeOp");
         };
         assert_eq!(opname, "copyunicodecontent");
+    }
+
+    /// jtransform.py:2074 — a `Ptr(BYTEARRAY)` first argument is unsupported
+    /// (`raise NotSupported`); pyre returns `None` so the call falls through
+    /// to the residual-call path instead of misclassifying it as `STR`.
+    #[test]
+    fn stroruni_copy_contents_bytearray_falls_through() {
+        use crate::translator::rtyper::lltypesystem::rbytearray::BYTEARRAYPTR;
+        let config = GraphTransformConfig::default();
+        let transformer = Transformer::new(&config);
+        let args = stroruni_copy_contents_args(BYTEARRAYPTR.clone());
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::Live,
+        };
+        assert!(
+            transformer
+                ._handle_stroruni_call("stroruni.copy_contents", &op, &args)
+                .is_none()
+        );
     }
 
     /// The not-yet-ported `stroruni.*` spellings (concat / slice / equal /

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2964,6 +2964,16 @@ impl<'a> Transformer<'a> {
                     return prepend_const_prefix(&mut const_prefix_ops, result);
                 }
             }
+            // jtransform.py:503-504 — rgc.* oopspecs → _handle_rgc_call.
+            // Unhandled spellings return `None` and fall through to the
+            // residual-call path.
+            if base.starts_with("rgc.") {
+                if let Some(result) =
+                    self._handle_rgc_call(base, op, target, args, result_ty, graph_name, graph)
+                {
+                    return prepend_const_prefix(&mut const_prefix_ops, result);
+                }
+            }
             // NOTE: conditional_call!/conditional_call_elidable!/record_known_result!
             // are handled by jitcode_lower (proc-macro level), NOT here.
             // The codewriter AST parser does not expand macro_rules!, so these
@@ -3099,6 +3109,45 @@ impl<'a> Transformer<'a> {
                     },
                 }]))
             }
+            _ => None,
+        }
+    }
+
+    /// Port of `jtransform.py:2193 _handle_rgc_call`, `ll_shrink_array` arm:
+    ///
+    /// ```python
+    /// def _handle_rgc_call(self, op, oopspec_name, args):
+    ///     if oopspec_name == 'rgc.ll_shrink_array':
+    ///         return self._handle_oopspec_call(op, args,
+    ///                     EffectInfo.OS_SHRINK_ARRAY, EffectInfo.EF_CAN_RAISE)
+    /// ```
+    ///
+    /// Lowers to a `residual_call` whose calldescr carries the `ShrinkArray`
+    /// oopspecindex and the `CanRaise` effect, so `handle_residual_call`
+    /// appends the trailing `-live-`.  Other `rgc.*` spellings return `None`
+    /// and fall through to the residual-call path.
+    fn _handle_rgc_call(
+        &mut self,
+        oopspec_name: &str,
+        op: &SpaceOperation,
+        target: &CallTarget,
+        args: &[crate::flowspace::model::Variable],
+        result_ty: &ValueType,
+        graph_name: &str,
+        graph: &mut FunctionGraph,
+    ) -> Option<RewriteResult> {
+        match oopspec_name {
+            "rgc.ll_shrink_array" => Some(self._handle_oopspec_call(
+                graph,
+                op,
+                target,
+                args,
+                result_ty,
+                graph_name,
+                OopSpecIndex::ShrinkArray,
+                Some(majit_ir::descr::ExtraEffect::CanRaise),
+                None,
+            )),
             _ => None,
         }
     }
@@ -8201,7 +8250,11 @@ mod tests {
             panic!("expected Replace");
         };
         assert_eq!(ops.len(), 1);
-        let OpKind::LoweredBlackholeOp { opname, args: bh_args } = &ops[0].kind else {
+        let OpKind::LoweredBlackholeOp {
+            opname,
+            args: bh_args,
+        } = &ops[0].kind
+        else {
             panic!("expected LoweredBlackholeOp, got {:?}", ops[0].kind);
         };
         assert_eq!(opname, "copystrcontent");
@@ -8249,6 +8302,103 @@ mod tests {
         assert!(
             transformer
                 ._handle_stroruni_call("stroruni.concat", &op, &args)
+                .is_none()
+        );
+    }
+
+    /// jtransform.py:2193-2195 — `rgc.ll_shrink_array` lowers to a residual
+    /// call carrying the `ShrinkArray` oopspecindex and `CanRaise` effect,
+    /// so `handle_residual_call` appends a trailing `-live-`.
+    #[test]
+    fn rgc_ll_shrink_array_lowers_to_shrink_array_residual_call() {
+        use crate::call::CallControl;
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+        use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
+        use crate::translator::rtyper::rtyper::variable_with_lltype;
+
+        let mut cc = CallControl::new();
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config).with_callcontrol(&mut cc);
+
+        let mut graph = FunctionGraph::new("shrink");
+        let p = variable_with_lltype("p", STRPTR.clone());
+        let smaller = variable_with_lltype("smallerlength", LowLevelType::Signed);
+        let args = vec![p, smaller];
+        let result_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "result".into(),
+                    ty: ValueType::Ref(None),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let result_ty = ValueType::Ref(None);
+        let target = CallTarget::function_path(["ll_shrink_array"]);
+        let op = SpaceOperation {
+            result: Some(result_var),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: args.clone(),
+                result_ty: result_ty.clone(),
+            },
+        };
+        let rewritten = transformer
+            ._handle_rgc_call(
+                "rgc.ll_shrink_array",
+                &op,
+                &target,
+                &args,
+                &result_ty,
+                "shrink",
+                &mut graph,
+            )
+            .expect("ll_shrink_array must be handled");
+        let RewriteResult::Replace(ops) = rewritten else {
+            panic!("expected Replace");
+        };
+        assert!(
+            ops.iter()
+                .any(|o| matches!(o.kind, OpKind::CallResidual { .. })),
+            "expected a CallResidual, got {ops:?}"
+        );
+        // CanRaise → trailing -live-.
+        assert!(
+            matches!(ops.last().map(|o| &o.kind), Some(OpKind::Live)),
+            "CanRaise oopspec call must append a trailing -live-"
+        );
+    }
+
+    /// Other `rgc.*` spellings are not ported and fall through to the
+    /// residual-call path.
+    #[test]
+    fn rgc_unported_spellings_fall_through() {
+        use crate::call::CallControl;
+        use crate::translator::rtyper::lltypesystem::lltype::LowLevelType;
+        use crate::translator::rtyper::rtyper::variable_with_lltype;
+
+        let mut cc = CallControl::new();
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config).with_callcontrol(&mut cc);
+        let mut graph = FunctionGraph::new("rgc_other");
+        let args = vec![variable_with_lltype("x", LowLevelType::Signed)];
+        let op = SpaceOperation {
+            result: None,
+            kind: OpKind::Live,
+        };
+        assert!(
+            transformer
+                ._handle_rgc_call(
+                    "rgc.something_else",
+                    &op,
+                    &CallTarget::function_path(["something_else"]),
+                    &args,
+                    &ValueType::Void,
+                    "rgc_other",
+                    &mut graph,
+                )
                 .is_none()
         );
     }

--- a/majit/majit-translate/src/tool/error.rs
+++ b/majit/majit-translate/src/tool/error.rs
@@ -201,6 +201,8 @@ fn render_somevalue(value: &crate::annotator::model::SomeValue) -> String {
         SomeValue::BuiltinMethod(_) => "SomeBuiltinMethod()".into(),
         SomeValue::WeakRef(_) => "SomeWeakRef()".into(),
         SomeValue::TypeOf(_) => "SomeTypeOf(...)".into(),
+        SomeValue::StringBuilder(_) => "SomeStringBuilder()".into(),
+        SomeValue::UnicodeBuilder(_) => "SomeUnicodeBuilder()".into(),
     }
 }
 

--- a/majit/majit-translate/src/translator/goal/query.rs
+++ b/majit/majit-translate/src/translator/goal/query.rs
@@ -123,6 +123,8 @@ fn some_value_class_name(s: &SomeValue) -> String {
         SomeValue::BuiltinMethod(_) => "SomeBuiltinMethod",
         SomeValue::WeakRef(_) => "SomeWeakRef",
         SomeValue::TypeOf(_) => "SomeTypeOf",
+        SomeValue::StringBuilder(_) => "SomeStringBuilder",
+        SomeValue::UnicodeBuilder(_) => "SomeUnicodeBuilder",
     }
     .to_string()
 }

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -9,7 +9,7 @@
 
 #![allow(non_snake_case, non_upper_case_globals)]
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock, OnceLock};
 
 use crate::flowspace::model::{
     Block, BlockRefExt, ConstValue, Constant, FunctionGraph, GraphFunc, Hlvalue, Link,
@@ -22,6 +22,7 @@ use crate::translator::rtyper::lltypesystem::lltype::{
     ForwardReference, LowLevelType, Ptr, PtrTarget, Struct,
 };
 use crate::translator::rtyper::lltypesystem::rstr::{STRPTR, UNICODEPTR};
+use crate::translator::rtyper::rmodel::{Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
     constant_with_lltype, helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
@@ -5166,13 +5167,16 @@ pub fn build_ll_build_helper_graph(
 pub struct BaseStringBuilderRepr;
 
 /// RPython `class StringBuilderRepr(BaseStringBuilderRepr)`.
-#[derive(Debug, Default)]
-pub struct StringBuilderRepr;
+#[derive(Debug)]
+pub struct StringBuilderRepr {
+    state: ReprState,
+}
 
 impl StringBuilderRepr {
-    /// RPython `StringBuilderRepr.lowleveltype = lltype.Ptr(STRINGBUILDER)`.
-    pub fn lowleveltype(&self) -> &'static LowLevelType {
-        &STRINGBUILDERPTR
+    pub fn new() -> Self {
+        StringBuilderRepr {
+            state: ReprState::new(),
+        }
     }
 
     /// RPython `StringBuilderRepr.basetp = STR`.
@@ -5181,14 +5185,38 @@ impl StringBuilderRepr {
     }
 }
 
+impl Default for StringBuilderRepr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Repr for StringBuilderRepr {
+    /// RPython `StringBuilderRepr.lowleveltype = lltype.Ptr(STRINGBUILDER)`.
+    fn lowleveltype(&self) -> &LowLevelType {
+        &STRINGBUILDERPTR
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "StringBuilderRepr"
+    }
+}
+
 /// RPython `class UnicodeBuilderRepr(BaseStringBuilderRepr)`.
-#[derive(Debug, Default)]
-pub struct UnicodeBuilderRepr;
+#[derive(Debug)]
+pub struct UnicodeBuilderRepr {
+    state: ReprState,
+}
 
 impl UnicodeBuilderRepr {
-    /// RPython `UnicodeBuilderRepr.lowleveltype = lltype.Ptr(UNICODEBUILDER)`.
-    pub fn lowleveltype(&self) -> &'static LowLevelType {
-        &UNICODEBUILDERPTR
+    pub fn new() -> Self {
+        UnicodeBuilderRepr {
+            state: ReprState::new(),
+        }
     }
 
     /// RPython `UnicodeBuilderRepr.basetp = UNICODE`.
@@ -5197,23 +5225,44 @@ impl UnicodeBuilderRepr {
     }
 }
 
-static STRINGBUILDER_REPR: LazyLock<StringBuilderRepr> = LazyLock::new(StringBuilderRepr::default);
-static UNICODEBUILDER_REPR: LazyLock<UnicodeBuilderRepr> =
-    LazyLock::new(UnicodeBuilderRepr::default);
+impl Default for UnicodeBuilderRepr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Repr for UnicodeBuilderRepr {
+    /// RPython `UnicodeBuilderRepr.lowleveltype = lltype.Ptr(UNICODEBUILDER)`.
+    fn lowleveltype(&self) -> &LowLevelType {
+        &UNICODEBUILDERPTR
+    }
+
+    fn state(&self) -> &ReprState {
+        &self.state
+    }
+
+    fn class_name(&self) -> &'static str {
+        "UnicodeBuilderRepr"
+    }
+}
 
 /// RPython `stringbuilder_repr = StringBuilderRepr()`.
-pub fn stringbuilder_repr() -> &'static StringBuilderRepr {
-    &STRINGBUILDER_REPR
+pub fn stringbuilder_repr() -> Arc<StringBuilderRepr> {
+    static REPR: OnceLock<Arc<StringBuilderRepr>> = OnceLock::new();
+    REPR.get_or_init(|| Arc::new(StringBuilderRepr::new())).clone()
 }
 
 /// RPython `unicodebuilder_repr = UnicodeBuilderRepr()`.
-pub fn unicodebuilder_repr() -> &'static UnicodeBuilderRepr {
-    &UNICODEBUILDER_REPR
+pub fn unicodebuilder_repr() -> Arc<UnicodeBuilderRepr> {
+    static REPR: OnceLock<Arc<UnicodeBuilderRepr>> = OnceLock::new();
+    REPR.get_or_init(|| Arc::new(UnicodeBuilderRepr::new()))
+        .clone()
 }
 
 #[cfg(test)]
 mod tests {
     use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, PtrTarget};
+    use crate::translator::rtyper::rmodel::Repr;
 
     #[test]
     fn stringpiece_prev_piece_points_back_to_stringpiece() {
@@ -5268,6 +5317,22 @@ mod tests {
             super::stringbuilder_repr().lowleveltype(),
             super::unicodebuilder_repr().lowleveltype()
         );
+    }
+
+    #[test]
+    fn builder_reprs_impl_repr_trait_and_coerce_to_dyn() {
+        let sb = super::stringbuilder_repr();
+        assert_eq!(sb.class_name(), "StringBuilderRepr");
+        assert_eq!(sb.lowleveltype(), &*super::STRINGBUILDERPTR);
+
+        let ub = super::unicodebuilder_repr();
+        assert_eq!(ub.class_name(), "UnicodeBuilderRepr");
+        assert_eq!(ub.lowleveltype(), &*super::UNICODEBUILDERPTR);
+
+        // The reprs must be usable as `Arc<dyn Repr>` so the rtyper's
+        // `inputarg` / `gendirectcall` machinery can consume them.
+        let _dyn_sb: std::sync::Arc<dyn Repr> = super::stringbuilder_repr();
+        let _dyn_ub: std::sync::Arc<dyn Repr> = super::unicodebuilder_repr();
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -22,9 +22,10 @@ use crate::translator::rtyper::lltypesystem::lltype::{
     ForwardReference, LowLevelType, Ptr, PtrTarget, Struct,
 };
 use crate::translator::rtyper::lltypesystem::rstr::{STRPTR, UNICODEPTR};
-use crate::translator::rtyper::rmodel::{Repr, ReprState};
+use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    constant_with_lltype, helper_pygraph_from_graph, variable_with_lltype, void_field_const,
+    ConvertedTo, HighLevelOp, constant_with_lltype, helper_pygraph_from_graph,
+    variable_with_lltype, void_field_const,
 };
 
 fn ptr_to_lowlevel(target: LowLevelType) -> LowLevelType {
@@ -5185,6 +5186,65 @@ impl StringBuilderRepr {
     }
 }
 
+/// RPython `BaseStringBuilderRepr.rtype_method_getlength(self, hop)`
+/// (`rbuilder.py:42-45`):
+///
+/// ```python
+/// def rtype_method_getlength(self, hop):
+///     vlist = hop.inputargs(self)
+///     hop.exception_cannot_occur()
+///     return hop.gendirectcall(self.ll_getlength, *vlist)
+/// ```
+///
+/// Shared body for the StringBuilderRepr / UnicodeBuilderRepr impls —
+/// both bind the same `ll_getlength` container-length lowering, only the
+/// builder pointer lltype (`Ptr(STRINGBUILDER)` vs `Ptr(UNICODEBUILDER)`)
+/// differs, which the helper-graph cache key keeps distinct.
+fn rtype_builder_getlength(
+    self_repr: &dyn Repr,
+    hop: &HighLevelOp,
+    builder_ptr_lltype: LowLevelType,
+) -> RTypeResult {
+    let vlist = hop.inputargs(vec![ConvertedTo::Repr(self_repr)])?;
+    hop.exception_cannot_occur()?;
+    let ptr_for_builder = builder_ptr_lltype.clone();
+    let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+        "ll_getlength".to_string(),
+        vec![builder_ptr_lltype],
+        LowLevelType::Signed,
+        move |_rtyper, _args, _result| {
+            build_ll_getlength_helper_graph("ll_getlength", ptr_for_builder)
+        },
+    )?;
+    hop.gendirectcall(&helper, vlist)
+}
+
+/// RPython `BaseStringBuilderRepr.rtype_bool(self, hop)`
+/// (`rbuilder.py:52-55`):
+///
+/// ```python
+/// def rtype_bool(self, hop):
+///     vlist = hop.inputargs(self)
+///     hop.exception_cannot_occur()
+///     return hop.gendirectcall(self.ll_bool, *vlist)
+/// ```
+fn rtype_builder_bool(
+    self_repr: &dyn Repr,
+    hop: &HighLevelOp,
+    builder_ptr_lltype: LowLevelType,
+) -> RTypeResult {
+    let vlist = hop.inputargs(vec![ConvertedTo::Repr(self_repr)])?;
+    hop.exception_cannot_occur()?;
+    let ptr_for_builder = builder_ptr_lltype.clone();
+    let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+        "ll_bool".to_string(),
+        vec![builder_ptr_lltype],
+        LowLevelType::Bool,
+        move |_rtyper, _args, _result| build_ll_bool_helper_graph("ll_bool", ptr_for_builder),
+    )?;
+    hop.gendirectcall(&helper, vlist)
+}
+
 impl Default for StringBuilderRepr {
     fn default() -> Self {
         Self::new()
@@ -5203,6 +5263,20 @@ impl Repr for StringBuilderRepr {
 
     fn class_name(&self) -> &'static str {
         "StringBuilderRepr"
+    }
+
+    fn rtype_bool(&self, hop: &HighLevelOp) -> RTypeResult {
+        rtype_builder_bool(self, hop, STRINGBUILDERPTR.clone())
+    }
+
+    fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
+        match method_name {
+            "getlength" => rtype_builder_getlength(self, hop, STRINGBUILDERPTR.clone()),
+            _ => Err(TyperError::message(format!(
+                "missing {}.rtype_method_{method_name}",
+                self.class_name()
+            ))),
+        }
     }
 }
 
@@ -5243,6 +5317,20 @@ impl Repr for UnicodeBuilderRepr {
 
     fn class_name(&self) -> &'static str {
         "UnicodeBuilderRepr"
+    }
+
+    fn rtype_bool(&self, hop: &HighLevelOp) -> RTypeResult {
+        rtype_builder_bool(self, hop, UNICODEBUILDERPTR.clone())
+    }
+
+    fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
+        match method_name {
+            "getlength" => rtype_builder_getlength(self, hop, UNICODEBUILDERPTR.clone()),
+            _ => Err(TyperError::message(format!(
+                "missing {}.rtype_method_{method_name}",
+                self.class_name()
+            ))),
+        }
     }
 }
 
@@ -6334,5 +6422,176 @@ mod tests {
         assert_eq!(super::unroll_func_for_size.len(), 9);
         assert_eq!(super::unroll_func_for_size[0].2, 2);
         assert_eq!(super::unroll_func_for_size.last().unwrap().2, super::MAX_N);
+    }
+
+    /// Builds a unary `HighLevelOp` whose sole argument carries `repr` /
+    /// `builder_ptr_lltype`, mirroring `rstr.rs`'s `build_string_unary_hop`.
+    /// The `SomePtr` s-binding is non-constant so `inputarg` routes through
+    /// `convertvar`, which short-circuits (same repr) and yields the arg
+    /// variable unchanged.
+    fn build_builder_unary_hop(
+        rtyper: std::rc::Rc<crate::translator::rtyper::rtyper::RPythonTyper>,
+        llops: std::rc::Rc<
+            std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>,
+        >,
+        opname: &str,
+        builder_ptr_lltype: LowLevelType,
+        result_lltype: LowLevelType,
+        repr: std::sync::Arc<dyn Repr>,
+    ) -> crate::translator::rtyper::rtyper::HighLevelOp {
+        use crate::flowspace::model::{Hlvalue, SpaceOperation, Variable};
+        let LowLevelType::Ptr(inner) = builder_ptr_lltype.clone() else {
+            panic!("builder lltype must be a Ptr");
+        };
+        let v_arg = Variable::new();
+        v_arg.set_concretetype(Some(builder_ptr_lltype));
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(result_lltype));
+        let hop = crate::translator::rtyper::rtyper::HighLevelOp::new(
+            rtyper,
+            SpaceOperation::new(
+                opname.to_string(),
+                vec![Hlvalue::Variable(v_arg)],
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops,
+        );
+        hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
+        hop.args_s.borrow_mut().push(
+            crate::annotator::model::SomeValue::Ptr(
+                crate::translator::rtyper::lltypesystem::lltype::SomePtr::new(*inner),
+            ),
+        );
+        hop.args_r.borrow_mut().push(Some(repr));
+        hop
+    }
+
+    fn setup_rtyper() -> (
+        std::rc::Rc<crate::annotator::annrpython::RPythonAnnotator>,
+        std::rc::Rc<crate::translator::rtyper::rtyper::RPythonTyper>,
+    ) {
+        let ann =
+            crate::annotator::annrpython::RPythonAnnotator::new(None, None, None, false);
+        let rtyper =
+            std::rc::Rc::new(crate::translator::rtyper::rtyper::RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        // `ann` is returned so the caller keeps it alive — RPythonTyper
+        // holds only a Weak upgrade to the annotator.
+        (ann, rtyper)
+    }
+
+    fn assert_single_direct_call_to(
+        llops: &std::rc::Rc<
+            std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>,
+        >,
+        helper_name: &str,
+    ) {
+        use crate::flowspace::model::Hlvalue;
+        let ops = llops.borrow();
+        assert_eq!(ops.ops.len(), 1, "expected one direct_call");
+        assert_eq!(ops.ops[0].opname, "direct_call");
+        let Hlvalue::Constant(c) = &ops.ops[0].args[0] else {
+            panic!("expected Constant funcptr, got {:?}", ops.ops[0].args[0]);
+        };
+        let dbg = format!("{:?}", c.value);
+        assert!(dbg.contains(helper_name), "expected funcptr '{helper_name}' in {dbg}");
+    }
+
+    /// rbuilder.py:42-45 — `rtype_method_getlength` lowers to a single
+    /// `direct_call` against the `ll_getlength` helper graph.
+    #[test]
+    fn stringbuilder_rtype_method_getlength_emits_direct_call() {
+        use crate::flowspace::model::Hlvalue;
+        let (_ann, rtyper) = setup_rtyper();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(
+            crate::translator::rtyper::rtyper::LowLevelOpList::new(rtyper.clone(), None),
+        ));
+        let hop = build_builder_unary_hop(
+            rtyper.clone(),
+            llops.clone(),
+            "getlength",
+            super::STRINGBUILDERPTR.clone(),
+            LowLevelType::Signed,
+            super::stringbuilder_repr() as std::sync::Arc<dyn Repr>,
+        );
+        let result = super::stringbuilder_repr()
+            .rtype_method("getlength", &hop)
+            .unwrap_or_else(|err| panic!("rtype_method getlength: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_single_direct_call_to(&llops, "ll_getlength");
+    }
+
+    /// rbuilder.py:52-55 — `rtype_bool` lowers to a single `direct_call`
+    /// against the `ll_bool` helper graph.
+    #[test]
+    fn stringbuilder_rtype_bool_emits_direct_call() {
+        use crate::flowspace::model::Hlvalue;
+        let (_ann, rtyper) = setup_rtyper();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(
+            crate::translator::rtyper::rtyper::LowLevelOpList::new(rtyper.clone(), None),
+        ));
+        let hop = build_builder_unary_hop(
+            rtyper.clone(),
+            llops.clone(),
+            "bool",
+            super::STRINGBUILDERPTR.clone(),
+            LowLevelType::Bool,
+            super::stringbuilder_repr() as std::sync::Arc<dyn Repr>,
+        );
+        let result = super::stringbuilder_repr()
+            .rtype_bool(&hop)
+            .unwrap_or_else(|err| panic!("rtype_bool: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_single_direct_call_to(&llops, "ll_bool");
+    }
+
+    /// rbuilder.py:42-45 mirror for UnicodeBuilderRepr — same shape,
+    /// distinct builder pointer lltype (`Ptr(UNICODEBUILDER)`).
+    #[test]
+    fn unicodebuilder_rtype_method_getlength_emits_direct_call() {
+        use crate::flowspace::model::Hlvalue;
+        let (_ann, rtyper) = setup_rtyper();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(
+            crate::translator::rtyper::rtyper::LowLevelOpList::new(rtyper.clone(), None),
+        ));
+        let hop = build_builder_unary_hop(
+            rtyper.clone(),
+            llops.clone(),
+            "getlength",
+            super::UNICODEBUILDERPTR.clone(),
+            LowLevelType::Signed,
+            super::unicodebuilder_repr() as std::sync::Arc<dyn Repr>,
+        );
+        let result = super::unicodebuilder_repr()
+            .rtype_method("getlength", &hop)
+            .unwrap_or_else(|err| panic!("rtype_method getlength: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_single_direct_call_to(&llops, "ll_getlength");
+    }
+
+    /// rbuilder.py:52-55 mirror for UnicodeBuilderRepr.
+    #[test]
+    fn unicodebuilder_rtype_bool_emits_direct_call() {
+        use crate::flowspace::model::Hlvalue;
+        let (_ann, rtyper) = setup_rtyper();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(
+            crate::translator::rtyper::rtyper::LowLevelOpList::new(rtyper.clone(), None),
+        ));
+        let hop = build_builder_unary_hop(
+            rtyper.clone(),
+            llops.clone(),
+            "bool",
+            super::UNICODEBUILDERPTR.clone(),
+            LowLevelType::Bool,
+            super::unicodebuilder_repr() as std::sync::Arc<dyn Repr>,
+        );
+        let result = super::unicodebuilder_repr()
+            .rtype_bool(&hop)
+            .unwrap_or_else(|err| panic!("rtype_bool: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_single_direct_call_to(&llops, "ll_bool");
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -5337,7 +5337,8 @@ impl Repr for UnicodeBuilderRepr {
 /// RPython `stringbuilder_repr = StringBuilderRepr()`.
 pub fn stringbuilder_repr() -> Arc<StringBuilderRepr> {
     static REPR: OnceLock<Arc<StringBuilderRepr>> = OnceLock::new();
-    REPR.get_or_init(|| Arc::new(StringBuilderRepr::new())).clone()
+    REPR.get_or_init(|| Arc::new(StringBuilderRepr::new()))
+        .clone()
 }
 
 /// RPython `unicodebuilder_repr = UnicodeBuilderRepr()`.
@@ -6431,9 +6432,7 @@ mod tests {
     /// variable unchanged.
     fn build_builder_unary_hop(
         rtyper: std::rc::Rc<crate::translator::rtyper::rtyper::RPythonTyper>,
-        llops: std::rc::Rc<
-            std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>,
-        >,
+        llops: std::rc::Rc<std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>>,
         opname: &str,
         builder_ptr_lltype: LowLevelType,
         result_lltype: LowLevelType,
@@ -6458,11 +6457,11 @@ mod tests {
             llops,
         );
         hop.args_v.borrow_mut().extend(hop.spaceop.args.clone());
-        hop.args_s.borrow_mut().push(
-            crate::annotator::model::SomeValue::Ptr(
+        hop.args_s
+            .borrow_mut()
+            .push(crate::annotator::model::SomeValue::Ptr(
                 crate::translator::rtyper::lltypesystem::lltype::SomePtr::new(*inner),
-            ),
-        );
+            ));
         hop.args_r.borrow_mut().push(Some(repr));
         hop
     }
@@ -6471,10 +6470,8 @@ mod tests {
         std::rc::Rc<crate::annotator::annrpython::RPythonAnnotator>,
         std::rc::Rc<crate::translator::rtyper::rtyper::RPythonTyper>,
     ) {
-        let ann =
-            crate::annotator::annrpython::RPythonAnnotator::new(None, None, None, false);
-        let rtyper =
-            std::rc::Rc::new(crate::translator::rtyper::rtyper::RPythonTyper::new(&ann));
+        let ann = crate::annotator::annrpython::RPythonAnnotator::new(None, None, None, false);
+        let rtyper = std::rc::Rc::new(crate::translator::rtyper::rtyper::RPythonTyper::new(&ann));
         rtyper
             .initialize_exceptiondata()
             .expect("initialize_exceptiondata in test setup");
@@ -6484,9 +6481,7 @@ mod tests {
     }
 
     fn assert_single_direct_call_to(
-        llops: &std::rc::Rc<
-            std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>,
-        >,
+        llops: &std::rc::Rc<std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>>,
         helper_name: &str,
     ) {
         use crate::flowspace::model::Hlvalue;
@@ -6497,7 +6492,10 @@ mod tests {
             panic!("expected Constant funcptr, got {:?}", ops.ops[0].args[0]);
         };
         let dbg = format!("{:?}", c.value);
-        assert!(dbg.contains(helper_name), "expected funcptr '{helper_name}' in {dbg}");
+        assert!(
+            dbg.contains(helper_name),
+            "expected funcptr '{helper_name}' in {dbg}"
+        );
     }
 
     /// rbuilder.py:42-45 — `rtype_method_getlength` lowers to a single

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -24,7 +24,7 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 use crate::translator::rtyper::lltypesystem::rstr::{STRPTR, UNICODEPTR};
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, constant_with_lltype, helper_pygraph_from_graph,
+    ConvertedTo, HighLevelOp, constant_with_lltype, functionptr_const, helper_pygraph_from_graph,
     variable_with_lltype, void_field_const,
 };
 
@@ -5184,6 +5184,18 @@ impl StringBuilderRepr {
     pub fn basetp(&self) -> &'static LowLevelType {
         &crate::translator::rtyper::lltypesystem::rstr::STR
     }
+
+    /// RPython `AbstractStringBuilderRepr.rtyper_new(self, hop)`
+    /// (`rtyper/rbuilder.py:8-13`), inherited by `StringBuilderRepr`.
+    pub fn rtyper_new(&self, hop: &HighLevelOp) -> RTypeResult {
+        rtype_builder_new(
+            hop,
+            STRINGBUILDERPTR.clone(),
+            STRINGBUILDER.clone(),
+            STRPTR.clone(),
+            "mallocstr",
+        )
+    }
 }
 
 /// RPython `BaseStringBuilderRepr.rtype_method_getlength(self, hop)`
@@ -5245,6 +5257,81 @@ fn rtype_builder_bool(
     hop.gendirectcall(&helper, vlist)
 }
 
+/// RPython `AbstractStringBuilderRepr.rtyper_new(self, hop)`
+/// (`rtyper/rbuilder.py:8-13`):
+///
+/// ```python
+/// def rtyper_new(self, hop):
+///     if len(hop.args_v) == 0:
+///         v_arg = hop.inputconst(lltype.Signed, INIT_SIZE)
+///     else:
+///         v_arg = hop.inputarg(lltype.Signed, 0)
+///     hop.exception_cannot_occur()
+///     return hop.gendirectcall(self.ll_new, v_arg)
+/// ```
+///
+/// Shared body for the StringBuilderRepr / UnicodeBuilderRepr constructor
+/// lowering. `self.ll_new` resolves to the concrete `ll_new` helper graph
+/// whose whole callee closure is materialised here: `ll_min` (via the
+/// hardcoded `lowlevel_helper_function` builder) and `mallocstr` /
+/// `mallocunicode` (via `build_ll_mallocstr_helper_graph`), both baked in
+/// as `direct_call` callee constants by [`functionptr_const`]. The
+/// helper-graph cache keys stay distinct across STR / UNICODE because the
+/// `ll_new` result lltype and the malloc helper name differ.
+fn rtype_builder_new(
+    hop: &HighLevelOp,
+    builder_ptr_lltype: LowLevelType,
+    builder_struct: LowLevelType,
+    buf_lltype: LowLevelType,
+    malloc_name: &'static str,
+) -> RTypeResult {
+    use crate::translator::rtyper::lltypesystem::rstr::build_ll_mallocstr_helper_graph;
+    use crate::translator::rtyper::rbuilder::INIT_SIZE;
+    let v_arg = if hop.nb_args() == 0 {
+        Hlvalue::Constant(HighLevelOp::inputconst(
+            ConvertedTo::LowLevelType(&LowLevelType::Signed),
+            &ConstValue::Int(INIT_SIZE),
+        )?)
+    } else {
+        hop.inputarg(ConvertedTo::LowLevelType(&LowLevelType::Signed), 0)?
+    };
+    hop.exception_cannot_occur()?;
+
+    let ptr_for_builder = builder_ptr_lltype.clone();
+    let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+        "ll_new".to_string(),
+        vec![LowLevelType::Signed],
+        builder_ptr_lltype,
+        move |rtyper, _args, _result| {
+            let min = rtyper.lowlevel_helper_function(
+                "ll_min",
+                vec![LowLevelType::Unsigned, LowLevelType::Unsigned],
+                LowLevelType::Unsigned,
+            )?;
+            let min_fn = functionptr_const(rtyper, &min)?;
+
+            let malloc_buf = buf_lltype.clone();
+            let malloc = rtyper.lowlevel_helper_function_with_builder(
+                malloc_name.to_string(),
+                vec![LowLevelType::Signed],
+                buf_lltype.clone(),
+                move |_r, _a, _res| build_ll_mallocstr_helper_graph(malloc_name, malloc_buf),
+            )?;
+            let mallocfn = functionptr_const(rtyper, &malloc)?;
+
+            build_ll_new_helper_graph(
+                "ll_new",
+                ptr_for_builder.clone(),
+                builder_struct.clone(),
+                buf_lltype.clone(),
+                min_fn,
+                mallocfn,
+            )
+        },
+    )?;
+    hop.gendirectcall(&helper, vec![v_arg])
+}
+
 impl Default for StringBuilderRepr {
     fn default() -> Self {
         Self::new()
@@ -5296,6 +5383,18 @@ impl UnicodeBuilderRepr {
     /// RPython `UnicodeBuilderRepr.basetp = UNICODE`.
     pub fn basetp(&self) -> &'static LowLevelType {
         &crate::translator::rtyper::lltypesystem::rstr::UNICODE
+    }
+
+    /// RPython `AbstractStringBuilderRepr.rtyper_new(self, hop)`
+    /// (`rtyper/rbuilder.py:8-13`), inherited by `UnicodeBuilderRepr`.
+    pub fn rtyper_new(&self, hop: &HighLevelOp) -> RTypeResult {
+        rtype_builder_new(
+            hop,
+            UNICODEBUILDERPTR.clone(),
+            UNICODEBUILDER.clone(),
+            UNICODEPTR.clone(),
+            "mallocunicode",
+        )
     }
 }
 
@@ -6544,6 +6643,72 @@ mod tests {
             .unwrap_or_else(|err| panic!("rtype_bool: {err:?}"));
         assert!(matches!(result, Some(Hlvalue::Variable(_))));
         assert_single_direct_call_to(&llops, "ll_bool");
+    }
+
+    /// Builds a nullary `HighLevelOp` (constructor call with no arguments)
+    /// whose result carries `builder_ptr_lltype`. `rtyper_new` reads
+    /// `hop.nb_args() == 0` and materialises the `INIT_SIZE` const arg.
+    fn build_builder_nullary_hop(
+        rtyper: std::rc::Rc<crate::translator::rtyper::rtyper::RPythonTyper>,
+        llops: std::rc::Rc<std::cell::RefCell<crate::translator::rtyper::rtyper::LowLevelOpList>>,
+        builder_ptr_lltype: LowLevelType,
+    ) -> crate::translator::rtyper::rtyper::HighLevelOp {
+        use crate::flowspace::model::{Hlvalue, SpaceOperation, Variable};
+        let v_result = Variable::new();
+        v_result.set_concretetype(Some(builder_ptr_lltype));
+        crate::translator::rtyper::rtyper::HighLevelOp::new(
+            rtyper,
+            SpaceOperation::new(
+                "simple_call".to_string(),
+                Vec::new(),
+                Hlvalue::Variable(v_result),
+            ),
+            Vec::new(),
+            llops,
+        )
+    }
+
+    /// rtyper/rbuilder.py:8-13 — `rtyper_new` on a zero-argument
+    /// constructor lowers to a single `direct_call` against the `ll_new`
+    /// helper graph (the `INIT_SIZE` default feeds the const arg).
+    #[test]
+    fn stringbuilder_rtyper_new_zero_args_emits_direct_call() {
+        use crate::flowspace::model::Hlvalue;
+        let (_ann, rtyper) = setup_rtyper();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(
+            crate::translator::rtyper::rtyper::LowLevelOpList::new(rtyper.clone(), None),
+        ));
+        let hop = build_builder_nullary_hop(
+            rtyper.clone(),
+            llops.clone(),
+            super::STRINGBUILDERPTR.clone(),
+        );
+        let result = super::stringbuilder_repr()
+            .rtyper_new(&hop)
+            .unwrap_or_else(|err| panic!("rtyper_new: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_single_direct_call_to(&llops, "ll_new");
+    }
+
+    /// The `UnicodeBuilderRepr` constructor lowers to its own `ll_new`
+    /// (distinct helper-graph cache key via the UNICODE result lltype).
+    #[test]
+    fn unicodebuilder_rtyper_new_zero_args_emits_direct_call() {
+        use crate::flowspace::model::Hlvalue;
+        let (_ann, rtyper) = setup_rtyper();
+        let llops = std::rc::Rc::new(std::cell::RefCell::new(
+            crate::translator::rtyper::rtyper::LowLevelOpList::new(rtyper.clone(), None),
+        ));
+        let hop = build_builder_nullary_hop(
+            rtyper.clone(),
+            llops.clone(),
+            super::UNICODEBUILDERPTR.clone(),
+        );
+        let result = super::unicodebuilder_repr()
+            .rtyper_new(&hop)
+            .unwrap_or_else(|err| panic!("rtyper_new: {err:?}"));
+        assert!(matches!(result, Some(Hlvalue::Variable(_))));
+        assert_single_direct_call_to(&llops, "ll_new");
     }
 
     /// rbuilder.py:42-45 mirror for UnicodeBuilderRepr — same shape,

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -630,6 +630,85 @@ pub(crate) fn build_ll_strlen_helper_graph(
     ))
 }
 
+/// Synthesise `mallocstr` / `mallocunicode` (`lltypesystem/rstr.py:35-46`):
+///
+/// ```python
+/// def mallocstr(length):
+///     ll_assert(length >= 0, "negative string length")
+///     r = malloc(TP, length)
+///     if not we_are_translated() or not malloc_zero_filled:
+///         r.hash = 0
+///     return r
+/// ```
+///
+/// Single block: `malloc_varsize(STR/UNICODE, gc, length)` then
+/// `setfield(r, 'hash', 0)`. `ll_assert` is a translation-time no-op, and
+/// the zero-fill guard collapses to always initialising the hash field
+/// (matching the inline `mallocstr` shape emitted by the int-to-string
+/// helpers). `name` selects the helper identity (`"mallocstr"` /
+/// `"mallocunicode"`) and `ptr_lltype` selects `Ptr(STR)` vs
+/// `Ptr(UNICODE)`.
+pub(crate) fn build_ll_mallocstr_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
+
+    let struct_lltype = struct_lltype_from_strptr(&ptr_lltype)?;
+    let signed_const = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let hash_field_const =
+        || constant_with_lltype(ConstValue::byte_str("hash"), LowLevelType::Void);
+
+    let length_arg = variable_with_lltype("length", LowLevelType::Signed);
+    let startblock = Block::shared(vec![Hlvalue::Variable(length_arg.clone())]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    let result = variable_with_lltype("r", ptr_lltype);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "malloc_varsize",
+        vec![
+            lowlevel_type_const(struct_lltype),
+            gc_flavor_const()?,
+            Hlvalue::Variable(length_arg),
+        ],
+        Hlvalue::Variable(result.clone()),
+    ));
+    let set_hash = variable_with_lltype("set", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "setfield",
+        vec![
+            Hlvalue::Variable(result.clone()),
+            hash_field_const(),
+            signed_const(0),
+        ],
+        Hlvalue::Variable(set_hash),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["length".to_string()],
+        func,
+    ))
+}
+
 /// Synthesise `LLHelpers.ll_chr2str` (`lltypesystem/rstr.py:363-369`):
 ///
 /// ```python
@@ -9107,6 +9186,70 @@ mod tests {
     #[test]
     fn build_ll_strlen_rejects_non_ptr_input_lltype() {
         let err = build_ll_strlen_helper_graph("ll_strlen", LowLevelType::Char)
+            .expect_err("non-Ptr input must fail");
+        assert!(format!("{err:?}").contains("Ptr(STR/UNICODE)"));
+    }
+
+    /// rstr.py:35-46 — `mallocstr(length)` lowers to
+    /// `malloc_varsize(STR, gc, length)` + `setfield(r, 'hash', 0)`,
+    /// returning `Ptr(STR)`.
+    #[test]
+    fn build_ll_mallocstr_emits_malloc_varsize_then_hash_zero() {
+        let helper = build_ll_mallocstr_helper_graph("mallocstr", STRPTR.clone())
+            .expect("build_ll_mallocstr_helper_graph");
+        assert_eq!(helper.func.name, "mallocstr");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let opnames: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(opnames, vec!["malloc_varsize", "setfield"]);
+        // setfield's field-name constant is `"hash"`, value constant 0.
+        let setfield_args = &startblock.operations[1].args;
+        assert_eq!(setfield_args.len(), 3);
+        let Hlvalue::Constant(field) = &setfield_args[1] else {
+            panic!("setfield field-name must be a Constant");
+        };
+        assert!(matches!(field.value, ConstValue::ByteStr(ref b) if b == b"hash"));
+        let Hlvalue::Constant(zero) = &setfield_args[2] else {
+            panic!("setfield value must be a Constant");
+        };
+        assert!(matches!(zero.value, ConstValue::Int(0)));
+        // The returned value carries `Ptr(STR)`.
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(ret.concretetype.borrow().clone(), Some(STRPTR.clone()));
+        assert_eq!(startblock.inputargs.len(), 1);
+    }
+
+    /// `mallocunicode` is the `Ptr(UNICODE)` mirror — same op sequence,
+    /// distinct struct/pointer lltype and helper identity.
+    #[test]
+    fn build_ll_mallocunicode_mirrors_mallocstr_against_unicode() {
+        let helper = build_ll_mallocstr_helper_graph("mallocunicode", UNICODEPTR.clone())
+            .expect("build_ll_mallocstr_helper_graph for UNICODE");
+        assert_eq!(helper.func.name, "mallocunicode");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let opnames: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|op| op.opname.as_str())
+            .collect();
+        assert_eq!(opnames, vec!["malloc_varsize", "setfield"]);
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(ret.concretetype.borrow().clone(), Some(UNICODEPTR.clone()));
+    }
+
+    /// `mallocstr` is only meaningful against `Ptr(STR/UNICODE)`.
+    #[test]
+    fn build_ll_mallocstr_rejects_non_ptr_input_lltype() {
+        let err = build_ll_mallocstr_helper_graph("mallocstr", LowLevelType::Char)
             .expect_err("non-Ptr input must fail");
         assert!(format!("{err:?}").contains("Ptr(STR/UNICODE)"));
     }

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -2835,6 +2835,12 @@ pub enum ReprKey {
     /// RPython `SomeInteriorPtr.rtyper_makekey = (self.__class__,
     /// self.ll_ptrtype)` (rptr.py:24). Same by-value lltype key as [`Ptr`].
     InteriorPtr(LowLevelType),
+    /// RPython `SomeStringBuilder.rtyper_makekey = (self.__class__,)`
+    /// (rstring.py:1228). Class-tag singleton.
+    StringBuilder,
+    /// RPython `SomeUnicodeBuilder.rtyper_makekey = (self.__class__,)`
+    /// (rstring.py:1268). Class-tag singleton.
+    UnicodeBuilder,
     /// Pending variant — carries a textual discriminator from
     /// `rtyper_makekey` arm that hasn't been ported yet.
     Pending(String),
@@ -2994,6 +3000,10 @@ pub fn rtyper_makekey(s_obj: &crate::annotator::model::SomeValue) -> ReprKey {
                 s.ll_ptrtype.clone(),
             ),
         ),
+        // rstring.py:1228/1268 — SomeStringBuilder / SomeUnicodeBuilder
+        // rtyper_makekey = (self.__class__,).
+        SomeValue::StringBuilder(_) => ReprKey::StringBuilder,
+        SomeValue::UnicodeBuilder(_) => ReprKey::UnicodeBuilder,
         // Remaining variants defer to their r*.rs ports. Emit a
         // deterministic `Pending` key so the reprs cache still
         // distinguishes entries by variant-shape — identical

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -3254,6 +3254,17 @@ pub fn rtyper_makerepr(
         SomeValue::LLADTMeth(adtmeth) => {
             Ok(std::sync::Arc::new(LLADTMethRepr::new(adtmeth)) as std::sync::Arc<dyn Repr>)
         }
+        // rstring.py:1224-1226 / 1264-1266 — SomeStringBuilder /
+        // SomeUnicodeBuilder rtyper_makerepr return the module-global
+        // stringbuilder_repr / unicodebuilder_repr singletons.
+        SomeValue::StringBuilder(_) => Ok(
+            crate::translator::rtyper::lltypesystem::rbuilder::stringbuilder_repr()
+                as std::sync::Arc<dyn Repr>,
+        ),
+        SomeValue::UnicodeBuilder(_) => Ok(
+            crate::translator::rtyper::lltypesystem::rbuilder::unicodebuilder_repr()
+                as std::sync::Arc<dyn Repr>,
+        ),
     }
 }
 
@@ -4809,5 +4820,19 @@ mod tests {
         ));
         let err = rtyper_makerepr(&sv, &rtyper).expect_err("should surface self-weak error");
         assert!(err.to_string().contains("self-weak"));
+    }
+
+    #[test]
+    fn rtyper_makerepr_stringbuilder_returns_builder_reprs() {
+        use crate::annotator::model::{SomeStringBuilder, SomeUnicodeBuilder};
+        let rtyper = rtyper_for_tests();
+
+        let sb = SomeValue::StringBuilder(SomeStringBuilder::new());
+        let r = rtyper_makerepr(&sb, &rtyper).expect("stringbuilder repr");
+        assert_eq!(r.class_name(), "StringBuilderRepr");
+
+        let ub = SomeValue::UnicodeBuilder(SomeUnicodeBuilder::new());
+        let r = rtyper_makerepr(&ub, &rtyper).expect("unicodebuilder repr");
+        assert_eq!(r.class_name(), "UnicodeBuilderRepr");
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -7051,11 +7051,18 @@ mod tests {
     fn functionptr_const_names_helper_graph_with_matching_signature() {
         let (_ann, rtyper) = make_live_rtyper();
         let llfn = rtyper
-            .lowlevel_helper_function("ll_check_chr", vec![LowLevelType::Signed], LowLevelType::Void)
+            .lowlevel_helper_function(
+                "ll_check_chr",
+                vec![LowLevelType::Signed],
+                LowLevelType::Void,
+            )
             .unwrap();
         let c_func = super::functionptr_const(&rtyper, &llfn).expect("functionptr const");
         let Some(LowLevelType::Ptr(ptr)) = &c_func.concretetype else {
-            panic!("functionptr const must be Ptr(Func), got {:?}", c_func.concretetype);
+            panic!(
+                "functionptr const must be Ptr(Func), got {:?}",
+                c_func.concretetype
+            );
         };
         let PtrTarget::Func(func_type) = &ptr.TO else {
             panic!("functionptr const Ptr.TO must be Func, got {:?}", ptr.TO);

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -5286,12 +5286,16 @@ fn lowlevel_overflow_check_wrapper_graph(
     Ok(helper_pygraph_from_graph(graph, argnames, func))
 }
 
-fn direct_call_operation(
+/// Build the `functionptr` constant that names `ll_function`'s helper
+/// graph — the callee const a `direct_call` operation takes as its first
+/// argument. Reused wherever a synthesised graph embeds another low-level
+/// helper as a `direct_call` callee (e.g. the StringBuilder `ll_build` /
+/// `ll_append*` closures wiring their `ll_fold_pieces` / `ll_grow_by`
+/// sub-helpers as constants).
+pub(crate) fn functionptr_const(
     rtyper: &RPythonTyper,
     ll_function: &LowLevelFunction,
-    args_v: Vec<Hlvalue>,
-    result: Variable,
-) -> Result<SpaceOperation, TyperError> {
+) -> Result<Constant, TyperError> {
     let graph = ll_function.graph.as_ref().ok_or_else(|| {
         TyperError::missing_rtype_operation(format!(
             "low-level helper {} has no annotated helper graph",
@@ -5316,8 +5320,19 @@ fn direct_call_operation(
         )));
     }
     let func_ptr_type = LowLevelType::Ptr(Box::new(func_ptr._TYPE.clone()));
-    let c_func = inputconst_from_lltype(&func_ptr_type, &ConstValue::LLPtr(Box::new(func_ptr)))
-        .expect("functionptr constant must match Ptr(FuncType)");
+    Ok(
+        inputconst_from_lltype(&func_ptr_type, &ConstValue::LLPtr(Box::new(func_ptr)))
+            .expect("functionptr constant must match Ptr(FuncType)"),
+    )
+}
+
+fn direct_call_operation(
+    rtyper: &RPythonTyper,
+    ll_function: &LowLevelFunction,
+    args_v: Vec<Hlvalue>,
+    result: Variable,
+) -> Result<SpaceOperation, TyperError> {
+    let c_func = functionptr_const(rtyper, ll_function)?;
     let mut call_args = Vec::with_capacity(args_v.len() + 1);
     call_args.push(Hlvalue::Constant(c_func));
     call_args.extend(args_v);
@@ -7030,6 +7045,24 @@ mod tests {
                         .is_some_and(|target| BlockKey::of(target) == BlockKey::of(&exceptblock))
             }));
         }
+    }
+
+    #[test]
+    fn functionptr_const_names_helper_graph_with_matching_signature() {
+        let (_ann, rtyper) = make_live_rtyper();
+        let llfn = rtyper
+            .lowlevel_helper_function("ll_check_chr", vec![LowLevelType::Signed], LowLevelType::Void)
+            .unwrap();
+        let c_func = super::functionptr_const(&rtyper, &llfn).expect("functionptr const");
+        let Some(LowLevelType::Ptr(ptr)) = &c_func.concretetype else {
+            panic!("functionptr const must be Ptr(Func), got {:?}", c_func.concretetype);
+        };
+        let PtrTarget::Func(func_type) = &ptr.TO else {
+            panic!("functionptr const Ptr.TO must be Func, got {:?}", ptr.TO);
+        };
+        assert_eq!(func_type.args, vec![LowLevelType::Signed]);
+        assert_eq!(func_type.result, LowLevelType::Void);
+        assert!(matches!(c_func.value, ConstValue::LLPtr(_)));
     }
 
     #[test]


### PR DESCRIPTION
Continues the `lltypesystem/rbuilder.py` StringBuilder port into the repr-wiring and codewriter layers.

## Commits
- **impl Repr for StringBuilderRepr / UnicodeBuilderRepr** — the builder reprs gain `lowleveltype`/`state`/`class_name` and coerce to `Arc<dyn Repr>` so the rtyper's `inputarg`/`gendirectcall` machinery can consume them.
- **wire getlength + bool rtype methods** — `rtype_bool` + `rtype_method("getlength")` overrides on both reprs (`rbuilder.py:42-45`/`52-55`): `inputargs(self)` + `exception_cannot_occur()` + `gendirectcall` against the `ll_getlength` / `ll_bool` helper graphs. Shared free functions carry the body for both reprs; the helper-graph cache key keeps STRINGBUILDER vs UNICODEBUILDER distinct.
- **build mallocstr / mallocunicode helper graph** — `build_ll_mallocstr_helper_graph` synthesizes `rstr.py:35-46 new_malloc`: `malloc_varsize(struct, gc, length)` + `setfield(r, 'hash', 0)`, returning `Ptr(STR)` / `Ptr(UNICODE)`. First member of the deferred STR adtmeth table.
- **lower stroruni.copy_contents to copystrcontent** — ports the copy_contents arm of `jtransform.py:2049 _handle_stroruni_call` + the `stroruni.*` prefix dispatch. A `stroruni.copy_contents` oopspec call rewrites to a `copystrcontent` (Ptr(STR)) / `copyunicodecontent` (Ptr(UNICODE)) `LoweredBlackholeOp`.
- **lower rgc.ll_shrink_array to ShrinkArray residual call** — ports the ll_shrink_array arm of `jtransform.py:2193 _handle_rgc_call` + the `rgc.*` prefix dispatch, routing through `_handle_oopspec_call` with the `ShrinkArray` oopspecindex and `CanRaise` effect.

Each commit lands with its own unit tests; `cargo test -p majit-translate --lib` is green.

— *authored by Claude*