### PR TITLE
#346: retire rtyper-legacy walker leaves — residualize statics/hooks + malloc_typed + subclass recognizer (census 47→37)

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -676,6 +676,18 @@ impl<'c> Lowerer<'c> {
                             __builder.residual_call_ref_canonical_via_target(__fn_idx, __typed_args, #reg);
                         },
                     );
+                    // jtransform.py:467-470 — a residual ref call can raise, so
+                    // the trailing `-live-` follows it exactly as the shared
+                    // path below emits for the other explicit residual arms.
+                    // This arm returns early (to attach `struct_type`), so it
+                    // cannot fall through to that shared emission and must emit
+                    // the marker itself.
+                    if post_live_after_call {
+                        self.emit_op(
+                            OpMeta::live_marker(),
+                            quote! { let _ = __builder.live_placeholder(); },
+                        );
+                    }
                     // Check `call_returns` config for a declared return
                     // struct type, enabling subsequent `result.field`
                     // access to resolve through `ref_fields`.

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -321,12 +321,20 @@ fn emit_helper_call_target_fn(
     // naming keeps it off the user-facing surface.
     let vis = &func.vis;
     let helper_name = &func.sig.ident;
+    // An `unsafe fn` helper must be called inside an `unsafe` block from the
+    // generated `extern "C"` trampoline; a safe helper is called bare (an
+    // `unsafe` wrapper there would be an unused-unsafe warning).
+    let call_expr = if func.sig.unsafety.is_some() {
+        quote! { unsafe { #helper_name(#(#converted_args),*) } }
+    } else {
+        quote! { #helper_name(#(#converted_args),*) }
+    };
     let wrapper = match helper_call_kind_for_return(&func.sig.output) {
         HelperCallKind::Void => quote! {
             #[doc(hidden)]
             #[allow(non_snake_case)]
             #vis extern "C" fn #trace_target_name(#(#wrapper_params),*) {
-                #helper_name(#(#converted_args),*);
+                #call_expr;
             }
         },
         HelperCallKind::Int | HelperCallKind::Ref => {
@@ -334,9 +342,7 @@ fn emit_helper_call_target_fn(
                 return Ok(None);
             };
             let Some(converted_return) = helper_return_to_i64(
-                quote! {
-                    #helper_name(#(#converted_args),*)
-                },
+                call_expr.clone(),
                 ty,
             ) else {
                 return Ok(None);
@@ -357,13 +363,11 @@ fn emit_helper_call_target_fn(
                 #[doc(hidden)]
                 #[allow(non_snake_case)]
                 #vis extern "C" fn #trace_target_name(#(#wrapper_params),*) -> f64 {
-                    #helper_name(#(#converted_args),*)
+                    #call_expr
                 }
             };
             let Some(concrete_return) = helper_return_to_i64(
-                quote! {
-                    #helper_name(#(#converted_args),*)
-                },
+                call_expr.clone(),
                 ty,
             ) else {
                 return Ok(None);

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -341,10 +341,7 @@ fn emit_helper_call_target_fn(
             let ReturnType::Type(_, ty) = &func.sig.output else {
                 return Ok(None);
             };
-            let Some(converted_return) = helper_return_to_i64(
-                call_expr.clone(),
-                ty,
-            ) else {
+            let Some(converted_return) = helper_return_to_i64(call_expr.clone(), ty) else {
                 return Ok(None);
             };
             quote! {
@@ -366,10 +363,7 @@ fn emit_helper_call_target_fn(
                     #call_expr
                 }
             };
-            let Some(concrete_return) = helper_return_to_i64(
-                call_expr.clone(),
-                ty,
-            ) else {
+            let Some(concrete_return) = helper_return_to_i64(call_expr.clone(), ty) else {
                 return Ok(None);
             };
             let concrete_wrapper = quote! {

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2088,7 +2088,10 @@ pub(crate) fn register_unsafe_fn_stubs(
 ///   `Void` result.
 /// - `core::f64::<Impl>::is_infinite` / `core::slice::<Impl>::is_empty`
 ///   return `bool` — `Bool` result.
-/// - `std::f64::<Impl>::floor` returns `f64` — `Float` result.
+/// - `std::f64::<Impl>::floor` / `std::f64::<Impl>::powf` return `f64` —
+///   `Float` result.
+/// - `core::f64::<Impl>::to_bits` returns `u64` reinterpreted as `i64` —
+///   `Signed` result.
 ///
 /// Paths whose faithful result is a non-scalar value the stub carrier
 /// cannot express (`alloc::fmt::format` → `String`,
@@ -2115,6 +2118,16 @@ const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
         &["std", "f64", "<Impl>", "floor"],
         &["self"],
         LowLevelType::Float,
+    ),
+    (
+        &["std", "f64", "<Impl>", "powf"],
+        &["self", "n"],
+        LowLevelType::Float,
+    ),
+    (
+        &["core", "f64", "<Impl>", "to_bits"],
+        &["self"],
+        LowLevelType::Signed,
     ),
 ];
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1579,6 +1579,25 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         if canonical_strip == ["lltype", "malloc_raw"] {
             continue;
         }
+        // The `pyobject::ll_issubclass` / `ll_issubclass_const` / `ll_isinstance`
+        // runtime helpers and their shared `subclass_range_read` seqlock body
+        // are never lifted: `flowspace_adapter::translate_op` rewrites every
+        // `ll_issubclass`/`ll_isinstance` call site into the high-level
+        // `issubtype`/`isinstance` op, which the rtyper lowers to a fresh
+        // `int_between`-over-`subclassrange` helper graph
+        // (`lowlevel_issubclass_helper_graph`, the `rclass.py:1133` body).  The
+        // pyre-object bodies additionally read `SUBCLASS_RANGE_SEQ` through a
+        // startup-only seqlock (an adaptation with no upstream analog) that the
+        // tracer cannot model; with all call sites rewritten these graphs are
+        // dead, so skip registering them rather than record a poison lift-error
+        // (the same shape as the `malloc_typed` skip above).
+        if canonical_strip == ["pyobject", "ll_issubclass"]
+            || canonical_strip == ["pyobject", "ll_issubclass_const"]
+            || canonical_strip == ["pyobject", "ll_isinstance"]
+            || canonical_strip == ["pyobject", "subclass_range_read"]
+        {
+            continue;
+        }
         let entry = if let Some(canonical_key) = by_canonical_path.get(&canonical_strip) {
             if canonical_key != &key {
                 registry.alias(key.clone(), canonical_key);

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1594,6 +1594,41 @@ pub fn translate_op(
                             FlowspaceOp::new("simple_call", vec![bound_method, source], result),
                         ]);
                     }
+                    // `ll_issubclass(subcls, cls)` / `ll_isinstance(obj, cls)`
+                    // (`pyre-object/src/pyobject.rs`, ports of `rclass.py:1133`
+                    // / `:1143`).  Their bodies read `subclassrange_{min,max}`
+                    // through a pyre-only seqlock (`subclass_range_read` over
+                    // `SUBCLASS_RANGE_SEQ`, an adaptation for the two-pass
+                    // startup renumbering that has no upstream analog); tracing
+                    // into that body stalls at the unmodellable static load.
+                    // Upstream never lets the JIT see the call: the rtyper
+                    // lowers `issubtype`/`isinstance` to `ll_issubclass`/
+                    // `ll_isinstance` and the inliner folds the helper into a
+                    // single `int_between` over the immutable vtable fields
+                    // (`OBJECT_VTABLE` `hints={'immutable': True}`,
+                    // rclass.py:167-174).  Mirror that by rewriting the
+                    // recognised call back into the high-level operation, so
+                    // `ClassRepr.rtype_issubtype` (`rclass.rs:1500`) /
+                    // `InstanceRepr.rtype_isinstance` (`rclass.rs:3682`) emit
+                    // the seqlock-free `int_between` helper the same as a
+                    // Python-level `issubtype`/`isinstance`.
+                    if segments.len() >= 2 && segments[segments.len() - 2] == "pyobject" {
+                        let leaf = segments[segments.len() - 1].as_str();
+                        let opname = match leaf {
+                            "ll_issubclass" => Some("issubtype"),
+                            "ll_isinstance" => Some("isinstance"),
+                            _ => None,
+                        };
+                        if let Some(opname) = opname {
+                            if arg_hls.len() != 2 {
+                                return Err(TyperError::message(format!(
+                                    "`{leaf}` requires exactly two args (value, class), got {}",
+                                    arg_hls.len()
+                                )));
+                            }
+                            return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
+                        }
+                    }
                     // Fail-closed on an UNFUSED `lltype::malloc_typed`.  Only the
                     // numeric boxing structs recognised by `fuse_boxing_alloc`
                     // (`model.rs payload_fields` — `W_FloatObject` / `W_IntObject`
@@ -4190,6 +4225,80 @@ mod tests {
             }
             other => panic!("result must be Variable, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn translate_op_ll_issubclass_call_rewrites_to_issubtype() {
+        // `ll_issubclass(subcls, cls)` (rclass.py:1133) must be recognised
+        // and rewritten to the flowspace `issubtype` op so the rtyper lowers
+        // it to `int_between` over the immutable subclassrange fields, rather
+        // than tracing into the pyre-only seqlock body.
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_fixture");
+        let vars = mint_vars(&mut graph, 4);
+        let subcls_hl = Variable::new();
+        let cls_hl = Variable::new();
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(subcls_hl.clone()));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(cls_hl.clone()));
+        value_map.insert(vars[3].clone(), Hlvalue::Variable(Variable::new()));
+        let op = SpaceOperation {
+            result: Some(vars[3].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["pyre_object".into(), "pyobject".into(), "ll_issubclass".into()],
+                },
+                args: vec![vars[1].clone(), vars[2].clone()],
+                result_ty: ValueType::Bool,
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("ll_issubclass must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(
+            translated[0].opname, "issubtype",
+            "ll_issubclass must emit the flowspace `issubtype` opname",
+        );
+        assert_eq!(translated[0].args.len(), 2, "issubtype args: [subcls, cls]");
+        match &translated[0].args[0] {
+            Hlvalue::Variable(v) => assert_eq!(v, &subcls_hl, "args[0] must be subcls"),
+            other => panic!("args[0] must be Variable, got {other:?}"),
+        }
+        match &translated[0].args[1] {
+            Hlvalue::Variable(v) => assert_eq!(v, &cls_hl, "args[1] must be cls"),
+            other => panic!("args[1] must be Variable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn translate_op_ll_isinstance_call_rewrites_to_isinstance() {
+        // `ll_isinstance(obj, cls)` (rclass.py:1143) recognised and rewritten
+        // to the flowspace `isinstance` op — same seqlock-free lowering path.
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_fixture");
+        let vars = mint_vars(&mut graph, 4);
+        let obj_hl = Variable::new();
+        let cls_hl = Variable::new();
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(obj_hl.clone()));
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(cls_hl.clone()));
+        value_map.insert(vars[3].clone(), Hlvalue::Variable(Variable::new()));
+        let op = SpaceOperation {
+            result: Some(vars[3].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["pyre_object".into(), "pyobject".into(), "ll_isinstance".into()],
+                },
+                args: vec![vars[1].clone(), vars[2].clone()],
+                result_ty: ValueType::Bool,
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("ll_isinstance must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(
+            translated[0].opname, "isinstance",
+            "ll_isinstance must emit the flowspace `isinstance` opname",
+        );
+        assert_eq!(translated[0].args.len(), 2, "isinstance args: [obj, cls]");
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -4245,7 +4245,11 @@ mod tests {
             result: Some(vars[3].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["pyre_object".into(), "pyobject".into(), "ll_issubclass".into()],
+                    segments: vec![
+                        "pyre_object".into(),
+                        "pyobject".into(),
+                        "ll_issubclass".into(),
+                    ],
                 },
                 args: vec![vars[1].clone(), vars[2].clone()],
                 result_ty: ValueType::Bool,
@@ -4285,7 +4289,11 @@ mod tests {
             result: Some(vars[3].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::FunctionPath {
-                    segments: vec!["pyre_object".into(), "pyobject".into(), "ll_isinstance".into()],
+                    segments: vec![
+                        "pyre_object".into(),
+                        "pyobject".into(),
+                        "ll_isinstance".into(),
+                    ],
                 },
                 args: vec![vars[1].clone(), vars[2].clone()],
                 result_ty: ValueType::Bool,

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -379,10 +379,11 @@ pub(crate) fn function_new_impl(
     let is_builtin =
         !code.is_null() && unsafe { crate::gateway::is_builtin_code(code as PyObjectRef) };
     if !is_builtin {
-        if let Some(raw) =
-            pyre_object::gc_hook::try_gc_alloc_stable(FUNCTION_GC_TYPE_ID, FUNCTION_OBJECT_SIZE)
-                .filter(|p| !p.is_null())
-        {
+        let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
+            FUNCTION_GC_TYPE_ID,
+            FUNCTION_OBJECT_SIZE,
+        );
+        if !raw.is_null() {
             unsafe {
                 std::ptr::write(raw as *mut Function, function);
             }

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -308,7 +308,16 @@ pub fn function_new_with_closure(
     )
 }
 
-fn function_new_impl(
+/// Allocate a `Function` object, GC-managed for user code and immortal for
+/// builtin code.
+///
+/// Reads `FUNCTION_OBJECT_SIZE`/`FUNCTION_GC_TYPE_ID` and calls
+/// `lltype::malloc_typed` (`NewWithVtable`) the tracer cannot model; the JIT
+/// residualises the call instead of tracing into it
+/// (`@dont_look_inside`, `rlib/jit.py:139`), the `box_str_constant` /
+/// `try_gc_add_root` twin.
+#[majit_macros::dont_look_inside]
+pub(crate) fn function_new_impl(
     ob_type: &'static PyType,
     code: *const (),
     name: String,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -435,6 +435,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::gc_roots::shadow_stack_get",
+        "pyre_object::shadow_stack_get",
+        pyre_object::gc_roots::shadow_stack_get as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::typeobject::w_type_set_uses_object_setattr",
         "pyre_object::w_type_set_uses_object_setattr",
         crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),
@@ -513,6 +519,15 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::function::function_new_impl",
         "pyre_interpreter::function_new_impl",
         crate::function::function_new_impl as *const (),
+    );
+    // #346: null-collapsing stable-alloc primitive residualised via
+    // `#[dont_look_inside]`, keeping the thread-local GC hook dispatch out of
+    // the trace.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_alloc_stable_raw",
+        "pyre_object::try_gc_alloc_stable_raw",
+        pyre_object::gc_hook::try_gc_alloc_stable_raw as *const (),
     );
     push_fnaddr(
         &mut entries,

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -492,6 +492,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_add_root",
         pyre_object::gc_hook::try_gc_add_root as *const (),
     );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_remove_root",
+        "pyre_object::try_gc_remove_root",
+        pyre_object::gc_hook::try_gc_remove_root as *const (),
+    );
     // #346: four direct `malloc_typed` (`NewWithVtable`) roots residualised
     // via `#[dont_look_inside]`; each binds both the qualified module path and
     // the glob-re-exported root alias. `function_new_impl` lives in this crate
@@ -538,6 +544,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         &mut entries,
         "pyre_interpreter::objspace::std::mapdict::_obj_setdict",
         crate::objspace::std::mapdict::_obj_setdict as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::std::mapdict::_obj_getdict",
+        crate::objspace::std::mapdict::_obj_getdict as *const (),
     );
     // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic and
     // `longobject::bigint_gc_type_id` reads the init-assigned `BIGINT_GC_TYPE_ID`

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -461,6 +461,31 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::pin_root",
         pyre_object::gc_roots::pin_root as *const (),
     );
+    // `mark_prebuilt_roots_dirty` sets the static `PREBUILT_ROOTS_DIRTY`
+    // bit, `box_str_constant` reads the TLS `STRING_CONSTANT_CACHE`, and
+    // `try_gc_add_root` dispatches the TLS `GC_ADD_ROOT_HOOK` — all through
+    // state the tracer cannot model (the `pin_root` / `try_gc_write_barrier`
+    // twins).  Their `#[dont_look_inside]` calls bind the Rust `fn` directly
+    // by qualified path (`-> ()` / pointer / `-> bool` signatures are
+    // JIT-representable).
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_roots::mark_prebuilt_roots_dirty",
+        "pyre_object::mark_prebuilt_roots_dirty",
+        pyre_object::gc_roots::mark_prebuilt_roots_dirty as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::unicodeobject::box_str_constant",
+        "pyre_object::box_str_constant",
+        pyre_object::unicodeobject::box_str_constant as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_add_root",
+        "pyre_object::try_gc_add_root",
+        pyre_object::gc_hook::try_gc_add_root as *const (),
+    );
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::module::_weakref::interp__weakref::dereference",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -486,6 +486,34 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_add_root",
         pyre_object::gc_hook::try_gc_add_root as *const (),
     );
+    // #346: four direct `malloc_typed` (`NewWithVtable`) roots residualised
+    // via `#[dont_look_inside]`; each binds both the qualified module path and
+    // the glob-re-exported root alias. `function_new_impl` lives in this crate
+    // so it binds through `crate::`.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::bytesobject::w_bytes_from_bytes",
+        "pyre_object::w_bytes_from_bytes",
+        pyre_object::bytesobject::w_bytes_from_bytes as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::alloc_dict_object",
+        "pyre_object::alloc_dict_object",
+        pyre_object::dictmultiobject::alloc_dict_object as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_module_dict_new_with_storage_proxy",
+        "pyre_object::w_module_dict_new_with_storage_proxy",
+        pyre_object::dictmultiobject::w_module_dict_new_with_storage_proxy as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::function::function_new_impl",
+        "pyre_interpreter::function_new_impl",
+        crate::function::function_new_impl as *const (),
+    );
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::module::_weakref::interp__weakref::dereference",

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2905,6 +2905,13 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
 ///     assert flag
 ///     return w_dict
 /// ```
+///
+/// `dont_look_inside` — the `_obj_setdict` read twin: the miss path reads
+/// the address-keyed `INSTANCE_DICT` thread-local side table (and allocates
+/// a fresh dict), state the tracer cannot model; the call residualises via
+/// the registered fnaddr (`@objectmodel.dont_inline` upstream,
+/// mapdict.py:826).
+#[majit_macros::dont_look_inside]
 pub fn _obj_getdict(self_ref: PyObjectRef) -> PyObjectRef {
     // mapdict.py:828-838: read the "dict" SPECIAL slot; on a miss build the
     // MapDictStrategy view and write it back into that slot. `strategy.erase(self)`

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -305,12 +305,11 @@ impl FrameBox {
     /// `pyframe_object_custom_trace`) is regime-independent; `Drop`
     /// distinguishes them with `try_gc_owns_object`.
     pub fn new(frame: PyFrame) -> Self {
-        if let Some(raw) = pyre_object::gc_hook::try_gc_alloc_stable(
+        let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
             PYFRAME_GC_TYPE_ID,
             std::mem::size_of::<PyFrame>(),
-        )
-        .filter(|p| !p.is_null())
-        {
+        );
+        if !raw.is_null() {
             pyre_object::gc_interp::note_alloc();
             let ptr = raw as *mut PyFrame;
             unsafe {

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -132,10 +132,9 @@ pub fn w_pytraceback_new(
     // pointers), mirroring `FrameBox::new` (`pyframe.rs:307`).  Before
     // the GC hook is wired (bootstrap, tests) `try_gc_alloc_stable`
     // returns `None`; fall back to the leaked `malloc_typed` block.
-    if let Some(raw) =
-        pyre_object::gc_hook::try_gc_alloc_stable(PYTRACEBACK_GC_TYPE_ID, PYTRACEBACK_OBJECT_SIZE)
-            .filter(|p| !p.is_null())
-    {
+    let raw =
+        pyre_object::gc_hook::try_gc_alloc_stable_raw(PYTRACEBACK_GC_TYPE_ID, PYTRACEBACK_OBJECT_SIZE);
+    if !raw.is_null() {
         pyre_object::gc_interp::note_alloc();
         let ptr = raw as *mut PyTraceback;
         unsafe {

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -132,8 +132,10 @@ pub fn w_pytraceback_new(
     // pointers), mirroring `FrameBox::new` (`pyframe.rs:307`).  Before
     // the GC hook is wired (bootstrap, tests) `try_gc_alloc_stable`
     // returns `None`; fall back to the leaked `malloc_typed` block.
-    let raw =
-        pyre_object::gc_hook::try_gc_alloc_stable_raw(PYTRACEBACK_GC_TYPE_ID, PYTRACEBACK_OBJECT_SIZE);
+    let raw = pyre_object::gc_hook::try_gc_alloc_stable_raw(
+        PYTRACEBACK_GC_TYPE_ID,
+        PYTRACEBACK_OBJECT_SIZE,
+    );
     if !raw.is_null() {
         pyre_object::gc_interp::note_alloc();
         let ptr = raw as *mut PyTraceback;

--- a/pyre/pyre-object/src/bytesobject.rs
+++ b/pyre/pyre-object/src/bytesobject.rs
@@ -35,6 +35,11 @@ impl crate::lltype::GcType for W_BytesObject {
 }
 
 /// Allocate a new bytes object from a byte slice.
+///
+/// Allocates the `W_BytesObject` via `malloc_typed` (`NewWithVtable`) which
+/// the tracer cannot model; the JIT residualises the call instead of tracing
+/// into it (`@dont_look_inside`, `rlib/jit.py:139`).
+#[majit_macros::dont_look_inside]
 pub fn w_bytes_from_bytes(bytes: &[u8]) -> PyObjectRef {
     let len = bytes.len();
     // The `data` Vec lives on the raw heap (manually freed elsewhere),

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -41,11 +41,10 @@ pub fn w_super_new(super_type: PyObjectRef, obj: PyObjectRef) -> PyObjectRef {
         ob_type: &SUPER_TYPE as *const PyType,
         w_class: get_instantiate(&SUPER_TYPE),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable(W_SUPER_GC_TYPE_ID, W_SUPER_OBJECT_SIZE)
-        .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_SUPER_GC_TYPE_ID, W_SUPER_OBJECT_SIZE);
     let super_type = crate::gc_roots::shadow_stack_get(save_point);
     let obj = crate::gc_roots::shadow_stack_get(save_point + 1);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_Super,
@@ -146,12 +145,12 @@ pub fn w_property_new(fget: PyObjectRef, fset: PyObjectRef, fdel: PyObjectRef) -
         ob_type: &PROPERTY_TYPE as *const PyType,
         w_class: get_instantiate(&PROPERTY_TYPE),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable(W_PROPERTY_GC_TYPE_ID, W_PROPERTY_OBJECT_SIZE)
-        .filter(|p| !p.is_null());
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable_raw(W_PROPERTY_GC_TYPE_ID, W_PROPERTY_OBJECT_SIZE);
     let fget = crate::gc_roots::shadow_stack_get(save_point);
     let fset = crate::gc_roots::shadow_stack_get(save_point + 1);
     let fdel = crate::gc_roots::shadow_stack_get(save_point + 2);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_Property,

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -870,16 +870,19 @@ pub unsafe fn w_dict_walk_entries_mut(obj: PyObjectRef, mut visitor: impl FnMut(
 #[majit_macros::dont_look_inside]
 pub fn alloc_dict_object(value: W_DictObject, stable: bool) -> PyObjectRef {
     let raw = if stable {
-        crate::gc_hook::try_gc_alloc_stable(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
+        crate::gc_hook::try_gc_alloc_stable_raw(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
     } else {
         crate::gc_hook::try_gc_alloc(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
+            .filter(|p| !p.is_null())
+            .unwrap_or(std::ptr::null_mut())
     };
-    match raw.filter(|p| !p.is_null()) {
-        Some(raw) => unsafe {
+    if !raw.is_null() {
+        unsafe {
             std::ptr::write(raw as *mut W_DictObject, value);
             raw as PyObjectRef
-        },
-        None => crate::lltype::malloc_typed(value) as PyObjectRef,
+        }
+    } else {
+        crate::lltype::malloc_typed(value) as PyObjectRef
     }
 }
 

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -860,7 +860,15 @@ pub unsafe fn w_dict_walk_entries_mut(obj: PyObjectRef, mut visitor: impl FnMut(
     }
 }
 
-fn alloc_dict_object(value: W_DictObject, stable: bool) -> PyObjectRef {
+/// Allocate and initialise a heap `W_DictObject`.
+///
+/// Dispatches the thread-local GC allocation hook (`try_gc_alloc` /
+/// `try_gc_alloc_stable`) the tracer cannot model, falling back to
+/// `lltype::malloc_typed` (`NewWithVtable`); the JIT residualises the
+/// call instead of tracing into it (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the `box_str_constant` / `try_gc_add_root` twin.
+#[majit_macros::dont_look_inside]
+pub fn alloc_dict_object(value: W_DictObject, stable: bool) -> PyObjectRef {
     let raw = if stable {
         crate::gc_hook::try_gc_alloc_stable(W_DICT_GC_TYPE_ID, W_DICT_OBJECT_SIZE)
     } else {
@@ -1035,6 +1043,14 @@ pub fn w_module_dict_new() -> PyObjectRef {
 /// `ns` on a local miss.  Used by `dict_storage_to_dict` so source
 /// modules surface as W_ModuleDictObject while the frame-side
 /// `PyFrame.w_globals = *mut DictStorage` carrier still works.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`):
+/// the body performs an unported `lltype::malloc_typed` NewWithVtable
+/// (`W_ModuleDictObject`) that survives `fuse_boxing_alloc` unfused, so
+/// the JIT residualises the whole call to a stable runtime fnaddr
+/// instead of tracing the allocation.  The `-> PyObjectRef` result is a
+/// plain GCREF with no discriminant to erase.
+#[majit_macros::dont_look_inside]
 pub fn w_module_dict_new_with_storage_proxy(ns: *mut u8) -> PyObjectRef {
     let strategy = crate::lltype::malloc_raw(crate::celldict::ModuleDictStrategy::new());
     let storage = unsafe { crate::lltype::malloc_raw((*strategy).get_empty_storage()) };

--- a/pyre/pyre-object/src/dictproxyobject.rs
+++ b/pyre/pyre-object/src/dictproxyobject.rs
@@ -83,10 +83,9 @@ pub fn w_dict_proxy_new(w_mapping: PyObjectRef) -> PyObjectRef {
         w_class: get_instantiate(&MAPPING_PROXY_TYPE),
     };
     let raw =
-        crate::gc_hook::try_gc_alloc_stable(W_DICT_PROXY_GC_TYPE_ID, W_DICT_PROXY_OBJECT_SIZE)
-            .filter(|p| !p.is_null());
+        crate::gc_hook::try_gc_alloc_stable_raw(W_DICT_PROXY_GC_TYPE_ID, W_DICT_PROXY_OBJECT_SIZE);
     let w_mapping = crate::gc_roots::shadow_stack_get(save_point);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_DictProxyObject,

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -59,8 +59,7 @@ pub fn w_float_new(value: f64) -> PyObjectRef {
         floatval: value,
     };
     if crate::gc_interp::enabled() {
-        let raw =
-            crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
+        let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
         if !raw.is_null() {
             crate::gc_interp::note_alloc();
             unsafe {

--- a/pyre/pyre-object/src/floatobject.rs
+++ b/pyre/pyre-object/src/floatobject.rs
@@ -59,10 +59,9 @@ pub fn w_float_new(value: f64) -> PyObjectRef {
         floatval: value,
     };
     if crate::gc_interp::enabled() {
-        if let Some(raw) =
-            crate::gc_hook::try_gc_alloc_stable(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE)
-                .filter(|p| !p.is_null())
-        {
+        let raw =
+            crate::gc_hook::try_gc_alloc_stable_raw(W_FLOAT_GC_TYPE_ID, W_FLOAT_OBJECT_SIZE);
+        if !raw.is_null() {
             crate::gc_interp::note_alloc();
             unsafe {
                 std::ptr::write(raw as *mut W_FloatObject, obj);

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -47,14 +47,13 @@ pub fn w_method_new(
         ob_type: &METHOD_TYPE as *const PyType,
         w_class: get_instantiate(&METHOD_TYPE),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable(W_METHOD_GC_TYPE_ID, W_METHOD_OBJECT_SIZE)
-        .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_METHOD_GC_TYPE_ID, W_METHOD_OBJECT_SIZE);
     // Re-read the pinned roots after the allocation; a minor collection
     // inside the GC malloc may have relocated them.
     let w_function = crate::gc_roots::shadow_stack_get(save_point);
     let w_self = crate::gc_roots::shadow_stack_get(save_point + 1);
     let w_class = crate::gc_roots::shadow_stack_get(save_point + 2);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut Method,
@@ -122,11 +121,12 @@ pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
         ob_type: &STATICMETHOD_TYPE as *const PyType,
         w_class: get_instantiate(&STATICMETHOD_TYPE),
     };
-    let raw =
-        crate::gc_hook::try_gc_alloc_stable(W_STATICMETHOD_GC_TYPE_ID, W_STATICMETHOD_OBJECT_SIZE)
-            .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        W_STATICMETHOD_GC_TYPE_ID,
+        W_STATICMETHOD_OBJECT_SIZE,
+    );
     let func = crate::gc_roots::shadow_stack_get(save_point);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut StaticMethod,
@@ -176,11 +176,12 @@ pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
         ob_type: &CLASSMETHOD_TYPE as *const PyType,
         w_class: get_instantiate(&CLASSMETHOD_TYPE),
     };
-    let raw =
-        crate::gc_hook::try_gc_alloc_stable(W_CLASSMETHOD_GC_TYPE_ID, W_CLASSMETHOD_OBJECT_SIZE)
-            .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        W_CLASSMETHOD_GC_TYPE_ID,
+        W_CLASSMETHOD_OBJECT_SIZE,
+    );
     let func = crate::gc_roots::shadow_stack_get(save_point);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut ClassMethod,

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -345,7 +345,10 @@ pub fn clear_gc_root_hooks() {
 /// # Safety
 /// Caller must keep `slot` valid until [`try_gc_remove_root`] is
 /// called with the same pointer.
-#[inline]
+// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell`
+// indirection) stays opaque to the JIT — the `try_gc_write_barrier`
+// twin; calls residualize via the registered fnaddr (`rlib/jit.py:139`).
+#[majit_macros::dont_look_inside]
 pub unsafe fn try_gc_add_root(slot: *mut *mut u8) -> bool {
     GC_ADD_ROOT_HOOK.with(|cell| match cell.get() {
         Some(f) => {

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -78,6 +78,20 @@ pub fn try_gc_alloc_stable(type_id: u32, payload_size: usize) -> Option<*mut u8>
     GC_ALLOC_STABLE_HOOK.with(|cell| cell.get().map(|f| f(type_id, payload_size)))
 }
 
+/// Null-collapsing view of [`try_gc_alloc_stable`] for JIT-traced callers.
+///
+/// Returns `null` both when no hook is installed and when the hook itself
+/// returned `null`; every traced caller already treats those two cases
+/// identically (fall back to `malloc_typed`), so the `Option` discriminant
+/// carries no information the caller reads.  Residualising this primitive
+/// (`@dont_look_inside`, `rlib/jit.py:139`) keeps the thread-local hook
+/// dispatch out of the trace — a `*mut u8` return has no discriminant to
+/// erase, unlike the `Option<*mut u8>` accessor.
+#[majit_macros::dont_look_inside]
+pub fn try_gc_alloc_stable_raw(type_id: u32, payload_size: usize) -> *mut u8 {
+    try_gc_alloc_stable(type_id, payload_size).unwrap_or(core::ptr::null_mut())
+}
+
 thread_local! {
     static GC_ALLOC_COLLECTING_HOOK: Cell<Option<GcAllocHookFn>> = const { Cell::new(None) };
 }

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -375,7 +375,10 @@ pub unsafe fn try_gc_add_root(slot: *mut *mut u8) -> bool {
 
 /// Remove a previously-registered root via the installed callback.
 /// Returns `true` when the callback was invoked.
-#[inline]
+// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell`
+// indirection) stays opaque to the JIT — the `try_gc_add_root` twin;
+// calls residualize via the registered fnaddr (`rlib/jit.py:139`).
+#[majit_macros::dont_look_inside]
 pub fn try_gc_remove_root(slot: *mut *mut u8) -> bool {
     GC_REMOVE_ROOT_HOOK.with(|cell| match cell.get() {
         Some(f) => {

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -207,7 +207,11 @@ static PREBUILT_ROOTS_DIRTY: AtomicBool = AtomicBool::new(true);
 /// (incminimark `remember_young_pointer` analog).  Call from every helper
 /// that stores a `PyObjectRef` into a structure reached only by the
 /// `walk_pyframe_roots` band-aid walks.
-#[inline]
+///
+/// Sets the static `PREBUILT_ROOTS_DIRTY` bit the tracer cannot model; the
+/// JIT residualises the call instead of tracing into it (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the `pin_root` twin.
+#[majit_macros::dont_look_inside]
 pub fn mark_prebuilt_roots_dirty() {
     PREBUILT_ROOTS_DIRTY.store(true, Ordering::Relaxed);
 }

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -151,7 +151,11 @@ pub fn shadow_stack_len() -> usize {
 /// is out of bounds. Used by tests and ad-hoc host-side debugging to
 /// confirm the slot contents survive across nested brackets — the GC
 /// itself uses [`walk_shadow_stack`] for the collection-time visit.
-#[inline]
+///
+/// Reads the thread-local `SHADOW_STACK` the tracer cannot type; the JIT
+/// residualises the read instead of tracing into it (`@dont_look_inside`,
+/// `rlib/jit.py:139`), the [`shadow_stack_len`] twin.
+#[majit_macros::dont_look_inside]
 pub fn shadow_stack_get(index: usize) -> PyObjectRef {
     SHADOW_STACK.with(|s| s.borrow()[index])
 }

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -59,10 +59,8 @@ pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
     // memory. Allocate stable (non-moving old-gen) so the many raw
     // `*GeneratorIterator` / `frame_ptr` readers keep a fixed address, and
     // fall back to the immortal alloc only when the GC is not installed.
-    if let Some(raw) =
-        crate::gc_hook::try_gc_alloc_stable(W_GENERATOR_GC_TYPE_ID, W_GENERATOR_OBJECT_SIZE)
-            .filter(|p| !p.is_null())
-    {
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_GENERATOR_GC_TYPE_ID, W_GENERATOR_OBJECT_SIZE);
+    if !raw.is_null() {
         crate::gc_interp::note_alloc();
         unsafe {
             std::ptr::write(raw as *mut GeneratorIterator, value);

--- a/pyre/pyre-object/src/generator.rs
+++ b/pyre/pyre-object/src/generator.rs
@@ -59,7 +59,8 @@ pub fn w_generator_new(frame_ptr: *mut u8) -> PyObjectRef {
     // memory. Allocate stable (non-moving old-gen) so the many raw
     // `*GeneratorIterator` / `frame_ptr` readers keep a fixed address, and
     // fall back to the immortal alloc only when the GC is not installed.
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_GENERATOR_GC_TYPE_ID, W_GENERATOR_OBJECT_SIZE);
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable_raw(W_GENERATOR_GC_TYPE_ID, W_GENERATOR_OBJECT_SIZE);
     if !raw.is_null() {
         crate::gc_interp::note_alloc();
         unsafe {

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -100,9 +100,8 @@ pub fn w_int_new(value: i64) -> PyObjectRef {
         intval: value,
     };
     if crate::gc_interp::enabled() {
-        if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE)
-            .filter(|p| !p.is_null())
-        {
+        let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
+        if !raw.is_null() {
             crate::gc_interp::note_alloc();
             unsafe {
                 std::ptr::write(raw as *mut W_IntObject, obj);

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -530,22 +530,18 @@ fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> 
     // `list_object_custom_trace` and remembered by `list_write_barrier` below;
     // `int_items.block` / `float_items.block` are old-gen leaf arrays the same
     // trace marks live.
-    let raw = match crate::gc_hook::try_gc_alloc_stable(W_LIST_GC_TYPE_ID, W_LIST_OBJECT_SIZE)
-        .filter(|p| !p.is_null())
-    {
-        Some(p) => p,
-        None => {
-            let boxed = Box::new(W_ListObject {
-                ob_header: header,
-                length,
-                items: items_block,
-                strategy,
-                int_items,
-                float_items,
-            });
-            return Box::into_raw(boxed) as PyObjectRef;
-        }
-    };
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_LIST_GC_TYPE_ID, W_LIST_OBJECT_SIZE);
+    if raw.is_null() {
+        let boxed = Box::new(W_ListObject {
+            ob_header: header,
+            length,
+            items: items_block,
+            strategy,
+            int_items,
+            float_items,
+        });
+        return Box::into_raw(boxed) as PyObjectRef;
+    }
     // Re-read the (possibly relocated) nursery items block after the header alloc.
     if let Some(s) = block_root {
         items_block = crate::gc_roots::shadow_stack_get(s) as *mut ItemsBlock;

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -177,9 +177,8 @@ pub fn alloc_bigint_nursery_collecting(value: BigInt) -> *mut BigInt {
 pub fn alloc_bigint_stable(value: BigInt) -> *mut BigInt {
     let tid = bigint_gc_type_id();
     if tid != 0 {
-        if let Some(raw) =
-            crate::gc_hook::try_gc_alloc_stable(tid, BIGINT_PAYLOAD_SIZE).filter(|p| !p.is_null())
-        {
+        let raw = crate::gc_hook::try_gc_alloc_stable_raw(tid, BIGINT_PAYLOAD_SIZE);
+        if !raw.is_null() {
             // Charge the limb-`Vec` bytes against the old-gen external total so a
             // directly-old-gen bignum's footprint enters the major threshold now,
             // not only at the next major's recompute. No minor is forced, so this
@@ -228,13 +227,13 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
         // rooted as a GcRef slot rather than a PyObjectRef.
         let mut slot = value as *mut u8;
         let pinned = unsafe { crate::gc_hook::try_gc_add_root(&mut slot as *mut *mut u8) };
-        let raw = crate::gc_hook::try_gc_alloc_stable(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE)
-            .filter(|p| !p.is_null());
+        let raw =
+            crate::gc_hook::try_gc_alloc_stable_raw(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE);
         let value = slot as *mut BigInt;
         if pinned {
             crate::gc_hook::try_gc_remove_root(&mut slot as *mut *mut u8);
         }
-        if let Some(raw) = raw {
+        if !raw.is_null() {
             // Advance the dispatch-loop safepoint counter, as w_int_new /
             // w_float_new do for their stable allocs — otherwise a long-dominated
             // interpreter workload never reaches the safepoint threshold and the

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -227,8 +227,7 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
         // rooted as a GcRef slot rather than a PyObjectRef.
         let mut slot = value as *mut u8;
         let pinned = unsafe { crate::gc_hook::try_gc_add_root(&mut slot as *mut *mut u8) };
-        let raw =
-            crate::gc_hook::try_gc_alloc_stable_raw(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE);
+        let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_LONG_GC_TYPE_ID, W_LONG_OBJECT_SIZE);
         let value = slot as *mut BigInt;
         if pinned {
             crate::gc_hook::try_gc_remove_root(&mut slot as *mut *mut u8);

--- a/pyre/pyre-object/src/memoryview.rs
+++ b/pyre/pyre-object/src/memoryview.rs
@@ -61,17 +61,15 @@ pub fn w_memoryview_alloc_header(released: bool) -> PyObjectRef {
         view: std::ptr::null(),
         released,
     };
-    match crate::gc_hook::try_gc_alloc_stable(
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         <W_MemoryView as crate::lltype::GcType>::type_id(),
         <W_MemoryView as crate::lltype::GcType>::SIZE,
-    )
-    .filter(|p| !p.is_null())
-    {
-        Some(raw) => {
-            unsafe { std::ptr::write(raw as *mut W_MemoryView, payload) };
-            raw as PyObjectRef
-        }
-        None => crate::lltype::malloc_typed(payload) as PyObjectRef,
+    );
+    if !raw.is_null() {
+        unsafe { std::ptr::write(raw as *mut W_MemoryView, payload) };
+        raw as PyObjectRef
+    } else {
+        crate::lltype::malloc_typed(payload) as PyObjectRef
     }
 }
 

--- a/pyre/pyre-object/src/nestedscope.rs
+++ b/pyre/pyre-object/src/nestedscope.rs
@@ -37,10 +37,9 @@ pub fn w_cell_new(value: PyObjectRef) -> PyObjectRef {
     // closure cellvar) must itself be GC-traced; a `malloc_typed`
     // (`std::alloc`) cell is invisible to `is_managed_heap_object`, so the
     // mark-sweep skips it and the only-reachable-via-cell value is swept.
-    let raw = crate::gc_hook::try_gc_alloc_stable(W_CELL_GC_TYPE_ID, W_CELL_OBJECT_SIZE)
-        .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_CELL_GC_TYPE_ID, W_CELL_OBJECT_SIZE);
     let value = crate::gc_roots::shadow_stack_get(save_point);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut Cell,

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -249,12 +249,11 @@ pub unsafe fn dealloc_instance_items_block(block: *mut ItemsBlock) {
 /// when no GC hook is installed. `cap` may be zero (header-only block).
 unsafe fn alloc_mapdict_storage_block(cap: usize) -> *mut ItemsBlock {
     let payload = ITEMS_BLOCK_ITEMS_OFFSET + cap * std::mem::size_of::<PyObjectRef>();
-    if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(W_MAPDICT_STORAGE_GC_TYPE_ID, payload) {
-        if !raw.is_null() {
-            let block = raw as *mut ItemsBlock;
-            unsafe { (*block).capacity = cap };
-            return block;
-        }
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_MAPDICT_STORAGE_GC_TYPE_ID, payload);
+    if !raw.is_null() {
+        let block = raw as *mut ItemsBlock;
+        unsafe { (*block).capacity = cap };
+        return block;
     }
     unsafe { alloc_items_block(cap) }
 }
@@ -603,19 +602,18 @@ pub unsafe fn alloc_typed_items_block(cap: usize, tid: u32) -> *mut TypedItemsBl
     let cap = cap.max(1);
     if itemsblock_gc_enabled() {
         let payload = TYPED_ITEMS_BLOCK_ITEMS_OFFSET + cap * std::mem::size_of::<u64>();
-        if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(tid, payload) {
-            if !raw.is_null() {
-                let block = raw as *mut TypedItemsBlock;
-                unsafe {
-                    (*block).capacity = cap;
-                    std::ptr::write_bytes(
-                        typed_items_block_items_base(block),
-                        0,
-                        cap * std::mem::size_of::<u64>(),
-                    );
-                }
-                return block;
+        let raw = crate::gc_hook::try_gc_alloc_stable_raw(tid, payload);
+        if !raw.is_null() {
+            let block = raw as *mut TypedItemsBlock;
+            unsafe {
+                (*block).capacity = cap;
+                std::ptr::write_bytes(
+                    typed_items_block_items_base(block),
+                    0,
+                    cap * std::mem::size_of::<u64>(),
+                );
             }
+            return block;
         }
     }
     let layout = typed_items_block_layout(cap);

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -112,14 +112,17 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
 /// subsystem) to cover transient Ref slots, then switch this call back
 /// to `try_gc_alloc` for the movable nursery.
 fn alloc_instance_object(value: W_ObjectObject) -> PyObjectRef {
-    match crate::gc_hook::try_gc_alloc_stable(W_OBJECT_OBJECT_GC_TYPE_ID, W_OBJECT_OBJECT_SIZE)
-        .filter(|p| !p.is_null())
-    {
-        Some(raw) => unsafe {
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
+        W_OBJECT_OBJECT_GC_TYPE_ID,
+        W_OBJECT_OBJECT_SIZE,
+    );
+    if !raw.is_null() {
+        unsafe {
             std::ptr::write(raw as *mut W_ObjectObject, value);
             raw as PyObjectRef
-        },
-        None => crate::lltype::malloc(value) as PyObjectRef,
+        }
+    } else {
+        crate::lltype::malloc(value) as PyObjectRef
     }
 }
 

--- a/pyre/pyre-object/src/objectobject.rs
+++ b/pyre/pyre-object/src/objectobject.rs
@@ -112,10 +112,8 @@ pub fn w_instance_new(w_type: PyObjectRef) -> PyObjectRef {
 /// subsystem) to cover transient Ref slots, then switch this call back
 /// to `try_gc_alloc` for the movable nursery.
 fn alloc_instance_object(value: W_ObjectObject) -> PyObjectRef {
-    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
-        W_OBJECT_OBJECT_GC_TYPE_ID,
-        W_OBJECT_OBJECT_SIZE,
-    );
+    let raw =
+        crate::gc_hook::try_gc_alloc_stable_raw(W_OBJECT_OBJECT_GC_TYPE_ID, W_OBJECT_OBJECT_SIZE);
     if !raw.is_null() {
         unsafe {
             std::ptr::write(raw as *mut W_ObjectObject, value);

--- a/pyre/pyre-object/src/setobject.rs
+++ b/pyre/pyre-object/src/setobject.rs
@@ -86,27 +86,25 @@ fn alloc_set_with_type(tp: &'static PyType) -> PyObjectRef {
     // through the plain `malloc_typed` (no TRACK_YOUNG_PTRS) would leave
     // young elements unforwarded and collected. Falls back to
     // `malloc_typed` when no GC hook is installed (unit tests).
-    match crate::gc_hook::try_gc_alloc_stable(W_SET_GC_TYPE_ID, W_SET_OBJECT_SIZE)
-        .filter(|p| !p.is_null())
-    {
-        Some(raw) => {
-            unsafe {
-                std::ptr::write(
-                    raw as *mut W_SetObject,
-                    W_SetObject {
-                        ob_header: header,
-                        items,
-                        len: 0,
-                    },
-                );
-            }
-            raw as PyObjectRef
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_SET_GC_TYPE_ID, W_SET_OBJECT_SIZE);
+    if !raw.is_null() {
+        unsafe {
+            std::ptr::write(
+                raw as *mut W_SetObject,
+                W_SetObject {
+                    ob_header: header,
+                    items,
+                    len: 0,
+                },
+            );
         }
-        None => crate::lltype::malloc_typed(W_SetObject {
+        raw as PyObjectRef
+    } else {
+        crate::lltype::malloc_typed(W_SetObject {
             ob_header: header,
             items,
             len: 0,
-        }) as PyObjectRef,
+        }) as PyObjectRef
     }
 }
 

--- a/pyre/pyre-object/src/sliceobject.rs
+++ b/pyre/pyre-object/src/sliceobject.rs
@@ -39,12 +39,11 @@ pub fn w_slice_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> 
         ob_type: &SLICE_TYPE as *const PyType,
         w_class: get_instantiate(&SLICE_TYPE),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable(W_SLICE_GC_TYPE_ID, W_SLICE_OBJECT_SIZE)
-        .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_SLICE_GC_TYPE_ID, W_SLICE_OBJECT_SIZE);
     let start = crate::gc_roots::shadow_stack_get(save_point);
     let stop = crate::gc_roots::shadow_stack_get(save_point + 1);
     let step = crate::gc_roots::shadow_stack_get(save_point + 2);
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_SliceObject,

--- a/pyre/pyre-object/src/specialisedtupleobject.rs
+++ b/pyre/pyre-object/src/specialisedtupleobject.rs
@@ -108,12 +108,11 @@ pub fn w_specialised_tuple_ii_new(value0: i64, value1: i64) -> PyObjectRef {
         ob_type: &SPECIALISED_TUPLE_II_TYPE as *const PyType,
         w_class: get_instantiate(&TUPLE_TYPE),
     };
-    if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         SPECIALISED_TUPLE_II_GC_TYPE_ID,
         SPECIALISED_TUPLE_II_OBJECT_SIZE,
-    )
-    .filter(|p| !p.is_null())
-    {
+    );
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_SpecialisedTupleObject_ii,
@@ -141,12 +140,11 @@ pub fn w_specialised_tuple_ff_new(value0: f64, value1: f64) -> PyObjectRef {
         ob_type: &SPECIALISED_TUPLE_FF_TYPE as *const PyType,
         w_class: get_instantiate(&TUPLE_TYPE),
     };
-    if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         SPECIALISED_TUPLE_FF_GC_TYPE_ID,
         SPECIALISED_TUPLE_FF_OBJECT_SIZE,
-    )
-    .filter(|p| !p.is_null())
-    {
+    );
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_SpecialisedTupleObject_ff,
@@ -185,12 +183,11 @@ pub fn w_specialised_tuple_oo_new(value0: PyObjectRef, value1: PyObjectRef) -> P
         ob_type: &SPECIALISED_TUPLE_OO_TYPE as *const PyType,
         w_class: get_instantiate(&TUPLE_TYPE),
     };
-    if let Some(raw) = crate::gc_hook::try_gc_alloc_stable(
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(
         SPECIALISED_TUPLE_OO_GC_TYPE_ID,
         SPECIALISED_TUPLE_OO_OBJECT_SIZE,
-    )
-    .filter(|p| !p.is_null())
-    {
+    );
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_SpecialisedTupleObject_oo,

--- a/pyre/pyre-object/src/tupleobject.rs
+++ b/pyre/pyre-object/src/tupleobject.rs
@@ -127,8 +127,7 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         ob_type: &TUPLE_TYPE as *const PyType,
         w_class: get_instantiate(&TUPLE_TYPE),
     };
-    let raw = crate::gc_hook::try_gc_alloc_stable(W_TUPLE_GC_TYPE_ID, W_TUPLE_OBJECT_SIZE)
-        .filter(|p| !p.is_null());
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_TUPLE_GC_TYPE_ID, W_TUPLE_OBJECT_SIZE);
 
     // pop_roots: read the relocated item pointers back out of the shadow
     // stack, then build the items block. On the Phase L2 nursery path
@@ -141,7 +140,7 @@ pub fn w_tuple_new_array_backed(items: Vec<PyObjectRef>) -> PyObjectRef {
         .collect();
     let items_block = unsafe { alloc_tuple_items_block_gc(&relocated) };
 
-    if let Some(raw) = raw {
+    if !raw.is_null() {
         unsafe {
             std::ptr::write(
                 raw as *mut W_TupleObject,

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -105,6 +105,11 @@ thread_local! {
 }
 
 /// Box a string constant into a heap Python str object.
+///
+/// Reads the thread-local `STRING_CONSTANT_CACHE` the tracer cannot model;
+/// the JIT residualises the call instead of tracing into it
+/// (`@dont_look_inside`, `rlib/jit.py:139`), the `box_str`/`pin_root` twin.
+#[majit_macros::dont_look_inside]
 pub fn box_str_constant(value: &Wtf8) -> PyObjectRef {
     STRING_CONSTANT_CACHE.with(|cache| {
         if let Some(&cached) = cache.borrow().get(value) {


### PR DESCRIPTION
This branch continues the gh#346 effort to retire the legacy rtyper walker by making the two-phase real path lift graphs the legacy walker currently handles.

## Changes

- **`dont_look_inside` residualization of runtime statics/hooks** — mark accessors/hooks that read a `thread_local`/`static` the tracer cannot model as `#[dont_look_inside]` and bind their fnaddrs in `jit_trace_fnaddrs` so the calls residualize to stable runtime addresses:
  - `box_str_constant` (`STRING_CONSTANT_CACHE`), `try_gc_add_root` (`GC_ADD_ROOT_HOOK`), `mark_prebuilt_roots_dirty` (`PREBUILT_ROOTS_DIRTY`)
  - `try_gc_remove_root` (`GC_REMOVE_ROOT_HOOK` dispatch), `_obj_getdict` (address-keyed `INSTANCE_DICT` side table)
  - `try_gc_alloc_stable` via a null-collapsing `try_gc_alloc_stable_raw(type_id, payload_size) -> *mut u8` wrapper (None and Some(null) both collapse to null, matching every caller's fall-back-to-malloc check), plus `shadow_stack_get` surfaced once the `GC_ALLOC_STABLE_HOOK` cascade cleared
  - 4 `malloc_typed` roots: `w_bytes_from_bytes`, `alloc_dict_object`, `w_module_dict_new_with_storage_proxy`, `function_new_impl` — residualized instead of tracing into a body whose `lltype::malloc_typed` (`NewWithVtable`) survives `fuse_boxing_alloc` unfused

- **Translator-only recognizer** — `translate_op`'s `CallTarget::FunctionPath` arm rewrites `pyobject::ll_issubclass(subcls, cls)` to the flowspace `issubtype` op and `pyobject::ll_isinstance(obj, cls)` to `isinstance`, so the rtyper lowers via the synthesized `int_between`-over-`subclassrange` helper instead of tracing the runtime helper body. `populate_call_registry_from_call_graphs` skips lifting the now-dead `ll_issubclass` / `ll_issubclass_const` / `ll_isinstance` / `subclass_range_read` helper graphs. The `subclass_range_read` seqlock leaf (over `SUBCLASS_RANGE_SEQ`) is retired the RPython-orthodox way, no QuasiImmut.

- **`FOREIGN_STDLIB_EXTERNALS` rows** — add `std::f64::<Impl>::powf` (Float) and `core::f64::<Impl>::to_bits` (Signed) to the annotator-only opaque-external table.

- **Parity fix** — the value-position `ResidualRef` arm returns early to attach the `call_returns` struct type and so skips the shared `post_live_after_call` `-live-` emission; since `ResidualRef` maps to `CondCallEffectSlot::CanRaise` (`explicit_call_emits_post_live` true), the arm now emits the trailing `-live-` marker before its early return (jtransform.py:467-470).

## Verification

`python3 ./pyre/check.py` passes dynasm/cranelift/wasm 183/183 across 3 backend runs for the landed work.

## Census

Distinct unlifted graphs: 47 → 37 over this branch's work.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT tracing support for more runtime helpers, including object creation, dictionary access, and GC/root operations.

* **Bug Fixes**
  * Fixed tracing and translation for `isinstance` and `issubclass`-style calls so they map correctly during execution.
  * Improved handling of several allocation paths to reduce tracing issues and fallback inconsistencies.
  * Added safer handling for certain helper calls so unsupported internals are kept out of traced execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->