### PR TITLE
jit: kept-stack branch guard bridge resume — vable stack overlay + deferred seed

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -8837,7 +8837,7 @@ fn vstack_enter_exception_handler(
 /// `resume_jitcode_pc_for`, used by the full-body walk to stamp a guard's
 /// snapshot with the Python opcode the blackhole resumes (and re-executes)
 /// at — matching the trait path's `orgpc` snapshot coordinate.
-fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
+pub(crate) fn python_pc_for_jitcode_pc(metadata: &crate::PyJitCodeMetadata, jit_pc: usize) -> u32 {
     // Exact inverse: `first_jit_pc_by_py_pc[py]` is the byte offset of the
     // FIRST instruction opcode `py` emitted (`usize::MAX` = the PC emitted
     // no jitcode of its own), so the containing opcode is the largest `py`

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1257,6 +1257,7 @@ pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         let length_i = all_liveness[off] as u32;
         let length_r = all_liveness[off + 1] as u32;
         let length_f = all_liveness[off + 2] as u32;
+        // #367 diagnostic removed — use post-decode logging instead.
         let mut cursor = off + 3;
         use majit_translate::liveness::LivenessIterator;
 
@@ -1482,6 +1483,23 @@ pub(crate) struct BridgeSemanticMaps {
 }
 
 pub(crate) fn bridge_semantic_maps_at(jitcode_index: i32, pc: i32) -> BridgeSemanticMaps {
+    bridge_semantic_maps_at_with_jitcode_pc(jitcode_index, pc, majit_ir::resumedata::NO_JITCODE_PC)
+}
+
+/// #367: when a kept-stack branch guard carries the guard's own jitcode
+/// coordinate (`jitcode_pc != NO_JITCODE_PC`), the pcdep/depth tables
+/// must be keyed at the GUARD's Python PC — the encode side
+/// (`collect_outer_active_boxes`) already keys its pcdep by
+/// `liveness_py_pc = guard_py_pc`, and the liveness decode
+/// (`frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`) resolves
+/// through the carried `jitcode_pc`. Without this the decode-side
+/// color→slot inversion reads the merge-target PC's pcdep (where the
+/// computed kept temp is dead), leaving the temp as `OpRef::NONE`.
+pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
+    jitcode_index: i32,
+    pc: i32,
+    jitcode_pc: i32,
+) -> BridgeSemanticMaps {
     ensure_finish_setup();
     METAINTERP_SD.with(|r| {
         let sd = r.borrow();
@@ -1516,7 +1534,21 @@ pub(crate) fn bridge_semantic_maps_at(jitcode_index: i32, pc: i32) -> BridgeSema
         // coordinate the Ref bank uses when the marker is set; that change is
         // deferred to the symbolic-stack work (#423) since an unvalidated
         // resume-coordinate flip can itself miscompile.
-        let real_pc = majit_ir::resumedata::decode_resume_pc(pc).0 as usize;
+        //
+        // #367: when the carried `jitcode_pc` is set (kept-stack branch
+        // guard), resolve the guard's Python PC from the jitcode coordinate
+        // and use it for the pcdep/depth lookup, matching the encode side's
+        // `liveness_py_pc = guard_py_pc` keying. The guard PC is where the
+        // computed kept operand-stack temps are live; at the merge-target PC
+        // they've been consumed and carry no pcdep entry.
+        let real_pc = if jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC && jitcode_pc >= 0 {
+            crate::jitcode_dispatch::python_pc_for_jitcode_pc(
+                &payload.metadata,
+                jitcode_pc as usize,
+            ) as usize
+        } else {
+            majit_ir::resumedata::decode_resume_pc(pc).0 as usize
+        };
         let stack_depth_at_pc = payload
             .metadata
             .depth_at_py_pc
@@ -7581,6 +7613,14 @@ impl JitState for PyreJitState {
             frame0.pc,
             frame0.jitcode_pc,
         );
+        // #367: for a kept-stack branch guard, the vable's
+        // `valuestackdepth` may reflect the merge-target depth (consumed
+        // stack) rather than the guard's deeper live depth. The guard PC's
+        // pcdep `stack_depth_at_pc` (from `depth_at_py_pc`, resolved through
+        // the carried `jitcode_pc`) IS the guard-time depth. Use the larger
+        // of the two so the color→slot inversion covers the kept temps.
+        // This is deferred until after `maps` is read (below, line ~7754)
+        // via a re-adjustment of the semantic mirror length.
         let stack_only = bridge_valuestackdepth.saturating_sub(nlocals);
         let bridge_reg_len = nlocals + stack_only;
         let mut bridge_registers_r = vec![OpRef::NONE; bridge_reg_len];
@@ -7618,25 +7658,12 @@ impl JitState for PyreJitState {
         // out) once validated, mirroring the LoadGlobal-fold / multiframe
         // gap-10 flips; the opt-out keeps the prior symbolic-bridge
         // behavior available for A/B.
-        let mut seed_bridge_locals =
-            std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
-        // A branch-guard kept-stack resume (`frame0.jitcode_pc` carries the
-        // guard's own jitcode pc; only kept-stack branch guards set it) resumes
-        // AT the guard pc with the not-taken arm's operand-stack temps still
-        // live (`lo <= x <= hi` keeps `x` below the compare truth; short-circuit
-        // `and`/`or` and the conditional expression keep their left operand).
-        // Stamping a concrete on such a kept operand freezes a downstream branch
-        // that consumes it: `x <= hi`'s residual compare const-folds against the
-        // seeded `x` to a `Const` bool, and `generate_guard` skips the guard for
-        // a `Const` condition (`isinstance(box, Const): return`) — so the second
-        // branch direction is pinned to the resuming iteration's `x` and the
-        // loop over/under-counts.  The kept operand must stay a symbolic input
-        // arg here (the guard fires, the value is guarded, not folded); the seed
-        // stays on the non-kept-stack resumes (guard_value / guard_class / plain
-        // short resumes) it was added for.  Only reachable with the guard-pc
-        // resume coordinate live (the `pc_map` baseline resumes past the pop, so
-        // the kept temp is absent from its frame and never seeded).
-        if seed_bridge_locals && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC {
+        let mut seed_bridge_locals = std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
+        // #367: kept-stack branch-guard bridges disable the concrete
+        // seed pending full Blocker 2 validation.
+        if seed_bridge_locals
+            && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC
+        {
             seed_bridge_locals = false;
         }
         let mut value_cursor = 0usize;
@@ -7709,7 +7736,6 @@ impl JitState for PyreJitState {
             sym.registers_f[reg_idx] = resolved;
             value_cursor += 1;
         }
-        let semantic_prefix_len = nlocals + stack_only;
         // Reconstruct the slot-indexed semantic register file
         // (`[locals.., stack_tail..]`) from the color-indexed resume decode.
         // The decode just filled `bridge_registers_r` by abstract-register
@@ -7723,7 +7749,39 @@ impl JitState for PyreJitState {
         // `[0,nlocals)` prefix to identity colors (now retired). Invert each
         // live color to its slot via `semantic_ref_slot_for_reg_color` so the
         // mirror is correct under freely-colored locals.
-        let maps = crate::state::bridge_semantic_maps_at(frame0.jitcode_index, frame0.pc);
+        let maps = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
+            frame0.jitcode_index,
+            frame0.pc,
+            frame0.jitcode_pc,
+        );
+        // #367: for a kept-stack branch guard, the vable's runtime
+        // `valuestackdepth` reflects the merge-target depth (post
+        // consumption) rather than the guard's deeper live depth. The
+        // guard-PC pcdep `stack_depth_at_pc` IS the guard-time depth
+        // (with kept temps live). Widen `semantic_prefix_len` to the
+        // pcdep depth so the color→slot inversion covers kept temps.
+        let stack_only = stack_only.max(maps.stack_depth_at_pc);
+        let semantic_prefix_len = nlocals + stack_only;
+        // Extend bridge_registers_r to cover the wider depth.
+        if bridge_registers_r.len() < semantic_prefix_len {
+            bridge_registers_r.resize(semantic_prefix_len, OpRef::NONE);
+        }
+        if majit_metainterp::majit_log_enabled()
+            && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC
+        {
+            let old_so = bridge_valuestackdepth.saturating_sub(nlocals);
+            eprintln!(
+                "[jit][#367-bridge] jitcode_pc={} pc={} pcdep={:?} \
+                 depth_at_guard={} vsd={} stack_only={}→{}",
+                frame0.jitcode_pc,
+                frame0.pc,
+                maps.pcdep_entries,
+                maps.stack_depth_at_pc,
+                bridge_valuestackdepth,
+                old_so,
+                stack_only,
+            );
+        }
         // virtualizable.py:86-98 + pyjitpl.py:3430 synchronize_virtualizable:
         // the frame's `locals_cells_stack_w` array (the vable image) is the
         // authoritative post-guard source for the frame's locals. At an

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1257,7 +1257,7 @@ pub fn frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
         let length_i = all_liveness[off] as u32;
         let length_r = all_liveness[off + 1] as u32;
         let length_f = all_liveness[off + 2] as u32;
-        // #367 diagnostic removed — use post-decode logging instead.
+        // Diagnostic removed — use post-decode logging instead.
         let mut cursor = off + 3;
         use majit_translate::liveness::LivenessIterator;
 
@@ -1486,7 +1486,7 @@ pub(crate) fn bridge_semantic_maps_at(jitcode_index: i32, pc: i32) -> BridgeSema
     bridge_semantic_maps_at_with_jitcode_pc(jitcode_index, pc, majit_ir::resumedata::NO_JITCODE_PC)
 }
 
-/// #367: when a kept-stack branch guard carries the guard's own jitcode
+/// When a kept-stack branch guard carries the guard's own jitcode
 /// coordinate (`jitcode_pc != NO_JITCODE_PC`), the pcdep/depth tables
 /// must be keyed at the GUARD's Python PC — the encode side
 /// (`collect_outer_active_boxes`) already keys its pcdep by
@@ -1535,7 +1535,7 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
         // deferred to the symbolic-stack work (#423) since an unvalidated
         // resume-coordinate flip can itself miscompile.
         //
-        // #367: when the carried `jitcode_pc` is set (kept-stack branch
+        // When the carried `jitcode_pc` is set (kept-stack branch
         // guard), resolve the guard's Python PC from the jitcode coordinate
         // and use it for the pcdep/depth lookup, matching the encode side's
         // `liveness_py_pc = guard_py_pc` keying. The guard PC is where the
@@ -7613,14 +7613,14 @@ impl JitState for PyreJitState {
             frame0.pc,
             frame0.jitcode_pc,
         );
-        // #367: for a kept-stack branch guard, the vable's
+        // For a kept-stack branch guard, the vable's
         // `valuestackdepth` may reflect the merge-target depth (consumed
         // stack) rather than the guard's deeper live depth. The guard PC's
         // pcdep `stack_depth_at_pc` (from `depth_at_py_pc`, resolved through
         // the carried `jitcode_pc`) IS the guard-time depth. Use the larger
         // of the two so the color→slot inversion covers the kept temps.
-        // This is deferred until after `maps` is read (below, line ~7754)
-        // via a re-adjustment of the semantic mirror length.
+        // This is deferred until after `maps` is read (below) via a
+        // re-adjustment of the semantic mirror length.
         let stack_only = bridge_valuestackdepth.saturating_sub(nlocals);
         let bridge_reg_len = nlocals + stack_only;
         let mut bridge_registers_r = vec![OpRef::NONE; bridge_reg_len];
@@ -7658,14 +7658,17 @@ impl JitState for PyreJitState {
         // out) once validated, mirroring the LoadGlobal-fold / multiframe
         // gap-10 flips; the opt-out keeps the prior symbolic-bridge
         // behavior available for A/B.
-        let mut seed_bridge_locals = std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
-        // #367: kept-stack branch-guard bridges disable the concrete
-        // seed pending full Blocker 2 validation.
-        if seed_bridge_locals
-            && frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC
-        {
-            seed_bridge_locals = false;
-        }
+        let mut seed_bridge_locals =
+            std::env::var("PYRE_FBW_BRIDGE_LOCAL_SEED").as_deref() != Ok("0");
+        // For kept-stack branch guards the body-internal marker's
+        // liveness colors do not 1:1-correspond to semantic slots — a
+        // color that lives a temp at the body marker may name a different
+        // slot at the guard PC.  Seeding concrete values at the
+        // consume_boxes stage (color-indexed) stamps the wrong value onto
+        // the OpRef, causing downstream branch folds to take the wrong
+        // direction.  Defer seeding to the post-overlay stage where the
+        // mirror is slot-indexed and values are authoritative.
+        let seed_deferred_to_overlay = frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC;
         let mut value_cursor = 0usize;
         for &reg_idx in &reg_indices.int {
             let value = &frame0.values[value_cursor];
@@ -7680,7 +7683,10 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
+            if seed_bridge_locals
+                && !seed_deferred_to_overlay
+                && !matches!(concrete_val, majit_ir::Value::Void)
+            {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;
@@ -7703,7 +7709,10 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
+            if seed_bridge_locals
+                && !seed_deferred_to_overlay
+                && !matches!(concrete_val, majit_ir::Value::Void)
+            {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;
@@ -7726,7 +7735,10 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
+            if seed_bridge_locals
+                && !seed_deferred_to_overlay
+                && !matches!(concrete_val, majit_ir::Value::Void)
+            {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;
@@ -7754,7 +7766,7 @@ impl JitState for PyreJitState {
             frame0.pc,
             frame0.jitcode_pc,
         );
-        // #367: for a kept-stack branch guard, the vable's runtime
+        // For a kept-stack branch guard, the vable's runtime
         // `valuestackdepth` reflects the merge-target depth (post
         // consumption) rather than the guard's deeper live depth. The
         // guard-PC pcdep `stack_depth_at_pc` IS the guard-time depth
@@ -7771,7 +7783,7 @@ impl JitState for PyreJitState {
         {
             let old_so = bridge_valuestackdepth.saturating_sub(nlocals);
             eprintln!(
-                "[jit][#367-bridge] jitcode_pc={} pc={} pcdep={:?} \
+                "[jit][kept-stack-bridge] jitcode_pc={} pc={} pcdep={:?} \
                  depth_at_guard={} vsd={} stack_only={}→{}",
                 frame0.jitcode_pc,
                 frame0.pc,
@@ -7913,6 +7925,27 @@ impl JitState for PyreJitState {
             for s in 0..nlocals {
                 overlay_local(&mut mirror[s], s);
             }
+            // Pcdep-live kept-stack colors absent from the body marker's
+            // liveness leave their stack slots NONE after the color→slot
+            // inversion above.  The vable image (`locals_cells_stack_w`)
+            // is authoritative post-guard, so fill NONE stack slots from
+            // it — symmetric to the local overlay.
+            for s in nlocals..semantic_prefix_len.min(mirror.len()) {
+                if mirror[s].is_none() {
+                    if let Some(v) = vable_array_items.get(s).copied() {
+                        if !v.is_none() {
+                            mirror[s] = v;
+                            if seed_bridge_locals {
+                                if let Some(&cv) = live_local_values.get(s) {
+                                    if !matches!(cv, majit_ir::Value::Void) {
+                                        ctx.try_set_opref_concrete(v, cv);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             mirror
         };
         let bridge_locals: Vec<OpRef> = semantic_mirror.iter().take(nlocals).copied().collect();
@@ -7960,6 +7993,24 @@ impl JitState for PyreJitState {
         // matching what the trace-time mirror reads expect — NOT the
         // color-indexed `bridge_registers_r`. Portal reds (frame/ec) live in
         // their dedicated `sym` fields, so they are absent here by design.
+        //
+        // Deferred concrete seeding for kept-stack branch guards.
+        // At the consume_boxes stage the register bank is color-indexed,
+        // and the body marker's colors may not correspond 1:1 to semantic
+        // slots — seeding there stamps the wrong value.  After the
+        // overlay the mirror is slot-indexed and authoritative, so seed
+        // each non-NONE slot from the GC-rooted live frame values.
+        if seed_bridge_locals && seed_deferred_to_overlay {
+            for (s, opref) in semantic_mirror.iter().enumerate() {
+                if !opref.is_none() {
+                    if let Some(&cv) = live_local_values.get(s) {
+                        if !matches!(cv, majit_ir::Value::Void) {
+                            ctx.try_set_opref_concrete(*opref, cv);
+                        }
+                    }
+                }
+            }
+        }
         sym.registers_r = semantic_mirror;
         sym.symbolic_local_types = {
             let mut types = bridge_local_types.clone();

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -4512,7 +4512,7 @@ fn filter_liveness_in_place(
         // map non-empty and the runtime on the correct (overlay) path.
         {
             let pcdep = pcdep_color_slots;
-            // #367: publish each member PC's OWN per-PC color→slot entry, NOT
+            // Publish each member PC's OWN per-PC color→slot entry, NOT
             // the cross-PC union. The folded `-live-` marker's `union_r` makes
             // the conservative-superset live SET correct (preserving extra
             // registers never harms), but UNIONing the (color, slot) inversion


### PR DESCRIPTION
## Summary

Resolve two bridge-compilation blockers for kept-stack branch guards (chained comparisons, short-circuit `and`/`or` patterns) that caused every guard failure to blackhole-walk instead of compiling a bridge.

### Changes

**Bridge pcdep coordinate alignment** (`5810d7c618`):
- `bridge_semantic_maps_at_with_jitcode_pc`: resolve guard PC via `python_pc_for_jitcode_pc` for pcdep/depth lookup, matching encode-side coordinate
- Depth widening: `stack_only = max(vsd, pcdep_depth)` covers kept temps

**Vable stack overlay + deferred seed** (`6641b45a1b`):
- Fill NONE stack slots from vable image after color→slot inversion, covering pcdep-live colors absent from body marker liveness (Blocker 2: ResidualCallArgUnbound)
- Defer concrete seeding to post-overlay slot-indexed mirror for kept-stack branch guards, avoiding body-marker color→slot mismatch (Blocker 1: GotoIfNotValueNotConcrete / seed miscompile)
- Align `const_ref_slots_at_pc_at` with the same jitcode_pc coordinate (pre-existing asymmetry fix from Codex parity review §3)

### Root causes

**Blocker 2**: Body-internal `-live-` marker's liveness group excludes pcdep-live colors → `bridge_registers_r[color]` = NONE → color→slot inversion produces NONE slot.

**Blocker 1**: Color-indexed consume_boxes seed stamps wrong concrete onto OpRef when body marker color ≠ guard PC semantic slot → downstream branch folds take wrong direction.

### Acceptance criteria (#367)

| Criterion | Status |
|---|---|
| AC1: Int/Float-bank unboxed operand-stack temp repro | **Latent** — Python operand stack is always W_Root (Ref-banked). `build_pcdep_color_slots` uses `Kind::Ref` only (`codewriter.rs:4794`). No Int/Float operand-stack slot is reachable in current codegen. Recorded as latent per issue instructions. |
| AC2: `pyre/check.py` green | ✅ dynasm 180/180, cranelift 180/180, wasm 180/180 |
| AC3: Byte-exact kept-stack corpus | ✅ `chained_comparison`, `kept_stack_branch_depths`, `kept_stack_depth_gt1`, `kept_stack_depth_gt1_heap` — all byte-exact vs CPython |
| AC4: `PYRE_PCDEP_VALIDATE` clean | ✅ No totality violations |

### Remaining structural work (latent, documented)

D1/D2 (typed pcdep producer/capture for Int/Float banks) are structurally incomplete but unreachable: the Ref-only limitation is latent because pyre's operand-stack image is all-`W_Root`. The decline `BranchGuardKeptStackUnsupported` is narrowed to `depth_gt_1 && !vstack_valid` (invalid-mirror-only, zero fires on corpus). These can be addressed when Int/Float-bank reachability is demonstrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)