### PR TITLE
wasm: retire PYRE_WASM_CA/ENABLE_BRIDGES/INLINE_ALLOC env gates

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -751,10 +751,6 @@ pub fn build_wasm_module(
     // (see `NurseryAllocParams`); `None` keeps allocations on the helper.
     nursery: Option<&NurseryAllocParams>,
     fail_index_base: u32,
-    // Whether this trace is compiled as a LOOP (`compile_loop`) rather than a
-    // bridge. The base alone cannot tell them apart: both draw it from the
-    // global fail-index space (`failguard::fail_descr_base`).
-    is_loop: bool,
     // Table slot of the loop a JUMP-with-no-local-LABEL re-enters (a loop-closing
     // bridge). `0` for a loop trace (its JUMP is a local back-edge `br`) and for a
     // straight-line bridge (no JUMP). When set, the terminal external JUMP writes
@@ -792,17 +788,12 @@ pub fn build_wasm_module(
     // trace reads it and `compile_bridge` (guest-side) writes it. On native
     // builds the trace is never executed, so `alloc_bridge_cells` returns 0 and
     // the dispatch is omitted entirely — the module stays byte-identical.
-    // Label-less traces that still want guard cells: the self-recursive
-    // CALL_ASSEMBLER case (`PYRE_WASM_CA`) chains a guard exit of a Label-less
-    // recursion LOOP (`is_loop`, not a bridge) into its CA bridge; and with
-    // bridge chaining on, a BRIDGE's own guards chain nested sub-bridges the
+    // Label-less traces still want guard cells: the self-recursive
+    // CALL_ASSEMBLER case chains a guard exit of a Label-less recursion LOOP
+    // into its CA bridge, and a BRIDGE's own guards chain nested sub-bridges the
     // same way (a hot guard inside a chained bridge would otherwise round-trip
-    // to the host forever). Both gated on their runtime flags, so flag-off
-    // stays byte-identical.
-    let want_dispatch = !guards.is_empty()
-        && (ops.iter().any(|op| op.opcode == OpCode::Label)
-            || (is_loop && crate::wasm_ca_enabled())
-            || (!is_loop && crate::wasm_bridges_enabled()));
+    // to the host forever). So any guarded trace wants dispatch cells.
+    let want_dispatch = !guards.is_empty();
     let (cells_base, cells_owner) = if want_dispatch {
         alloc_bridge_cells(guards.len())
     } else {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -227,7 +227,7 @@ pub fn active_gc_collection_counts() -> (usize, usize) {
 /// the `gc_stress` feature is compiled in (the fast path would bypass its
 /// per-allocation stress collections), or no allocation op qualifies.
 fn nursery_alloc_params(ops: &[Op]) -> Option<codegen::NurseryAllocParams> {
-    if majit_gc::gc_stress_enabled() || !wasm_inline_alloc_enabled() {
+    if majit_gc::gc_stress_enabled() {
         return None;
     }
     let tids: std::collections::HashSet<u32> = ops
@@ -598,75 +598,6 @@ pub struct WasmBackend {
     constants: majit_ir::VecMap<u32, i64>,
     /// llmodel.py:64-69 self.vtable_offset.
     vtable_offset: Option<usize>,
-    /// `PYRE_WASM_CA` (default ON; `=0` kill switch): compile a self-recursive
-    /// single-int `CallAssemblerR` bridge into an in-module `call_indirect`
-    /// into the source loop's table slot (guest→guest recursion) instead of
-    /// declining it to a per-call host round-trip. Read from the
-    /// process-global [`WASM_CA_ENABLED`] at construction so flag-off is
-    /// byte-identical. Callee frames are GC-visible libc-jitframes
-    /// (per-frame `jf_gcmap`, jf-shadow-stack rooted; see
-    /// `wasm_jit_ca_alloc_frame`), so the arm is collection-safe at any
-    /// nursery size.
-    wasm_ca_enabled: bool,
-}
-
-/// Process-global toggle for the self-recursive CALL_ASSEMBLER arm, default
-/// ON (without it the fib recursion shape round-trips through the host per
-/// call — suite `fib_recursive` times out). The wasm guest has no environment
-/// (`std::env::var` always fails there), so the host runner reads
-/// `PYRE_WASM_CA` (`=0` disables) and flips this through the
-/// `pyre_jit_set_wasm_ca` export — mirroring how `pyre_jit_set_enable_bridges`
-/// plumbs the bridge tracer flag. `WasmBackend::new` snapshots it.
-static WASM_CA_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
-
-/// Host entry point for the `pyre_jit_set_wasm_ca` export (and native tests).
-pub fn set_wasm_ca_enabled(enabled: bool) {
-    WASM_CA_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
-}
-
-/// Whether the self-recursive CALL_ASSEMBLER arm is enabled. Read by `codegen`
-/// to allocate bridge-dispatch cells for a guarded *loop* even when it has no
-/// `Label` (the fib recursion shape), so its guard exit can chain into the CA
-/// bridge in-module instead of round-tripping to the host.
-pub fn wasm_ca_enabled() -> bool {
-    WASM_CA_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Process-global toggle for in-module bridge chaining, mirroring
-/// `call_jit::WASM_BRIDGES_ENABLED` (the tracer-side flag the
-/// `pyre_jit_set_enable_bridges` export sets; the export pushes it here too).
-/// `execute_token` reads it to size every host frame's Ref-home region at
-/// least `failguard::FRAME_REF_HOME_FLOOR` — the sizing the frame-fit accept
-/// check in `compile_bridge` relies on — while keeping the flag-off frame
-/// layout untouched. Default ON (`PYRE_WASM_ENABLE_BRIDGES=0` disables via
-/// the runner).
-static WASM_BRIDGES_ENABLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(true);
-
-/// Host entry point for the `pyre_jit_set_enable_bridges` export (and tests).
-pub fn set_wasm_bridges_enabled(enabled: bool) {
-    WASM_BRIDGES_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
-}
-
-/// Whether in-module bridge chaining is enabled (see `WASM_BRIDGES_ENABLED`).
-pub fn wasm_bridges_enabled() -> bool {
-    WASM_BRIDGES_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Inline nursery-bump allocation fast path (rewrite.py malloc fast path;
-/// see `codegen::NurseryAllocParams`). Default ON; `PYRE_WASM_INLINE_ALLOC=0`
-/// (plumbed by the runner through `pyre_jit_set_inline_alloc`) is the kill
-/// switch — every `New*` then goes back through the allocation helper call.
-static WASM_INLINE_ALLOC_ENABLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(true);
-
-/// Toggle the inline nursery-bump fast path (kill switch plumbing).
-pub fn set_wasm_inline_alloc_enabled(enabled: bool) {
-    WASM_INLINE_ALLOC_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
-}
-
-fn wasm_inline_alloc_enabled() -> bool {
-    WASM_INLINE_ALLOC_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// GC type id of the `JitFrame`. The single registration authority is `eval.rs`
@@ -774,7 +705,6 @@ impl WasmBackend {
             trace_counter: 0,
             constants: majit_ir::VecMap::new(),
             vtable_offset: None,
-            wasm_ca_enabled: WASM_CA_ENABLED.load(std::sync::atomic::Ordering::Relaxed),
         }
     }
 
@@ -1227,7 +1157,6 @@ impl majit_backend::Backend for WasmBackend {
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
                 fail_index_base,
-                true,                         // is_loop
                 0, // external_jump_slot: a loop's JUMP is a local back-edge `br`
                 0, // external_jump_key: unused without an external JUMP
                 codegen::CaParams::default(), // a loop never emits the CA arm
@@ -1429,14 +1358,13 @@ impl majit_backend::Backend for WasmBackend {
 
         // is_loop=false: a bridge's terminal JUMP with no LABEL is a loop-closing
         // bridge whose re-entry target is plumbed via `external_jump_slot`.
-        // PYRE_WASM_CA: lift the CALL_ASSEMBLER decline for a self-recursive
-        // single-int bridge (the fib shape) so the CA arm lowers it to an
-        // in-module `call_indirect` into the source loop instead.
+        // Lift the CALL_ASSEMBLER decline for a self-recursive single-int bridge
+        // (the fib shape) so the CA arm lowers it to an in-module `call_indirect`
+        // into the source loop instead.
         // The CA arm must be able to complete a callee deopt; without the
         // registered `wasm_ca_resume_deopt` slot it could not, so decline the
         // lift (the host round-trip path still handles the CALL_ASSEMBLER).
-        let allow_ca = self.wasm_ca_enabled
-            && ca_deopt_helper_slot() != 0
+        let allow_ca = ca_deopt_helper_slot() != 0
             && bridge_is_self_recursive_int_ca(ops, original_token.number);
         if let Some(reason) = wasm_unsupported_trace_reason(ops, false, allow_ca) {
             diag_bump(1); // declined: CALL_ASSEMBLER
@@ -1796,19 +1724,15 @@ impl majit_backend::Backend for WasmBackend {
         // deopt to read zeroed nursery memory. `count_ref_homes` matches the
         // `num_ref_homes` `build_wasm_module` returns below.
         //
-        // With bridge chaining on, the recursion can also chain into NESTED
-        // bridges (and sibling loops via loop-closing tail calls) while running
-        // ON a CA callee frame — and those were accepted against the
-        // `FRAME_REF_HOME_FLOOR` bound `execute_token` guarantees for HOST
-        // frames. The callee frame must give the same guarantee, or a chained
-        // bridge homes/reads Ref slots past the frame's sized (and gcmap-walked)
-        // region — wrong-value corruption (suite `recursion_memo_branch` /
-        // `generator_tree_recursion`). Mirror `execute_token`'s `chain_floor`.
-        let chain_floor = if wasm_bridges_enabled() {
-            failguard::FRAME_REF_HOME_FLOOR
-        } else {
-            0
-        };
+        // The recursion can also chain into NESTED bridges (and sibling loops via
+        // loop-closing tail calls) while running ON a CA callee frame — and those
+        // were accepted against the `FRAME_REF_HOME_FLOOR` bound `execute_token`
+        // guarantees for HOST frames. The callee frame must give the same
+        // guarantee, or a chained bridge homes/reads Ref slots past the frame's
+        // sized (and gcmap-walked) region — wrong-value corruption (suite
+        // `recursion_memo_branch` / `generator_tree_recursion`). Mirror
+        // `execute_token`'s `chain_floor`.
+        let chain_floor = failguard::FRAME_REF_HOME_FLOOR;
         let ca_ref_homes = if allow_ca {
             source_num_ref_homes
                 .max(codegen::count_ref_homes(inputargs, ops))
@@ -1856,7 +1780,6 @@ impl majit_backend::Backend for WasmBackend {
                 wb_fn_ptr,
                 nursery_alloc_params(ops).as_ref(),
                 base,
-                false, // is_loop
                 // A loop-closing bridge's terminal JUMP re-enters the target
                 // loop (own or sibling, resolved via `LABEL_TARGETS`) through
                 // its table slot via a tail call, resuming at the label
@@ -2198,19 +2121,14 @@ impl majit_backend::Backend for WasmBackend {
         // and the Ref-home region (now at HOME_SLOT_BASE = MIN_FRAME_BYTES + 8).
         // `vec![0i64]` zeroes it, so a fresh host entry reads key 0 (preamble).
         //
-        // A self-recursive CALL_ASSEMBLER bridge (`PYRE_WASM_CA`) runs its
-        // outermost call in this frame and may home more Refs than the loop, so
-        // size for the LARGER of the two (`ca_bridge_ref_homes`); the extra slots
-        // are zeroed and GC-rooted below exactly like the loop's own homes.
-        // With bridge chaining on, a cross-trace tail call can land in a loop
-        // or bridge homing more Refs than this one, so also size at least
-        // `FRAME_REF_HOME_FLOOR` — the bound `compile_bridge`'s frame-fit
-        // accept checks rely on. Flag-off keeps the exact old sizing.
-        let chain_floor = if wasm_bridges_enabled() {
-            failguard::FRAME_REF_HOME_FLOOR
-        } else {
-            0
-        };
+        // A self-recursive CALL_ASSEMBLER bridge runs its outermost call in this
+        // frame and may home more Refs than the loop, so size for the LARGER of
+        // the two (`ca_bridge_ref_homes`); the extra slots are zeroed and
+        // GC-rooted below exactly like the loop's own homes.
+        // A cross-trace tail call can land in a loop or bridge homing more Refs
+        // than this one, so also size at least `FRAME_REF_HOME_FLOOR` — the bound
+        // `compile_bridge`'s frame-fit accept checks rely on.
+        let chain_floor = failguard::FRAME_REF_HOME_FLOOR;
         let eff_ref_homes = compiled
             .num_ref_homes
             .max(compiled.ca_bridge_ref_homes.get())
@@ -2243,7 +2161,7 @@ impl majit_backend::Backend for WasmBackend {
             // frame pointer keeps every local-0-relative codegen access
             // unchanged. (See `build_home_gcmap` for the wasm32 Signed-item
             // layout.)
-            if wasm_ca_enabled() && wasm_jitframe_tid() != 0 {
+            if wasm_jitframe_tid() != 0 {
                 use majit_backend::jitframe::{FIRST_ITEM_OFFSET, JitFrame};
                 let sign = std::mem::size_of::<isize>();
                 // Data region (frame_size i64 slots) expressed in Signed items.

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -54,7 +54,6 @@ fn test_empty_trace() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -118,7 +117,6 @@ fn test_int_add_loop() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -184,7 +182,6 @@ fn test_float_ops() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -226,7 +223,6 @@ fn test_call_generates_import() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -325,7 +321,6 @@ fn test_guard_types() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -374,7 +369,6 @@ fn test_exception_guards() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -419,7 +413,6 @@ fn test_guard_gc_type_uses_immediate_typeid() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -486,7 +479,6 @@ fn test_guard_is_object_lowers_to_typeinfo_test() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -541,7 +533,6 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -563,7 +554,6 @@ fn test_guard_subclass_lowers_to_subclassrange_check() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -634,7 +624,6 @@ fn test_sameas_and_conversions() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -691,7 +680,6 @@ fn test_overflow_ops() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -752,7 +740,6 @@ fn test_single_label_peeled_loop_validates() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),
@@ -820,7 +807,6 @@ fn test_multi_label_peeled_resumes_at_last_label_validates() {
         0,
         None, // nursery
         0,    // fail_index_base
-        true, // is_loop
         0,    // external_jump_slot
         0,    // external_jump_key
         codegen::CaParams::default(),

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1424,12 +1424,6 @@ impl<S: JitState> JitDriver<S> {
         env: &S::Env,
     ) -> Option<usize> {
         let dbg = std::env::var_os("MAJIT_CLOSEDBG").is_some();
-        if std::env::var_os("PYRE_NO_DE").is_some() {
-            // W2 diagnostic: skip direct-entry into the compiled inner loop;
-            // fall back to plain interpretation from the close pc.
-            self.meta.single_pass_compiled_key.take();
-            return None;
-        }
         let key = match self.meta.single_pass_compiled_key.take() {
             Some(k) => k,
             None => {

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -3564,15 +3564,7 @@ impl CallControl {
                 // guard, `std::ptr::copy(s,d,n)` would leaf-match
                 // unrelated 2-arg `copy` impl methods and corrupt
                 // `getcalldescr`'s arity check.
-                //
-                // `PYRE_STRICT_TARGET_TO_PATH=1` (audit-only) disables
-                // the leaf-match outright so a CI sweep can quantify
-                // how often the cross-module fallback fires.  Production
-                // runs leave the env var unset.
                 if segments.len() > 2 {
-                    return Some(path);
-                }
-                if std::env::var_os("PYRE_STRICT_TARGET_TO_PATH").is_some() {
                     return Some(path);
                 }
                 if let Some(leaf) = segments.last() {
@@ -3727,15 +3719,8 @@ impl CallControl {
                     // falls through to the trait resolution path, which mirrors
                     // Rust's name-resolution ambiguity error rather than
                     // silently picking one.
-                    //
-                    // `PYRE_STRICT_TARGET_TO_PATH=1` disables the
-                    // receiver-leaf fallback alongside the FunctionPath
-                    // branch above so audit sweeps observe both fallback
-                    // surfaces consistently.
-                    if std::env::var_os("PYRE_STRICT_TARGET_TO_PATH").is_none() {
-                        if let Some(path) = self.suffix_match_impl_method(receiver, name.as_str()) {
-                            return Some(path);
-                        }
+                    if let Some(path) = self.suffix_match_impl_method(receiver, name.as_str()) {
+                        return Some(path);
                     }
                 }
                 // Fall back to trait method resolution for polymorphic calls.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11267,8 +11267,8 @@ fn output_type_is_objectptr(ty: &TyRef, llbc: &Llbc) -> bool {
 ///     keys on a leaf-ish form after stripping wrappers).
 ///
 /// Shapes the resolver does not yet recognise produce a `??<key>:<json>`
-/// marker so the differential gate (`PYRE_STRUCT_DIFF`) surfaces them
-/// for a follow-up widening rather than silently mislabelling a field.
+/// marker that surfaces them for a follow-up widening rather than silently
+/// mislabelling a field.
 fn tyref_to_ast_string(ty: &TyRef, llbc: &Llbc) -> String {
     let body = match ty {
         TyRef::Inline { value: (_, v) } => Some(v),

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -31,12 +31,9 @@
 //! `program.functions` carry the per-method graphs the rest of the
 //! pipeline consumes.  `auto_discover_workspace_llbc_paths` in `lib.rs`
 //! resolves `<workspace>/build/llbc/{pyre-object,pyre-interpreter,pyre-jit}.ullbc`
-//! when `PYRE_MIR_FRONTEND_LLBC` is unset; that canonical set is
-//! REQUIRED.  Setting
-//! `PYRE_REQUIRE_MIR_FRONTEND=1` makes
-//! `build_semantic_program_via_active_frontend` panic when no LLBC source
-//! resolves, so production builds (which set the flag in
-//! `pyre/check.py::build_backend`) assert that graphs come from MIR.
+//! when `PYRE_MIR_FRONTEND_LLBC` is unset; that canonical set is REQUIRED.
+//! `build_semantic_program_via_active_frontend` panics when no LLBC source
+//! resolves, so every build asserts that graphs come from MIR.
 //!
 //! Per-method graphs come straight from MIR.  `extract_trait_impls` /
 //! `extract_inherent_impl_methods` index `program.functions` via

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -591,16 +591,9 @@ impl PyreCallRegistry {
     ///   distinct from a same-leaf free function.
     /// - Multi-match aliases of the same source (identical
     ///   `host_object` Arc identity) converge on a single resolution.
-    ///
-    /// `PYRE_STRICT_TARGET_TO_PATH=1` (audit-only) disables the
-    /// cross-module safety net, keeping the strict-mode envelope
-    /// consistent across registry-build and codewriter call resolution.
     pub fn lookup_with_leaf_match(&self, key: &FunctionPathKey) -> Option<Rc<PyreFunctionEntry>> {
         if let Some(entry) = self.lookup(key) {
             return Some(entry);
-        }
-        if std::env::var_os("PYRE_STRICT_TARGET_TO_PATH").is_some() {
-            return None;
         }
         let segments = key.segments();
         if segments.is_empty() || segments.len() > 2 {

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -25,7 +25,9 @@ this pass; the rest are load-bearing kill switches for open reworks.
 
 Hardwired ON. Behaviour is byte-identical (each was default-ON already; only
 the opt-out capability is gone). The **wasm trio** removed the env read +
-guest export + `set_*` + `AtomicBool` static, reader fns collapsed to `true`;
+guest export + `set_*` + `AtomicBool` static; the constant-`true` reader fns
+were then deleted outright and their call sites folded (including the dead
+`is_loop` parameter of `build_wasm_module` this exposed);
 verified compile-clean on native `majit-backend-wasm`, native
 `pyre-jit`+`pyre-wasm-runner` (`--features dynasm`), and the wasm32
 `pyre-wasm --features wasm-host` guest. The **#171 pair** inlined the
@@ -42,6 +44,46 @@ the branch ships.
 | PYRE_WASM_INLINE_ALLOC | inline nursery-bump alloc fast path | same | `gc_stress` still forces the helper-call path, so the stress override survives |
 | PYRE_171_ORTHODOX | orthodox `w_list_append` charon-body descent (int-storage) | #171 PR#318/#322 MERGED | epic merged; user-approved retirement 2026-07-05 (overriding the standing user-curated note for this cleanup) |
 | PYRE_171_OBJ_APPEND | orthodox descent for object-strategy lists | same | same; the `&& enabled()` conjuncts were inlined, helpers deleted |
+
+## §1b — Default-OFF experiments retired 2026-07-05 (4)
+
+Second pass over §5's "default-OFF experiments": each gate was judged against
+the vendored RPython/PyPy source — is the ON-path a WIP parity port (keep) or
+a pyre-invented mechanism that contradicts the PyPy design and can never
+become default (delete the ON-path)? Four were removed (−299/+5 across 6
+files); default behaviour is byte-identical since every deleted path was
+opt-in dead code.
+
+| var | ON-path | why permanently unlandable |
+|---|---|---|
+| PYRE_KEPT_OVERRIDE | `StackSource` bytecode-provenance lattice sourcing a kept stack slot from a local at bridge resume (~230 L, liveness.rs + state.rs consumer) | no PyPy analog — resume rebuilds the operand stack from resume-data boxes, never re-analyzes bytecode; the guard-half was already deleted as vstack-mirror-superseded in PR#292 (`910ffd4e64`), this was the orphaned bridge-half |
+| PYRE_RELAX_124 | force-bypass of the two kept-stack branch-guard declines | known-unsound diagnostic: regressed 23/25→17/25 on the #124 corpus in an earlier retirement; the sanctioned route is the vstack mirror (#73/#423), under which the declines die naturally |
+| PYRE_NO_DE | suppress single-pass direct entry, fall back to re-interpretation | W2-era diagnostic (W2 refuted); direct entry is the `ContinueRunningNormally` portal shape itself |
+| PYRE_STRICT_TARGET_TO_PATH | audit probe disabling the cross-module leaf-match fallbacks in call-target→CallPath resolution (3 sites) | one-time #91 quantification sweep; development since has refined the fallback (suffix-carrier, alias-cluster dedup), i.e. the fallback is the accepted adaptation endpoint |
+
+**Deferred, not retired** (active on other branches; touching them on pc-map
+would only manufacture conflicts):
+
+- **P2 quintet** (`PYRE_P2_DRAIN`, `_FRAMESTACK`, `_COMPILE`, `_FS_COMPILE`,
+  `_AUTHORITATIVE`) — one dependency tree, owned by the #215 session on
+  `fib_recursive` (PR#374). A full scaffold deletion (`765b24e3ba`, −1931 L)
+  was authored there and then deliberately reverted + reset away: the carrier
+  turned out load-bearing (without it a `frames.len()>1` resume compiles a
+  degenerate single-frame bridge — wrong values/SEGV), and `8731115130` now
+  installs it unconditionally, leaving the gates as driver selectors only.
+  Their fate belongs to that branch.
+- **PYRE_SAME_GREENKEY** — the gated path is broken by construction (its
+  ConstInt filter over `green_boxes` InputArg placeholders is always empty, so
+  it declines every close and hangs); the real fix (close compares ALL greens
+  vs `header_greens`, gate dropped) already exists on the local `aheui` branch
+  (`019a494e13`). Delegated there untouched.
+
+**Judged KEEP** (genuine WIP parity ports): `PYRE_SINGLE_PASS` +
+`PYRE_AUTHORITATIVE` (two stages of the gh#344 single-executor epic;
+rework.md F2 "must finish"), `PYRE_INNER_CLOSE` (the missing half of
+`pyjitpl.py:3018-3060 reached_loop_header`; implied ON by single-pass, and
+`PYRE_NO_INNER_CLOSE` stays with it), `PYRE_FBW_VABLE_SCALAR_CA` (S0 seam of
+the vable-owner rework toward `direct_assembler_call` scalar args).
 
 ## §2 — Not gates (11): Rust identifiers, not env vars
 
@@ -114,11 +156,12 @@ Kept as-is; listed for completeness.
   `_GIN`, `_INLINE_RECOG`, `PYRE_WASM_DUMP_ALL_TRACES`, `_DUMP_BAD_TRACE`,
   `_EXEC_TRACE`, `_JIT_STATS`, `PYRE_INTERP_RETURN_LOG`, `PYRE_NBODY_DEBUG`,
   `PYRE_DEBUG_CALL`, `PYRE_DEBUG_CLASS`.
-- **Default-OFF experiments (~14)** — not "already activated", so out of scope:
-  `PYRE_FBW_VABLE_SCALAR_CA`, `PYRE_SINGLE_PASS`, `PYRE_KEPT_OVERRIDE`,
-  `PYRE_P2_AUTHORITATIVE`, `_COMPILE`, `_DRAIN`, `_FRAMESTACK`, `_FS_COMPILE`,
-  `PYRE_AUTHORITATIVE`, `PYRE_STRICT_TARGET_TO_PATH`, `PYRE_SAME_GREENKEY`,
-  `PYRE_INNER_CLOSE`, `PYRE_RELAX_124`, `PYRE_NO_DE`.
+- **Default-OFF experiments (10 remaining)** — triaged in §1b (4 retired, 4
+  kept as WIP parity ports, 6 deferred to their owning branches):
+  `PYRE_FBW_VABLE_SCALAR_CA`, `PYRE_SINGLE_PASS`, `PYRE_AUTHORITATIVE`,
+  `PYRE_INNER_CLOSE` (keep); `PYRE_P2_AUTHORITATIVE`, `_COMPILE`, `_DRAIN`,
+  `_FRAMESTACK`, `_FS_COMPILE` (fib_recursive/PR#374), `PYRE_SAME_GREENKEY`
+  (aheui).
 - **Config / value / master switches (~18)** — tuning, paths, modes; keep:
   `PYRE_FBW_REC_UNROLL`, `PYRE_WALKER_STORE_SUBSCR_FNADDR`,
   `PYRE_MIR_FRONTEND_LLBC`, `PYRE_WASM_ENGINE`, `_FUEL`, `_MODULE`, `_NO_CACHE`,
@@ -131,11 +174,11 @@ Kept as-is; listed for completeness.
 
 | bucket | count |
 |---|---|
-| retired this pass | 5 |
+| retired (§1 default-ON pass + §1b default-OFF pass) | 5 + 4 |
 | not gates (identifiers) | 11 |
 | dead (no read site) | 9 |
 | live default-ON, kept until epic closes | ~28 |
 | diagnostics (OFF) | ~34 |
-| default-OFF experiments | ~14 |
+| default-OFF experiments (4 keep + 6 deferred) | 10 |
 | config / value / master | ~18 |
 | test harness | 1 |

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -1,0 +1,141 @@
+# PYRE_* gate triage
+
+**Status**: living record. WS4 deliverable of `rework.md` (finding F5, gate
+debt). Audited 2026-07-05 on branch `pc-map` by reading the actual
+read-expression at every source site (four census passes). Polarity rule:
+`is_some()`/`=="1"`/`.unwrap_or(false)` → default **OFF**; `is_none()` /
+`!= Ok("0")` / `.unwrap_or(true)` → default **ON**; a parse of
+number/path/list/mode → **VALUE** (config, not a boolean gate).
+
+The charter (§3.6, A7) says a gate is a staging area, not a home: each live
+default-ON experiment gate is kept only until its epic closes, then its OFF
+path is deleted and the gate retired. This table is the standing list of what
+to retire and when.
+
+## Headline
+
+The raw `rg 'PYRE_[A-Z0-9_]+'` count (~119) overstates the debt. **~20 of the
+matches are not env gates at all** (Rust consts, macro-generated identifiers,
+runtime symbols, or comment-only dead references). Real live env vars ≈ 99, of
+which ~33 are default-ON experiment gates. Of those 33, the **wasm trio** and
+the **#171 pair** were cleanly settled (epic closed / merged) and are retired
+this pass; the rest are load-bearing kill switches for open reworks.
+
+## §1 — Retired this pass (5)
+
+Hardwired ON. Behaviour is byte-identical (each was default-ON already; only
+the opt-out capability is gone). The **wasm trio** removed the env read +
+guest export + `set_*` + `AtomicBool` static, reader fns collapsed to `true`;
+verified compile-clean on native `majit-backend-wasm`, native
+`pyre-jit`+`pyre-wasm-runner` (`--features dynasm`), and the wasm32
+`pyre-wasm --features wasm-host` guest. The **#171 pair** inlined the
+`&& enabled()` conjuncts and deleted the two helper fns; verified compile-clean
+on `pyre-jit-trace --features dynasm` (exit 0; the `assembler.rs:1029` build.rs
+panic in the log is the pre-existing stale-LLBC fail-open, not from this
+change). #171 e2e is a JIT hot path — the full check.py suite should run before
+the branch ships.
+
+| var | feature | landed | why safe to retire |
+|---|---|---|---|
+| PYRE_WASM_CA | self-recursive CALL_ASSEMBLER guest→guest `call_indirect` arm | wasm campaign `654df9dd46`, suite 169/169 | wasm backend is separate; open wasm issues (#352/#262) are orthogonal to CA correctness |
+| PYRE_WASM_ENABLE_BRIDGES | in-module inter-trace bridge chaining | same | same |
+| PYRE_WASM_INLINE_ALLOC | inline nursery-bump alloc fast path | same | `gc_stress` still forces the helper-call path, so the stress override survives |
+| PYRE_171_ORTHODOX | orthodox `w_list_append` charon-body descent (int-storage) | #171 PR#318/#322 MERGED | epic merged; user-approved retirement 2026-07-05 (overriding the standing user-curated note for this cleanup) |
+| PYRE_171_OBJ_APPEND | orthodox descent for object-strategy lists | same | same; the `&& enabled()` conjuncts were inlined, helpers deleted |
+
+## §2 — Not gates (11): Rust identifiers, not env vars
+
+The audit regex matched non-env identifiers. These are real code; **do not
+delete, do not count as gates.**
+
+- `PYRE_STR_DESCR`, `PYRE_STR_BYTE_LEN_DESCR`, `PYRE_UNICODE_DESCR`,
+  `PYRE_UNICODE_LEN_DESCR` — field-descriptor `const`s (`pyre-jit-trace/src/pyre_cpu.rs`)
+- `PYRE_CLASS_DESCRIPTOR` — macro-built identifier `W_{}_PYRE_CLASS_DESCRIPTOR` (`pyre-macros`)
+- `PYRE_PARAM_NAMES`, `PYRE_PARAM_REQUIRED` — macro `const __PYRE_PARAM_*` (`pyre-macros`)
+- `PYRE_JIT_GRAPH_MODULES` — compile-time `const &[&str]` module manifest (`generated.rs`)
+- `PYRE_REF_OPAQUE` — `OpaqueType::gc("PYRE_REF_OPAQUE")` type label (`annotator/builtin.rs`)
+- `PYRE_JIT_DISABLED` — a `OnceLock<bool>` cache name holding the `PYRE_JIT==0` result (`pyre-jit/src/eval.rs`); the env var is `PYRE_JIT`
+- `PYRE_STACKTOOBIG` — `pub static PyreStackTooBig` runtime symbol (`stack_check.rs`)
+
+## §3 — Dead (9): no env read site
+
+No source reads these. Comment-only or absent. **Historical measurement notes
+are preserved in place per N7** (they record why code was deemed dead / what a
+census verified); they are not live gates and cost nothing.
+
+| var | state |
+|---|---|
+| PYRE_50 | absent — zero occurrences |
+| PYRE_RTYPER | comments/diag-labels only; the real/legacy dual-gate runs unconditionally |
+| PYRE_STRUCT_DIFF | comment only (`front/mir.rs`) — reference removed 2026-07-05 |
+| PYRE_REQUIRE_MIR_FRONTEND | module-doc mention only (`front/mod.rs`); the doc claimed check.py sets it, but the LLBC requirement is unconditional — stale claim removed 2026-07-05 |
+| PYRE_VSTACK_USE | planned flag, never wired (`jitcode_dispatch.rs` design notes) — vaporware references removed 2026-07-05 |
+| PYRE_PATH3_VERIFY_STACK_READ | retired probe; "zero mismatch" note kept |
+| PYRE_REMAP_PROBE | retired probe; "0 fires 2026-06-11" measurement kept |
+| PYRE_S8B_HARNESS | retired census; "82/82 agreement" measurement kept |
+| PYRE_MODULE_LOOP_TRACE | retired switch; historical note kept |
+
+## §4 — Live default-ON gates KEPT (retire when the epic closes)
+
+Each is default-ON but still a load-bearing kill switch for an open rework; its
+OFF path is a needed safety net. Retire at the listed trigger (A7).
+
+| var | subsystem | retire when |
+|---|---|---|
+| PYRE_FULL_BODY_WALK | master: full-body-walk tracer vs trait leg | WS1 / #344 / #366 single-executor lands (the OFF path *is* the trait leg #344 deletes) |
+| PYRE_FBW_INLINE, _INLINE_MULTIFRAME, _INLINE_NSFOLD, _LOOP_CALLEE_CA | walker inlining (#62/#68/gap-10) | same epic cluster |
+| PYRE_FBW_CALL_ASSEMBLER, _NO_REPLAY_EXIT, _RAISE, _REC_CA | walker return/raise/recursion | same |
+| PYRE_FBW_ABORT_FLUSH, _BRANCH_FLUSH, _END_FLUSH, _BRIDGE_LOCAL_SEED | shadow-stack flush/seed on resume | same (couples to F1 resume convergence) |
+| PYRE_FBW_BUILTIN_FOLD, _LOADGLOBAL_FOLD, _LOADNAME_FOLD, _STORENAME_FOLD | const-folds in walker bodies | same (fold correctness interlocks with the walker) |
+| PYRE_FBW_NESTED_RESID_ABORT | nested-residual abort vs replay | same |
+| PYRE_TWO_PHASE_RTYPE, PYRE_TUPLE_PER_SHAPE_CLASSDEF | rtyper prepass / per-shape tuple classdef | WS2 / #346 rtyper epic |
+| PYRE_ORIGINAL_BOXES | greens++reds original_boxes index shape | box-identity #202 / resume F1 |
+| PYRE_MIR_FRAMESTATE | framestate-threaded MIR lowering | MIR front-end #176/#181/#346 |
+| PYRE_GC_ITEMSBLOCK, PYRE_GC_PREBUILT_REMEMBER, PYRE_GC_INTERP_COLLECT | GC-managed items / prebuilt minor-skip / interp collect A/B | WS3 / #355 / F3 GC rework |
+| PYRE_57_INLINE_NEXT | FOR_ITER inline-next fastpath | #57 / task#50 (has admitted unsoundness) |
+| PYRE_CL_NO_CLOSING_JUMP | cranelift attached-loop closing jump | #245 cranelift perf (explicit rollback hatch) |
+| PYRE_NO_INNER_CLOSE | cross-loop-cut inner-close override | #152 cross-loop residency |
+
+`PYRE_GC_INTERP` is default-ON on wasm32 only (`unwrap_or(cfg!(wasm32))`),
+default-OFF on native — not a clean removal candidate.
+
+## §5 — Other live gates (not removal targets by the "already-ON" criterion)
+
+Kept as-is; listed for completeness.
+
+- **Diagnostics (~34, default-OFF)** — print/log/dump/probe/assert only; tooling,
+  not experiments: `PYRE_FBW_DEBUG_ABORT`, `_INLINE_DIAG`, `_MF_DIAG`,
+  `_STRICT_DIAG`, `PYRE_WALK_PERFN_JITCODE`, `PYRE_DUMP_PERFN_JITCODE`,
+  `PYRE_P2_DIAG`, `PYRE_PCDEP_VALIDATE`, `PYRE_MIR_FRAMESTATE_DEBUG`,
+  `_FRAMESTATE_STRICT`, `PYRE_MIR_FRONTEND_DEBUG`, `PYRE_VSTACK_DIAG`,
+  `PYRE_PROBE_AUTHORITATIVE`, `_BH_STARTUP`, `_SNAPSHOT`, `_SUBSCR`,
+  `PYRE_S9_PROBE`, `PYRE_PROFILE_DRAIN`, `_PIPELINE`, `PYRE_MFRAME_DIAG`,
+  `PYRE_RTYPER_VERBOSE`, `PYRE_JTRANSFORM_SHADOW`, `PYRE_DIAG124C`, `_51C`,
+  `_GIN`, `_INLINE_RECOG`, `PYRE_WASM_DUMP_ALL_TRACES`, `_DUMP_BAD_TRACE`,
+  `_EXEC_TRACE`, `_JIT_STATS`, `PYRE_INTERP_RETURN_LOG`, `PYRE_NBODY_DEBUG`,
+  `PYRE_DEBUG_CALL`, `PYRE_DEBUG_CLASS`.
+- **Default-OFF experiments (~14)** — not "already activated", so out of scope:
+  `PYRE_FBW_VABLE_SCALAR_CA`, `PYRE_SINGLE_PASS`, `PYRE_KEPT_OVERRIDE`,
+  `PYRE_P2_AUTHORITATIVE`, `_COMPILE`, `_DRAIN`, `_FRAMESTACK`, `_FS_COMPILE`,
+  `PYRE_AUTHORITATIVE`, `PYRE_STRICT_TARGET_TO_PATH`, `PYRE_SAME_GREENKEY`,
+  `PYRE_INNER_CLOSE`, `PYRE_RELAX_124`, `PYRE_NO_DE`.
+- **Config / value / master switches (~18)** — tuning, paths, modes; keep:
+  `PYRE_FBW_REC_UNROLL`, `PYRE_WALKER_STORE_SUBSCR_FNADDR`,
+  `PYRE_MIR_FRONTEND_LLBC`, `PYRE_WASM_ENGINE`, `_FUEL`, `_MODULE`, `_NO_CACHE`,
+  `PYRE_GC_INTERP`, `PYRE_JIT`, `PYRE_NO_JIT`, `PYRE_STDLIB`,
+  `PYRE_CHECK_PYPY3`, `PYRE_CHECK_PYTHON3`, `PYRE_SANDBOX_NO_SECCOMP`,
+  `PYRE_SHARED_BUILD`, `PYRE_SYNTH_PYPY`, `_PYRE`, `_PYTHON`.
+- **Test harness (1)**: `PYRE_MIR_STRESS_LLBC`.
+
+## Summary
+
+| bucket | count |
+|---|---|
+| retired this pass | 5 |
+| not gates (identifiers) | 11 |
+| dead (no read site) | 9 |
+| live default-ON, kept until epic closes | ~28 |
+| diagnostics (OFF) | ~34 |
+| default-OFF experiments | ~14 |
+| config / value / master | ~18 |
+| test harness | 1 |

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -18452,7 +18452,6 @@ fn handle(
                 };
                 let kept_stack = resume_depth.is_some_and(|d| d > 0);
                 let depth_gt_1 = resume_depth.is_some_and(|d| d > 1);
-                let relax_124 = std::env::var_os("PYRE_RELAX_124").is_some();
                 // #73 mirror-sourced kept-stack compile: a kept-stack guard
                 // COMPILES whenever the walk-level operand-stack mirror
                 // (`ctx.vstack_boxes`) covers EVERY kept resume slot
@@ -18583,7 +18582,7 @@ fn handle(
                 // wrong depth, so a kept-stack arm in a later function would skip
                 // the decline and silently miscompile.  `kept_stack` reads the
                 // correct per-function depth and closes that gap.
-                if (kept_stack || kept_stack_any_leg) && !relax_124 && !mirror_covers_kept {
+                if (kept_stack || kept_stack_any_leg) && !mirror_covers_kept {
                     let liveness =
                         branch_arm_resume_ref_liveness(other_target, ctx.outer_jitcode_index);
                     // Hazard (1): the not-taken arm reads a regular Ref register
@@ -18664,8 +18663,7 @@ fn handle(
                 // INVALID mirror (an undermodeled walk: inline sub-walk /
                 // Unmodeled opcode) leaves the kept slots without a reliable
                 // per-slot source, so decline → interpreter (correct).
-                // `PYRE_RELAX_124` forces depth > 1 through for diagnosis.
-                if depth_gt_1 && !relax_124 && !ctx.vstack_valid {
+                if depth_gt_1 && !ctx.vstack_valid {
                     return Err(DispatchError::BranchGuardKeptStackUnsupported { pc: op.pc });
                 }
                 ctx.trace_ctx.record_guard(opcode, &[valuebox], 0);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -623,8 +623,9 @@ pub struct WalkContext<'frame, 'static_a: 'frame> {
     /// and `stack_sync` falls back to the legacy read (zero regression).
     ///
     /// SLICE 1 (#423): infrastructure landed fully INERT — the mirror is
-    /// maintained but the snapshot read stays LEGACY unless `PYRE_VSTACK_USE`
-    /// is set; `PYRE_VSTACK_DIAG` only logs mirror-vs-legacy disagreement.
+    /// maintained as side-data but the snapshot read stays LEGACY (no
+    /// authoritative flip is wired); `PYRE_VSTACK_DIAG` only logs
+    /// mirror-vs-legacy disagreement.
     pub vstack_boxes: Vec<OpRef>,
     /// #73: the absolute operand-stack depth `vstack_boxes` currently
     /// reflects — the depth ON ENTRY to the Python opcode at
@@ -1318,7 +1319,7 @@ pub fn step(
     // reconciles the previous opcode's stack effect into `ctx.vstack_boxes`
     // BEFORE this op runs.  Writes ONLY the new `vstack_*` fields — never
     // the existing registers / snapshot / control flow — so the mirror is
-    // pure side-data until a later slice flips `PYRE_VSTACK_USE`.  No-op
+    // pure side-data until a later slice makes the read authoritative.  No-op
     // unless the full-body walk owns the virtualizable shadow and the
     // mirror is still valid.
     step_vstack_mirror(ctx, pc);
@@ -2499,8 +2500,8 @@ pub fn dispatch_via_miframe(
         // Seed at the FIRST-walked jitcode pc (`position`), not `entry_py_pc`,
         // so the first `step_vstack_mirror` is a no-op (no spurious
         // entry-boundary reconcile of the not-yet-executed first opcode).
-        // Pure side-data: the snapshot read stays LEGACY unless a later slice
-        // flips `PYRE_VSTACK_USE`.
+        // Pure side-data: the snapshot read stays LEGACY until a later slice
+        // makes it authoritative.
         seed_vstack_mirror(&mut wc, sym, position);
         let outcome = walk(jitcode_code, position, &mut wc);
         // Read final last_exc_value before wc drops so the borrow
@@ -12526,9 +12527,8 @@ fn dispatch_residual_call_iRd_kind(
     // replacing the opaque `bh_call_fn` residual (orthodox descent of the
     // real `w_list_append` body; see `try_walker_orthodox_list_append`).  The
     // call arrives as `CallFn` with `dst_bank == 'r'` (the None result is a
-    // Ref, not void) and `r_args = [bound-method, PY_NULL, value]`.  Default
-    // ON (`PYRE_171_ORTHODOX=0` opts out); falls through to the
-    // residual for any non-matching shape (SAFE).  The eager append rides
+    // Ref, not void) and `r_args = [bound-method, PY_NULL, value]`.  Falls
+    // through to the residual for any non-matching shape (SAFE).  The eager append rides
     // `FBW_APPEND_JOURNAL`, whose commit/rollback epilogues run on FBW walk
     // ends (same lifecycle as the STORE_SUBSCR store journal).
     //
@@ -12553,8 +12553,8 @@ fn dispatch_residual_call_iRd_kind(
     // does not, verified by a two-list alternating-receiver append stress
     // (any wrong receiver box corrupts the cross-checked lists) and the
     // parity suite folding function-entry helper appends on both backends.
-    // #171 ORTHODOX descent (default ON — `PYRE_171_ORTHODOX=0` opts out):
-    // descend the real `w_list_append` body, recording its array ops native.
+    // #171 ORTHODOX descent: descend the real `w_list_append` body,
+    // recording its array ops native.
     // A decline (`None`) falls through to the generic residual below; an
     // un-lowered in-body helper aborts the trace (graceful interpreter
     // fallback).  Gated to top full-body frames, not inside a sub-walk.
@@ -12563,7 +12563,6 @@ fn dispatch_residual_call_iRd_kind(
         && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && pyre_171_orthodox_enabled()
         && try_walker_orthodox_list_append(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -12576,8 +12575,7 @@ fn dispatch_residual_call_iRd_kind(
     // bound-method callable), so it arrives with `dst_bank == 'v'`.  Fold it
     // through the same `w_list_append` descent as the CallFn method-call form.
     // Gated to top full-body frames, not inside a sub-walk (same
-    // caller-side-effect doubling concern as the CallFn form).  Default ON
-    // (`PYRE_171_ORTHODOX=0` opts out).
+    // caller-side-effect doubling concern as the CallFn form).
     if ctx.is_authoritative_executor
         && ctx.is_full_body_walk
         && !INLINE_SUBWALK_CAPTURE_BOUNDARY.with(|c| c.get())
@@ -12593,9 +12591,7 @@ fn dispatch_residual_call_iRd_kind(
         // point in `try_walker_orthodox_list_append_opcode` is side-effect-free
         // (it declines BEFORE emitting any IR), so surfacing the abort here is
         // safe.  Mirrors the pre-#171 `emit_abort_permanent` lowering.
-        if pyre_171_orthodox_enabled()
-            && try_walker_orthodox_list_append_opcode(ctx, code, op, &r_args, dst)?.is_some()
-        {
+        if try_walker_orthodox_list_append_opcode(ctx, code, op, &r_args, dst)?.is_some() {
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
         return Err(DispatchError::UnfoldableListAppendResidualUnsupported { pc: op.pc });
@@ -15355,28 +15351,6 @@ fn try_walker_specialize_builtin_len(
     Ok(Some(()))
 }
 
-/// #171 orthodox descent gate (default ON — `PYRE_171_ORTHODOX=0` opts
-/// out).  The descent of the real `w_list_append` charon body is the
-/// `list.append` int-storage specialization; an unresolved in-body helper
-/// declines via `OrthodoxSubWalkTraceUnsupported` (graceful interpreter
-/// fallback), so a stale build-time jitcode never commits a wrong trace.
-fn pyre_171_orthodox_enabled() -> bool {
-    std::env::var("PYRE_171_ORTHODOX").as_deref() != Ok("0")
-}
-
-/// #171 object-storage append gate (default ON — `PYRE_171_OBJ_APPEND=0`
-/// opts out): extend the orthodox `list.append` descent to object-strategy
-/// lists (a `Ref` value stored into the object items block) in addition to
-/// the int-storage specialization.  Shares the orthodox-fold entry gate
-/// (authoritative full-body walk, not inside an inline sub-walk — see the
-/// call site), so the object path carries the same loop/full-body
-/// restriction as the int fold; an unresolved object-store leaf declines
-/// via `OrthodoxSubWalkTraceUnsupported` (graceful interpreter fallback),
-/// so a miss never commits a wrong trace.
-fn pyre_171_obj_append_enabled() -> bool {
-    std::env::var("PYRE_171_OBJ_APPEND").as_deref() != Ok("0")
-}
-
 /// Global descr-pool sub-jitcode lookup (resolves a global jitcode index
 /// through `ALL_JITCODES`, mirroring the shadow walker's lookup).  A
 /// build-time canonical sub-body (`w_list_append`) carries no per-fn descr
@@ -15409,7 +15383,7 @@ static GLOBAL_SUB_JITCODE_LOOKUP_FN: fn(usize) -> Option<SubJitCodeBody> =
 /// BEFORE emitting any IR for a non-matching shape (SAFE fallback to the fold
 /// / residual).
 ///
-/// STATUS (default ON — `PYRE_171_ORTHODOX=0` opts out): the descr-pool
+/// STATUS: the descr-pool
 /// wiring, the host-static const relocation, and the list header field
 /// descr-group bridge (`make_descr_from_bh` strategy/length/items →
 /// `W_LIST_DESCR_GROUP`) are all in place — the strategy `switch` and the
@@ -15554,12 +15528,10 @@ unsafe fn orthodox_list_append_recognize(
     let int_ok = pyre_object::w_list_uses_int_storage(inner_self)
         && pyre_object::is_plain_int1(value)
         && !pyre_object::pyobject::is_long(value);
-    // Object-storage extension (default ON, `PYRE_171_OBJ_APPEND=0` opts
-    // out): any non-null `Ref` value stored into the object items block —
-    // no unboxing, so the value carries no type precondition.
-    let obj_ok = pyre_171_obj_append_enabled()
-        && pyre_object::w_list_uses_object_storage(inner_self)
-        && !value.is_null();
+    // Object-storage extension: any non-null `Ref` value stored into the
+    // object items block — no unboxing, so the value carries no type
+    // precondition.
+    let obj_ok = pyre_object::w_list_uses_object_storage(inner_self) && !value.is_null();
     // Float-storage specialization: a strict `W_FloatObject` stored
     // unboxed. `FloatListStrategy.is_correct_type` (listobject.py:2061) is
     // `type(w_obj) is W_FloatObject`, the strict predicate the body's Float
@@ -15633,7 +15605,7 @@ fn orthodox_list_append_commit(
     // enforces ob_type==INT_TYPE at runtime.  The value's integer payload
     // stays symbolic — only its class is pinned.
     //
-    // Object-storage append (`PYRE_171_OBJ_APPEND`) stores the value as a
+    // Object-storage append stores the value as a
     // plain GC ref with no unboxing, so it carries no type precondition —
     // skip the INT_TYPE pin (the sub-walk's object-storage store path does
     // not read the value's class).

--- a/pyre/pyre-jit-trace/src/liveness.rs
+++ b/pyre/pyre-jit-trace/src/liveness.rs
@@ -15,19 +15,6 @@ fn skip_caches(code: &CodeObject, mut pos: usize) -> usize {
     pos
 }
 
-/// Provenance of one operand-stack slot in the forward source analysis.
-/// `Local(idx)` means the slot definitely holds the value of local `idx`
-/// (it was pushed by a `LOAD_FAST idx` and carried unchanged); `Other`
-/// means the slot's value is computed / merged / unknown.  The analysis is
-/// CONSERVATIVE: any opcode it does not model precisely produces `Other`,
-/// so a recovered `Local(idx)` is only ever reported when certain — a wrong
-/// provenance is never emitted, the worst case is declining to recover.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum StackSource {
-    Local(u32),
-    Other,
-}
-
 /// codewriter/liveness.py parity: bytecode liveness analysis.
 /// For each bytecode PC, tracks which locals are live (may be read
 /// on some path before being reassigned) and the operand stack depth.
@@ -56,15 +43,6 @@ pub struct LiveVars {
     /// RPython JitCode treats stack as registers with liveness.
     /// For Python bytecodes, stack depth determines which slots are live.
     stack_depth_at: Vec<usize>,
-    /// Per-PC operand-stack slot provenance at ENTRY to the PC (before the
-    /// op executes), `None` for unreachable PCs.  Slot 0 is the bottom of
-    /// the operand stack (above locals/cells).  Feeds the #124 kept-stack
-    /// resume recovery: a short-circuit `and`/`or` guard keeps the tested
-    /// local on the not-taken arm, but the walk executed the taken arm and
-    /// folded a constant into the kept slot's reused register — so the
-    /// guard-pc source `Local(idx)` lets the snapshot read the live local
-    /// box (`registers_r[local_color_map[idx]]`) instead of the stale fold.
-    stack_source_at: Vec<Option<Vec<StackSource>>>,
 }
 
 impl LiveVars {
@@ -79,7 +57,6 @@ impl LiveVars {
                 defined_bits: Vec::new(),
                 words_per_pc: 0,
                 stack_depth_at: Vec::new(),
-                stack_source_at: Vec::new(),
             };
         }
         let nlocals = code.varnames.len().max(1);
@@ -307,59 +284,6 @@ impl LiveVars {
             }
         }
 
-        // Forward operand-stack provenance analysis (#124 kept-stack
-        // recovery).  `before[pc]` = source stack at ENTRY to pc.  Monotone
-        // toward `Other` (merges only widen specific→Other), so the
-        // worklist converges; depths agree with `stack_depth_at` (the
-        // authoritative height), this only tracks each slot's source.
-        let mut before: Vec<Option<Vec<StackSource>>> = vec![None; n + 1];
-        // Gated experimental feature (#124 kept-stack provenance); default off
-        // so the baseline pays no analysis cost.  Leaving `before` all-`None`
-        // makes `stack_slot_source_local` return `None` everywhere (the
-        // consumer override then never fires).
-        let kept_provenance_on = std::env::var_os("PYRE_KEPT_OVERRIDE").is_some();
-        before[0] = Some(Vec::new());
-        let mut src_changed = kept_provenance_on;
-        // A monotone analysis (slots only widen Local->Other, lengths fixed on
-        // first touch) converges in O(n) sweeps; cap as a backstop so a
-        // pathological CFG can never hang the tracer.  Exhausting the cap
-        // leaves some pcs less precise, which the consumer tolerates.
-        let mut src_iters = 0usize;
-        let src_iter_cap = n + 4;
-        while src_changed && src_iters < src_iter_cap {
-            src_iters += 1;
-            src_changed = false;
-            for pc in 0..n {
-                let Some(entry) = before[pc].clone() else {
-                    continue;
-                };
-                let Some((instr, op_arg)) = pyre_interpreter::decode_instruction_at(code, pc)
-                else {
-                    src_changed |= merge_source_stack(&mut before[pc + 1], &entry);
-                    continue;
-                };
-                let (ft, br) = source_stack_effects(&instr, op_arg, &entry);
-                if !is_unconditional_jump(&instr) {
-                    src_changed |= merge_source_stack(&mut before[pc + 1], &ft);
-                }
-                if let Some(tgt) = target_pc(code, &instr, pc, op_arg) {
-                    if tgt <= n {
-                        src_changed |= merge_source_stack(&mut before[tgt], &br);
-                    }
-                }
-                // Exception-handler entries: the unwinder rebuilds the value
-                // stack, so every slot is non-local — model as all-`Other`
-                // sized to the handler entry depth.
-                for &(s, e, tgt, hdepth) in &exc_handlers {
-                    if pc >= s && pc < e && tgt <= n {
-                        let handler = vec![StackSource::Other; hdepth];
-                        src_changed |= merge_source_stack(&mut before[tgt], &handler);
-                    }
-                }
-            }
-        }
-        let stack_source_at = before;
-
         // Forward must-analysis: a local is defined at PC `p` iff it
         // has been stored on every path reaching `p`. Entry set is
         // the function's argument slots; each join intersects (AND).
@@ -497,19 +421,6 @@ impl LiveVars {
             defined_bits,
             words_per_pc,
             stack_depth_at,
-            stack_source_at,
-        }
-    }
-
-    /// Source local of operand-stack `slot` (0 = bottom) at ENTRY to `pc`,
-    /// or `None` when the slot is computed/merged/unknown or `pc` is
-    /// unreachable.  The #124 kept-stack recovery reads this at a branch
-    /// guard's pc to source the kept operand from the live local instead of
-    /// the reused (stale-fold) register.
-    pub fn stack_slot_source_local(&self, pc: usize, slot: usize) -> Option<u32> {
-        match self.stack_source_at.get(pc)?.as_ref()?.get(slot)? {
-            StackSource::Local(idx) => Some(*idx),
-            StackSource::Other => None,
         }
     }
 
@@ -633,149 +544,6 @@ fn propagate_defined(
     }
     if changed {
         worklist.push(target);
-    }
-}
-
-/// Stack effects: (fallthrough_depth, branch_depth).
-/// Returns new absolute stack depths after the instruction.
-/// Merge `incoming` into the entry source stack at a PC. First touch
-/// installs it; later touches widen any disagreeing slot to `Other`
-/// (monotone, so the worklist converges). Returns whether anything changed.
-fn merge_source_stack(slot: &mut Option<Vec<StackSource>>, incoming: &[StackSource]) -> bool {
-    match slot {
-        None => {
-            *slot = Some(incoming.to_vec());
-            true
-        }
-        Some(existing) => {
-            if existing.len() != incoming.len() {
-                // Depth disagreement (a pc reached at two different stack
-                // depths). Keep the first-seen length and report no change —
-                // flipping to the incoming length each visit would oscillate
-                // forever (the merge would never reach a fixpoint).  The
-                // consumer reads a specific slot and tolerates an absent /
-                // out-of-range source, so keeping the first length is safe.
-                return false;
-            }
-            let mut changed = false;
-            for (e, i) in existing.iter_mut().zip(incoming.iter()) {
-                if *e != StackSource::Other && *e != *i {
-                    *e = StackSource::Other;
-                    changed = true;
-                }
-            }
-            changed
-        }
-    }
-}
-
-/// Rebuild a source stack at `target_d` slots conservatively from `before`.
-/// Pure pushes keep the lower slots and add `Other` on top; a net-zero op
-/// replaces only the top with `Other` (TO_BOOL / unary); a net pop clears to
-/// all-`Other` (single-pop vs multi-pop-push is indistinguishable by depth,
-/// so the safe choice is to drop provenance).
-fn rebuild_other(before: &[StackSource], target_d: usize) -> Vec<StackSource> {
-    let d = before.len();
-    if target_d > d {
-        let mut s = before.to_vec();
-        s.resize(target_d, StackSource::Other);
-        s
-    } else if target_d == d {
-        let mut s = before.to_vec();
-        if let Some(last) = s.last_mut() {
-            *last = StackSource::Other;
-        }
-        s
-    } else {
-        vec![StackSource::Other; target_d]
-    }
-}
-
-/// Forward per-slot source effect of `instr` on the entry source stack
-/// `before`, returning `(fall_through, branch_target)` source stacks.
-/// Precise for the opcodes a short-circuit `and`/`or` (and the surrounding
-/// loop body) uses — `LOAD_FAST` pushes `Local`, `COPY` duplicates, `SWAP`
-/// reorders, true no-ops pass through — and conservatively `Other` for
-/// everything else (sized from `stack_effects`, the authoritative depth).
-fn source_stack_effects(
-    instr: &pyre_interpreter::bytecode::Instruction,
-    op_arg: pyre_interpreter::OpArg,
-    before: &[StackSource],
-) -> (Vec<StackSource>, Vec<StackSource>) {
-    use pyre_interpreter::bytecode::Instruction;
-    let d = before.len();
-    let same = |s: Vec<StackSource>| (s.clone(), s);
-    match instr {
-        Instruction::Nop
-        | Instruction::Resume { .. }
-        | Instruction::Cache
-        | Instruction::NotTaken
-        | Instruction::ExtendedArg
-        | Instruction::DeleteFast { .. }
-        | Instruction::DeleteName { .. }
-        | Instruction::DeleteGlobal { .. }
-        | Instruction::DeleteDeref { .. }
-        | Instruction::CopyFreeVars { .. } => same(before.to_vec()),
-        Instruction::LoadFast { var_num }
-        | Instruction::LoadFastBorrow { var_num }
-        | Instruction::LoadFastCheck { var_num }
-        | Instruction::LoadFastAndClear { var_num } => {
-            let mut s = before.to_vec();
-            s.push(StackSource::Local(var_num.get(op_arg).as_usize() as u32));
-            same(s)
-        }
-        Instruction::LoadFastLoadFast { var_nums }
-        | Instruction::LoadFastBorrowLoadFastBorrow { var_nums } => {
-            let pair = var_nums.get(op_arg);
-            let mut s = before.to_vec();
-            s.push(StackSource::Local(u32::from(pair.idx_1())));
-            s.push(StackSource::Local(u32::from(pair.idx_2())));
-            same(s)
-        }
-        Instruction::Copy { i } => {
-            // COPY i duplicates the i-th value from the top (1-based).
-            let idx = i.get(op_arg) as usize;
-            let src = if idx >= 1 && idx <= d {
-                before[d - idx]
-            } else {
-                StackSource::Other
-            };
-            let mut s = before.to_vec();
-            s.push(src);
-            same(s)
-        }
-        Instruction::Swap { i } => {
-            // SWAP i exchanges the top with the i-th value from the top.
-            let idx = i.get(op_arg) as usize;
-            let mut s = before.to_vec();
-            if d >= 1 && idx >= 1 && idx <= d {
-                s.swap(d - 1, d - idx);
-            }
-            same(s)
-        }
-        Instruction::PopTop
-        | Instruction::PopJumpIfTrue { .. }
-        | Instruction::PopJumpIfFalse { .. }
-        | Instruction::PopJumpIfNone { .. }
-        | Instruction::PopJumpIfNotNone { .. } => {
-            // POP_TOP and POP_JUMP_IF_* pop exactly the top value (the latter
-            // on BOTH the fall-through and the branch arm); every operand-stack
-            // slot below is untouched and keeps its source.  Modeling this
-            // precisely — instead of the conservative `rebuild_other` net-pop
-            // wipe — keeps a short-circuit `and`/`or`'s operand BELOW the
-            // popped condition/value (e.g. `acc` kept on the stack across the
-            // guard in `acc = acc + (a or b)`, where the not-taken arm's
-            // `POP_TOP` would otherwise drop `acc`'s provenance) `Local`-sourced
-            // through the merge, so the bridge/blackhole can recover it from the
-            // live local instead of a reused (stale-fold) merge color.
-            let mut s = before.to_vec();
-            s.pop();
-            same(s)
-        }
-        _ => {
-            let (ft_d, br_d) = stack_effects(instr, op_arg, d);
-            (rebuild_other(before, ft_d), rebuild_other(before, br_d))
-        }
     }
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7770,7 +7770,7 @@ impl JitState for PyreJitState {
                 }
             }
         };
-        let mut semantic_mirror: Vec<OpRef> = if maps.is_portal_bridge || !maps.has_color_map {
+        let semantic_mirror: Vec<OpRef> = if maps.is_portal_bridge || !maps.has_color_map {
             // No per-CodeObject regalloc: colors are slot-identity, so the
             // color bank IS the slot mirror over the semantic prefix. Keep the
             // in-place identity overlay (stack slots NONE-only, locals vable).
@@ -7857,38 +7857,6 @@ impl JitState for PyreJitState {
             }
             mirror
         };
-        // #124/#73 Blocker A: a kept operand-stack slot whose per-PC liveness
-        // source is a live local reads a STALE merge color through the
-        // color→slot inversion above.  Regalloc reuses a color for different
-        // values between the guard pc (where the resume register file was
-        // captured) and the resume pc (whose `stack_color_map`/`pcdep` the
-        // inversion uses), so `bridge_registers_r[color]` holds a sibling
-        // value, not the kept local (e.g. `acc=acc+(a or b)` resumes with
-        // operand-stack slot 0 = `acc` but the slot-0 color holds `b` at the
-        // guard).  The semantic local mirror `[0,nlocals)` is already correct
-        // (vable-overlaid from the live frame), and `StackSource::Local`
-        // guarantees the slot still equals that local's current value, so
-        // source such a stack slot from its source local.  This is the bridge
-        // analog of the guard-side local-provenance override
-        // (jitcode_dispatch.rs `kept_slot_local_shadow_recoverable`).
-        if let Some(code_ptr) = METAINTERP_SD.with(|r| {
-            r.borrow()
-                .jitcodes
-                .get(frame0.jitcode_index as usize)
-                .map(|jc| jc.payload.code_ptr)
-        }) {
-            if !code_ptr.is_null() {
-                let lv = crate::liveness::liveness_for(code_ptr);
-                for d in 0..stack_only {
-                    if let Some(local_idx) = lv.stack_slot_source_local(frame0.pc as usize, d) {
-                        let li = local_idx as usize;
-                        if li < nlocals && nlocals + d < semantic_mirror.len() {
-                            semantic_mirror[nlocals + d] = semantic_mirror[li];
-                        }
-                    }
-                }
-            }
-        }
         let bridge_locals: Vec<OpRef> = semantic_mirror.iter().take(nlocals).copied().collect();
         // #124 kept operand-stack temps: the stack tail of the same
         // slot-indexed mirror (`[nlocals, nlocals + stack_only)`), so a

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2125,22 +2125,6 @@ fn bridge_source_identity_from_descr(
 /// On failure (trace abort, start failure), returns false so the caller
 /// falls through to resume_in_blackhole (RPython pyjitpl.py:2906-2907
 /// SwitchToBlackhole → run_blackhole_interp_to_cancel_tracing).
-/// Runtime toggle for the wasm bridge tracer (default ON). The runner's
-/// `pyre_jit_set_enable_bridges` export flips it (`PYRE_WASM_ENABLE_BRIDGES=0`
-/// disables) so chaining can be A/B-measured without rebuilding the guest
-/// module.
-#[cfg(target_arch = "wasm32")]
-pub static WASM_BRIDGES_ENABLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(true);
-
-/// Set the wasm bridge-tracer enable flag (see `WASM_BRIDGES_ENABLED`).
-#[cfg(target_arch = "wasm32")]
-pub fn set_wasm_bridges_enabled(enabled: bool) {
-    WASM_BRIDGES_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
-}
-
-// On wasm the early decline makes the native bridge body unreachable when the
-// tracer is disabled; the suppression is intentional and wasm-only.
 // dont_look_inside: bridge-compile machinery the tracer must not enter.
 #[cfg_attr(target_arch = "wasm32", allow(unreachable_code))]
 #[majit_macros::dont_look_inside]
@@ -2182,23 +2166,6 @@ pub fn trace_and_compile_from_bridge(
         // the caller into `resume_in_blackhole` (pyjitpl.py:711).
         return false;
     };
-
-    // Wasm bridge tracer kill switch (`WASM_BRIDGES_ENABLED`, default ON):
-    // declining here drops every guard failure to blackhole-from-guard, the
-    // chaining-free fallback, for A/B measurement.
-    #[cfg(target_arch = "wasm32")]
-    if !WASM_BRIDGES_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
-        let _ = (
-            frame,
-            raw_values,
-            exit_layout,
-            guard_exc,
-            green_key,
-            trace_id,
-            fail_index,
-        );
-        return false;
-    }
 
     let info = {
         let (_, info) = crate::eval::driver_pair();

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -244,36 +244,6 @@ fn run(module_path: &PathBuf, source: &str) -> Result<i32> {
     let run_python = instance.get_typed_func::<(u32, u32), u64>(&mut store, "pyre_run_python")?;
     let dealloc = instance.get_typed_func::<(u32, u32), ()>(&mut store, "pyre_dealloc")?;
 
-    // Wasm bridge tracer (inter-trace chaining) is ON by default in the guest;
-    // PYRE_WASM_ENABLE_BRIDGES=0 disables it (any other value re-enables) for
-    // A/B measurement. No-op if the export is absent (older modules).
-    if let Ok(v) = std::env::var("PYRE_WASM_ENABLE_BRIDGES") {
-        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_enable_bridges")
-        {
-            f.call(&mut store, u32::from(v != "0"))?;
-        }
-    }
-
-    // Inline nursery-bump allocation fast path is ON by default in the guest;
-    // PYRE_WASM_INLINE_ALLOC=0 disables it (any other value re-enables) for
-    // A/B measurement. No-op if the export is absent (older modules).
-    if let Ok(v) = std::env::var("PYRE_WASM_INLINE_ALLOC") {
-        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_inline_alloc") {
-            f.call(&mut store, u32::from(v != "0"))?;
-        }
-    }
-
-    // Self-recursive CALL_ASSEMBLER guest→guest `call_indirect` arm is ON by
-    // default in the guest; PYRE_WASM_CA=0 disables it (any other value
-    // re-enables) for A/B measurement. The guest has no environment, so the
-    // flag is plumbed through this export. No-op if the export is absent
-    // (older modules).
-    if let Ok(v) = std::env::var("PYRE_WASM_CA") {
-        if let Ok(f) = instance.get_typed_func::<u32, ()>(&mut store, "pyre_jit_set_wasm_ca") {
-            f.call(&mut store, u32::from(v != "0"))?;
-        }
-    }
-
     let src = source.as_bytes();
     let len = src.len() as u32;
     let in_ptr = if len == 0 {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -317,39 +317,6 @@ pub extern "C" fn pyre_jit_mc_diag(i: u32) -> u64 {
     majit_metainterp::mc_diag(i as usize)
 }
 
-/// Toggle the wasm bridge tracer (inter-trace chaining, default ON) at
-/// runtime, set by the host runner from `PYRE_WASM_ENABLE_BRIDGES`. Exported
-/// (not an import) for the same function-index-stability reason as the diag
-/// readers.
-#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
-#[unsafe(no_mangle)]
-pub extern "C" fn pyre_jit_set_enable_bridges(enabled: u32) {
-    pyre_jit::call_jit::set_wasm_bridges_enabled(enabled != 0);
-    // Backend-side mirror: `execute_token` sizes every host frame's Ref-home
-    // region for cross-trace chaining when this is on.
-    majit_backend_wasm::set_wasm_bridges_enabled(enabled != 0);
-}
-
-/// Enable the self-recursive CALL_ASSEMBLER guest→guest `call_indirect` arm
-/// (`PYRE_WASM_CA`) at runtime, set by the host runner from an env flag. The
-/// guest has no environment, so this export is the only way to reach the flag;
-/// same export-not-import / function-index-stability rationale as the diag
-/// readers and `pyre_jit_set_enable_bridges`.
-#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
-#[unsafe(no_mangle)]
-pub extern "C" fn pyre_jit_set_wasm_ca(enabled: u32) {
-    majit_backend_wasm::set_wasm_ca_enabled(enabled != 0);
-}
-
-/// Toggle the inline nursery-bump allocation fast path (default ON;
-/// `PYRE_WASM_INLINE_ALLOC=0` kill switch). Same plumbing rationale as
-/// `pyre_jit_set_wasm_ca`.
-#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
-#[unsafe(no_mangle)]
-pub extern "C" fn pyre_jit_set_inline_alloc(enabled: u32) {
-    majit_backend_wasm::set_wasm_inline_alloc_enabled(enabled != 0);
-}
-
 #[cfg(any(feature = "web", feature = "wasm-host"))]
 static PANIC_HOOK: Once = Once::new();
 


### PR DESCRIPTION
Hardwire the self-recursive CALL_ASSEMBLER arm, in-module bridge chaining, and the inline nursery-bump alloc fast path on. Removes the runner env reads, the pyre_jit_set_wasm_ca / _enable_bridges / _inline_alloc guest exports, the set_* host entry points, and the WASM_*_ENABLED atomics (including call_jit's WASM_BRIDGES_ENABLED and its bridge kill-switch guard). Reader fns now return true. The atomics already defaulted true, so generated code is unchanged; gc_stress still forces the alloc helper path.

PYRE_REQUIRE_MIR_FRONTEND, PYRE_VSTACK_USE, and PYRE_STRUCT_DIFF appear only in comments; none is read anywhere. Rewrite the notes to state the actual behavior (LLBC requirement is unconditional; the vstack mirror stays inert side-data; unrecognised shapes are marked for widening) without naming flags that do not exist. Record the cleanup in gate-triage.md.

`&& enabled()` conjuncts at the three call sites, delete the pyre_171_orthodox_enabled / pyre_171_obj_append_enabled helpers, and drop the stale gate mentions from the surrounding comments. Both gates were default-ON, so the folded/object-storage descent is unchanged. Record in gate-triage.md.

Assisted-by: Claude

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
