### PR TITLE
#355: PyFrame as Python-visible frame W_Root (retire sys.namespace stub)

### DIFF
--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1405,6 +1405,16 @@ fn eval_loop(frame: &mut PyFrame) -> PyResult {
                 }
                 return Err(err);
             }
+            // A trace callback may perform a debugger line-jump by setting
+            // `frame.f_lineno` (`PyFrame::fset_f_lineno` → `last_instr =
+            // best_addr`).  Honour it: if a tracer is installed and it
+            // moved `last_instr` off the instruction we were about to
+            // dispatch, resume from the jump target instead of `pc`.  The
+            // `gettrace` null-check keeps this off the no-tracer hot path.
+            if unsafe { !(*ec).gettrace().is_null() } && frame.last_instr as usize != pc {
+                next_instr = frame.last_instr as usize;
+                continue;
+            }
         }
         let (opcode_pc, instruction, op_arg) = decode_instruction_for_dispatch(code, pc)?;
         let fallthrough = opcode_pc + 1;

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -8,208 +8,25 @@ use std::sync::OnceLock;
 
 use crate::PyFrame;
 
-fn trace_frame_type() -> PyObjectRef {
-    static TYPE: OnceLock<usize> = OnceLock::new();
-    let raw = *TYPE.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type("frame", |_| {});
-        // The wrapper wants a per-instance mapdict store; a `__dict__`
-        // rawdict key would instead claim the typedef manages the dict
-        // (typedef.py:40) and suppress the mapdict one
-        // (typeobject.py:253-257), so flip `hasdict` directly — the
-        // `create_dict_slot` flag flip (typeobject.py:1222-1226).
-        unsafe { pyre_object::w_type_set_hasdict(tp, true) };
-        tp as usize
-    });
-    raw as PyObjectRef
-}
-
-/// Copy callback-visible mutations on the trace-frame wrapper back to
-/// the live `PyFrame`'s debug data.
+/// Return the live `PyFrame` as the Python-visible `frame` object passed
+/// to a trace / profile callback.
 ///
-/// PyPy's `_trace` passes the live frame to the callback (`jit.hint(
-/// frame, access_directly=False)`), so `frame.f_trace = local` and
-/// `frame.f_lineno = N` from inside the callback land directly on
-/// `frame.debug`.  Pyre wraps the frame in a `pyre_object` instance
-/// because `PyFrame` is not itself a `PyObject`, so a setattr on the
-/// wrapper would otherwise stay isolated.  After the callback returns,
-/// read the wrapper's mutated attributes and propagate the changes to
-/// the live frame, preserving the user-visible semantics for the
-/// common case (debugger setting `frame.f_trace` to a per-frame
-/// callback while returning `None`).
-///
-/// The `_trace` w_result branch still wins (`executioncontext.py:386-
-/// 391`): a non-None callback return value overrides whichever value
-/// the setattr left behind, matching CPython issue11992 bug-for-bug
-/// compatibility.
-fn flush_trace_frame_writeback(
-    frame: *mut PyFrame,
-    w_frame: PyObjectRef,
-    init_lineno: isize,
-) -> Result<(), crate::PyError> {
-    if frame.is_null() || w_frame.is_null() {
-        return Ok(());
-    }
-    let new_f_trace = match crate::baseobjspace::getattr_str(w_frame, "f_trace") {
-        Ok(v) => v,
-        Err(_) => return Ok(()),
-    };
-    // pyframe.py:785-791 fset_f_trace:
-    //   if space.is_w(w_trace, space.w_None):
-    //       self.getorcreatedebug().w_f_trace = None
-    //   else:
-    //       d = self.getorcreatedebug()
-    //       d.w_f_trace = w_trace
-    //       d.f_lineno = self.get_last_lineno()
-    // The non-None branch also realigns f_lineno to the current
-    // bytecode line so trace events fire from the new tracer's
-    // perspective immediately.
-    unsafe {
-        let d = (*frame).getorcreatedebug(init_lineno);
-        let is_clear = new_f_trace.is_null() || new_f_trace == pyre_object::w_none();
-        if is_clear {
-            d.w_f_trace = pyre_object::PY_NULL;
-        } else if new_f_trace != d.w_f_trace {
-            d.w_f_trace = new_f_trace;
-            d.f_lineno = (*frame).get_last_lineno();
-        }
-    }
-    if let Ok(new_f_lineno_obj) = crate::baseobjspace::getattr_str(w_frame, "f_lineno") {
-        if !new_f_lineno_obj.is_null() && unsafe { pyre_object::is_int(new_f_lineno_obj) } {
-            let new_lineno = unsafe { pyre_object::w_int_get_value(new_f_lineno_obj) };
-            // TODO: pyframe.py:683-764
-            // `PyFrame.fset_f_lineno` is the upstream setter. It runs
-            // line-jump validation against the bytecode (block stack
-            // unwinding through SETUP_LOOP/SETUP_EXCEPT, code address
-            // recomputation via PyCode._signature_addr_to_line, and
-            // last_instr realignment). Pyre's wrapper writes only
-            // debug.f_lineno because PyFrame is not yet a PyObject
-            // and the validator's PyCode internals (try/except
-            // boundaries, generator restart guards) are not exposed
-            // through the wrapper interface. The full setter port
-            // is gated on the PyFrame ↔ PyObject identity epic.
-            unsafe {
-                let d = (*frame).getorcreatedebug(init_lineno);
-                d.f_lineno = new_lineno as isize;
-            }
-        }
-    }
-    // pyframe.py:799-806 fset_f_trace_lines / fset_f_trace_opcodes.
-    // Both setters apply `space.is_true(w_trace)` to coerce arbitrary
-    // truthy values; pyre's `is_true` is the equivalent.
-    if let Ok(new_lines_obj) = crate::baseobjspace::getattr_str(w_frame, "f_trace_lines") {
-        if !new_lines_obj.is_null() {
-            let new_lines = unsafe { crate::baseobjspace::is_true(new_lines_obj) }?;
-            unsafe {
-                (*frame).getorcreatedebug(init_lineno).f_trace_lines = new_lines;
-            }
-        }
-    }
-    if let Ok(new_opcodes_obj) = crate::baseobjspace::getattr_str(w_frame, "f_trace_opcodes") {
-        if !new_opcodes_obj.is_null() {
-            let new_opcodes = unsafe { crate::baseobjspace::is_true(new_opcodes_obj) }?;
-            unsafe {
-                (*frame).getorcreatedebug(init_lineno).f_trace_opcodes = new_opcodes;
-            }
-        }
-    }
-    Ok(())
-}
-
+/// `pyframe.py:_trace` hands the callback the real frame
+/// (`jit.hint(frame, access_directly=False)`).  Now that `PyFrame` is a
+/// W_Root (`FRAME_TYPE` typedef), pyre does the same: the callback's
+/// `frame.f_lineno = N` / `frame.f_trace = local` land directly on the
+/// live frame's getsets, so no `sys.namespace` wrapper and no
+/// writeback pass is needed.  The frame is the current executing frame
+/// (on the `CURRENT_FRAME` chain and thus GC-rooted) for the whole
+/// callback, so returning it is safe; mark it escaped so the JIT keeps
+/// it materialised while the callback holds a reference
+/// (`pyframe.py:176 mark_as_escaped`).
 fn wrap_trace_frame(frame: *mut PyFrame) -> PyObjectRef {
     if frame.is_null() {
         return pyre_object::w_none();
     }
-    let w_frame = pyre_object::w_instance_new(trace_frame_type());
-    unsafe {
-        let frame_ref = &mut *frame;
-        // `pyframe.py:766 fget_f_globals` returns `self.w_globals`
-        // (already a W_DictObject).  Pyre's eager `w_globals` slot
-        // matches that identity; reading it here avoids a second
-        // `dict_storage_to_dict` round-trip below.
-        let w_globals = frame_ref.get_w_globals();
-        let w_locals = frame_ref.get_w_locals();
-        let w_trace = frame_ref.get_w_f_trace();
-        // pypy/interpreter/pyframe.py:154 fget_f_back walks the
-        // f_backref vref to materialise the parent frame.  Pyre's
-        // wrapper has to do the same eagerly because the wrapper is a
-        // plain pyre_object instance (no `__getattr__` slot wired to
-        // the live struct yet).  Recursion depth tracks
-        // the live stack depth, which is bounded by Python's
-        // recursion limit; the wrappers are short-lived (allocated
-        // per callback invocation) so the per-trace overhead scales
-        // with stack depth rather than total executed bytecodes.
-        let f_back_obj = wrap_trace_frame(frame_ref.get_f_back());
-        crate::baseobjspace::setdictvalue(w_frame, "f_code", frame_ref.pycode as PyObjectRef);
-        crate::baseobjspace::setdictvalue(w_frame, "f_back", f_back_obj);
-        // pyframe.py:768-771 fget_f_builtins → self.get_builtin().getdict(space)
-        crate::baseobjspace::setdictvalue(w_frame, "f_builtins", frame_ref.fget_f_builtins());
-        // `pyframe.py:766 fget_f_globals` returns `self.w_globals`
-        // directly — same identity as `module.__dict__` so trace
-        // hooks (`sys.settrace`) observe `frame.f_globals is
-        // module.__dict__`.  Pyre routes through
-        // `dict_storage_to_dict` which returns the canonical dict
-        // wrapper paired with the storage (mirror_target invariant);
-        // allocating a fresh dict per trace callback would silently
-        // break that identity.  `f_locals` follows the same shape (PyPy
-        // `pyframe.py:546 fast2locals` then `self.debugdata.w_locals`).
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_globals",
-            if w_globals.is_null() {
-                pyre_object::w_none()
-            } else {
-                w_globals
-            },
-        );
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_locals",
-            // pyframe.py:546 fast2locals (run by the trace gate before this
-            // callback) caches the locals mapping in `w_locals`; expose
-            // it directly.  A frame with no locals bound surfaces as None.
-            if w_locals.is_null() {
-                pyre_object::w_none()
-            } else {
-                w_locals
-            },
-        );
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_lineno",
-            pyre_object::w_int_new(frame_ref.fget_f_lineno() as i64),
-        );
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_lasti",
-            pyre_object::w_int_new(frame_ref.fget_f_lasti() as i64),
-        );
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_trace",
-            if w_trace.is_null() {
-                pyre_object::w_none()
-            } else {
-                w_trace
-            },
-        );
-        // pyframe.py:796-806 fget_f_trace_lines / fget_f_trace_opcodes
-        // — exposed as bools.  PyPy stores the live values on the
-        // frame's debug data; pyre's wrapper mirrors them so the user
-        // callback can read or set them.  flush_trace_frame_writeback
-        // copies the wrapper's post-callback values back onto the
-        // live frame.
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_trace_lines",
-            pyre_object::w_bool_from(frame_ref.get_f_trace_lines()),
-        );
-        crate::baseobjspace::setdictvalue(
-            w_frame,
-            "f_trace_opcodes",
-            pyre_object::w_bool_from(frame_ref.get_f_trace_opcodes()),
-        );
-    }
-    w_frame
+    unsafe { (*frame).mark_as_escaped() };
+    frame as PyObjectRef
 }
 
 /// pypy/interpreter/executioncontext.py:10-15 app_profile_call.
@@ -1480,13 +1297,9 @@ impl ExecutionContext {
                     w_callback,
                     &[frame_obj, w_event, w_arg],
                 );
-                // Mirror in-callback `frame.f_trace = local` /
-                // `frame.f_lineno = N` mutations back onto the live
-                // PyFrame before processing w_result. PyPy passes the
-                // raw frame to the callback, so its setattrs land
-                // directly; pyre runs the callback against a wrapper
-                // and must propagate explicitly.
-                flush_trace_frame_writeback(frame, frame_obj, init_lineno)?;
+                // The callback received the live frame, so its
+                // `frame.f_trace = local` / `frame.f_lineno = N` setattrs
+                // already landed on the frame's getsets — no writeback pass.
                 let w_result = call_result?;
                 if w_result != pyre_object::w_none() {
                     unsafe {

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1319,7 +1319,15 @@ impl ExecutionContext {
             unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
                 if d.f_lineno == lineno {
-                    d.f_lineno = old_lineno;
+                    // executioncontext.py:397-404 — for generator/coroutine
+                    // resumptions (`event == 'call'` while `last_instr >= 0`)
+                    // keep `d.f_lineno` at the yield line so the instruction
+                    // right after `YIELD_VALUE` (still on the same source
+                    // line) does not fire a spurious line event; skip the
+                    // restore in that case.
+                    if event != "call" || (*frame).last_instr < 0 {
+                        d.f_lineno = old_lineno;
+                    }
                 }
                 d.is_in_line_tracing = prev_line_tracing;
             }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -70,78 +70,6 @@ fn make_sys_namespace_instance() -> PyObjectRef {
     w_instance_new(sys_namespace_type())
 }
 
-/// TODO: pyre does not yet expose `PyFrame` as a
-/// Python-visible W_Root with a typedef carrying
-/// `f_back/f_locals/f_globals/f_code/f_lineno` GetSetProperty
-/// descriptors (`pypy/interpreter/pyframe.py:769-786`).  The proper
-/// port mirrors `W_PyFrame.typedef` and lets `frame.f_back` walk the
-/// real execution chain via `fget_f_back`.  Until that lands,
-/// `sys._getframe` returns a `sys.namespace` stub populated from the
-/// PyFrame fields by hand.
-///
-/// To avoid the pre-fix degradation where `f_back` was always `None`
-/// — breaking the canonical `while f: f = f.f_back` traversal — this
-/// helper walks the entire `f_back` chain eagerly and links each
-/// stub to the previous one via its own `f_back` slot, mirroring the
-/// PyPy frame chain shape one stub at a time.  The cost is one stub
-/// allocation per live frame on every `_getframe` call; an
-/// acceptable price for stack-walking parity until the proper
-/// PyFrame typedef port lands.
-fn build_frame_stub_chain(
-    top: *mut crate::pyframe::PyFrame,
-) -> Result<PyObjectRef, crate::PyError> {
-    let mut frames: Vec<*mut crate::pyframe::PyFrame> = Vec::new();
-    let mut cursor = top;
-    while !cursor.is_null() {
-        frames.push(cursor);
-        cursor = unsafe { (*cursor).get_f_back() };
-    }
-    let mut prev_stub: PyObjectRef = w_none();
-    let mut top_stub: PyObjectRef = w_none();
-    // Build from oldest to newest so each stub can attach the
-    // already-built older stub as its `f_back`.  The final
-    // (innermost) stub becomes the return value.
-    for &frame_ptr in frames.iter().rev() {
-        let stub = make_sys_namespace_instance();
-        let frame_ref = unsafe { &mut *frame_ptr };
-        // `pyframe.py:540-545 getdictscope`: PyPy materialises
-        // `f_locals` by running `fast2locals()` and exposing the
-        // resulting `debugdata.w_locals` dict.  `fast2locals` writes through
-        // the live locals mapping and can raise, so propagate the error rather
-        // than masking it as an empty `f_locals`.
-        let w_locals_obj = frame_ref.getdictscope()?;
-        // pyframe.py:128 get_w_globals_storage returns the globals dict object.  The
-        // canonical `w_globals` is seeded by every frame constructor and
-        // is the source of truth for the frame's globals.
-        let w_globals = frame_ref.get_w_globals();
-        let pycode = frame_ref.pycode as pyre_object::PyObjectRef;
-        let lineno = frame_ref.fget_f_lineno() as i64;
-        crate::baseobjspace::setdictvalue(
-            stub,
-            "f_globals",
-            if w_globals.is_null() {
-                pyre_object::w_none()
-            } else {
-                w_globals
-            },
-        );
-        crate::baseobjspace::setdictvalue(
-            stub,
-            "f_locals",
-            if w_locals_obj.is_null() {
-                w_dict_new()
-            } else {
-                w_locals_obj
-            },
-        );
-        crate::baseobjspace::setdictvalue(stub, "f_code", pycode);
-        crate::baseobjspace::setdictvalue(stub, "f_back", prev_stub);
-        crate::baseobjspace::setdictvalue(stub, "f_lineno", w_int_new(lineno));
-        prev_stub = stub;
-        top_stub = stub;
-    }
-    Ok(top_stub)
-}
 
 /// Build a `sys.namespace` frame stub for `traceback.tb_frame`
 /// (`typedef.rs init_pytraceback_type`).
@@ -416,17 +344,14 @@ pub fn register_module(ns: &mut DictStorage) {
                 remaining -= 1;
                 current = unsafe { (*current).get_f_back() };
             }
-            // `pyframe.py:773 f_back = GetSetProperty(W_PyFrame
-            // .fget_f_back)` returns the previous PyFrame in the
-            // execution chain.  Pyre exposes frames as `sys.namespace`
-            // stubs (see TODO on
-            // `make_sys_namespace_instance` — the proper port is to
-            // surface PyFrame as a typedef-described user-visible
-            // type).  Within the stub model, walk the `f_back` chain
-            // greedily so each stub's `f_back` points to the next
-            // stub instead of `None`, otherwise traversal patterns
-            // (`while f: f = f.f_back`) terminate at depth 1.
-            build_frame_stub_chain(current)
+            // `pyframe.py:767 f_back = GetSetProperty(PyFrame.fget_f_back)`.
+            // Return the live `PyFrame` itself as the user-visible `frame`
+            // object (`FRAME_TYPE` typedef); `f_back` chains lazily through
+            // the getset.  Mark it escaped so the JIT keeps the frame
+            // materialised for the exposed reference (pyframe.py:176
+            // `mark_as_escaped`).
+            unsafe { (*current).mark_as_escaped() };
+            Ok(current as pyre_object::PyObjectRef)
         }),
     );
     // sys.exc_info() → (type, value, traceback)

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -326,13 +326,19 @@ pub fn register_module(ns: &mut DictStorage) {
                     "frame index must not be negative",
                 ));
             }
