### PR TITLE
majit: staged observer/replay → single walker (#344 Slices 1-2)

### DIFF
--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -2291,17 +2291,37 @@ fn rewrite_body(
                                     // transfer state directly and skip the body
                                     // re-run, so nothing should replay the queue.
                                     majit_metainterp::cancel_observer_replay();
+                                    // Push the walk-mutated scalar state fields
+                                    // (e.g. a walk-advanced `selected`) from the
+                                    // still-live persistent sym into native
+                                    // `state`. The walk advances these on the sym
+                                    // via BC_STORE_STATE_FIELD only; native
+                                    // `state` is frozen at trace-start (S_k), so
+                                    // without this the scalars stay stale — and a
+                                    // `recover` that re-derives caches FROM a
+                                    // scalar (stacksize from selected) would then
+                                    // read the wrong index. Must precede both
+                                    // `recover` (which refines storage-backed
+                                    // caches from the current scalars) and
+                                    // `try_resume_into_compiled_loop` (which reads
+                                    // the native scalars to seed the compiled
+                                    // loop). Mirrors the authoritative branch's
+                                    // ordering. No-op with no scalar state fields
+                                    // or no live sym.
+                                    #driver.writeback_authoritative_state_fields(
+                                        &mut #state,
+                                    );
                                     // Transfer any loop-carried reds the walk
                                     // captured, then re-derive the
                                     // storage-backed cache fields (stacksize,
                                     // selected/storage refs) from the
                                     // walk-advanced shared storage via the
-                                    // `recover` hook. The native `state`'s scalar
-                                    // fields are frozen at trace-start (S_k) — the
-                                    // walk mutates only the shared storage and
-                                    // the JitCode machine — so the cache fields
-                                    // are one iteration stale; `recover` is what
-                                    // brings them to the walk-final state (S_k+1).
+                                    // `recover` hook. `__sp_reds` is empty today
+                                    // (merge-point red-operand slots don't map to
+                                    // native state fields; the scalar write-back
+                                    // above is the authoritative scalar source),
+                                    // so this block is scaffolding for a future
+                                    // JIT whose merge point carries real reds.
                                     if !__sp_reds.is_empty() {
                                         let __sp_meta = majit_metainterp::JitState::build_meta(
                                             &#state, __sp_pc, #env,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1391,13 +1391,14 @@ impl<S: JitState> JitDriver<S> {
         self.meta.authoritative_next_pc.take()
     }
 
-    /// D2 per-opcode single-executor: after the authoritative walker executed
-    /// one opcode (`OpcodeComplete`), push the walk's scalar state fields from
-    /// the still-live persistent sym back into native `state`. Native's own
-    /// dispatch arm was skipped, so scalars the walk mutated (notably a SEL's
-    /// new `selected`) live only in the sym until this write-back. No-op when
-    /// no sym is live. Called from the `jit_merge_point!` authoritative branch
-    /// before `recover_after_compiled_run`.
+    /// Push the walk's scalar state fields from the still-live persistent sym
+    /// back into native `state`. The walk advances a scalar (notably a SEL's
+    /// new `selected`) on the sym only; native `state` stays at its trace-start
+    /// value until this write-back. No-op when no sym is live. Called from both
+    /// single-executor `jit_merge_point!` branches (per-opcode authoritative and
+    /// whole-circuit single-pass), before `recover_after_compiled_run` so
+    /// recover refines the storage-derived caches (e.g. stacksize from the
+    /// now-current selected) from the written-back scalars.
     #[inline]
     pub fn writeback_authoritative_state_fields(&self, state: &mut S) {
         if let Some(sym) = self.sym.as_ref() {
@@ -1809,18 +1810,20 @@ impl<S: JitState> JitDriver<S> {
                 if crate::single_pass_enabled() {
                     // Resume pc is the walk-final green pc the dispatch stashed
                     // (an interpreter program pc, NOT the JitCode op cursor). The
-                    // reds vector published here is INTENTIONALLY empty: a
-                    // state-field JIT (aheui) carries its loop-carried state in
-                    // the shared storage the walk already advanced, and the
-                    // merge-point hook's `recover` re-derives the cache fields
-                    // (stacksize, selected/storage refs) from it. `dispatch`
-                    // does populate `ctx.walk_final_reds` from the merge point's
-                    // red-operand slots, but that register-bank snapshot is NOT a
-                    // valid `restore_values` source for the state-field model —
-                    // those slots do not map to native state fields, so restoring
-                    // them would write the wrong values; only `recover` is
-                    // authoritative here. A JIT whose merge point carries real red
-                    // operands would instead source reds here, but none that
+                    // reds vector published here is INTENTIONALLY empty. The
+                    // merge-point hook transfers walk-final loop state without it:
+                    // scalar state fields (e.g. selected) are written back from
+                    // the live sym by `writeback_authoritative_state_fields`, then
+                    // `recover` re-derives the storage-backed cache fields
+                    // (stacksize, storage refs) from the walk-advanced shared
+                    // storage. `dispatch` does populate `ctx.walk_final_reds` from
+                    // the merge point's red-operand slots, but that register-bank
+                    // snapshot is NOT a valid `restore_values` source for the
+                    // state-field model — those slots are type-grouped operand
+                    // order, not `collect_jump_args` order, and include reds (e.g.
+                    // floats) with no state-field target, so restoring them would
+                    // write the wrong values. A JIT whose merge point carries real
+                    // red operands would instead source reds here, but none that
                     // close exist today.
                     let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
                     if let Some(p) = pc {

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -126,8 +126,8 @@ pub use pyjitpl::{
     build_state_field_snapshot, call_int_function, call_ref_function, call_void_function,
     cancel_observer_replay, consume_observed_float_call, consume_observed_getfield,
     consume_observed_int_call, consume_observed_ref_call, consume_observed_void_call, counters,
-    in_observer_mode, in_observer_replay, observer_arg_to_i64, observer_i64_to_value,
-    single_pass_enabled, struct_field_write_effect_info, trace_jitcode, trace_jitcode_observer,
+    in_observer_replay, observer_arg_to_i64, observer_i64_to_value, single_pass_enabled,
+    struct_field_write_effect_info, trace_jitcode, trace_jitcode_observer,
     trace_jitcode_observer_with_args, trace_jitcode_observer_with_args_and_runtime,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6,11 +6,11 @@ pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
     StandaloneFrameStack, authoritative_executor_enabled, cancel_observer_replay,
     consume_observed_float_call, consume_observed_getfield, consume_observed_int_call,
-    consume_observed_ref_call, consume_observed_void_call, in_observer_mode, in_observer_replay,
-    observer_arg_to_i64, observer_i64_to_value, single_pass_enabled,
-    struct_field_write_effect_info, trace_jitcode, trace_jitcode_observer,
-    trace_jitcode_observer_with_args, trace_jitcode_observer_with_args_and_runtime,
-    trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
+    consume_observed_ref_call, consume_observed_void_call, in_observer_replay, observer_arg_to_i64,
+    observer_i64_to_value, single_pass_enabled, struct_field_write_effect_info, trace_jitcode,
+    trace_jitcode_observer, trace_jitcode_observer_with_args,
+    trace_jitcode_observer_with_args_and_runtime, trace_jitcode_with_args,
+    trace_jitcode_with_args_and_runtime,
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};
 pub use dispatch::{call_int_function, call_ref_function, call_void_function};

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -21,18 +21,18 @@ use crate::jitcode::{self, JitArgKind, JitCallArg, JitCallTarget, JitCode, JitCo
 use crate::{TraceAction, TraceCtx};
 
 thread_local! {
-    // Tracing observer state is per-metainterp / per-thread in PyPy
-    // (`MetaInterp.history`); a process-global flag would let one thread's
-    // tracing wrap another thread's outer-interpreter helper calls. Keep it
-    // thread-local alongside the replay queue.
-    static OBSERVER_MODE: Cell<bool> = const { Cell::new(false) };
+    // The executed-but-not-yet-replayed residual call queue for a recording
+    // walk. The record side (walk-scoped) pushes; the replay side
+    // (outer-body-scoped) drains via `consume_observed_*_call`. The
+    // trace-recording mode flag itself lives on `TraceCtx::observer_mode`
+    // (the walk has `ctx` in scope), not thread-local.
     static OBSERVED_CALLS: RefCell<VecDeque<ObservedCall>> = const { RefCell::new(VecDeque::new()) };
     // Set when a recording walk ends with executed-but-not-yet-replayed
     // calls on OBSERVED_CALLS. The outer mainloop body that runs right
     // after the walk consumes the queue through `consume_observed_*_call`
     // and the flag clears itself when the queue empties. Split from
-    // OBSERVER_MODE so the record side (walk-scoped) and the replay side
-    // (outer-body-scoped) cannot leak into each other.
+    // the record-side mode flag so the record side (walk-scoped) and the
+    // replay side (outer-body-scoped) cannot leak into each other.
     static OBSERVER_REPLAY: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -69,13 +69,6 @@ enum ObservedCall {
         offset: usize,
         result: i64,
     },
-}
-
-/// Returns whether the current thread is running `JitCodeMachine::run_to_end`
-/// in observer mode (i.e., trace recording).  See `OBSERVER_MODE` doc.
-#[inline(always)]
-pub fn in_observer_mode() -> bool {
-    OBSERVER_MODE.with(|m| m.get())
 }
 
 /// Returns whether the outer interpreter is replaying the call queue left
@@ -454,10 +447,11 @@ pub fn consume_observed_getfield(obj: usize, offset: usize) -> Option<i64> {
     })
 }
 
-/// RAII guard that toggles `OBSERVER_MODE` on for its lifetime.
-struct ObserverGuard {
-    previous: bool,
-}
+/// RAII guard that owns the observed-call replay queue lifecycle for a walk:
+/// it starts the queue empty on `enter` and hands it over to the outer
+/// interpreter on `drop`. The trace-recording mode flag itself lives on the
+/// walk's `TraceCtx` (`observer_mode`), not here.
+struct ObserverGuard;
 
 fn observer_debug() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -501,30 +495,20 @@ pub fn authoritative_executor_enabled() -> bool {
 
 impl ObserverGuard {
     fn enter() -> Self {
-        let previous = OBSERVER_MODE.with(|m| m.replace(true));
         if observer_debug() {
             let n = OBSERVED_CALLS.with(|q| q.borrow().len());
-            eprintln!("[observer] enter (previous={previous}, stale_queue_len={n})");
+            eprintln!("[observer] enter (stale_queue_len={n})");
         }
         // A leftover queue means the previous walk's replay span did not
         // consume exactly what the walker executed; start fresh.
         OBSERVED_CALLS.with(|q| q.borrow_mut().clear());
         OBSERVER_REPLAY.with(|m| m.set(false));
-        Self { previous }
+        Self
     }
 }
 
 impl Drop for ObserverGuard {
     fn drop(&mut self) {
-        OBSERVER_MODE.with(|m| m.set(self.previous));
-        // Hand the executed-call queue over to the outer interpreter: the
-        // mainloop body that runs right after the walk re-runs the walked
-        // span and must REPLAY these calls (consume_observed_*_call)
-        // rather than execute them a second time. This holds for every
-        // walk outcome — on CloseLoop the queue covers one full loop
-        // circuit, on Abort it covers the executed prefix; either way the
-        // outer body consumes the queue in order and falls back to real
-        // execution once it empties.
         // Hand the executed-call queue over to the outer interpreter: the
         // mainloop body that runs right after the walk re-runs the walked
         // span and must REPLAY these calls (consume_observed_*_call)
@@ -545,10 +529,7 @@ impl Drop for ObserverGuard {
         OBSERVER_REPLAY.with(|m| m.set(handover));
         if observer_debug() {
             let n = OBSERVED_CALLS.with(|q| q.borrow().len());
-            eprintln!(
-                "[observer] drop (restore={}, replay_handover={handover}, queue_len={n})",
-                self.previous
-            );
+            eprintln!("[observer] drop (replay_handover={handover}, queue_len={n})");
         }
     }
 }
@@ -3124,7 +3105,7 @@ where
                     bytecode,
                     jitcode::insns::BC_GETFIELD_GC_I_PURE | jitcode::insns::BC_GETFIELD_GC_R_PURE
                 );
-                if !is_pure && in_observer_mode() {
+                if !is_pure && ctx.observer_mode {
                     record_observed_getfield(struct_ptr as usize, offset, loaded);
                 }
                 let kind = if is_ref {
@@ -5121,7 +5102,7 @@ where
                             );
                         }
                     }
-                    if in_observer_mode() {
+                    if ctx.observer_mode {
                         record_observed_void_call(concrete_ptr, &concrete_args);
                     }
                     // `pyjitpl.py:3711-3716 do_not_in_trace_call`:
@@ -5223,7 +5204,7 @@ where
                     // the outer body has no consume_observed_*_call wrapper
                     // for them (replay_kind_for_policy returns None) and
                     // pure re-execution is harmless.
-                    if in_observer_mode() && !effectinfo.check_is_elidable() {
+                    if ctx.observer_mode && !effectinfo.check_is_elidable() {
                         record_observed_void_call(concrete_ptr, &concrete_args);
                     }
                     // pyjitpl.py:2046-2049 — after the residual call,
@@ -5444,7 +5425,7 @@ where
                             );
                         }
                     }
-                    if in_observer_mode() {
+                    if ctx.observer_mode {
                         record_observed_void_call(concrete_ptr, &concrete_args);
                     }
                     // `pyjitpl.py:3711-3716 do_not_in_trace_call`:
@@ -5523,7 +5504,7 @@ where
                             )
                         }
                     };
-                    if in_observer_mode() && !effectinfo.check_is_elidable() {
+                    if ctx.observer_mode && !effectinfo.check_is_elidable() {
                         record_observed_int_call(concrete_ptr, &concrete_args, concrete);
                     }
                     // pyjitpl.py:2046-2049 — vrefs_after_residual_call
@@ -5738,7 +5719,7 @@ where
                             );
                         }
                     }
-                    if in_observer_mode() {
+                    if ctx.observer_mode {
                         record_observed_void_call(concrete_ptr, &concrete_args);
                     }
                     // `pyjitpl.py:3711-3716 do_not_in_trace_call`:
@@ -5814,7 +5795,7 @@ where
                             )
                         }
                     };
