### PR TITLE
jit: compile kept-stack branch-guard bridges (#377) — resume at guard jitcode offset + aliased-color slot fill

### DIFF
--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1075,6 +1075,28 @@ pub fn frame_value_count_at(jitcode_index: i32, pc: i32, carried_jitcode_pc: i32
     })
 }
 
+/// Resolve the JitCode byte offset the full-body walk should RESUME at for a
+/// bridge whose guard carried `carried_jitcode_pc`. Mirrors the blackhole's
+/// `resolve_resume_pc_with_jitcode_pc` (`call_jit.rs` `resolve_jitcode`): a
+/// kept-stack branch guard resumes at its OWN mid-opcode jitcode offset (the
+/// `goto_if_not`), not the opcode-entry marker `pc_map[py_pc]` — re-executing
+/// the whole opcode from entry would read abstract-register colors dead at the
+/// guard. Returns `None` when no coordinate resolves (the caller keeps the
+/// `pc_map` entry).
+pub fn resolve_bridge_walk_entry_at(
+    jitcode_index: i32,
+    pc: i32,
+    carried_jitcode_pc: i32,
+) -> Option<usize> {
+    ensure_finish_setup();
+    METAINTERP_SD.with(|r| {
+        let sd = r.borrow();
+        let jc = sd.jitcodes.get(jitcode_index as usize)?;
+        jc.payload
+            .resolve_resume_pc_with_jitcode_pc(pc, carried_jitcode_pc, sd.op_live)
+    })
+}
+
 /// virtualizable.py:86-98 `read_boxes` parity: assemble the
 /// `virtualizable_boxes` layout the tracing-time vable mirror expects
 /// and hand it to `TraceCtx::init_virtualizable_boxes`. Used by both