-            // `vm.py:43-54 getframe`: starts from the top frame and
-            // walks `f_back` `depth` times.  The `f is None` guard runs
-            // at the *start* of every iteration including the first, so
-            // a missing top frame must raise rather than fabricate a
-            // stub.  Pyre's previous code returned an empty namespace
-            // when `current` was null, which masked stack-exhaustion.
-            let mut current = crate::eval::CURRENT_FRAME.with(|cf| cf.get());
+            // `vm.py:44-54 getframe`: start from
+            // `ec.gettopframe_nohidden()` and walk
+            // `ec.getnextframe_nohidden(f)` `depth` times, so
+            // `hidden_applevel` gateway / bridge frames are skipped
+            // (matching `f_back`).  The `f is None` guard runs at the
+            // *start* of every iteration including the first, so a
+            // missing top frame raises rather than fabricating a stub.
+            let ec = current_execution_context();
+            let mut current = if ec.is_null() {
+                std::ptr::null_mut()
+            } else {
+                unsafe { (*ec).gettopframe_nohidden() }
+            };
             let mut remaining = depth_signed as usize;
             loop {
                 if current.is_null() {
@@ -342,7 +348,8 @@ pub fn register_module(ns: &mut DictStorage) {
                     break;
                 }
                 remaining -= 1;
-                current = unsafe { (*current).get_f_back() };
+                current =
+                    crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
             }
             // `pyframe.py:767 f_back = GetSetProperty(PyFrame.fget_f_back)`.
             // Return the live `PyFrame` itself as the user-visible `frame`

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3476,8 +3476,8 @@ mod tests {
     // ── mark_stacks (f_lineno jump validation) ──
 
     use super::{
-        StackKind, mark_compatible_stack, mark_first_line_not_before, mark_lines, mark_stacks,
-        MARK_EMPTY_STACK, MARK_UNINITIALIZED,
+        MARK_EMPTY_STACK, MARK_UNINITIALIZED, StackKind, mark_compatible_stack,
+        mark_first_line_not_before, mark_lines, mark_stacks,
     };
 
     #[test]
@@ -3551,7 +3551,10 @@ mod tests {
         // loop iterator).
         let obj = super::mark_push_value(MARK_EMPTY_STACK, StackKind::Object);
         let iter = super::mark_push_value(MARK_EMPTY_STACK, StackKind::Iterator);
-        assert!(mark_compatible_stack(iter, obj), "Object target accepts any non-Null");
+        assert!(
+            mark_compatible_stack(iter, obj),
+            "Object target accepts any non-Null"
+        );
         assert!(
             !mark_compatible_stack(obj, iter),
             "Iterator target rejects Object source"

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -939,7 +939,7 @@ fn mark_compatible_stack(mut from_stack: i64, target_stack: i64) -> bool {
 /// (`frameobject.c explain_incompatible_stack`).
 fn mark_explain_incompatible_stack(target_stack: i64) -> &'static str {
     if target_stack == MARK_OVERFLOWED {
-        return "stack is too deep to analyze";
+        return "stack too deep to analyze";
     }
     if target_stack == MARK_UNINITIALIZED {
         return "can't jump into an exception handler, or code may be unreachable";
@@ -1074,11 +1074,17 @@ fn mark_stacks(code: &CodeObject, len: usize) -> Vec<i64> {
                     stacks[next_i] = next_stack;
                 }
                 Instruction::ForIter { delta } => {
+                    // Fall-through: iterator stays on the stack, the loop
+                    // variable (Object) is pushed above it.  Exhaustion
+                    // branch: the iterator stays on the stack (net 0) — it
+                    // is popped later by `POP_ITER`, matching the runtime
+                    // stack effect (liveness.rs ForIter `(d+1, d)`).  No
+                    // loop variable is pushed on that branch.
                     let target_stack = mark_push_value(next_stack, StackKind::Object);
                     stacks[next_i] = target_stack;
                     let j = next_i + delta.get(op_arg).as_usize();
                     if j <= len {
-                        stacks[j] = target_stack;
+                        stacks[j] = next_stack;
                     }
                 }
                 Instruction::EndAsyncFor => {
@@ -1086,7 +1092,15 @@ fn mark_stacks(code: &CodeObject, len: usize) -> Vec<i64> {
                     stacks[next_i] = next_stack;
                 }
                 Instruction::PushExcInfo => {
-                    next_stack = mark_push_value(next_stack, StackKind::Except);
+                    // Runtime (codewriter PushExcInfo): pop the new
+                    // exception, push the previous exception (Except slot),
+                    // then push the new exception back (Object).  Net +1,
+                    // but the shape is `[.., Except, Object]` — model both
+                    // slots so `f_lineno` jump validation matches the live
+                    // handler stack.
+                    let below = mark_pop_value(next_stack);
+                    next_stack = mark_push_value(below, StackKind::Except);
+                    next_stack = mark_push_value(next_stack, StackKind::Object);
                     stacks[next_i] = next_stack;
                 }
                 Instruction::PopExcept => {
@@ -2320,10 +2334,16 @@ impl PyFrame {
         w_builtin
     }
 
-    /// PyPy-compatible `fget_f_back`.
+    /// pyframe.py:764 `fget_f_back` — the next non-hidden frame, i.e.
+    /// `ExecutionContext.getnextframe_nohidden(self)`, skipping
+    /// `hidden_applevel` gateway / bridge frames.  The plain
+    /// `get_f_back()` accessor (used internally, including by the
+    /// nohidden walker itself) returns the raw `f_backref` link.
     #[inline]
     pub fn fget_f_back(&self) -> *mut PyFrame {
-        self.get_f_back()
+        crate::executioncontext::ExecutionContext::getnextframe_nohidden(
+            self as *const PyFrame as *mut PyFrame,
+        )
     }
 
     /// pyframe.py:641-642 fget_code → self.getcode().  Returns the `PyCode`
@@ -2545,14 +2565,11 @@ impl PyFrame {
                 "can't jump from the 'call' trace event of a new frame",
             ));
         }
-        // Can't jump from a `yield` statement (the frame is mid-yield).
-        if let Some((crate::bytecode::Instruction::YieldValue { .. }, _)) =
-            crate::pyopcode::decode_instruction_at(self.code(), self.last_instr as usize)
-        {
-            return Err(crate::PyError::value_error(
-                "can't jump from a yield statement",
-            ));
-        }
+        // A jump from a frame suspended at `YIELD_VALUE` is permitted
+        // (`frame_lineno_set_impl` lists `PY_MONITORING_EVENT_PY_YIELD`
+        // in the same allowed group as line/jump events); the pending
+        // yield value is accounted for by the `is_suspended` unwind
+        // below, so no early rejection here.
         // Only allow jumps when tracing a `line` event (`is_in_line_tracing`).
         if !self.getdebug().map_or(false, |d| d.is_in_line_tracing) {
             return Err(crate::PyError::value_error(
@@ -2615,7 +2632,7 @@ impl PyFrame {
                 }
             } else if err < 0 {
                 if start_stack == MARK_OVERFLOWED {
-                    msg = "stack is too deep to analyze".to_string();
+                    msg = "stack too deep to analyze".to_string();
                 } else if start_stack == MARK_UNINITIALIZED {
                     msg = "can't jump from unreachable code".to_string();
                 } else {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -784,6 +784,391 @@ pub fn offset2lineno(code: &CodeObject, stopat: isize) -> usize {
         .unwrap_or(lineno)
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// `f_lineno` jump validation — a port of CPython 3.14's `mark_stacks`
+// (`Objects/frameobject.c`).
+//
+// PyPy's `fset_f_lineno` (`pyframe.py`) validates a debugger line-jump
+// against the 3.11-era block model: it scans for `SETUP_LOOP` /
+// `SETUP_FINALLY` / `END_FINALLY` / `POP_BLOCK` and walks `co_lnotab`.
+// pyre runs 3.14-structural bytecode where those block-setup opcodes are
+// pseudo-ops the compiler lowers into `co_exceptiontable`; there is no
+// `co_lnotab`.  A line-by-line PyPy port is therefore impossible — the
+// opcodes it inspects don't exist here.  The behaviour-correct 3.14
+// equivalent is `mark_stacks`: a fixpoint reachability analysis that
+// abstracts each operand-stack slot to a `Kind`, so a jump is admitted
+// only when the source and target abstract stacks are compatible.
+// ─────────────────────────────────────────────────────────────────────
+
+/// `frameobject.c` `Kind` — the abstract contents of one operand-stack
+/// slot.  Packed 3 bits per slot into an `i64` (`BITS_PER_BLOCK = 3`),
+/// so the abstract stack of up to `MAX_STACK_ENTRIES = 21` slots is a
+/// single integer that can be compared for equality across paths.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+enum StackKind {
+    Iterator = 1,
+    Except = 2,
+    Object = 3,
+    Null = 4,
+    Lasti = 5,
+}
+
+const MARK_BITS_PER_BLOCK: i64 = 3;
+const MARK_MASK: i64 = (1 << MARK_BITS_PER_BLOCK) - 1;
+/// `1 << (63 - BITS_PER_BLOCK)` — a stack whose unsigned value is at or
+/// above this would lose its top slot when shifted left.  The negative
+/// sentinels (`OVERFLOWED` / `UNINITIALIZED`) reinterpret as huge
+/// unsigned values, so this test also propagates them.
+const MARK_WILL_OVERFLOW: u64 = 1u64 << (63 - MARK_BITS_PER_BLOCK);
+
+/// `frameobject.c` sentinels for a per-instruction abstract stack.
+const MARK_UNINITIALIZED: i64 = -2;
+const MARK_OVERFLOWED: i64 = -1;
+const MARK_EMPTY_STACK: i64 = 0;
+
+#[inline]
+fn mark_push_value(stack: i64, kind: StackKind) -> i64 {
+    mark_push_kind_bits(stack, kind as i64)
+}
+
+/// `push_value` with the kind supplied as raw bits — used by `COPY`,
+/// which re-pushes a slot peeked from the stack (whose kind is not
+/// statically one of the [`StackKind`] variants).
+#[inline]
+fn mark_push_kind_bits(stack: i64, kind_bits: i64) -> i64 {
+    if (stack as u64) >= MARK_WILL_OVERFLOW {
+        MARK_OVERFLOWED
+    } else {
+        (stack << MARK_BITS_PER_BLOCK) | kind_bits
+    }
+}
+
+#[inline]
+fn mark_pop_value(stack: i64) -> i64 {
+    // Arithmetic right shift preserves the OVERFLOWED / UNINITIALIZED
+    // sentinels (both negative).
+    stack >> MARK_BITS_PER_BLOCK
+}
+
+#[inline]
+fn mark_top_of_stack(stack: i64) -> i64 {
+    stack & MARK_MASK
+}
+
+#[inline]
+fn mark_peek(stack: i64, n: i64) -> i64 {
+    (stack >> (MARK_BITS_PER_BLOCK * (n - 1))) & MARK_MASK
+}
+
+#[inline]
+fn mark_stack_swap(stack: i64, n: i64) -> i64 {
+    let top = mark_top_of_stack(stack);
+    let nth = mark_peek(stack, n);
+    let shift = MARK_BITS_PER_BLOCK * (n - 1);
+    let stack = stack & !(MARK_MASK << shift) | (top << shift);
+    (stack & !MARK_MASK) | nth
+}
+
+/// `frameobject.c pop_to_level` — pop the abstract stack down to `level`
+/// slots.
+#[inline]
+fn mark_pop_to_level(mut stack: i64, level: i32) -> i64 {
+    let mut depth = 0i64;
+    let mut s = stack;
+    while s > MARK_EMPTY_STACK {
+        s = mark_pop_value(s);
+        depth += 1;
+    }
+    while depth > level as i64 {
+        stack = mark_pop_value(stack);
+        depth -= 1;
+    }
+    stack
+}
+
+/// True when a jump from `from` kind to `to` kind is admissible
+/// (`frameobject.c compatible_kind`).
+#[inline]
+fn mark_compatible_kind(from: i64, to: i64) -> bool {
+    if to == 0 {
+        return false;
+    }
+    if to == StackKind::Object as i64 {
+        return from != StackKind::Null as i64;
+    }
+    if to == StackKind::Null as i64 {
+        return true;
+    }
+    from == to
+}
+
+/// `frameobject.c compatible_stack` — pop `from_stack` to the target
+/// depth, then compare each slot's kind.
+fn mark_compatible_stack(mut from_stack: i64, target_stack: i64) -> bool {
+    if from_stack < 0 || target_stack < 0 {
+        return false;
+    }
+    let mut to = target_stack;
+    // Depth of each packed stack.
+    let depth = |mut s: i64| -> i64 {
+        let mut d = 0;
+        while s > MARK_EMPTY_STACK {
+            s = mark_pop_value(s);
+            d += 1;
+        }
+        d
+    };
+    while depth(from_stack) > depth(to) {
+        from_stack = mark_pop_value(from_stack);
+    }
+    while to > MARK_EMPTY_STACK {
+        if from_stack <= MARK_EMPTY_STACK {
+            return false;
+        }
+        if !mark_compatible_kind(mark_top_of_stack(from_stack), mark_top_of_stack(to)) {
+            return false;
+        }
+        from_stack = mark_pop_value(from_stack);
+        to = mark_pop_value(to);
+    }
+    from_stack == MARK_EMPTY_STACK
+}
+
+/// Diagnostic for an incompatible target stack
+/// (`frameobject.c explain_incompatible_stack`).
+fn mark_explain_incompatible_stack(target_stack: i64) -> &'static str {
+    if target_stack == MARK_OVERFLOWED {
+        return "stack is too deep to analyze";
+    }
+    if target_stack == MARK_UNINITIALIZED {
+        return "can't jump into an exception handler, or code may be unreachable";
+    }
+    let top = mark_top_of_stack(target_stack);
+    if top == StackKind::Except as i64 {
+        "can't jump into an 'except' block as there's no exception"
+    } else if top == StackKind::Lasti as i64 {
+        "can't jump into a re-raising block as there's no location"
+    } else if top == StackKind::Object as i64 || top == StackKind::Null as i64 {
+        "incompatible stacks"
+    } else if top == StackKind::Iterator as i64 {
+        "can't jump into the body of a for loop"
+    } else {
+        "incompatible stacks"
+    }
+}
+
+/// `frameobject.c marklines` — the source line that starts at each
+/// instruction-unit index (`-1` where no line change begins).
+fn mark_lines(code: &CodeObject, len: usize) -> Vec<i32> {
+    let mut lines = vec![-1i32; len];
+    let first = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
+    let mut last_line = -1i32;
+    for i in 0..len {
+        // `locations[i].0` is the start SourceLocation of unit `i`.
+        let line = code
+            .locations
+            .get(i)
+            .map(|(start, _)| start.line.get() as i32)
+            .unwrap_or(first);
+        if line != last_line && line != -1 {
+            lines[i] = line;
+            last_line = line;
+        }
+    }
+    lines
+}
+
+/// `frameobject.c first_line_not_before` — the smallest line `>= line`
+/// present in `lines`, or `-1`.
+fn mark_first_line_not_before(lines: &[i32], line: i32) -> i32 {
+    let mut result = i32::MAX;
+    for &l in lines {
+        if l < result && l >= line {
+            result = l;
+        }
+    }
+    if result == i32::MAX { -1 } else { result }
+}
+
+/// `frameobject.c mark_stacks` — fixpoint abstract-interpretation of the
+/// operand stack.  Returns `stacks[i]` = the packed abstract stack on
+/// entry to unit `i` (`UNINITIALIZED` where unreachable), length
+/// `len + 1`.
+fn mark_stacks(code: &CodeObject, len: usize) -> Vec<i64> {
+    use crate::bytecode::Instruction;
+
+    let mut stacks = vec![MARK_UNINITIALIZED; len + 1];
+    stacks[0] = MARK_EMPTY_STACK;
+
+    let mut todo = true;
+    while todo {
+        todo = false;
+        // ── Scan instructions ──
+        let mut i = 0usize;
+        while i < len {
+            let mut next_stack = stacks[i];
+            let Some((opcode, op_arg)) = crate::pyopcode::decode_instruction_at(code, i) else {
+                i += 1;
+                continue;
+            };
+            // `decode_instruction_at` already accumulates EXTENDED_ARG
+            // prefixes into `op_arg` at the real opcode's index.  Mirror
+            // CPython's inner `while opcode == EXTENDED_ARG` loop by
+            // propagating this unit's entry stack onto the following unit
+            // (the next prefix or the real opcode), so an instruction with
+            // an EXTENDED_ARG prefix inherits the prefix's entry stack.
+            if matches!(opcode, Instruction::ExtendedArg) {
+                if i + 1 < stacks.len() {
+                    stacks[i + 1] = next_stack;
+                }
+                i += 1;
+                continue;
+            }
+            let raw_arg: u32 = op_arg.into();
+            let caches = opcode.cache_entries();
+            let next_i = i + caches + 1;
+
+            if next_stack == MARK_UNINITIALIZED {
+                i = next_i;
+                continue;
+            }
+
+            // Relative jump targets are measured from `next_i` (past the
+            // opcode's cache slots), matching `absolutize_jump_target`.
+            match opcode {
+                Instruction::PopJumpIfFalse { delta }
+                | Instruction::PopJumpIfTrue { delta }
+                | Instruction::PopJumpIfNone { delta }
+                | Instruction::PopJumpIfNotNone { delta } => {
+                    let j = next_i + delta.get(op_arg).as_usize();
+                    next_stack = mark_pop_value(next_stack);
+                    if j <= len {
+                        stacks[j] = next_stack;
+                    }
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::Send { delta } => {
+                    let j = next_i + delta.get(op_arg).as_usize();
+                    if j <= len {
+                        stacks[j] = next_stack;
+                    }
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::JumpForward { delta } => {
+                    let j = next_i + delta.get(op_arg).as_usize();
+                    if j <= len {
+                        stacks[j] = next_stack;
+                    }
+                }
+                Instruction::JumpBackward { delta }
+                | Instruction::JumpBackwardNoInterrupt { delta } => {
+                    let j = next_i.saturating_sub(delta.get(op_arg).as_usize());
+                    if stacks[j] == MARK_UNINITIALIZED && j < i {
+                        todo = true;
+                    }
+                    stacks[j] = next_stack;
+                }
+                Instruction::GetIter | Instruction::GetAiter => {
+                    next_stack = mark_push_value(mark_pop_value(next_stack), StackKind::Iterator);
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::ForIter { delta } => {
+                    let target_stack = mark_push_value(next_stack, StackKind::Object);
+                    stacks[next_i] = target_stack;
+                    let j = next_i + delta.get(op_arg).as_usize();
+                    if j <= len {
+                        stacks[j] = target_stack;
+                    }
+                }
+                Instruction::EndAsyncFor => {
+                    next_stack = mark_pop_value(mark_pop_value(next_stack));
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::PushExcInfo => {
+                    next_stack = mark_push_value(next_stack, StackKind::Except);
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::PopExcept => {
+                    next_stack = mark_pop_value(next_stack);
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::ReturnValue => {
+                    // End of a path.
+                }
+                Instruction::RaiseVarargs { .. } | Instruction::Reraise { .. } => {
+                    // End of a path.
+                }
+                Instruction::PushNull => {
+                    next_stack = mark_push_value(next_stack, StackKind::Null);
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::LoadGlobal { .. } => {
+                    next_stack = mark_push_value(next_stack, StackKind::Object);
+                    if raw_arg & 1 != 0 {
+                        next_stack = mark_push_value(next_stack, StackKind::Null);
+                    }
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::LoadAttr { .. } => {
+                    if raw_arg & 1 != 0 {
+                        next_stack = mark_pop_value(next_stack);
+                        next_stack = mark_push_value(next_stack, StackKind::Object);
+                        next_stack = mark_push_value(next_stack, StackKind::Null);
+                    }
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::Swap { .. } => {
+                    next_stack = mark_stack_swap(next_stack, raw_arg as i64);
+                    stacks[next_i] = next_stack;
+                }
+                Instruction::Copy { .. } => {
+                    next_stack =
+                        mark_push_kind_bits(next_stack, mark_peek(next_stack, raw_arg as i64));
+                    stacks[next_i] = next_stack;
+                }
+                _ => {
+                    // `PyCompile_OpcodeStackEffect(opcode, oparg)` — the
+                    // net slot delta, with every pushed slot abstracted to
+                    // Object.
+                    let mut delta = opcode.stack_effect(raw_arg);
+                    while delta < 0 {
+                        next_stack = mark_pop_value(next_stack);
+                        delta += 1;
+                    }
+                    while delta > 0 {
+                        next_stack = mark_push_value(next_stack, StackKind::Object);
+                        delta -= 1;
+                    }
+                    stacks[next_i] = next_stack;
+                }
+            }
+            i = next_i;
+        }
+
+        // ── Scan the exception table ──
+        for entry in crate::pycode::decode_exceptiontable(&code.exceptiontable) {
+            let start_offset = (entry.start / 2) as usize;
+            let handler = (entry.target / 2) as usize;
+            let level = entry.depth as i32;
+            let lasti = entry.lasti;
+            if start_offset >= stacks.len() || handler >= stacks.len() {
+                continue;
+            }
+            if stacks[start_offset] != MARK_UNINITIALIZED && stacks[handler] == MARK_UNINITIALIZED {
+                todo = true;
+                let mut target_stack = mark_pop_to_level(stacks[start_offset], level);
+                if lasti {
+                    target_stack = mark_push_value(target_stack, StackKind::Lasti);
+                }
+                target_stack = mark_push_value(target_stack, StackKind::Except);
+                stacks[handler] = target_stack;
+            }
+        }
+    }
+    stacks
+}
+
 /// pyframe.py:105-106 — cell + free variable slot count.
 ///
 /// Returns the number of *extra* slots beyond `varnames` needed for
@@ -2127,10 +2512,145 @@ impl PyFrame {
         }
     }
 
-    /// pyframe.py:680 fset_f_lineno (simplified — full version validates jumps)
-    #[inline]
-    pub fn fset_f_lineno(&mut self, new_f_lineno: isize) {
-        self.getorcreate_debug_data(-1).f_lineno = new_f_lineno;
+    /// `frameobject.c frame_lineno_set` — set the line the frame will
+    /// resume at, validating the jump against [`mark_stacks`].
+    ///
+    /// Only a trace function may jump (`get_w_f_trace()` non-null); the
+    /// jump target must land on a real source line, must not enter an
+    /// exception handler / for-loop body / re-raise block, and the source
+    /// and target abstract operand stacks must be compatible.  On success
+    /// the operand stack is unwound to the target depth (closing dropped
+    /// values, restoring `exc_info` for popped `Except` slots) and
+    /// `last_instr` is repointed.
+    ///
+    /// Deviation: `frame_lineno_set` also binds `None` to any local the
+    /// compiler proved live-but-unbound at the target (the `PyStackRef_None`
+    /// pass over `co_localspluskinds`).  pyre keeps unbound locals as
+    /// `PY_NULL` guarded by `LOAD_FAST_CHECK`, so that pass is omitted; the
+    /// only observable difference is an `UnboundLocalError` where the
+    /// jumped-to code reads such a local before assigning it, versus
+    /// silently seeing `None`.
+    pub fn fset_f_lineno(&mut self, new_f_lineno: isize) -> Result<(), crate::PyError> {
+        // frame_lineno_set: you can only jump from within a trace
+        // function, not via `_getframe` / similar hackery.
+        if self.get_w_f_trace().is_null() {
+            return Err(crate::PyError::value_error(
+                "f_lineno can only be set by a trace function.",
+            ));
+        }
+        // A newly-entered frame (call event) has no dispatched
+        // instruction yet.
+        if self.last_instr == -1 {
+            return Err(crate::PyError::value_error(
+                "can't jump from the 'call' trace event of a new frame",
+            ));
+        }
+        // Can't jump from a `yield` statement (the frame is mid-yield).
+        if let Some((crate::bytecode::Instruction::YieldValue { .. }, _)) =
+            crate::pyopcode::decode_instruction_at(self.code(), self.last_instr as usize)
+        {
+            return Err(crate::PyError::value_error(
+                "can't jump from a yield statement",
+            ));
+        }
+        // Only allow jumps when tracing a `line` event (`is_in_line_tracing`).
+        if !self.getdebug().map_or(false, |d| d.is_in_line_tracing) {
+            return Err(crate::PyError::value_error(
+                "can only jump from a 'line' trace event",
+            ));
+        }
+        // `frame_is_suspended` — a generator/coroutine frame that has
+        // started, is not currently running, and is not exhausted has a
+        // pending `yield` value on the stack that the resume will pop, so
+        // the unwind must account for it.
+        let is_suspended = if self._is_generator_or_coroutine() {
+            let w_gen = self.get_generator();
+            !w_gen.is_null()
+                && unsafe {
+                    pyre_object::generator::w_generator_is_started(w_gen)
+                        && !pyre_object::generator::w_generator_is_running(w_gen)
+                        && !pyre_object::generator::w_generator_is_exhausted(w_gen)
+                }
+        } else {
+            false
+        };
+
+        let code = self.code();
+        let len = code.instructions.len();
+        let first_line = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
+
+        let mut new_lineno = new_f_lineno as i32;
+        if new_lineno < first_line {
+            return Err(crate::PyError::value_error(format!(
+                "line {new_lineno} comes before the current code block"
+            )));
+        }
+
+        let lines = mark_lines(code, len);
+        new_lineno = mark_first_line_not_before(&lines, new_lineno);
+        if new_lineno < 0 {
+            return Err(crate::PyError::value_error(format!(
+                "line {new_f_lineno} comes after the current code block"
+            )));
+        }
+
+        let stacks = mark_stacks(code, len);
+        let last_instr = self.last_instr as usize;
+        let start_stack = *stacks.get(last_instr).unwrap_or(&MARK_UNINITIALIZED);
+
+        let mut best_stack = MARK_OVERFLOWED;
+        let mut best_addr: isize = -1;
+        let mut err: i32 = -1;
+        let mut msg: String = "cannot find bytecode for specified line".to_string();
+        for i in 0..len {
+            if lines[i] != new_lineno {
+                continue;
+            }
+            let target_stack = stacks[i];
+            if mark_compatible_stack(start_stack, target_stack) {
+                err = 0;
+                if target_stack > best_stack {
+                    best_stack = target_stack;
+                    best_addr = i as isize;
+                }
+            } else if err < 0 {
+                if start_stack == MARK_OVERFLOWED {
+                    msg = "stack is too deep to analyze".to_string();
+                } else if start_stack == MARK_UNINITIALIZED {
+                    msg = "can't jump from unreachable code".to_string();
+                } else {
+                    msg = mark_explain_incompatible_stack(target_stack).to_string();
+                    err = 1;
+                }
+            }
+        }
+        if err != 0 {
+            return Err(crate::PyError::value_error(msg));
+        }
+
+        // Unwind the operand stack from `start_stack` down to
+        // `best_stack`, closing dropped values.  A dropped `Except` slot
+        // restores the previous `exc_info` (pyre keeps the active
+        // exception in the TLS current-exception slot, saved beneath the
+        // handler on the value stack — see `push_exc_info`).
+        let mut cur_stack = start_stack;
+        if is_suspended {
+            // Account for the value popped by yield.
+            cur_stack = mark_pop_value(cur_stack);
+        }
+        while cur_stack > best_stack {
+            let popped = self.popvalue();
+            if mark_top_of_stack(cur_stack) == StackKind::Except as i64 {
+                // The popped value is the saved previous exception; make
+                // it current again.
+                crate::eval::set_current_exception(popped);
+            }
+            cur_stack = mark_pop_value(cur_stack);
+        }
+
+        self.getorcreate_debug_data(-1).f_lineno = new_lineno as isize;
+        self.last_instr = best_addr;
+        Ok(())
     }
 
     /// PyPy-compatible `setfastscope`.
@@ -2951,5 +3471,90 @@ mod tests {
 
         let loaded = load_const_from_code(&code, ellipsis_index);
         assert_eq!(loaded, pyre_object::special::w_ellipsis());
+    }
+
+    // ── mark_stacks (f_lineno jump validation) ──
+
+    use super::{
+        StackKind, mark_compatible_stack, mark_first_line_not_before, mark_lines, mark_stacks,
+        MARK_EMPTY_STACK, MARK_UNINITIALIZED,
+    };
+
+    #[test]
+    fn mark_stacks_entry_is_empty_and_reachable() {
+        let code = crate::compile_exec("x = 1\ny = x + 1\n").expect("compile");
+        let len = code.instructions.len();
+        let stacks = mark_stacks(&code, len);
+        // Entry to the first instruction is the empty stack.
+        assert_eq!(stacks[0], MARK_EMPTY_STACK);
+        // Every real (decodable, non-cache) instruction is reachable in
+        // straight-line code — none stay UNINITIALIZED.
+        for pc in 0..len {
+            if let Some((instr, _)) = crate::pyopcode::decode_instruction_at(&code, pc) {
+                if matches!(instr, crate::bytecode::Instruction::Cache) {
+                    continue;
+                }
+                assert_ne!(
+                    stacks[pc], MARK_UNINITIALIZED,
+                    "pc {pc} ({instr:?}) should be reachable"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mark_stacks_for_iter_target_carries_iterator() {
+        // The FOR_ITER body sees the iterator underneath the loop var, so
+        // the abstract stack at the body has an Iterator slot at bottom.
+        let code = crate::compile_exec("t = 0\nfor i in range(3):\n    t += i\n").expect("compile");
+        let len = code.instructions.len();
+        let stacks = mark_stacks(&code, len);
+        // Find a GET_ITER; the slot it produces is Iterator and stays on
+        // the stack through the loop body.
+        let mut saw_iterator_slot = false;
+        for pc in 0..len {
+            if stacks[pc] > MARK_EMPTY_STACK
+                && (stacks[pc] & 0b111 == StackKind::Iterator as i64
+                    || (stacks[pc] >> 3) & 0b111 == StackKind::Iterator as i64)
+            {
+                saw_iterator_slot = true;
+                break;
+            }
+        }
+        assert!(
+            saw_iterator_slot,
+            "a for-loop's abstract stacks should contain an Iterator slot"
+        );
+    }
+
+    #[test]
+    fn mark_lines_and_first_line_not_before() {
+        let code = crate::compile_exec("a = 1\nb = 2\nc = 3\n").expect("compile");
+        let len = code.instructions.len();
+        let lines = mark_lines(&code, len);
+        let first = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
+        // The earliest recorded line is the first source line.
+        let min_line = lines.iter().copied().filter(|&l| l >= 0).min().unwrap();
+        assert_eq!(min_line, first);
+        // A request before the code resolves to the first line.
+        assert_eq!(mark_first_line_not_before(&lines, first), first);
+        // A request past the end resolves to -1.
+        assert_eq!(mark_first_line_not_before(&lines, first + 1000), -1);
+    }
+
+    #[test]
+    fn compatible_stack_same_and_incompatible() {
+        // Identical stacks are compatible.
+        assert!(mark_compatible_stack(MARK_EMPTY_STACK, MARK_EMPTY_STACK));
+        // An Object target accepts an Iterator source popped to depth, but
+        // an Iterator target rejects an Object source (can't fabricate a
+        // loop iterator).
+        let obj = super::mark_push_value(MARK_EMPTY_STACK, StackKind::Object);
+        let iter = super::mark_push_value(MARK_EMPTY_STACK, StackKind::Iterator);
+        assert!(mark_compatible_stack(iter, obj), "Object target accepts any non-Null");
+        assert!(
+            !mark_compatible_stack(obj, iter),
+            "Iterator target rejects Object source"
+        );
     }
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2581,16 +2581,25 @@ impl PyFrame {
                 "can't jump from the 'call' trace event of a new frame",
             ));
         }
-        // A jump from a frame suspended at `YIELD_VALUE` is permitted
+        // Jumps are allowed from a `line` trace event, and — outside a
+        // line event — only when the frame is suspended at `YIELD_VALUE`
         // (`frame_lineno_set_impl` lists `PY_MONITORING_EVENT_PY_YIELD`
-        // in the same allowed group as line/jump events); the pending
+        // in the same allowed group as line/jump events).  The pending
         // yield value is accounted for by the `is_suspended` unwind
-        // below, so no early rejection here.
-        // Only allow jumps when tracing a `line` event (`is_in_line_tracing`).
+        // below.  pyframe.py:685-689:
+        //     if not d.is_in_line_tracing:
+        //         if ord(code[self.last_instr]) != YIELD_VALUE:
+        //             raise "can only jump from a 'line' trace event"
         if !self.getdebug().map_or(false, |d| d.is_in_line_tracing) {
-            return Err(crate::PyError::value_error(
-                "can only jump from a 'line' trace event",
-            ));
+            let at_yield = matches!(
+                crate::pyopcode::decode_instruction_at(self.code(), self.last_instr as usize),
+                Some((crate::bytecode::Instruction::YieldValue { .. }, _))
+            );
+            if !at_yield {
+                return Err(crate::PyError::value_error(
+                    "can only jump from a 'line' trace event",
+                ));
+            }
         }
         // `frame_is_suspended` — a generator/coroutine frame that has
         // started, is not currently running, and is not exhausted has a

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -19,6 +19,26 @@ const _: () = assert!(
         == std::mem::size_of::<Rc<PyExecutionContext>>()
 );
 
+/// `types.FrameType` — the PyType every `PyFrame`'s `ob_header` points at.
+/// pyframe.py `class PyFrame(W_Root)` with `typedef.py:736 PyFrame.typedef
+/// = TypeDef("frame", ...)`. The descriptors (`f_back`, `f_locals`, …) are
+/// attached to this type by the `frame` typedef; until then it is a bare
+/// identity tag so a frame carries a valid `ob_type` like every other
+/// W_Root (mirrors `pytraceback::PYTRACEBACK_TYPE`).
+pub static FRAME_TYPE: PyType = new_pytype("frame");
+
+/// Build the `ob_header` for a freshly-created `PyFrame` — `ob_type`
+/// pinned to [`FRAME_TYPE`], `w_class` the cached `W_TypeObject`
+/// (null during bootstrap before `init_typeobjects`). Mirrors
+/// `pytraceback::pytraceback_new`'s header construction.
+#[inline]
+fn frame_ob_header() -> PyObject {
+    PyObject {
+        ob_type: &FRAME_TYPE as *const PyType,
+        w_class: get_instantiate(&FRAME_TYPE),
+    }
+}
+
 /// Execution frame for a single Python code block.
 ///
 /// Unified `locals_cells_stack_w` array layout:
@@ -38,6 +58,12 @@ const _: () = assert!(
 /// in registers. A "force" flushes them back to the heap.
 #[repr(C)]
 pub struct PyFrame {
+    /// `PyObject` prefix (`ob_type` / `w_class`) making the frame a
+    /// Python-visible `W_Root` — `pyframe.py class PyFrame(W_Root)`.
+    /// `ob_type` points at [`FRAME_TYPE`]. Kept at offset 0 like every
+    /// other `PyObject`-layout struct so `ob_type` reads land on the
+    /// typeptr the JIT `GuardClass` / `type()` expect.
+    pub ob_header: PyObject,
     /// Raw pointer to the shared execution context.
     /// The top-level frame leaks the Rc via `Rc::into_raw`.
     /// Callee frames just copy the pointer (no atomic refcount ops).
@@ -1134,6 +1160,7 @@ impl PyFrame {
             crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
         }
         let mut frame = PyFrame {
+            ob_header: frame_ob_header(),
             execution_context,
             pycode: code,
             locals_cells_stack_w: unsafe {
@@ -1253,6 +1280,7 @@ impl PyFrame {
             crate::w_code_frame_stores_global(code as PyObjectRef, w_globals);
         }
         let mut frame = PyFrame {
+            ob_header: frame_ob_header(),
             execution_context,
             pycode: code,
             locals_cells_stack_w: unsafe {
@@ -1297,6 +1325,7 @@ impl PyFrame {
         // so inline-frame STORE_GLOBAL is recorded as deferred IR (no concrete
         // write during the walk) and the compiled loop applies it exactly once.
         let mut frame = FrameBox::new(PyFrame {
+            ob_header: frame_ob_header(),
             execution_context: self.execution_context,
             pycode: self.pycode,
             locals_cells_stack_w: unsafe { alloc_fixed_array_from_vec(self.locals_w().to_vec()) },
@@ -2317,6 +2346,7 @@ impl PyFrame {
         }
 
         let mut frame = PyFrame {
+            ob_header: frame_ob_header(),
             execution_context,
             pycode: code,
             locals_cells_stack_w,
@@ -2631,6 +2661,7 @@ pub fn createframe_obj(
     let size = num_locals + num_cells + max_stack;
     let w_builtin = crate::baseobjspace::frame_builtin_obj(w_globals, execution_context);
     let mut frame = FrameBox::new(PyFrame {
+        ob_header: frame_ob_header(),
         execution_context,
         pycode: code,
         locals_cells_stack_w: unsafe { alloc_fixed_array_with_header(size, PY_NULL) },

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1941,6 +1941,78 @@ impl PyFrame {
         self.get_f_back()
     }
 
+    /// pyframe.py:641-642 fget_code → self.getcode().  Returns the `PyCode`
+    /// wrapper object (`self.pycode`) itself, which is what `frame.f_code`
+    /// yields to Python — not the inner `CodeObject`.
+    #[inline]
+    pub fn fget_f_code(&self) -> PyObjectRef {
+        self.pycode as PyObjectRef
+    }
+
+    /// pyframe.py:849-853 descr_repr — `<frame at 0x…, file '…', line …,
+    /// code …>` via `getrepr(space, "frame", moreinfo)`.
+    pub fn descr_repr(&self) -> String {
+        let code = self.code();
+        format!(
+            "<frame at {:p}, file '{}', line {}, code {}>",
+            self as *const PyFrame,
+            code.source_path.as_str(),
+            self.get_last_lineno(),
+            code.obj_name.as_str(),
+        )
+    }
+
+    /// pyframe.py:805-846 descr_clear — `F.clear()`: clear most references
+    /// held by the frame.  Refuses on an executing (non-generator) frame or
+    /// a running generator; otherwise clears `w_f_trace`, resets `w_locals`
+    /// to a fresh dict, and replaces every local / cell / free var / stack
+    /// slot (cells are rebound to fresh empty cells so a shared inner/outer
+    /// cell is not mutated).
+    pub fn descr_clear(&mut self) -> Result<(), crate::PyError> {
+        if !self.frame_finished_execution {
+            if !self._is_generator_or_coroutine() {
+                return Err(crate::PyError::runtime_error(
+                    "cannot clear an executing frame",
+                ));
+            }
+            let w_gen = self.get_generator();
+            if !w_gen.is_null() {
+                if unsafe { pyre_object::generator::w_generator_is_running(w_gen) } {
+                    return Err(crate::PyError::runtime_error(
+                        "cannot clear an executing frame",
+                    ));
+                }
+                unsafe { pyre_object::generator::w_generator_set_exhausted(w_gen) };
+            }
+        }
+
+        if let Some(debug) = self.getdebug() {
+            let had_locals = !debug.w_locals.is_null();
+            let d = self.getorcreate_debug_data(-1);
+            d.w_f_trace = pyre_object::PY_NULL;
+            if had_locals {
+                d.w_locals = unsafe { pyre_object::w_dict_new() };
+            }
+        }
+
+        // Clear locals, cell/free vars, and the stack.  A cell slot is
+        // rebound to a fresh empty cell (not mutated in place, since it may
+        // still be shared by an inner/outer function).
+        let len = self.locals_w().len();
+        for i in 0..len {
+            let w_oldvalue = self.locals_w()[i];
+            let w_newvalue = if !w_oldvalue.is_null() && unsafe { pyre_object::is_cell(w_oldvalue) }
+            {
+                pyre_object::w_cell_new(pyre_object::PY_NULL)
+            } else {
+                pyre_object::PY_NULL
+            };
+            self.locals_w_mut()[i] = w_newvalue;
+        }
+        self.valuestackdepth = 0;
+        Ok(())
+    }
+
     /// pyframe.py:773 fget_f_lasti → space.newint(self.last_instr)
     #[inline]
     pub fn fget_f_lasti(&self) -> isize {

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -2367,12 +2367,15 @@ impl PyFrame {
         )
     }
 
-    /// pyframe.py:805-846 descr_clear — `F.clear()`: clear most references
-    /// held by the frame.  Refuses on an executing (non-generator) frame or
-    /// a running generator; otherwise clears `w_f_trace`, resets `w_locals`
-    /// to a fresh dict, and replaces every local / cell / free var / stack
-    /// slot (cells are rebound to fresh empty cells so a shared inner/outer
-    /// cell is not mutated).
+    /// `frame_clear` (`frame.clear()`): clear most references held by the
+    /// frame.  Refuses on an executing (non-generator) frame or a running
+    /// generator (`"cannot clear an executing frame"`) and on a generator
+    /// frame suspended at a `yield` (`"cannot clear a suspended frame"`);
+    /// a not-yet-started or already-exhausted generator is finalized
+    /// (marked exhausted).  Otherwise clears `w_f_trace`, resets
+    /// `w_locals` to a fresh dict, and replaces every local / cell / free
+    /// var / stack slot (cells are rebound to fresh empty cells so a
+    /// shared inner/outer cell is not mutated).
     pub fn descr_clear(&mut self) -> Result<(), crate::PyError> {
         if !self.frame_finished_execution {
             if !self._is_generator_or_coroutine() {
@@ -2387,6 +2390,19 @@ impl PyFrame {
                         "cannot clear an executing frame",
                     ));
                 }
+                // A generator started but not exhausted is suspended at a
+                // `yield`; clearing it would drop the live operand stack
+                // out from under a later `resume`, so refuse.
+                let suspended = unsafe {
+                    pyre_object::generator::w_generator_is_started(w_gen)
+                        && !pyre_object::generator::w_generator_is_exhausted(w_gen)
+                };
+                if suspended {
+                    return Err(crate::PyError::runtime_error(
+                        "cannot clear a suspended frame",
+                    ));
+                }
+                // Not started or already exhausted: finalize.
                 unsafe { pyre_object::generator::w_generator_set_exhausted(w_gen) };
             }
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -286,8 +286,55 @@ pub struct FrameBox {
 }
 
 impl FrameBox {
-    /// Move `frame` onto the heap behind a zeroed GC header.
+    /// Move `frame` onto the heap behind a GC header.
+    ///
+    /// `pyframe.py class PyFrame(W_Root)` — an executing frame is a normal
+    /// GC object whose lifetime is its reachability.  When the GC hook is
+    /// installed this allocates a non-moving old-gen `PYFRAME_GC_TYPE_ID`
+    /// block (the same `try_gc_alloc_stable` path every `W_*` uses, e.g.
+    /// `function.rs:373`); the block is reclaimed by a major mark-sweep
+    /// once no root (`walk_pyframe_roots` over the `CURRENT_FRAME` /
+    /// `f_backref` chain) reaches it, so `Drop` performs no manual free
+    /// (`executioncontext.py:91-107 leave` frees nothing either).
+    ///
+    /// Before the hook is wired (bootstrap, tests) `try_gc_alloc_stable`
+    /// returns `None`; fall back to the `std::alloc` `GcFramePrefix` box,
+    /// which `Drop` frees manually.  The two regimes share one memory
+    /// layout — an 8-byte GC header immediately before the frame body — so
+    /// every reader (`frame - GC_HEADER_SIZE` write-barrier header,
+    /// `pyframe_object_custom_trace`) is regime-independent; `Drop`
+    /// distinguishes them with `try_gc_owns_object`.
     pub fn new(frame: PyFrame) -> Self {
+        if let Some(raw) = pyre_object::gc_hook::try_gc_alloc_stable(
+            PYFRAME_GC_TYPE_ID,
+            std::mem::size_of::<PyFrame>(),
+        )
+        .filter(|p| !p.is_null())
+        {
+            pyre_object::gc_interp::note_alloc();
+            let ptr = raw as *mut PyFrame;
+            unsafe {
+                std::ptr::write(ptr, frame);
+            }
+            // The old-gen frame may hold pointers to freshly nursery-born
+            // argument / locals objects; remember it for the next minor
+            // tracer, exactly as `generator.rs:72` does for a stable
+            // generator wrapping young frame contents.
+            pyre_object::gc_hook::try_gc_write_barrier(raw);
+            return FrameBox { ptr };
+        }
+        FrameBox::new_boxed(frame)
+    }
+
+    /// Allocate a frame that is NOT GC-managed even when the GC hook is
+    /// installed — a plain `std::alloc` `GcFramePrefix` box reclaimed by
+    /// `Drop`.  Used for tracer snapshots (`snapshot_for_tracing`), which
+    /// a tracer holds off the `CURRENT_FRAME` chain across an entire
+    /// `trace_bytecode` walk: a major cycle can complete mid-walk, and no
+    /// root reaches the snapshot, so GC lifetime would reclaim it while the
+    /// tracer still reads it.  A deterministic scope-end free is correct
+    /// for these transient, tracer-private copies.
+    pub fn new_boxed(frame: PyFrame) -> Self {
         let raw = Box::into_raw(Box::new(GcFramePrefix {
             gc_header: 0,
             frame,
@@ -327,13 +374,21 @@ impl FrameBox {
     /// needs for the borrowed-`&mut self` case.
     pub fn into_generator(mut self) -> crate::PyResult {
         self.fix_array_ptrs();
+        // A suspended generator frame is off the call chain — `f_back` is
+        // None until a resume re-links it (`executioncontext.py enter`
+        // rebinds `f_backref = topframeref`; pyre does the same at
+        // `execute_frame`).  Null it now so the generator's custom trace,
+        // which greys the frame block and recurses `f_backref`, never greys
+        // the (possibly already-freed) caller frame captured at suspend.
+        self.f_backref = std::ptr::null_mut();
         let frame_ptr = self.into_raw();
         // `w_generator_new` allocates and may trigger a collection. Until the
-        // generator owns `frame_ptr`, the frame's locals/args live only in its
-        // `locals_cells_stack_w` — the caller has already dropped them from its
-        // own stack — so root that slot across the allocation. The frame struct
-        // itself is a plain heap allocation (not a nursery object), so only the
-        // locals array needs protecting.
+        // generator owns `frame_ptr` (and its custom trace greys the frame
+        // block), the frame's locals/args live only in its
+        // `locals_cells_stack_w` — the caller has already dropped them from
+        // its own stack — so root that slot across the allocation. The frame
+        // block is non-moving (old-gen when GC-managed, `std::alloc`
+        // otherwise), so only the locals array needs protecting.
         let _root = LocalsRoot::new(frame_ptr);
         let generator = pyre_object::generator::w_generator_new(frame_ptr as *mut u8);
         unsafe {
@@ -360,6 +415,17 @@ impl std::ops::DerefMut for FrameBox {
 
 impl Drop for FrameBox {
     fn drop(&mut self) {
+        // GC-managed (old-gen) frames are reclaimed by a major mark-sweep
+        // when no root reaches them (`pyframe.py class PyFrame(W_Root)`;
+        // `executioncontext.py:91-107 leave` frees nothing).  Their
+        // `PyFrame::drop` side effects (freeing the locals array / debug
+        // data / block chain) run from the registered `PYFRAME_GC_TYPE_ID`
+        // destructor at sweep, not here.  Only the `std::alloc` fallback
+        // box is freed manually — reconstruct and drop it, which runs
+        // `PyFrame::drop` for that block.
+        if pyre_object::gc_hook::try_gc_owns_object(self.ptr as *mut u8) {
+            return;
+        }
         unsafe {
             let prefix = (self.ptr as *mut u8).sub(GC_HEADER_SIZE) as *mut GcFramePrefix;
             drop(Box::from_raw(prefix));
@@ -440,7 +506,33 @@ unsafe fn clear_block_chain(ptr: &mut *mut FrameBlock) {
 
 impl Drop for PyFrame {
     fn drop(&mut self) {
-        if !self.locals_cells_stack_w.is_null() {
+        // Reached only for a `std::alloc`-backed frame (the `FrameBox`
+        // fallback box, or a bare stack `PyFrame`): its `locals_cells_stack_w`
+        // is always a `std::alloc` array, so free it here.  GC-managed frames
+        // never run `PyFrame::drop` (their `FrameBox::drop` returns early);
+        // their contents are freed by the `PYFRAME_GC_TYPE_ID` destructor.
+        unsafe { self.free_owned_contents(true) };
+    }
+}
+
+impl PyFrame {
+    /// Free the frame's owned off-GC resources — the `locals_cells_stack_w`
+    /// array, the `FrameDebugData` box, and the `FrameBlock` chain.  Shared
+    /// by `Drop for PyFrame` (the `std::alloc` fallback path) and the
+    /// `PYFRAME_GC_TYPE_ID` destructor (`pyframe_object_destructor`) run when
+    /// a GC-managed frame is swept.
+    ///
+    /// `free_locals_array` gates freeing `locals_cells_stack_w`: it is a
+    /// `std::alloc` block for every `FrameBox`/stack frame (free it), but a
+    /// GC-managed `PY_OBJECT_ARRAY_GC_TYPE_ID` array for a JIT-built inline
+    /// frame (the GC sweeps it — freeing it here would double-free).  The
+    /// caller decides by querying `try_gc_owns_object` on the array.
+    ///
+    /// # Safety
+    /// Runs at most once per frame — the pointers are nulled as they are
+    /// freed so a second call is a no-op.
+    pub unsafe fn free_owned_contents(&mut self, free_locals_array: bool) {
+        if free_locals_array && !self.locals_cells_stack_w.is_null() {
             unsafe { dealloc_array_with_gc_header(self.locals_cells_stack_w) };
             self.locals_cells_stack_w = std::ptr::null_mut();
         }
@@ -449,9 +541,7 @@ impl Drop for PyFrame {
             clear_block_chain(&mut self.lastblock);
         }
     }
-}
 
-impl PyFrame {
     /// Access locals_cells_stack_w (deref the pointer).
     #[inline]
     pub fn locals_w(&self) -> &FixedObjectArray {
@@ -1316,15 +1406,27 @@ impl PyFrame {
     /// recording a trace to keep the real frame state unchanged until the
     /// interpreter actually executes the same path.
     pub fn snapshot_for_tracing(&self) -> FrameBox {
-        // Frame-LOCAL state (locals_cells_stack_w / valuestackdepth / last_instr)
-        // is COPIED, so snapshot mutations to locals/stack are discarded — that
-        // is the abort-safety the snapshot exists for.  `w_globals` (below) is
-        // the SAME dict ptr, so a concrete shared-heap write during recording
-        // would leak to the real heap and double-apply on the compiled loop's
-        // re-run.  Gap 10 removed that path: the concrete executor is retired,
-        // so inline-frame STORE_GLOBAL is recorded as deferred IR (no concrete
-        // write during the walk) and the compiled loop applies it exactly once.
-        let mut frame = FrameBox::new(PyFrame {
+        // A tracer holds this snapshot off the `CURRENT_FRAME` chain across
+        // the whole `trace_bytecode` walk, during which a major GC cycle can
+        // complete; no root reaches it, so it must NOT have GC lifetime —
+        // `new_boxed` gives it a deterministic scope-end free.
+        let mut frame = FrameBox::new_boxed(self.build_snapshot_frame());
+        // fix_array_ptrs AFTER Box allocation: inline_buf ptr must
+        // point to the heap-allocated frame, not a stale stack address.
+        frame.fix_array_ptrs();
+        frame
+    }
+
+    /// Build the copied `PyFrame` value shared by the tracer snapshot and
+    /// the generator snapshot.  Frame-LOCAL state (`locals_cells_stack_w` /
+    /// `valuestackdepth` / `last_instr`) is COPIED, so snapshot mutations to
+    /// locals/stack are discarded — the abort-safety the snapshot exists
+    /// for.  `w_globals` is the SAME dict ptr, so a concrete shared-heap
+    /// write during recording would leak to the real heap and double-apply
+    /// on the compiled loop's re-run; Gap 10 removed that path (inline-frame
+    /// STORE_GLOBAL records as deferred IR, applied exactly once).
+    fn build_snapshot_frame(&self) -> PyFrame {
+        PyFrame {
             ob_header: frame_ob_header(),
             execution_context: self.execution_context,
             pycode: self.pycode,
@@ -1341,9 +1443,16 @@ impl PyFrame {
             f_backref: self.f_backref,
             w_builtin: self.w_builtin,
             w_globals: self.w_globals,
-        });
-        // fix_array_ptrs AFTER Box allocation: inline_buf ptr must
-        // point to the heap-allocated frame, not a stale stack address.
+        }
+    }
+
+    /// Snapshot a borrowed frame into a GC-managed owned frame for
+    /// `initialize_as_generator`.  Unlike `snapshot_for_tracing` this uses
+    /// `FrameBox::new` (GC lifetime): a generator's suspended frame lives as
+    /// long as the generator object reaches it (`generator.py` holds the
+    /// frame), and the generator's custom trace greys the frame block.
+    pub fn snapshot_for_generator(&self) -> FrameBox {
+        let mut frame = FrameBox::new(self.build_snapshot_frame());
         frame.fix_array_ptrs();
         frame
     }
@@ -2391,8 +2500,10 @@ impl PyFrame {
         // pyframe.py:259 wraps `self` directly. A borrowed `&mut self` cannot
         // hand ownership to the generator, so snapshot into an owned FrameBox
         // first. Callers that already own a FrameBox should use
-        // `FrameBox::into_generator` to skip this copy.
-        self.snapshot_for_tracing().into_generator()
+        // `FrameBox::into_generator` to skip this copy.  Use the GC-managed
+        // snapshot: the generator owns the frame for its whole life, off the
+        // `CURRENT_FRAME` chain, so its lifetime is GC reachability.
+        self.snapshot_for_generator().into_generator()
     }
 
     #[inline]

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -75,9 +75,11 @@ pub const PYTRACEBACK_W_NEXT_OFFSET: usize = std::mem::offset_of!(PyTraceback, w
 pub const PYTRACEBACK_LINENO_OFFSET: usize = std::mem::offset_of!(PyTraceback, lineno);
 pub const PYTRACEBACK_W_CODE_OFFSET: usize = std::mem::offset_of!(PyTraceback, w_code);
 
-/// GC type id assigned to `PyTraceback`.  Next free slot after
-/// `W_DICT_VIEW_ITERATOR_GC_TYPE_ID = 42` in pyre-object.
-pub const PYTRACEBACK_GC_TYPE_ID: u32 = 43;
+/// GC type id assigned to `PyTraceback`.  Pre-registered in
+/// `pyre-jit/src/eval.rs` immediately after `PyCode`
+/// (`W_CODE_GC_TYPE_ID = 43`), so it takes the next slot (44); the
+/// registration site pins this with a `debug_assert_eq!`.
+pub const PYTRACEBACK_GC_TYPE_ID: u32 = 44;
 
 pub const PYTRACEBACK_OBJECT_SIZE: usize = std::mem::size_of::<PyTraceback>();
 
@@ -109,7 +111,7 @@ pub fn w_pytraceback_new(
     pyre_object::gc_roots::pin_root(w_next);
     pyre_object::gc_roots::pin_root(w_code);
 
-    pyre_object::lltype::malloc_typed(PyTraceback {
+    let value = PyTraceback {
         ob_header: PyObject {
             ob_type: &PYTRACEBACK_TYPE as *const PyType,
             w_class: get_instantiate(&PYTRACEBACK_TYPE),
@@ -119,7 +121,34 @@ pub fn w_pytraceback_new(
         w_next,
         lineno,
         w_code,
-    }) as PyObjectRef
+    };
+
+    // Executing frames are GC-managed non-moving oldgen blocks
+    // (`PYFRAME_GC_TYPE_ID`); to keep `tb_frame` alive across the
+    // traceback's lifetime the traceback itself must be a GC object
+    // whose `pytraceback_object_custom_trace` forwards the `frame`
+    // edge.  Allocate into oldgen (non-moving — raw `*mut PyTraceback`
+    // readers and the exception `w_traceback` chain hold bare
+    // pointers), mirroring `FrameBox::new` (`pyframe.rs:307`).  Before
+    // the GC hook is wired (bootstrap, tests) `try_gc_alloc_stable`
+    // returns `None`; fall back to the leaked `malloc_typed` block.
+    if let Some(raw) =
+        pyre_object::gc_hook::try_gc_alloc_stable(PYTRACEBACK_GC_TYPE_ID, PYTRACEBACK_OBJECT_SIZE)
+            .filter(|p| !p.is_null())
+    {
+        pyre_object::gc_interp::note_alloc();
+        let ptr = raw as *mut PyTraceback;
+        unsafe {
+            std::ptr::write(ptr, value);
+        }
+        // The oldgen traceback references the freshly-born `w_next` /
+        // `w_code` (and, once GC-owned, the frame); remember it for the
+        // next minor tracer.
+        pyre_object::gc_hook::try_gc_write_barrier(raw);
+        return ptr as PyObjectRef;
+    }
+
+    pyre_object::lltype::malloc_typed(value) as PyObjectRef
 }
 
 /// # Safety
@@ -318,7 +347,7 @@ mod tests {
 
     #[test]
     fn pytraceback_gc_type_id_matches_descr() {
-        assert_eq!(PYTRACEBACK_GC_TYPE_ID, 43);
+        assert_eq!(PYTRACEBACK_GC_TYPE_ID, 44);
         assert_eq!(
             <PyTraceback as pyre_object::lltype::GcType>::type_id(),
             PYTRACEBACK_GC_TYPE_ID

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3514,16 +3514,29 @@ fn init_pytraceback_type(ns: &mut DictStorage) {
         make_getset_property_named(next_getter, next_setter, pyre_object::PY_NULL, "tb_next"),
     );
 
-    // pytraceback.py:34 descr_get_tb_frame — `PyFrame` is not a
-    // Python-visible W_Root, so return a `sys.namespace` frame stub
-    // built from the data the traceback retains (`w_code` + stamped
-    // line number).  Convergence path documented in `pytraceback.rs`.
+    // pytraceback.py:34 descr_get_tb_frame — return the live `PyFrame`
+    // itself (`FRAME_TYPE` typedef) as the user-visible `frame` object.
+    // The traceback keeps the raising frame's chain reachable through
+    // `pytraceback_object_custom_trace`, so a GC-owned frame is still
+    // alive here.  The guard must match the custom_trace's guard
+    // (`try_gc_owns_object`): only frames forwarded as managed edges
+    // survive; a non-Gc frame (Box tracer snapshot / already-freed arena
+    // callee, never forwarded) falls back to the `sys.namespace` stub
+    // built from the retained `w_code` + stamped line number.
     let frame_getter = make_builtin_function_with_arity(
         "tb_frame",
         |args| {
             let tb = args[1];
             if tb.is_null() {
                 return Ok(pyre_object::w_none());
+            }
+            let frame = unsafe { crate::pytraceback::w_pytraceback_get_frame(tb) };
+            if !frame.is_null() && pyre_object::gc_hook::try_gc_owns_object(frame as *mut u8) {
+                // Mark escaped so the JIT keeps the frame materialised for
+                // the exposed reference (pyframe.py:176 `mark_as_escaped`),
+                // mirroring `sys._getframe`.
+                unsafe { (*frame).mark_as_escaped() };
+                return Ok(frame as pyre_object::PyObjectRef);
             }
             let (w_code, lineno) = unsafe {
                 (
@@ -3612,7 +3625,11 @@ fn init_frame_type(ns: &mut DictStorage) {
                 return Ok(pyre_object::w_none());
             }
             let w = unsafe { &*f }.get_w_globals();
-            Ok(if w.is_null() { pyre_object::w_none() } else { w })
+            Ok(if w.is_null() {
+                pyre_object::w_none()
+            } else {
+                w
+            })
         },
         2,
     );
@@ -3632,7 +3649,11 @@ fn init_frame_type(ns: &mut DictStorage) {
                 return Ok(pyre_object::w_none());
             }
             let w = unsafe { &mut *f }.getdictscope()?;
-            Ok(if w.is_null() { pyre_object::w_dict_new() } else { w })
+            Ok(if w.is_null() {
+                pyre_object::w_dict_new()
+            } else {
+                w
+            })
         },
         2,
     );
@@ -3692,7 +3713,11 @@ fn init_frame_type(ns: &mut DictStorage) {
                 return Ok(pyre_object::w_none());
             }
             let w = unsafe { &*f }.fget_f_builtins();
-            Ok(if w.is_null() { pyre_object::w_none() } else { w })
+            Ok(if w.is_null() {
+                pyre_object::w_none()
+            } else {
+                w
+            })
         },
         2,
     );
@@ -3768,7 +3793,11 @@ fn init_frame_type(ns: &mut DictStorage) {
                 return Ok(pyre_object::w_none());
             }
             let w = unsafe { &*f }.fget_f_trace();
-            Ok(if w.is_null() { pyre_object::w_none() } else { w })
+            Ok(if w.is_null() {
+                pyre_object::w_none()
+            } else {
+                w
+            })
         },
         2,
     );

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -445,6 +445,16 @@ pub fn init_typeobjects() {
             traceback_type as usize,
         );
 
+        // frame — PyPy: typedef.py:736-753 PyFrame.typedef.
+        // `assert not PyFrame.typedef.acceptable_as_base_class` (typedef.py:754)
+        // — no `__new__`, cannot be subclassed.
+        let frame_type = new_typeobject_with_base("frame", init_frame_type, object_type);
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(frame_type, false) };
+        reg.insert(
+            &crate::pyframe::FRAME_TYPE as *const PyType as usize,
+            frame_type as usize,
+        );
+
         // function — PyPy: funcobject.py
         // Functions are descriptors: function.__get__ returns a bound method.
         let function_type = new_typeobject_with_base("function", init_function_type, object_type);
@@ -3551,6 +3561,348 @@ fn init_pytraceback_type(ns: &mut DictStorage) {
                     pyre_object::w_str_new("tb_lasti"),
                     pyre_object::w_str_new("tb_lineno"),
                 ]))
+            },
+            1,
+        ),
+    );
+}
+
+/// `pypy/interpreter/typedef.py:736-753 PyFrame.typedef` — the `frame`
+/// type's getset descriptors + `clear` / `__repr__`.  The receiver
+/// (`args[1]`) is a live `PyFrame` object (its `ob_header.ob_type` is
+/// `FRAME_TYPE`); every field access casts it to `*mut PyFrame`.  A read
+/// through a null / already-freed receiver returns `None` rather than
+/// dereferencing.  `f_lineno`'s setter uses the existing simplified
+/// `fset_f_lineno` (the full `mark_stacks` jump validation is a separate
+/// port); the read-only getsets and `f_trace*` setters mirror
+/// `pyframe.py:641-806` directly.
+fn init_frame_type(ns: &mut DictStorage) {
+    use crate::pyframe::PyFrame;
+
+    // Helper: resolve the receiver to `&mut PyFrame`, or return `w_none()`
+    // (the closures each inline this because Rust closures can't share a
+    // borrow-returning helper cleanly).
+    fn frame_ptr(w_obj: pyre_object::PyObjectRef) -> *mut PyFrame {
+        w_obj as *mut PyFrame
+    }
+
+    // f_code — read-only; the `PyCode` wrapper (pyframe.py:641 fget_code).
+    let code_getter = make_builtin_function_with_arity(
+        "f_code",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            Ok(unsafe { &*f }.fget_f_code())
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_code",
+        make_getset_descriptor_named(code_getter, "f_code"),
+    );
+
+    // f_globals — read-only (pyframe.py:647 fget_w_globals).
+    let globals_getter = make_builtin_function_with_arity(
+        "f_globals",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let w = unsafe { &*f }.get_w_globals();
+            Ok(if w.is_null() { pyre_object::w_none() } else { w })
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_globals",
+        make_getset_descriptor_named(globals_getter, "f_globals"),
+    );
+
+    // f_locals — read-only; runs `fast2locals` (pyframe.py:644
+    // fget_getdictscope), so it needs `&mut` and can raise.
+    let locals_getter = make_builtin_function_with_arity(
+        "f_locals",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let w = unsafe { &mut *f }.getdictscope()?;
+            Ok(if w.is_null() { pyre_object::w_dict_new() } else { w })
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_locals",
+        make_getset_descriptor_named(locals_getter, "f_locals"),
+    );
+
+    // f_back — read-only; the next non-hidden frame (pyframe.py:767).
+    let back_getter = make_builtin_function_with_arity(
+        "f_back",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let back = unsafe { &*f }.get_f_back();
+            Ok(if back.is_null() {
+                pyre_object::w_none()
+            } else {
+                back as pyre_object::PyObjectRef
+            })
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_back",
+        make_getset_descriptor_named(back_getter, "f_back"),
+    );
+
+    // f_lasti — read-only instruction-unit index (pyframe.py:770).
+    let lasti_getter = make_builtin_function_with_arity(
+        "f_lasti",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            Ok(pyre_object::w_int_new(unsafe { &*f }.fget_f_lasti() as i64))
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_lasti",
+        make_getset_descriptor_named(lasti_getter, "f_lasti"),
+    );
+
+    // f_builtins — read-only builtin dict (pyframe.py:761).
+    let builtins_getter = make_builtin_function_with_arity(
+        "f_builtins",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let w = unsafe { &*f }.fget_f_builtins();
+            Ok(if w.is_null() { pyre_object::w_none() } else { w })
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_builtins",
+        make_getset_descriptor_named(builtins_getter, "f_builtins"),
+    );
+
+    // f_lineno — read/write (pyframe.py:654 fget_f_lineno / :666 fset).
+    // The getter returns `None` for an untraced frame whose line is -1;
+    // the setter uses pyre's simplified `fset_f_lineno` (full mark_stacks
+    // jump validation is a separate port).
+    let lineno_getter = make_builtin_function_with_arity(
+        "f_lineno",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let frame = unsafe { &*f };
+            let lineno = frame.get_last_lineno();
+            if frame.get_w_f_trace().is_null() {
+                if lineno == -1 {
+                    return Ok(pyre_object::w_none());
+                }
+                return Ok(pyre_object::w_int_new(lineno as i64));
+            }
+            let lineno = if lineno == -1 {
+                frame
+                    .code()
+                    .first_line_number
+                    .map_or(-1, |n| n.get() as isize)
+            } else {
+                lineno
+            };
+            Ok(pyre_object::w_int_new(lineno as i64))
+        },
+        2,
+    );
+    let lineno_setter = make_builtin_function_with_arity(
+        "f_lineno",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let new_lineno = crate::baseobjspace::int_w(args[2])
+                .map_err(|_| crate::PyError::value_error("lineno must be an integer"))?;
+            unsafe { &mut *f }.fset_f_lineno(new_lineno as isize);
+            Ok(pyre_object::w_none())
+        },
+        3,
+    );
+    dict_storage_store(
+        ns,
+        "f_lineno",
+        make_getset_property_named(
+            lineno_getter,
+            lineno_setter,
+            pyre_object::PY_NULL,
+            "f_lineno",
+        ),
+    );
+
+    // f_trace — read/write/delete (pyframe.py:773-785).
+    let trace_getter = make_builtin_function_with_arity(
+        "f_trace",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            let w = unsafe { &*f }.fget_f_trace();
+            Ok(if w.is_null() { pyre_object::w_none() } else { w })
+        },
+        2,
+    );
+    let trace_setter = make_builtin_function_with_arity(
+        "f_trace",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if !f.is_null() {
+                unsafe { &mut *f }.fset_f_trace(args[2]);
+            }
+            Ok(pyre_object::w_none())
+        },
+        3,
+    );
+    let trace_deleter = make_builtin_function_with_arity(
+        "f_trace",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if !f.is_null() {
+                unsafe { &mut *f }.fdel_f_trace();
+            }
+            Ok(pyre_object::w_none())
+        },
+        2,
+    );
+    dict_storage_store(
+        ns,
+        "f_trace",
+        make_getset_property_named(trace_getter, trace_setter, trace_deleter, "f_trace"),
+    );
+
+    // f_trace_lines — read/write bool (pyframe.py:787-791).
+    let trace_lines_getter = make_builtin_function_with_arity(
+        "f_trace_lines",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            Ok(pyre_object::w_bool_from(
+                unsafe { &*f }.fget_f_trace_lines(),
+            ))
+        },
+        2,
+    );
+    let trace_lines_setter = make_builtin_function_with_arity(
+        "f_trace_lines",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if !f.is_null() {
+                let v = crate::baseobjspace::is_true(args[2])?;
+                unsafe { &mut *f }.fset_f_trace_lines(v);
+            }
+            Ok(pyre_object::w_none())
+        },
+        3,
+    );
+    dict_storage_store(
+        ns,
+        "f_trace_lines",
+        make_getset_property_named(
+            trace_lines_getter,
+            trace_lines_setter,
+            pyre_object::PY_NULL,
+            "f_trace_lines",
+        ),
+    );
+
+    // f_trace_opcodes — read/write bool (pyframe.py:793-797).
+    let trace_opcodes_getter = make_builtin_function_with_arity(
+        "f_trace_opcodes",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if f.is_null() {
+                return Ok(pyre_object::w_none());
+            }
+            Ok(pyre_object::w_bool_from(
+                unsafe { &*f }.fget_f_trace_opcodes(),
+            ))
+        },
+        2,
+    );
+    let trace_opcodes_setter = make_builtin_function_with_arity(
+        "f_trace_opcodes",
+        |args| {
+            let f = frame_ptr(args[1]);
+            if !f.is_null() {
+                let v = crate::baseobjspace::is_true(args[2])?;
+                unsafe { &mut *f }.fset_f_trace_opcodes(v);
+            }
+            Ok(pyre_object::w_none())
+        },
+        3,
+    );
+    dict_storage_store(
+        ns,
+        "f_trace_opcodes",
+        make_getset_property_named(
+            trace_opcodes_getter,
+            trace_opcodes_setter,
+            pyre_object::PY_NULL,
+            "f_trace_opcodes",
+        ),
+    );
+
+    // clear() — interp2app (pyframe.py:805 descr_clear).
+    dict_storage_store(
+        ns,
+        "clear",
+        make_builtin_function_with_arity(
+            "clear",
+            |args| {
+                let f = frame_ptr(args[0]);
+                if !f.is_null() {
+                    unsafe { &mut *f }.descr_clear()?;
+                }
+                Ok(pyre_object::w_none())
+            },
+            1,
+        ),
+    );
+
+    // __repr__ — interp2app (pyframe.py:849 descr_repr).
+    dict_storage_store(
+        ns,
+        "__repr__",
+        make_builtin_function_with_arity(
+            "__repr__",
+            |args| {
+                let f = frame_ptr(args[0]);
+                if f.is_null() {
+                    return Ok(pyre_object::w_str_new("<frame (null)>"));
+                }
+                Ok(pyre_object::w_str_new(&unsafe { &*f }.descr_repr()))
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -910,6 +910,7 @@ pub fn init_typeobjects() {
     });
 
     patch_builtin_function_descriptors();
+    patch_frame_traceback_descriptors();
     patch_getset_descriptor_metadata();
     patch_typeobject_descriptor_names();
 }
@@ -6720,6 +6721,46 @@ fn patch_builtin_function_descriptors() {
                 // mutate / write back dance.
                 unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, bf_type) };
             }
+        }
+    }
+}
+
+/// typedef.py:736-770 — `PyFrame.typedef` / `PyTraceback.typedef` build
+/// their getsets as `GetSetProperty(PyFrame.fget_*, cls=PyFrame)` /
+/// `GetSetProperty(PyTraceback.descr_*, cls=PyTraceback)`.  The `cls`
+/// stamps `reqcls`, so a getset invoked with a foreign receiver
+/// (`type(f).f_code.__get__(1, int)`) raises the descriptor
+/// `TypeError` in `__get__`/`__set__` instead of reaching the closure,
+/// which casts the receiver straight to `*mut PyFrame` /
+/// `*mut PyTraceback` and would otherwise read at struct offsets on
+/// arbitrary memory.  The frame/traceback getsets are created
+/// reqcls-less (`make_getset_descriptor_named`), so patch the slot in
+/// place once both typeobjects exist — the same shape as
+/// `patch_builtin_function_descriptors`.
+fn patch_frame_traceback_descriptors() {
+    for layout in [
+        &crate::pyframe::FRAME_TYPE as *const PyType,
+        &crate::pytraceback::PYTRACEBACK_TYPE as *const PyType,
+    ] {
+        let w_type = gettypefor(layout).unwrap_or(pyre_object::PY_NULL);
+        if w_type.is_null() {
+            continue;
+        }
+        let dict_ptr = unsafe { pyre_object::w_type_get_dict_ptr(w_type) } as *mut DictStorage;
+        if dict_ptr.is_null() {
+            continue;
+        }
+        let ns = unsafe { &*dict_ptr };
+        let descrs: Vec<PyObjectRef> = ns
+            .entries()
+            .filter_map(|(_, &descr)| {
+                (!descr.is_null()
+                    && unsafe { pyre_object::typedef::is_getset_property(descr) })
+                .then_some(descr)
+            })
+            .collect();
+        for descr in descrs {
+            unsafe { pyre_object::typedef::w_getset_set_reqcls(descr, w_type) };
         }
     }
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -6754,9 +6754,8 @@ fn patch_frame_traceback_descriptors() {
         let descrs: Vec<PyObjectRef> = ns
             .entries()
             .filter_map(|(_, &descr)| {
-                (!descr.is_null()
-                    && unsafe { pyre_object::typedef::is_getset_property(descr) })
-                .then_some(descr)
+                (!descr.is_null() && unsafe { pyre_object::typedef::is_getset_property(descr) })
+                    .then_some(descr)
             })
             .collect();
         for descr in descrs {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3572,10 +3572,9 @@ fn init_pytraceback_type(ns: &mut DictStorage) {
 /// (`args[1]`) is a live `PyFrame` object (its `ob_header.ob_type` is
 /// `FRAME_TYPE`); every field access casts it to `*mut PyFrame`.  A read
 /// through a null / already-freed receiver returns `None` rather than
-/// dereferencing.  `f_lineno`'s setter uses the existing simplified
-/// `fset_f_lineno` (the full `mark_stacks` jump validation is a separate
-/// port); the read-only getsets and `f_trace*` setters mirror
-/// `pyframe.py:641-806` directly.
+/// dereferencing.  `f_lineno`'s setter is [`PyFrame::fset_f_lineno`],
+/// which validates the line-jump via `mark_stacks`; the read-only getsets
+/// and `f_trace*` setters mirror `pyframe.py:641-806` directly.
 fn init_frame_type(ns: &mut DictStorage) {
     use crate::pyframe::PyFrame;
 
@@ -3705,8 +3704,9 @@ fn init_frame_type(ns: &mut DictStorage) {
 
     // f_lineno — read/write (pyframe.py:654 fget_f_lineno / :666 fset).
     // The getter returns `None` for an untraced frame whose line is -1;
-    // the setter uses pyre's simplified `fset_f_lineno` (full mark_stacks
-    // jump validation is a separate port).
+    // the setter is `fset_f_lineno`, which validates the debugger
+    // line-jump via `mark_stacks` and raises `ValueError` on an illegal
+    // target (only permitted from within a trace function).
     let lineno_getter = make_builtin_function_with_arity(
         "f_lineno",
         |args| {
@@ -3743,7 +3743,7 @@ fn init_frame_type(ns: &mut DictStorage) {
             }
             let new_lineno = crate::baseobjspace::int_w(args[2])
                 .map_err(|_| crate::PyError::value_error("lineno must be an integer"))?;
-            unsafe { &mut *f }.fset_f_lineno(new_lineno as isize);
+            unsafe { &mut *f }.fset_f_lineno(new_lineno as isize)?;
             Ok(pyre_object::w_none())
         },
         3,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3372,18 +3372,85 @@ fn init_dict_view_values_type(ns: &mut DictStorage) {
 /// )
 /// ```
 ///
-/// Pyre wires `tb_lasti`, `tb_lineno`, `tb_next`, `__dir__`.  Gaps
-/// with cited convergence paths:
-///   - `tb_frame` returns `None` — needs `PyFrame` to grow a
-///     `PyObject` header (`pyframe.rs:39` currently `repr(C)`
-///     without one).  Snapshot stub (using `w_code` + `lineno` +
-///     recursive `tb_next.tb_frame` for `f_back`) is the bridge.
-///   - `__new__` needs the same `PyFrame` W_Root surface (per
-///     `pytraceback.py:67` `space.interp_w(PyFrame, w_frame)`).
-///   - `__reduce__` / `__setstate__` (`:74-97`) need the
-///     `_pickle_support.traceback_new` builtin module which pyre
-///     hasn't ported.
+/// Pyre wires `tb_lasti`, `tb_lineno`, `tb_next`, `tb_frame`,
+/// `__new__`, `__dir__`.
+///   - `tb_frame` returns the live `PyFrame` (`FRAME_TYPE`) when it is
+///     GC-owned, else a `sys.namespace` stub for a non-Gc / freed
+///     frame (see the getter below).
+///   - `__new__` = `TracebackType(tb_next, tb_frame, tb_lasti,
+///     tb_lineno)` (3.7+ constructor), taking a live `frame` object.
+///   - `__reduce__` / `__setstate__` are intentionally NOT wired:
+///     CPython 3.14 tracebacks are not picklable (`pickle.dumps(tb)`
+///     raises `TypeError: cannot pickle 'traceback' object`, and
+///     `traceback` has no `__setstate__`).  PyPy's `_pickle_support`
+///     path is PyPy-specific and would add non-CPython behavior, so it
+///     is deliberately omitted (behavior authority = CPython 3.14).
+/// `TracebackType(tb_next, tb_frame, tb_lasti, tb_lineno)` — the 3.7+
+/// traceback constructor.  `args[0]` is the class; the four positional
+/// arguments follow.  `tb_next` is a traceback or `None`; `tb_frame`
+/// must be a `frame`; `tb_lasti` / `tb_lineno` are ints.  CPython's
+/// `tb_lasti` is a byte offset, so it is halved to pyre's instruction-
+/// unit form for storage (the `tb_lasti` getter multiplies back by 2).
+fn traceback_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() != 5 {
+        return Err(crate::PyError::type_error(format!(
+            "TracebackType() takes exactly 4 arguments ({} given)",
+            args.len().saturating_sub(1)
+        )));
+    }
+    let w_next = args[1];
+    let w_frame = args[2];
+    let w_lasti = args[3];
+    let w_lineno = args[4];
+
+    // tb_next: a traceback or None.
+    let next = if unsafe { pyre_object::is_none(w_next) } {
+        pyre_object::PY_NULL
+    } else if unsafe { crate::pytraceback::is_pytraceback(w_next) } {
+        w_next
+    } else {
+        return Err(crate::PyError::type_error(format!(
+            "expected traceback object or None, got '{}'",
+            type_name_of(w_next)
+        )));
+    };
+
+    // tb_frame: must be a `frame` object (`FRAME_TYPE`).
+    if w_frame.is_null()
+        || !unsafe { pyre_object::py_type_check(w_frame, &crate::pyframe::FRAME_TYPE) }
+    {
+        return Err(crate::PyError::type_error(format!(
+            "TracebackType() argument 'tb_frame' must be frame, not {}",
+            type_name_of(w_frame)
+        )));
+    }
+    let frame = w_frame as *mut crate::pyframe::PyFrame;
+
+    // tb_lasti / tb_lineno: integers.  `tb_lasti` arrives as a CPython
+    // byte offset; store the instruction-unit form (`/ 2`).
+    if !unsafe { pyre_object::is_int(w_lasti) } {
+        return Err(crate::PyError::type_error(format!(
+            "an integer is required (got type {})",
+            type_name_of(w_lasti)
+        )));
+    }
+    if !unsafe { pyre_object::is_int(w_lineno) } {
+        return Err(crate::PyError::type_error(format!(
+            "an integer is required (got type {})",
+            type_name_of(w_lineno)
+        )));
+    }
+    let lasti = unsafe { pyre_object::w_int_get_value(w_lasti) } / 2;
+    let lineno = unsafe { pyre_object::w_int_get_value(w_lineno) };
+    let w_code = unsafe { (*frame).fget_f_code() };
+
+    Ok(crate::pytraceback::w_pytraceback_new(
+        frame, lasti, next, lineno, w_code,
+    ))
+}
+
 fn init_pytraceback_type(ns: &mut DictStorage) {
+    dict_storage_store(ns, "__new__", make_new_descr(traceback_descr_new));
     // pytraceback.py:45-49 descr_get_tb_lasti / descr_set_tb_lasti.
     //
     // pyre stores `lasti` as an instruction-unit index (`PyFrame.last_instr`
@@ -3520,9 +3587,17 @@ fn init_pytraceback_type(ns: &mut DictStorage) {
     // `pytraceback_object_custom_trace`, so a GC-owned frame is still
     // alive here.  The guard must match the custom_trace's guard
     // (`try_gc_owns_object`): only frames forwarded as managed edges
-    // survive; a non-Gc frame (Box tracer snapshot / already-freed arena
-    // callee, never forwarded) falls back to the `sys.namespace` stub
+    // survive; a non-Gc frame falls back to the `sys.namespace` stub
     // built from the retained `w_code` + stamped line number.
+    //
+    // A frame is non-Gc only when the GC stable-alloc hook was never
+    // installed: that hook (and the whole GC subsystem) is set up inside
+    // the JIT-driver initializer, which `PYRE_JIT=0` short-circuits, so
+    // in interpreter-only runs every frame is a `std::alloc` box freed on
+    // return — returning it would be a use-after-free.  On the shipping
+    // JIT path frames are GC-owned oldgen blocks and the stub is dead.
+    // Decoupling GC init from the JIT driver (letting the fallback go)
+    // is tracked separately.
     let frame_getter = make_builtin_function_with_arity(
         "tb_frame",
         |args| {
@@ -3671,10 +3746,13 @@ fn init_frame_type(ns: &mut DictStorage) {
             if f.is_null() {
                 return Ok(pyre_object::w_none());
             }
-            let back = unsafe { &*f }.get_f_back();
+            let back = unsafe { &*f }.fget_f_back();
             Ok(if back.is_null() {
                 pyre_object::w_none()
             } else {
+                // Exposing the frame to app level: mark escaped so the JIT
+                // materialises it (pyframe.py:176), mirroring `_getframe`.
+                unsafe { (*back).mark_as_escaped() };
                 back as pyre_object::PyObjectRef
             })
         },
@@ -3686,7 +3764,14 @@ fn init_frame_type(ns: &mut DictStorage) {
         make_getset_descriptor_named(back_getter, "f_back"),
     );
 
-    // f_lasti — read-only instruction-unit index (pyframe.py:770).
+    // f_lasti — read-only bytecode offset (pyframe.py:770).
+    //
+    // pyre stores `last_instr` as an instruction-unit index (increments
+    // by 1 per instruction); CPython's `f_lasti` is a byte offset
+    // (2 bytes per code unit).  Report the byte-offset form (× 2) so
+    // `dis` / `code.co_positions()` consumers that do `f_lasti // 2`
+    // recover the right instruction — the same adaptation `tb_lasti`
+    // uses (`typedef.rs` tb_lasti getter).
     let lasti_getter = make_builtin_function_with_arity(
         "f_lasti",
         |args| {
@@ -3694,7 +3779,9 @@ fn init_frame_type(ns: &mut DictStorage) {
             if f.is_null() {
                 return Ok(pyre_object::w_none());
             }
-            Ok(pyre_object::w_int_new(unsafe { &*f }.fget_f_lasti() as i64))
+            Ok(pyre_object::w_int_new(
+                unsafe { &*f }.fget_f_lasti() as i64 * 2,
+            ))
         },
         2,
     );

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1324,7 +1324,11 @@ static PYFRAME_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_interpreter::pyframe::PyFrame>(),
         PYFRAME_GC_TYPE_ID,
-        0,
+        // `NewWithVtable` writes this typeptr at `cpu.vtable_offset`
+        // (`OB_TYPE_OFFSET = 0`), populating the frame's `ob_header.ob_type`
+        // so a JIT-built inline callee frame carries the same `frame` type
+        // tag as a `FrameBox`-constructed one.
+        &pyre_interpreter::pyframe::FRAME_TYPE as *const _ as usize,
         &[
             (
                 "PyFrame.locals_cells_stack_w",

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -328,8 +328,20 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     let gen_obj = unsafe { &mut *(obj_addr as *mut pyre_object::generator::GeneratorIterator) };
     if !gen_obj.frame_ptr.is_null() {
         let frame = gen_obj.frame_ptr as *mut PyFrame;
-        let mut adapter = |slot: &mut majit_ir::GcRef| f(slot as *mut majit_ir::GcRef);
-        pyre_interpreter::eval::walk_suspended_generator_frame(frame, &mut adapter);
+        if pyre_object::gc_hook::try_gc_owns_object(gen_obj.frame_ptr) {
+            // GC-managed suspended frame: forward the `frame_ptr` slot as a
+            // managed edge so mark greys the frame block, and its own
+            // `pyframe_object_custom_trace` recursively forwards the
+            // locals/cells/valuestack — keeping both the block and its
+            // contents live without sweeping the frame the generator holds.
+            f(&mut gen_obj.frame_ptr as *mut *mut u8 as *mut majit_ir::GcRef);
+        } else {
+            // `std::alloc` fallback frame (no GC hook at generator birth):
+            // the block is never swept, so only its contents need
+            // forwarding, in place.
+            let mut adapter = |slot: &mut majit_ir::GcRef| f(slot as *mut majit_ir::GcRef);
+            pyre_interpreter::eval::walk_suspended_generator_frame(frame, &mut adapter);
+        }
     }
 }
 
@@ -645,6 +657,28 @@ unsafe fn pyframe_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut ma
         f(&mut d.w_locals as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
         f(&mut d.w_f_trace as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
     }
+}
+
+/// Destructor for `PyFrame` (type id [`PYFRAME_GC_TYPE_ID`]).
+///
+/// A GC-managed frame is reclaimed by a major mark-sweep once no root
+/// reaches it (`pyframe.py class PyFrame(W_Root)`; `FrameBox::drop`
+/// performs no manual free for these).  This runs at sweep to release the
+/// frame's owned off-GC resources — the `FrameDebugData` box, the
+/// `FrameBlock` chain, and the `locals_cells_stack_w` array — mirroring
+/// `PyFrame::drop`, which handles the `std::alloc` fallback frames instead.
+///
+/// The locals array is freed only when it is a `std::alloc` block (every
+/// `FrameBox` frame): a JIT-built inline frame's array is a GC-managed
+/// `PY_OBJECT_ARRAY_GC_TYPE_ID` block the collector sweeps on its own, so
+/// freeing it here would double-free.  `try_gc_owns_object` distinguishes
+/// them — the same regime split `pyframe_object_custom_trace` uses.
+unsafe fn pyframe_object_destructor(obj_addr: usize) {
+    let frame = unsafe { &mut *(obj_addr as *mut PyFrame) };
+    let array = frame.locals_cells_stack_w;
+    let free_locals_array =
+        !array.is_null() && !pyre_object::gc_hook::try_gc_owns_object(array as *mut u8);
+    unsafe { frame.free_owned_contents(free_locals_array) };
 }
 
 /// RPython jitexc.py:53 ContinueRunningNormally parity.
@@ -1475,15 +1509,29 @@ thread_local! {
         // `custom_trace` fully replaces offset tracing on both the minor
         // (collector.rs:1471) and major-mark (collector.rs:1746) paths.
         //
-        // Only frames stamped with this type id (nursery frames from
-        // `emit_new_pyframe_inline_self_recursive`) are traced this way.
-        // `std::alloc`-backed `FrameBox` / callee-arena frames carry
-        // `type_id = 0`, sit outside the GC heap, and are reached only as
-        // roots via `walk_pyframe_roots` / `walk_jit_callee_frame_roots`.
-        let pyframe_tid = gc.register_type(majit_gc::trace::TypeInfo::with_custom_trace(
-            std::mem::size_of::<pyre_interpreter::pyframe::PyFrame>(),
-            pyframe_object_custom_trace,
-        ));
+        // Frames stamped with this type id: JIT-built inline frames
+        // (`emit_new_pyframe_inline_self_recursive`, whose locals array is a
+        // GC-managed `PY_OBJECT_ARRAY_GC_TYPE_ID` block) AND executing /
+        // generator `FrameBox` frames (`FrameBox::new` via
+        // `try_gc_alloc_stable`, whose locals array is a stationary
+        // `std::alloc` block).  The custom trace's regime split
+        // (`try_gc_owns_object`) handles both.  Callee-arena JIT frames
+        // remain `type_id = 0` off-GC blocks reached only as roots via
+        // `walk_jit_callee_frame_roots` (S2c).
+        //
+        // The destructor releases a swept GC-managed frame's owned off-GC
+        // resources (debug data, block chain, and the `std::alloc` locals
+        // array of a `FrameBox` frame — NOT a JIT inline frame's GC array) —
+        // `FrameBox::drop` no longer frees them under policy A
+        // (`executioncontext.py:91-107 leave` frees nothing; frame lifetime
+        // is GC reachability).
+        let pyframe_tid = gc.register_type(
+            majit_gc::trace::TypeInfo::with_custom_trace(
+                std::mem::size_of::<pyre_interpreter::pyframe::PyFrame>(),
+                pyframe_object_custom_trace,
+            )
+            .with_destructor_fn(pyframe_object_destructor),
+        );
         debug_assert_eq!(pyframe_tid, PYFRAME_GC_TYPE_ID);
         // `W_DictProxyObject` carries a single GC-traceable
         // `w_mapping: PyObjectRef` slot (the wrapped W_DictObject —

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -576,6 +576,77 @@ unsafe fn memoryview_object_destructor(obj_addr: usize) {
     }
 }
 
+/// Custom trace for `PyFrame` (type id [`PYFRAME_GC_TYPE_ID`]).
+///
+/// Forwards exactly the frame-owned GC slots that the interpreter root
+/// walker `pyre-interpreter::eval::walk_pyframe_roots` visits per frame,
+/// so a type-directed trace of a header-tagged `PyFrame` sees the same
+/// root set the ad-hoc walker does.  A flat `gc_ptr_offsets` list cannot
+/// express two of those slots: the `locals_cells_stack_w` items when the
+/// array is a stationary `std::alloc` block (regime-a — the collector
+/// never enters `trace_and_update_object` on a non-nursery array so its
+/// varsize walker never runs), and the `debugdata->{w_locals, w_f_trace}`
+/// refs, which live one pointer indirection away inside a non-GC
+/// `malloc`'d `FrameDebugData`.  Both require a custom trace.
+///
+/// Forwarded (mirrors `walk_pyframe_roots` eval.rs:496-556):
+///   - `f_backref` — the parent frame pointer.
+///   - `pycode` — visited to match the walker; inert while code objects
+///     are Box-immortal (`is_nursery_object_start` short-circuits).
+///   - `locals_cells_stack_w` — the array pointer.  When the array is a
+///     GC-managed (moving) nursery block its slot is forwarded and the
+///     type-9 varsize walker forwards the items; when it is a stationary
+///     `std::alloc` block each item is forwarded in place — the same
+///     regime split as `list_object_custom_trace` / `tuple_object_custom_trace`.
+///   - `f_generator_nowref`, `w_yielding_from`, `w_builtin`, `w_globals`
+///     — the ref-bearing statics.
+///   - `debugdata->w_locals`, `debugdata->w_f_trace` — null-guarded.
+///
+/// Excluded (matches the walker): `execution_context` (persistent, not
+/// GC), `debugdata`/`lastblock` (non-GC heap), the module-dict / method-
+/// cache / prebuilt-family global walks (those are not frame-owned; the
+/// root walker performs them once per collection, not per frame).
+unsafe fn pyframe_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let frame = unsafe { &mut *(obj_addr as *mut PyFrame) };
+
+    f(&mut frame.f_backref as *mut *mut PyFrame as *mut majit_ir::GcRef);
+    f(&mut frame.pycode as *mut *const () as *mut majit_ir::GcRef);
+
+    // locals_cells_stack_w: forward the array pointer, then its items.
+    let array = frame.locals_cells_stack_w;
+    if !array.is_null() {
+        if pyre_object::gc_hook::try_gc_owns_object(array as *mut u8) {
+            // GC-managed (moving) nursery block: hand the collector the
+            // array field slot; the type-9 varsize walker forwards the
+            // items once the array itself is copied.
+            f(&mut frame.locals_cells_stack_w as *mut *mut pyre_object::FixedObjectArray
+                as *mut majit_ir::GcRef);
+        } else {
+            // Stationary `std::alloc` block (type_id 0, never entered by
+            // `trace_and_update_object`): forward each item in place. Walk
+            // the FULL fixed-length array, not just the live prefix —
+            // matching `walk_pyframe_roots` (eval.rs:626), which forwards
+            // popped-in-transit argument slots past `valuestackdepth`.
+            let arr = unsafe { &mut *array };
+            let base = arr.items_mut_ptr();
+            for i in 0..arr.len() {
+                f(unsafe { base.add(i) } as *mut majit_ir::GcRef);
+            }
+        }
+    }
+
+    f(&mut frame.f_generator_nowref as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut frame.w_yielding_from as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut frame.w_builtin as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut frame.w_globals as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+
+    if !frame.debugdata.is_null() {
+        let d = unsafe { &mut *frame.debugdata };
+        f(&mut d.w_locals as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+        f(&mut d.w_f_trace as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    }
+}
+
 /// RPython jitexc.py:53 ContinueRunningNormally parity.
 pub(crate) enum LoopResult {
     Done(PyResult),
@@ -1392,50 +1463,26 @@ thread_local! {
         // `pyre-interpreter::pyframe::PyFrame` — execution frame for a
         // Python code block. NOT an `rclass.OBJECT`-shaped instance
         // (no `ob_type` header — virtualizable struct laid out for the
-        // JIT virtualize pass), so register through `with_gc_ptrs`
+        // JIT virtualize pass), so register with a bare size + trace hook
         // rather than `object_subclass`.
         //
-        // GC-traceable fields (the standard nursery tracer forwards
-        // these when a nursery `PyFrame` survives a minor collection):
-        //   - `locals_cells_stack_w`: `*mut FixedObjectArray` — when
-        //     `emit_new_pyframe_inline_self_recursive` emits
-        //     `NewArrayClear` for the locals array the array itself
-        //     lives in the nursery, so its pointer must be forwarded.
-        //   - `f_generator_nowref` / `w_yielding_from`: `PyObjectRef`
-        //     slots that may point at nursery objects.
-        //   - `f_backref`: `*mut PyFrame` — once chained inline calls
-        //     produce nested nursery `PyFrame`s the parent pointer
-        //     must be forwarded to the new address.
-        // Excluded: `execution_context` (Rc::into_raw, persistent),
-        // `pycode` (static PyCode), `debugdata` / `lastblock`
-        // (heap-allocated, not GC), `w_globals` (Box-allocated
-        // DictStorage, not GC).
+        // The trace hook `pyframe_object_custom_trace` forwards exactly
+        // the frame-owned GC slots `walk_pyframe_roots` visits per frame.
+        // A flat `gc_ptr_offsets` list cannot express two of them — the
+        // `locals_cells_stack_w` items when the array is a stationary
+        // `std::alloc` block, and the `debugdata->{w_locals, w_f_trace}`
+        // refs one indirection away — so a custom trace is required.
+        // `custom_trace` fully replaces offset tracing on both the minor
+        // (collector.rs:1471) and major-mark (collector.rs:1746) paths.
         //
-        // `walk_pyframe_roots` (`pyre-interpreter::eval`) still walks
-        // `CURRENT_FRAME → f_backref` and visits the items inside
-        // `locals_cells_stack_w`; that path covers `std::alloc`-backed
-        // PyFrames today and is the entry point that hands control to
-        // the standard tracer for nursery-backed frames once
-        // it is taught about forwarding.
-        let pyframe_tid = gc.register_type(majit_gc::trace::TypeInfo::with_gc_ptrs(
+        // Only frames stamped with this type id (nursery frames from
+        // `emit_new_pyframe_inline_self_recursive`) are traced this way.
+        // `std::alloc`-backed `FrameBox` / callee-arena frames carry
+        // `type_id = 0`, sit outside the GC heap, and are reached only as
+        // roots via `walk_pyframe_roots` / `walk_jit_callee_frame_roots`.
+        let pyframe_tid = gc.register_type(majit_gc::trace::TypeInfo::with_custom_trace(
             std::mem::size_of::<pyre_interpreter::pyframe::PyFrame>(),
-            vec![
-                pyre_interpreter::pyframe::PYFRAME_LOCALS_CELLS_STACK_OFFSET,
-                pyre_interpreter::pyframe::PYFRAME_F_GENERATOR_NOWREF_OFFSET,
-                pyre_interpreter::pyframe::PYFRAME_W_YIELDING_FROM_OFFSET,
-                pyre_interpreter::pyframe::PYFRAME_F_BACKREF_OFFSET,
-                // Lazy-cached canonical W_DictObject sibling for
-                // `frame.w_globals`.  Once `get_w_globals` resolves
-                // the pointer it stays alive for the frame's lifetime
-                // (`dict_storage_to_dict` mirror_target invariant), so
-                // the slot must be visited by the nursery tracer to
-                // forward the dict pointer if it survives a minor
-                // collection.  Excluded slots (`w_globals`,
-                // `execution_context`, `pycode`, `debugdata`,
-                // `lastblock`) all point at non-nursery memory and
-                // remain off-list.
-                pyre_interpreter::pyframe::PYFRAME_W_GLOBALS_OFFSET,
-            ],
+            pyframe_object_custom_trace,
         ));
         debug_assert_eq!(pyframe_tid, PYFRAME_GC_TYPE_ID);
         // `W_DictProxyObject` carries a single GC-traceable

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -345,6 +345,40 @@ unsafe fn generator_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut 
     }
 }
 
+/// Custom trace for `PyTraceback` (`pytraceback.py:17 PyTraceback`).
+///
+/// PyPy's `PyTraceback.frame` is a normal `PyFrame` W_Root, so its
+/// tracer reaches the frame (and thence its locals / `f_backref`
+/// chain) through the ordinary reference.  Pyre stores `frame` as a
+/// raw `*mut PyFrame` and the two `PyObjectRef` slots (`w_next`,
+/// `w_code`) inline; none are reachable through `gc_ptr_offsets`
+/// (the type was registered with empty offsets), so forward all three
+/// here:
+///
+///   * `w_next` — the chained caller-side traceback link.
+///   * `w_code` — the raising frame's PyCode snapshot (kept alive so
+///     source-path / function-name metadata survives).
+///   * `frame` — forwarded as a managed edge **only** when
+///     `try_gc_owns_object(frame)` holds (an executing/oldgen frame,
+///     `PYFRAME_GC_TYPE_ID`).  Mark greys the frame block and its own
+///     `pyframe_object_custom_trace` recurses into locals/cells/
+///     valuestack and the `f_backref` chain, so a frame reachable only
+///     through a live traceback (the whole point of `tb_frame`) is not
+///     reclaimed.  A non-Gc frame (Box tracer snapshot / arena callee,
+///     already freed by the time the traceback escapes) is left
+///     dangling exactly as before — never dereferenced.
+unsafe fn pytraceback_object_custom_trace(
+    obj_addr: usize,
+    f: &mut dyn FnMut(*mut majit_ir::GcRef),
+) {
+    let tb = unsafe { &mut *(obj_addr as *mut pyre_interpreter::pytraceback::PyTraceback) };
+    f(&mut tb.w_next as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    f(&mut tb.w_code as *mut pyre_object::PyObjectRef as *mut majit_ir::GcRef);
+    if !tb.frame.is_null() && pyre_object::gc_hook::try_gc_owns_object(tb.frame as *mut u8) {
+        f(&mut tb.frame as *mut *mut pyre_interpreter::pyframe::PyFrame as *mut majit_ir::GcRef);
+    }
+}
+
 unsafe fn dict_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     // Strategy-side dispatch — `W_DictObject.dstorage: *mut u8` erases
     // the storage layout, so each strategy walks its own native shape
@@ -631,8 +665,10 @@ unsafe fn pyframe_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut ma
             // GC-managed (moving) nursery block: hand the collector the
             // array field slot; the type-9 varsize walker forwards the
             // items once the array itself is copied.
-            f(&mut frame.locals_cells_stack_w as *mut *mut pyre_object::FixedObjectArray
-                as *mut majit_ir::GcRef);
+            f(
+                &mut frame.locals_cells_stack_w as *mut *mut pyre_object::FixedObjectArray
+                    as *mut majit_ir::GcRef,
+            );
         } else {
             // Stationary `std::alloc` block (type_id 0, never entered by
             // `trace_and_update_object`): forward each item in place. Walk
@@ -1654,6 +1690,35 @@ thread_local! {
             &pyre_interpreter::pycode::CODE_TYPE as *const _ as usize,
             w_code_tid,
         );
+        // `pytraceback.py:17 PyTraceback` — pre-registered here, right
+        // after PyCode, with a custom trace that forwards `w_next` /
+        // `w_code` and (when GC-owned) the raw `frame` edge so a frame
+        // reachable only through `tb.tb_frame` survives.  Like PyCode it
+        // stays in `all_foreign_pytypes()` and is skipped by the loop's
+        // `contains_key` guard, so the net register-call count through
+        // `W_MODULE_DICT_GC_TYPE_ID = 48` is unchanged (one explicit
+        // registration here, one fewer from the loop) — no downstream
+        // hardcoded tid shifts.  Allocation routes through
+        // `try_gc_alloc_stable` (`w_pytraceback_new`), so the trace fires
+        // for real oldgen tracebacks.
+        let w_pytraceback_tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
+            std::mem::size_of::<pyre_interpreter::pytraceback::PyTraceback>(),
+            object_tid,
+            pytraceback_object_custom_trace,
+        ));
+        debug_assert_eq!(
+            w_pytraceback_tid,
+            pyre_interpreter::pytraceback::PYTRACEBACK_GC_TYPE_ID
+        );
+        majit_gc::GcAllocator::register_vtable_for_type(
+            &mut gc,
+            &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE as *const _ as usize,
+            w_pytraceback_tid,
+        );
+        pytype_to_tid.insert(
+            &pyre_interpreter::pytraceback::PYTRACEBACK_TYPE as *const _ as usize,
+            w_pytraceback_tid,
+        );
         // W_ObjectObject's PyType (`INSTANCE_TYPE`) stays bound to
         // `object_tid` (`OBJECT_GC_TYPE_ID = 0`) in `pytype_to_tid`:
         // it is the `object` root, and giving the *vtable* a separate
@@ -1672,10 +1737,11 @@ thread_local! {
         // `int_between(cls.min, subcls.min, cls.max)` (rclass.py:1133).
         // `pyre_object::pyobject::all_foreign_pytypes()` covers object
         // module PyTypes; `pyre_interpreter::all_foreign_pytypes()`
-        // covers interpreter-level PyTypes (PYTRACEBACK_TYPE /
-        // FUNCTION_TYPE / BUILTIN_CODE_TYPE) that flow through tracing as
-        // constant callable/code pointers.  `CODE_TYPE` is pre-registered
-        // above (tid 43) and so skipped here by the `contains_key` guard.
+        // covers interpreter-level PyTypes (FUNCTION_TYPE /
+        // BUILTIN_CODE_TYPE) that flow through tracing as constant
+        // callable/code pointers.  `CODE_TYPE` and `PYTRACEBACK_TYPE` are
+        // both pre-registered above and so skipped here by the
+        // `contains_key` guard.
         for (pytype, parent) in pyre_object::pyobject::all_foreign_pytypes()
             .iter()
             .chain(pyre_interpreter::all_foreign_pytypes().iter())

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4034,6 +4034,23 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
                 } {
                     return LoopResult::Done(Err(err));
                 }
+                // A trace callback may perform a debugger line-jump by
+                // setting `frame.f_lineno` (`fset_f_lineno` → `last_instr
+                // = best_addr`).  The opcode for this iteration was
+                // decoded from the pre-jump `pc`; honour the jump by
+                // restarting the loop so the target is re-decoded,
+                // mirroring the interpreter loop's post-trace redirect.
+                // The baseline set before the trace is `last_instr =
+                // opcode_pc` (line above); a moved `last_instr` is the
+                // jump target.  This loop reads `pc = frame.next_instr()`
+                // (= `last_instr + 1`) at the top, so rebase the target
+                // through `set_last_instr_from_next_instr` for the next
+                // iteration to land on it rather than one past it.
+                if frame.last_instr as usize != opcode_pc {
+                    let jump_target = frame.last_instr as usize;
+                    frame.set_last_instr_from_next_instr(jump_target);
+                    continue;
+                }
             } else {
                 // executioncontext.py:163-165 — `actionflag.
                 // decrement_ticker(decr_by)` runs every bytecode, and


### PR DESCRIPTION
close #355 — make `PyFrame` a Python-visible `frame` W_Root following PyPy's
heap-frame + virtualizable model, and retire the `sys.namespace` frame stub for
the three frame producers (`sys._getframe`, trace/profile callbacks,
`traceback.tb_frame`).

Follows the issue's S1→S4 slicing. All changes are PyPy-faithful in structure
(CPython 3.14 behavior, PyPy/RPython implementation).

## Slices

- **S0** (`850ecb37bb`) — type-directed `PyFrame` GC trace via a custom hook
  (`pyframe_object_custom_trace`), replacing the fixed `gc_ptr_offsets`; closes
  the `w_builtin` / debug-data gaps and makes the locals-array walk
  regime-independent.
- **S1** (`1e1dafce11`) — give `PyFrame` a `PyObject` header (`ob_type` = the new
  `frame` type). Layout offsets in `frame_layout.rs` / vable / descr auto-shift
  off `offset_of!`; LLBC re-extracted.
- **S2** (`20a9ef9e1c`) — executing and generator frames get GC lifetime
  (policy A: no manual free at `leave`; reachability-collected). Three regimes:
  executing chain frames = Gc oldgen (walker greys), tracing snapshots = Box
  (deterministic Drop), generator frames = Gc + traced `frame_ptr` edge.
  type-37 destructor runs `PyFrame::drop` side-effects at sweep.
- **mark_stacks** (`0ad2b3b83a`) — port CPython 3.14's `mark_stacks` fixpoint
  stack-kind analysis so `f_lineno` writes validate debugger line jumps.
- **S3** (`8cf64132a6`) — `frame` typedef + all 13 GetSetProperty descriptors
  (`f_code`/`f_globals`/`f_locals`/`f_back`/`f_lasti`/`f_builtins` +
  `f_lineno`/`f_trace`/`f_trace_lines`/`f_trace_opcodes` + `clear`/`__repr__`);
  `sys._getframe()` returns the live frame + `mark_as_escaped`.
- **S4a** (`fc5f50af9c`) — trace/profile callbacks receive the real frame;
  `trace_frame_type` + `flush_trace_frame_writeback` deleted.
- **S4b** (`e8a0378706`) — `traceback.tb_frame` returns the real frame by making
  `PyTraceback` genuinely GC-managed (custom_trace forwards `w_next`/`w_code` +
  the `frame` edge guarded by `try_gc_owns_object`; oldgen allocation; tid pinned
  after PyCode, net-zero on downstream tids).

## Verification

- `check.py --backend dynasm,cranelift` → **171/171 both backends**.
- GC-stress probes (frames / generators / tracebacks held across `gc.collect()`
  under `PYPY_GC_NURSERY=131072`) green on both backends.

## Notes

- The `sys.namespace` frame stub (`make_traceback_frame_stub`) is kept only as a
  fallback for non-Gc frames (tracer Box snapshots / already-freed arena callees,
  which under `PYRE_JIT=0` are freed by the time a traceback is read) — returning
  such a frame would be a use-after-free. Under the production release+JIT path
  frames are Gc-owned oldgen blocks, so the real frame is returned.
- Arena/callee JIT frames are intentionally left as-is (PyPy virtualizes inlined
  callees to registers with no heap frame; the arena + `walk_jit_callee_frame_roots`
  is the faithful adaptation — making them GC garbage would lower parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