-                    if in_observer_mode() && !effectinfo.check_is_elidable() {
+                    if ctx.observer_mode && !effectinfo.check_is_elidable() {
                         record_observed_ref_call(concrete_ptr, &concrete_args, concrete);
                     }
                     // pyjitpl.py:2046-2049 — vrefs_after_residual_call
@@ -5991,7 +5972,7 @@ where
                             );
                         }
                     }
-                    if in_observer_mode() {
+                    if ctx.observer_mode {
                         record_observed_void_call(concrete_ptr, &concrete_args);
                     }
                     // `pyjitpl.py:3711-3716 do_not_in_trace_call`:
@@ -6061,7 +6042,7 @@ where
                             )
                         }
                     };
-                    if in_observer_mode() && !effectinfo.check_is_elidable() {
+                    if ctx.observer_mode && !effectinfo.check_is_elidable() {
                         record_observed_float_call(
                             concrete_ptr,
                             &concrete_args,
@@ -6309,7 +6290,7 @@ where
                         if first_val != 0 {
                             call_void_function(concrete_ptr, &concrete_args);
                             // Always record concrete_ptr (see BC_RESIDUAL_CALL_VOID).
-                            if in_observer_mode() {
+                            if ctx.observer_mode {
                                 record_observed_void_call(concrete_ptr, &concrete_args);
                             }
                         }
@@ -6324,7 +6305,7 @@ where
                         let concrete_result = if first_val == 0 {
                             let result = call_int_function(concrete_ptr, &concrete_args);
                             // Always record concrete_ptr (see BC_RESIDUAL_CALL_VOID).
-                            if in_observer_mode() {
+                            if ctx.observer_mode {
                                 record_observed_int_call(concrete_ptr, &concrete_args, result);
                             }
                             result
@@ -6356,7 +6337,7 @@ where
                             // Ref-shaped result: queue entry uses the Ref
                             // variant so a wrapped Ref policy's
                             // `consume_observed_ref_call` matches.
-                            if in_observer_mode() {
+                            if ctx.observer_mode {
                                 record_observed_ref_call(concrete_ptr, &concrete_args, result);
                             }
                             result
@@ -7210,7 +7191,7 @@ where
 ///
 /// Used by `#[jit_interp]`-generated `__trace_*` wrappers where the outer
 /// Rust mainloop runs the same opcode body alongside the metainterp's
-/// jitcode execution. The observer-mode flag (see [`OBSERVER_MODE`])
+/// jitcode execution. The observer-mode flag (`TraceCtx::observer_mode`)
 /// instructs `run_one_step` to *execute* concrete-side residual function-
 /// pointer calls (BC_CALL_INT / BC_RESIDUAL_CALL_VOID and friends) and
 /// also push each invocation into [`OBSERVED_CALLS`]. The outer mainloop
@@ -7251,7 +7232,11 @@ where
     FLabel: Fn(usize) -> usize,
 {
     let _observer_guard = ObserverGuard::enter();
-    trace_jitcode_with_args(ctx, sym, jitcode, pc, label_at, argboxes)
+    let prev_observer_mode = ctx.observer_mode;
+    ctx.observer_mode = true;
+    let action = trace_jitcode_with_args(ctx, sym, jitcode, pc, label_at, argboxes);
+    ctx.observer_mode = prev_observer_mode;
+    action
 }
 
 /// Observer-mode variant of [`trace_jitcode_with_args_and_runtime`] —
@@ -7272,7 +7257,11 @@ where
     R: JitCodeRuntime,
 {
     let _observer_guard = ObserverGuard::enter();
-    trace_jitcode_with_args_and_runtime(ctx, sym, jitcode, pc, runtime, argboxes)
+    let prev_observer_mode = ctx.observer_mode;
+    ctx.observer_mode = true;
+    let action = trace_jitcode_with_args_and_runtime(ctx, sym, jitcode, pc, runtime, argboxes);
+    ctx.observer_mode = prev_observer_mode;
+    action
 }
 
 /// `b1 is b2` crude fastpath result for comparison opcodes —

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7234,9 +7234,19 @@ where
     let _observer_guard = ObserverGuard::enter();
     let prev_observer_mode = ctx.observer_mode;
     ctx.observer_mode = true;
-    let action = trace_jitcode_with_args(ctx, sym, jitcode, pc, label_at, argboxes);
+    // Restore observer_mode on both normal return and unwind (try/finally
+    // parity): trace-time panics are caught and recovered higher up
+    // (`run_to_end`, `note_jit_panic_or_reraise`), so a plain post-call
+    // statement would leak `observer_mode = true` into the recovered outer
+    // interpreter. Mirrors the previous `ObserverGuard::drop` restore.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        trace_jitcode_with_args(ctx, sym, jitcode, pc, label_at, argboxes)
+    }));
     ctx.observer_mode = prev_observer_mode;
-    action
+    match result {
+        Ok(action) => action,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 /// Observer-mode variant of [`trace_jitcode_with_args_and_runtime`] —
@@ -7259,9 +7269,19 @@ where
     let _observer_guard = ObserverGuard::enter();
     let prev_observer_mode = ctx.observer_mode;
     ctx.observer_mode = true;
-    let action = trace_jitcode_with_args_and_runtime(ctx, sym, jitcode, pc, runtime, argboxes);
+    // Restore observer_mode on both normal return and unwind (try/finally
+    // parity): trace-time panics are caught and recovered higher up
+    // (`run_to_end`, `note_jit_panic_or_reraise`), so a plain post-call
+    // statement would leak `observer_mode = true` into the recovered outer
+    // interpreter. Mirrors the previous `ObserverGuard::drop` restore.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        trace_jitcode_with_args_and_runtime(ctx, sym, jitcode, pc, runtime, argboxes)
+    }));
     ctx.observer_mode = prev_observer_mode;
-    action
+    match result {
+        Ok(action) => action,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 /// `b1 is b2` crude fastpath result for comparison opcodes —

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -361,6 +361,13 @@ pub struct TraceCtx {
     /// `recover` cannot reconstruct (loop-carried state held in a red bank but
     /// never written back to the shared heap). Empty unless single-pass.
     pub walk_final_reds: Vec<majit_ir::Value>,
+    /// Trace-recording mode: `true` while the JitCode dispatch walk is
+    /// recording a trace (the record-side of the observer/replay handover).
+    /// Set for the lifetime of a `trace_jitcode_observer_*` walk and read by
+    /// the `record_observed_*` gate in `run_one_step`. This is the RPython
+    /// `MetaInterp.history`-carried "am I tracing" state, held on the walk
+    /// context (one executor with `ctx` in scope) rather than a thread-local.
+    pub(crate) observer_mode: bool,
     /// pyjitpl.py:1087 parity: quasi-immutable field read needs a
     /// GUARD_NOT_INVALIDATED with full snapshot at the field read's orgpc.
     /// Stores Some(orgpc) when pending.
@@ -1178,6 +1185,7 @@ impl TraceCtx {
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
             walk_final_reds: Vec::new(),
+            observer_mode: false,
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
             has_compiled_targets_fn: None,
@@ -1252,6 +1260,7 @@ impl TraceCtx {
             initial_inputarg_consts: vec![],
             walk_final_pc: None,
             walk_final_reds: Vec::new(),
+            observer_mode: false,
             pending_guard_not_invalidated_pc: None,
             forced_virtualizable: None,
             has_compiled_targets_fn: None,


### PR DESCRIPTION
Converts the generic majit `#[jit_interp]` meta-tracing engine toward a single authoritative walker (PyPy `MetaInterp.interpret` parity), staged. Macro-only blast radius — does not touch `pyre`/`check.py`. Closes progress on #344 Slices 1 & 2.

## Commits

- `6d94b53176` **Slice 1** — move `OBSERVER_MODE` thread-local to `TraceCtx::observer_mode` field. The trace-recording mode flag is now a field read by the 12 `record_observed_*` gates in `run_one_step`; the two `trace_jitcode_observer_*` entry functions set/restore it around the walk. `in_observer_mode()` + the `OBSERVER_MODE` TLS are deleted. `ObserverGuard` is reduced to the `OBSERVED_CALLS`/`OBSERVER_REPLAY` queue lifecycle (still TLS because record side and replay side run in different scopes). Delivers acceptance criterion 2.
- `e74a19b18c` **Slice 1 fix** — restore `observer_mode` on unwind in the two `trace_jitcode_observer` entries. majit catches and recovers trace-time panics (`catch_unwind` in dispatch), so a walk that unwinds would otherwise leak `observer_mode=true` into the recovered outer interp. The two entries now wrap the walk in `catch_unwind(AssertUnwindSafe)`, restore on both paths, and `resume_unwind` — matching the old RAII `ObserverGuard::drop` semantics.
- `9a2df5bd8e` **Slice 2** — write back walk-final scalar state fields in the whole-circuit single-pass merge branch. Adds `writeback_authoritative_state_fields(&mut state)` to branch (B) (`;state` single-pass), mirroring the per-opcode authoritative branch (A). native `state` scalar fields are frozen at trace-start and the walk advances only `sym`; `recover` (aheui `refresh_state_from_storage`) derives `stacksize` from `self.selected` but does not set `selected`, so writeback must precede `recover` + `try_resume`. Only functional change is one method call; the rest is comment corrections.

## Verification

- `majit-metainterp` + `majit-macros` build (`--features dynasm`); `jit_interp_*` tests 47 pass.
- All 11 `majit/examples` crates: single-pass ON + OFF, 130 tests pass (incl. tl/tlc replay path).
- aheui `logo --jit` = 996310 bytes, identical to `--no-jit`; all 5 aheui samples oracle-match.
- Codex parity review (Slice 2, scoped `HEAD~1..HEAD`): §1/§2/§3 None; §4 three structural adaptations, all won't-fix(documented) — Codex classifies the writeback as "preserves PyPy semantics rather than regressing parity".

## Remaining (not in this PR)

- **Slice 3** — convert `majit/examples/*` to the single-executor path and delete `OBSERVED_CALLS` / `OBSERVER_REPLAY` / `record_observed_*` / `consume_observed_*` / `observed_call_mismatch` (acceptance criteria 1 and 3).