@@ -2007,6 +2029,19 @@ pub struct PyreSym {
     /// back to NONE, and so the full-body-walk argbox seed can recover the
     /// kept conditional-expression / short-circuit value (#124).
     pub(crate) bridge_stack_oprefs: Option<Vec<OpRef>>,
+    /// Kept-stack branch-guard resume coordinate for the full-body walk: the
+    /// guard's OWN jitcode byte offset (`frame0.jitcode_pc`, the mid-opcode
+    /// `goto_if_not`), resolved the same way the blackhole resolves its
+    /// `setposition` (`resolve_resume_pc_with_jitcode_pc`).  A chained-compare /
+    /// short-circuit guard resumes mid-opcode: the opcode-entry marker
+    /// (`pc_map[py_pc]`) re-executes the whole comparison from the top, reading
+    /// abstract-register colors that were live at entry but dead (recolored /
+    /// consumed) at the guard — colors the guard snapshot never preserved.  The
+    /// walk must resume where the blackhole does (the guard offset), so the
+    /// re-executed suffix only reads colors the resume data actually carries.
+    /// `None` for a non-branch-guard / portal-bridge resume, where the walk
+    /// keeps the `pc_map[py_pc]` opcode-entry offset.
+    pub(crate) bridge_walk_entry_pc: Option<usize>,
     /// The color-indexed Ref register bank as `consume_boxes`
     /// (resume.py:1055) fills `f.registers_r` — one box per abstract
     /// register color the guard's resume numbering named. This is the
@@ -3857,6 +3892,7 @@ impl PyreSym {
             nlocals: 0,
             bridge_local_oprefs: None,
             bridge_stack_oprefs: None,
+            bridge_walk_entry_pc: None,
             bridge_registers_r: None,
             bridge_local_types: None,
             vable_last_instr: OpRef::NONE,
@@ -7725,10 +7761,13 @@ impl JitState for PyreJitState {
                 backend,
                 &mut virtuals_cache,
             );
-            if seed_bridge_locals
-                && !seed_deferred_to_overlay
-                && !matches!(concrete_val, majit_ir::Value::Void)
-            {
+            // The Int bank is color-indexed (no slot overlay to defer to), and
+            // for a kept-stack branch guard the walk resumes at the guard's own
+            // coordinate where `reg_indices.int` colors are authoritative — so
+            // stamp the concrete directly here (the `seed_deferred_to_overlay`
+            // deferral only applies to the Ref slot-mirror). The guard's
+            // GUARD_TRUE/GUARD_FALSE needs this concrete to fold its direction.
+            if seed_bridge_locals && !matches!(concrete_val, majit_ir::Value::Void) {
                 ctx.try_set_opref_concrete(resolved, concrete_val);
             }
             let reg_idx = reg_idx as usize;
@@ -8237,6 +8276,21 @@ impl JitState for PyreJitState {
         // rebuilt registers_r and the full-body-walk argbox seed recover the
         // kept conditional-expression / short-circuit value.
         sym.bridge_stack_oprefs = Some(bridge_stack);
+        // Kept-stack branch guards (`frame0.jitcode_pc != NO_JITCODE_PC`) resume
+        // the full-body walk at the guard's OWN mid-opcode jitcode offset — the
+        // same coordinate the blackhole `setposition`s to — instead of the
+        // opcode-entry marker `pc_map[py_pc]`. Resolve it now (identical to the
+        // blackhole's `resolve_resume_pc_with_jitcode_pc`) and hand it to
+        // `run_perfn_walk` via `sym`. `None` leaves the walk on the pc_map entry.
+        sym.bridge_walk_entry_pc = if frame0.jitcode_pc != majit_ir::resumedata::NO_JITCODE_PC {
+            crate::state::resolve_bridge_walk_entry_at(
+                frame0.jitcode_index,
+                frame0.pc,
+                frame0.jitcode_pc,
+            )
+        } else {
+            None
+        };
         sym.bridge_local_types = Some(bridge_local_types);
         // consume_boxes (resume.py:1055) fills `f.registers_r` by abstract
         // register color; keep that color-indexed decode so a cross-frame

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7955,17 +7955,23 @@ impl JitState for PyreJitState {
                 .copied()
                 .collect()
         } else {
-            // Per-CodeObject: invert each live local/stack color to its slot.
+            // Per-CodeObject: fill each live local/stack slot from its color.
             let mut mirror = vec![OpRef::NONE; semantic_prefix_len];
-            let mut color_to_slot: Vec<usize> = vec![usize::MAX; bridge_registers_r.len()];
-            // #348 Part (2): per-PC color→slot inversion. Entries are sorted
-            // by `(color, slot)`, so for a color shared by an aliased
-            // local+stack pair the stack slot (larger slot) overwrites —
-            // matching `semantic_ref_slot_for_reg_color`'s stack-first
-            // tie-break. Out-of-prefix slots are dropped by the
-            // `s >= semantic_prefix_len` guard.  #73: pcdep is the SOLE
-            // color→slot source here; the flat `local_color_map` /
-            // `stack_color_map` fallback is drained.
+            // #348 Part (2): per-PC slot fill. `pcdep_entries` maps each live
+            // slot to its TRUE per-program-point color, so drive the fill by
+            // SLOT (not color): write `mirror[slot] = bridge_registers_r[color]`
+            // for every entry. A color shared by multiple slots — an aliased
+            // `DUP_TOP` / `ROT_THREE` operand-stack pair, or a local aliased
+            // onto the stack — writes its single value into EVERY slot it
+            // covers. A prior color→slot inversion kept only one slot per
+            // color (stack-first tie-break), leaving the sibling aliased slot
+            // `OpRef::NONE`; the vable image is also NULL for pure trace temps
+            // (`kept_stack_branch_depths` `0 < a < b < 9` keeps two copies of
+            // the same compare operand across the guard), so that slot folded
+            // to concrete `GcRef(0)` and the residual declined. Out-of-prefix
+            // slots are dropped by the `s >= semantic_prefix_len` guard.  #73:
+            // pcdep is the SOLE color→slot source here; the flat
+            // `local_color_map` / `stack_color_map` fallback is drained.
             for &(bank, color, slot) in &maps.pcdep_entries {
                 // Only Ref-bank colors map to bridge_registers_r slots.
                 // Int/Float bank entries are structurally recorded but
@@ -7978,8 +7984,8 @@ impl JitState for PyreJitState {
                     continue;
                 }
                 let col = color as usize;
-                if col < color_to_slot.len() {
-                    color_to_slot[col] = s;
+                if col < bridge_registers_r.len() {
+                    mirror[s] = bridge_registers_r[col];
                 }
             }
             // pcdep-totality guard (#73): the drained flat-else previously
@@ -8002,11 +8008,6 @@ impl JitState for PyreJitState {
                          (jitcode_index={}, pc={})",
                         frame0.jitcode_index, frame0.pc
                     );
-                }
-            }
-            for (c, &s) in color_to_slot.iter().enumerate() {
-                if s != usize::MAX && s < mirror.len() {
-                    mirror[s] = bridge_registers_r[c];
                 }
             }
             for s in 0..nlocals {
@@ -8091,7 +8092,22 @@ impl JitState for PyreJitState {
             for (s, opref) in semantic_mirror.iter().enumerate() {
                 if !opref.is_none() {
                     if let Some(&cv) = live_local_values.get(s) {
-                        if !matches!(cv, majit_ir::Value::Void) {
+                        // Skip a NULL (`GcRef(0)`) source: an operand-stack slot
+                        // above the frame's materialized `valuestackdepth` reads
+                        // NULL from `locals_cells_stack_w` because the kept temp
+                        // lives in the guard's register file / resume data, not
+                        // the frame array. When a color aliases two slots
+                        // (`DUP_TOP` / `ROT_THREE`), one slot may carry the real
+                        // value and its sibling the NULL hole; both stamp the
+                        // SAME opref, so a NULL stamp would clobber the real one
+                        // (last write wins) and fold the residual's Ref arg to
+                        // concrete NULL → `MayForceNullRefArgUnsupported`. A real
+                        // frame Ref is never NULL here, so skipping NULL only
+                        // drops the unmaterialized-hole case.
+                        if !matches!(
+                            cv,
+                            majit_ir::Value::Void | majit_ir::Value::Ref(majit_ir::GcRef(0))
+                        ) {
                             ctx.try_set_opref_concrete(*opref, cv);
                         }
                     }

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -1199,9 +1199,14 @@ fn run_perfn_walk(
         Vec::new()
     };
 
-    let Some((code_len, mut walk_result)) =
-        dispatch_perfn_frame(&mut mi, &pjc, entry, &argboxes_r, &argboxes_i, authoritative)
-    else {
+    let Some((code_len, mut walk_result)) = dispatch_perfn_frame(
+        &mut mi,
+        &pjc,
+        entry,
+        &argboxes_r,
+        &argboxes_i,
+        authoritative,
+    ) else {
         return None;
     };
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -315,6 +315,7 @@ fn dispatch_perfn_frame(
     pjc: &std::sync::Arc<crate::PyJitCode>,
     entry: usize,
     argboxes_r: &[majit_ir::OpRef],
+    argboxes_i: &[majit_ir::OpRef],
     authoritative: bool,
 ) -> Option<(usize, PerfnWalkResult)> {
     // Resolve the five terminal descrs off MetaInterpStaticData so the
@@ -414,7 +415,7 @@ fn dispatch_perfn_frame(
         pjc.jitcode.constants_i.as_slice(),
         pjc.jitcode.constants_f.as_slice(),
         argboxes_r,
-        &[],
+        argboxes_i,
         &[],
     );
     Some((code_len, walk_result))
@@ -895,7 +896,7 @@ fn run_perfn_walk(
         eprintln!("[walk-perfn] no per-CodeObject PyJitCode for code={w_code:?}");
         return None;
     };
-    let Some(entry) = pjc.resume_jitcode_pc_for(start_pc) else {
+    let Some(pc_map_entry) = pjc.resume_jitcode_pc_for(start_pc) else {
         // The frozen pc_map of this already-built body does not encode
         // `start_pc` as a resume coordinate, so the same body walked from
         // the same entry recurs identically on every retrace.  Decline the
@@ -911,6 +912,15 @@ fn run_perfn_walk(
         fbw_decline(crate::driver::make_green_key(w_code, start_pc));
         return None;
     };
+    // A kept-stack branch-guard bridge resumes at the guard's OWN mid-opcode
+    // jitcode offset (`setup_bridge_sym` resolved it into
+    // `sym.bridge_walk_entry_pc`, the same coordinate the blackhole
+    // `setposition`s to) — NOT the opcode-entry marker `pc_map[start_pc]`.
+    // Resuming at the entry marker re-executes the whole opcode from the top,
+    // reading abstract-register colors that were live at entry but dead
+    // (recolored / already consumed) at the guard, which the guard's resume
+    // data never preserved. See the field doc on `PyreSym::bridge_walk_entry_pc`.
+    let entry = sym.bridge_walk_entry_pc.unwrap_or(pc_map_entry);
     // The full-body walk drives a PORTAL trace, so the body must carry
     // the portal entry shape (`FrameInputs::Portal`: `[frame, ec]` red
     // inputs + the frame-vable locals prologue).  A body first compiled
@@ -1054,21 +1064,43 @@ fn run_perfn_walk(
         // expression / short-circuit / chained-compare value.  Leaving e.g.
         // the pycode green at the kept temp's color feeds a stale code object
         // into its binary op (`unsupported operand type(s) for +: 'code' and
-        // 'int'`).  Override the kept operand-stack colors
-        // [nlocals..nlocals+stack_only) with the resume-data OpRefs
-        // setup_bridge_sym resolved; in that semantic prefix the abstract-
-        // register color equals the semantic slot.  Locals (read through the
-        // vable) and frame/ec (at their own colors) keep the seeding above.
+        // 'int'`).  Seed the guard's live abstract-register colors from the
+        // resume-data OpRefs setup_bridge_sym resolved.  Locals (read through
+        // the vable) and frame/ec (at their own colors) keep the seeding above.
         //
-        // The `nl + i` slot→color shortcut collides with a red-input color
-        // when `portal_frame_reg == nlocals` (e.g. fib: frame=r1, nlocals=1,
-        // so operand-stack slot 0 → color 1 == frame).  A kept operand-stack
-        // temp never occupies a red-input color, so skip those: seeding a temp
-        // over the frame color overwrites the standard virtualizable identity
-        // and forces every later `vable_*` op onto the nonstandard leg
-        // (NonStandardVableFinishPortalUnsupported abort).
+        // A kept operand-stack temp never occupies a red-input color, so skip
+        // `reserved_red_colors`: seeding a temp over the frame color overwrites
+        // the standard virtualizable identity and forces every later `vable_*`
+        // op onto the nonstandard leg (NonStandardVableFinishPortalUnsupported
+        // abort).
         if is_bridge_trace {
-            if let Some(ref bridge_stack) = sym.bridge_stack_oprefs {
+            if sym.bridge_walk_entry_pc.is_some() {
+                // Kept-stack branch guard resumed at the guard's own jitcode
+                // offset (`entry` above).  The live registers there are the
+                // guard-time abstract-register colors the resume data decoded
+                // into `bridge_registers_r` (color-indexed, `consume_boxes`
+                // parity, resume.py:1055) — the SAME bank the blackhole's
+                // `init_register_files` + resume fill would hold.  Seed each
+                // non-NONE color directly; the `nlocals + depth` slot→color
+                // shortcut below is wrong here because a kept temp's abstract
+                // color is not `nlocals + depth` under free register coloring.
+                if let Some(ref bridge_regs_r) = sym.bridge_registers_r {
+                    for (color, &opref) in bridge_regs_r.iter().enumerate() {
+                        if opref.is_none() {
+                            continue;
+                        }
+                        let color = color as u8;
+                        if reserved_red_colors.contains(&color) {
+                            continue;
+                        }
+                        seed(color, opref);
+                    }
+                }
+            } else if let Some(ref bridge_stack) = sym.bridge_stack_oprefs {
+                // Non-branch-guard / portal-bridge resume at the opcode-entry
+                // marker: in the semantic prefix the abstract-register color
+                // equals the semantic slot, so the `nlocals + depth` slot→color
+                // shortcut over the slot-indexed `bridge_stack_oprefs` holds.
                 let nl = sym.nlocals;
                 for (i, &opref) in bridge_stack.iter().enumerate() {
                     if !opref.is_none() {
@@ -1145,8 +1177,30 @@ fn run_perfn_walk(
         v
     };
 
+    // Int-bank seed for a kept-stack branch-guard bridge: the guard reads its
+    // condition from an Int register (the `b < 9` compare result) that ran
+    // BEFORE the guard, so resuming at the guard offset requires it from the
+    // resume data. `setup_bridge_sym` decoded the Int bank color-indexed into
+    // `sym.registers_i` (concrete already stamped there); pass it positionally
+    // so `dispatch_via_miframe` writes `top_regs_i[color] = value`. Empty for a
+    // non-branch-guard resume (`bridge_walk_entry_pc == None`), where the walk
+    // enters at the opcode boundary with no live mid-opcode Int temps.
+    let argboxes_i: Vec<majit_ir::OpRef> = if sym.bridge_walk_entry_pc.is_some() {
+        // Clamp to the jitcode's Int register count: `sym.registers_i` may carry
+        // trailing scratch/constant colors beyond `num_regs_i`, and
+        // `dispatch_via_miframe` rejects an argbox list longer than the callee
+        // bank (`InlineCallIntArityMismatch`). Only the leading `num_regs_i`
+        // colors are real Int registers the walk reads.
+        let num_regs_i = pjc.jitcode.num_regs_i() as usize;
+        let mut v = sym.registers_i.clone();
+        v.truncate(num_regs_i);
+        v
+    } else {
+        Vec::new()
+    };
+
     let Some((code_len, mut walk_result)) =
-        dispatch_perfn_frame(&mut mi, &pjc, entry, &argboxes_r, authoritative)
+        dispatch_perfn_frame(&mut mi, &pjc, entry, &argboxes_r, &argboxes_i, authoritative)
     else {
         return None;
     };


### PR DESCRIPTION
Fixes the #377 performance cliff: chained-compare / short-circuit loops
(`0 < a < b < 9`, `(i % 7) and (i + 3)`) ran 1.45–2.5× **slower** with the JIT
than `PYRE_NO_JIT` because the not-taken-arm bridge never compiled — it aborted
every attempt, declined to the trait tracer, and thrashed the blackhole for
~50% of iterations. Correctness was always byte-exact; the cost was pure
compile-decline.

Two commits, both decode-side (`pyre-jit-trace`), no encode/codewriter change.

## 1. Resume the full-body walk at the guard's jitcode offset (`504f9b4eb7`)

A kept-stack branch guard carries its own mid-opcode `jitcode_pc`. The blackhole
resumes the bridge there (via `resolve_resume_pc_with_jitcode_pc`), but the
full-body walk (`run_perfn_walk`) resumed at `pc_map[py_pc]` — the opcode-ENTRY
marker — re-executing the whole chained-compare opcode from the top and reading
abstract-register colors dead/recolored at the guard → `ResidualCallArgUnbound`.

Fix: make the walk resume where the blackhole does. New
`PyreSym::bridge_walk_entry_pc` (set in `setup_bridge_sym` when
`jitcode_pc != NO_JITCODE_PC`); `run_perfn_walk` enters there and seeds each
non-NONE color from the color-indexed `bridge_registers_r` instead of the old
`nl+i` slot shortcut. Gated behind `bridge_walk_entry_pc.is_some()`, so
portal / after-residual resumes are unchanged.

## 2. Fill aliased-color kept-stack slots + skip NULL frame-holes (`52b3aa685f`)

The adversarial `kept_stack_branch_depths` bench still aborted
`MayForceNullRefArgUnsupported` at two guards. Root cause was **not** the
encode-side liveness capture (fresh probes confirmed the guard's `-live-` marker
captures the kept-temp color); it was two decode-side bugs in
`setup_bridge_sym`'s per-CodeObject mirror-build:

- **Aliased-color slot loss.** A chained compare uses `DUP_TOP`/`ROT_THREE`, so
  one abstract color owns two operand-stack slots. The old `color_to_slot`
  `Vec<usize>` 1:1 inversion kept only one slot (stack-first tie-break), leaving
  the sibling `OpRef::NONE`. Fixed by driving the fill by **slot**:
  `mirror[slot] = bridge_registers_r[color]` per pcdep entry.
- **NULL frame-hole clobber.** The deferred-overlay concrete seed stamps each
  mirror opref from `locals_cells_stack_w`. A stack slot above the frame's
  materialized `valuestackdepth` reads `GcRef(0)` there; for an aliased color
  one slot carries the real value and its sibling the NULL hole, and both stamp
  the same opref, so the NULL (last write) clobbered the real concrete → the
  residual's Ref arg folded to concrete NULL. Fixed by skipping a `GcRef(0)`
  source in the deferred seed.

## Payoff (dynasm, macOS arm64, JIT vs `PYRE_NO_JIT`)

| bench | before | after |
|---|---|---|
| kept_stack_depth_gt1 | 2.48× | 0.04× |
| kept_stack_depth_gt1_heap | 2.49× | ✓ |
| short_circuit_value_local_kept | 2.16× | ✓ |
| short_circuit_boxed_int_cross_fn | 2.11× | ✓ |
| short_circuit_value_kept_stack | 1.59× | 0.10× |
| kept_stack_branch_depths | 2.12× | 0.088× (11× faster) |

All 6 recovered (JIT now faster than the interpreter); abort census empty.

## Verification

- Correctness bit-exact across all named benches (JIT = `PYRE_NO_JIT` = CPython 3.14).
- `check.py`: dynasm 183/183, cranelift 183/183, wasm 183/183.
- `cargo test -p pyre-jit-trace`: pass.
- `PYRE_PCDEP_VALIDATE=1`: `inj_violations=0` (the slot-driven fill preserves color-map injectivity — a color covering multiple slots is exactly the aliased-copy case).
- Codex parity review: sections 1/2/3 all None.

Ref #377.
