### PR TITLE
Docs

### DIFF
--- a/eu_report.md
+++ b/eu_report.md
@@ -1,0 +1,2170 @@
+# The PyPy EU Reports (2004–2007): A Digest
+
+This document summarizes the 31 public deliverables of the EU-funded PyPy project
+(IST FP6-004779, "Researching a Highly Flexible and Modular Language Platform and
+Implementing it by Leveraging the Open Source Python Language and Community",
+1 December 2004 – 31 March 2007, 28 months). It reports **only what the documents
+state** — all judgments of success or failure below are the original authors'
+own, quoted or attributed. Analysis of which claims remain valid today is kept
+out of this file (see `eu_report_assessment.md`); design consequences for pyre
+are in `pyre/design.md`.
+
+This is a *reference* digest, written to be consulted when making design
+decisions: mechanisms are described at working technical depth, alternatives
+that the authors considered and rejected are recorded alongside what shipped,
+and every number the reports give is preserved with its context.
+
+Source: the PyPy `extradoc` repository, `eu-report/` directory (D01–D14
+deliverables plus the Final Activity Report); local copy at
+`~/Downloads/extradoc-branch-extradoc/eu-report/`. Appendix A maps every
+section's deliverable IDs to the exact source PDF filenames.
+
+---
+## 1. Project frame and timeline (D14.1, D14.3, D14.4, D14.5, Final Activity Report)
+
+### 1.1 Origins and contractual frame
+
+- Concept began as mailing-list discussions in late 2002, "inspired by but
+  also frustrated with the results of two successful Python implementations,
+  Psycho [sic] and Stackless." First community sprint: Hildesheim, Germany,
+  **February 2003** (mailing list grew 0 → 144 subscribers by 2003-02-28).
+  During summer 2003 (third sprint) the team concluded full-time funding was
+  needed; the proposal was submitted to the European Commission on
+  **31 October 2003**; negotiations ran from March 2004; the funded project
+  started **1 December 2004**.
+- Contract: Sixth Framework Programme, IST Priority 2, STREP, contract
+  IST FP6-004779. Originally 24 months in three internal phases (9+9+6),
+  extended by amendment to **28 months**, ending 31 March 2007. Five
+  contractual amendments in total; Amendment 4 restructured the original
+  **58 deliverables into 21 contractual deliverables**; D14.5 states the final
+  shape as "14 work packages and in total 30 deliverables."
+- Consortium: DFKI (Saarbrücken, coordinator), AB Strakt → later **Open End**
+  (Göteborg), Logilab (Paris), Change Maker (Göteborg), merlinux GmbH
+  (Hildesheim), tismerysoft GmbH (Berlin), Heinrich-Heine-Universität
+  Düsseldorf, Impara GmbH (Magdeburg, joined later); plus four "Physical
+  Person" partners (Laura Creighton, Richard Emslie, Eric van Riet Paap,
+  Niklaus Haldimann). Governance: a Management Team at consortium level and a
+  **Technical Board** of core developers (Krekel, Rigo, Tismer, Pedroni);
+  monthly consortium IRC meetings; weekly developer "pypy-sync" meetings.
+
+### 1.2 Phases and milestones
+
+| Phase | Focus (stated) | Milestone |
+|---|---|---|
+| 1 (to 31 Aug 2005) | "Building a Novel Language Research Tool" | 0.6 + 0.7 releases: a self-contained novel Python implementation |
+| 2 | "High Performance" | 0.9 release: "a 20-fold performance improvement by a series of static and core translation optimizations" |
+| 3 | "Validation & Flexibility" | PyPy 1.0: the JIT compiler generator plus validation prototypes |
+
+The reports themselves note the phase boundaries blurred: phase 2 "already
+validated a number of architectural aspects and also increased flexibility of
+the whole system, originally a topic for phase 3"; the extension compiler
+(WP03), configuration (WP13) and validation (WP12) were pulled forward "on
+commercial/community demand."
+
+### 1.3 Releases and speed trajectory
+
+| Release | Date | Content (as stated) |
+|---|---|---|
+| 0.6 / 0.6.1 | 20 May 2005 | Core interpreter on top of CPython; compliance 92.08% total, 88.15% of test modules fully passing (vs CPython 2.3.4 suite); ~80% of built-in types (~100 types) ported; "90% of the core modules of the standard library are supported" |
+| 0.7 | 28 Aug 2005 | First *translated*, self-contained pypy-c; whole-program type inference ("the annotator") over RPython; first LLVM backend experiments |
+| 0.8 | 3 Nov 2005 | Translatable parser/compiler; more translation aspects measured |
+| 0.9 | 26 Jun 2006 | 20× faster than 0.7; stackless features, GC framework woven by transformation, extension compiler, logic variables, weakrefs under custom GCs; "core language tests continue to pass at a rate of 95% or better" |
+| 0.99 | 17 Feb 2007 | High-level backends (CLI and others) |
+| 1.0 | 27 Mar 2007 | JIT compiler generator, transparent proxies, AOP, taint space |
+
+Speed trajectory as stated across the reports: PyPy-on-CPython ~2000× slower
+than CPython → first pypy-c ~200× slower (0.7) → 0.8 roughly 10–20× slower →
+0.9 "still 2.5–10 times slower than CPython on popular benchmarks" →
+1.0 "runs benchmarks at about half of CPython's speed ... not even considering
+JIT technologies which will definitely provide a significant edge." The 1.0
+statement is accompanied by: "With more refined garbage collection techniques
+we believe that we can get very close to CPython speed."
+
+### 1.4 Scale
+
+- Code base: ~30k LOC (+8k test) at start of funding → ~250 KLOC (60 KLOC
+  test, ~3000 automated tests) at 0.9 → **~340k LOC (+82k test)** and
+  **11,805 automated tests** at the final report.
+- Community: "approximately 300–500 people follow the project closely" at end
+  of phase 1; in June 2006 "more than 50 developers are following changes to
+  the code base, from which only around 20 people are benefiting from EU
+  funding"; developer mailing list crossed 300 subscribers.
+- 19 week-long sprints (final-report count) across Europe, the US and Japan,
+  every 6–8 weeks; participant counts per sprint ranged 7–24.
+- Companies engaging with sprints/workshops (listed in D14.3):
+  Hewlett-Packard, Philips Medical System, Canonical, CCP Games, Greenpeace
+  International, Iona Technologies, EWT LLC, Next Limit Technologies, IBM.
+  One offered a sponsored sprint in exchange for performance work; "PyPy
+  could not participate in the sponsored sprint in question due to
+  differences in objectives and focus at the time."
+
+### 1.5 Final self-assessment
+
+"After 28 months of intense research, development and management activity,
+the final PyPy 1.0 milestone delivered all expected results and fulfilled its
+objectives." The JIT compiler generator is named **"the major research result
+of the project."** The same documents state the frank limitation: "PyPy's
+Python interpreter is still not generally usable. The main blocking factor is
+the lack of extension modules," the consequence of a deliberate early
+decision — "The project consciously decided early to first aim at realizing
+the full vision of PyPy's original claim, targeting the research oriented
+results before putting engineering and refactoring efforts into better
+extension module support. Indeed PyPy 1.0 has some of the rough edges that
+can be expected from the offspring of a research effort like PyPy."
+
+### 1.6 The l × o × p thesis (Final Activity Report)
+
+PyPy's stated purpose: language implementers otherwise write l × o × p
+interpreters for l languages, o low-level design decisions (memory
+management, threading model, target environment), and p platforms. PyPy makes
+each parameter independent: evolve or replace the interpreter (l), tweak the
+translation process (o), write new backends (p). Explicit contrast with
+standardized VMs: ".NET … enforces p = 1. We believe that enforcing the use
+of one common environment is not necessary." The final report's summary
+claim: "PyPy breaks the compromise between flexibility, simplicity and speed
+for implementing today's dynamic computer languages."
+
+The three publishable/exploitable results the final report names:
+1. **The PyPy language implementation platform** — "supporting multiple
+   different dynamic languages, with Python, JavaScript and Prolog currently
+   implemented"; backends C/POSIX, LLVM (low-level), CLI/.NET, Smalltalk, JVM
+   (high-level); "the Python/C/POSIX combination approaching readiness for
+   production use"; MIT license.
+2. **The flexible Python interpreter** — "a fully compliant interpreter for
+   the Python 2.4 language … more flexible and open to language research and
+   enhancements than any pre-existing implementation of Python."
+3. **The py.test testing framework** — released separately, MIT license, with
+   commercial support from merlinux.
+
+---
+## 2. The Standard Interpreter (D04.1, D04.2, D04.3, D04.4)
+
+The four WP04 deliverables document releases 0.6–0.8 and constitute the
+canonical architecture reference for the interpreter. D04.2 states its own
+origin: architecture/coding documentation was bundled into it "due to an
+omission in the Description of Work."
+
+### 2.1 Bytecode interpreter / object space split
+
+The Standard Interpreter is divided into two independent subsystems:
+
+- the **bytecode interpreter**: control flow, frames, exceptions, tracebacks,
+  and the value stack of *black-box wrapped objects*. It uses "the same
+  compact bytecode format as CPython 2.4". Each bytecode is implemented by a
+  Python function which delegates operations on application-level objects to
+  an object space — "This interpretation and delegation is the core of the
+  bytecode interpreter."
+- the **object space**: "creates all objects and knows how to perform
+  operations on the objects … a library offering a fixed API, a set of
+  operations with implementations that correspond to the known semantics of
+  Python objects." Example given: `add` performs numeric addition on numbers
+  and concatenation on sequences. **All operations take and return wrapped
+  objects.** Only a few very simple operations let the interpreter learn
+  anything about a value — "The most important one is `is_true()`, which
+  returns a boolean interpreter-level value," needed for conditional-branch
+  bytecodes.
+
+Four object spaces plug into the same interpreter:
+
+| Space | Role | Notes from the reports |
+|---|---|---|
+| **Standard** | the real implementation | W_IntObject, W_ListObject, … — "the equivalent of the C structures PyIntObject, PyListObject" |
+| **Trace** | records/prints every operation, frame event, bytecode | "The ease of implementation … underlines the power of the Object Space abstraction. Effectively it is a simple proxy object space"; enabled at runtime by `__pytrace__ = 1`; used pedagogically to show how abstract interpretation records execution |
+| **Thunk** | lazy values + `become` (global identity exchange) | 100–152 LOC; wraps another space, forcing arguments to operations; "all objects grow a field possibly pointing to an object that should be used instead of them"; translatable since 0.8 |
+| **Flow** | records operations into control-flow graphs | the front end of the translator (§3.2); "it is actually just an alternate representation for the function" |
+
+The 0.8 report (D04.4) names the two extensibility axes this architecture
+deliberately provides: **syntactic** (the translatable parser/compiler; "hook
+at the syntactic level") and **semantic** (object-space delegation; "this
+exploits the object space interface as a surface to hook into language
+semantics") — both stated as requirements from WP09/WP10 (aspects,
+design-by-contract, constraints).
+
+### 2.2 Application level vs interpreter level
+
+A two-level code model with strict conventions (D04.2 §6.6, coding guide):
+
+- `w_xxx` = wrapped (app-level) object; `xxx_w` = interp-level container of
+  wrapped objects (a list/dict *of* wrapped objects — not a wrapped
+  list/dict); `space` = the object space instance, always passed under that
+  name. Wrapped values include `w_self`.
+- App-level `a + b` is interp-level `space.add(w_a, w_b)` — the stated
+  analogy is CPython's C level (`PyNumber_Add(p_a, p_b)`).
+- Never use `w_x == w_y` or `w_x is w_y` ("DON'T DO THAT" — no reason two
+  wrappers are related even if they hold the same value); never `if w_x:`
+  (an error). Use `space.eq_w`, `space.is_w`, `space.is_true`.
+- `space.unwrap` "must be avoided whenever possible … only when you are well
+  aware that you are cheating, in unit tests or bootstrapping code"; the
+  typed variants (`int_w`, `str_w`, `float_w`, `interpclass_w`,
+  `unpackiterable`) are the sanctioned probes.
+- All app-level exceptions are carried by **`OperationError`** at interp
+  level, sharply distinguishing app-level failures from interpreter-level
+  bugs. Raise: `raise OperationError(space.w_XxxError, space.wrap("msg"))`.
+  Catch by `e.match(space, space.w_XxxError)` — **not** by comparing
+  `e.w_type`, which misses subclasses. A stated future direction (never
+  qualified further): replacing OperationError with a family of common
+  exception classes (AppKeyError, AppIndexError, … with a generic AppError).
+- **"Application level is often preferable"**: app-level code is
+  substantially higher-level, easier to write and debug (the worked example
+  is `dict.update` — three obvious lines at app level vs a verbose
+  `space.call_method`/`space.iter`/`space.next` loop catching StopIteration
+  at interp level). "In almost all parts of PyPy, you find application level
+  code in the middle of interpreter-level code." The only caveat is
+  bootstrapping order (app-level helpers need an initialized space).
+
+**Gateways** cross the barrier in both directions
+(pypy/interpreter/gateway.py), described as "somewhat involved, mostly due to
+the fact that the type-infering annotator needs to keep track of the types of
+objects flowing across those barriers":
+
+- `interp2app(func)` exposes an interp-level function at app level; an
+  **`unwrap_spec`** (e.g. `[ObjSpace, W_Root, Arguments]`) declares how
+  app-level arguments are unwrapped.
+- `app2interp` / `gateway.applevel(...)` let interp-level code call app-level
+  helpers transparently (worked example: the metaclass-finding algorithm is
+  written at app level and invoked from the `BUILD_CLASS` opcode). The
+  stated benefit: the app-level implementation can later be rewritten at
+  interp level without changing callers.
+- Gateway stubs, frame classes and argument-parsing code are **generated at
+  initialization time** "in order to let the annotator only see rather
+  static program flows with homogeneous name-value assignments on function
+  invocations" — full Python dynamism is allowed at bootstrap and invisible
+  to analysis.
+
+Builtin modules are **mixed modules** (`pypy/module/*/__init__.py` declaring
+`appleveldefs` and `interpleveldefs` dictionaries; `app_`-prefixed submodules
+are app-level; inline interp expressions allowed, e.g.
+`'None': '(space.w_None)'`). "There is no extra facility for
+pure-interpreter-level modules because we haven't needed it so far."
+Pure-Python rewrites go to `pypy/lib/`. Module lookup order:
+`pypy/module` (mixed builtins) → PYTHONPATH → `pypy/lib/` →
+`lib-python/modified-2.4.1/` → `lib-python/2.4.1/` ("Never ever checkin
+anything here" — stdlib modifications are made on an `svn cp`'d copy so the
+two directories can be diffed). Modifications were often needed because PyPy
+made all classes new-style by default while CPython's stdlib relied on some
+being old-style (old-style support existed behind `--oldstyle`, implemented
+mostly as user-level code).
+
+### 2.3 Bytecode interpreter internals (D04.2 §7)
+
+- Interpreting a code object = instantiate a **Frame** and call
+  `frame.eval()`. Both CPython and PyPy are stack-based VMs. Frame state:
+  a "fast scope" array of wrapped locals, a **blockstack** (nested
+  control-flow: while/try), the value stack, a reference to the globals
+  dict, and traceback debugging info.
+- PyPy constructs **four specialized frame classes**, chosen per code
+  object: `PyInterpFrame` (plain), `PyNestedScopeFrame`, `PyGeneratorFrame`,
+  `PyNestedScopeGeneratorFrame` (inheriting from both) — specialization
+  generated at initialization time, invisible to the annotator.
+- **Code** objects mirror CPython attribute-for-attribute (co_flags,
+  co_stacksize, co_code, co_argcount, co_varnames, co_nlocals, co_names,
+  co_consts, co_cellvars, co_freevars, co_filename, co_firstlineno, co_name,
+  co_lnotab) and create frames via `create_frame()` — "with proper support of
+  parser and compiler this should allow to create custom Frame objects
+  extending the execution of functions in various ways" (already used for
+  generators and nested scopes).
+- **Function** carries func_doc/name/code/defaults/dict/globals/closure and
+  a `__get__` descriptor producing **Method**; both execute through
+  `call_args()` taking an **Arguments** instance (argument.py), which owns
+  positional/keyword/default/star/star-keyword binding and error reporting —
+  "Function argument parsing is a significant complexity," the stated reason
+  for the generated specialized code.
+- **Module** and **MixedModule** classes; `__builtin__` is the example mixed
+  module.
+- Introspection is descriptor-based: Function, Code, Frame, Module are all
+  **`Wrappable`**; a space asks a wrapped object for its type via
+  `getclass`, then calls the type's `lookup(name)` for the descriptor
+  (typedef.py). The reports cite Raymond Hettinger's descriptor how-to as
+  the model.
+
+The **object space interface** (D04.2 §8.2, "a draft version … still
+evolving, although the public interface is not evolving as much as the
+internal interface") consists of: administrative methods (`initialize`,
+`getexecutioncontext`); the full operation table mirroring CPython's abstract
+object interface (id, type, issubtype, iter, repr, str, len, hash,
+getattr/setattr/delattr, getitem/setitem/delitem, unary and binary arithmetic
+including all `inplace_*` variants, comparisons, `contains`, descriptor
+get/set/delete, `next` — which raises a real NoValue at exhaustion — `call`,
+`call_function`, `is_`, `isinstance`, `exception_match`); object creation
+(`wrap`, `newbool`, `newtuple`, `newlist`, `newdict` — which takes an
+interp-level list of pairs, not a dict — `newslice`, `newstring`,
+`newunicode`); conversions (`unwrap`, `int_w`, `str_w`, `float_w`,
+`interpclass_w`, `is_true`, `unpackiterable`); and data members
+(space.builtin, space.sys, w_None, w_True, w_False, w_Ellipsis,
+w_NotImplemented, plus ObjSpace.MethodTable/BuiltinModuleTable/ConstantTable/
+ExceptionTable).
+
+### 2.4 The Standard Object Space
+
+- "The direct equivalent of CPython's object library (the 'Objects/'
+  subdirectory)": abstract parent `W_Object`, subclasses `W_IntObject`,
+  `W_ListObject`, … A wrapped object is a black box for the main loop.
+- **Everything is wrapped, including integers.** The rationale is stated at
+  length: using plain host integers would force case-testing everywhere
+  (the analogy drawn is CPython's `PyObject*`-except-ints or odd-pointer
+  small-int tricks, which "puts extra burden on the whole C code");
+  "wrapping integers as instances is the simple path, while using plain
+  integers instead is the complex path, not the other way around"; plain-int
+  representation "is a later optimization … it could be introduced by the
+  code generators at translation time" (which is what the tagged-pointer
+  work in §4 later did).
+- **Multimethod dispatch** replaces CPython's `Object/abstract.c` rules.
+  Implementations are named per argument classes (`add__Int_Int(space, w1,
+  w2)` — the worked example uses `.intval`, `ovfcheck(x+y)`, and raises
+  `FailedToImplement(space.w_OverflowError, …)` to fall through to the next
+  candidate). *Delegate* functions convert between implementations
+  (e.g. int→float). Python-level `__add__`/`__radd__` methods are produced
+  by **slicing** the multimethod tables on the first/second argument,
+  reproducing CPython object-model corner cases (`NotImplemented` returns).
+  The stated translation hope: multimethods "can probably be translated to a
+  different low-level dispatch implementation that would be binary
+  compatible with CPython's (basically the PyTypeObject structure and its
+  function pointers)," or "more straightforwardly converted into some
+  efficient multimethod code" if compatibility is not required.
+- **Two modules per type**: the type-specification module `xxxtype.py`
+  (the user-visible type object; e.g. listtype.py enumerates list methods)
+  and the implementation module `xxxobject.py` (data storage + operations);
+  `__new__()` locates the implementation and instantiates it. The declared
+  goal: "It is possible (though not done so far) to provide several
+  implementations of the instances of the same Python type. The `__new__()`
+  method could decide to create one or the other" — invisible to the user.
+  A `typedef` class attribute points an implementation back to its type
+  specification. (D06.1's multidicts/multilists/string-variants, §4, are
+  this mechanism exercised.)
+
+### 2.5 RPython as seen from the coding guide (D04.2 §10)
+
+"We have no formal language definition as we think it is more practical to
+discuss and evolve the set of restrictions while working on the whole
+program analysis." Unlike source-to-source translators (Starkiller is the
+named contrast), analysis starts from **live code objects** after bootstrap
+(§3.1). The rules the coding guide fixes:
+
+- **Flow restrictions**: a variable holds values of at most one type at each
+  control-flow point (None mixed with instances is allowed as null pointer);
+  module globals are constants; all control structures allowed except
+  `yield` (no generators); no run-time definition of classes or functions;
+  exceptions fully supported under the rules below.
+- **Object restrictions**: no variable-length tuples (each element-type ×
+  length combination is a distinct type); lists are allocated arrays
+  (over-allocated so append is fast) with only common index/slice forms
+  allowed (bound-checked only when an IndexError handler is present; no
+  step; negative indexes restricted); dicts need a unique hashable key type
+  (historically string-only, later generalized — with the note that "the
+  implementation could safely decide that all string dict keys should be
+  interned"); methods and class attributes don't change after startup;
+  statically-called functions may use defaults and varargs but dynamic
+  dispatch "enforces very simple, uniform signatures (currently only in
+  opcode dispatch)"; `len` is a special form (a structure never measured by
+  len may drop its length field).
+- **Integer model**: machine-sized signed arithmetic with silent wrap-around
+  after translation, plus explicit helpers: `ovfcheck()` (wraps a single
+  arithmetic op; pre-translation it detects int→long promotion, post-
+  translation it becomes one overflow-checking C operation),
+  `ovfcheck_lshift()`, `intmask()` (wrap-around; code generators ignore it
+  entirely), and `r_uint` (a pure-Python word-sized unsigned class carried
+  through annotation; mixing signed with r_uint yields unsigned). "We have
+  no equivalent of the 'int' versus 'long int' distinction of C at the
+  moment and assume 'long ints' everywhere."
+- **Exception rules**: by default, simple operations raise no exceptions
+  after translation *unless an exception handler is present* — "supplying an
+  exception handler is how you ask for error checking," and its absence is
+  an assertion the operation cannot fail. **The rule does not apply to
+  calls: any called function is assumed to be allowed to raise any
+  exception.** Explicit raises are always generated. Running on CPython
+  keeps all checks live — "PyPy is Debuggable on Top of CPython," catching
+  violated implicit assertions.
+
+### 2.6 Parser and compiler (D04.3, D04.4)
+
+Requirements stated three times: **flexible, translatable, extensible** —
+"extend the grammar for more language features but still using existing
+bytecode" and "eventually extend the bytecode generation," driven by WP09/
+WP10 needs.
+
+The history is a sequence of explicit pivots (each with its stated reason):
+
+1. **First version**: regex tokenizer; grammar parser produced a tree of
+   nested tuples fed to CPython's pure-Python `compiler` package.
+2. **Second version**: (a) tokenizer replaced by **Jonathan David Riehl's
+   DFA/automata tokenizer** — "much easier to convert to RPython than the
+   original tokenizer (at that time the regular expression module was not
+   written in RPython yet)"; (b) "nested tuples of variable length cannot be
+   translated with PyPy," so a **StackElement** composite (terminal/
+   non-terminal instances) mirrored the tuple tree "in an RPythonic way,"
+   with the still-untranslatable compiler converting back to tuples.
+3. **Third version — AstBuilder**: builds the AST *directly during parsing*,
+   dropping CPython's Transformer, which was "buggy, complex and … difficult
+   to translate to RPython." The precise typing obstruction is recorded: the
+   transformer input tuples `('rulename', arg-or-token, lineno)` cannot be
+   RPython-typed because the second slot is heterogeneous, and "the path we
+   chose was to produce AST directly with the AST builder." Noted structural
+   difficulty of the direct approach: AstBuilder reduces bottom-up, so
+   context is sometimes missing (`a.b` is a different node on the left vs
+   right of an assignment); resolved by post-modification or deferred node
+   instantiation.
+
+Architecture: three independent actors — **Tokenizer** (DFA-based;
+Memento-pattern `context()`/`restore()` for backtracking, since "Python's
+grammar is mostly LL(1)" but not strictly), **Parser** (grammar rules as a
+**Composite** of GrammarElement subclasses: Sequence, Alternative,
+KleeneStar, Token, each with recursive-descent `match()`), and **Builder**
+(interchangeable; the source of the version history above). "The three parts
+we just described are really independent, and that's one of the reasons why
+our parser is so flexible."
+
+The Python grammar is **built at startup from CPython's pristine `Grammar`
+file** through a grammar-of-grammars (the Grammar file's own syntax "never
+changes across versions," so its parser is defined once; a two-pass
+EBNFVisitor links rule symbols and creates anonymous `:`-prefixed subrules).
+Motivation: "As the syntax is likely to change between different versions of
+Python, it is important for PyPy to have an automated way to build a correct
+grammar object depending on the version of Python we want to use."
+
+The compiler is a **~50% rewrite of CPython's `compiler` package** (which
+CPython itself never uses for normal compilation). ASTs are traversed twice
+— once to gather scoping information, once to emit a flow graph of bytecode.
+RPython-driven changes: the dynamic visitor (`getattr(visitor, "visit_%s" %
+classname)`) was replaced by a generated static `accept()` per node class;
+state passed down the tree via variable signatures was rewritten as stacks on
+the visitor. "In the process of porting this original package to RPython, we
+discovered a number of unexpected problems and bugs. This made the porting
+more involved and time-consuming than expected"; comparisons against either
+CPython compiler were judged unreliable (the Python package "has a lot of
+bugs in corner cases"; the C compiler applies optimizations "for which we
+don't care for now"), so the operational criterion chosen was: "we chose to
+consider our compiler operational as long as all the compliance tests pass."
+
+Bytecode assembly: **FlowGraph/PyFlowGraph** of branchless Blocks;
+`flattenGraph` topologically sorts to minimize jumps, then patches jump
+targets. Recorded limitation: forward long jumps (>65435 bytes) are not
+implemented — "long jumps … can only be made backward" — justified by
+CPython parity, the rarity of such code objects, and "a sure sign of bad
+programming practice." The line-number table uses CPython's compressed
+two-byte encoding. All instructions were wrapped in `Instr` instances for
+RPython compliance.
+
+Stated future evolutions (D04.3 §7): static syntax experiments by editing
+the grammar file; **dynamic** syntax modification ("an Oz-like syntax for
+logic/constraint programming triggered by `import csp_syntax`"); AST
+rewriting before compilation (optimizations, AOP/DbC injection); extending
+bytecodes judged "certainly not trivial" and probably unneeded.
+
+### 2.7 Testing conventions established by WP04
+
+Two kinds of unit tests: **interp-level tests** (run on CPython against a
+space) and **app-level tests** (`AppTest*`, run by PyPy's interpreter;
+cannot import interp-level modules; data passed via `setup_class` and
+`w_`-prefixed class attributes). The `-o` switch selects the object space.
+Compliance tests are CPython's regression suite with modified copies kept
+under `lib-python/modified-X.Y.Z/` so the delta against the pristine tree is
+diffable. An issue tracker (roundup) is driven from svn commit messages.
+
+---
+## 3. RPython and the translation toolchain (D05.1–D05.4, D07.1)
+
+D05.1 ("Compiling Dynamic Language Implementations", 43 pp) is the
+theoretical core of the corpus — flow space, annotator with a formal model
+and proofs, RTyper, backends. D05.2 is the 0.7 release report; D05.3 covers
+memory management and threading as translation aspects; D05.4 is the
+overview paper with the measured aspect costs; D07.1 (§4 below) finishes the
+GC and stackless stories.
+
+### 3.1 The core idea: analysing live programs
+
+- Full static analysis of Python is framed as impossible in principle: "The
+  notion of 'declaration', central in compiled languages, is entirely missing
+  in Python." Class/function/module definitions are *statements executed at
+  runtime*; `os.py` builds its interface dynamically per host OS; import
+  hooks are common. "This point of view should help explain why analysis of
+  a program is theoretically impossible: there is no declared structure to
+  analyse" (D05.1 §3.1). The authors consider this more fundamental than the
+  classical `eval`/introspection arguments.
+- The pivot: analyse **live programs in memory** after bootstrap. "In some
+  sense, we use the full Python as a preprocessor for a subset of the
+  language, called RPython." Three levels of restriction are contrasted:
+  analysing dead source (gives up all dynamism); analysing a frozen memory
+  image (gives up dynamism after a point — "natural in Smalltalk-like image
+  environments"); PyPy goes further and allows fully dynamic sections *as
+  long as they are entered a bounded number of times*. Worked example:
+  `interpreter/gateway.py` builds a custom wrapper class per function — a
+  finite set, but one that is hard to enumerate manually, so **the inference
+  tool itself invokes the class-building code as part of inference**.
+- RPython is deliberately **not formally defined**: "we have no formal
+  language definition as we think it is more practical to discuss and evolve
+  the set of restrictions while working on the whole program analysis"; its
+  definition is informally "Python without the operations and effects that
+  are not supported by our analysis toolchain." Being RPython is a property
+  of *entire programs* (the annotator is a global analysis). "It is mainly
+  because of this trade-off situation [flow space vs annotator capability]
+  that the definition of RPython has shifted over time" (D04.2).
+- Lineage from Psyco's dynamic analysis: the ability to "fall back to
+  regular interpretation for parts that cannot be understood is a central
+  feature."
+
+### 3.2 The Flow Object Space (D05.1 §5)
+
+The *unmodified* bytecode interpreter runs with a special object space whose
+objects are empty placeholders; recorded operations give "an assembler-like
+view of what the function performs." "An object space is thus an
+interpretation domain; the Flow Object Space is an abstract interpretation
+domain." The flow space is described as a "short but generic plug-in" — it
+"enables an interpreter for any language to work as a front-end", and syntax
+or bytecode changes need implementing only once, in the standard
+interpreter.
+
+Mechanics as documented:
+
+- The flow space interrupts the interpreter after every bytecode and
+  synthesizes a **frame state** (position-dependent data: bytecode index,
+  exception-handler stack; plus the flattened list of variables/constants),
+  comparing it with previously seen states at the same position. New state →
+  new block; identical state → backlink (loop closed); "similar enough"
+  (same position-dependent part) → **merge** into a more general state via a
+  union operation: two equal constants unify to that constant, everything
+  else unifies to a fresh variable. If the merged state is strictly more
+  general, the existing block is cleared and re-used ("Reusing the block
+  avoids the proliferation of over-specific blocks" — e.g. it prevents
+  unrolling the first loop iteration with the counter constant).
+- **Branching**: `is_true` on a variable must capture both paths. "Without
+  proper continuations in Python," an explicit replay scheme is used: normal
+  blocks (**SpamBlocks**) carry a frame state; branch outcomes create
+  special blocks (**EggBlocks**) with *no* frame state, forming a binary
+  tree under the nearest SpamBlock; an EggBlock is reached by **replaying**
+  the recording from the root block, with replaying recorders checking that
+  the same operations are re-issued and answering each `is_true` per the
+  branch. This captures all flow paths *including those internal to the
+  interpreter engine*, not just those visible in bytecode — e.g.
+  `UNPACK_SEQUENCE n` generates a tree with n+1 branches. Stated
+  limitation: the engine may not use an unbounded loop to implement a single
+  bytecode; all loops must exist in the bytecode, because backlinks are only
+  inserted from the end of one bytecode to the beginning of another.
+- **Dynamic merging**: a block is only created at a bytecode that actually
+  produces an operation, so merging happens only there — which
+  constant-folds aggressively across branches (two syntactically different
+  functions can produce the same graph). **Admitted consequence**: the flow
+  space "is not guaranteed to terminate" — a constant infinite loop is
+  followed forever. The stated mitigation is cultural, not technical: "we
+  make sure that the code that we send to the Flow Space is first
+  well-tested. This philosophy will be seen again."
+- **Geninterp**: app-level helper code is automatically turned into
+  interp-level code by flowing it and emitting one `space.xxx()` call per
+  recorded operation; the goto-less output uses a `next_block` dispatch
+  loop, which dynamic merging later constant-folds away when such code is
+  re-analysed.
+- Graphs are in **SSI form** (Static Single Information, an extension of
+  SSA): every variable is used in exactly one block; live values are passed
+  along links like call parameters instead of phi nodes; each block declares
+  input variables. Operations are written `z = opname(x1,…,xn)|z'` where z'
+  is an auxiliary variable used by special rules (see the list rule below).
+
+### 3.3 The Annotator (D05.1 §6)
+
+Forward abstract interpretation over a lattice, with a formal model and
+proofs — the term "annotation" is chosen over "type" because "an annotation
+is a set of possible values, and such a set is not always the set of all
+objects of a specific Python type."
+
+- **Lattice**: `Bot`/`Top`; `Bool ≤ NonNegInt ≤ Int`; `Char ≤ Str`;
+  `Inst(class)` with `Inst(sub) ≤ Inst(base)`; `List(v)` where v is a hidden
+  variable summarising the items (List terms mutually unordered);
+  `Pbc(set)` (subsets of the finite, discovered-as-you-go set of pre-built
+  constants: functions, classes, potential bound methods C.f, frozen
+  pre-built constants, None = Pbc({None})); **nullable twins** of
+  string/instance/Pbc annotations track what can be NULL after translation
+  (all lists implicitly nullable). Every annotation also has a
+  single-known-object constant variant. The full extended lattice (Dict,
+  Tuple, Float, UnicodePoint, Iterator, …) lives in
+  `pypy/annotation/model.py`.
+- **Why forward-only**: Python "gives useful info about a variable only from
+  how it was produced, not how it is used" — deliberately "a more naive
+  approach than … Hindley-Milner." A state is (bindings b: V→A, equivalence
+  relation E on V); rules generalise the state monotonically; a fixed point
+  is reached because the lattice has no infinite ascending chain.
+- **Mutable objects are named the hard part**: "Tracking mutable objects is
+  the difficult part of our approach." Lists are homogenised (RPython has no
+  heterogeneous lists); aliasing is handled by embedding a **hidden item
+  variable** in each `List(v)` annotation, shared by all aliases, so
+  generalising an item type instantly reschedules every reader. Merging two
+  lists identifies their hidden variables — "This process gradually builds a
+  partition of all lists in the program, where two lists are in the same
+  part if they are combined in any way."
+- **Classes/instances**: attributes are attached to the class where first
+  seen written; polymorphic use lifts them to the common base. Stated
+  assumptions/limits: "the annotator is limited to single inheritance plus
+  simple mix-ins"; all instances reaching a program point must share a
+  user-defined common base (not `object`); bound methods may be passed
+  around but **not stored back into instances** ("It is a limitation of our
+  annotator to not distinguish these two levels — there is only one set of
+  v_{C.attr} variables for both" class- and instance-level attributes). A
+  `lookup_filter` mechanism recovers precision lost by identifying attribute
+  variables up the hierarchy.
+- **Calls**: one combined rule per `simple_call` handles Pbc sets mixing
+  functions, classes and methods — "Calling a class returns an instance and
+  flows the annotations into the constructor __init__."
+- **Proofs and cost**: generalisation, termination, and soundness are proved
+  for the static model (§6.9; the authors call the goal "an intuitive
+  understanding of why annotation works"); with the non-static extensions,
+  termination is provable only under "a computable bound on the number of
+  functions and classes that can ever exist at run-time" (true for PyPy).
+  "No formal complexity bound" is given — "Worst-case scenarios would expose
+  severe theoretical problems. In practice, these scenarios are unlikely."
+  Empirically: annotating all of PyPy (~20,000 blocks / ~4,000 functions)
+  took **~5 minutes**, with each rule re-applied 20–40× — "suggesting
+  n·log(n) practical complexity." A stated future need that never shipped in
+  the EU period: **modular annotation** (imposing annotations at interface
+  boundaries so parts can be annotated independently).
+- **Non-static extensions** (§6.10) — "in practice annotation is much less
+  'static'":
+  - **Specialization** by explicit flags: per-argument-annotation copies;
+    per-argument-value; **ignoring** (the call is dropped — used for
+    test/debug code); **by arity** (default for `*args`); **ctr_location**
+    (a fresh class copy per instantiation site — "a simple but potentially
+    over-specializing way to get class polymorphism"); **memo** (the call is
+    fully computed at annotation time and compiled as a table lookup).
+  - **Concrete-mode execution**: memo functions and everything they call are
+    concretely executed during annotation with *no* staticness restriction,
+    typically instantiating classes, sometimes building new classes and
+    functions — "used quite extensively in PyPy"; "switching to concrete
+    mode execution is an integral part of our annotation process."
+  - **Constant propagation** exists mainly for **dead-code removal**, not
+    speed ("low-level compilers already do this well") — a
+    `Bool(const=False)` branch is simply never followed. This is the
+    mechanism by which bootstrap-only code is hidden from analysis (frozen
+    pre-built constants force their caches, so the `if not_computed_yet:`
+    branch is dead).
+  - **Narrowing**: `isinstance(obj, Sub)` and comparisons narrow annotations
+    per-branch via an extended Bool annotation carrying (true-case,
+    false-case) refinements per variable.
+- **Error philosophy**: "we do not generally try to prove the correctness
+  and safety of the user program, preferring to rely on test coverage" —
+  e.g. concatenating two nullable strings is taken as a *hint* they are not
+  None, not an error. Degeneration to `Top` is reported at its first
+  appearance (only possible once the toolchain matured; Top had been an
+  essential fallback during development).
+
+### 3.4 RTyper and the low-level object model (D05.1 §7.1, D05.3 §4)
+
+"The central bridge" between annotator and backends: it emits no source, but
+replaces each RPython-level operation with low-level operations, chosen by
+**representation objects** keyed on annotations — one representation per
+used annotation.
+
+- **Two type systems**: **lltype** — C-like: primitives, structs, arrays,
+  function pointers, opaque types, non-primitives handled only via pointers;
+  memory management still partially implicit (the backend inserts
+  refcounting/GC). **ootype** — classes/instances for OO backends (see
+  §6.2). Subclassing under lltype = nested substructures: an instance of B
+  is a struct whose first field is the substructure for parent A; "These
+  structure layouts are quite similar to how classes are usually implemented
+  in C++."
+- Documented vtable layout (D05.3 §4): one vtable per class;
+  `object_vtable` = {parenttypeptr, rtti, subclassrange_min,
+  subclassrange_max, name, instantiate()}; subclass vtables inline the
+  parent vtable and append method function pointers and data class
+  attributes; instances = {typeptr} plus inlined parent struct plus own
+  fields.
+- **Subclass checking** is cited as the flexibility show-piece: a naive
+  linear parent walk was replaced by the **relative numbering algorithm**
+  (subclassrange_min/max) "by changing just the appropriate code of the
+  rtyping process."
+- **Identity hashes of pre-built constants**: the default identity hash is
+  the address, but a PBC's pre-translation hash may already have been
+  captured; the solution is an extra per-instance field caching the
+  pre-translation address (zero for fresh objects, filled on first hash) —
+  "A similar strategy is required, anyway, if we want to use a copying
+  garbage collector later on."
+- **Cached functions with PBC arguments**: a function from a finite Pbc set
+  is executed concretely at annotation time and compiled as a field read on
+  the PBCs.
+- **Representation choice driven by annotation**: resizable lists get an
+  extra indirection (struct → array) with over-allocation; never-resized
+  lists become plain arrays; lists known to be unmutated `range()` results
+  store only start/stop. The stated plan for **tagged pointers** ("instead
+  of boxing … requiring explicit hints on the classes; field access would
+  become masking operations") is the origin of the D07.1 experiment (§4).
+- **Helpers and LLPython**: any operation with no direct C equivalent gets a
+  helper *written in Python* and fed back through flow space → annotator →
+  RTyper, with different default specializations at that level (several
+  copies per low-level argument type). "This approach shows that our
+  annotator is versatile enough to accommodate different kinds of
+  sub-languages at different levels … the resulting language feels like a
+  basic C++ without any type or template declarations." A D14.2 slide
+  records the rejected alternative: "Originally we tried to do the job the
+  RTyper does at the same time as source generation. Failed. Miserably."
+
+### 3.5 Backends (D05.1 §7.2, D05.2)
+
+- "Basically straightforward, [but] messy in practice." The backend owns
+  memory management, the exception model, and execution-model changes
+  (coroutines). Little code is shared even between GenC and GenLLVM, which
+  consume the same low-level graphs.
+- **GenC** works in two passes: (1) recursively collect all functions and
+  pre-built data structures, recording struct types; (2) emit forward struct
+  declarations → struct definitions → forward function/data declarations →
+  bodies and static initializers. Each block becomes labeled C with jumps;
+  a few "primitive" functions have no graph and are hand-written in a
+  support C file.
+- Another rejected code-generation alternative is recorded: "writing a lot
+  of template C code that gets filled with concrete types" was tried and
+  abandoned in favour of the RTyper + backend split.
+- D05.2 outcome summary for 0.7: toolchain for C and LLVM; "ref counting and
+  Boehm garbage collectors," thread models, and platforms (Mac OS X, Linux,
+  Windows) selectable modularly; compiled pypy-c "200 times slower than
+  CPython and a factor of 10 times faster than pypy running on top of
+  CPython. Execution speed was considerably improved shortly after the
+  release." Early Java backend work "mothballed"; Impara joined for the
+  Squeak backend; JavaScript experiments noted.
+### 3.6 Translation aspects — the doctrine and its measured cost (D05.3, D05.4, D07.1)
+
+The reports' central architectural claim: low-level concerns are **not present
+in the interpreter source** and are woven in during translation.
+
+- "The implementation code simply makes no reference to memory management …
+  This contrasts with CPython where the decision to use reference counting is
+  reflected tens or even hundreds of times in each C source file." And, in
+  D07.1's restatement: refcounting chosen early "accounts for the fact that
+  operations to increase and decrease reference counts are sprinkled over all
+  the source files, which makes changing this choice very hard."
+- "Any combination of aspects can be selected freely, avoiding the problem of
+  combinatorial explosion of variants which can be seen in manually written
+  interpreters." (See §6.4 for the 1.0 compatibility matrix that qualifies
+  this in practice.)
+- **The helper-graph pattern**, used by every transformation: new
+  functionality (GC logic, stackless bookkeeping) is written as RPython
+  "system code" helpers, sent through the same toolchain to produce extra
+  graphs, and "the transformation proper only inserts calls to these extra
+  graphs into the original graphs as appropriate."
+- The correctness argument is made explicitly for refcounting: CPython
+  programmers must make "a large number of not-quite-trivial decisions about
+  the refcounting code," and "Experience suggests that mistakes will always
+  creep in, leading to crashes or leaks … it is surely better to not write
+  the reference count manipulations at all. … Writing the code that emits the
+  correct reference count manipulations is surely harder than writing any
+  single piece of explicit refcounting code, but once it is done and tested,
+  it just works without further effort."
+- **Multiple interpreters** come for free: with a single space instance the
+  `space` pointer is a pre-built constant and *disappears* from generated
+  code (arguments, locals, fields); with two instances a space attribute is
+  kept automatically — "the best of both worlds." (CPython's interpreter-state
+  API is cited as inherently partial — interned strings are a file-level
+  static shared between interpreters, and an `interp` pointer on every object
+  was judged too costly there.)
+- **Measured aspect costs at 0.8** (D05.4, October 2005; binary ≈5.6 MB on a
+  Linux Pentium; "We have not particularly optimized any of these aspects
+  yet"): stackless +8% time / +28% size (~300 lines of changes, done at the
+  Paris sprint "in a couple of days" — versus "about six months" for the
+  original invasive CPython stackless patches); two object-space copies +10%
+  / +40%; thunk space +6% / +13%; refcounting **2× slower than Boehm**.
+  **Composability check**: five aspects × two choices = 32 possible
+  translations; the predicted cost of stackless+thunk (1.06 × 1.08 ≈ 1.14×)
+  matched the measured 1.15×.
+
+### 3.7 Memory management (D05.3 §5, D07.1 §4.2)
+
+- **Boehm** (conservative) and **naive refcounting** were the first two
+  production GCs. The Boehm transformer "does mostly nothing but replace the
+  allocating operations with the special Boehm versions" — plus it exploits
+  toolchain knowledge to pick the best allocation function per type
+  (pointer-free objects like strings use the untraced variant). Documented
+  Boehm pitfall: conservative scanning kept objects alive whenever an
+  integer had a pointer's bit pattern — which *actually happened* because
+  identity hashes were the memory address; the fix was to use the **bit-wise
+  inverse** of the address as hash. Measured: Boehm 4.4–5.8× slower than
+  CPython; "Boehm seems to be the fastest garbage collector option we
+  currently have."
+- **Refcounting** is judged in its own report: placement "far from being
+  optimal" (no redundancy elimination, no trusted references), no cycle
+  collection at all ("a fundamental flaw of reference counting … CPython
+  solves this with special cyclic-garbage code that PyPy lacks"), 7.7–7.8×
+  slower than CPython — "one of the slowest of our GCs"; "not … a very
+  interesting area to work on since it is a lot easier to get high
+  performance using other algorithms," though nominally "a possibly viable
+  option" pending optimization.
+- **The GC framework**: exact GCs written in RPython against `Address`
+  objects, testable on a **memory simulator** on CPython ("does not involve
+  constant segmentation faults"), then woven in by the **GC transformer**.
+  Explicitly inspired by MMTk ("Much more work and fine-tuning has gone into
+  MMTK, though"). Details the reports record:
+  - The transformer replaces allocations with GC helper calls and
+    reads/writes with **read/write-barrier calls** where the GC requires
+    them; performance-critical helpers (allocation fast path, write barrier)
+    can be marked always-inline — "similar to the control over inlining that
+    MMTK uses."
+  - Object layout information flows through **compile-time `typeid`
+    tables** (all types known statically).
+  - The simulator evolved from byte-level simulated memory to symbolic
+    address arithmetic: address offsets "are represented purely
+    symbolically," arenas are simulated objects that can be declared
+    exhausted for testing, and freed explicitly-managed objects give useful
+    errors when touched. GC-internal data structures are flagged for
+    explicit management.
+  - Three framework GCs existed at D05.3 (copying, mark-and-sweep, deferred
+    refcounting) but ran only on the simulator; by D07.1 **mark-and-sweep**
+    was the production framework GC: two header words per object (mark bit +
+    typeid; a link chaining all allocated objects), finalizer-needing
+    objects on a separate list, resurrection supported, and finalizers run
+    **at most once** — a deliberate behaviour change from CPython, where
+    finalizers can run "arbitrarily often — a fact that has been a source
+    for interpreter crashes." Measured: 5.7–5.8× slower than CPython
+    ("quite reasonable … although not quite as fast as with the Boehm
+    collector").
+- **Root finding** is called "one of the hardest problems" without compiler
+  cooperation — "especially hard … using only ANSI C and in a platform
+  independent way." The shipped solution is an explicit **root stack**
+  (push/pop inserted by the transformer; "not overly good performance").
+  The implemented alternative — unwind the stack via the stackless
+  transformation and read roots from the heap frame chain — was **measured
+  worse**: 13–15% slower and +70% code (every malloc becomes a potential
+  unwind point), "very bad instruction-cache behaviour neutralizing
+  improvements." A stated future possibility: "use information from the
+  still-unfinished just-in-time compiler to find roots on the C stack" (the
+  JIT knows the frame layout it generated).
+- **Moving/copying GCs** were future work, blocked at the time by two named
+  obstacles: consistent identity hashes across moves (the PBC hash-field
+  technique of §3.4 is noted as the required shape) and **rctypes** (the
+  external-call machinery could not tolerate moving objects — "the major
+  factor stopping us from experimenting with advanced GCs so far," per
+  D03.1).
+- D05.3's **escape-analysis** precursor ("exploding" an object into one
+  variable per field when it provably dies with its frame) is recorded with
+  the caveat that it "only works well in the presence of function inlining"
+  since most allocations happen inside small helpers.
+
+### 3.8 Stackless (D05.3 §6.3, D05.4 §4.1, D07.1 §3)
+
+Motto: "A Python Implementation That Uses the C Stack as a Cache."
+
+- **The design decision underneath**: the interpreter deliberately keeps
+  **interpreter-level recursion for app-level calls** — in Python almost any
+  operation can lead to a non-tail-recursive call, so a non-recursive
+  interpreter would be "extremely tedious" (the recorded lesson of Stackless
+  Python v1, which "required extensive modifications to support continuing
+  past anything other than a direct Python to Python call, which made
+  tracking the development of the Python language extremely difficult").
+  Instead, the **stackless transformation** rewrites the graphs at
+  translation time.
+- **Mechanism**: a special `UnwindException` unwinds the whole C stack like
+  an uncaught exception, but every interrupted function catches it, saves
+  its live locals into a heap frame, and re-raises; the heap mirror is a
+  linked list of GC'd frame structures, each holding a back pointer, a
+  compact integer identifying function + resume position (one global table
+  maps it back), and the live locals. Because each resume point would need
+  its own struct layout, the transformer **type-erases and sorts the saved
+  fields** "to reduce the number of different layout variants to reasonable
+  levels." At the bottom sits a hand-written **driver** that pops and
+  resumes saved frames one at a time, transporting return values and
+  exceptions between callee and caller.
+- **Resume points are placed *after* calls.** The rejected alternative
+  (placing them before calls and re-performing the calls — tried in the
+  literature, [PICOIL]) is contrasted with two stated advantages of
+  after-call placement: it handles frame chains deeper than the C stack
+  limit (the whole chain never needs to be resident), and it makes
+  microthread switching **amortized constant-time** ("particularly important
+  for our main use case of many massively parallel microthreads frequently
+  switching control"). Only the innermost frame is ever restored; "the
+  'real' stack … is but a cache for the top section of the current
+  heap-based frame chain."
+- **Stack-overflow checks** are placed by computing **back edges of the call
+  graph** and inserting a check before those calls only — every recursive
+  cycle meets at least one check, fast paths meet none.
+- **Performance design goal**: "we never take a pointer to any local
+  variable," so C register allocation still works; restore writes happen
+  immediately before a jump to the resume point, so they compile to writes
+  into the allocated registers. Measured (rev 34906): +17–19% time on
+  Boehm builds, +26–28% on framework-GC builds; code 2.1–2.4×. The rejected
+  "locals in a struct" approach measured **+60–64%**. D05.4's earlier
+  numbers (+8%, +28% size) predate the 0.9-era rework. Stackless features
+  "are not thread-safe so far … although this is not a deep problem."
+- **The primitive layer**: `stack_unwind()`, `stack_frames_depth()`, and the
+  core coroutine primitive `yield_current_frame_to_caller()` returning an
+  opaque `frame_stack_top` with `.switch()`. Documented hard rules: every
+  `frame_stack_top` must be resumed **exactly once** (never → leak; twice →
+  crash), and a function that yielded its frame must not raise (no implicit
+  parent). The interface is "extremely primitive" by design and wrapped in
+  plain RPython (the Coroutine class); on more flexible platforms the same
+  interface could be implemented natively (Squeak, or assembly stack
+  copying).
+- **Stack reconstruction** — named resume points (`resume_point("label",
+  vars…, returns=varR)`), `resume_state_create(back_frame, "label",
+  values…)` and `resume_state_invoke(return_type, frame_top)` let an RPython
+  program "artificially rebuild a chain of calls in a reflective way,
+  completely from scratch, and jump to it." "We know of no equivalent of
+  this feature in the literature." The consumer is coroutine pickling:
+  unpickling a chain of Python-level frames requires manufacturing the
+  corresponding interpreter-level frame chain.
+- **App-level offering** (the 0.9 `stackless` module — interface declared
+  "in-flux"): **coroutines** (explicit switch; bind/switch/kill; kill's
+  exception "currently not visible at app-level, so uncatchable and
+  try/finally not honored — will be fixed in the future"); **tasklets and
+  channels** ("roughly compatible" with Stackless Python, implemented *at
+  application level* in `pypy/lib/stackless.py` on top of coroutines — "the
+  code tries to resemble the stackless C code as much as possible. This
+  makes the code somewhat unpythonic"; strictly round-robin scheduling;
+  channels are meeting points, not queues); **greenlets** (tree-structured,
+  identical to the py-lib interface; PyPy's "do not suffer from the cyclic
+  GC limitation that the CPython greenlets have").
+- **Coroutine pickling**: frames are fully picklable (bytecode reference +
+  locals); globals/modules pickled by name; the pickle stores a bytecode
+  index, so "the user program cannot be modified at all between pickling and
+  unpickling!"; pickling **fails if the suspension point involves indirectly
+  invoked Python frames** (operators calling `__xyz__`, builtins calling
+  back, signal handlers) — "not supported yet." Measured: pickling ~7–9 ms,
+  unpickling ~10–12 ms ("implemented mostly at application-level, which
+  explains their slowness").
+- **Coroutine cloning** (GC-pool based; the claimed novel contribution:
+  "The approach of using the GC to allow a form of coroutine cloning is, to
+  the best of our knowledge, novel"): correct semantics chosen = duplicate
+  exactly the objects *created by* the cloned coroutine, share the rest;
+  implemented by giving the GC a per-coroutine allocation **pool** and
+  switching pools on coroutine switch; byte-level copies with recursive
+  copying inside the pool. Requires `--stackless --gc=framework` together.
+  `fork()` returns a child clone UNIX-style. The showcased consumer is
+  logic-programming search (§7). The report's conclusion holds this up as
+  the integration proof: cloning uses the GC pools + the stackless heap
+  frames + the coroutine abstraction — "no C code was involved in any of
+  this."
+- **Composability**: coroutine models "do not compose naturally" — two
+  unrelated usages of switching conflict through the single implicit "main."
+  The fix: per-user **"views"** (`stackless.usercostate`), each with its own
+  main/current; switching is implicit within the target's view. Stated
+  future direction: "we will probably change the app-level interface … to
+  not expose coroutines and greenlets at all, but only views." The
+  composability design is claimed as new "as far as we know."
+- **Microbenchmarks** (D07.1 §3.3.7): PyPy coroutine/greenlet switch time is
+  **independent of stack depth** (~6–17 μs), while CPython's greenlet switch
+  is **linear in depth** (1.81 μs at depth 0 → 25.93 μs at depth 100 — each
+  switch memcpys the whole greenlet stack). OS threads: 8.4 MB virtual per
+  thread on default Linux → a 32-bit address space exhausts at ~382 threads.
+- **Motivating deployment**: CCP Games (EVE Online) used and sponsored
+  Stackless Python; a CEO quote credits its concurrency model as the
+  foundation of their success. The stated application classes: simulations
+  with thousands of agents; servers with many concurrent clients; web
+  servers resuming continuations ("breaking the back button" example);
+  checkpoint/migration in clusters; and logic-programming choice points via
+  cloning.
+
+---
+## 4. Core optimizations (D06.1) and translation-level optimizations (D07.1 §4.1)
+
+### 4.1 Method
+
+"Because optimization is at its core such an empirical activity, we begin by
+describing the process by which we assessed the benefit of each attempt at
+optimization." Five benchmarks were settled on (finding suitable ones is
+called "no trivial task"):
+
+| Benchmark | What it stresses (as stated) |
+|---|---|
+| pystone | "the archetypal Python benchmark, but in no way typical Python code" (Dhrystone lineage) |
+| richards | "of all the benchmarks most tests the performance of method calls" |
+| templess | regular expressions and string handling |
+| gadfly | pure-Python SQL database; non-trivial algorithms, heavy long-integer use |
+| mako | Unicode handling |
+
+The last three allocate much more memory, hence stress the GC. Plus
+microbenchmarks per interpreter part, and **automated nightly runs** of
+pystone/richards to catch regressions. Environment: a 4-core Xeon 3.2 GHz
+(single core used). Headline: "the speed of a compiled PyPy with all
+optimizations enabled is more than twice that of a binary with some
+optimizations disabled" — and the real total is higher, since clear wins
+adopted before the D13.1 toggle framework were never made optional.
+
+### 4.2 Multimethod dispatch compression
+
+- The original automatically-generated **chained double dispatch** grew
+  quadratically: N types × N vtable entries per doubly-dispatched
+  multimethod, until vtables occupied "more than 50% of the total size" of
+  the executable.
+- Replaced by **Multiple Row Displacement** (Pang et al.): a pair of
+  integers per vtable plus small compressed tables. Effect on the C
+  backend: **−2.5 MB, almost half the binary**, at "a few percent slower"
+  runtime — explained as double-dispatch being one double indirect jump vs
+  MRD's ~4 arithmetic instructions + one indirect jump, "and indirect jumps
+  are costly on modern processors, so effects even out." Verdict:
+  "double-dispatch is marginally faster … but requires a prohibitively large
+  amount of static data, making [MRD] a better practical choice."
+- On the OO backend (pypy-cli/Mono) the trade inverts: **MRD measured 15%
+  slower**, so double dispatch remained the OO default. (Indirect *method*
+  calls are what OO platforms optimize; indirect *function* calls need
+  delegates.)
+
+### 4.3 The D06.1 empirical record, optimization by optimization
+
+Author-judged results, with the numbers they reported (baseline 1.0, lower
+is better, unless stated):
+
+| Optimization | Verdict / numbers |
+|---|---|
+| Prebuilt small-integer boxes (−5..99 / −5..256) | **Mixed/negative**: 0.98–1.06 across benchmarks; suspected **bad cache effects** (fresh integers are cache-hot; prebuilt ones need extra loads); the marginal win required "a hack to prefetch the `intval` field" |
+| String join objects, string slice objects, ropes | 3% faster to 9% slower, "no clear tendency" — apps are tuned for flat strings; benefits only for code written against the new complexity profile (e.g. an editor buffer over ropes); noted side-benefit: ropes keep naive algorithms efficient |
+| Multidicts + StrDictImplementation | **15–40% improvement**, "the bulk likely from not needing method dispatch to check key equality"; "dictionaries play a central role in Python, performance-wise" |
+| SmallStr/SmallDict (sequential-search small dicts) | "almost no effect" — most lookups hit a few large dicts (modules, builtins) |
+| SharedDict (key-sharing instance dicts) | Memory for 1M two-attribute instances: 140,136 KB vs 266,860 KB baseline (CPython 202,548; `__slots__` 96,640) — "`__slots__` behaviour, transparently"; speed ~1% faster to 10% slower |
+| Multilists: range lists, list slices, chunk lists | 3% faster to 11% slower; noted: with range lists "xrange would not be necessary" |
+| Optimal resizable arrays (Brodnik) | "as bad as 4 times slower" — optimal in theory, huge constants |
+| CALL_LIKELY_BUILTIN + shadowing-tracking module dicts | 0.81–0.89 (11–19% faster); "not a pure win — it slows writes to global variables slightly" |
+| Shadow tracking (instance-attr shadowing flag on dict impl) | richards 21%, pystone 14%, templess 4% faster; disabled entirely for instances that ever shadow — "further research could improve on this" |
+| Method cache (per-class version_tag, global (tag,name) table) | richards up to 23% at 1024 entries; 128 entries already good, 512 sufficient for templess; "caches the result of *any* lookup"; compared with PICs: one global cache uses less memory and is "unlikely to miss often in tight loops" |
+| LOOKUP_METHOD/CALL_METHOD | ~6%; "either a net win or have no effect" |
+| All three method optimizations combined | richards 0.53, pystone 0.78, templess 0.75 — "up to 47% … surpassing even what could have been expected from the individual speed-ups" |
+| Precomputed `__xyz__` lookups on builtin types (translation-time, `cache__xyz__` fields on W_TypeObject) | "an obvious big win with no trade-off": disabling costs 22–32%; included in every baseline |
+| Switch-based dispatch loop | Mixed 0.91–1.05; "we can only guess" — suspected code-size/locality effects after inlining |
+| Argument-passing fast paths | call microbenchmarks: 5.03–6.56× slower than CPython (Mar 2006) → **2.65–3.44×** (Mar 2007) |
+| Type-special-casing in bytecodes (int+int, list[int]) | 0.96–1.02, "did not give conclusive speed-ups … the normal dispatching mechanisms are well-optimized already" |
+| String interning; app-level-string-accepting interfaces; exception-avoiding interfaces | reported without numbers; pervasive |
+
+Mechanism notes the reports give for the load-bearing ones:
+
+- **Multidicts**: a dict is a thin identity wrapper delegating to a swappable
+  implementation object; mutators may return a replacement implementation.
+  Ten implementations existed (Empty, SmallStr, Str, Small, RDict, Bucket,
+  Shared, Wary, ShadowTracking, Measuring). Empty is a singleton on the
+  space (fresh dicts are cheap); the first insert picks Str vs RDict by key
+  type; switching later "is an exceedingly rare occurrence," which justified
+  not sharing storage across implementations. MeasuringDictImplementation
+  existed purely to collect usage statistics (analysed with R).
+  WaryDict/ShadowTracking serve CALL_LIKELY_BUILTIN and shadow tracking.
+- **CALL_LIKELY_BUILTIN**: the compiler emits it for calls whose target name
+  is a builtin; a special module-dict implementation tracks which builtin
+  names are shadowed by globals; the bytecode makes two cheap checks
+  (module-dict shadowing? `__builtin__` changed?) and on the common
+  both-false path calls the builtin directly with no dict lookups.
+- **Method cache**: `version_tag` is a tiny object on each type; any class-
+  dict change replaces the tag on the class *and all subclasses*, so the
+  global (tag, name) table can never return stale entries. Rejected
+  alternative recorded: per-class "flattened" namespace dicts (fast but
+  non-linear memory for deep hierarchies). Future hardening listed: 2/4-way
+  set-associative tables, or randomly refreshing a type's tag after
+  repeated misses.
+- **CALL_METHOD**: `obj.meth(x)` normally materializes a bound-method object
+  at LOAD_ATTR that dies immediately. LOOKUP_METHOD performs the same lookup
+  with full semantics but pushes an *inlined* bound method as two stack
+  slots (im_func, im_self — None placeholder when the attribute wasn't a
+  plain class function); CALL_METHOD N inspects the im_self slot and, when
+  set, treats it as an extra first argument. "A few variants were tried;
+  this one is the first that fully preserves semantics and gives major
+  speed-ups." CPython patches in this space ([py709744] CALL_ATTR) had
+  stalled on complexity/benefit balance; PyPy's method cache "already has
+  been" ported to CPython ([py1685986]).
+- **Dispatch loop**: Python has no switch statement, so dispatch was written
+  as an if-chain made viable by a translation-time pass that recognizes
+  chains of comparisons of one value against constants and emits a switch
+  in the flow graph.
+- **Avoiding exceptions**: performance-critical interfaces return None
+  instead of raising (`getdictvalue`, `finditem`) because exceptions "must
+  be instantiated → memory pressure."
+
+### 4.4 Bottom line of D06.1
+
+All-toggleable-optimizations-on vs off: richards 0.40, pystone 0.56,
+templess 0.65, gadfly 0.71, mako 0.62. Against CPython 2.4.4 (best backend,
+pypy-llvm): richards 1.17×, pystone 1.55×, templess 5.41×, gadfly 6.38×,
+mako 7.65× slower — "depends very strongly on the amount of memory being
+allocated"; "the biggest single improvement would likely be from the
+addition of a more sophisticated garbage collector, something that is out of
+scope for this work package." Closing claim: "The flexibility of PyPy's
+Python implementation has been essential to the task of experimenting with
+and especially assessing these new implementations, vindicating the effort
+we put in to allow this flexibility."
+
+### 4.5 Translation-level optimizations (D07.1 §4.1)
+
+Context the report gives: on first full translation, pypy-c was "between 22
+times slower (for the Richards benchmark) and roughly 460 times slower for
+the pystone benchmark" than CPython; "one of the biggest sources of
+inefficiencies is the large amount of time spent managing memory" — RPython
+allocates at an extremely fast rate, so most optimizations reduce
+allocations or predict lifetimes.
+
+- **Inlining**: copy the callee graph into the caller; statically-known
+  targets only. "Primary motivation: to enable further optimizations
+  (notably malloc removal)." The explicit-exception-edge graph model makes
+  inlining across try/except hard (each potentially-raising operation gets
+  explicit handler jumps; a heuristic matches directly-caught exceptions and
+  "in more complicated cases inlining is not performed"). Heuristics: static
+  instruction count + a "median execution cost" solving linear equations
+  over guessed branch frequencies; smallest-first with recalculation; ties
+  made **deterministic** (fewest-callers-first) after nondeterminism proved
+  troublesome. Alone: pystone +52%, richards +64% — "these numbers probably
+  show that … the GCC compiler itself could benefit from performing more
+  aggressive inlining."
+- **Malloc removal**: `for i in range(n)` allocates three heap objects (the
+  range, its iterator, the StopIteration instance) that this kills after
+  inlining. Candidate = a variable set created by a single malloc and only
+  accessed by field reads/writes; the analysis gives up on escape into
+  calls/returns/other structures — unless the containing structure is itself
+  removed, which can re-enable the candidate. Removes ~20% of mallocs on the
+  default build; on top of inlining: richards +18%, pystone +43%. "Made
+  useful only by the inliner … inlining was tweaked in such a way that
+  malloc removal can work effectively."
+- **Escape analysis / stack allocation**: deliberately "naive, pessimistic"
+  (creation-point sets, forward-propagated; escaping = returned, raised, or
+  stored into another object; stack allocation refused for variable-sized
+  objects, allocations in loops, and finalizable objects). With malloc
+  removal on: only +3–7% (they cover the same cases); with malloc removal
+  off: +40% pystone / +30% richards.
+- **Pointer tagging**: implemented "uncharacteristically … not by pervasive
+  source code changes, but by minimal support in the translation tool-chain"
+  — an optional **156-line module**. Small integers are a regular RPython
+  class in the source; during translation instances become odd-tagged words;
+  only the "read dynamic type" operation was changed (tag bit → the small-int
+  class vtable). It pays off only combined with **record-time constant
+  folding of vtable reads** (the generated vtables are constant structures;
+  "C compilers can't do this — they lack this info"), which turns the
+  indirect method call into a direct one. Measured: without const-folding
+  pystone +4% / richards −3%; with const-folding pystone +7% / richards +1%.
+  Fundamentally incompatible with CLI/JVM backends; at 1.0 only supported
+  with Boehm. Claimed novelty: "the automatic insertion of pointer tagging
+  as a translation-time optimization is novel in PyPy."
+
+The D07.1 consolidated table (July 2006 revision, AMD Opteron; relative to
+the default build = inlining + malloc removal + Boehm): no-optimizations
+2.20–2.24×; just-inlining 1.34–1.47×; inlining+malloc-removal 1.03–1.13×;
+escape-analysis ~0.93–0.97; tagged-pointers+constfold 0.93–0.99; refcounting
+1.77–1.79; mark-and-sweep 1.30; mark-and-sweep with stackless-unwind roots
+1.55–1.63. CPython on the same machine: 0.23. (pypy-c-0.7, refcounting:
+104.7× on pystone — the starting point of the campaign.)
+
+A recurring stated lesson closes the section: theoretically superior data
+structures usually show no benefit on real applications tuned for CPython's
+cost model; the flexibility to *measure* alternatives on real programs is
+presented as the valuable thing.
+
+---
+## 5. The 2007 JIT: partial evaluation and the JIT generator (D08.1, D08.2)
+
+**Scope note (from the documents themselves)**: this is the first-generation
+JIT — a *compiler generator* derived by binding-time analysis and
+"timeshifting" of the interpreter's low-level graphs. The documents do not
+mention tracing.
+
+### 5.1 Goal and framing
+
+- "The main research goal … since the inception of the PyPy project": don't
+  write a JIT; **generate** it from the interpreter. Hand-written JITs "may
+  require a lot of effort" and "may well be fragile with respect to changes
+  to language and its semantics"; open-source language communities "do not
+  usually consider ease of compilation as a design constraint"; the typical
+  main implementation is "a straight-forward bytecode interpreter with no
+  dynamic compilation."
+- The framework is **off-line partial evaluation**: for an interpreter
+  `f(x, y)` (x = the bytecode, y = the frame), produce a *generating
+  extension* `f1(x)` — "a compiler for the very same language for which
+  f(x, y) is an interpreter." Footnote: "What we get in PyPy is more
+  precisely a just-in-time compiler: if promotion is used, compiling ahead
+  of time is not possible."
+- **Rejected alternative, explicitly**: building the generating extension by
+  self-applying an on-line partial evaluator (the second Futamura
+  projection) — "So far it is unclear if this approach can lead to optimal
+  results, or even if it scales well. In PyPy we selected a more direct
+  approach: the generating extension is produced by transformation of the
+  control flow graphs of the interpreter, guided by the binding times. We
+  call this process timeshifting."
+- **Classical PE rejected as insufficient** for dynamic languages: "the
+  input program contains mostly no kind of type information"; therefore
+  "Compilation should be able to suspend, let the produced code run to
+  collect run-time information (for example language-level types), and then
+  resume with this extra information."
+- Three phases are distinguished: **translation time** (purely off-line:
+  binding-time analysis + timeshifting), **compile time** (the generated
+  compiler running during program execution), **run time** — "compile time
+  and run time are actually highly interleaved."
+- The three techniques named as what made the approach scale: **promotion**,
+  **virtualizable structures**, and **need-oriented binding-time analysis**.
+
+### 5.2 Machinery
+
+**Binding-time analysis.** Performed on the interpreter's *low-level* graphs
+(post-RTyping) by the annotator re-used in a new mode — the
+**hint-annotator** — propagating "not types but value dependencies and
+manually-provided binding time hints." **Green** = compile-time-known,
+**red** = runtime; "all variables are red by default." Propagation: a
+side-effect-free operation with all-green arguments may be green;
+non-foldable operations are red; at join points any red input makes the
+result red (a green join is *not* made eagerly, because the residual
+function may retain control flow the join value depends on).
+
+**Hints are need-oriented.** The design goal is to "minimize the number of
+explicit hints" without pushing to extremes. `hint(v, concrete=True)`
+requires the value green and **backward-forces everything it depends on to
+be green**, erroring if a dependency cannot be green (e.g. a read from a
+non-immutable field). The stated rationale against forward propagation: it
+"may mark as compile-time either more variables than expected (which leads
+to over-specialization …) or less variables than expected (preventing
+specialization … where it would be the most useful)"; the need-oriented
+approach "reduces the problem of over-specialization, and it prevents
+under-specialization: an unsatisfiable hint … is reported as an error,"
+correctable "by promoting a well-chosen variable among the ones that v1
+depends on." `hint(v, promote=True)` is the local escape hatch: "copying a
+red value into a green one, which is not possible in classical approaches to
+partial evaluation." Other hints: **deep-freeze** (mark an object immutable
+so reads constant-fold), **global merge points**, `_virtualizable_`.
+
+**Timeshifting.** The colored graphs are mutated into the generating
+extension — "it changes the time at which the graphs are meant to be run,
+from run-time to compile-time." Green-only pure operations stay unchanged
+and run at compile time — "(This is the case that makes the whole approach
+worthwhile: some operations become purely compile-time.)" Red operations
+become calls to helpers that emit a residual operation and return a **boxed
+representation** of the result — a box holding either a runtime location
+(register/stack slot) or an immediate constant. Because boxes can hold
+immediate constants, the helpers constant-fold — "the timeshifted graphs are
+performing some **on-line partial evaluation** in addition to the off-line
+job." Timeshifting runs in two phases: graph transformation inserting
+pseudo-operations, then an RTyper-based pass replacing them with support-code
+calls.
+
+**Splits and merges.** A compile-time-undecided branch duplicates the
+compilation state and compiles both sides. At merge points the state must be
+generalized (widened) or paths kept separate; the classical tension is
+quoted — "merging too eagerly may loose important precision and not merging
+eagerly enough may create too many redundant residual code paths (to the
+point of preventing termination of the compiler)" — and the resolution is
+admitted to be provisional: "So far, we did not investigate this problem in
+detail. We settled for a simple widening heuristic: two different
+compile-time constants merge as a run-time value … This heuristic seems to
+work for PyPy to some extent."
+
+**Calls.** Timeshifted callees are inlined into the caller by default;
+"inlining only stops at re-entrant calls to the interpreter main loop," so
+"at the level of the interpreted language, each function (or method) gets
+compiled into a single piece of residual code."
+
+**Promotion.** "The essential new feature introduced in PyPy when compared
+to existing partial evaluation techniques (it was actually first introduced
+in Psyco)"; the converse of PE's "lift"; "the central enabling primitive to
+make timeshifting a practical approach to language independent dynamic
+compiler generation." The documents' framing points:
+
+- Why it is impossible classically: "Promotion requires interleaving
+  compile-time and run-time phases … impossible in the 'classical'
+  approaches … in which the compiler always runs fully ahead of execution."
+- The constraint-theoretic argument: binding times are mutually constrained
+  and for a dynamic-language interpreter "this set of constraints may have
+  no interesting global solution" — most variables can, in some corner case,
+  depend on runtime data. Promotion lets constraints "be occasionally
+  violated: corner cases do not necessarily have to influence the common
+  case, and local solutions can be patched together."
+- It generalizes **polymorphic inline caches** (the generated updatable
+  switch "plays the role of a polymorphic inline cache," except the switch
+  "does not necessarily have to be on the type of an object") and PE's
+  "The Trick" (which "is only applicable for finite sets of values").
+- Implementation: the generated code contains an updatable switch ending in
+  a `continue_compilation(value, <state data pointer>)` callback; on a new
+  runtime value the compiler resumes, emits the new case, and **patches the
+  switch in place**. The worked example in D08.2 shows `b = a/10;
+  c = promote(b); d = c + 5` compiling to a compare-chain that grows a
+  `call print(9)` case after first seeing `r2 == 4`.
+- **State compression ("paths")**: a full compiler-state snapshot per switch
+  "can never be reclaimed because new run-time values may always show up
+  later"; instead full snapshots are stored only at user-marked **global
+  merge points** (the interpreter main-loop join "is a typical place"), and
+  each promotion stores only a lightweight path in a tree that lets the
+  compiler *replay* its actions from the last snapshot to rebuild its state.
+- **Space exhaustion is handled crudely (their word)**: "we simply reserve
+  more space elsewhere and patch the final jump accordingly"; better
+  strategies (discarding old cases, "sometimes giving up entirely and
+  compiling a general version") are listed as unimplemented.
+- Guidance on where to promote (Appendix 1): small integers; "the
+  interpreter-level class of an object before an indirect method call" (a
+  constant class lets the compiler inline the callee); occasionally, "with
+  care," whole objects (e.g. exactly which Function object is being called).
+
+**Virtual structures.** Allocations are kept "exploded" — the compiler
+variable holds a *virtual structure* containing one variable per field, each
+of which can be runtime, compile-time, or again virtual — until the pointer
+**escapes** to a non-virtual location ("forcing"). Because red values
+represent *locations*, a getfield/setfield on a virtual structure just moves
+location references at compile time; nothing is copied at run time. The
+worked example: in `a+b+c` over `W_IntObject`, the intermediate box becomes
+virtual, its `intval` referencing the register holding the first addition's
+result, and the promotion of its (compile-time-constant) type is free —
+"a+b+c only requires three switches instead of four." Lists and
+dictionaries can also be virtual; the **exception state is handled by
+explicit operations inserted before timeshifting and then virtualized
+away**. In a tight integer loop "the residual code is theoretically optimal
+— all type propagation and boxing/unboxing occurs at compile-time."
+
+**Virtualizable structures.** Invented for **frame objects**, which cannot
+be virtual because they are sometimes built by non-JIT code and in any case
+"immediately escape into the global list of frames that is used to support
+the frame stack introspection primitives that Python exposes" — "even though
+in practice most of frame objects are deallocated without ever having been
+introspected." A virtualizable structure "exists at run-time in the heap,
+but is simultaneously treated as virtual by the compiler." The class-level
+`_virtualizable_` hint makes the toolchain add a **hidden field** to such
+objects; every field access anywhere in the program first checks it, and
+non-JIT code finding it set "invokes a JIT-generated callback to perform the
+reading or updating of the field from the point of view of its virtual
+structure representation." "This is the only case so far in which the
+presence of the JIT compiler imposes a global change to the rest of the
+program." Frames stay heap-allocated "but most of them will always remain
+essentially empty," and introspection "still work[s] perfectly." The
+indirection cost is acknowledged, with a mitigation: a declaration usable
+during type inference that a given code region cannot see a
+virtual-counterpart frame, eliding the check.
+
+**Correctness by construction.** "By construction, the JIT should work
+correctly on absolutely any kind of Python code: generators, nested scopes,
+exec statements, `sys._getframe().f_back.f_back.f_locals`, etc." — the
+latter "an example of expression that no existing Python or Python-like
+compiler emulates correctly." The contrast drawn with Psyco: Psyco "gives up
+compiling Python functions if they use constructs it does not support, and
+is not 100% compatible with introspection of frames. By construction the
+PyPy JIT does not have these limitations."
+
+**Code size.** Support code (merge logic etc.): ~3,500 lines RPython;
+hint-annotator + timeshifter: ~3,800 lines Python; each machine backend
+(IA32, PPC): ~3,500 lines RPython. "There is a well-defined interface
+between the JIT compiler support code and the backends … The unusual part of
+the interface is the support for the run-time updatable switches."
+
+### 5.3 Operation as shipped in 1.0 (D08.1)
+
+- Build: `translate.py --jit targetpypystandalone`. The resulting pypy-c
+  contains both a regular interpreter and the generated compiler — and the
+  built-in JIT makes the *interpreter itself* "a bit slower than the one
+  found in a pypy-c compiled without JIT."
+- **Invocation is manual**: `import pypyjit; pypyjit.enable(f.func_code)`;
+  the first call compiles, subsequent calls run machine code. "We did not
+  work yet on profile-directed identification of program hot spots."
+- Entry mechanism (Appendix 1, tiny1 example): the timeshifted function is
+  patched so that a call looks up its **green arguments** (e.g. the bytecode
+  string) in a cache; on a miss it invokes the compiler with the greens as
+  constants and the reds as variables; then it invokes the cached machine
+  code. "Interpreting the same bytecode over and over again with different
+  values of x and y should be the fast path."
+- Backends: IA32 and PowerPC; tested on Linux, Mac OS X (Intel and PPC),
+  Windows. Machine code dumps via `PYPYJITLOG` + a viewer built on objdump.
+- Configuration: the JIT was supported **only in the default configuration**
+  (D13.1 matrix, §6.4); combining with thunk/taint spaces "probably works
+  too, but we don't expect it to generate good code before we add some extra
+  hints in the source code of the object spaces."
+- Testing admission: "Although the JIT generation process is well-tested, we
+  only have a few tests directly for the final pypy-c."
+- The framing quote of the appendix: "Ideally, turning an interpreter into a
+  JIT compiler is only a matter of adding a few hints. In practice, the
+  current JIT generation framework has many limitations and rough edges
+  requiring workarounds."
+
+### 5.4 Results and admitted limitations
+
+- Benchmark: one pure-arithmetic nested-while function, f1(2117). Reference
+  machine numbers (ratios vs unoptimized gcc; "relative results have been
+  found to vary by 25% depending on the machine"):
+
+  | Configuration | sec/call | vs unopt. gcc |
+  |---|---|---|
+  | CPython 2.4.4 | 0.82 | 132× |
+  | CPython + Psyco 1.5.2 | 0.0062 | 1.00× |
+  | pypy-c, JIT off | 1.77 | 285× |
+  | pypy-c, JIT on | 0.0091 | **1.47×** |
+  | gcc | 0.0062 | 1× |
+  | gcc -O2 | 0.0022 | 0.35× |
+
+  "Matches the target of 1.5× that we set ourselves"; 1.15× on one Intel
+  Mac. Interpretation offered: "all the abstraction overhead has been
+  correctly removed"; the remaining gap is "only due to a suboptimal
+  low-level machine code generation backend." The result "require[s] the
+  generated compiler to completely cut the overhead and fold at compile-time
+  some rather involved lookup algorithms like Python's binary operation
+  dispatch. Promotion proved itself to be sufficiently powerful to achieve
+  this."
+- Coverage honestly scoped: "enough hints were added … such that at least
+  integer operations can be dynamically compiled into efficient code and
+  dispatch loop overhead is removed. … more extensive hints are necessary to
+  have more generalized speed-ups. Their addition is going to be part of
+  work to be done after the project."
+- Interpreter-side cost claimed small: "Some slight reorganisation of the
+  interpreter main loop without semantics influence, marking the frames as
+  virtualizable, and adding hints at a few crucial points was all that was
+  necessary."
+- **Open issues, in the authors' own list (D08.2 §3.7)**:
+  - Eager branch compilation "can easily result in residual code explosion.
+    Depending on the source interpreter this can also result in
+    non-termination issues, where compilation never completes." Psyco-style
+    fully-lazy compilation "neatly sidesteps termination issues"; "the best
+    solution is probably something in between these extremes."
+  - Fallbacks needed when too many values are promoted at one point;
+    "the widening heuristics for merging needs to be refined"; "we need more
+    flexible control about what to inline."
+  - The JIT must be made aware of the other translation aspects (GC,
+    stackless) to emit correct residual code.
+  - "The machine code backends can be improved."
+  - The stated **open research question**: "can we layer our kind of JIT
+    compiler on top of a virtual machine that already contains a lower-level
+    JIT compiler? … can we delegate the difficult questions of machine code
+    generation to a lower independent layer, e.g. inlining, re-optimization
+    …?"
+- Closing claim (D08.2 §5): "our results make viable an approach to
+  implement dynamic languages that needs only a straight-forward bytecode
+  interpreter to be written. Dynamic compilers would be generated
+  automatically guided by the placement of hints" — implementations "robust
+  against language changes up to the need to maintain and possibly change
+  the hints."
+
+---
+## 6. Backends, extension modules, configuration (D03.1, D12.1, D13.1)
+
+### 6.1 Language tracking and the extension compiler (D03.1)
+
+**Language tracking.** PyPy started on CPython 2.3.x, switched to **2.4.1**
+in summer 2005 and deliberately held there — 2.5 "is not yet widely
+deployed, so that programmers still restrain from using the new features";
+"it is customary for a Python version to only become widely accepted and
+relied upon after the '.1' or '.2' release." Selected 2.5 features were
+backported (conditional expressions PEP 308, `with` PEP 343); others were
+"clean-ups of historical accidents" PyPy already had (new-style exceptions,
+ssize_t sizes); `__index__` (PEP 357) was "yet to be implemented." Adopting
+features was "fairly easy" thanks to "the expressiveness of Python compared
+to C and the flexibility of relevant parts of the design (e.g. our bytecode
+compiler)." No automated CPython-tracking tooling was built — judged
+"superfluous" because many PyPy developers were themselves active CPython
+contributors.
+
+**Extension-module strategy.** The stated core drawback of C extensions for
+PyPy: explicit low-level detail (locks, memory management) "would prevent
+the same module from being used in several differently compiled versions of
+pypy-c." The chosen approach: write extension modules in **RPython**, as
+**mixed modules**, usable **four ways** from one source — (1) directly on
+CPython through a **CPy Object Space** (whose space operations are
+"essentially just external function calls to the C functions of the CPython
+API"), (2) compiled by the stand-alone **Extension Compiler** into a regular
+CPython extension `.so`, (3) under PyPy-on-CPython, (4) built into pypy-c.
+"The translation step is optional: it is a way to recover performance"
+(modules are plain ctypes-using Python until translated) — the stated
+contrast with Pyrex, whose input is not actually Python. The one-source
+approach "could be adapted to target other Python implementations as well
+(Jython, IronPython), enabling a one-source-fits-all approach."
+
+**rctypes** (ctypes restricted to RPython, statically compiled): dynamic
+ctypes declarations are allowed at bootstrap only; during translation "all
+replaced by regular, static C code that no longer uses the libffi library."
+The report documents an explicit **mid-flight pivot** between two
+implementations:
+
+1. **First approach — RTyper-integrated**: each ctypes operation lowered
+   individually during RTyping; memory-owning boxes mapped to
+   `GcStruct("name_owner", ("c_data", Struct(...)))` where the inner struct
+   follows the exact C layout. The recorded reasons for abandoning it:
+   "quite tedious to have to write code that generates detailed low-level
+   operations for each high-level ctypes operation — and most importantly,
+   it is not flexible enough"; "problems were recently found in corner cases
+   of memory management"; and **it blocked moving GCs** — "the major factor
+   stopping us from experimenting with advanced GCs so far."
+2. **Second approach — a pure-RPython library (`rctypesobject`) driven by
+   the generic ControllerEntry mechanism** (controllers map operations on
+   arbitrary Python objects to glue RPython classes during annotation).
+   Work in progress at report time; **no performance figures were
+   collected**; work "postponed … in favor of more urgent tasks."
+
+Recorded gaps: c_float/c_wchar unsupported; custom allocators and
+return-value error checkers unsupported; the extension compiler "does not
+support special methods at the moment" (`__xyz__`). The section's own
+conclusion: "The Extension Compiler is still work in progress."
+
+### 6.2 High-level backends and ootype (D12.1)
+
+- **ootype** was created because lltype "loses too much information" for OO
+  targets (an RPython list lowered to `struct {int length; int* items;}`
+  retains no trace of being a list). Its model is "quite Java-like": static
+  strongly-typed methods/attributes, all methods virtual, **single
+  inheritance** from ROOT ("it's impossible to efficiently support multiple
+  inheritance if the platform supports only single inheritance"), built-in
+  String/StringBuilder/List/Dict/CustomDict parametrized by type, method
+  overloading supported only for native-library access. Both type systems
+  share the arithmetic primitives.
+- The deliberate contrast with Jython/IronPython: those compile Python to
+  *native* bytecode with a runtime in the host language; PyPy compiles the
+  *interpreter* to the platform and keeps executing Python bytecode on it —
+  "this extra level of indirection results in a speed penalty … but also
+  gives a lot more flexibility" (e.g. swappable object spaces). Host-library
+  integration "is not completely supported in PyPy yet, but it will be."
+- **GenCLI** (the most mature; from Antonio Cuni's master's thesis): emits
+  IL for ilasm, "starting from the entry point and recursively traversing
+  the call tree — considerably simpler than the approach of GenC."
+  Functions-as-values become generated delegate classes; CustomDict becomes
+  a generated IEqualityComparer; classes-as-values are `System.Type` +
+  reflective `RuntimeNew`. The `clr` module exposes .NET classes at app
+  level through three layers (static RPython bindings whose signatures are
+  harvested by an external C# reflection tool; a Python/CLI object bridge;
+  reflective app-level class construction via a descriptor-based
+  MethodWrapper); exceptions "still incomplete": "every .NET exception is
+  mapped to Python StandardError."
+  **Measured** (richards, ms/iteration): on Windows/MS CLR — C# 7.09,
+  gencli-richards 13.31 (≈1.8×), CPython 1139.6, IronPython 1751.2,
+  pypy-cli-interp-level 5952.5, pypy-cli-app-level 12010.5. On Linux/Mono
+  the GenCLI-vs-C# gap widens to ≈3.4× ("Mono JIT … is specifically
+  tailored for code produced by the C# compiler"). The pypy-cli ≈6.8×
+  IronPython gap is decomposed as **1.8 (backend) × 2 (interpretation
+  overhead) × 1.8 (stdobjspace vs IronPython runtime)**; the backend factor
+  is "attributable to the youngness of GenCLI and will likely converge to
+  zero."
+- **GenJVM**: emits Jasmin assembler ("Sun has not defined a standard
+  textual format for JVM byte-code"); "fairly smooth" thanks to ootype and
+  reused CLI-backend code, but could not yet translate the full interpreter;
+  rpystone ~20× slower than C with "no applied optimizations." Documented
+  JVM frictions: no unsigned arithmetic (library comparisons); generics via
+  erasure + verified casts; functions as one-class-per-function with virtual
+  `invoke`; **exceptions must wrap** (`JvmExceptionWrapper`, losing
+  class-based catch — alternatives noted: map RPython Exception to
+  Throwable, or signal exceptions via return values); the future hazard of
+  the 64 kB method limit (the SSI form is noted as what would make automatic
+  method splitting easy).
+- **GenJS**: does *not* aim to run the interpreter; compiles RPython
+  applications to browser JavaScript with transparently-proxied server calls
+  (XMLHttpRequest, auto-serialized given known signatures) and a CPython
+  wrapper so the same program is testable off-browser — the stated focus is
+  the missing testing story for browser code. Prototype OO is bridged by a
+  copy-down `inherit` function, valid because "RPython does not allow
+  changing base class members at runtime anyway." External APIs (DOM,
+  Mochikit) are described via `BasicExternal` signature stubs — "the real
+  methods are never seen by the annotator."
+
+### 6.3 Interpreter feature prototypes (D12.1)
+
+- **Taint object space** (information-flow security): a proxying space
+  between interpreter and StdObjSpace, both untouched. Capability-based
+  security was explicitly rejected as a direction ("would have mostly
+  required working at the language design, and not so much at implementation
+  level" — Python has no encapsulation, pervasive reflection, shared
+  builtins). Objects are regular or tainted; `taint`/`untaint` builtins;
+  every operation with a tainted argument produces a tainted result;
+  failures become **tainted bombs** that raise only on declassification
+  (immediate errors would leak information); unboxing operations (output,
+  truth-testing) always error, so "control flow cannot depend on tainted
+  values"; `taint_atomic` wraps functions. "By construction it is not
+  possible for user programs to circumvent taint-wrapping." **~300 LOC;
+  ~33% slowdown translated** ("the most straightforward implementation").
+  Presented at IBM Zürich (Feb 2007, with Michael Franz): "we have already
+  accomplished the state-of-the-art with our prototype." Stated open
+  research question: control flow depending on sensitive data "in the
+  absence of whole program analysis."
+- **Transparent proxies**: objects that masquerade as instances of any
+  (builtin) type with a controller function intercepting every operation
+  (`make_proxy(controller, type=list)` satisfies `type(l) is list`).
+  Motivated by Python's descriptor-based object model making conventional
+  proxying "quite challenging" (subclassing builtins doesn't help — internal
+  operations reach the opaque inherited part). Implemented for builtins as
+  one more multimethod implementation per type; for internal types (frames)
+  by type-check-and-fallback. **<300 LOC**, optional at translation time,
+  "no significant impact on the rest of the application." Compared to
+  .NET's TransparentProxy/RealProxy. Consumers documented: the
+  `distributed` prototype (transparent lazy remote objects over an RPC-like
+  protocol; only atomic immutables by value; works for builtin instances
+  including frames/tracebacks → remote debugging with local-looking remote
+  tracebacks; "it is very hard to distinguish a remote object from a local
+  one"), and the preferred **orthogonal persistence** design (selective
+  transparent interception of changes, judged easier than pruning the
+  reachability graph of a suspended computation).
+- Summary sentence for both: "in all cases, pervasive changes were not
+  required."
+
+### 6.4 Configuration and integration (D13.1)
+
+- The configuration framework distinguishes **option descriptions/schemata**
+  (a tree of typed options with defaults, dependency/conflict/suggestion
+  relations declared as data, auto-generated command-line parser and
+  documentation) from **configurations** (one concrete choice). "Every time
+  an option is set, all its dependencies are checked"; values are
+  **write-once**. "Checks … are done at translation time: the translated
+  PyPy interpreter does not contain any actual checks for configuration
+  values and also does not contain the code which would be executed if a
+  different value … was used" — options behave like C preprocessor macros.
+  Built PyPy-unspecific for reuse.
+- **The 1.0 compatibility matrix** (Figure 1 of D13.1) records what actually
+  composes:
+  - WP06 interpreter optimizations compose with everything — except **tagged
+    integers**, which need RTyper support, "cannot work with statically and
+    strongly typed high-level target environments such as the CLR and the
+    Java VM for fundamental reasons," and at 1.0 worked only with Boehm.
+  - WP07: the framework GCs are pointless on JVM/CLR (own GC); the stackless
+    transformation "currently only works with the C backend" (a "temporary
+    restriction" for OO backends; LLVM excluded "for minor technical
+    reasons"); inlining and malloc removal were ported to OO backends; stack
+    allocation "cannot work for fundamental reasons."
+  - WP08: **the JIT was deliberately supported only in the default
+    configuration** (std objspace, Boehm, no stackless, no tagged ints) and
+    "can currently only be translated using the C and the LLVM backend,
+    since it is built to work with the low level type system only." The
+    taint space works with everything *except* the JIT ("some
+    StdObjSpace-specific code, which should be fixable easily").
+  - WP09: the logic space needs clonable coroutines (stackless + framework
+    GC) → C backend only, PyPy GCs only ("unlikely to ever work with an
+    object-oriented backend").
+  - WP10 (AOP) is purely a parser-level feature, independent of everything —
+    with the recorded caveat that "one has to be very careful that aspects
+    don't affect code that one does not expect them to affect."
+  - High-level backends were "one of the hardest features to integrate"
+    (deep RTyper changes — the ootype system — plus new translation steps).
+- **Build tooling**: translate.py (step ordering, interactive debugging
+  console, flow-graph viewer); an experimental **build farm** (meta server on
+  codespeak + donated build servers + request clients, over py-lib execnet;
+  results as ZIP links; status web page).
+- **Debian packaging**: the source package splits into **pypy-dev, pypy,
+  pypy-stackless, pypy-logic, pypy-lib, pypy-doc** (plus maintenance of
+  python-codespeak-lib for py.test); flavors exist precisely because
+  differently-configured interpreters are different binaries. Debian's
+  autobuilders across 11 architectures are cited as free porting/QA.
+
+---
+## 7. Research prototypes (D09.1, D10.1, D11.1)
+
+### 7.1 Logic and constraint programming (D09.1)
+
+- **What was built**: logic variables (`W_Var` at interp level; free/bound
+  single-assignment; `newvar`/`bind`/`unify`, aliasing between free
+  variables) in a dedicated **Logic object space**; dataflow synchronization
+  (touching a free variable suspends the coroutine until it is bound;
+  `wait`, `wait_needed` for lazy producers; `future` spawning a coroutine
+  bound to a result variable); a grammar extension `choice:`/`or:` for
+  non-deterministic choice; Oz-style **computation spaces** driven by an
+  external solver through an ask/choose/commit protocol; and search by
+  **GC-pool coroutine cloning** (§3.8). The constraint engine (CSP as
+  (X, D, C); domains, expressions, AllDistinct; solvers written in pure
+  Python) has its performance-critical propagation core as a pure RPython
+  library, also usable standalone without the logic space.
+- **Architecture credits** (the conclusion's own list): the first-class
+  object space ("allows to wrap additional semantics around normal Python
+  semantics"), RPython ("facilitates writing interpreter-level code"),
+  interpreter-level multimethods ("proved to be very convenient" for the
+  new builtins), the GC framework's cloning ("impossible with the
+  Böhm-Weiser GC"), and coroutines. Verdict quoted verbatim: **"We can
+  assert without doubt that this work would have been completely impossible
+  within CPython."**
+- **Honest status at ship**: "as of this report, the key functionality of
+  space cloning still doesn't work"; "operations related to search with
+  logic programs don't work … However, the non-concurrent version of the
+  constraint solver is usable." The debugging loop is recorded as the
+  blocker: a full translation with the logic space takes "almost two hours
+  on a fast machine," followed by stepping through "several millions lines"
+  of generated C laced with GC root push/pops.
+- Recorded design doubts and rejected directions: logic variables' "half
+  transparency" wraps nearly every operation in `wait` — "one could
+  reasonably argue that the run-time price is too high, and that it is not
+  pythonic"; Schulte-style constraint combinators "left out" (involved, and
+  measured elsewhere as underperforming); Constraint Handling Rules out of
+  scope; cloning-vs-trailing is defended by the Oz group's measurements plus
+  the argument that cloning "inherently opens the ability to distribute the
+  load amongst several CPUs … whereas trailing does not support parallelism
+  at all."
+- **OWL/SPARQL application**: an OWL-DL reasoner by conversion to a
+  constraint problem (not tableaux); SPARQL front end offering "variables at
+  the predicate position, which even Pellet does not"; target ontology LT
+  World (~1500 classes, ~15 MB). A full consistency check took **~90
+  minutes**; testing was limited to a small manually-corrected subset;
+  "various queries produce correct answers, but we are … not satisfied with
+  the results yet." The application evaluation is "the only part considered
+  non-final," delayed by resolver bugs and the departure of the key
+  developer.
+
+### 7.2 AOP, design-by-contract, RPylint (D10.1)
+
+- The enabling mechanisms: the grammar is changeable at runtime and
+  `parser.install_compiler_hook(callback)` fires on every AST construction
+  (imports and `eval`/`exec`), with read-only visit and mutating
+  `node.mutate(ASTMutator)` traversal.
+- The pure-Python `aop` module weaves at **import time** by AST mutation:
+  Aspect metaclass, before/after/around/introduce advices, AspectC++-style
+  point-cut regexes. Documented drawbacks of static weaving: modules with
+  existing `.pyc` files bypass the weaver; the importing file itself is
+  parsed before the hook installs. Of two ways to inject compiled advice
+  code, the indirection through a `__aop__` builtin was chosen over
+  reparsing to AST.
+- Candid self-judgments: "it is not clear whether working at the AST level
+  to weave advices gives significant advantages over the dynamic approach
+  used by all other implementations of AOP in Python" — though the AST hook
+  is "a very powerful tool … potentially the first step towards adding
+  macros to the language." For DbC: "we feel that this approach … is not
+  the best one in a language such as Python, and did not push the effort
+  too far" — CPython-compatible libraries (PyDBC/pycontract) are called
+  "a more pythonic way."
+- **RPylint** exists because of the translator's error ergonomics: slow,
+  non-incremental, first-error-only, messages "not as explicit as expected,"
+  surfacing as stack traces. It is a Pylint extension checking RPython rules
+  at source level (banned constructs/builtins/protocols, multiple
+  inheritance, type consistency, homogeneous lists, constant globals,
+  negative slices), plus a test framework pairing translatable/
+  untranslatable snippets with expected messages — proposed as de-facto
+  documentation, "one problem with RPython is that the language has no
+  specification and is evolving as PyPy is being developed." Its inference
+  differs from the toolchain's, so passing RPylint "make[s] it impossible to
+  guarantee the success of the translation"; judged useful for beginners and
+  porting estimates, not for experts.
+
+### 7.3 Embedded devices (D11.1)
+
+- Five options assessed, with verdicts: (1) full generated interpreter on
+  the device — "for now not feasible" (a generated interpreter is "an order
+  of magnitude larger" than CPython: ≈5.3 MB vs ≈1.0 MB file size); (2) a
+  reduced-language interpreter — "an interesting way to investigate," but
+  "nothing in the current code of PyPy allows doing this out-of-the-box"
+  (though deriving a reduced object space is argued to be easy in
+  principle); (3) an RPython *interpreter* — rejected as a category error
+  ("RPython was not designed with an interpreted goal in mind"); (4) using
+  language-aspect extensions for safety; (5) **compile RPython applications
+  with the toolchain** — "pretty much possible … with very minimal effort";
+  this is what the case study did.
+- **Case study**: the stdlib HTTP server ported to RPython (rpyhttp) for
+  Axis ETRAX 100LX devices (2–8 MB flash, 8–32 MB RAM). Time budget: ~7
+  days total — **60% making stdlib code RPython-compliant, 35% improving
+  RPython itself** (multi-char strip, tuple comparison, negative indices);
+  the server logic "took five minutes." The port catalog is a concrete
+  census of RPython friction: rsocket instead of socket; no negative
+  indices except -1; one-char single-argument `split`; positional-only `%`
+  formatting without `%r`/`%x`; no `*args`/`**kwargs`; no
+  `getattr(self, 'do_' + command)` dynamic dispatch (→ if/elif chains);
+  file I/O via `os.read`/`os.write` on descriptors; several stdlib
+  functions reimplemented (os.path ops, urlparse, quote, escape).
+  Result: a binary whose text segment is roughly Boa's size (87 KB vs
+  71 KB) with comparable request-serving CPU times.
+- **Pain points recorded** (the embedded lens on the whole toolchain):
+  exception-check code bloat after every call (C backend returns NULL like
+  CPython; C++ exceptions or setjmp/longjmp noted as size levers);
+  framework-GC per-call root bookkeeping vs Boehm ("significant overhead
+  both in terms of code size and performance"; "the Boehm garbage collector
+  is probably the lightest available"); **no modular build** ("cannot link
+  … using a minimalistic version of the libc (e.g. uclibc)" without
+  libm/libpthread); no real-time or memory-constrained GC; cryptic
+  one-at-a-time translation errors; docs not RPython-oriented. "The two
+  hardest points are modular compilation and the real-time garbage
+  collector."
+- Future leads named: **microPyPy** (a reduced interpreter for a subset
+  "less limited than RPython" — with the admission that nothing supports
+  this yet), toolchain-as-static-checker (stack-depth bounds, recursion
+  detection, Stanford-checker-style rules), real-time GC. Overall verdict:
+  "a valuable and viable solution for embedded applications on not too
+  small devices," but "currently not suitable … for regular Python
+  programmers" — RPython "still a bit tedious," libraries missing — "most
+  of them are merely a matter of the PyPy project maturing beyond the state
+  of a research project."
+
+---
+## 8. Process, QA, testing (D01.x, D02.x, D14.2, D14.5)
+
+### 8.1 Testing doctrine (D02.3, D01.1)
+
+- The stated backbone: "Development and research within the PyPy project
+  relies on automated testing and a test-driven development approach." D01.1
+  names the automated test suite "the main tool for handling exceptions and
+  for very quickly identifying and implementing corrective actions" and "the
+  primary quality assurance tool and strategy," with the explicit mandate:
+  **"It is a requirement to add new tests for each newly added features and
+  for each fixed bug."** Policy before commit: run tests and make sure no
+  regression occurred; failures are traceable to the source change that
+  broke tested behaviour.
+- Stated experience claim: "high quality testing tools can positively impact
+  development speed and quality." The codebase is described as containing
+  "several thousand automated unit and functional tests, running in several
+  languages and operating systems."
+
+### 8.2 The test taxonomy (D02.3)
+
+The architecture "requires testing to occur at multiple levels."
+Project-specific `py.test` extensions recognize several test types that
+"co-exist … and can be uniformly driven by py.test invocations":
+
+1. **Interpreter-level tests** — set up with an Object Space, run directly
+   on CPython; test low-level interpreter or translation aspects.
+2. **Application-level tests** — run through PyPy's own interpreter on top
+   of CPython, and additionally "can run directly on a translated PyPy
+   version (which is considerably faster as it avoids the double
+   interpretation overhead)."
+3. **Compliance tests** — the CPython regression suite, instrumented to run
+   either through PyPy's interpreter or on a translated binary. Both the
+   getting-started page and the sprint slides state "PyPy passes around 95%
+   of CPythons core language regression tests."
+4. **JavaScript tests** — ECMA regression tests running on the emerging
+   JavaScript interpreter (py.test is "not limited to Python code").
+5. **Documentation tests** — website generation plus full link and
+   reference-integrity checks, via a py.test extension.
+
+Running everything at once "takes a very long time, and enormous amounts of
+memory"; an autotest driver executed tests directory-by-directory and
+published nightly summary pages. Automated test runs *and automated
+translations* ran each night on HHU-donated machines "to identify
+integration problems early" (D02.1); nightly pystone/richards runs guarded
+performance regressions (D06.1, §4.1).
+
+### 8.3 py.test and the py lib (D02.3)
+
+- **Rationale vs unittest**: subclass-based unittest extension "often
+  intermingles project specific integration code with these advanced
+  features and thus prevents re-use from other projects." py.test instead
+  lets projects "modify and amend aspects of the testing process without
+  requiring intrusive changes to the actual testing code."
+- Features as stated: no framework class hierarchy (collection by naming
+  convention, conventions modifiable); a **modified `assert` statement**
+  reporting the values in a failed assertion ("assertions about truth values
+  are regular Python expressions"); automatic stdout capture (debug prints
+  can stay in test code permanently); failure introspection down to an
+  interactive debugger on the failing frame; all collection/execution/
+  reporting behavior customizable per-directory via `conftest.py` (used in
+  PyPy to exclude directories and to drive remotely-run Windows GUI tests
+  from Linux).
+- **Ad-hoc distributed testing** over `py.execnet` (compile-and-execute
+  program text on remote hosts over SSH/sockets, objects exchanged via
+  Channels, zero remote installation beyond a Python interpreter):
+  distributes the suite to multiple hosts — "considerable speed up,"
+  especially for tests that translate snippets to C or .NET. A real-time
+  progress web application was itself built with PyPy's JavaScript backend.
+  Distributed testing "has encouraged developers to perform larger test runs
+  before committing." execnet also coordinated translation build jobs and
+  SVN replication.
+- **apigen** derives argument/return types and call chains by monitoring
+  calls during test runs — "hard to obtain statically in a dynamic
+  language"; doubles as "an indicator for the quality of the tests."
+- The py lib was released separately (**0.9.0, February 2007, MIT license**,
+  CPython 2.3–2.5); its collection/state-management concepts were adopted by
+  **nose**; described as "one of the major Python testing tools."
+
+### 8.4 Sprint-driven development (D14.2, D01.2-4)
+
+- The dissemination/development strategy is "leveraging the community" via
+  **Sprint Driven Development**: one-week face-to-face coding sessions,
+  "minimizing many of the risks of traditional distributed and dispersed
+  F/OSS development" — agile practices (pair programming, whole team, TDD,
+  daily planning), explicitly *not* SCRUM's "sprint."
+- Sprints are the main contributor entry point: "a majority of today's PyPy
+  contributors entered the project in this way." Newcomer travel was
+  reimbursed via the "Physical Partner" model and the "Summer-of-PyPy"
+  programme.
+- Each newcomer sprint opens with the tutorial "PyPy — Crash Course/Sprint
+  Intro" (**42 pages, ~1 hour**; presented at **9 public sprints to ~50
+  newcomers** during the project). Its stated philosophy: teach "just enough
+  to support the main work in the sprint which is coding — 'learning by
+  doing'"; the overview must be "almost immediately followed up by pair
+  programming with someone more experienced."
+- Newcomer testimonials (four Summer-of-PyPy participants) converge on: the
+  online docs give a broad view but are insufficient alone; **the IRC
+  channel (#pypy) and sprint pairing made the decisive difference** ("what
+  definitely made the difference was the IRC channel" — Cuni; "Otherwise I
+  don't think I would be able to enter the PyPy project at all" —
+  Fijalkowski).
+- **Scale**: 7 sprints before EU funding (2003–2004); **18 sprints during**
+  (Leysin 2005-01 through Hildesheim 2007-03), participant counts 6–24;
+  16 sprint reports doubled as the external newsletter.
+
+### 8.5 QA plan and coordination structure (D01.1, D01.2-4)
+
+- D01.1 states the tension openly: "The agile practices being implemented
+  within the project collide with the traditional project management
+  approach of detailed segmented plans." The response is a "minimalistic
+  approach" — "document procedures and features only when deemed necessary,"
+  with ~6-monthly **Internal Review Workshops ("Learning Loops")** revising
+  the procedures themselves.
+- QA is grouped into four categories: automated procedures (VCS, test
+  suites, tracking infra), open procedures (peer review with few or no
+  access restrictions), role procedures, and agile procedures
+  (sprint-driven development plus layered evaluation loops). Risk strategy:
+  "cyclic, iterative approaches … allow for early risk identification" —
+  sprints (project level), monthly consortium meetings, weekly 30-minute
+  **pypy-sync** IRC meetings + Technical Board (technical level).
+- Coordination record: **27 pypy-sync meetings, 15 Technical Board
+  meetings, 17 Consortium meetings (3 physical), 7 Management Team
+  meetings** during funding. Internal reporting ran primarily on
+  **SVN-commit-notification emails** (every change traceable to author +
+  log) plus IRC; monthly timesheets in a shared repository; "Deviations
+  larger than 10% need to be explained on consortium level." Conflict
+  resolution: consensus first, then vote, then arbitration. Technical
+  development requests/bugs in a public Roundup issue tracker.
+- Notable structural fact: none of the Technical Board's core developers
+  represented partners holding consortium-management budget; EU deliverable
+  reports were run by a rotating "report release manager" — "a technique
+  borrowed from open source software release management."
+
+### 8.6 Infrastructure and openness (D02.1)
+
+- Everything on self-run **codespeak.net** (chosen over SourceForge for
+  "more control and transparency"; Subversion was not readily available
+  elsewhere early on). Stated open-access policy: anyone can work in private
+  areas then contribute; "hardly any contributor can do permanent damage to
+  a fully versioned file system"; "There were no incidents of abuse of this
+  open policy"; infrastructure "should be very careful to not impose
+  restrictions which lead to unnecessary overheads." Over 200 registered
+  users by March 2007; very few outages in 28 months, "never resulting in
+  data damage or loss."
+- Repository resilience: an svn-sync-repo mirror replaying revisions at
+  ~1-minute delay, daily tiered backups, single-login hooks. Website pages
+  generated from reStructuredText under version control; video
+  documentation distributed by BitTorrent (**6,955 successful downloads of
+  40 torrents by 2007-02**; "well over 7,500" by March).
+- **Growth over the 28 months**: code **~30,000 → ~340,000 lines**, test
+  code **~8,000 → ~82,000 lines**; pypy-dev subscribers ~150 → ~330 (324 on
+  2007-02-19); ~40,000 monthly site visits; 250,000 IRC lines with ~20
+  people present in #pypy on average.
+
+### 8.7 Release scheme (D02.2)
+
+- Two-track model: continuous public SVN ("the 'revisions' were usually
+  consistent in the sense that all automated tests passed. We developed
+  tools to track this consistency and determine which revision has
+  regressions") plus **six formal releases** "to settle and formally
+  announce … making sure that we have appropriate documentation and a clear
+  message":
+
+| Release | Date | Stated content |
+|---|---|---|
+| 0.6 | 2005-05-20 | core Python interpreter (on CPython) |
+| 0.7 | 2005-08-28 | first *translated* Python interpreter |
+| 0.8 | 2005-11-03 | more translation aspects, optimizations |
+| 0.9 | 2006-06-26 | stackless, extension compiler, framework GCs, logic programming |
+| 0.99 | 2007-02-17 | high-level backends, optimizations |
+| 1.0 | 2007-03-27 | optimizations, JIT compiler generator, transparent proxies, AOP |
+
+- A single mainline **dist** branch with derived release tags "proved
+  sufficient"; experimental work usually merged back into mainline. The
+  release process became "increasingly refined and automated," to the point
+  that "the effort to perform such a release lies mostly in considering and
+  expanding our test sets, and updating and reviewing documentation."
+  Release managers temporarily control the development branch before a
+  release.
+- Recorded scaling concern (March 2007): "as the number of backends and PyPy
+  features and options increases, it is not easily possible to ensure that
+  dist is stable with respect to an increasing set of test combinations" —
+  the planned answer was a trunk/dist split (develop on trunk, copy stable
+  tested snapshots to dist), with mainline integrity resting on "a group of
+  trusted contributors."
+
+### 8.8 Documentation structure (D14.2)
+
+Three deliberate documentation strands: **user documentation**
+(getting-started doubling as release notes and online tutorial — a quoted
+user calls it "about the clearest, best such page I have ever seen"),
+**project documentation** (talks, EU reports published for community
+feedback, sprint reports, video archive — a "whole brained" approach
+documenting process as well as code, also used by academic researchers), and
+**source-code documentation** (per-component: why the component is needed,
+what services it performs, main design decisions, with examples and tests —
+positioned as "second-line support" behind getting-started). The
+getting-started source-tree map (interpreter/, objspace/std/, translator/,
+annotation/, rpython/ with per-type `rxxxx.py` files) is the canonical
+"where to start reading" index.
+
+---
+## 9. Deviations, difficulties and retrospective judgments (D14.x, Final)
+
+### 9.1 Deviations the project itself recorded
+
+1. **Duration extended 24 → 28 months** (requested during phase 2). Stated
+   reasons: resource-deployment limitations, following up Review
+   recommendations, and the changed (more specialized, commercially driven)
+   nature of sprints and workshops. "Fortunately, the Commission reacted with
+   flexibility when we requested changes to the work plan, project duration
+   and also prepayment calculations."
+2. **Key-person health incident**: Tismerysoft's key person was stopped by
+   serious health issues from early June 2006, halting that partner's WP07
+   (massive parallelism) work; other partners "collaboratively completed the
+   most crucial WP7 results" for the 0.9 release; the WP07 report shipped
+   2–3 months late; the project prepared "for the situation where this
+   partner cannot return to the project at all."
+3. **Deliverable restructuring**: Amendment 4 restructured 58 deliverables
+   into 21 contractual deliverables; five amendments total. Interim reports
+   (D07.1, D09.1) were invented mid-project, "endorsed by reviewers, to
+   provide status before the actual deliverable is due," and were "also used
+   by community members to prepare for sprints."
+4. **Phase-3 work pulled forward** (extension compiler WP03, validation WP12,
+   integration/configuration WP13) on commercial/community demand and for
+   post-funding sustainability.
+5. **Extension-module support consciously deprioritized** in favour of the
+   research vision; PyPy 1.0 consequently "still not generally usable" (§1.5).
+6. RPython deliberately **not generalized** for standalone/commercial use
+   during the project ("it was not feasible to focus on improving and
+   enriching RPython for other purposes"), despite commercial interest in
+   RPython as "a 'better Java'".
+7. **Unforeseen directions added by the community**: JavaScript backend and
+   the beginnings of a JavaScript interpreter, AJAX tooling, CLI/.NET and JVM
+   backends, a Scheme interpreter — "resulting in new features and
+   directions, not foreseen at the start of the EU project." The reports
+   treat this as positive validation, "welcomed and supported by the PyPy
+   core group, because it served both as early validation of PyPy's
+   architecture and broadening its overall applicability."
+8. **EU-style per-partner effort tracking deviated** because "the bulk of the
+   development work done in PyPy was self-organized and peer-driven" — "the
+   tracking of planned work and cost consumption per partner did deviate both
+   when it came to development work and management work which had to be
+   explained and justified."
+
+### 9.2 Funding-mechanics difficulties (Final Report §1.6)
+
+- Paying individual OSS contributors under FP6 was "very hard": the
+  "Physical Partner" model required contract amendments and full consortium
+  duties — "far too heavy an obligation for experts that only contribute one
+  or a few intense work weeks and only receive travel reimbursement." The
+  lightweight **"Summer of PyPy"** model (inspired by Google Summer of Code;
+  five participants approved) was invented as the fix and "was very
+  successful," with the side effect of reaching undergraduate/postgraduate
+  students. Their work triggered the JavaScript interpreter, the
+  JavaScript/AJAX mapping, the CLI backend, and the JVM backend.
+- The 50% co-financing rule was "burdensome" for the SME-majority consortium:
+  "It can be hard for SME's to focus on the long-term goals of serious
+  research and development work, while simultaneously having to make money to
+  finance its own share of the costs." The report recommends a higher SME
+  funding rate for FP7.
+- Transnational hiring was effectively blocked ("huge differences in
+  taxation, labour laws and general lack of support"); consultant hiring
+  counts as sub-contracting and "is hard to use ... in practice." "We have on
+  several occasions had to forgo hiring people that would have improved
+  project performance."
+
+### 9.3 Retrospective judgments on the process
+
+- The central tension: "the project experienced a growing need to balance
+  contractual obligations with a community wanting to follow its own ideas
+  and priorities. It would become more difficult to combine the mentoring
+  approach with the complex and time-critical contractual tasks within one
+  sprint." Reaction: sprints became **pre-targeted** either at internal
+  milestones or at newcomer mentoring.
+- "The project succeeded because of the 'people factor' and because of the
+  huge amount of work and energy core people was prepared to invest."
+- Sprint-driven development is judged by its own report (D14.5) to be "not a
+  methodology, but rather a practice, and in general a practice is not
+  inherently agile" — but PyPy's implementation of it "was indeed an agile
+  implementation" and "the primary success factor for managing to balance
+  community interaction and demands with a plan-driven frame work."
+- Post-funding forecast (written before the end): sprint frequency will drop
+  to "maybe not more than four sprints per year"; development "will likely be
+  structured in a more typical Open Source style: advances will be driven by
+  somewhat separate interests, namely engineering, academic and commercial
+  interests. A group of trusted individual contributors has been installed to
+  keep conceptual integrity."
+
+External recognition quoted in D14.4 (a Ruby developer): "doing the types of
+things the PyPy team has done is HARD. So hard that even with great funding,
+lots of experience, and quite a bit of time, they still aren't where they
+might want to be yet. And therefore, for some of these other teams, it might
+make a lot more sense to harness the work the PyPy team has already done
+instead of doing it all on their own."
+
+---
+## 10. Cross-cutting statements of philosophy (verbatim anchors)
+
+- "The primary goal is to allow us to implement the full Python language only
+  once, as an interpreter, and derive interesting tools from it." (D05.1)
+- "The source of our Standard Interpreter is an executable specification of
+  the Python language." (D07.1)
+- "Static analysis is and remains slightly fragile … This is also a reason why
+  we believe that dynamic analysis is ultimately more powerful." (D05.1 §8.1)
+- "Our approach gives us flexibility and lets us choose various aspects at
+  translation time instead of encoding them into the implementation itself."
+  (D05.3)
+- "It is surely better to not write the reference count manipulations at all.
+  … once it is done and tested, it just works without further effort." (D05.4)
+- "A JIT compiler generator renders the issue of performance mostly orthogonal
+  to the evolution and maintenance of the language interpreter." (D14.4)
+- "Ideally, turning an interpreter into a JIT compiler is only a matter of
+  adding a few hints. In practice, the current JIT generation framework has
+  many limitations and rough edges requiring workarounds." (D08.1 App. 1)
+- "Interpreters for dynamic languages can be implemented on a high level of
+  abstraction, yet be brought to run at least as efficiently as today's common
+  lower level implementations." (D14.4)
+- "It is a requirement to add new tests for each newly added features and for
+  each fixed bug." (D01.1)
+- "The flexibility of PyPy's Python implementation has been essential to the
+  task of experimenting with and especially assessing these new
+  implementations, vindicating the effort we put in to allow this
+  flexibility." (D06.1)
+
+---
+
+## Appendix A. Deliverable index
+
+| ID | Title (abbrev.) | Content |
+|---|---|---|
+| D01.1, D01.2-4 | QA plan; project organization | Minimal-procedure QA; TDD as primary QA tool; roles, meetings, tracking |
+| D02.1, D02.2, D02.3 | Tools/website; release scheme; testing framework | codespeak infra; six releases + continuous SVN; py.test, test taxonomy, distributed testing |
+| D03.1 | Extension compiler | 2.4.1 target; mixed modules; CPy object space; rctypes and its pivot |
+| D04.1–D04.4 | Standard interpreter | Object spaces; app/interp levels; W_Objects, multimethods; parser/compiler rewrites; thunk space |
+| D05.1–D05.4 | Translation | Flow space, annotator (formal model), RTyper, backends; translation aspects; measured aspect costs |
+| D06.1 | Core optimizations | Benchmark methodology; multidicts, method optimizations, dispatch, per-optimization numbers |
+| D07.1 | Parallelism & translation aspects | Stackless transform, coroutines/tasklets/greenlets, pickling/cloning, composability; GC framework, GC transformer, all GC numbers |
+| D08.1, D08.2 | JIT | JIT generator: BTA, timeshifting, promotion, virtuals, virtualizables; 1.47× gcc result; open issues |
+| D09.1 | Logic/constraints | Logic object space, computation spaces, GC-cloning search; OWL/SPARQL; cloning not working at ship |
+| D10.1 | AOP | AST hooks, import-time weaving, DbC; RPylint |
+| D11.1 | Embedded | Five options; RPython web-server case study; size/modularity blockers |
+| D12.1 | High-level backends & prototypes | ootype; GenCLI/GenJVM/GenJS; taint space; transparent proxies |
+| D13.1 | Integration & configuration | Translation-time config system; 1.0 compatibility matrix; build farm; Debian |
+| D14.1–D14.5, Final | Milestones, process, final report | Phase results, deviations, sprint methodology, l×o×p, final self-assessment |
+
+### A.1 Source files
+
+Exact filenames in the source directory (`eu-report/`), one per deliverable:
+
+| ID | File |
+|---|---|
+| D01.1 | `D01.1-Create_QA_plan_for_the_project.pdf` |
+| D01.2-4 | `D01.2-4_Project_Organization-2007-03-28.pdf` |
+| D02.1 | `D02.1_Development_Tools_and_Website-2007-03-21.pdf` |
+| D02.2 | `D02.2_Release_Scheme-2007-03-30.pdf` |
+| D02.3 | `D02.3_Testing_Framework-2007-03-23.pdf` |
+| D03.1 | `D03.1_Extension_Compiler-2007-03-21.pdf` |
+| D04.1 | `D04.1_Partial_Python_Implementation_on_top_of_CPython.pdf` |
+| D04.2 | `D04.2_Complete_Python_Implementation_on_top_of_CPython.pdf` |
+| D04.3 | `D04.3_Report_about_the_parser_and_bytecode_compiler.pdf` |
+| D04.4 | `D04.4_Release_PyPy_as_a_research_tool.pdf` |
+| D05.1 | `D05.1_Publish_on_translating_a_very-high-level_description.pdf` |
+| D05.2 | `D05.2_A_compiled,_self-contained_version_of_PyPy.pdf` |
+| D05.3 | `D05.3_Publish_on_implementation_with_translation_aspects.pdf` |
+| D05.4 | `D05.4_Publish_on_encapsulating_low_level_language_aspects.pdf` |
+| D06.1 | `D06.1_Core_Optimizations-2007-04-30.pdf` |
+| D07.1 | `D07.1_Massive_Parallelism_and_Translation_Aspects-2007-02-28.pdf` |
+| D08.1 | `D08.1_JIT_Compiler_Release-2007-04-30.pdf` |
+| D08.2 | `D08.2_JIT_Compiler_Architecture-2007-05-01.pdf` |
+| D09.1 (interim) | `D09.1_Constraint_Solving_and_Semantic_Web-interim-2007-02-28.pdf` |
+| D09.1 (final) | `D09.1_Constraint_Solving_and_Semantic_Web-2007-05-11.pdf` |
+| D10.1 | `D10.1_Aspect_Oriented_Programming_in_PyPy-2007-03-22.pdf` |
+| D11.1 | `D11.1_PyPy_for_Embedded_Devices-2007-03-26.pdf` |
+| D12.1 | `D12.1_H-L-Backends_and_Feature_Prototypes-2007-03-22.pdf` |
+| D13.1 | `D13.1_Integration_and_Configuration-2007-03-30.pdf` |
+| D14.1 | `D14.1_Report_about_Milestone_Phase_1.pdf` |
+| D14.2 | `D14.2_Tutorials_and_Guide_Through_the_PyPy_Source_Code-2007-03-22.pdf` |
+| D14.3 | `D14.3_Report_about_Milestone_Phase_2-final-2006-08-03.pdf` |
+| D14.4 | `D14.4_Report_About_Milestone_Phase_3-2007-05-01.pdf` |
+| D14.5 | `D14.5_Documentation_of_the_development_process-2007-03-30.pdf` |
+| Final | `PYPY-EU-Final-Activity-Report.pdf` |
+
+## Appendix B. Key quantitative anchors
+
+Translation and aspects:
+
+- Annotating PyPy: ~20k blocks / ~4k functions, ~5 min, rules re-applied
+  20–40×.
+- Aspects at 0.8: stackless +8%/+28%; refcount 2× vs Boehm; thunk +6%/+13%;
+  composition prediction 1.14× vs measured 1.15×.
+- Stackless at 0.9-era: +17–28% time, 2.1–2.4× code; struct-locals
+  alternative +60–64%.
+- GCs vs CPython: Boehm 4.4–5.8×; mark-and-sweep 5.7–5.8×; refcount 7.7–7.8×.
+- Inlining +52–64%; +malloc removal → 1.03–1.13 of default; escape analysis
+  redundant with malloc removal; tagged pointers +7% (with const-folding);
+  malloc removal kills ~20% of mallocs.
+- First full translation: 22× (richards) to ~460× (pystone) slower than
+  CPython; pypy-c-0.7 with refcounting 104.7× on pystone.
+
+Interpreter optimizations:
+
+- All interpreter optimizations: >2× (richards 2.5×).
+- Multidicts +15–40%; three method optimizations combined: richards 0.53
+  (47% faster); precomputed `__xyz__` lookups: disabling costs 22–32%;
+  CALL_LIKELY_BUILTIN 11–19%.
+- Multiple Row Displacement: −2.5 MB, almost half the binary, a few percent
+  slower (but 15% slower than double dispatch on CLI/Mono).
+- SharedDict: 1M two-attribute instances 140 MB vs 266 MB baseline (CPython
+  202 MB, `__slots__` 96 MB).
+
+JIT and backends:
+
+- JIT on arithmetic: 1.47× unoptimized gcc (target was 1.5×); Psyco 1.00×.
+- pypy-cli ≈6.8× IronPython = 1.8 (backend) × 2 (interpretation) × 1.8
+  (objspace).
+- 1.0 vs CPython (no JIT): richards 1.17×, pystone 1.55×, memory-heavy 5–8×.
+- Binary size: pypy-c ≈5.3 MB vs CPython ≈1.0 MB.
+- Taint space: ~300 LOC, ~33% slowdown; transparent proxies <300 LOC.
+
+Process:
+
+- Code ~30k → ~340k lines; test code ~8k → ~82k lines over 28 months.
+- ~95% of CPython core regression tests pass; PyPy-on-CPython ~2000× slower
+  than CPython.
+- 18 sprints during funding (6–24 participants); 6 releases; 27 pypy-sync
+  meetings.

--- a/eu_report_assessment.md
+++ b/eu_report_assessment.md
@@ -1,0 +1,117 @@
+# Assessment: what in the EU reports is still right, and what is not
+
+Companion to `eu_report.md` (the objective digest — read it first). That file
+contains only what the 2004–2007 documents say; **this** file judges those
+claims against two later bodies of evidence: (a) what PyPy itself did in the
+following ~18 years (the current source tree under `pypy/` and `rpython/` in
+this repository is the ground truth), and (b) what pyre/majit has already
+reproduced or contradicted. The normative conclusions for pyre are drawn in
+`pyre/design.md`; this file is the evidence table.
+
+Legend: **VALIDATED** — held up as stated; **SUPERSEDED** — the implementation
+was replaced but the underlying concept survived (usually in changed form);
+**REFUTED** — abandoned by PyPy itself or contradicted by later evidence;
+**OPEN** — still genuinely undecided.
+
+---
+
+## 1. The big bets
+
+| EU-report claim | Verdict | What actually happened |
+|---|---|---|
+| The interpreter is "an executable specification"; the JIT must be *generated* from it, never hand-written | **VALIDATED** | The single most durable idea in the corpus. The tracing JIT (2008+) is a different *generator*, but the principle — performance orthogonal to interpreter evolution — is exactly what let PyPy track 2.7→3.x with one JIT. This is the founding axiom of majit. |
+| The specific JIT generator: binding-time analysis + timeshifting (offline partial evaluation) | **REFUTED** | Abandoned within ~2 years of the final report, replaced by the meta-tracing JIT (pyjitpl5). The reports' own §3.7 "open issues" (eager-branch code explosion, non-termination, unrefined widening, no hotspot detection) list precisely the reasons. The authors' hedge — "the best solution is probably something in between these extremes [eager PE vs Psyco-lazy]" — was prophetic: tracing *is* the lazy extreme, made practical. |
+| Promotion, red/green binding times, virtuals, virtualizables, deep-freeze/immutability hints | **VALIDATED** | Every one of these concepts survived the PE→tracing rewrite and is load-bearing in `rpython/jit/` today: `promote()`, greens/reds on JitDriver, virtuals in the optimizer, `_virtualizable_` frames, `@elidable`/quasi-immutable fields. Architecture insight outlived implementation strategy. |
+| "Dynamic analysis is ultimately more powerful [than static]" (D05.1 §8.1) | **VALIDATED** | By PyPy's own trajectory: the static PE JIT lost to runtime tracing; static type inference (annotator) survived only as an offline build step, never as the optimization engine. |
+| Manual JIT invocation (`pypyjit.enable`) acceptable, hotspot detection "not worked on yet" | **REFUTED** | Tracing JIT made counter-based hotspot detection (`jit_merge_point`/`can_enter_jit` thresholds) fundamental. No modern deployment exposes manual enabling as the primary interface. |
+| "By construction, the JIT should work correctly on absolutely any kind of Python code" (frame introspection, `sys._getframe…`) | **VALIDATED** | Survived as PyPy's core correctness discipline: the JIT falls back to the interpreter (blackhole/deopt) rather than restricting the language. Directly encoded in pyre's AGENTS.md frame-identity rule: JIT/interpreter divergence is a *generation defect*, never an accepted limitation. |
+| 1.47× unoptimized gcc on arithmetic ⇒ "abstraction overhead has been correctly removed" | Technically true, **misleading in scope** | The result was real but held only for the integer-arithmetic kernel with hand-placed hints. General speedups arrived only with tracing (post-project), exactly as the report's fine print admitted ("more extensive hints are necessary … after the project"). Lesson: kernel benchmarks validate machinery, not the product. |
+
+## 2. Interpreter architecture
+
+| Claim | Verdict | Notes |
+|---|---|---|
+| Bytecode-interpreter / object-space separation with wrapped black-box objects | **VALIDATED** (as an internal layering) | Modern PyPy and pyre both keep interpreter vs `objspace/std` (pyre-interpreter vs pyre-object). The W_Root/`w_` discipline, `OperationError`, gateway/`unwrap_spec` machinery all survive nearly verbatim. |
+| Objspace as a *pluggable* runtime extension point (thunk, taint, logic, proxying spaces) | **REFUTED** | Every alternative object space was deleted. Proxying spaces multiply dispatch cost and are hostile to the JIT (every operation must be traceable through the proxy). The flow object space was also divorced from the objspace interface (`rpython/flowspace/`). What survived is the *interface*, not the pluggability. |
+| Multimethod dispatch + table slicing in StdObjSpace | **REFUTED** | Modern PyPy removed the multimethod machinery; operations are plain methods/descriptors on W_ classes. The EU-era justification ("can probably be translated to … efficient multimethod code") never paid off; the JIT made dispatch cost irrelevant and the machinery pure complexity. pyre correctly ports the *modern* shape. |
+| Two-modules-per-type layout (`xxxtype.py` + `xxxobject.py`) | **REFUTED** | Merged into single `xxxobject.py` files in modern PyPy. |
+| Multiple hidden implementations of one user-visible type | **VALIDATED — in changed form** | The multidict/multilist idea matured into **storage strategies** (list/dict/set strategies, mapdicts, celldicts) — adaptive per-instance representation, chosen at runtime, JIT-visible. The exotic static variants (ropes, string slices, optimal arrays) died exactly as D06.1's own measurements predicted. |
+| "Wrap everything, including ints; unboxing is a translation-time optimization" | **VALIDATED** with a caveat | The clean-source/optimize-later doctrine held. But the promised optimization (tagged pointers) stayed off by default in PyPy; what actually removed boxing cost was the JIT (virtuals). pyre note: pyre's `tagged-int.plan.md` revisits this with different economics (Rust enums/NaN-boxing options); the EU-era measurement (+7% at best, only with const-folding) is a sober prior. |
+| Frame classes specialized/generated at bootstrap; argument parsing via generated code | **SUPERSEDED** | The mechanism (metaprogramming at bootstrap, invisible to the annotator) is RPython-specific. The need it served — keeping the analyzable code static — is served in pyre by Rust's own static types and proc macros. |
+| Parser/compiler: flexible grammar-from-data, AST-direct building | **SUPERSEDED** | The three-generation pivot story is a good case study in porting-vs-rewriting, but syntax-extensibility as a goal (Oz-syntax, `import csp_syntax`, AOP hooks) died. pyre uses RustPython's compiler front-end targeting CPython 3.14 bytecode — the "track CPython exactly" pole won over the "extensible syntax" pole. |
+
+## 3. Translation and aspects
+
+| Claim | Verdict | Notes |
+|---|---|---|
+| Whole-program type inference over a live program image; RPython deliberately unspecified | **SUPERSEDED** for pyre; costly even for PyPy | It worked, but the costs the reports admit (slow, non-incremental, first-error-only, cryptic diagnostics — the entire reason RPylint existed) were never fixed; "modular annotation" (D05.1's stated future need) never happened. Rust + Charon LLBC extraction gives pyre the same whole-program low-level view with a real type system, incremental builds, and real error messages. The annotator survives in majit only as the *binding-time/representation* analysis it also was in RPython's JIT, not as type recovery. |
+| Translation aspects: GC, threading model, stackless, sandbox woven at translation time, invisible in interpreter source | **VALIDATED** — the second most durable idea | PyPy's GC transformer, sandbox transform, and (while it lived) stackless transform all confirmed it. pyre already re-instantiates it: majit-gc weaving/write-barrier hooks, rsandbox as a compile-time aspect (PR#304), JIT generation itself as "just another aspect". The refutation of *manual* refcounting sprinkled through CPython sources is as true in 2026 as in 2005 — and is now also the free-threading argument. |
+| "Any combination of aspects can be selected freely" | **PARTLY REFUTED** | D13.1's own compatibility matrix already showed the combinatorial claim failing (JIT = default config only; logic space = framework GC + stackless only; tagged ints = Boehm only). Post-EU PyPy pruned the matrix instead of completing it: one GC, one backend, one objspace. Real lesson: aspects are valuable, but each supported *combination* is a product you must test; keep the matrix small. |
+| Refcounting "a possibly viable option" worth optimizing | **REFUTED** | 2× slower naive, no cycle collection; deleted. Exact generational moving GC won (minimark → incminimark), fulfilling D06.1's "biggest single improvement would likely be … a more sophisticated garbage collector". majit-gc (nursery+oldgen+incremental+card marking) is the port of the winner, not the contenders. |
+| GC-in-the-implementation-language + memory simulator for testing | **VALIDATED** | incminimark is RPython; testable on the simulator. majit-gc being Rust-on-Rust with test harnesses is the same move. |
+| Root finding "one of the hardest problems"; future idea: let the JIT find roots since it knows frame layout | **VALIDATED** | Shadow-stack won for interpreter code (asmgcc was tried and removed); JIT-known frame layout became GC-traced jitframes. pyre's wasm Option A GC-traced JITFRAME and the PyFrame→W_Root work (#355) are the same resolution. |
+| Stackless transform: portable CPS-style unwinding, "C stack as cache", +17–28% cost | **REFUTED** as shipped | PyPy retired the graph transform and adopted stacklets/continulets — small per-platform assembly stack switching, i.e. the approach the reports had positioned as the fallback. The composability ("views") analysis and coroutine-pickling semantics remain intellectually valid; the mechanism does not. pyre should not resurrect the transform. |
+| Extension modules in RPython + rctypes; "one source fits all Python implementations" | **REFUTED** | rctypes died (its own report documents the pivot mid-flight and the moving-GC blockage); the extension compiler never became usable. What worked later: cpyext (C-API emulation) and cffi. The strategic error the final report admits — deferring extension-module engineering — cost PyPy a decade of adoption. Direct warning label for pyre's HPy/ABI roadmap item. |
+| ootype + CLI/JVM/JS backends; "p" axis of l×o×p | **REFUTED** | ootype and all high-level backends were deleted from RPython (~2012-13). The C backend is the only survivor. The "l" axis, by contrast, was genuinely validated post-project (Pyrolog, Topaz, HippyVM, Pycket, RSqueak) — the framework *is* language-generic. For pyre: majit's multi-consumer design (pyre, aheui-mjit, toy interpreters) inherits the validated axis; backend proliferation should follow cranelift/dynasm/wasm need, not platform evangelism. |
+| Config system: translation-time resolution, write-once options, dependency checking | **VALIDATED** | Still how RPython builds work. pyre's analog is Cargo features + build.rs codegen for build-time choices and `PYRE_*` env gates for runtime experiment flags; the discipline worth keeping is D13.1's: declared dependencies between options, and a small, explicitly supported matrix. |
+
+## 4. Optimizations (D06.1) — the empirical record
+
+- The **methodology** aged better than most results: benchmark suite spanning
+  workload types, nightly regression tracking, per-optimization toggles,
+  publishing negative results. This is check.py's lineage.
+- **Individually validated**: method cache with type version tags (still in
+  PyPy *and* CPython — the report predicted the port), CALL_METHOD-style
+  bound-method elision (CPython 3.11 LOAD_METHOD/adaptive specializations are
+  the same idea), key-sharing instance dicts (CPython 3.3 PEP 412 = SharedDict),
+  string interning, exception-free internal interfaces.
+- **Individually refuted**: prebuilt int boxes (cache-hostile), ropes/string
+  slices/multilists as defaults, small-dict linear scan, bytecode
+  type-special-casing (the JIT does it better), CALL_LIKELY_BUILTIN (dropped
+  once the JIT subsumed it).
+- The **meta-lesson stands**: representation cleverness that fights the host
+  hardware (extra indirection, cache misses) or assumes untuned application
+  code loses on real programs. Measure; keep a kill switch; expect "no clear
+  tendency" as the usual outcome.
+
+## 5. Process
+
+| Claim | Verdict | Notes |
+|---|---|---|
+| TDD as the primary QA instrument; tests instead of proofs; a test per feature and per bug | **VALIDATED** | Also how PyPy still works, and how pyre works (cargo test ×2 feature configs, compliance suites, `check.py` gate). |
+| Multi-level test taxonomy (interp-level / app-level / compliance / translation) | **VALIDATED** | Maps 1:1 onto pyre: Rust unit tests / extra_tests + cpython_tests / lib-python compliance / majit-translate prepass+examples. |
+| Distributed testing because translation tests dominate wall-clock | **VALIDATED** as a warning | Whole-program translation latency (~2h for the logic build in D09.1) was a permanent tax on PyPy development. pyre's equivalents (LLBC re-extraction minutes, prepass rebuilds) need the same active management (fingerprint skipping already exists). |
+| Sprints/community process | Context-bound | Historically interesting; not normative for pyre. The transferable kernel: releases gated on green suites + docs, continuous trunk consistency, "no formal task distribution" self-organization. |
+
+## 6. Still-open questions the reports flagged
+
+- **Merge/widening policy** ("merging too eagerly may loose important
+  precision and not merging eagerly enough may create too many redundant
+  residual code paths") — the tracing JIT re-encounters this as trace scope,
+  retracing, and bridge-vs-loop decisions. pyre is living inside this problem
+  today (#345 compile bottlenecks, cross-loop-cut, bridge chaining).
+- **Promotion state retention** ("can never be reclaimed") — still true in
+  spirit: guard_value bridges and cached greens accumulate; PyPy manages it
+  with trace limits/retrace counts rather than solving it.
+- **Layering a meta-JIT on a lower-level JIT/VM** (D08.2 §3.7's research
+  question) — pyre answers a variant daily: majit on cranelift, majit-on-wasmi,
+  wasm backend. The question of how much to delegate downward (regalloc,
+  inlining) vs control directly is still live engineering, not settled theory.
+- **Reduced/"micro" interpreter builds** (D11.1) — never built by PyPy;
+  pyre-wasm's size/coverage constraints re-open it.
+
+## 7. Summary judgment
+
+The corpus is two documents interleaved. One is a **strategy** — generate
+everything from a single high-level executable specification; postpone
+low-level decisions to translation; let tests, not proofs, carry correctness;
+measure and keep the losers toggled off. That strategy is validated nearly
+without exception, by PyPy's next two decades and by pyre's own results.
+The other is a **portfolio of 2005–2007 implementations** of that strategy —
+the PE JIT, multimethods, pluggable spaces, ootype backends, CPS stackless,
+rctypes, refcounting — of which almost every item was later deleted *by the
+same team*, usually for reasons their own reports already recorded as open
+issues. The reports are therefore most valuable read as: (a) the canonical
+statement of the strategy, (b) a catalog of measured dead ends that need not
+be re-explored, and (c) proof that the team's willingness to delete its own
+flagship implementations was itself part of the strategy.

--- a/majit/README.md
+++ b/majit/README.md
@@ -2,7 +2,7 @@
 
 **M**eta-tr**A**cing **JIT** compiler framework — or, if you prefer, **Ma**gical **JIT**.
 
-majit is a Rust port of [RPython's JIT infrastructure](https://rpython.readthedocs.io/en/latest/jit/index.html). Given an interpreter written in Rust, majit automatically generates a tracing JIT compiler for it.
+majit is a Rust port of [RPython's JIT infrastructure](https://rpython.readthedocs.io/en/latest/jit/index.html). Given an interpreter written in Rust, majit generates a tracing JIT compiler for it.
 
 ## What it does
 
@@ -27,18 +27,19 @@ fn mainloop(program: &Program, state: &mut State, driver: &mut JitDriver<State>)
 }
 ```
 
-Hot loops are detected, traced, optimized, and compiled to native code via Cranelift. Guard failures fall back to the interpreter transparently.
+Hot loops are detected, traced, optimized, and compiled to native code. Guard failures fall back to the interpreter transparently.
 
 ## Similarities with RPython
 
-majit and the RPython JIT share the same core ideas:
+majit and the RPython JIT share the same core ideas — and, per the project's parity rule, the same module names and data structures:
 
 - **Meta-tracing**: traces the interpreter itself, optimizing at the interpreter execution level rather than the bytecode level
 - **Guard-based speculation**: records type/value assumptions as guards; deoptimizes to the interpreter on failure
 - **Trace → Optimize → Compile → Execute pipeline**
-- **8-pass optimizer**: IntBounds, Rewrite, Virtualize, String, Pure, Guard, Simplify, Heap
+- **optimizeopt pass pipeline**: IntBounds, Rewrite, Virtualize, String, Pure, Guard, Simplify, Heap (plus generated rewrite rules in `ruleopt`)
 - **Escape analysis**: eliminates virtual object allocations (NEW → field tracking → force on escape)
 - **Resume/blackhole deoptimization**: restores interpreter state on guard failure
+- **Hint vocabulary**: `promote`, greens/reds, `elidable`, `dont_look_inside`, virtualizables, quasi-immutable fields — same names, same need-oriented placement
 
 ## Differences from RPython
 
@@ -46,7 +47,7 @@ majit and the RPython JIT share the same core ideas:
 
 RPython translates a **restricted Python subset** to C at compile time. The annotator infers types, and the rtyper lowers them to low-level representations. JIT hints (`jit_merge_point`, `promote`, `elidable`, etc.) are inserted directly into Python source.
 
-majit works with **plain Rust**. No type inference is needed (the Rust compiler already handles that), and JIT hints are provided as proc-macro attributes:
+majit works with **plain Rust**. Type recovery is not needed (the Rust compiler already did it), and JIT hints are proc-macro attributes:
 
 | RPython | majit |
 |---------|-------|
@@ -56,29 +57,47 @@ majit works with **plain Rust**. No type inference is needed (the Rust compiler 
 | `driver.jit_merge_point(...)` | `jit_merge_point!(driver, ...)` |
 | `driver.can_enter_jit(...)` | `can_enter_jit!(driver, ...)` |
 
-### Translation vs analysis
+### Translation: live image vs extracted artifacts
 
-RPython's codewriter **fully translates** RPython source into JitCode (bytecode). All types and control flow are finalized at translation time.
+RPython analyses a **live program image** (full Python runs as a preprocessor, then flowspace/annotator/rtyper analyse the loaded functions) and its codewriter translates the interpreter into JitCode bytecode that the meta-interpreter executes.
 
-majit **auto-generates and injects trace code at build time**. There are two paths:
+majit runs the **same pipeline at `cargo build` time over extracted artifacts**. There are two front-ends:
 
-1. **`majit-analyze` path (used by pyre-jit)**: `build.rs` calls `majit_analyze::analyze_multiple_pipeline_with_config()` to parse interpreter sources and run the canonical graph pipeline, then `generate_trace_code_from_pipeline()` to produce trace helper functions, writing them to `OUT_DIR/jit_trace_gen.rs`. The main crate pulls them in via `include!`. This path extracts opcode dispatch arms, resolves cross-file trait impls, classifies helpers, collects type layouts, and treats the graph pipeline as the single translator source-of-truth.
+1. **Charon LLBC path (used by pyre)**: the interpreter crates are extracted
+   to `.ullbc` low-level IR with [Charon](https://github.com/AeneasVerif/charon)
+   (`scripts/install-charon.py`, `scripts/extract-llbc.py`), and
+   **majit-translate** consumes them through the RPython pipeline shape —
+   `front` → `flowspace/` → `annotator/` → `rtyper/` → `codewriter/` — to
+   produce JitCode. `majit-charon-reader` is the input layer. Like RPython's
+   frozen image, extraction can go stale: source changes are invisible until
+   re-extraction (fingerprint skipping handles the common case).
 
-2. **`#[jit_interp]` proc-macro path (used by aheui-mjit)**: `build.rs` reads the interpreter source, extracts opcode match arms, and auto-generates a JIT mainloop annotated with `#[jit_interp]`, writing it to `OUT_DIR/jit_mainloop_gen.rs`. The proc macro lowers `while`/`loop` to branch bytecodes, `match` to guard chains, and `for` loops to abort fallback (equivalent to RPython's `@dont_look_inside`).
+2. **`#[jit_interp]` proc-macro path (used by aheui-mjit and `examples/`)**:
+   `build.rs` reads the interpreter source, extracts opcode match arms, and
+   generates a JIT mainloop annotated with `#[jit_interp]`. The proc macro
+   lowers `while`/`loop` to branch bytecodes, `match` to guard chains, and
+   unsupported shapes to residual-call fallback (the `@dont_look_inside`
+   equivalent).
 
-Both paths achieve **automatic generation and injection**. The remaining difference from RPython is **generality** — how many interpreter shapes and complex CFG patterns can be directly lowered, rather than falling back to opaque residual calls.
+The remaining gap to RPython is **generality**: how many interpreter shapes
+lower directly instead of falling back to opaque residual calls. Fallbacks
+are tracked by a census, not accepted silently.
 
 ### Backend
 
-RPython maintains **6 hand-written assembler backends** for x86, ARM, AArch64, s390x, and PPC (~300K LOC).
+RPython maintains **hand-written assembler backends** for x86, ARM, AArch64, s390x, and PPC (~300K LOC).
 
-majit uses a single [Cranelift](https://cranelift.dev/) backend for all platforms. Cranelift handles ISA-specific code generation, register allocation, and instruction selection, greatly reducing backend code.
+majit delegates instruction selection and register allocation downward and keeps three thin backends behind one `Backend` trait (`majit-backend`, the `AbstractCPU` analog):
+
+- **majit-backend-cranelift** — the portable default ([Cranelift](https://cranelift.dev/))
+- **majit-backend-dynasm** — direct machine-code emission via dynasm-rs where measured to matter
+- **majit-backend-wasm** — emits WebAssembly trace modules (browser via wasm-bindgen, or native embedders like wasmi/wasmtime)
 
 ### GC
 
 RPython's incminimark GC is deeply integrated with the JIT and uses an lltype-based low-level memory model.
 
-majit's GC (`majit-gc`) implements the same algorithms (nursery + oldgen + incremental marking + card marking) but operates on top of Rust's ownership model. JIT-GC integration hooks (`jit_remember_young_pointer`, `gc_step`, `pin`/`unpin`) are also provided.
+majit's GC (`majit-gc`) ports the same lineage (nursery + oldgen + incremental marking + card marking) on top of Rust's ownership model, with the JIT-GC integration hooks (`jit_remember_young_pointer`, `gc_step`, `pin`/`unpin`) and shadow-stack root finding.
 
 ### SIMD
 
@@ -89,26 +108,36 @@ majit uses Cranelift's `I64X2`/`F64X2` SIMD types for platform-independent vecto
 ## Crate structure
 
 ```
-majit/                          # facade crate (re-exports all below)
-├── majit-ir/                   # IR: OpCode, Type, Value, Descr traits
-├── majit-opt/                  # Optimizer: 8-pass pipeline + auxiliaries
-├── majit-trace/                # Tracing: hot counter, recorder, warm state
-├── majit-codegen/              # Backend abstraction: Backend trait
-├── majit-codegen-cranelift/    # Cranelift backend: native code generation
-├── majit-meta/                 # Meta-interpreter: JitDriver, MetaInterp, resume
-├── majit-gc/                   # GC: nursery, oldgen, incremental, card marking
-├── majit-macros/               # Proc macros: #[jit_driver], #[jit_interp], etc.
-├── majit-runtime/              # Runtime: jit_merge_point!, can_enter_jit!
-├── majit-analyze/              # Static analyzer: source → trace code generation
-└── examples/                   # 8 toy interpreters (tlr, tl, tla, tiny2, ...)
+majit/                        # facade crate (re-exports the crates below)
+├── majit-ir/                 # IR: resoperation model, Descr, effectinfo, intbounds, resume data
+├── majit-trace/              # Tracing engine: hot counters, recorder, warm state
+├── majit-metainterp/         # Meta-interpreter: pyjitpl, optimizeopt/ruleopt, resume,
+│                             #   blackhole, warmspot/warmstate, virtualizable, heapcache
+├── majit-translate/          # Build-time translation pipeline:
+│                             #   front → flowspace → annotator → rtyper → codewriter
+├── majit-charon-reader/      # Parser for Charon .llbc/.ullbc JSON (majit-translate input)
+├── majit-backend/            # Backend trait (AbstractCPU parity)
+├── majit-backend-cranelift/  # Cranelift code generation
+├── majit-backend-dynasm/     # dynasm-rs direct machine-code backend
+├── majit-backend-wasm/       # WebAssembly backend (wasm-encoder)
+├── majit-gc/                 # GC: nursery + oldgen + incremental + card marking
+├── majit-macros/             # Proc macros: #[jit_driver], #[elidable], #[dont_look_inside], …
+├── charon-corpus/            # Checked-in LLBC corpus for translate tests
+└── examples/                 # 11 toy interpreters (tl, tla, tlc, tlr, tiny2, tiny3,
+                              #   tinyframe, braininterp, calc, dualtape, i64env)
 ```
 
-## Performance
+Consumers today: **pyre** (`pyre-jit`, `pyre-jit-trace` — the Charon path),
+**aheui-mjit** and the in-tree `examples/` (the proc-macro path). majit never
+depends on pyre; the multi-consumer setup is deliberate — it is the proof of
+generality, the role RPython's non-Python interpreters played.
 
-| Interpreter | Program | Interpreter | JIT | Speedup |
-|------------|---------|-------------|-----|---------|
-| aheuijit | logo.aheui | 6.1s | 0.05s | **110x** |
-| pyre | fib(20) | — | correct result | JIT works |
+## Verification
+
+- `cargo test` per crate (run with a backend feature, e.g. `--features dynasm`).
+- The dual-backend synthetic suite `python3 ./pyre/check.py` runs every pyre
+  fixture under both native backends and byte-compares output; it is the
+  acceptance gate for JIT changes, alongside the benchmark suite.
 
 ## License
 

--- a/majit/README.md
+++ b/majit/README.md
@@ -87,10 +87,10 @@ are tracked by a census, not accepted silently.
 
 RPython maintains **hand-written assembler backends** for x86, ARM, AArch64, s390x, and PPC (~300K LOC).
 
-majit delegates instruction selection and register allocation downward and keeps three thin backends behind one `Backend` trait (`majit-backend`, the `AbstractCPU` analog):
+majit keeps three thin backends behind one `Backend` trait (`majit-backend`, the `AbstractCPU` analog) instead of hand-writing a full backend per ISA:
 
-- **majit-backend-cranelift** — the portable default ([Cranelift](https://cranelift.dev/))
-- **majit-backend-dynasm** — direct machine-code emission via dynasm-rs where measured to matter
+- **majit-backend-dynasm** — the current primary backend: direct machine-code emission via dynasm-rs (low compile latency)
+- **majit-backend-cranelift** — portable option that delegates instruction selection and register allocation downward ([Cranelift](https://cranelift.dev/))
 - **majit-backend-wasm** — emits WebAssembly trace modules (browser via wasm-bindgen, or native embedders like wasmi/wasmtime)
 
 ### GC

--- a/pyre/README.md
+++ b/pyre/README.md
@@ -10,6 +10,8 @@ PyPy proved that a meta-tracing JIT can make Python fast. pyre takes that proven
 
 The key insight: pyre's JIT framework [MaJIT](../majit/) handles tracing, optimization, and native code generation. This means the pyre interpreter itself can stay close to a straightforward Rust program that executes Python bytecodes, while MaJIT provides the tracing JIT machinery around it. In the same way that PyPy is "just a Python interpreter" that RPython makes fast, pyre is "just a Rust interpreter" that MaJIT makes fast.
 
+The deeper goal is to **reproduce RPython in Rust**. RPython's real value was never one specific interpreter but the framework that turns an ordinary interpreter into a fast VM — and MaJIT is that reproduction. PyPy is the most complete language ever built on RPython, so porting PyPy is how we prove and complete MaJIT's reproduction of RPython. pyre is the vehicle; a faithful RPython-in-Rust is the destination.
+
 ## Status
 
 pyre is under active development. Loop tracing and function inlining work, and the JIT now fires on integer-, float-, and exception-heavy loops alike. Most benchmarks run within ~1.5–3x of PyPy and several times faster than CPython; recursive-call-heavy code (fib_recursive) is the main remaining gap. Many Python features are not yet implemented.

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -1,0 +1,344 @@
+# pyre Design Charter
+
+**Status**: normative. This document states the design axioms, the layer
+architecture, the adaptation decisions, and the macro-strategy that govern
+pyre and majit development. It is grounded in three sources, in order of
+authority:
+
+1. **The current PyPy/RPython source tree** (`pypy/`, `rpython/` in this
+   repository) — the living, corrected result of twenty years of evolution.
+   For any mechanism, this is ground truth for *what* to build.
+2. **The PyPy EU reports (2004–2007)** — digested in `../eu_report.md`,
+   judged in `../eu_report_assessment.md`. The reports are the canonical
+   statement of *why* the architecture is shaped this way: the founders'
+   reasoning, their measurements, and — read against later history — a
+   catalog of dead ends that must not be re-explored. Code tells us what
+   PyPy is; the reports tell us what PyPy meant.
+3. **pyre's own measured results** — memory files, benchmark history,
+   check.py.
+
+When these conflict: current PyPy code beats the EU reports on mechanism;
+the EU reports beat folklore on rationale; pyre's own measurements beat both
+on what works *in Rust*.
+
+---
+
+## 1. Mission and layer correspondence
+
+pyre's goal, stated once: **put an RPython-equivalent layer (majit) on top of
+Rust, and a PyPy-equivalent (pyre) on top of that.**
+
+| PyPy world | pyre world | Notes |
+|---|---|---|
+| RPython the language | **Rust** | The host language is no longer a Python subset; it is a real language with a real type system. See §3.1. |
+| RPython translator (flowspace → annotator → rtyper) | **majit-translate** (`front/ast` → `flowspace/` → `annotator/` → `rtyper/`) over **Charon LLBC** artifacts | Same pipeline, same module names, run at `cargo build` time over extracted `.ullbc` instead of live bytecode. |
+| `jtransform`/codewriter → JitCode | **codewriter/** → JitCode | Identical role. |
+| metainterp, optimizer, resume, blackhole | **majit-metainterp / majit-trace** | Line-by-line port of the *tracing* JIT (pyjitpl5 lineage), not the 2007 PE JIT. |
+| x86/ARM/… hand-written backends (~300k LOC) | **majit-backend-cranelift / -dynasm / -wasm** | Machine-code generation delegated downward; see §3.4. |
+| incminimark GC | **majit-gc** (nursery + oldgen + incremental + card marking) | Port of the winner, not of Boehm/refcount/mark-sweep. |
+| sandbox transform | **rsandbox** | Compile-time sandbox aspect. |
+| `pypy/interpreter/` + `pypy/objspace/std/` | **pyre-interpreter + pyre-object** | Structural port, same names, same relative locations. |
+| CPython 2.7/3.10 compat | **CPython 3.14** compat | Bit-exact; RustPython compiler front-end supplies bytecode. |
+| GIL | **no GIL** | See §3.3. |
+
+majit is a general framework: pyre is its primary consumer but majit must
+never depend on pyre. Secondary consumers (aheui-mjit, toy interpreters,
+wasmi experiments) exist deliberately — they are the generality proof, the
+role PyPy's Prolog/JavaScript interpreters played for RPython.
+
+---
+
+## 2. Axioms
+
+These are the EU-era strategic claims that survived twenty years of
+evidence (assessment §7). They are not up for casual renegotiation.
+
+**A1 — Single executable specification.** The interpreter source *is* the
+semantics of pyre. The JIT is generated from it; it is never written to have
+semantics of its own. Any behavioral divergence between compiled traces and
+the interpreter is a **generation defect to fix in majit**, never an accepted
+limitation, and never justified by "the interpreter is Rust". (This is the
+meta-tracing principle; AGENTS.md states the enforcement details, including
+frame identity.)
+
+**A2 — Low-level policy is woven, not written.** Memory management, sandbox,
+concurrency machinery, code generation, representation tricks live in the
+translation/build layer or in majit, not in interpreter source. The EU
+reports' strongest empirical finding stands: encoding a low-level decision
+throughout an interpreter's source (CPython's refcounting) makes it
+effectively unchangeable. pyre-interpreter must stay readable as "a
+straightforward Rust program that executes Python bytecode".
+
+**A3 — Runtime information is the optimization engine.** Static analysis
+(annotator/rtyper prepass) exists to *generate the machinery*; the machinery
+optimizes with runtime facts — tracing, promotion/guards, virtuals,
+virtualizables, quasi-immutability. PyPy's own static-PE JIT losing to
+tracing is the controlling precedent. Corollary: when choosing between a
+smarter compile-time analysis and a runtime guard, default to the guard.
+
+**A4 — Fall back, never restrict.** Full CPython 3.14 semantics by
+construction: traces deopt to the interpreter (blackhole/resume) rather than
+the language being restricted to what compiles. `sys._getframe`-class
+introspection must work. Correctness is bit-exact — no float tolerances, no
+"close enough" (root-cause the divergent operation instead).
+
+**A5 — Tests over proofs; measurement over theory.** Every feature and every
+bug fix carries a test. Default-flips of optimizations require the full
+benchmark suite; negative and null results get recorded, not forgotten.
+Expect D06.1's usual outcome — "no clear tendency" — and keep every
+experimental mechanism behind a kill switch until evidence flips it.
+
+**A6 — Port the winner, at parity.** The porting target is *modern* PyPy
+source, line-by-line, with data-structure parity (no invented side tables,
+no "simplified" shapes — AGENTS.md rules). The EU reports document many
+mechanisms (multimethods, PE JIT, ootype, CPS stackless, refcounting) that
+modern PyPy deleted; those are rationale history, not porting targets.
+
+**A7 — Deletion is part of the method.** PyPy's team deleted its own
+flagship implementations when evidence turned, usually for reasons they had
+already written down as open issues. pyre inherits this: gated experiments
+are cheap to delete; long-lived gates that never flip are debt; a mechanism
+kept "because we built it" is a bug in the process.
+
+---
+
+## 3. Adaptations — where pyre deliberately diverges from the reports
+
+The EU insights cannot be applied verbatim; the substrate changed. Each
+adaptation below names what is kept and what is replaced.
+
+### 3.1 "Analyse live programs" → analyse extracted artifacts
+
+The reports' core front-end move — run full Python as a *preprocessor*, then
+analyse the live image with bounded dynamism — solved a problem Rust does not
+have: recovering static structure from an unspecified dynamic language.
+pyre replaces it with:
+
+- **Rust's type system** does what the annotator's type recovery did, at
+  zero project cost, with real diagnostics. The chronic RPython pains the
+  reports admit (no specification, whole-program-or-nothing, first-error-only,
+  cryptic messages, RPylint as a band-aid) are structurally absent.
+- **Charon `.ullbc` extraction** plays the role of the frozen live image:
+  a whole-program low-level view of the interpreter for majit-translate.
+  The price is the same one PyPy paid for image freezing — staleness: source
+  changes are invisible until re-extraction. This is a permanent operational
+  discipline (fingerprint skipping, forced re-extract), not a temporary bug.
+- **Bootstrap dynamism** (RPython's metaclass tricks, generated gateway
+  classes, memo functions) maps to proc macros and `build.rs` codegen.
+  The annotator that remains in majit is the one RPython's *JIT* needed:
+  binding-time and representation analysis over low-level bodies — greens vs
+  reds, what is promotable, what is elidable — not type inference.
+
+What is *kept* from the front-end story: the fall-back principle. RPython let
+un-analysable code fall back to interpretation; majit lets un-lowerable
+interpreter constructs fall back to residual calls / `dont_look_inside`.
+The norm (A1) is that each such fallback is a tracked gap with a census, not
+a silent permanent hole — the whole point of the prepass census workflow.
+
+### 3.2 Hints: need-oriented, few, and load-bearing
+
+The reports' hint philosophy transfers intact and is worth restating because
+it constrains API design for majit forever: hints are **need-oriented** —
+placed at the few points where runtime constancy is valuable (`promote`,
+green fields, `elidable`, merge points, virtualizables) — and an
+unsatisfiable requirement must be a loud error, not silent
+de-specialization. majit expresses these as proc-macro attributes with the
+exact RPython names. Adding a new kind of hint to work around a translator
+weakness is the wrong direction; fix the translator (A1).
+
+### 3.3 Threading: the aspect argument, inverted to no-GIL
+
+D05.4 treats the GIL as one pluggable concurrency model among several and
+keeps all concurrency policy out of interpreter semantics. pyre accepts the
+framing and picks the other plug: **free-threaded from day one**. The same
+separation argument does the work — because PyPy's interpreter source never
+encoded GIL assumptions into *semantics*, a no-GIL port is even expressible.
+Consequences that are already policy:
+
+- GIL-dependent RPython machinery (heapcache reset on GIL release,
+  `release_gil` effect info) keeps its names for parity but has no
+  production call sites.
+- Where RPython used ambient singletons justified by the GIL, pyre must
+  justify each adaptation explicitly (TLS with a documented PyPy audit —
+  the BACK_EDGE_BH_BUILDER precedent), never silently.
+- The GC and object model must be designed for concurrent mutators *as an
+  aspect-layer concern* (majit-gc), not by sprinkling atomics through
+  pyre-object.
+
+### 3.4 Backends: answer D08.2's open question with "delegate"
+
+D08.2 closed with a research question: can the meta-JIT sit on a lower-level
+code generator that owns regalloc/instruction selection? RPython answered
+"no" by default and paid ~300k LOC of hand-written backends. pyre answers
+**yes**: Cranelift (plus dynasm where measured to matter, plus wasm as a
+target of its own). The trade is explicit: we accept a less specialized
+lowest layer in exchange for not owning six instruction sets. When Cranelift
+is the bottleneck (compile latency, missing patterns), the recourse ladder
+is: fix usage → dynasm fast path → upstream Cranelift work — not a
+hand-written pyre backend.
+
+### 3.5 What is explicitly *not* on the map (anti-roadmap)
+
+Each item below was built by PyPy, measured, and deleted or abandoned —
+the reports plus later history are the evidence (assessment §§2–3). Do not
+rebuild them in pyre/majit without new, written justification that addresses
+why the original failed:
+
+- **Pluggable object spaces** (thunk/taint/logic/proxy spaces). The objspace
+  *interface* stays; runtime-swappable semantics died — JIT-hostile,
+  dispatch-costly. Security = rsandbox at the translation layer instead.
+- **Multimethod dispatch + table slicing** in the object space.
+- **Two-modules-per-type** layout; EU-era std-objspace shapes generally.
+- **High-level backends / ootype** (JVM/CLI/JS). pyre-wasm is not this: it
+  is a low-level target through the same lltype-like pipeline.
+- **CPS/graph-transform stackless.** If deep coroutine support is ever
+  needed, follow modern PyPy (stacklets/continulets — small per-platform
+  assembly), not D07.1's transform. The "views" composability analysis
+  remains valid input for any future design.
+- **rctypes-style FFI** ("write extensions in RPython/Rust and translate
+  them everywhere"). The C-extension story must follow the approaches that
+  actually worked (cpyext-class emulation / HPy / cffi-class FFI) — §5,
+  Phase C.
+- **Exotic default representations** (ropes, string slices, prebuilt int
+  boxes, optimal arrays). Adaptive **storage strategies** — the shape that
+  shipped — are the porting target.
+- **Syntax extensibility** as a goal. pyre tracks CPython exactly; the
+  compiler front-end is not an extension point.
+- **Naive refcounting**, conservative GC as default, or any GC not derived
+  from the incminimark lineage.
+
+### 3.6 Configuration: small supported matrix, build-time resolution
+
+D13.1's mechanism (options resolved at translation time, dependency-checked,
+write-once) maps to Cargo features + build-time codegen; its *lesson* maps to
+policy: the 1.0 compatibility matrix showed "any combination of aspects"
+failing in practice, and post-EU PyPy pruned to essentially one supported
+configuration. pyre keeps:
+
+- **One blessed default configuration** that is always green and always
+  benchmarked (this is what CI and check.py gate).
+- Experimental behavior behind `PYRE_*` env gates or features, default-off,
+  each with an owner-issue and an intended flip-or-delete decision. A gate is
+  a staging area, not a home.
+- Aspect combinations (e.g. wasm × JIT × GC modes) are individually declared
+  supported or unsupported; silence means unsupported.
+
+---
+
+## 4. Norms (operating rules)
+
+**N1 — Layering.** majit never depends on pyre. pyre-interpreter stays
+traceable "straightforward Rust"; when majit-translate cannot lower an
+interpreter construct, the default resolution is a majit improvement, the
+fallback is a *tracked* residual call, and the forbidden resolution is
+contorting interpreter semantics to please the translator. "Rust can't be
+meta-traced" is never a valid excuse (AGENTS.md).
+
+**N2 — Parity.** Line-by-line structural parity with modern PyPy/RPython:
+same modules, names, data structures. No Rust-native collection where
+RPython used an attribute/forwarded slot; borrow-checker workarounds minimal
+and documented with the RPython original cited. Do not delete RPython
+methods to "simplify". (Full rules: AGENTS.md; they are part of this
+charter.)
+
+**N3 — Frame identity.** One red frame per interpreted frame, everywhere:
+tracing (MIFrame), resume, blackhole, bridges. Collapsing inlined callees
+onto shared anchors is the known root cause of a whole bug class
+(LOAD_GLOBAL namespace confusion, pycode miscompiles). The reports' own
+virtualizable design assumed per-frame identity; RPython's 1-red-arg frame
+shape is the convergence target.
+
+**N4 — Correctness gates.** `cargo check` + `cargo test` (both feature
+configs) green before commit; full benchmark suite (all 8) after JIT
+changes with no regressions; bit-exact CPython 3.14 parity for observable
+behavior; compliance-suite pass rate only moves up. Root-cause fixes only —
+no workaround modules, no tolerances.
+
+**N5 — Empirical flips.** An optimization becomes default-ON only with:
+benchmark evidence on the suite (not one kernel — the 1.47×-gcc lesson),
+green tests, and a kill switch that stays for one stabilization period.
+Record refutations in memory/docs; D06.1-style negative results are a
+deliverable, not an embarrassment.
+
+**N6 — Translation latency is a first-class cost.** Whole-program
+translation friction taxed PyPy for two decades (2h builds in D09.1; "the
+attention of another dev for the whole sprint" culture). Guard pyre's loop:
+incremental Rust builds, LLBC fingerprint skipping, prepass performance,
+and no O(n²) in trace/compile paths (the #345 class). Wall-clock of the
+edit-test cycle is reviewed like a benchmark.
+
+**N7 — Documentation of thinking, not just code.** The EU reports' lasting
+value is that the *reasoning* was written down, which is what made later
+deletion rational rather than amnesiac. pyre's analogs — issue epics, memory
+files, this charter — must record why, what was measured, and what would
+falsify the decision. A major mechanism landing without a written rationale
+is incomplete.
+
+---
+
+## 5. Macro-strategy: the ten-year arc
+
+The EU project's honest final ledger — research vision delivered, product
+usability consciously deferred, and the deferral costing a decade — defines
+pyre's sequencing. The phases overlap; the ordering states *priority under
+contention*, not a waterfall.
+
+**Phase A — The JIT spine (now).** Make meta-tracing-by-translation
+boringly correct and PyPy-fast on the benchmark suite. Concretely: eliminate
+compilation cliffs (unported opcodes/`abort_permanent`, no-token loops,
+recursion walls), converge frame/resume machinery on RPython shapes (frame
+identity epics, pc_map retirement, resume rebuild parity), and close the
+fib_recursive-class call-frame gap. Exit criterion: parity-class performance
+with PyPy on the suite with the JIT never producing wrong answers. This
+phase outranks everything, because it is the part the reports proved *can*
+fail structurally (the 2007 JIT) and the part every later phase builds on.
+
+**Phase B — Language and stdlib completeness.** CPython 3.14 compliance ramp
+(regrtest enablement, test-infra rounds, GC-root classes of bugs), full
+built-in coverage, generators/async, memory-model soundness under the
+compliance suites. This is the "engineering after research" that PyPy
+deferred; pyre schedules it as a standing workstream that grows as Phase A
+stabilizes, not as an afterthought.
+
+**Phase C — Adoption surfaces.** The two things history says decide real
+use: **C-extension compatibility** (choose and execute an HPy/cpyext-class
+strategy — with the rctypes failure and the cpyext cost curve as priors;
+target a decision document, then years of grind) and **no-GIL parallelism
+actually delivered** (thread scheduling, concurrent GC hardening, and the
+free-threading ecosystem story that CPython 3.13+ opened). no-GIL is pyre's
+principal differentiator against both CPython and PyPy; it must land as an
+aspect-layer property (§3.3), never as interpreter-source complexity.
+
+**Phase D — Platform axes.** The validated axes of l×o×p, modernized:
+**wasm** as the p-axis (browser/edge/embedded — D11.1's reopened questions:
+size budgets, reduced builds, sandbox-by-substrate), **rsandbox** as the
+o-axis security aspect, cross-platform backend maturity (dynasm/AArch64/x86
+via cranelift). Each platform combination enters the supported matrix
+explicitly (§3.6) with its own CI, or stays experimental.
+
+**Phase E — majit as a public framework.** The l-axis: majit as *the* way to
+give a Rust interpreter a tracing JIT — the role RPython proved with
+Pyrolog/Topaz/HippyVM. Requires: API stability, documentation of the hint
+vocabulary, at least two non-pyre consumers in CI (aheui-mjit today), and
+the discipline that pyre-specific needs land as general mechanisms or not at
+all. This is last not because it matters least but because a framework
+extracted from one working product beats a framework designed for
+hypothetical ones — also an EU-report lesson ("RPython was 'just' the
+implementation language" until it was proven).
+
+**Standing constraints across all phases**: N1–N7; the anti-roadmap (§3.5);
+and the A7 duty to delete. Every phase inherits the reports' deepest single
+lesson: *the architecture survives because the interpreter stays a clean
+executable specification and everything else is generated, woven, measured —
+and replaceable.*
+
+---
+
+## 6. Amending this charter
+
+This charter changes by evidence, in writing: a proposal must cite the
+measurement or upstream-PyPy precedent that motivates it, state which axiom
+or norm it modifies, and record what was tried before. Additions to the
+anti-roadmap require the failure evidence; removals from it require new
+justification addressing the original failure. The document history is part
+of the document.

--- a/pyre/design.md
+++ b/pyre/design.md
@@ -34,7 +34,7 @@ Rust, and a PyPy-equivalent (pyre) on top of that.**
 | RPython translator (flowspace → annotator → rtyper) | **majit-translate** (`front/ast` → `flowspace/` → `annotator/` → `rtyper/`) over **Charon LLBC** artifacts | Same pipeline, same module names, run at `cargo build` time over extracted `.ullbc` instead of live bytecode. |
 | `jtransform`/codewriter → JitCode | **codewriter/** → JitCode | Identical role. |
 | metainterp, optimizer, resume, blackhole | **majit-metainterp / majit-trace** | Line-by-line port of the *tracing* JIT (pyjitpl5 lineage), not the 2007 PE JIT. |
-| x86/ARM/… hand-written backends (~300k LOC) | **majit-backend-cranelift / -dynasm / -wasm** | Machine-code generation delegated downward; see §3.4. |
+| x86/ARM/… hand-written backends (~300k LOC) | **majit-backend-dynasm / -cranelift / -wasm** | Three thin backends behind one trait, current primary dynasm; see §3.4. |
 | incminimark GC | **majit-gc** (nursery + oldgen + incremental + card marking) | Port of the winner, not of Boehm/refcount/mark-sweep. |
 | sandbox transform | **rsandbox** | Compile-time sandbox aspect. |
 | `pypy/interpreter/` + `pypy/objspace/std/` | **pyre-interpreter + pyre-object** | Structural port, same names, same relative locations. |
@@ -165,17 +165,67 @@ Consequences that are already policy:
   aspect-layer concern* (majit-gc), not by sprinkling atomics through
   pyre-object.
 
-### 3.4 Backends: answer D08.2's open question with "delegate"
+**GC under free threading (settled 2026-07, gh#396).** The architecture is a
+**stop-the-world safepoint harness around an unchanged incminimark core** —
+the HotSpot/SGen shape, explicitly not PEP 703's non-moving route.
+
+- *Contract restatement.* What incminimark actually relies on is (a)
+  exclusive heap access during each collection **step**, (b) enumerability
+  of all roots at that instant, (c) all inter-step mutations caught by the
+  write barrier. The GIL was PyPy's implementation of (a); safepoints are
+  pyre's implementation of the same contract. The audit that this holds for
+  the *incremental* major is source-verified: major slices already execute
+  at minor-collection time (`minor_collection_with_major_progress`,
+  incminimark.py:824), hence inside STW windows; the barrier is deliberately
+  newvalue-agnostic ("the incremental GC nowadays relies on this fact",
+  incminimark.py:1516-1518) and its records are consumed at the next minor
+  (VISITED clear + `more_objects_to_trace` re-append, incminimark.py:
+  2079-2083). Concurrency therefore lives entirely in the harness — mutator
+  registry, safepoint polls (allocation sites, runtime entry/exit, loop
+  back-edges: precisely the sites where the existing rooting invariant
+  already holds), TLABs, per-thread store buffers — and the ported
+  collection algorithms are not rewritten.
+- *Moving nursery is kept.* JIT inline nursery allocation is a performance
+  pillar; embedder-boundary pointer stability is solved by pinning (upstream
+  already has it: `GCFLAG_PINNED`, incminimark.py:148) or oldgen promotion,
+  not by adopting a non-moving allocator.
+- *Deviation zones are exactly four*, and everything else remains parity
+  (N2): (1) allocation front-end, single bump pointer → per-thread TLAB
+  chunks carved from the one nursery region (per-chunk pinning walls);
+  (2) the barrier **producer** side — atomic header-flag RMW, per-thread
+  SSBs flushing into the canonical `old_objects_pointing_to_young`, so the
+  consumer code stays a line-by-line port; (3) codegen addressing:
+  `nursery_free` baked static address → thread-context-relative, with the
+  inline fast-path shape unchanged; (4) the safepoint subsystem itself,
+  which has no upstream counterpart (and therefore no merge surface).
+- *Non-options, with their failure mode*: a GIL (contradicts this section);
+  per-access locks on the GC handle (fixes the data race, not the
+  moving-collector root-visibility race — demonstrated by the gh#396
+  cargo-test heap corruption); interior mutability without synchronization
+  (hides the UB); per-thread heaps (breaks shared-heap semantics, and
+  process-global caches already made it flaky in practice); a concurrent
+  non-STW collector (requires rewriting incminimark's tracing/evacuation).
+- *TLS discipline refined*: thread-local state is legitimate exactly where
+  the design is per-thread (TLABs, mutator contexts); what is forbidden is
+  a TLS raw pointer into unsynchronized shared mutable state — the gh#396
+  defect. Staged execution plan (P0 soundness core → P1 TLAB/SSB/back-edge
+  polls → P2 `_thread` + object-model epic) is recorded on gh#396.
+
+### 3.4 Backends: three thin backends, not six hand-written
 
 D08.2 closed with a research question: can the meta-JIT sit on a lower-level
 code generator that owns regalloc/instruction selection? RPython answered
-"no" by default and paid ~300k LOC of hand-written backends. pyre answers
-**yes**: Cranelift (plus dynasm where measured to matter, plus wasm as a
-target of its own). The trade is explicit: we accept a less specialized
-lowest layer in exchange for not owning six instruction sets. When Cranelift
-is the bottleneck (compile latency, missing patterns), the recourse ladder
-is: fix usage → dynasm fast path → upstream Cranelift work — not a
-hand-written pyre backend.
+"no" by default and paid ~300k LOC of hand-written backends. pyre's answer is
+to keep **three thin backends behind one trait** rather than owning six full
+instruction sets. The current primary is **dynasm** — direct machine-code
+emission via dynasm-rs, favored for compile latency and fine control;
+**Cranelift** is the portable option that does take regalloc/instruction
+selection downward (the literal "yes" to D08.2's question); **wasm** is a
+target of its own. The trade is explicit: a less specialized lowest layer in
+exchange for not owning six instruction sets. When a backend is the
+bottleneck (compile latency, missing patterns), the recourse ladder is: fix
+usage → dynasm fast path → upstream Cranelift work — not a hand-written pyre
+backend.
 
 ### 3.5 What is explicitly *not* on the map (anti-roadmap)
 
@@ -206,6 +256,18 @@ why the original failed:
   compiler front-end is not an extension point.
 - **Naive refcounting**, conservative GC as default, or any GC not derived
   from the incminimark lineage.
+
+**Anti-roadmap vs. provisional alternatives — a distinction.** The
+exclusions above concern *re-adopting a mechanism PyPy abandoned* (ropes,
+multimethods, ootype…) as a default; reversing one requires the §6
+justification. They say nothing about pyre's own **provisional
+implementations** of the *winning* mechanisms. Where the faithful port is not
+yet in place, a simpler alternative is an acceptable **interim** — provided
+the orthodox port stays the target (A6/N2), the deviation is tracked
+(A7, §3.1), and it remains **reversible to the canonical implementation**.
+Shipping an alternative now never forecloses correcting to the orthodox one
+when measurement or need calls for it; that correction is expected, not a
+policy change.
 
 ### 3.6 Configuration: small supported matrix, build-time resolution
 

--- a/pyre/rework.md
+++ b/pyre/rework.md
@@ -1,0 +1,332 @@
+# pyre Rework Program
+
+**Status**: proposed. Companion to `design.md` (the charter). Where the
+charter states what pyre must be, this document states where today's code
+violates it, with evidence, and defines the corrective program. It was
+produced by auditing the tree (branch `pc-map`, 2026-07-05) against the
+charter's axioms A1–A7 and norms N1–N7. Evidence citations are of two kinds:
+code locations verified in this audit, and the issue/epic record (memory
+files, PRs) for damage history.
+
+The verdict up front: **the skeleton is right, the JIT spine is where the
+violations live.** The layer map of charter §1 is real in the tree; none of
+the anti-roadmap (§3.5) items have been rebuilt. The structural defects are
+concentrated in four places, all inside trace/resume/translate/GC-roots —
+exactly the Phase A territory the charter says outranks everything.
+
+---
+
+## 1. Findings
+
+### F1 — The snapshot/resume machinery invented its own coordinate system
+
+**What exists.** `SnapshotFrame` stores the *Python bytecode* PC where
+RPython's `resume.py` stores the JitCode offset, and recovers the JitCode
+position through a lossy `pc_map` built at trace time
+(`majit-metainterp/src/pyjitpl.rs:506`, readers at
+`pyre-jit-trace/src/state.rs:1009–1248`, `resumedata.rs:84`). Bolted on top
+is a second, correct coordinate — a per-frame `jitcode_pc: i32` word
+(`resume.rs:279`) with a `NO_JITCODE_PC` sentinel — which branch-guard
+resume now prefers (#73/#366, gates already removed). So one snapshot
+carries **two coordinate systems**, one of them lossy, plus a translation
+layer (`resolve_resume_pc*`) that PyPy never needed.
+
+**Violates.** A6/N2 (parity: no invented representations), and via its
+consequences A1 (traces that resume at the wrong position are semantics the
+interpreter never had).
+
+**Evidenced damage.** This is the root of the worst shipped-bug class:
+the FOR_ITER "not an iterator" crash live on origin/main (guard-failure
+resume writes a green pycode into a red iterator slot), the loop-carried
+`or` deopt underflow, and the whole task50/#215 slot-vs-color epic. Each
+was a symptom of resume reconstructing state through the invented
+coordinates instead of resume.py's.
+
+**Correct shape.** `rpython/jit/metainterp/resume.py`: snapshot frames
+keyed by JitCode position natively; numbering via `rd_numb`/numb_state;
+`rebuild_from_resumedata` as the single reconstruction path. pyre already
+has the analog entry points (`eval.rs:6429–6743`, `dispatch_perfn_frame`,
+`setup_reconstructed_callee_frame`) — the representation underneath must
+converge.
+
+**Tracking.** Fully issued: gh#366 (tracer interprets JitCode directly —
+the enabling engine), gh#368 (delete `pc_map` + `resume_jitcode_pc_for`,
+Artifact 1), gh#369 (retire the carried `jitcode_pc` side-channel,
+Artifact 3), gh#367 (bank-aware pcdep color-slot map, Artifact 2 /
+slot-vs-color); groundwork gh#73 + PR#365 (closed, M3 milestone). Related:
+gh#343 (multi-frame virtual-PyFrame rematerialization on deopt),
+gh#371 (compile-time walker coalescing residual).
+
+### F2 — Trace time has a hand-written interpreter twin (three executors)
+
+**What exists.** PyPy has two executors: metainterp (trace time) and
+blackhole (deopt time). pyre has three: inside trace time, a walker leg
+(`full_body_walk_trace` / `run_perfn_walk`,
+`pyre-jit-trace/src/jitcode_dispatch.rs:466,2265,2464`) coexists with a
+trait leg — `OpcodeHandler` impls on `MIFrame` that the code itself
+describes as "the trace-time twin of PyFrame's impls in pyre-interpreter"
+(`pyre-jit-trace/src/lib.rs:87`). Virtualizable handling stays on the trait
+leg because the walker cannot observe a force without executing the callee.
+
+**Violates.** A1 directly. A hand-written trace-time twin *is* a JIT with
+semantics of its own; every divergence between the twin and PyFrame is a
+miscompile waiting for an input. Two trace-time legs over the same bytecode
+double the divergence surface.
+
+**Evidenced damage.** walker BYPASS misfire under suspend → stack
+underflow (task#29), wasm re-entry corruption by the walk loop (timeout
+BUG#2), aheui never-close. Each was the two legs disagreeing.
+
+**Correct shape.** One trace-time executor. The W4 single-executor epic
+(PR#311, walker-as-tracer) already points here; it must finish, and the
+trait twin must be deleted (A7), with the vable-force blocker solved the
+way PyPy's metainterp does it rather than by keeping a second leg.
+
+**Tracking.** gh#344 (observer/replay two-executor → single authoritative
+walker) is the epic; its original scope was the generic majit engine only,
+and the pyre-side half — deleting the `OpcodeHandler` trace-time twin and
+the `is_full_body_walk` bifurcation — is now recorded there as a scope
+supplement (2026-07-05 comment). gh#342 and gh#115 track the walker
+coverage gaps that force the trait leg to stay alive.
+
+### F3 — GC root registration is a post-hoc walker registry
+
+**What exists.** `MAX_EXTRA_ROOT_WALKERS = 16`
+(`majit-gc/src/shadow_stack.rs:681`), a fixed array that panics on
+overflow, currently holding **14 walkers**: 13 registered from
+`pyre-jit/src/eval.rs:2106–2247` (rd_consts, partial/active trace, compile
+snapshot, jitcode constants, FBW journals ×2, interpreter side table,
+signal handlers, weakref boxes, sre patterns, jit callee frames, pyre
+objects) plus the gc-table walker (`majit-gc/src/gcreftracer.rs:175`).
+
+**Violates.** A2 (memory policy woven, not accreted). Nearly every walker
+was added *after* a use-after-free (signal handlers #30, weakref boxes #31,
+sre patterns #29, weakref registration #188…). Each is a confession that
+some object lives outside GC discipline as an untracked immortal; the
+registry is reactive whack-a-mole with a hard cap.
+
+**Correct shape.** incminimark's model: shadow stack for stack roots,
+the prebuilt-object protocol for immortals, GC-traced frames for the JIT
+(the resolution D05.x itself predicted — "let the JIT find roots since it
+knows frame layout"). gh#355 (PyFrame→W_Root, landed through S2) is the
+template: move each walker's object population under normal GC tracing and
+delete the walker.
+
+**Tracking.** gh#355. Originally it covered frames only; the full registry
+retirement (taxonomy of the 14 walkers, prebuilt-protocol absorption of the
+immortal populations, shrinking `MAX_EXTRA_ROOT_WALKERS` as the progress
+metric) is now recorded there as a scope supplement (2026-07-05 comment).
+
+### F4 — majit-translate coverage is sustained by per-case seams
+
+**What exists.** Rust idioms still lack systematic lowering: the #346
+generic `E::Value` monomorphization gap diverges ~124 opcode graphs
+(front-end abstract-shell on multi-impl traits); the #131 Result/Option
+work concluded its clean front-synth seam is **exhausted** (remaining:
+UnionError lattice, Vec/IndexMap, boxing, iterators). Constructs that don't
+lower degrade not into tracked residual calls but into `abort_permanent`
+**compilation cliffs** — the gh#373 class, where a hot loop silently never
+compiles (demonstrated 32×/20× cliffs; latent no-token variants).
+
+**Violates.** A1 ("Rust can't be meta-traced is never a valid excuse") and
+charter §3.1's norm that every fallback is a census-tracked gap, never a
+silent hole.
+
+**Correct shape.** The rtyper/exceptiontransform parity ports already
+chosen: Epic A approach-1 (unique-KIND monomorphization) for #346, Option A
+shape-agnostic exceptiontransform for #131, with the census workflow as the
+completeness instrument and `abort_permanent` reduced to a small, listed,
+justified residue.
+
+**Tracking.** Well issued: gh#346 (two-phase coverage roadmap, the epic;
+successor of the closed gh#131) with per-gap instance issues gh#336
+(rrange), gh#337 (rlist), gh#182 (rbuiltin typers), gh#339 (boxing
+NewWithVtable), gh#181 (box_value Void), gh#176 (phi threading), gh#180
+(gctransform), gh#139 (EffectInfo). The cliff symptom is gh#373.
+
+### F5 — Deficiencies (right design, unfinished) — the debt list
+
+- **Compilation cliffs**: unported opcode classes (CallIntrinsic2, GetLen,
+  LoadSpecial — the CALL_INTRINSIC_1 fix `f0f68547ba` is the template;
+  gh#373), nested-loop/cross-loop no-token walls (gh#152, gh#177;
+  cross-loop-cut S0–S3 approved), recursion/call-frame wall (gh#126,
+  gh#343; the closed gh#215 was the umbrella).
+- **Gate debt**: **119 distinct `PYRE_*` env gates** in the tree (28 in the
+  FBW family alone). Charter §3.6: a gate is a staging area, not a home.
+  No triage table exists. *No tracking issue.*
+- **Documentation rot (N7)**: `majit/README.md` documented the deleted
+  majit-analyze era (crates majit-opt/meta/codegen/runtime/analyze vs the
+  actual majit-translate/metainterp/backend-* tree). **Resolved 2026-07-05:
+  rewritten to the actual crate tree and pipeline.** (The suspected
+  duplicate `readme.md` was a case-insensitive-filesystem artifact; only
+  `README.md` is tracked.)
+- **Phase C debt with a deadline flavor**: no C-extension strategy decision
+  document. The EU final report's admitted decade-costing error is exactly
+  this deferral; the charter (§5 Phase C) requires a decision document —
+  writing it does not require Phase A to be finished. Tracked as gh#376.
+
+### Explicit non-findings (audited and ruled parity or justified)
+
+- `MIFrame` as a type distinct from `PyFrame` is **parity** (PyPy's
+  pyjitpl has MIFrame); the defect is the hand-written *OpcodeHandler twin*
+  on it (F2), not the type split.
+- Snapshots staying `Box` while frames became W_Root (#355 policy) —
+  deliberate, documented, keep.
+- TLS singletons (BACK_EDGE_BH_BUILDER etc.) — audited against PyPy's
+  GIL-justified singletons and documented per charter §3.3; keep.
+- Thin backends behind one trait (dynasm primary, Cranelift, wasm) — charter
+  §3.4 answer; not rework territory even where compile latency hurts
+  (recourse ladder applies).
+
+---
+
+## 2. Workstreams
+
+### WS1 — Trace/resume convergence (F1 + F2) — *the* priority
+
+Goal: one trace-time executor, one resume coordinate system, both at
+resume.py/pyjitpl.py parity. F1 and F2 are one workstream because the
+resume representation is written by the tracer: retiring pc_map requires
+every snapshot writer to know its JitCode position, which is what the
+single-executor walker provides.
+
+Increments (each lands green on N4 gates, each with its kill switch):
+
+1. **Finish gh#366 direct-pc coverage**: extend `jitcode_pc` capture to the
+   remaining guard classes (GuardNoException/GuardNotForced), flip default.
+   Exit: every snapshot frame carries a valid direct coordinate.
+2. **Invert the representation** (gh#368 + gh#369): make the JitCode offset
+   the primary `SnapshotFrame` field (resume.py shape); delete the
+   Python-PC field, the snapshot `pc_map` (pyjitpl.rs:506), and the
+   `resolve_resume_pc*` translation layer (gh#368), then the carried
+   `jitcode_pc` side-channel it obsoletes (gh#369). Python-level PC, where
+   genuinely needed (frame f_lasti, tracebacks), is derived the way PyPy
+   derives it, not stored as the resume key.
+3. **Numbering parity**: converge serialization on resume.py's
+   rd_numb/numb_state tagged numbering, including non-Ref banks (gh#367);
+   complete rebuild_from_resumedata parity for multi-frame reconstruction
+   (gh#343; the dispatch_perfn_frame / setup_reconstructed_callee_frame
+   scaffolding exists; the slot-vs-color seeding panic is the open edge).
+   *The full-numbering-parity umbrella itself has no issue* — file one if
+   residue remains after gh#367/gh#368/gh#369 close.
+4. **Single executor (W4)**: make walker-as-tracer the only trace-time
+   leg; solve the vable-force observation blocker via the metainterp
+   mechanism; delete the `OpcodeHandler` trace-time twin and the
+   `is_full_body_walk` bifurcation (A7). gh#344 owns both halves (the
+   pyre-side twin deletion was added to its scope 2026-07-05);
+   gh#342/gh#115 track the walker coverage gaps.
+
+Regression corpus (all must be tests before the increments that fix them):
+the pr354 FOR_ITER-in-called-function crash repro, the loop-carried `or`
+deopt underflow repro, rc_d32.py double-append, aheui logo --jit, the wasm
+timeout re-entry cases.
+
+Exit criteria: `pc_map`, `resolve_resume_pc*`, `OpcodeHandler` twin, and
+`is_full_body_walk` no longer exist in the tree; full benchmark suite (all
+8) no regressions; crash corpus green; slot-vs-color epic closeable.
+
+### WS2 — majit-translate systematization (F4)
+
+Goal: no silent cliffs; Rust-idiom lowering is systematic, census-driven.
+
+1. **#346 Epic A** (unique-KIND generic monomorphization) to close the
+   ~124-graph divergence — this is the current largest single source of
+   un-lowered bodies.
+2. **#131 Option A** shape-agnostic exceptiontransform through the
+   remaining inventory (UnionError lattice, Vec/IndexMap, boxing,
+   iterators), in census order.
+3. **Cliff conversion**: every remaining `abort_permanent` source either
+   ports (the CALL_INTRINSIC_1 → HLOp template: CallIntrinsic2, GetLen,
+   LoadSpecial) or becomes a *tracked* residual call in the census with an
+   owner issue. The latent gh#373 no-token variants get repros first.
+
+Exit criteria: census reports zero unlisted abort_permanent sources; the
+known 32×/20× cliff benchmarks compile; gh#346 (and its instance issues)
+closed or reduced to listed residue. Parallelizable with WS1 (different
+crates, different people-time).
+
+### WS3 — GC roots rework (F3)
+
+Goal: retire the extra-root-walker registry by absorbing its populations
+into normal GC discipline. Tracked in gh#355 (scope supplemented
+2026-07-05 to cover the full registry retirement).
+
+1. **Taxonomy pass**: classify the 14 walkers into (a) trace/JIT state
+   that belongs in GC-traced structures (rd_consts, partial/active trace,
+   compile snapshot, jitcode constants, callee frames — the #355/W_Root
+   track), (b) interpreter-global populations that belong on the
+   prebuilt-object protocol (signal handlers, sre patterns, side tables),
+   (c) genuine GC-internal tables (gcreftracer) that stay.
+2. **Absorb class (a)** along the #355 S2c/S3/S4 track (arena task#7,
+   typedef, stub retirement) — this work is already sequenced.
+3. **Absorb class (b)** via the prebuilt/immortal protocol with traced
+   children (the #29 immortal-children fix generalized), deleting each
+   walker as its population moves.
+4. Shrink `MAX_EXTRA_ROOT_WALKERS` as walkers retire — the shrinking
+   constant is the progress metric; the panic-on-overflow branch should
+   become unreachable and then deleted.
+
+Verification: the GC probe suite, nursery-stress oracle
+(small-nursery runs, the PYPY_GC_NURSERY=131072 technique), and the
+regrtest harness under moving collection (the oldgen-nonmoving concession
+should become deletable — that is the real exit test).
+
+### WS4 — Hygiene batch (F5, continuous)
+
+1. **Gate triage** (done 2026-07-05): `gate-triage.md` classifies all
+   ~119 `PYRE_*` matches. Findings: ~20 are not gates (Rust
+   identifiers) or dead (no read site); ~99 real env vars, ~33 default-ON
+   experiments. The **wasm trio** (`PYRE_WASM_CA`, `_ENABLE_BRIDGES`,
+   `_INLINE_ALLOC`) was retired (hardwired ON, machinery deleted, verified
+   compile-clean native + wasm32). The other ~30 default-ON gates are
+   load-bearing kill switches for open reworks (FBW/executor #344/#366,
+   rtyper #346, GC #355, for-iter #57) — each retires when its epic closes
+   (A7). See `gate-triage.md` §4 for the per-gate retire trigger.
+2. **README rewrite**: `majit/README.md` to the actual crate tree.
+   **Done 2026-07-05.**
+3. **Phase C decision document** (gh#376): C-extension strategy
+   (HPy/cpyext-class options, rctypes failure and cpyext cost curve as
+   priors) — a document, not an implementation; unblocks nothing but
+   forgets nothing.
+
+---
+
+## 3. Sequencing and interaction
+
+Priority under contention (charter §5 order): **WS1 > WS2 > WS3 > WS4**,
+with the qualifications:
+
+- WS1 increments 1–3 are the critical path — they root out the shipped
+  miscompile class. Increment 4 (W4) is the largest single piece; its
+  prerequisite work (per-opcode entry_py_pc advance, concrete seeding) is
+  already landed on the for-iter/rewrite-tracer lines.
+- WS2 is parallel-safe with WS1 (majit-translate vs
+  majit-metainterp/pyre-jit-trace) and is the precondition for Phase A's
+  cliff-free exit criterion.
+- WS3 rides the already-sequenced #355 track; its class-(b) work is
+  independent and can interleave.
+- WS4 items 1–2 are cheap and immediate; the gate triage should happen
+  *early* because WS1/WS2 will otherwise keep adding gates to an untriaged
+  pile (every WS increment's kill switch enters the table at birth, with
+  its flip-or-delete date).
+
+Each workstream closes by the charter's own instruments: N4 gates for
+every landing, N5 evidence for every default flip, N7 written rationale
+(epic memory file or issue) for every mechanism deleted or replaced.
+
+---
+
+## 4. What falsifies this program
+
+Per charter §6, the program is amendable by evidence. Specifically:
+
+- If WS1 increment 2 shows the Python-PC field is load-bearing for
+  something PyPy handles differently at a structural level (not a bug),
+  the finding F1 remedy narrows to "keep derived, not stored".
+- If the W4 vable-force blocker proves to require metainterp behavior that
+  the walker architecture cannot express, F2's remedy escalates from
+  "finish W4" to "re-evaluate the walker against a straight pyjitpl port"
+  — a bigger rework, to be proposed separately with the evidence.
+- If WS3's class-(b) absorption measurably regresses minor-collection
+  pause (prebuilt scanning cost), the registry survives *for that class
+  only*, documented as the deliberate adaptation it currently isn't.


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive digest of PyPy’s EU-era reports, including architecture, optimization, JIT, research prototypes, testing, and project outcomes.
  * Added an evidence-based assessment comparing historical claims with PyPy and pyre/majit implementations.
  * Updated majit documentation to describe current translation workflows, backends, garbage collection, crate structure, and verification.
  * Expanded pyre documentation with its Rust reimplementation goals, design charter, and proposed rework program.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->