### PR TITLE
Delegate value logic and module backends to RustPython crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -730,7 +730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1034,6 +1034,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_casemap"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "070f98b5b82798fcb93654bf96ed9f40064fc44c86f51a09ea711092cd5cc5be"
+dependencies = [
+ "icu_casemap_data",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties",
+ "icu_provider",
+ "potential_utf",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "846b0857ca091204be3c874bc93daaf89d4777e8d2d20b0d3ffe8f671d98014b"
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1063,7 @@ checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "serde",
  "utf8_iter",
  "yoke",
  "zerofrom",
@@ -1055,10 +1078,34 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
@@ -1088,6 +1135,8 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1153,6 +1202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,7 +1265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1537,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b6f86fdbb1eb9955946be91775239dfcb0acdb1a51bb07d5fc9b8c854f5ccd"
 dependencies = [
  "hashbrown 0.16.1",
- "itertools",
+ "itertools 0.14.0",
  "libm",
  "ryu",
 ]
@@ -1561,7 +1619,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0197a2f5cfee19d59178e282985c6ca79a9233e26a2adcf40acb693896aa09f6"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "libm",
  "malachite-base",
  "wide",
@@ -1573,7 +1631,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2add95162aede090c48f0ee51bea7d328847ce3180aa44588111f846cc116b"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
 ]
@@ -1919,6 +1977,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -2441,17 +2501,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "malachite-bigint",
  "memchr",
@@ -2462,20 +2522,20 @@ dependencies = [
  "rustpython-literal",
  "rustpython-ruff_python_ast",
  "rustpython-ruff_text_size",
+ "rustpython-unicode",
  "rustpython-wtf8",
  "thiserror 2.0.18",
- "unicode_names2 2.0.0",
 ]
 
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "ascii",
  "bitflags 2.11.1",
  "getrandom 0.4.2",
- "itertools",
+ "itertools 0.15.0",
  "libc",
  "lock_api",
  "malachite-base",
@@ -2485,15 +2545,15 @@ dependencies = [
  "num-traits",
  "radium",
  "rustpython-literal",
+ "rustpython-unicode",
  "rustpython-wtf8",
  "siphasher",
- "unicode_names2 2.0.0",
 ]
 
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -2507,11 +2567,11 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "bitflags 2.11.1",
  "bitflagset",
- "itertools",
+ "itertools 0.15.0",
  "lz4_flex",
  "malachite-bigint",
  "num-complex",
@@ -2523,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "bitflags 2.11.1",
  "getrandom 0.4.2",
@@ -2548,13 +2608,13 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "hexf-parse",
- "icu_properties",
  "is-macro",
  "lexical-parse-float",
  "num-traits",
+ "rustpython-unicode",
  "rustpython-wtf8",
 ]
 
@@ -2601,7 +2661,7 @@ name = "rustpython-ruff_python_trivia"
 version = "0.15.9"
 source = "git+https://github.com/RustPython/ruff.git?tag=0.15.19-rustpython#3c1ab2dd9987f190f3df94d28452ed5e65e106af"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "rustpython-ruff_source_file",
  "rustpython-ruff_text_size",
  "unicode-ident",
@@ -2627,23 +2687,36 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "bitflags 2.11.1",
- "icu_properties",
  "num_enum",
  "optional",
+ "rustpython-unicode",
  "rustpython-wtf8",
+]
+
+[[package]]
+name = "rustpython-unicode"
+version = "0.5.0"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+dependencies = [
+ "icu_casemap",
+ "icu_normalizer",
+ "icu_properties",
+ "rustpython-wtf8",
+ "unicode_names2 3.1.0",
+ "writeable",
 ]
 
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
 dependencies = [
  "ascii",
  "bstr",
- "itertools",
+ "itertools 0.15.0",
  "memchr",
 ]
 
@@ -2869,7 +2942,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2932,7 +3005,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3027,6 +3100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -3177,12 +3251,12 @@ dependencies = [
 
 [[package]]
 name = "unicode_names2"
-version = "2.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+checksum = "82c3e18d850bb6ebd57735e5654f0af65e572b05c2397e7b2b1a7c6a792cc29c"
 dependencies = [
  "phf",
- "unicode_names2_generator 2.0.0",
+ "unicode_names2_generator 3.1.0",
 ]
 
 [[package]]
@@ -3199,13 +3273,19 @@ dependencies = [
 
 [[package]]
 name = "unicode_names2_generator"
-version = "2.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+checksum = "849744a58c479122ff24910d7ca57f312b62613ef0412dc327776ae6b235d16a"
 dependencies = [
  "phf_codegen",
  "rand",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3658,7 +3738,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object 0.39.1",
  "pulley-interpreter",
@@ -3825,7 +3905,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4150,6 +4230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,6 +4314,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -4236,6 +4323,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,7 +2034,9 @@ dependencies = [
 name = "pyre-interpreter"
 version = "0.0.2"
 dependencies = [
+ "base64",
  "caseless",
+ "crc32fast",
  "indexmap",
  "libc",
  "lz4_flex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +617,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -724,7 +730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -761,6 +767,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -1191,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1644,6 +1660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2109,6 +2135,7 @@ name = "pyre-native"
 version = "0.0.2"
 dependencies = [
  "blake2",
+ "flate2",
  "md-5",
  "sha1",
  "sha2",
@@ -2412,7 +2439,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2786,6 +2813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,7 +2867,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2897,7 +2930,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3790,7 +3823,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4216,6 +4249,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1549,6 +1549,17 @@ dependencies = [
  "libm",
  "malachite-base",
  "wide",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2add95162aede090c48f0ee51bea7d328847ce3180aa44588111f846cc116b"
+dependencies = [
+ "itertools",
+ "malachite-base",
+ "malachite-nz",
 ]
 
 [[package]]
@@ -2014,6 +2025,7 @@ dependencies = [
  "pyre-native",
  "pyre-object",
  "pyre-sandbox",
+ "rustpython-common",
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-host_env",
@@ -2400,7 +2412,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2423,6 +2435,29 @@ dependencies = [
  "rustpython-ruff_text_size",
  "rustpython-wtf8",
  "thiserror 2.0.18",
+ "unicode_names2 2.0.0",
+]
+
+[[package]]
+name = "rustpython-common"
+version = "0.5.0"
+source = "git+https://github.com/RustPython/RustPython.git?rev=83ce1a7cad790dcf95886f119c1585ee4089a41c#83ce1a7cad790dcf95886f119c1585ee4089a41c"
+dependencies = [
+ "ascii",
+ "bitflags 2.11.1",
+ "getrandom 0.4.2",
+ "itertools",
+ "libc",
+ "lock_api",
+ "malachite-base",
+ "malachite-bigint",
+ "malachite-q",
+ "num-complex",
+ "num-traits",
+ "radium",
+ "rustpython-literal",
+ "rustpython-wtf8",
+ "siphasher",
  "unicode_names2 2.0.0",
 ]
 
@@ -2799,7 +2834,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2862,7 +2897,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3755,7 +3790,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ dependencies = [
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-host_env",
+ "rustpython-literal",
  "rustpython-sre_engine",
  "rustpython-wtf8",
  "siphasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -730,7 +730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1265,7 +1265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2119,6 +2119,7 @@ dependencies = [
  "rustpython-host_env",
  "rustpython-literal",
  "rustpython-sre_engine",
+ "rustpython-unicode",
  "rustpython-wtf8",
  "siphasher",
  "stacker",
@@ -2501,7 +2502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3005,7 +3006,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3905,7 +3906,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "ascii",
  "bitflags 2.11.1",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "bitflags 2.11.1",
  "bitflagset",
@@ -2584,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "bitflags 2.11.1",
  "getrandom 0.4.2",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "bitflags 2.11.1",
  "num_enum",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "icu_casemap",
  "icu_normalizer",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/youknowone/RustPython.git?rev=a6271d25e426ecae4acab70f95271f0ef9badfaa#a6271d25e426ecae4acab70f95271f0ef9badfaa"
+source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
 dependencies = [
  "ascii",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,9 @@ sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
 blake2 = "0.10"
+# zlib backend (pyre-native only): zlib-rs is a pure-Rust zlib port whose
+# DEFLATE output is byte-identical to the reference C zlib.
+flate2 = { version = "1.1.9", default-features = false }
 
 # math
 pymath = { version = "0.2.0", features = ["malachite-bigint"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,13 +61,16 @@ pyre-jit-trace = { version = "0.0.2", path = "pyre/pyre-jit-trace" }
 pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
+# Temporarily pinned to the fork's `unicode` branch head (adds the
+# rustpython-unicode crate; not yet merged upstream). Move back to
+# RustPython/RustPython once the branch lands.
+rustpython-common = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+rustpython-literal = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+rustpython-compiler = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+rustpython-compiler-core = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+rustpython-host_env = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+rustpython-wtf8 = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,17 +61,16 @@ pyre-jit-trace = { version = "0.0.2", path = "pyre/pyre-jit-trace" }
 pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
-# Temporarily pinned to the fork's `unicode` branch head (adds the
-# rustpython-unicode crate; not yet merged upstream). Move back to
-# RustPython/RustPython once the branch lands.
-rustpython-common = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-rustpython-literal = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-rustpython-compiler = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-rustpython-compiler-core = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-rustpython-host_env = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-rustpython-wtf8 = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-rustpython-unicode = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+# Pinned to upstream main, which now carries the rustpython-unicode crate,
+# the host_env mmap re-exports, and the float hash/format fixes (#8232).
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,9 @@ blake2 = "0.10"
 # zlib backend (pyre-native only): zlib-rs is a pure-Rust zlib port whose
 # DEFLATE output is byte-identical to the reference C zlib.
 flate2 = { version = "1.1.9", default-features = false }
+# binascii transforms (pure-Rust logic).
+base64 = "0.22"
+crc32fast = "1.4"
 
 # math
 pymath = { version = "0.2.0", features = ["malachite-bigint"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ pyre-jit-trace = { version = "0.0.2", path = "pyre/pyre-jit-trace" }
 pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ rustpython-compiler = { git = "https://github.com/youknowone/RustPython.git", re
 rustpython-compiler-core = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
 rustpython-host_env = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
 rustpython-wtf8 = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
+rustpython-unicode = { git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
 sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/youknowone/RustPython.git", rev = "a6271d25e426ecae4acab70f95271f0ef9badfaa" }
 
 # majit JIT framework

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ pyre-jit-trace = { version = "0.0.2", path = "pyre/pyre-jit-trace" }
 pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }
 rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "83ce1a7cad790dcf95886f119c1585ee4089a41c" }

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -45,6 +45,8 @@ pyre-sandbox = { workspace = true, optional = true }
 libc = { workspace = true }
 siphasher = { workspace = true }
 caseless = { workspace = true }
+base64 = { workspace = true }
+crc32fast = { workspace = true }
 indexmap = { workspace = true }
 paste = { workspace = true }
 unicode-xid = { workspace = true }

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -28,6 +28,7 @@ pyre-native = { workspace = true }
 rustpython-wtf8 = { workspace = true }
 rustpython-literal = { workspace = true }
 rustpython-common = { workspace = true }
+rustpython-unicode = { workspace = true }
 majit-gc = { workspace = true }
 majit-ir = { workspace = true }
 majit-macros = { workspace = true }

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -26,6 +26,7 @@ pyre-object = { workspace = true }
 pyre-macros = { workspace = true }
 pyre-native = { workspace = true }
 rustpython-wtf8 = { workspace = true }
+rustpython-literal = { workspace = true }
 majit-gc = { workspace = true }
 majit-ir = { workspace = true }
 majit-macros = { workspace = true }

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -27,6 +27,7 @@ pyre-macros = { workspace = true }
 pyre-native = { workspace = true }
 rustpython-wtf8 = { workspace = true }
 rustpython-literal = { workspace = true }
+rustpython-common = { workspace = true }
 majit-gc = { workspace = true }
 majit-ir = { workspace = true }
 majit-macros = { workspace = true }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -26,7 +26,9 @@ use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
 // ── Re-exports from split-out modules ────────────────────────────────
 pub use crate::objspace::descroperation::*;
-pub(crate) use crate::objspace::std::formatting::{format_g_like, normalise_exponent};
+pub(crate) use crate::objspace::std::formatting::{
+    format_g_like, format_no_type_prec, normalise_exponent,
+};
 
 // ── Pending dict-key-callback error slot ─────────────────────────────
 // The `r_dict(eq_w, hash_w)` callbacks (`pyre_object_hash_w_trampoline`

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -26,9 +26,6 @@ use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
 // ── Re-exports from split-out modules ────────────────────────────────
 pub use crate::objspace::descroperation::*;
-pub(crate) use crate::objspace::std::formatting::{
-    format_g_like, format_no_type_prec, normalise_exponent,
-};
 
 // ── Pending dict-key-callback error slot ─────────────────────────────
 // The `r_dict(eq_w, hash_w)` callbacks (`pyre_object_hash_w_trampoline`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4952,9 +4952,10 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         if is_str(obj) {
             let s = w_str_get_value(obj);
             // `float_from_string` strips PEP 515 underscore separators
-            // (between digits only) before parsing.
+            // (between digits only) before parsing; the numeric conversion
+            // uses the Python-literal float grammar.
             if let Some(cleaned) = strip_numeric_underscores(s.trim()) {
-                if let Ok(v) = cleaned.parse::<f64>() {
+                if let Some(v) = rustpython_literal::float::parse_str(&cleaned) {
                     return Ok(floatobject::w_float_new(v));
                 }
             }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -8850,7 +8850,11 @@ mod tests {
             -BigInt::from(u128::MAX),
         ];
         for b in &bigs {
-            assert_eq!(hash::hash_bigint(b), _hash_long(b), "hash_bigint vs _hash_long");
+            assert_eq!(
+                hash::hash_bigint(b),
+                _hash_long(b),
+                "hash_bigint vs _hash_long"
+            );
         }
     }
 
@@ -8878,7 +8882,7 @@ mod tests {
         let cases = [
             0.0f64,
             -0.0,
-            f64::from_bits(1),       // smallest positive subnormal
+            f64::from_bits(1), // smallest positive subnormal
             -f64::from_bits(1),
             5e-324,
             1e-310,                  // subnormal

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6447,46 +6447,21 @@ fn libm_frexp(v: f64) -> (f64, i32) {
     (f64::from_bits(mantissa_bits), exponent)
 }
 
-/// `pypy/objspace/std/tupleobject.py:358-401 descr_hash` line-by-line
-/// port — xxHash sequence hash (CPython 3.8+ tuple hash):
+/// `tupleobject.py:358-401 descr_hash` — the xxHash sequence hash, delegated
+/// to `rustpython_common::hash::hash_tuple`.  The caller has already computed
+/// each element's hash into `items`, so the fold is infallible here.
 ///
-/// ```python
-/// XXPRIME_1 = 0x9E3779B185EBCA87
-/// XXPRIME_2 = 0xC2B2AE3D27D4EB4F
-/// XXPRIME_5 = 0x27D4EB2F165667C5
-/// xxrotate = lambda x: (x << 31) | (x >> 33)
-///
-/// acc = XXPRIME_5
-/// for w_item in items:
-///     lane = space.hash_w(w_item)
-///     acc += lane * XXPRIME_2
-///     acc = xxrotate(acc)
-///     acc *= XXPRIME_1
-/// acc += len(items) ^ (XXPRIME_5 ^ 3527539)
-/// if acc == -1: acc = 1546275796 + 1
-/// return acc
-/// ```
-const XXPRIME_1: u64 = 11400714785074694791;
-const XXPRIME_2: u64 = 14029467366897019727;
-const XXPRIME_5: u64 = 2870177450012600261;
-
+/// The shared fold reproduces the accumulator loop and length mangle exactly.
+/// It also corrects the `acc == (uint)-1` sentinel: `tupleobject.py:403`
+/// computes `acc += (acc == -1) * (1546275796 + 1)`, so a wrapped `acc` of
+/// `-1` becomes `1546275796` — the value CPython's `tuplehash` also returns.
+/// The prior local port set the result to `1546275796 + 1` instead of adding
+/// to `acc`, an off-by-one in that (2**-64-probability) case; delegation fixes
+/// it.
 #[inline]
 fn _hash_tuple_xx(items: &[i64]) -> i64 {
-    let mut acc: u64 = XXPRIME_5;
-    for &lane in items {
-        acc = acc.wrapping_add((lane as u64).wrapping_mul(XXPRIME_2));
-        // xxrotate: rotate-left 31 bits.
-        acc = acc.rotate_left(31);
-        acc = acc.wrapping_mul(XXPRIME_1);
-    }
-    // Mangle in the length per `tupleobject.py:399`.
-    let n = items.len() as u64;
-    acc = acc.wrapping_add(n ^ (XXPRIME_5 ^ 3527539u64));
-    let mut h = acc as i64;
-    if h == -1 {
-        h = 1546275796 + 1;
-    }
-    h
+    rustpython_common::hash::hash_tuple(items.iter().map(|&h| Ok::<i64, ()>(h)))
+        .expect("element hashes are precomputed, so the fold cannot fail")
 }
 
 /// `pypy/objspace/std/unicodeobject.py:341-345 W_UnicodeObject.hash_w`
@@ -6549,40 +6524,22 @@ pub fn hash_str_bytes(bytes: &[u8]) -> i64 {
     _hash_str(bytes)
 }
 
-/// `pypy/objspace/std/setobject.py:623-642 W_FrozensetObject.descr_hash`
-/// line-by-line port:
+/// `setobject.py:623-642 W_FrozensetObject.descr_hash` — the order-independent
+/// XOR-fold, delegated to `rustpython_common::hash::FrozenSetHash`.  The caller
+/// has already computed each element's hash into `items`.
 ///
-/// ```python
-/// multi = r_uint(1822399083) + r_uint(1822399083) + 1
-/// hash = r_uint(1927868237)
-/// hash *= r_uint(self.length() + 1)
-/// for item in items:
-///     h = space.hash_w(item)
-///     value = (r_uint(h ^ (h << 16) ^ 89869747) * multi)
-///     hash = hash ^ value
-/// hash ^= (hash >> 11) ^ (hash >> 25)
-/// hash = hash * 69069 + 907133923
-/// hash = intmask(hash)
-/// if hash == -1: hash = 590923713
-/// return hash
-/// ```
+/// The shared accumulator is bit-identical: its `shuffle_bits`
+/// `((h ^ 89869747) ^ (h << 16)) * 3644798167` equals the port's
+/// `(h ^ (h << 16) ^ 89869747) * (1822399083 * 2 + 1)` (xor is associative;
+/// `3644798167 == 1822399083 * 2 + 1`), and the seed `(len + 1) * 1927868237`,
+/// the final dispersion, and the `-1 -> 590923713` sentinel all match.
 #[inline]
 fn _hash_frozenset(items: &[i64]) -> i64 {
-    let multi: u64 = 1822399083u64.wrapping_add(1822399083).wrapping_add(1);
-    let mut h: u64 = 1927868237;
-    h = h.wrapping_mul((items.len() as u64).wrapping_add(1));
+    let mut acc = rustpython_common::hash::FrozenSetHash::new(items.len());
     for &item_hash in items {
-        let item_u = item_hash as u64;
-        let v = (item_u ^ item_u.wrapping_shl(16) ^ 89869747u64).wrapping_mul(multi);
-        h ^= v;
+        acc.add(item_hash);
     }
-    h ^= (h >> 11) ^ (h >> 25);
-    h = h.wrapping_mul(69069).wrapping_add(907133923);
-    let mut hi = h as i64;
-    if hi == -1 {
-        hi = 590923713;
-    }
-    hi
+    acc.finish()
 }
 
 /// `pypy/objspace/std/objspace.py StdObjSpace.hash` parity — share one
@@ -9021,6 +8978,33 @@ mod tests {
         assert_eq!(_hash_str(b""), 0);
         assert_eq!(hash_str_bytes(b""), 0);
         assert_ne!(_hash_str(b"a"), 0);
+    }
+
+    /// Tuple and frozenset hashes delegate to `rustpython_common::hash`
+    /// (`hash_tuple` / `FrozenSetHash`).  Both fold only element hashes and are
+    /// seed-independent, so the values are fixed and match CPython 3.14.
+    /// `_hash_tuple_xx` / `_hash_frozenset` take the already-computed element
+    /// hashes; small ints hash to themselves and `hash(-1) == -2`.
+    #[test]
+    fn tuple_and_frozenset_hash_match_cpython() {
+        let h12 = _hash_tuple_xx(&[1, 2]);
+        let h34 = _hash_tuple_xx(&[3, 4]);
+        assert_eq!(_hash_tuple_xx(&[]), 5740354900026072187); // ()
+        assert_eq!(_hash_tuple_xx(&[1]), -6644214454873602895); // (1,)
+        assert_eq!(h12, -3550055125485641917); // (1, 2)
+        assert_eq!(_hash_tuple_xx(&[1, 2, 3]), 529344067295497451);
+        assert_eq!(_hash_tuple_xx(&[-2, 0, 1]), 5003556802939907908); // (-1, 0, 1)
+        assert_eq!(_hash_tuple_xx(&[h12, h34]), -1467267874458550984); // ((1,2), (3,4))
+        assert_eq!(_hash_tuple_xx(&[549755813930, -5]), 6589866070287121549); // (2**100+42, -5)
+
+        // Frozenset fold is order-independent (XOR), so element order is free.
+        let fs1 = _hash_frozenset(&[1]);
+        let fs2 = _hash_frozenset(&[2]);
+        assert_eq!(_hash_frozenset(&[]), 133146708735736); // frozenset()
+        assert_eq!(fs1, -558064481276695278); // frozenset({1})
+        assert_eq!(_hash_frozenset(&[1, 2, 3]), -272375401224217160);
+        assert_eq!(_hash_frozenset(&[-2, 0, 1]), 8868930259606097796); // {-1, 0, 1}
+        assert_eq!(_hash_frozenset(&[fs1, fs2]), 304806268181062474); // {fs{1}, fs{2}}
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6318,98 +6318,30 @@ const HASH_MODULUS: u64 = (1u64 << HASH_BITS) - 1;
 const HASH_INF: i64 = 314159;
 const HASH_NAN: i64 = 0;
 
-/// `pypy/objspace/std/intobject.py:1231-1249 _hash_int` line-by-line
-/// port —
-///
-/// ```python
-/// def _hash_int(a):
-///     sign = 1 - ((a < 0) << 1)
-///     x = r_uint(a)
-///     x *= r_uint(sign)
-///     x = (x & HASH_MODULUS) + (x >> HASH_BITS)
-///     x -= HASH_MODULUS * (x >= HASH_MODULUS)
-///     h = intmask(intmask(x) * sign)
-///     return h - (h == -1)
-/// ```
-///
-/// `intmask` is "wrap-around to i64" on 64-bit RPython; Rust uses
-/// `as i64` for the same effect.  `-1` is the CPython-reserved "no
-/// hash" sentinel, so any natural hash producing `-1` is bumped to
-/// `-2`.
+/// Numeric hash of a machine-word integer: reduce `a` modulo the
+/// Mersenne prime `HASH_MODULUS = 2**61 - 1` (the residue keeps `a`'s
+/// sign) and bump a `-1` result to `-2`.  Delegated to
+/// `rustpython_common::hash`; `mod_int` is `value % HASH_MODULUS` and
+/// `fix_sentinel` is the `-1 -> -2` guard.  Shares the reduction with
+/// `_hash_long`, so `hash(42) == hash(2**100 + 42)`-class invariants
+/// hold.  `mod_int`/`fix_sentinel` are `const fn`, so this inlines to
+/// the same arithmetic the hand-rolled port produced.
 #[inline]
 pub(crate) fn _hash_int(a: i64) -> i64 {
-    let sign: i64 = 1 - (((a < 0) as i64) << 1);
-    // r_uint(a) * r_uint(sign) — multiply as u64 to compute |a|
-    // without UB on `a == i64::MIN`.  When a < 0, sign == -1 and
-    // (-1 as u64) == u64::MAX; the wrapping product yields the
-    // two's-complement negation of a, i.e. its absolute value.
-    let mut x = (a as u64).wrapping_mul(sign as u64);
-    x = (x & HASH_MODULUS) + (x >> HASH_BITS);
-    if x >= HASH_MODULUS {
-        x -= HASH_MODULUS;
-    }
-    let h = (x as i64).wrapping_mul(sign);
-    h - (h == -1) as i64
+    use rustpython_common::hash;
+    hash::fix_sentinel(hash::mod_int(a))
 }
 
-/// `pypy/objspace/std/longobject.py:468-494 _hash_long` line-by-line
-/// port:
-///
-/// ```python
-/// def _hash_long(v):
-///     i = v.numdigits() - 1
-///     if i == -1: return 0
-///     x = _load_unsigned_digit(0)
-///     while i >= 0:
-///         x = ((x << _HASH_SHIFT) & HASH_MODULUS) | (x >> (HASH_BITS - _HASH_SHIFT))
-///         x += v.udigit(i)
-///         if SHIFT > HASH_BITS:
-///             x = (x & HASH_MODULUS) + (x >> HASH_BITS)
-///         if x >= HASH_MODULUS:
-///             x -= HASH_MODULUS
-///         i -= 1
-///     h = intmask(intmask(x) * v.get_sign())
-///     return h - (h == -1)
-/// ```
-///
-/// PyPy's `rbigint` uses 31-bit digits (`SHIFT = 31`); Rust's
-/// `num_bigint::BigInt` exposes `iter_u32_digits()` so we use
-/// `SHIFT = 32`.  Since `HASH_MODULUS = 2^61 - 1` is a Mersenne
-/// prime, `value mod HASH_MODULUS` is independent of the digit
-/// base — `_hash_int(v) == _hash_long(BigInt::from(v))` for any
-/// `v` that fits in `i64`.
+/// Numeric hash of an arbitrary-precision integer: `value` reduced
+/// modulo the Mersenne prime `HASH_MODULUS = 2**61 - 1` (the residue
+/// keeps the sign), with a `-1` result bumped to `-2`.  Delegated to
+/// `rustpython_common::hash::hash_bigint`.  Because the modulus is a
+/// Mersenne prime the residue is independent of the digit base, so
+/// `_hash_int(v) == _hash_long(BigInt::from(v))` for any `v` that fits
+/// a machine word.
 #[inline]
 pub(crate) fn _hash_long(v: &BigInt) -> i64 {
-    let sign = match v.sign() {
-        malachite_bigint::Sign::Plus => 1i64,
-        malachite_bigint::Sign::Minus => -1i64,
-        malachite_bigint::Sign::NoSign => return 0, // numdigits == 0
-    };
-    // Walk digits from MSB to LSB.  `iter_u32_digits()` yields
-    // little-endian; collect + reverse so we mirror PyPy's loop.
-    let digits: Vec<u32> = v.iter_u32_digits().collect();
-    let mut x: u64 = 0;
-    const SHIFT: u32 = 32;
-    const HASH_SHIFT: u32 = SHIFT % HASH_BITS; // 32 — `SHIFT > HASH_BITS` arm reached later
-    for &d in digits.iter().rev() {
-        // x = ((x << HASH_SHIFT) & HASH_MODULUS) | (x >> (HASH_BITS - HASH_SHIFT))
-        let left = (x.wrapping_shl(HASH_SHIFT)) & HASH_MODULUS;
-        let right = if HASH_BITS > HASH_SHIFT {
-            x >> (HASH_BITS - HASH_SHIFT)
-        } else {
-            0
-        };
-        x = left | right;
-        x = x.wrapping_add(d as u64);
-        if SHIFT > HASH_BITS {
-            x = (x & HASH_MODULUS) + (x >> HASH_BITS);
-        }
-        if x >= HASH_MODULUS {
-            x -= HASH_MODULUS;
-        }
-    }
-    let h = (x as i64).wrapping_mul(sign);
-    h - (h == -1) as i64
+    rustpython_common::hash::hash_bigint(v)
 }
 
 /// `pypy/objspace/std/floatobject.py:790-822 _hash_float` line-by-line
@@ -6443,6 +6375,13 @@ pub(crate) fn _hash_long(v: &BigInt) -> i64 {
 /// `hash(42) == hash(42.0)` invariant.  NaN is dispatched to
 /// `HASH_NAN` by the caller (PyPy's `W_FloatObject.descr_hash` does
 /// the NaN check before reaching `_hash_float`).
+///
+/// Kept local rather than delegated to
+/// `rustpython_common::hash::hash_float`: that routine's frexp
+/// (`float_ops::decompose_float`) normalises every input as if it had
+/// an implicit leading mantissa bit, so it produces the wrong exponent
+/// for subnormals and diverges there (`hash(5e-324)` is `16777216`, but
+/// it returns `8404992`).  `libm_frexp` below rescales subnormals first.
 #[inline]
 pub(crate) fn _hash_float(v: f64) -> i64 {
     if v.is_nan() {
@@ -6576,6 +6515,11 @@ fn _hash_tuple_xx(items: &[i64]) -> i64 {
 /// instead of panicking on the `&str` view.
 fn _hash_str(bytes: &[u8]) -> i64 {
     use core::hash::Hasher;
+    // Empty input hashes to 0 (`""` and `b""`), short-circuiting the
+    // siphash digest.
+    if bytes.is_empty() {
+        return 0;
+    }
     // `rpython/rlib/rsiphash.py:60-62 _build_key_from_seed` — when
     // `PYTHONHASHSEED=0` the key is the 16-byte all-zero buffer.
     // Pyre runs with the deterministic seed for reproducibility,
@@ -6583,6 +6527,12 @@ fn _hash_str(bytes: &[u8]) -> i64 {
     // user-overridable seed is straight-forward (`OnceLock<[u8; 16]>`
     // sampled from `getrandom` or the env var) once tests are
     // robust to it.
+    //
+    // Not delegated to `rustpython_common::hash::hash_str`: that path
+    // needs a `HashSecret`, whose all-zero key is un-constructable at
+    // the pinned rev (private `k0`/`k1`, only a seeded `new`), and it
+    // hashes through the slice `Hash` impl (length prefix) plus a
+    // `mod_int` reduction that this raw siphash24 digest omits.
     static SECRET: [u8; 16] = [0u8; 16];
     let mut hasher = siphasher::sip::SipHasher24::new_with_key(&SECRET);
     hasher.write(bytes);
@@ -8995,6 +8945,83 @@ fn builtin_import_stub(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The integer hashes now delegate to `rustpython_common::hash`
+    /// (`_hash_int` = `fix_sentinel(mod_int(a))`, `_hash_long` =
+    /// `hash_bigint`).  This locks the two crate entry points that reach
+    /// the same Mersenne reduction to one value across the machine-word
+    /// and big-integer ranges.
+    #[test]
+    fn common_hash_matches_pyre_int_helpers() {
+        use rustpython_common::hash;
+        let ints: [i64; 13] = [
+            0,
+            1,
+            -1,
+            42,
+            -42,
+            255,
+            i64::MAX,
+            i64::MIN,
+            HASH_MODULUS as i64,
+            HASH_MODULUS as i64 + 1,
+            (HASH_MODULUS as i64).wrapping_neg(),
+            1 << 40,
+            -(1 << 40),
+        ];
+        for &a in &ints {
+            assert_eq!(
+                hash::hash_bigint(&BigInt::from(a)),
+                _hash_int(a),
+                "hash_bigint vs _hash_int for {a}"
+            );
+        }
+        // -1 is the reserved sentinel, remapped to -2.
+        assert_eq!(_hash_int(-1), -2);
+        let bigs = [
+            BigInt::from(2).pow(100) + BigInt::from(42),
+            -(BigInt::from(2).pow(100)),
+            BigInt::from(2).pow(200) - BigInt::from(1),
+            BigInt::from(u128::MAX),
+            -BigInt::from(u128::MAX),
+        ];
+        for b in &bigs {
+            assert_eq!(hash::hash_bigint(b), _hash_long(b), "hash_bigint vs _hash_long");
+        }
+    }
+
+    /// Float hashing stays local: `rustpython_common::hash::hash_float`
+    /// mishandles subnormals (its frexp assumes a normalised mantissa),
+    /// so it diverges from the reference `hash(5e-324) == 16777216` that
+    /// `_hash_float` reproduces.  If this ever stops diverging, revisit
+    /// delegating `_hash_float`.
+    #[test]
+    fn float_hash_kept_local_matches_reference_on_subnormals() {
+        use rustpython_common::hash;
+        let smallest_subnormal = f64::from_bits(1);
+        assert_eq!(_hash_float(smallest_subnormal), 16777216);
+        assert_ne!(
+            hash::hash_float(smallest_subnormal),
+            Some(_hash_float(smallest_subnormal)),
+            "common::hash::hash_float no longer diverges on the smallest subnormal"
+        );
+        // Integral and NaN reference points.
+        assert_eq!(_hash_float(2.0), 2);
+        assert_eq!(_hash_float(f64::NAN), HASH_NAN);
+        // Non-subnormal finite floats still agree with common.
+        for &f in &[1.5f64, -1.5, 3.14, 1e20, 9.999e15] {
+            assert_eq!(hash::hash_float(f), Some(_hash_float(f)), "hash_float for {f}");
+        }
+    }
+
+    /// Empty `str`/`bytes` hash to 0; non-empty inputs take the siphash
+    /// digest.
+    #[test]
+    fn empty_str_and_bytes_hash_to_zero() {
+        assert_eq!(_hash_str(b""), 0);
+        assert_eq!(hash_str_bytes(b""), 0);
+        assert_ne!(_hash_str(b"a"), 0);
+    }
 
     #[test]
     fn test_hash_rejects_tuple_containing_unhashable_key() {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6314,8 +6314,7 @@ fn unhashable_type_error(obj: PyObjectRef) -> crate::PyError {
 /// numeric values land on the same residue.
 const HASH_BITS: u32 = 61;
 const HASH_MODULUS: u64 = (1u64 << HASH_BITS) - 1;
-/// `floatobject.py:29-30` HASH_INF / HASH_NAN sentinels.
-const HASH_INF: i64 = 314159;
+/// `floatobject.py:29-30` HASH_NAN sentinel.
 const HASH_NAN: i64 = 0;
 
 /// Numeric hash of a machine-word integer: reduce `a` modulo the
@@ -6344,107 +6343,15 @@ pub(crate) fn _hash_long(v: &BigInt) -> i64 {
     rustpython_common::hash::hash_bigint(v)
 }
 
-/// `pypy/objspace/std/floatobject.py:790-822 _hash_float` line-by-line
-/// port:
-///
-/// ```python
-/// def _hash_float(v):
-///     if math.isinf(v): return HASH_INF if v > 0 else -HASH_INF
-///     # nan hash handled elsewhere (W_FloatObject.descr_hash routes to HASH_NAN)
-///     m, e = math.frexp(v)
-///     sign = 1
-///     if m < 0: sign = -1; m = -m
-///     x = r_uint(0)
-///     while m:
-///         x = ((x << 28) & HASH_MODULUS) | x >> (HASH_BITS - 28)
-///         m *= 268435456.0          # 2**28
-///         e -= 28
-///         y = r_uint(m)
-///         m -= y
-///         x += y
-///         if x >= HASH_MODULUS: x -= HASH_MODULUS
-///     e = e % HASH_BITS if e >= 0 else HASH_BITS - 1 - ((-1 - e) % HASH_BITS)
-///     x = ((x << e) & HASH_MODULUS) | x >> (HASH_BITS - e)
-///     x = intmask(intmask(x) * sign)
-///     x -= (x == -1)
-///     return x
-/// ```
-///
-/// For finite floats whose value is an integer that fits in `i64`,
-/// this returns the same value as `_hash_int(v as i64)` — that's the
-/// `hash(42) == hash(42.0)` invariant.  NaN is dispatched to
-/// `HASH_NAN` by the caller (PyPy's `W_FloatObject.descr_hash` does
-/// the NaN check before reaching `_hash_float`).
-///
-/// Kept local rather than delegated to
-/// `rustpython_common::hash::hash_float`: that routine's frexp
-/// (`float_ops::decompose_float`) normalises every input as if it had
-/// an implicit leading mantissa bit, so it produces the wrong exponent
-/// for subnormals and diverges there (`hash(5e-324)` is `16777216`, but
-/// it returns `8404992`).  `libm_frexp` below rescales subnormals first.
+/// Numeric hash of a `float`.  `rustpython_common::hash::hash_float`
+/// reduces the mantissa/exponent modulo the Mersenne prime
+/// `HASH_MODULUS = 2**61 - 1` (keeping the sign), so `hash(2.0) == hash(2)`
+/// and the `±inf` sentinels are `±314159`; subnormals decompose exactly.
+/// It returns `None` for NaN, and the sole caller (`hash_value`) reaches
+/// here without a prior NaN check, so map that to `HASH_NAN`.
 #[inline]
 pub(crate) fn _hash_float(v: f64) -> i64 {
-    if v.is_nan() {
-        return HASH_NAN;
-    }
-    if v.is_infinite() {
-        return if v > 0.0 { HASH_INF } else { -HASH_INF };
-    }
-    // For integral values that fit in i64, short-circuit to
-    // `_hash_int(v as i64)` so `hash(2.0) == hash(2)`.  The frexp
-    // walk below produces the same result, but the integer fast path
-    // avoids floating-point noise on already-integer inputs.
-    if v.fract() == 0.0 && (i64::MIN as f64) <= v && v <= (i64::MAX as f64) {
-        return _hash_int(v as i64);
-    }
-    let (mut m, mut e) = libm_frexp(v);
-    let mut sign: i64 = 1;
-    if m < 0.0 {
-        sign = -1;
-        m = -m;
-    }
-    let mut x: u64 = 0;
-    while m != 0.0 {
-        x = ((x.wrapping_shl(28)) & HASH_MODULUS) | (x >> (HASH_BITS - 28));
-        m *= 268435456.0; // 2**28
-        e -= 28;
-        let y = m as u64;
-        m -= y as f64;
-        x = x.wrapping_add(y);
-        if x >= HASH_MODULUS {
-            x -= HASH_MODULUS;
-        }
-    }
-    // `e = e % HASH_BITS if e >= 0 else HASH_BITS - 1 - ((-1 - e) % HASH_BITS)`
-    let e_mod: u32 = if e >= 0 {
-        (e as u32) % HASH_BITS
-    } else {
-        HASH_BITS - 1 - (((-1 - e) as u32) % HASH_BITS)
-    };
-    x = ((x.wrapping_shl(e_mod)) & HASH_MODULUS) | (x >> (HASH_BITS - e_mod));
-    let h = (x as i64).wrapping_mul(sign);
-    h - (h == -1) as i64
-}
-
-/// Rust port of Python's `math.frexp(x) -> (mantissa, exponent)` where
-/// `x == mantissa * 2**exponent` and `0.5 <= |mantissa| < 1` (or both
-/// are 0).  `libm` isn't a workspace dep, so we use `f64::to_bits`
-/// to peek at the IEEE-754 exponent directly.
-#[inline]
-fn libm_frexp(v: f64) -> (f64, i32) {
-    if v == 0.0 || !v.is_finite() {
-        return (v, 0);
-    }
-    let bits = v.to_bits();
-    let raw_exp = ((bits >> 52) & 0x7ff) as i32;
-    if raw_exp == 0 {
-        // Subnormal — normalise by multiplying with 2**54.
-        let (m, e) = libm_frexp(v * (1u64 << 54) as f64);
-        return (m, e - 54);
-    }
-    let exponent = raw_exp - 1022;
-    let mantissa_bits = (bits & !(0x7ffu64 << 52)) | (1022u64 << 52);
-    (f64::from_bits(mantissa_bits), exponent)
+    rustpython_common::hash::hash_float(v).unwrap_or(HASH_NAN)
 }
 
 /// `tupleobject.py:358-401 descr_hash` — the xxHash sequence hash, delegated
@@ -8947,27 +8854,63 @@ mod tests {
         }
     }
 
-    /// Float hashing stays local: `rustpython_common::hash::hash_float`
-    /// mishandles subnormals (its frexp assumes a normalised mantissa),
-    /// so it diverges from the reference `hash(5e-324) == 16777216` that
-    /// `_hash_float` reproduces.  If this ever stops diverging, revisit
-    /// delegating `_hash_float`.
+    /// `_hash_float` delegates to `rustpython_common::hash::hash_float`,
+    /// which reproduces the reference `hash(5e-324) == 16777216` for
+    /// subnormals, the `hash(2.0) == hash(2)` integral invariant, and the
+    /// `±inf`/NaN sentinels.
     #[test]
-    fn float_hash_kept_local_matches_reference_on_subnormals() {
+    fn float_hash_delegates_to_common() {
         use rustpython_common::hash;
-        let smallest_subnormal = f64::from_bits(1);
-        assert_eq!(_hash_float(smallest_subnormal), 16777216);
-        assert_ne!(
-            hash::hash_float(smallest_subnormal),
-            Some(_hash_float(smallest_subnormal)),
-            "common::hash::hash_float no longer diverges on the smallest subnormal"
-        );
-        // Integral and NaN reference points.
+        // Subnormal reference point (the value that motivated the fix).
+        assert_eq!(_hash_float(f64::from_bits(1)), 16777216);
+        // Integral, zero, and sentinel reference points.
         assert_eq!(_hash_float(2.0), 2);
+        assert_eq!(_hash_float(-1.0), -2);
+        assert_eq!(_hash_float(0.0), 0);
+        assert_eq!(_hash_float(-0.0), 0);
+        assert_eq!(_hash_float(f64::INFINITY), 314159);
+        assert_eq!(_hash_float(f64::NEG_INFINITY), -314159);
+        // NaN hashes to HASH_NAN here; common returns None for it.
         assert_eq!(_hash_float(f64::NAN), HASH_NAN);
-        // Non-subnormal finite floats still agree with common.
-        for &f in &[1.5f64, -1.5, 3.14, 1e20, 9.999e15] {
-            assert_eq!(hash::hash_float(f), Some(_hash_float(f)), "hash_float for {f}");
+        assert_eq!(hash::hash_float(f64::NAN), None);
+        // Differential battery of tricky finite floats: `_hash_float` must
+        // equal `Some(hash_float(f))` on every one.
+        let cases = [
+            0.0f64,
+            -0.0,
+            f64::from_bits(1),       // smallest positive subnormal
+            -f64::from_bits(1),
+            5e-324,
+            1e-310,                  // subnormal
+            2.2250738585072014e-308, // smallest normal
+            0.1,
+            -0.1,
+            0.5,
+            1.0,
+            -1.0,
+            1.5,
+            -1.5,
+            2.0,
+            3.14,
+            123.456,
+            9.999e15,
+            1e16,
+            1e20,
+            1e100,
+            1e308,
+            f64::MAX,
+            f64::MIN,
+            -123456789.123456789,
+            9.995,
+            268435456.0, // 2**28
+            1.7976931348623157e308,
+        ];
+        for &f in &cases {
+            assert_eq!(
+                Some(_hash_float(f)),
+                hash::hash_float(f),
+                "hash_float divergence for {f}"
+            );
         }
     }
 

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -99,7 +99,11 @@ pub(crate) fn format_wtf8_repr(s: &Wtf8) -> String {
 fn bytearray_repr_string(data: &[u8]) -> String {
     let has_single = data.contains(&b'\'');
     let has_double = data.contains(&b'"');
-    let quote = if has_single && !has_double { b'"' } else { b'\'' };
+    let quote = if has_single && !has_double {
+        b'"'
+    } else {
+        b'\''
+    };
     let mut out = String::with_capacity(data.len() + 14);
     out.push_str("bytearray(b");
     out.push(quote as char);

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -79,39 +79,45 @@ pub(crate) fn format_float_repr(val: f64) -> String {
     rustpython_literal::float::to_string(val)
 }
 
-/// `rutf8.py:660 make_utf8_escape_function` (`quotes=True`) parity —
-/// pick the outer quote (prefer single, switch to double iff the string
-/// contains a single but no double), then escape backslash, the matching
-/// quote, common whitespace, and control characters.  Lone surrogate code
-/// points are escaped via `char_escape_helper` (`rutf8.py:647`) as
-/// `\uXXXX`.  Non-control scalar values pass through verbatim.
+/// `repr`-style string escaping: pick the outer quote (prefer `'`, switch
+/// to `"` when the value contains `'` but not `"`), escape the backslash,
+/// the chosen quote, whitespace and non-printable code points, and render
+/// lone surrogates as `\uXXXX`. Delegates to the shared escape engine in
+/// `rustpython_literal::escape`.
 pub(crate) fn format_wtf8_repr(s: &Wtf8) -> String {
-    let bytes = s.as_bytes();
-    let has_single = bytes.contains(&b'\'');
-    let has_double = bytes.contains(&b'"');
-    let quote = if has_single && !has_double { '"' } else { '\'' };
-    let mut out = String::with_capacity(bytes.len() + 2);
-    out.push(quote);
-    for cp in s.code_points() {
-        match cp.to_char() {
-            Some('\\') => out.push_str("\\\\"),
-            Some('\t') => out.push_str("\\t"),
-            Some('\n') => out.push_str("\\n"),
-            Some('\r') => out.push_str("\\r"),
-            Some(c) if c == quote => {
+    use rustpython_literal::escape::{Quote, UnicodeEscape};
+    let escape = UnicodeEscape::with_preferred_quote(s, Quote::Single);
+    let mut out = String::new();
+    escape.str_repr().write(&mut out).unwrap();
+    out
+}
+
+/// `bytearrayobject.py W_BytearrayObject.descr_repr` — `bytearray(b'...')`.
+/// The outer quote prefers `'`, flipping to `"` only when the data holds a
+/// `'` but no `"`; the body always backslash-escapes `'` and `\` and never
+/// escapes `"`, so a `'` survives as `\'` even under a `"` outer quote.
+fn bytearray_repr_string(data: &[u8]) -> String {
+    let has_single = data.contains(&b'\'');
+    let has_double = data.contains(&b'"');
+    let quote = if has_single && !has_double { b'"' } else { b'\'' };
+    let mut out = String::with_capacity(data.len() + 14);
+    out.push_str("bytearray(b");
+    out.push(quote as char);
+    for &c in data {
+        match c {
+            b'\'' | b'\\' => {
                 out.push('\\');
-                out.push(c);
+                out.push(c as char);
             }
-            Some(c) if (c as u32) < 0x20 || (c as u32) == 0x7f => {
-                out.push_str(&format!("\\x{:02x}", c as u32));
-            }
-            Some(c) => out.push(c),
-            // Lone surrogate (0xD800-0xDFFF) — char_escape_helper emits
-            // `\u` + four hex digits for codepoints in [0x100, 0x10000).
-            None => out.push_str(&format!("\\u{:04x}", cp.to_u32())),
+            b'\t' => out.push_str("\\t"),
+            b'\n' => out.push_str("\\n"),
+            b'\r' => out.push_str("\\r"),
+            0x20..=0x7e => out.push(c as char),
+            _ => out.push_str(&format!("\\x{c:02x}")),
         }
     }
-    out.push(quote);
+    out.push(quote as char);
+    out.push(')');
     out
 }
 
@@ -471,31 +477,21 @@ pub unsafe fn py_repr(obj: PyObjectRef) -> Result<String, crate::PyError> {
                 py_repr(pyre_object::sliceobject::w_slice_get_step(obj))?,
             )
         } else if pyre_object::is_bytes_like(obj) {
-            // `pypy/objspace/std/bytesobject.py W_BytesObject.descr_repr`
-            // and `bytearrayobject.py W_BytearrayObject.descr_repr` —
-            // ASCII-printable bytes pass through, control bytes use
-            // `\xNN`, single quotes get backslash-escaped (or the outer
-            // quote flips to double when both quote kinds appear, but
-            // pyre keeps the simpler single-quote form for now).
-            // bytearray wraps the bytes literal: `bytearray(b'...')`.
+            // `bytesobject.py W_BytesObject.descr_repr` — ASCII-printable
+            // bytes pass through, control/high bytes use `\xNN`, and the
+            // outer quote prefers `'`, flipping to `"` when the data holds a
+            // `'` but no `"`.
             let data = pyre_object::bytes_like_data(obj);
-            let mut body = String::with_capacity(data.len() + 4);
-            body.push_str("b'");
-            for &b in data {
-                match b {
-                    b'\\' => body.push_str("\\\\"),
-                    b'\'' => body.push_str("\\'"),
-                    b'\n' => body.push_str("\\n"),
-                    b'\r' => body.push_str("\\r"),
-                    b'\t' => body.push_str("\\t"),
-                    0x20..=0x7e => body.push(b as char),
-                    _ => body.push_str(&format!("\\x{b:02x}")),
-                }
-            }
-            body.push('\'');
             if pyre_object::bytearrayobject::is_bytearray(obj) {
-                format!("bytearray({body})")
+                // `bytearrayobject.py W_BytearrayObject.descr_repr` differs
+                // from the bytes form: it chooses the same outer quote but
+                // always backslash-escapes an inner `'` (never `"`), so the
+                // shared bytes escaper cannot express it.
+                bytearray_repr_string(data)
             } else {
+                let escape = rustpython_literal::escape::AsciiEscape::new_repr(data);
+                let mut body = String::new();
+                escape.bytes_repr().write(&mut body).unwrap();
                 body
             }
         } else if pyre_object::is_set_or_frozenset(obj) {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -71,62 +71,12 @@ unsafe fn dunder_returned_non_string(name: &str, result: PyObjectRef) -> crate::
     crate::PyError::type_error(format!("{name} returned non-string (type '{type_name}')"))
 }
 
-/// `pypy/objspace/std/floatobject.py W_FloatObject.descr_repr` parity.
-/// CPython prints lowercase `nan` / `inf`, uses scientific notation for
-/// magnitudes outside `[1e-4, 1e17)` (approximately), and otherwise
-/// uses positional form with at most 17 significant digits.  Pyre's
-/// approximation:
-///   - integral floats in the positional band → `"<n>.0"`
-///   - magnitude < 1e-4 or >= 1e16 → `"{:e}"` with explicit sign
-///   - otherwise → Rust's `Display` (`{}`)
+/// `floatobject.py W_FloatObject.descr_repr` — the shortest decimal string
+/// that round-trips to `val` (lowercase `nan`/`inf`, signed two-digit
+/// exponents, `.0` on integral values). Delegates to the shortest-repr
+/// formatter in `rustpython_literal::float`.
 pub(crate) fn format_float_repr(val: f64) -> String {
-    if val.is_nan() {
-        return "nan".to_string();
-    }
-    if val.is_infinite() {
-        return if val < 0.0 {
-            "-inf".to_string()
-        } else {
-            "inf".to_string()
-        };
-    }
-    let abs = val.abs();
-    if val == 0.0 {
-        return if val.is_sign_negative() {
-            "-0.0".to_string()
-        } else {
-            "0.0".to_string()
-        };
-    }
-    if abs >= 1e16 || abs < 1e-4 {
-        // Build `{m}e[+|-]NN` in CPython's float_repr style:
-        // exponent is signed, two-digit minimum.  Rust's `{:e}` emits
-        // unsigned exponent with no padding (`1e100`); rewrite to match
-        // CPython's `1e+100` / `1.5e-10`.
-        let raw = format!("{val:e}");
-        if let Some(epos) = raw.find('e') {
-            let (mantissa, exp) = raw.split_at(epos);
-            let exp = &exp[1..]; // drop 'e'
-            let (sign, mag) = if let Some(rest) = exp.strip_prefix('-') {
-                ("-", rest)
-            } else if let Some(rest) = exp.strip_prefix('+') {
-                ("+", rest)
-            } else {
-                ("+", exp)
-            };
-            let mag_padded = if mag.len() < 2 {
-                format!("0{mag}")
-            } else {
-                mag.to_string()
-            };
-            return format!("{mantissa}e{sign}{mag_padded}");
-        }
-        return raw;
-    }
-    if val.fract() == 0.0 {
-        return format!("{val:.1}");
-    }
-    format!("{val}")
+    rustpython_literal::float::to_string(val)
 }
 
 /// `rutf8.py:660 make_utf8_escape_function` (`quotes=True`) parity —

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -1,11 +1,17 @@
 //! binascii module — PyPy: `pypy/module/binascii/`.
 //!
-//! Pure-Rust base64 / hex / crc32 conversions, enough for `base64.py`,
-//! `email`, `quopri`, and the hashlib/zip helpers to import and run.
+//! base64 / hex / uu / quoted-printable / crc conversions. The byte transforms
+//! are a deliberate duplication of RustPython's verified `binascii` core, ported
+//! verbatim into [`transforms`] (pure `&[u8]` in / `Vec<u8>` out) and kept
+//! outside the LLBC extraction; this module is the W_Root argument/error glue.
+
+// Verbatim vendored transform core. `rlecode_hqx` / `rledecode_hqx` live here
+// for completeness but are not part of the 3.14 module surface (removed with
+// binhex), so they stay unexposed.
+#[allow(dead_code)]
+mod transforms;
 
 use pyre_object::*;
-
-const B64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 /// Accept a str (ASCII) or any bytes-like and surface the raw bytes.
 fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
@@ -22,112 +28,115 @@ fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     }
 }
 
-fn b64_encode(data: &[u8], newline: bool) -> Vec<u8> {
-    let mut out = Vec::with_capacity(data.len().div_ceil(3) * 4 + 1);
-    for chunk in data.chunks(3) {
-        let b0 = chunk[0] as u32;
-        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
-        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
-        let n = (b0 << 16) | (b1 << 8) | b2;
-        out.push(B64[(n >> 18 & 0x3f) as usize]);
-        out.push(B64[(n >> 12 & 0x3f) as usize]);
-        out.push(if chunk.len() > 1 {
-            B64[(n >> 6 & 0x3f) as usize]
-        } else {
-            b'='
-        });
-        out.push(if chunk.len() > 2 {
-            B64[(n & 0x3f) as usize]
-        } else {
-            b'='
-        });
+// ── errors ──────────────────────────────────────────────────────────────
+
+/// Build a `binascii.Error` (a `ValueError` subclass) carrying `msg`.
+fn binascii_error(msg: impl Into<String>) -> crate::PyError {
+    let msg = msg.into();
+    let mut err = crate::PyError::value_error(msg.clone());
+    if let Some(cls) = crate::builtins::lookup_exc_class("binascii.Error") {
+        let args = [cls, w_str_new(&msg)];
+        if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            err.exc_object = exc;
+        }
     }
-    if newline {
-        out.push(b'\n');
-    }
-    out
+    err
 }
 
-fn b64_decode(data: &[u8]) -> Result<Vec<u8>, crate::PyError> {
-    // Reverse lookup; ignore whitespace, stop at padding.
-    let mut rev = [255u8; 256];
-    for (i, &c) in B64.iter().enumerate() {
-        rev[c as usize] = i as u8;
+/// Map a base64 decode failure to the exact `binascii.Error` message.
+fn base64_decode_message(e: transforms::Base64DecodeError) -> String {
+    use transforms::Base64DecodeError as E;
+    match e {
+        E::InvalidByte {
+            index: 0,
+            byte: transforms::PAD,
+        } => "Leading padding not allowed".to_owned(),
+        E::InvalidByte {
+            byte: transforms::PAD,
+            ..
+        } => "Discontinuous padding not allowed".to_owned(),
+        E::InvalidByte { .. } => "Only base64 data is allowed".to_owned(),
+        E::InvalidLastSymbol {
+            byte: transforms::PAD,
+            ..
+        } => "Excess data after padding".to_owned(),
+        E::InvalidLastSymbol { index: length, .. } => format!(
+            "Invalid base64-encoded string: number of data characters ({length}) cannot be 1 more than a multiple of 4"
+        ),
+        E::InvalidLength(_) => "Incorrect padding".to_owned(),
     }
-    let mut bits = 0u32;
-    let mut nbits = 0u32;
-    let mut out = Vec::new();
-    for &c in data {
-        if c == b'=' {
-            break;
-        }
-        if c.is_ascii_whitespace() {
-            continue;
-        }
-        let v = rev[c as usize];
-        if v == 255 {
-            // Skip non-alphabet bytes (lenient, matching default mode).
-            continue;
-        }
-        bits = (bits << 6) | v as u32;
-        nbits += 6;
-        if nbits >= 8 {
-            nbits -= 8;
-            out.push((bits >> nbits) as u8);
-        }
-    }
-    Ok(out)
 }
 
-fn hex_encode(data: &[u8], sep: Option<(u8, usize)>) -> Vec<u8> {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = Vec::with_capacity(data.len() * 2);
-    for (i, &b) in data.iter().enumerate() {
-        if let Some((s, per)) = sep {
-            if per > 0 && i != 0 && i % per == 0 {
-                out.push(s);
-            }
-        }
-        out.push(HEX[(b >> 4) as usize]);
-        out.push(HEX[(b & 0xf) as usize]);
-    }
-    out
-}
-
-fn hex_decode(data: &[u8]) -> Result<Vec<u8>, crate::PyError> {
-    let stripped: Vec<u8> = data
-        .iter()
-        .copied()
-        .filter(|b| !b.is_ascii_whitespace())
-        .collect();
-    if stripped.len() % 2 != 0 {
-        return Err(crate::PyError::value_error("Odd-length string"));
-    }
-    let mut out = Vec::with_capacity(stripped.len() / 2);
-    let nibble = |c: u8| -> Result<u8, crate::PyError> {
-        match c {
-            b'0'..=b'9' => Ok(c - b'0'),
-            b'a'..=b'f' => Ok(c - b'a' + 10),
-            b'A'..=b'F' => Ok(c - b'A' + 10),
-            _ => Err(crate::PyError::value_error("Non-hexadecimal digit found")),
-        }
+/// Map a transform [`transforms::Error`] to the matching `binascii.Error`.
+fn transform_error(e: transforms::Error) -> crate::PyError {
+    let msg = match e {
+        transforms::Error::OddLengthString => "Odd-length string".to_owned(),
+        transforms::Error::NonHexadecimalDigit => "Non-hexadecimal digit found".to_owned(),
+        transforms::Error::IllegalChar => "Illegal char".to_owned(),
+        transforms::Error::TrailingGarbage => "Trailing garbage".to_owned(),
+        transforms::Error::TooLong => "At most 45 bytes at once".to_owned(),
+        transforms::Error::Base64(b) => base64_decode_message(b),
     };
-    for pair in stripped.chunks(2) {
-        out.push((nibble(pair[0])? << 4) | nibble(pair[1])?);
-    }
-    Ok(out)
+    binascii_error(msg)
 }
 
-fn crc32_compute(buf: &[u8], start: u32) -> u32 {
-    let mut crc = !start;
-    for &b in buf {
-        crc ^= b as u32;
-        for _ in 0..8 {
-            let mask = (crc & 1).wrapping_neg();
-            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
-        }
+// ── argument helpers ────────────────────────────────────────────────────
+
+/// Optional flag argument, read from `name=` or the positional slot `index`.
+/// A missing or `None` value yields `default`; anything else is truth-tested.
+fn arg_bool(
+    pos: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    name: &str,
+    index: usize,
+    default: bool,
+) -> bool {
+    match crate::builtins::kwarg_get(kwargs, name).or_else(|| pos.get(index).copied()) {
+        Some(o) if unsafe { is_none(o) } => default,
+        Some(o) => crate::baseobjspace::is_true(o).unwrap_or(default),
+        None => default,
     }
-    !crc
+}
+
+/// The `sep` / `bytes_per_sep` separator for `hexlify` / `b2a_hex`, validated
+/// exactly as the C accelerator: length-1, ASCII.
+fn arg_sep(
+    pos: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+) -> Result<(Option<u8>, isize), crate::PyError> {
+    let sep = match crate::builtins::kwarg_get(kwargs, "sep").or_else(|| pos.get(1).copied()) {
+        Some(o) if !unsafe { is_none(o) } => {
+            let bytes = as_bytes(o)?;
+            if bytes.len() != 1 {
+                return Err(crate::PyError::value_error("sep must be length 1."));
+            }
+            if !bytes[0].is_ascii() {
+                return Err(crate::PyError::value_error("sep must be ASCII."));
+            }
+            Some(bytes[0])
+        }
+        _ => None,
+    };
+    let bytes_per_sep = match crate::builtins::kwarg_get(kwargs, "bytes_per_sep")
+        .or_else(|| pos.get(2).copied())
+    {
+        Some(o) if !unsafe { is_none(o) } => crate::baseobjspace::int_w(o)? as isize,
+        _ => 1,
+    };
+    Ok((sep, bytes_per_sep))
+}
+
+fn arg_u32(
+    pos: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    name: &str,
+    index: usize,
+    default: u32,
+) -> Result<u32, crate::PyError> {
+    match crate::builtins::kwarg_get(kwargs, name).or_else(|| pos.get(index).copied()) {
+        Some(o) if !unsafe { is_none(o) } => Ok(crate::baseobjspace::int_w(o)? as u32),
+        _ => Ok(default),
+    }
 }
 
 crate::py_module! {
@@ -139,58 +148,83 @@ crate::py_module! {
         "Incomplete" => crate::builtins::lookup_exc_class("Exception").expect("Exception installed"),
     },
     functions: {
-        "b2a_base64" / * = |args| {
-            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
-            let newline = crate::builtins::kwarg_get(kwargs, "newline")
-                .or_else(|| pos.get(1).copied())
-                .map(|o| crate::baseobjspace::is_true(o).unwrap_or(true))
-                .unwrap_or(true);
-            Ok(w_bytes_from_bytes(&b64_encode(&data, newline)))
-        },
-        "a2b_base64" / * = |args| {
-            let (pos, _kwargs) = crate::builtins::split_builtin_kwargs(args);
-            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
-            Ok(w_bytes_from_bytes(&b64_decode(&data)?))
-        },
         "b2a_hex" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
             let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
-            let sep = crate::builtins::kwarg_get(kwargs, "sep")
-                .or_else(|| pos.get(1).copied())
-                .and_then(|o| as_bytes(o).ok())
-                .and_then(|b| b.first().copied());
-            let per = crate::builtins::kwarg_get(kwargs, "bytes_per_sep")
-                .or_else(|| pos.get(2).copied())
-                .map(|o| unsafe { w_int_get_value(o) } as usize)
-                .unwrap_or(1);
-            Ok(w_bytes_from_bytes(&hex_encode(&data, sep.map(|s| (s, per)))))
+            let (sep, bytes_per_sep) = arg_sep(pos, kwargs)?;
+            Ok(w_bytes_from_bytes(&transforms::hexlify(&data, sep, bytes_per_sep)))
         },
         "hexlify" / * = |args| {
             let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
             let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
-            let sep = crate::builtins::kwarg_get(kwargs, "sep")
-                .or_else(|| pos.get(1).copied())
-                .and_then(|o| as_bytes(o).ok())
-                .and_then(|b| b.first().copied());
-            let per = crate::builtins::kwarg_get(kwargs, "bytes_per_sep")
-                .or_else(|| pos.get(2).copied())
-                .map(|o| unsafe { w_int_get_value(o) } as usize)
-                .unwrap_or(1);
-            Ok(w_bytes_from_bytes(&hex_encode(&data, sep.map(|s| (s, per)))))
+            let (sep, bytes_per_sep) = arg_sep(pos, kwargs)?;
+            Ok(w_bytes_from_bytes(&transforms::hexlify(&data, sep, bytes_per_sep)))
         },
         "a2b_hex" / 1 = |args| {
             let data = as_bytes(args.first().copied().unwrap_or(w_none()))?;
-            Ok(w_bytes_from_bytes(&hex_decode(&data)?))
+            let out = transforms::unhexlify(&data).map_err(transform_error)?;
+            Ok(w_bytes_from_bytes(&out))
         },
         "unhexlify" / 1 = |args| {
             let data = as_bytes(args.first().copied().unwrap_or(w_none()))?;
-            Ok(w_bytes_from_bytes(&hex_decode(&data)?))
+            let out = transforms::unhexlify(&data).map_err(transform_error)?;
+            Ok(w_bytes_from_bytes(&out))
         },
         "crc32" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let init = arg_u32(pos, kwargs, "crc", 1, 0)?;
+            Ok(w_int_new(transforms::crc32(&data, init) as i64))
+        },
+        "crc_hqx" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let init = match crate::builtins::kwarg_get(kwargs, "crc").or_else(|| pos.get(1).copied()) {
+                Some(o) => crate::baseobjspace::int_w(o)? as u32,
+                None => return Err(crate::PyError::type_error(
+                    "crc_hqx() missing required argument 'crc' (pos 2)",
+                )),
+            };
+            Ok(w_int_new(transforms::crc_hqx(&data, init) as i64))
+        },
+        "a2b_base64" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let strict_mode = arg_bool(pos, kwargs, "strict_mode", 1, false);
+            let out = transforms::a2b_base64(&data, strict_mode).map_err(transform_error)?;
+            Ok(w_bytes_from_bytes(&out))
+        },
+        "b2a_base64" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let newline = arg_bool(pos, kwargs, "newline", 1, true);
+            Ok(w_bytes_from_bytes(&transforms::b2a_base64(&data, newline)))
+        },
+        "a2b_qp" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let header = arg_bool(pos, kwargs, "header", 1, false);
+            Ok(w_bytes_from_bytes(&transforms::a2b_qp(&data, header)))
+        },
+        "b2a_qp" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let quotetabs = arg_bool(pos, kwargs, "quotetabs", 1, false);
+            let istext = arg_bool(pos, kwargs, "istext", 2, true);
+            let header = arg_bool(pos, kwargs, "header", 3, false);
+            Ok(w_bytes_from_bytes(&transforms::b2a_qp(&data, quotetabs, istext, header)))
+        },
+        "a2b_uu" / 1 = |args| {
             let data = as_bytes(args.first().copied().unwrap_or(w_none()))?;
-            let start = args.get(1).map(|&o| unsafe { w_int_get_value(o) } as u32).unwrap_or(0);
-            Ok(w_int_new(crc32_compute(&data, start) as i64))
+            let out = transforms::a2b_uu(&data).map_err(transform_error)?;
+            Ok(w_bytes_from_bytes(&out))
+        },
+        "b2a_uu" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let backtick = arg_bool(pos, kwargs, "backtick", 1, false);
+            let out = transforms::b2a_uu(&data, backtick).map_err(transform_error)?;
+            Ok(w_bytes_from_bytes(&out))
         },
     },
 }

--- a/pyre/pyre-interpreter/src/module/binascii/mod.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/mod.rs
@@ -117,12 +117,11 @@ fn arg_sep(
         }
         _ => None,
     };
-    let bytes_per_sep = match crate::builtins::kwarg_get(kwargs, "bytes_per_sep")
-        .or_else(|| pos.get(2).copied())
-    {
-        Some(o) if !unsafe { is_none(o) } => crate::baseobjspace::int_w(o)? as isize,
-        _ => 1,
-    };
+    let bytes_per_sep =
+        match crate::builtins::kwarg_get(kwargs, "bytes_per_sep").or_else(|| pos.get(2).copied()) {
+            Some(o) if !unsafe { is_none(o) } => crate::baseobjspace::int_w(o)? as isize,
+            _ => 1,
+        };
     Ok((sep, bytes_per_sep))
 }
 

--- a/pyre/pyre-interpreter/src/module/binascii/transforms.rs
+++ b/pyre/pyre-interpreter/src/module/binascii/transforms.rs
@@ -1,0 +1,759 @@
+// spell-checker:ignore hexlify unhexlify uuencodes CRCTAB rlecode rledecode
+
+//! Runtime-independent `binascii` byte transforms — a verbatim copy of the
+//! verified RustPython `binascii` core (deliberate duplication).
+//!
+//! Every function here operates purely on byte slices and returns plain Rust
+//! values or a [`Error`]. Mapping to Python exceptions and argument handling is
+//! the caller's responsibility (see `mod.rs`).
+
+use base64::Engine;
+
+/// The base64 pad character `=`.
+pub const PAD: u8 = 61u8;
+const MAXLINESIZE: usize = 76; // Excluding the CRLF
+
+/// A transform error carrying enough information to build the matching
+/// `binascii.Error` message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// `unhexlify`: input length is odd.
+    OddLengthString,
+    /// `unhexlify`: a byte outside `[0-9a-fA-F]` was found.
+    NonHexadecimalDigit,
+    /// `a2b_uu`: an illegal character was found.
+    IllegalChar,
+    /// `a2b_uu`: trailing garbage after the decoded length.
+    TrailingGarbage,
+    /// `b2a_uu`: more than 45 bytes were passed.
+    TooLong,
+    /// `a2b_base64`: base64 decoding failed.
+    Base64(Base64DecodeError),
+}
+
+/// Mirrors the `base64::DecodeError` variants that `a2b_base64` produces, so the
+/// caller can build the exact Python error message without depending on the
+/// `base64` crate's error type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Base64DecodeError {
+    InvalidByte { index: usize, byte: u8 },
+    InvalidLastSymbol { index: usize, byte: u8 },
+    InvalidLength(usize),
+}
+
+const fn hex_nibble(n: u8) -> u8 {
+    match n {
+        0..=9 => b'0' + n,
+        10..=15 => b'a' + (n - 10),
+        _ => unreachable!(),
+    }
+}
+
+const fn unhex_nibble(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// `b2a_hex` / `hexlify`. `sep` is the (already validated, length-1 ASCII)
+/// separator byte, or `None` for no separator.
+#[must_use]
+pub fn hexlify(bytes: &[u8], sep: Option<u8>, bytes_per_sep: isize) -> Vec<u8> {
+    // If no separator or bytes_per_sep is 0, use simple hexlify
+    if sep.is_none() || bytes_per_sep == 0 || bytes.is_empty() {
+        let mut hex = Vec::<u8>::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            hex.push(hex_nibble(b >> 4));
+            hex.push(hex_nibble(b & 0xf));
+        }
+        return hex;
+    }
+
+    let sep_char = sep.unwrap();
+    let abs_bytes_per_sep = bytes_per_sep.unsigned_abs();
+
+    // If separator interval is >= data length, no separators needed
+    if abs_bytes_per_sep >= bytes.len() {
+        let mut hex = Vec::<u8>::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            hex.push(hex_nibble(b >> 4));
+            hex.push(hex_nibble(b & 0xf));
+        }
+        return hex;
+    }
+
+    // Calculate result length
+    let num_separators = (bytes.len() - 1) / abs_bytes_per_sep;
+    let result_len = bytes.len() * 2 + num_separators;
+    let mut hex = vec![0u8; result_len];
+
+    if bytes_per_sep < 0 {
+        // Left-to-right processing (negative bytes_per_sep)
+        let mut i = 0; // input index
+        let mut j = 0; // output index
+        let chunks = bytes.len() / abs_bytes_per_sep;
+
+        // Process complete chunks
+        for _ in 0..chunks {
+            for _ in 0..abs_bytes_per_sep {
+                let b = bytes[i];
+                hex[j] = hex_nibble(b >> 4);
+                hex[j + 1] = hex_nibble(b & 0xf);
+                i += 1;
+                j += 2;
+            }
+            if i < bytes.len() {
+                hex[j] = sep_char;
+                j += 1;
+            }
+        }
+
+        // Process remaining bytes
+        while i < bytes.len() {
+            let b = bytes[i];
+            hex[j] = hex_nibble(b >> 4);
+            hex[j + 1] = hex_nibble(b & 0xf);
+            i += 1;
+            j += 2;
+        }
+    } else {
+        // Right-to-left processing (positive bytes_per_sep)
+        let mut i = bytes.len() as isize - 1; // input index
+        let mut j = result_len as isize - 1; // output index
+        let chunks = bytes.len() / abs_bytes_per_sep;
+
+        // Process complete chunks from right
+        for _ in 0..chunks {
+            for _ in 0..abs_bytes_per_sep {
+                let b = bytes[i as usize];
+                hex[j as usize] = hex_nibble(b & 0xf);
+                hex[(j - 1) as usize] = hex_nibble(b >> 4);
+                i -= 1;
+                j -= 2;
+            }
+            if i >= 0 {
+                hex[j as usize] = sep_char;
+                j -= 1;
+            }
+        }
+
+        // Process remaining bytes
+        while i >= 0 {
+            let b = bytes[i as usize];
+            hex[j as usize] = hex_nibble(b & 0xf);
+            hex[(j - 1) as usize] = hex_nibble(b >> 4);
+            i -= 1;
+            j -= 2;
+        }
+    }
+
+    hex
+}
+
+/// `a2b_hex` / `unhexlify`.
+pub fn unhexlify(hex_bytes: &[u8]) -> Result<Vec<u8>, Error> {
+    if !hex_bytes.len().is_multiple_of(2) {
+        return Err(Error::OddLengthString);
+    }
+
+    let mut unhex = Vec::<u8>::with_capacity(hex_bytes.len() / 2);
+    for pair in hex_bytes.chunks_exact(2) {
+        if let (Some(n1), Some(n2)) = (unhex_nibble(pair[0]), unhex_nibble(pair[1])) {
+            unhex.push((n1 << 4) | n2);
+        } else {
+            return Err(Error::NonHexadecimalDigit);
+        }
+    }
+
+    Ok(unhex)
+}
+
+/// `crc32`. `init` is the (masked to u32) starting value.
+#[must_use]
+pub fn crc32(bytes: &[u8], init: u32) -> u32 {
+    let mut hasher = crc32fast::Hasher::new_with_initial(init);
+    hasher.update(bytes);
+    hasher.finalize()
+}
+
+/// `crc_hqx`. `init` is the (masked to u32) starting value.
+#[must_use]
+pub fn crc_hqx(bytes: &[u8], init: u32) -> u32 {
+    const CRCTAB_HQX: [u16; 256] = [
+        0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108, 0x9129, 0xa14a,
+        0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef, 0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294,
+        0x72f7, 0x62d6, 0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de, 0x2462,
+        0x3443, 0x0420, 0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485, 0xa56a, 0xb54b, 0x8528, 0x9509,
+        0xe5ee, 0xf5cf, 0xc5ac, 0xd58d, 0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695,
+        0x46b4, 0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d, 0xc7bc, 0x48c4, 0x58e5,
+        0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823, 0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948,
+        0x9969, 0xa90a, 0xb92b, 0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12,
+        0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a, 0x6ca6, 0x7c87, 0x4ce4,
+        0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41, 0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b,
+        0x8d68, 0x9d49, 0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70, 0xff9f,
+        0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a, 0x9f59, 0x8f78, 0x9188, 0x81a9, 0xb1ca, 0xa1eb,
+        0xd10c, 0xc12d, 0xf14e, 0xe16f, 0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046,
+        0x6067, 0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e, 0x02b1, 0x1290,
+        0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256, 0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e,
+        0xe54f, 0xd52c, 0xc50d, 0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+        0xa7db, 0xb7fa, 0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c, 0x26d3, 0x36f2, 0x0691,
+        0x16b0, 0x6657, 0x7676, 0x4615, 0x5634, 0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9,
+        0xb98a, 0xa9ab, 0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882, 0x28a3, 0xcb7d,
+        0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a, 0x4a75, 0x5a54, 0x6a37, 0x7a16,
+        0x0af1, 0x1ad0, 0x2ab3, 0x3a92, 0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8,
+        0x8dc9, 0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1, 0xef1f, 0xff3e,
+        0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8, 0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93,
+        0x3eb2, 0x0ed1, 0x1ef0,
+    ];
+
+    let mut crc = init & 0xffff;
+
+    for byte in bytes {
+        crc = ((crc << 8) & 0xFF00) ^ CRCTAB_HQX[((crc >> 8) as u8 ^ (byte)) as usize] as u32;
+    }
+
+    crc
+}
+
+/// `a2b_base64`.
+pub fn a2b_base64(b: &[u8], strict_mode: bool) -> Result<Vec<u8>, Error> {
+    // Converts between ASCII and base-64 characters. The index of a given number yields the
+    // number in ASCII while the value of said index yields the number in base-64. For example
+    // "=" is 61 in ASCII but 0 (since it's the pad character) in base-64, so BASE64_TABLE[61] == 0
+    #[rustfmt::skip]
+    const BASE64_TABLE: [i8; 256] = [
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,62, -1,-1,-1,63,
+        52,53,54,55, 56,57,58,59, 60,61,-1,-1, -1, 0,-1,-1, /* Note PAD->0 */
+        -1, 0, 1, 2,  3, 4, 5, 6,  7, 8, 9,10, 11,12,13,14,
+        15,16,17,18, 19,20,21,22, 23,24,25,-1, -1,-1,-1,-1,
+        -1,26,27,28, 29,30,31,32, 33,34,35,36, 37,38,39,40,
+        41,42,43,44, 45,46,47,48, 49,50,51,-1, -1,-1,-1,-1,
+
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+        -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
+    ];
+
+    if b.is_empty() {
+        return Ok(vec![]);
+    }
+
+    if strict_mode && b[0] == PAD {
+        return Err(Error::Base64(Base64DecodeError::InvalidByte {
+            index: 0,
+            byte: 61,
+        }));
+    }
+
+    let mut decoded: Vec<u8> = vec![];
+
+    let mut quad_pos = 0; // position in the nibble
+    let mut pads = 0;
+    let mut left_char: u8 = 0;
+    let mut padding_started = false;
+    for (i, &el) in b.iter().enumerate() {
+        if el == PAD {
+            padding_started = true;
+
+            pads += 1;
+            if quad_pos >= 2 && quad_pos + pads >= 4 {
+                if strict_mode && i + 1 < b.len() {
+                    // Represents excess data after padding error
+                    return Err(Error::Base64(Base64DecodeError::InvalidLastSymbol {
+                        index: i,
+                        byte: PAD,
+                    }));
+                }
+
+                return Ok(decoded);
+            }
+
+            continue;
+        }
+
+        let binary_char = BASE64_TABLE[el as usize];
+        if binary_char >= 64 || binary_char == -1 {
+            if strict_mode {
+                // Represents non-base64 data error
+                return Err(Error::Base64(Base64DecodeError::InvalidByte {
+                    index: i,
+                    byte: el,
+                }));
+            }
+            continue;
+        }
+
+        if strict_mode && padding_started {
+            // Represents discontinuous padding error
+            return Err(Error::Base64(Base64DecodeError::InvalidByte {
+                index: i,
+                byte: PAD,
+            }));
+        }
+        pads = 0;
+
+        // Decode individual ASCII character
+        match quad_pos {
+            0 => {
+                quad_pos = 1;
+                left_char = binary_char as u8;
+            }
+            1 => {
+                quad_pos = 2;
+                decoded.push((left_char << 2) | (binary_char >> 4) as u8);
+                left_char = (binary_char & 0x0f) as u8;
+            }
+            2 => {
+                quad_pos = 3;
+                decoded.push((left_char << 4) | (binary_char >> 2) as u8);
+                left_char = (binary_char & 0x03) as u8;
+            }
+            3 => {
+                quad_pos = 0;
+                decoded.push((left_char << 6) | binary_char as u8);
+                left_char = 0;
+            }
+            _ => unsafe {
+                // quad_pos is only assigned in this match statement to constants
+                core::hint::unreachable_unchecked()
+            },
+        }
+    }
+
+    match quad_pos {
+        0 => Ok(decoded),
+        1 => Err(Error::Base64(Base64DecodeError::InvalidLastSymbol {
+            index: decoded.len() / 3 * 4 + 1,
+            byte: 0,
+        })),
+        _ => Err(Error::Base64(Base64DecodeError::InvalidLength(quad_pos))),
+    }
+}
+
+/// `b2a_base64`.
+#[must_use]
+pub fn b2a_base64(data: &[u8], newline: bool) -> Vec<u8> {
+    // https://stackoverflow.com/questions/63916821
+    let mut encoded = base64::engine::general_purpose::STANDARD
+        .encode(data)
+        .into_bytes();
+    if newline {
+        encoded.push(b'\n');
+    }
+    encoded
+}
+
+#[inline]
+fn uu_a2b_read(c: u8) -> Result<u8, Error> {
+    // Check the character for legality
+    // The 64 instead of the expected 63 is because
+    // there are a few uuencodes out there that use
+    // '`' as zero instead of space.
+    if !(b' '..=(b' ' + 64)).contains(&c) {
+        if [b'\r', b'\n'].contains(&c) {
+            return Ok(0);
+        }
+        return Err(Error::IllegalChar);
+    }
+    Ok((c - b' ') & 0x3f)
+}
+
+/// `a2b_qp`.
+#[must_use]
+pub fn a2b_qp(buffer: &[u8], header: bool) -> Vec<u8> {
+    let len = buffer.len();
+    let mut out_data = Vec::with_capacity(len);
+
+    let mut idx = 0;
+
+    while idx < len {
+        if buffer[idx] == b'=' {
+            idx += 1;
+            if idx >= len {
+                break;
+            }
+            // Soft line breaks
+            if (buffer[idx] == b'\n') || (buffer[idx] == b'\r') {
+                if buffer[idx] != b'\n' {
+                    while idx < len && buffer[idx] != b'\n' {
+                        idx += 1;
+                    }
+                }
+                if idx < len {
+                    idx += 1;
+                }
+            } else if buffer[idx] == b'=' {
+                // broken case from broken python qp
+                out_data.push(b'=');
+                idx += 1;
+            } else if idx + 1 < len
+                && ((buffer[idx] >= b'A' && buffer[idx] <= b'F')
+                    || (buffer[idx] >= b'a' && buffer[idx] <= b'f')
+                    || (buffer[idx] >= b'0' && buffer[idx] <= b'9'))
+                && ((buffer[idx + 1] >= b'A' && buffer[idx + 1] <= b'F')
+                    || (buffer[idx + 1] >= b'a' && buffer[idx + 1] <= b'f')
+                    || (buffer[idx + 1] >= b'0' && buffer[idx + 1] <= b'9'))
+            {
+                // hex val
+                if let (Some(ch1), Some(ch2)) =
+                    (unhex_nibble(buffer[idx]), unhex_nibble(buffer[idx + 1]))
+                {
+                    out_data.push((ch1 << 4) | ch2);
+                }
+                idx += 2;
+            } else {
+                out_data.push(b'=');
+            }
+        } else if header && buffer[idx] == b'_' {
+            out_data.push(b' ');
+            idx += 1;
+        } else {
+            out_data.push(buffer[idx]);
+            idx += 1;
+        }
+    }
+
+    out_data
+}
+
+/// `b2a_qp`.
+#[must_use]
+pub fn b2a_qp(buf: &[u8], quotetabs: bool, istext: bool, header: bool) -> Vec<u8> {
+    let buflen = buf.len();
+    let mut line_len = 0;
+    let mut out_data_len = 0;
+    let mut crlf = false;
+    let mut ch;
+
+    let mut in_idx;
+    let mut out_idx;
+
+    in_idx = 0;
+    while in_idx < buflen {
+        if buf[in_idx] == b'\n' {
+            break;
+        }
+        in_idx += 1;
+    }
+    if buflen > 0 && in_idx < buflen && buf[in_idx - 1] == b'\r' {
+        crlf = true;
+    }
+
+    in_idx = 0;
+    while in_idx < buflen {
+        let mut delta = 0;
+        if (buf[in_idx] > 126)
+            || (buf[in_idx] == b'=')
+            || (header && buf[in_idx] == b'_')
+            || (buf[in_idx] == b'.'
+                && line_len == 0
+                && (in_idx + 1 == buflen
+                    || buf[in_idx + 1] == b'\n'
+                    || buf[in_idx + 1] == b'\r'
+                    || buf[in_idx + 1] == 0))
+            || (!istext && ((buf[in_idx] == b'\r') || (buf[in_idx] == b'\n')))
+            || ((buf[in_idx] == b'\t' || buf[in_idx] == b' ') && (in_idx + 1 == buflen))
+            || ((buf[in_idx] < 33)
+                && (buf[in_idx] != b'\r')
+                && (buf[in_idx] != b'\n')
+                && (quotetabs || ((buf[in_idx] != b'\t') && (buf[in_idx] != b' '))))
+        {
+            if (line_len + 3) >= MAXLINESIZE {
+                line_len = 0;
+                delta += if crlf { 3 } else { 2 };
+            }
+            line_len += 3;
+            delta += 3;
+            in_idx += 1;
+        } else if istext
+            && ((buf[in_idx] == b'\n')
+                || ((in_idx + 1 < buflen) && (buf[in_idx] == b'\r') && (buf[in_idx + 1] == b'\n')))
+        {
+            line_len = 0;
+            // Protect against whitespace on end of line
+            if (in_idx != 0) && ((buf[in_idx - 1] == b' ') || (buf[in_idx - 1] == b'\t')) {
+                delta += 2;
+            }
+            delta += if crlf { 2 } else { 1 };
+            in_idx += if buf[in_idx] == b'\r' { 2 } else { 1 };
+        } else {
+            if (in_idx + 1 != buflen) && (buf[in_idx + 1] != b'\n') && (line_len + 1) >= MAXLINESIZE
+            {
+                line_len = 0;
+                delta += if crlf { 3 } else { 2 };
+            }
+            line_len += 1;
+            delta += 1;
+            in_idx += 1;
+        }
+        out_data_len += delta;
+    }
+
+    let mut out_data = Vec::with_capacity(out_data_len);
+    in_idx = 0;
+    out_idx = 0;
+    line_len = 0;
+
+    while in_idx < buflen {
+        if (buf[in_idx] > 126)
+            || (buf[in_idx] == b'=')
+            || (header && buf[in_idx] == b'_')
+            || ((buf[in_idx] == b'.')
+                && (line_len == 0)
+                && (in_idx + 1 == buflen
+                    || buf[in_idx + 1] == b'\n'
+                    || buf[in_idx + 1] == b'\r'
+                    || buf[in_idx + 1] == 0))
+            || (!istext && ((buf[in_idx] == b'\r') || (buf[in_idx] == b'\n')))
+            || ((buf[in_idx] == b'\t' || buf[in_idx] == b' ') && (in_idx + 1 == buflen))
+            || ((buf[in_idx] < 33)
+                && (buf[in_idx] != b'\r')
+                && (buf[in_idx] != b'\n')
+                && (quotetabs || ((buf[in_idx] != b'\t') && (buf[in_idx] != b' '))))
+        {
+            if (line_len + 3) >= MAXLINESIZE {
+                // MAXLINESIZE = 76
+                out_data.push(b'=');
+                out_idx += 1;
+                if crlf {
+                    out_data.push(b'\r');
+                    out_idx += 1;
+                }
+                out_data.push(b'\n');
+                out_idx += 1;
+                line_len = 0;
+            }
+            out_data.push(b'=');
+            out_idx += 1;
+
+            ch = hex_nibble(buf[in_idx] >> 4);
+            if (b'a'..=b'f').contains(&ch) {
+                ch -= b' ';
+            }
+            out_data.push(ch);
+            ch = hex_nibble(buf[in_idx] & 0xf);
+            if (b'a'..=b'f').contains(&ch) {
+                ch -= b' ';
+            }
+            out_data.push(ch);
+
+            out_idx += 2;
+            in_idx += 1;
+            line_len += 3;
+        } else if istext
+            && ((buf[in_idx] == b'\n')
+                || ((in_idx + 1 < buflen) && (buf[in_idx] == b'\r') && (buf[in_idx + 1] == b'\n')))
+        {
+            line_len = 0;
+            if (out_idx != 0)
+                && ((out_data[out_idx - 1] == b' ') || (out_data[out_idx - 1] == b'\t'))
+            {
+                ch = hex_nibble(out_data[out_idx - 1] >> 4);
+                if (b'a'..=b'f').contains(&ch) {
+                    ch -= b' ';
+                }
+                out_data.push(ch);
+                ch = hex_nibble(out_data[out_idx - 1] & 0xf);
+                if (b'a'..=b'f').contains(&ch) {
+                    ch -= b' ';
+                }
+                out_data.push(ch);
+                out_data[out_idx - 1] = b'=';
+                out_idx += 2;
+            }
+
+            if crlf {
+                out_data.push(b'\r');
+                out_idx += 1;
+            }
+            out_data.push(b'\n');
+            out_idx += 1;
+            in_idx += if buf[in_idx] == b'\r' { 2 } else { 1 };
+        } else {
+            if (in_idx + 1 != buflen) && (buf[in_idx + 1] != b'\n') && (line_len + 1) >= 76 {
+                // MAXLINESIZE = 76
+                out_data.push(b'=');
+                out_idx += 1;
+                if crlf {
+                    out_data.push(b'\r');
+                    out_idx += 1;
+                }
+                out_data.push(b'\n');
+                out_idx += 1;
+                line_len = 0;
+            }
+            line_len += 1;
+            if header && buf[in_idx] == b' ' {
+                out_data.push(b'_');
+                out_idx += 1;
+                in_idx += 1;
+            } else {
+                out_data.push(buf[in_idx]);
+                out_idx += 1;
+                in_idx += 1;
+            }
+        }
+    }
+    out_data
+}
+
+/// `rlecode_hqx`.
+#[must_use]
+pub fn rlecode_hqx(buffer: &[u8]) -> Vec<u8> {
+    const RUN_CHAR: u8 = 0x90; // b'\x90'
+    let len = buffer.len();
+    let mut out_data = Vec::<u8>::with_capacity((len * 2) + 2);
+
+    let mut idx = 0;
+    while idx < len {
+        let ch = buffer[idx];
+
+        if ch == RUN_CHAR {
+            out_data.push(RUN_CHAR);
+            out_data.push(0);
+            return out_data;
+        }
+
+        let mut in_end = idx + 1;
+        while in_end < len && buffer[in_end] == ch && in_end < idx + 255 {
+            in_end += 1;
+        }
+
+        if in_end - idx > 3 {
+            out_data.push(ch);
+            out_data.push(RUN_CHAR);
+            out_data.push(((in_end - idx) % 256) as u8);
+            idx = in_end - 1;
+        } else {
+            out_data.push(ch);
+        }
+
+        idx += 1;
+    }
+    out_data
+}
+
+/// `rledecode_hqx`.
+#[must_use]
+pub fn rledecode_hqx(buffer: &[u8]) -> Vec<u8> {
+    const RUN_CHAR: u8 = 0x90; //b'\x90'
+    let len = buffer.len();
+    let mut out_data = Vec::<u8>::with_capacity(len);
+    let mut idx = 0;
+
+    out_data.push(buffer[idx]);
+    idx += 1;
+
+    while idx < len {
+        if buffer[idx] == RUN_CHAR {
+            if buffer[idx + 1] == 0 {
+                out_data.push(RUN_CHAR);
+            } else {
+                let ch = buffer[idx - 1];
+                let range = buffer[idx + 1];
+                idx += 1;
+                for _ in 1..range {
+                    out_data.push(ch);
+                }
+            }
+        } else {
+            out_data.push(buffer[idx]);
+        }
+        idx += 1;
+    }
+    out_data
+}
+
+/// `a2b_uu`.
+pub fn a2b_uu(b: &[u8]) -> Result<Vec<u8>, Error> {
+    // First byte: binary data length (in bytes)
+    let length = if b.is_empty() {
+        ((-0x20i32) & 0x3fi32) as usize
+    } else {
+        ((b[0] - b' ') & 0x3f) as usize
+    };
+
+    // Allocate the buffer
+    let mut res = Vec::<u8>::with_capacity(length);
+    let trailing_garbage_error = || Err(Error::TrailingGarbage);
+
+    for chunk in b.get(1..).unwrap_or_default().chunks(4) {
+        let (char_a, char_b, char_c, char_d) = {
+            let mut chunk = chunk
+                .iter()
+                .map(|&x| uu_a2b_read(x))
+                .collect::<Result<Vec<_>, _>>()?;
+            while chunk.len() < 4 {
+                chunk.push(0);
+            }
+            (chunk[0], chunk[1], chunk[2], chunk[3])
+        };
+
+        if res.len() < length {
+            res.push((char_a << 2) | (char_b >> 4));
+        } else if char_a != 0 || char_b != 0 {
+            return trailing_garbage_error();
+        }
+
+        if res.len() < length {
+            res.push(((char_b & 0xf) << 4) | (char_c >> 2));
+        } else if char_c != 0 {
+            return trailing_garbage_error();
+        }
+
+        if res.len() < length {
+            res.push(((char_c & 0x3) << 6) | char_d);
+        } else if char_d != 0 {
+            return trailing_garbage_error();
+        }
+    }
+
+    let remaining_length = length - res.len();
+    if remaining_length > 0 {
+        res.extend(vec![0; remaining_length]);
+    }
+    Ok(res)
+}
+
+/// `b2a_uu`.
+pub fn b2a_uu(b: &[u8], backtick: bool) -> Result<Vec<u8>, Error> {
+    #[inline]
+    const fn uu_b2a(num: u8, backtick: bool) -> u8 {
+        if backtick && num == 0 {
+            0x60
+        } else {
+            b' ' + num
+        }
+    }
+
+    let length = b.len();
+    if length > 45 {
+        return Err(Error::TooLong);
+    }
+    let mut res = Vec::<u8>::with_capacity(2 + length.div_ceil(3) * 4);
+    res.push(uu_b2a(length as u8, backtick));
+
+    for chunk in b.chunks(3) {
+        let char_a = *chunk.first().unwrap();
+        let char_b = *chunk.get(1).unwrap_or(&0);
+        let char_c = *chunk.get(2).unwrap_or(&0);
+
+        res.push(uu_b2a(char_a >> 2, backtick));
+        res.push(uu_b2a(((char_a & 0x3) << 4) | (char_b >> 4), backtick));
+        res.push(uu_b2a(((char_b & 0xf) << 2) | (char_c >> 6), backtick));
+        res.push(uu_b2a(char_c & 0x3f, backtick));
+    }
+
+    res.push(0xau8);
+    Ok(res)
+}

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -1175,12 +1175,12 @@ fn mmap_construct(
     let flags_arg = if args.len() >= 3 {
         (unsafe { pyre_object::w_int_get_value(args[2]) }) as libc::c_int
     } else {
-        libc::MAP_SHARED
+        host_mmap::MAP_SHARED
     };
     let prot_arg = if args.len() >= 4 {
         (unsafe { pyre_object::w_int_get_value(args[3]) }) as libc::c_int
     } else {
-        libc::PROT_READ | libc::PROT_WRITE
+        host_mmap::PROT_READ | host_mmap::PROT_WRITE
     };
     let access = if args.len() >= 5 {
         unsafe { pyre_object::w_int_get_value(args[4]) }
@@ -1193,9 +1193,13 @@ fn mmap_construct(
         0
     };
     let (flags, prot) = match access {
-        x if x == MMAP_ACCESS_READ => (libc::MAP_SHARED, libc::PROT_READ),
-        x if x == MMAP_ACCESS_WRITE => (libc::MAP_SHARED, libc::PROT_READ | libc::PROT_WRITE),
-        x if x == MMAP_ACCESS_COPY => (libc::MAP_PRIVATE, libc::PROT_READ | libc::PROT_WRITE),
+        x if x == MMAP_ACCESS_READ => (host_mmap::MAP_SHARED, host_mmap::PROT_READ),
+        x if x == MMAP_ACCESS_WRITE => {
+            (host_mmap::MAP_SHARED, host_mmap::PROT_READ | host_mmap::PROT_WRITE)
+        }
+        x if x == MMAP_ACCESS_COPY => {
+            (host_mmap::MAP_PRIVATE, host_mmap::PROT_READ | host_mmap::PROT_WRITE)
+        }
         _ => (flags_arg, prot_arg),
     };
     // fileno == -1 → anonymous mapping.  host_env expresses the mapping as an
@@ -1210,8 +1214,8 @@ fn mmap_construct(
     let mapped = if real_fd == -1 {
         host_mmap::map_anon(length).map_err(|e| mmap_io_err(e, "mmap"))?
     } else {
-        let mode = if prot & libc::PROT_WRITE != 0 {
-            if flags & libc::MAP_PRIVATE != 0 {
+        let mode = if prot & host_mmap::PROT_WRITE != 0 {
+            if flags & host_mmap::MAP_PRIVATE != 0 {
                 host_mmap::AccessMode::Copy
             } else {
                 host_mmap::AccessMode::Write
@@ -1249,28 +1253,29 @@ pub fn register_module(ns: &mut DictStorage) {
         crate::dict_storage_store(ns, "error", w_os_error);
 
         // Constants.  CPython exposes both POSIX MAP_/PROT_/MADV_ and the
-        // Python ACCESS_* aliases.  These Python-visible values still source
-        // from libc; a pending host_env patch re-exports them, after which
-        // this can switch to host_env in a one-line change.
+        // Python ACCESS_* aliases.  The portable subset sources from
+        // host_env's re-exports; the platform-specific extras host_env does
+        // not re-export (MAP_FIXED, the Linux-only MAP_* flags, PROT_NONE)
+        // stay on libc.
         crate::dict_storage_store(
             ns,
             "MAP_SHARED",
-            pyre_object::w_int_new(libc::MAP_SHARED as i64),
+            pyre_object::w_int_new(host_mmap::MAP_SHARED as i64),
         );
         crate::dict_storage_store(
             ns,
             "MAP_PRIVATE",
-            pyre_object::w_int_new(libc::MAP_PRIVATE as i64),
+            pyre_object::w_int_new(host_mmap::MAP_PRIVATE as i64),
         );
         crate::dict_storage_store(
             ns,
             "MAP_ANON",
-            pyre_object::w_int_new(libc::MAP_ANON as i64),
+            pyre_object::w_int_new(host_mmap::MAP_ANON as i64),
         );
         crate::dict_storage_store(
             ns,
             "MAP_ANONYMOUS",
-            pyre_object::w_int_new(libc::MAP_ANON as i64),
+            pyre_object::w_int_new(host_mmap::MAP_ANONYMOUS as i64),
         );
         crate::dict_storage_store(
             ns,
@@ -1313,17 +1318,17 @@ pub fn register_module(ns: &mut DictStorage) {
         crate::dict_storage_store(
             ns,
             "PROT_READ",
-            pyre_object::w_int_new(libc::PROT_READ as i64),
+            pyre_object::w_int_new(host_mmap::PROT_READ as i64),
         );
         crate::dict_storage_store(
             ns,
             "PROT_WRITE",
-            pyre_object::w_int_new(libc::PROT_WRITE as i64),
+            pyre_object::w_int_new(host_mmap::PROT_WRITE as i64),
         );
         crate::dict_storage_store(
             ns,
             "PROT_EXEC",
-            pyre_object::w_int_new(libc::PROT_EXEC as i64),
+            pyre_object::w_int_new(host_mmap::PROT_EXEC as i64),
         );
         crate::dict_storage_store(
             ns,
@@ -1345,27 +1350,27 @@ pub fn register_module(ns: &mut DictStorage) {
         crate::dict_storage_store(
             ns,
             "MADV_NORMAL",
-            pyre_object::w_int_new(libc::MADV_NORMAL as i64),
+            pyre_object::w_int_new(host_mmap::MADV_NORMAL as i64),
         );
         crate::dict_storage_store(
             ns,
             "MADV_RANDOM",
-            pyre_object::w_int_new(libc::MADV_RANDOM as i64),
+            pyre_object::w_int_new(host_mmap::MADV_RANDOM as i64),
         );
         crate::dict_storage_store(
             ns,
             "MADV_SEQUENTIAL",
-            pyre_object::w_int_new(libc::MADV_SEQUENTIAL as i64),
+            pyre_object::w_int_new(host_mmap::MADV_SEQUENTIAL as i64),
         );
         crate::dict_storage_store(
             ns,
             "MADV_WILLNEED",
-            pyre_object::w_int_new(libc::MADV_WILLNEED as i64),
+            pyre_object::w_int_new(host_mmap::MADV_WILLNEED as i64),
         );
         crate::dict_storage_store(
             ns,
             "MADV_DONTNEED",
-            pyre_object::w_int_new(libc::MADV_DONTNEED as i64),
+            pyre_object::w_int_new(host_mmap::MADV_DONTNEED as i64),
         );
 
         // Page-related constants (sys.PAGESIZE in CPython mmap module).

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -9,13 +9,82 @@ use crate::DictStorage;
 // ──────────────────────────────────────────────────────────────────────
 // mmap module — PyPy: pypy/module/mmap/.
 //
-// The `mmap.mmap(fileno, length, ...)` class wraps libc::mmap directly.
-// Per-instance state lives in the instance dict: `_ptr` (raw pointer as
-// i64), `_len` (i64), `_pos` (i64 cursor), `_access` (int).  The
-// pointer is invalidated on close()/`__exit__` via munmap(2); leaking
-// it (e.g. GC drops the instance before close) is acceptable, matching
-// CPython behaviour.
+// `mmap.mmap(fileno, length, ...)` maps through `host_env::mmap`
+// (memmap2-based, cross-platform), not raw libc.  Per-instance state
+// lives in the instance dict: `_ptr` (mapping pointer as i64), `_len`
+// (i64), `_pos` (i64 cursor), `_access` (int), `_id` (registry key).
+// The mapping is invalidated on close()/`__exit__` by dropping the
+// registry entry (→ unmap); leaking it (e.g. GC drops the instance
+// before close) is acceptable, matching CPython behaviour.
 // ──────────────────────────────────────────────────────────────────────
+
+// host_env's `MappedFile` is an RAII handle (memmap2) that unmaps on Drop,
+// but pyre's mmap object keeps its state in a Python dict, which cannot own
+// a Rust value.  The live `MappedFile` is therefore parked in this
+// process-global table keyed by an id stashed in the instance dict (`_id`);
+// `_ptr`/`_len` mirror `MappedFile::as_ptr()`/len so every read/write path
+// stays a raw-pointer access.  close()/`__exit__`/resize drop or replace the
+// entry; a map dropped by GC without close leaks its entry, exactly as the
+// previous raw-pointer code leaked the mapping.
+#[cfg(unix)]
+use rustpython_host_env::mmap as host_mmap;
+
+#[cfg(unix)]
+static MMAP_REGISTRY: std::sync::Mutex<std::collections::BTreeMap<u64, host_mmap::MappedFile>> =
+    std::sync::Mutex::new(std::collections::BTreeMap::new());
+#[cfg(unix)]
+static MMAP_NEXT_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+#[cfg(unix)]
+fn mmap_registry_insert(m: host_mmap::MappedFile) -> (u64, *const u8, usize) {
+    let ptr = m.as_ptr();
+    let len = m.as_slice().len();
+    let id = MMAP_NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    MMAP_REGISTRY.lock().unwrap().insert(id, m);
+    (id, ptr, len)
+}
+
+#[cfg(unix)]
+fn mmap_registry_remove(id: u64) {
+    if id != 0 {
+        MMAP_REGISTRY.lock().unwrap().remove(&id);
+    }
+}
+
+#[cfg(unix)]
+fn mmap_registry_replace(id: u64, m: host_mmap::MappedFile) -> (*const u8, usize) {
+    let ptr = m.as_ptr();
+    let len = m.as_slice().len();
+    // Inserting over the same key drops the previous MappedFile → unmaps it.
+    MMAP_REGISTRY.lock().unwrap().insert(id, m);
+    (ptr, len)
+}
+
+#[cfg(unix)]
+fn mmap_registry_flush(id: u64, offset: usize, size: usize) -> std::io::Result<()> {
+    match MMAP_REGISTRY.lock().unwrap().get(&id) {
+        Some(m) => m.flush_range(offset, size),
+        None => Ok(()),
+    }
+}
+
+#[cfg(all(unix, not(target_os = "redox")))]
+fn mmap_registry_madvise(
+    id: u64,
+    start: usize,
+    length: usize,
+    advice: i32,
+) -> std::io::Result<()> {
+    match MMAP_REGISTRY.lock().unwrap().get(&id) {
+        Some(m) => m.madvise_range(start, length, advice),
+        None => Ok(()),
+    }
+}
+
+#[cfg(unix)]
+fn mmap_io_err(e: std::io::Error, ctx: &str) -> crate::PyError {
+    crate::PyError::os_error_with_errno(e.raw_os_error().unwrap_or(0), ctx)
+}
 
 #[cfg(unix)]
 thread_local! {
@@ -169,11 +238,11 @@ fn init_mmap_type(ns: &mut DictStorage) {
             |args| {
                 let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
                 let p = mmap_get_attr_i64(obj, "_ptr") as usize;
-                let len = mmap_get_attr_i64(obj, "_len") as usize;
-                if p != 0 && len != 0 {
-                    let _ = unsafe { libc::munmap(p as *mut libc::c_void, len) };
+                if p != 0 {
+                    mmap_registry_remove(mmap_get_attr_i64(obj, "_id") as u64);
                     mmap_set_attr(obj, "_ptr", pyre_object::w_int_new(0));
                     mmap_set_attr(obj, "_len", pyre_object::w_int_new(0));
+                    mmap_set_attr(obj, "_id", pyre_object::w_int_new(0));
                 }
                 Ok(pyre_object::w_none())
             },
@@ -191,12 +260,14 @@ fn init_mmap_type(ns: &mut DictStorage) {
             crate::make_builtin_function_with_arity(
                 "closed",
                 |args| {
-                    let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                    // GetSetProperty fget callbacks receive (descriptor_self,
+                    // w_obj); the mmap instance is the second argument.
+                    let obj = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
                     Ok(pyre_object::w_bool_from(
                         mmap_get_attr_i64(obj, "_ptr") == 0,
                     ))
                 },
-                1,
+                2,
             ),
             "closed",
         ),
@@ -500,13 +571,9 @@ fn init_mmap_type(ns: &mut DictStorage) {
             if off.checked_add(n).map(|s| s > len).unwrap_or(true) {
                 return Err(crate::PyError::value_error("flush range out of bounds"));
             }
-            let r = unsafe { libc::msync(p.add(off) as *mut libc::c_void, n, libc::MS_SYNC) };
-            if r != 0 {
-                return Err(crate::PyError::os_error_with_errno(
-                    std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-                    "msync",
-                ));
-            }
+            let _ = p;
+            mmap_registry_flush(mmap_get_attr_i64(obj, "_id") as u64, off, n)
+                .map_err(|e| mmap_io_err(e, "msync"))?;
             Ok(pyre_object::w_none())
         }),
     );
@@ -635,11 +702,11 @@ fn init_mmap_type(ns: &mut DictStorage) {
         crate::make_builtin_function("__exit__", |args| {
             if let Some(&obj) = args.first() {
                 let p = mmap_get_attr_i64(obj, "_ptr") as usize;
-                let len = mmap_get_attr_i64(obj, "_len") as usize;
-                if p != 0 && len != 0 {
-                    let _ = unsafe { libc::munmap(p as *mut libc::c_void, len) };
+                if p != 0 {
+                    mmap_registry_remove(mmap_get_attr_i64(obj, "_id") as u64);
                     mmap_set_attr(obj, "_ptr", pyre_object::w_int_new(0));
                     mmap_set_attr(obj, "_len", pyre_object::w_int_new(0));
+                    mmap_set_attr(obj, "_id", pyre_object::w_int_new(0));
                 }
             }
             Ok(pyre_object::w_bool_from(false))
@@ -870,19 +937,20 @@ fn init_mmap_type(ns: &mut DictStorage) {
                     "madvise: start or length out of range",
                 ));
             }
-            #[cfg(unix)]
+            let _ = p;
+            #[cfg(all(unix, not(target_os = "redox")))]
             {
-                let rc = unsafe { libc::madvise((p + start) as *mut libc::c_void, length, option) };
-                if rc != 0 {
-                    return Err(crate::PyError::os_error_with_errno(
-                        std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-                        "madvise",
-                    ));
-                }
+                mmap_registry_madvise(
+                    mmap_get_attr_i64(obj, "_id") as u64,
+                    start,
+                    length,
+                    option,
+                )
+                .map_err(|e| mmap_io_err(e, "madvise"))?;
             }
-            #[cfg(not(unix))]
+            #[cfg(not(all(unix, not(target_os = "redox"))))]
             {
-                let _ = (p, length, option);
+                let _ = (length, option);
             }
             Ok(pyre_object::w_none())
         }),
@@ -976,9 +1044,19 @@ fn init_mmap_type(ns: &mut DictStorage) {
                 let fd = mmap_get_attr_i64(obj, "_fd") as libc::c_int;
                 let offset = mmap_get_attr_i64(obj, "_offset");
 
+                // host_env's `MappedFile` (memmap2) cannot mremap in place, so
+                // the Linux/Android resize re-creates the mapping at the new
+                // size and swaps the registry entry.  A file-backed map is
+                // re-mapped from the (ftruncated) fd; an anonymous map is
+                // remade and the surviving bytes copied.  The new mapping may
+                // land at a different address than an mremap would have, but
+                // that address is never exposed to Python, so the observable
+                // result is unchanged.  Platforms without mremap keep raising
+                // SystemError, matching PyPy's RValueError→SystemError.
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
-                    if fd >= 0 {
+                    let id = mmap_get_attr_i64(obj, "_id") as u64;
+                    let mapped = if fd >= 0 {
                         let r = unsafe {
                             libc::ftruncate(fd, (offset as libc::off_t) + newsize as libc::off_t)
                         };
@@ -988,23 +1066,24 @@ fn init_mmap_type(ns: &mut DictStorage) {
                                 "ftruncate",
                             ));
                         }
-                    }
-                    let newptr = unsafe {
-                        libc::mremap(
-                            p as *mut libc::c_void,
-                            old_len,
-                            newsize,
-                            libc::MREMAP_MAYMOVE,
-                        )
+                        let borrowed =
+                            unsafe { rustpython_host_env::crt_fd::Borrowed::borrow_raw(fd) };
+                        let (dup_fd, mapped) =
+                            host_mmap::map_file(borrowed, offset, newsize, host_mmap::AccessMode::Write)
+                                .map_err(|e| mmap_io_err(e, "mmap"))?;
+                        drop(dup_fd);
+                        mapped
+                    } else {
+                        let keep = old_len.min(newsize);
+                        let old = unsafe { std::slice::from_raw_parts(p, keep) }.to_vec();
+                        let mut mapped =
+                            host_mmap::map_anon(newsize).map_err(|e| mmap_io_err(e, "mmap"))?;
+                        mapped.as_mut_slice()[..keep].copy_from_slice(&old);
+                        mapped
                     };
-                    if newptr == libc::MAP_FAILED {
-                        return Err(crate::PyError::os_error_with_errno(
-                            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-                            "mremap",
-                        ));
-                    }
+                    let (newptr, newlen) = mmap_registry_replace(id, mapped);
                     mmap_set_attr(obj, "_ptr", pyre_object::w_int_new(newptr as usize as i64));
-                    mmap_set_attr(obj, "_len", pyre_object::w_int_new(newsize as i64));
+                    mmap_set_attr(obj, "_len", pyre_object::w_int_new(newlen as i64));
                     Ok(pyre_object::w_none())
                 }
                 #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -1119,32 +1198,41 @@ fn mmap_construct(
         x if x == MMAP_ACCESS_COPY => (libc::MAP_PRIVATE, libc::PROT_READ | libc::PROT_WRITE),
         _ => (flags_arg, prot_arg),
     };
-    // fileno == -1 → anonymous mapping.
+    // fileno == -1 → anonymous mapping.  host_env expresses the mapping as an
+    // `AccessMode` rather than raw prot/flags: a writable share maps as
+    // Write, a writable private map (MAP_PRIVATE) as Copy, and a
+    // non-writable map as Read.  This is exact for the ACCESS_* modes and the
+    // default read/write map; exotic low-level prot bits (PROT_EXEC/PROT_NONE)
+    // and placement flags (MAP_FIXED) collapse to the nearest mode.  `_access`
+    // still records the caller's original access argument, so repr() and the
+    // write-guard are unchanged.
     let real_fd = fd;
-    let final_flags = if real_fd == -1 {
-        flags | libc::MAP_ANON
+    let mapped = if real_fd == -1 {
+        host_mmap::map_anon(length).map_err(|e| mmap_io_err(e, "mmap"))?
     } else {
-        flags
+        let mode = if prot & libc::PROT_WRITE != 0 {
+            if flags & libc::MAP_PRIVATE != 0 {
+                host_mmap::AccessMode::Copy
+            } else {
+                host_mmap::AccessMode::Write
+            }
+        } else {
+            host_mmap::AccessMode::Read
+        };
+        let borrowed = unsafe { rustpython_host_env::crt_fd::Borrowed::borrow_raw(real_fd) };
+        let (dup_fd, mapped) = host_mmap::map_file(borrowed, offset, length, mode)
+            .map_err(|e| mmap_io_err(e, "mmap"))?;
+        // pyre keeps the caller's original fd for size()/resize(); the dup
+        // host_env made isn't needed once the mapping exists (the mapping
+        // survives fd close).
+        drop(dup_fd);
+        mapped
     };
-    let ptr = unsafe {
-        libc::mmap(
-            std::ptr::null_mut(),
-            length,
-            prot,
-            final_flags,
-            real_fd,
-            offset,
-        )
-    };
-    if ptr == libc::MAP_FAILED {
-        return Err(crate::PyError::os_error_with_errno(
-            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
-            "mmap",
-        ));
-    }
+    let (id, ptr, len) = mmap_registry_insert(mapped);
     let obj = pyre_object::w_instance_new(mmap_type());
     mmap_set_attr(obj, "_ptr", pyre_object::w_int_new(ptr as usize as i64));
-    mmap_set_attr(obj, "_len", pyre_object::w_int_new(length as i64));
+    mmap_set_attr(obj, "_len", pyre_object::w_int_new(len as i64));
+    mmap_set_attr(obj, "_id", pyre_object::w_int_new(id as i64));
     mmap_set_attr(obj, "_pos", pyre_object::w_int_new(0));
     mmap_set_attr(obj, "_access", pyre_object::w_int_new(access));
     mmap_set_attr(obj, "_fd", pyre_object::w_int_new(real_fd as i64));
@@ -1161,7 +1249,9 @@ pub fn register_module(ns: &mut DictStorage) {
         crate::dict_storage_store(ns, "error", w_os_error);
 
         // Constants.  CPython exposes both POSIX MAP_/PROT_/MADV_ and the
-        // Python ACCESS_* aliases.
+        // Python ACCESS_* aliases.  These Python-visible values still source
+        // from libc; a pending host_env patch re-exports them, after which
+        // this can switch to host_env in a one-line change.
         crate::dict_storage_store(
             ns,
             "MAP_SHARED",

--- a/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
+++ b/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
@@ -107,7 +107,9 @@ fn category_old(args: &[PyObjectRef]) -> PyResult {
 }
 
 fn bidirectional_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
-    Ok(w_str_new(db.bidirectional(one_char("bidirectional", args)?)))
+    Ok(w_str_new(
+        db.bidirectional(one_char("bidirectional", args)?),
+    ))
 }
 fn bidirectional(args: &[PyObjectRef]) -> PyResult {
     bidirectional_impl(&MODERN, args)
@@ -149,7 +151,9 @@ fn mirrored_old(args: &[PyObjectRef]) -> PyResult {
 }
 
 fn decomposition_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
-    Ok(w_str_new(&db.decomposition(one_char("decomposition", args)?)))
+    Ok(w_str_new(
+        &db.decomposition(one_char("decomposition", args)?),
+    ))
 }
 fn decomposition(args: &[PyObjectRef]) -> PyResult {
     decomposition_impl(&MODERN, args)

--- a/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
+++ b/pyre/pyre-interpreter/src/module/unicodedata/mod.rs
@@ -1,45 +1,342 @@
 //! unicodedata module — PyPy: `pypy/module/unicodedata/`.
 //!
-//! Stub providing `normalize` / `category` / `name` / `lookup` /
-//! `decimal` / `numeric` — enough to let `import unicodedata` succeed.
-//! `category` returns `"Cn"` (unassigned) for every code point;
-//! `normalize` is identity; `name` / `decimal` / `numeric` return the
-//! caller-supplied default if any, else raise.
+//! Real implementation backed by the runtime-independent
+//! `rustpython-unicode` crate.  The module-level functions read the latest
+//! bundled database; `unicodedata.ucd_3_2_0` reads the Unicode 3.2.0 view
+//! (used by `stringprep`).  `name` / `lookup` / `normalize` / `is_normalized`
+//! are version-independent, matching the crate, so the 3.2.0 instance shares
+//! those callables with the module.
+//!
+//! Signatures and error types/messages follow CPython 3.14.
+//!
+//! Data-version caveat: the pinned crate bundles a newer Unicode release
+//! (`unidata_version` reports 17.0.0) than CPython 3.14 (16.0.0), so results
+//! differ on code points that release newly assigns (they read as unassigned
+//! under 16.0.0), and on two assigned-character cases the crate handles
+//! differently: `decomposition` of Hangul LVT syllables yields the two-part
+//! `<LV> <T>` form rather than the fully expanded jamo, and `numeric` of
+//! vulgar-fraction code points carries f32-rounded values.  These are
+//! upstream-crate properties, to reconcile when the pin is revisited.
 
 use pyre_object::*;
+use rustpython_unicode::{self as ucd_core, NormalizeForm};
+use rustpython_wtf8::{CodePoint, Wtf8};
+
+use crate::{PyError, PyErrorKind};
+
+type PyResult = Result<PyObjectRef, PyError>;
+
+/// Latest bundled database view — the module-level functions.
+const MODERN: ucd_core::Ucd = ucd_core::Ucd::new(true);
+/// Unicode 3.2.0 view — `unicodedata.ucd_3_2_0`.
+const LEGACY: ucd_core::Ucd = ucd_core::Ucd::new(false);
+
+/// Extract the single-code-point argument of a character function.
+///
+/// `argno` is `Some(1)` for functions that also accept an optional default
+/// (the argument clinic numbers those "argument 1"); `None` for single-argument
+/// functions.  A non-string argument and a string not exactly one code point
+/// long both raise `TypeError`, matching the clinic's converter messages.
+fn extract_char(func: &str, argno: Option<u32>, obj: PyObjectRef) -> Result<CodePoint, PyError> {
+    let argword = match argno {
+        Some(n) => format!("argument {n}"),
+        None => "argument".to_string(),
+    };
+    if !unsafe { is_str(obj) } {
+        let ty = crate::baseobjspace::object_functionstr_type_name(obj);
+        return Err(PyError::type_error(format!(
+            "{func}() {argword} must be a unicode character, not {ty}"
+        )));
+    }
+    let s = unsafe { w_str_get_wtf8(obj) };
+    let mut cps = s.code_points();
+    if let Some(cp) = cps.next()
+        && cps.next().is_none()
+    {
+        return Ok(cp);
+    }
+    let n = s.code_points().count();
+    Err(PyError::type_error(format!(
+        "{func}(): {argword} must be a unicode character, not a string of length {n}"
+    )))
+}
+
+/// Single required character argument (`category`, `bidirectional`, …).
+fn one_char(func: &str, args: &[PyObjectRef]) -> Result<CodePoint, PyError> {
+    if args.len() != 1 {
+        return Err(PyError::type_error(format!(
+            "unicodedata.{func}() takes exactly one argument ({} given)",
+            args.len()
+        )));
+    }
+    extract_char(func, None, args[0])
+}
+
+/// Character argument plus an optional default (`digit`, `decimal`, `numeric`,
+/// `name`).
+fn char_and_default(
+    func: &str,
+    args: &[PyObjectRef],
+) -> Result<(CodePoint, Option<PyObjectRef>), PyError> {
+    if args.is_empty() {
+        return Err(PyError::type_error(format!(
+            "{func} expected at least 1 argument, got 0"
+        )));
+    }
+    if args.len() > 2 {
+        return Err(PyError::type_error(format!(
+            "{func} expected at most 2 arguments, got {}",
+            args.len()
+        )));
+    }
+    let cp = extract_char(func, Some(1), args[0])?;
+    Ok((cp, args.get(1).copied()))
+}
+
+// Version-sensitive queries: the module-level `fn` uses `MODERN`, the
+// `*_old` twin (bound onto `ucd_3_2_0`) uses `LEGACY`.
+
+fn category_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    Ok(w_str_new(db.category(one_char("category", args)?)))
+}
+fn category(args: &[PyObjectRef]) -> PyResult {
+    category_impl(&MODERN, args)
+}
+fn category_old(args: &[PyObjectRef]) -> PyResult {
+    category_impl(&LEGACY, args)
+}
+
+fn bidirectional_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    Ok(w_str_new(db.bidirectional(one_char("bidirectional", args)?)))
+}
+fn bidirectional(args: &[PyObjectRef]) -> PyResult {
+    bidirectional_impl(&MODERN, args)
+}
+fn bidirectional_old(args: &[PyObjectRef]) -> PyResult {
+    bidirectional_impl(&LEGACY, args)
+}
+
+fn east_asian_width_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    Ok(w_str_new(
+        db.east_asian_width(one_char("east_asian_width", args)?),
+    ))
+}
+fn east_asian_width(args: &[PyObjectRef]) -> PyResult {
+    east_asian_width_impl(&MODERN, args)
+}
+fn east_asian_width_old(args: &[PyObjectRef]) -> PyResult {
+    east_asian_width_impl(&LEGACY, args)
+}
+
+fn combining_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    Ok(w_int_new(db.combining(one_char("combining", args)?) as i64))
+}
+fn combining(args: &[PyObjectRef]) -> PyResult {
+    combining_impl(&MODERN, args)
+}
+fn combining_old(args: &[PyObjectRef]) -> PyResult {
+    combining_impl(&LEGACY, args)
+}
+
+fn mirrored_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    Ok(w_int_new(db.mirrored(one_char("mirrored", args)?) as i64))
+}
+fn mirrored(args: &[PyObjectRef]) -> PyResult {
+    mirrored_impl(&MODERN, args)
+}
+fn mirrored_old(args: &[PyObjectRef]) -> PyResult {
+    mirrored_impl(&LEGACY, args)
+}
+
+fn decomposition_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    Ok(w_str_new(&db.decomposition(one_char("decomposition", args)?)))
+}
+fn decomposition(args: &[PyObjectRef]) -> PyResult {
+    decomposition_impl(&MODERN, args)
+}
+fn decomposition_old(args: &[PyObjectRef]) -> PyResult {
+    decomposition_impl(&LEGACY, args)
+}
+
+fn digit_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    let (cp, default) = char_and_default("digit", args)?;
+    match db.digit(cp) {
+        Some(v) => Ok(w_int_new(v as i64)),
+        None => default.ok_or_else(|| PyError::value_error("not a digit")),
+    }
+}
+fn digit(args: &[PyObjectRef]) -> PyResult {
+    digit_impl(&MODERN, args)
+}
+fn digit_old(args: &[PyObjectRef]) -> PyResult {
+    digit_impl(&LEGACY, args)
+}
+
+fn decimal_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    let (cp, default) = char_and_default("decimal", args)?;
+    match db.decimal(cp) {
+        Some(v) => Ok(w_int_new(v as i64)),
+        None => default.ok_or_else(|| PyError::value_error("not a decimal")),
+    }
+}
+fn decimal(args: &[PyObjectRef]) -> PyResult {
+    decimal_impl(&MODERN, args)
+}
+fn decimal_old(args: &[PyObjectRef]) -> PyResult {
+    decimal_impl(&LEGACY, args)
+}
+
+fn numeric_impl(db: &ucd_core::Ucd, args: &[PyObjectRef]) -> PyResult {
+    let (cp, default) = char_and_default("numeric", args)?;
+    match db.numeric(cp) {
+        Some(v) => Ok(w_float_new(v)),
+        None => default.ok_or_else(|| PyError::value_error("not a numeric character")),
+    }
+}
+fn numeric(args: &[PyObjectRef]) -> PyResult {
+    numeric_impl(&MODERN, args)
+}
+fn numeric_old(args: &[PyObjectRef]) -> PyResult {
+    numeric_impl(&LEGACY, args)
+}
+
+// Version-independent queries: `name` / `lookup` / `normalize` /
+// `is_normalized` do not depend on the database version, so the 3.2.0 instance
+// binds the same callables.
+
+fn name(args: &[PyObjectRef]) -> PyResult {
+    let (cp, default) = char_and_default("name", args)?;
+    if let Some(name) = cp.to_char().and_then(ucd_core::character_name) {
+        return Ok(w_str_new(&name));
+    }
+    default.ok_or_else(|| PyError::value_error("no such name"))
+}
+
+fn lookup(args: &[PyObjectRef]) -> PyResult {
+    if args.len() != 1 {
+        return Err(PyError::type_error(format!(
+            "lookup expected 1 argument, got {}",
+            args.len()
+        )));
+    }
+    let obj = args[0];
+    if !unsafe { is_str(obj) } {
+        let ty = crate::baseobjspace::object_functionstr_type_name(obj);
+        return Err(PyError::type_error(format!(
+            "lookup() argument must be str, not {ty}"
+        )));
+    }
+    let name = unsafe { w_str_get_wtf8(obj) };
+    if let Ok(name) = name.as_str()
+        && let Some(ch) = ucd_core::lookup_character(name)
+    {
+        let mut buf = String::with_capacity(ch.len_utf8());
+        buf.push(ch);
+        return Ok(w_str_new(&buf));
+    }
+    Err(PyError::key_error(format!(
+        "undefined character name '{}'",
+        name.to_string_lossy()
+    )))
+}
+
+/// Parse the normalization-form argument (`NFC`/`NFKC`/`NFD`/`NFKD`).
+fn normalize_form(func: &str, obj: PyObjectRef) -> Result<NormalizeForm, PyError> {
+    if !unsafe { is_str(obj) } {
+        let ty = crate::baseobjspace::object_functionstr_type_name(obj);
+        return Err(PyError::type_error(format!(
+            "{func}() argument 1 must be str, not {ty}"
+        )));
+    }
+    let s = unsafe { w_str_get_wtf8(obj) }.as_str().unwrap_or_default();
+    s.parse::<NormalizeForm>()
+        .map_err(|()| PyError::value_error("invalid normalization form"))
+}
+
+/// Borrow the string argument to be normalized (`unistr`).
+fn normalize_text(func: &str, obj: PyObjectRef) -> Result<&'static Wtf8, PyError> {
+    if !unsafe { is_str(obj) } {
+        let ty = crate::baseobjspace::object_functionstr_type_name(obj);
+        return Err(PyError::type_error(format!(
+            "{func}() argument 2 must be str, not {ty}"
+        )));
+    }
+    Ok(unsafe { w_str_get_wtf8(obj) })
+}
+
+fn normalize(args: &[PyObjectRef]) -> PyResult {
+    if args.len() != 2 {
+        return Err(PyError::type_error(format!(
+            "normalize expected 2 arguments, got {}",
+            args.len()
+        )));
+    }
+    let form = normalize_form("normalize", args[0])?;
+    let text = normalize_text("normalize", args[1])?;
+    Ok(w_str_from_wtf8(ucd_core::normalize(form, text)))
+}
+
+fn is_normalized(args: &[PyObjectRef]) -> PyResult {
+    if args.len() != 2 {
+        return Err(PyError::type_error(format!(
+            "is_normalized expected 2 arguments, got {}",
+            args.len()
+        )));
+    }
+    let form = normalize_form("is_normalized", args[0])?;
+    let text = normalize_text("is_normalized", args[1])?;
+    Ok(w_bool_from(ucd_core::is_normalized(form, text)))
+}
 
 crate::py_module! {
     "unicodedata",
     interpleveldefs: {
-        "unidata_version" => w_str_new("15.1.0"),
+        "unidata_version" => w_str_new(&ucd_core::unicode_version()),
     },
     functions: {
-        "normalize" / 2 = |args| Ok(args.get(1).copied().unwrap_or_else(|| w_str_new(""))),
-        "category"  / 1 = |_| Ok(w_str_new("Cn")),
-        "name"      / * = |args| args.get(1).copied()
-            .ok_or_else(|| crate::PyError::value_error("no such name")),
-        "lookup"    / 1 = |_| Err(crate::PyError::key_error("character not found")),
-        "decimal"   / * = |args| args.get(1).copied()
-            .ok_or_else(|| crate::PyError::value_error("not a decimal")),
-        "numeric"   / * = |args| args.get(1).copied()
-            .ok_or_else(|| crate::PyError::value_error("not a numeric character")),
+        "category"         / * = category,
+        "bidirectional"    / * = bidirectional,
+        "east_asian_width" / * = east_asian_width,
+        "combining"        / * = combining,
+        "mirrored"         / * = mirrored,
+        "decomposition"    / * = decomposition,
+        "digit"            / * = digit,
+        "decimal"          / * = decimal,
+        "numeric"          / * = numeric,
+        "name"             / * = name,
+        "lookup"           / * = lookup,
+        "normalize"        / * = normalize,
+        "is_normalized"    / * = is_normalized,
     },
     extra_init: |ns| {
         // `unicodedata.ucd_3_2_0` — a `UCD` instance pinned to the Unicode
-        // 3.2 database (used by `stringprep`).  pyre carries no historical
-        // tables, so it reuses the module's stub callables.  Functions live
-        // in the instance __dict__, so attribute access returns them
-        // unbound — `ucd_3_2_0.category(ch)` dispatches exactly like the
-        // module-level `category(ch)`.
+        // 3.2.0 database (used by `stringprep`).  Version-sensitive queries
+        // bind their `*_old` twins (which read `Ucd::new(false)`);
+        // name/lookup/normalize/is_normalized share the module callables.
+        // Functions live in the instance __dict__, so attribute access
+        // returns them unbound — `ucd_3_2_0.category(ch)` dispatches with the
+        // single `ch` argument, exactly like `category(ch)`.
         let ucd_ty = crate::typedef::make_builtin_type("UCD", |_| {});
         unsafe { typeobject::w_type_set_hasdict(ucd_ty, true) };
         let ucd = w_instance_new(ucd_ty);
         let d = crate::baseobjspace::getdict(ucd);
-        for name in ["normalize", "category", "name", "lookup", "decimal", "numeric"] {
-            if let Some(f) = crate::runtime_ops::dict_storage_get(ns, name) {
-                unsafe { w_dict_setitem_str(d, name, f) };
-            }
-        }
+        let bind = |name: &'static str, func: crate::gateway::BuiltinCodeFn| {
+            let f = crate::gateway::make_module_builtin_function(name, func);
+            unsafe { w_dict_setitem_str(d, name, f) };
+        };
+        bind("category", category_old);
+        bind("bidirectional", bidirectional_old);
+        bind("east_asian_width", east_asian_width_old);
+        bind("combining", combining_old);
+        bind("mirrored", mirrored_old);
+        bind("decomposition", decomposition_old);
+        bind("digit", digit_old);
+        bind("decimal", decimal_old);
+        bind("numeric", numeric_old);
+        bind("name", name);
+        bind("lookup", lookup);
+        bind("normalize", normalize);
+        bind("is_normalized", is_normalized);
         unsafe { w_dict_setitem_str(d, "unidata_version", w_str_new("3.2.0")) };
         crate::dict_storage_store(ns, "ucd_3_2_0", ucd);
     },

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -1,11 +1,78 @@
 //! zlib module — PyPy: `pypy/module/zlib/`.
 //!
-//! Pure-Rust CRC-32 / Adler-32 checksums plus the module constants and the
-//! `error` type, enough for `gzip` / `zipfile` / `tarfile` to import. Actual
-//! DEFLATE compression is not implemented (no zlib backend is linked), so
-//! the `compress` / `decompress` family raises at call time.
+//! CRC-32 / Adler-32 checksums plus the DEFLATE compress/decompress surface.
+//! The DEFLATE machinery is a deliberate duplication of RustPython's zlib
+//! implementation, ported into `pyre_native::zlib` (flate2 / zlib-rs) and kept
+//! outside the LLBC extraction; this module is the W_Root object glue.
+//!
+//! `Compress` / `Decompress` / `_ZlibDecompressor` hold flate2 streaming state
+//! that cannot live in the Python dict, so it is parked in process-global
+//! registries keyed by an id stashed in each instance dict (`_id`). A streamer
+//! dropped by GC leaks its (post-finish, buffer-freed) registry entry; the
+//! heavy flate2 buffers are released by the backend at finish/eof.
 
 use pyre_object::*;
+use pyre_native::zlib as backend;
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// ── streaming-state registries ──────────────────────────────────────────
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static COMPRESSORS: Mutex<BTreeMap<u64, backend::Compressor>> = Mutex::new(BTreeMap::new());
+static DECOMPRESSORS: Mutex<BTreeMap<u64, backend::Decompressor>> = Mutex::new(BTreeMap::new());
+static ZDECOMPRESSORS: Mutex<BTreeMap<u64, backend::ZlibDecompressor>> = Mutex::new(BTreeMap::new());
+
+fn next_id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn get_id(obj: PyObjectRef) -> u64 {
+    let d = crate::baseobjspace::getdict(obj);
+    if d.is_null() {
+        return 0;
+    }
+    match unsafe { w_dict_getitem_str(d, "_id") } {
+        Some(v) if unsafe { is_int(v) } => (unsafe { w_int_get_value(v) }) as u64,
+        _ => 0,
+    }
+}
+
+fn set_id(obj: PyObjectRef, id: u64) {
+    let d = crate::baseobjspace::getdict(obj);
+    if !d.is_null() {
+        unsafe { w_dict_setitem_str(d, "_id", w_int_new(id as i64)) };
+    }
+}
+
+// ── errors ──────────────────────────────────────────────────────────────
+
+fn zlib_error(msg: impl Into<String>) -> crate::PyError {
+    let msg = msg.into();
+    let mut err = crate::PyError::value_error(msg.clone());
+    if let Some(cls) = crate::builtins::lookup_exc_class("zlib.error") {
+        let args = [cls, w_str_new(&msg)];
+        if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            err.exc_object = exc;
+        }
+    }
+    err
+}
+
+fn eof_error(msg: &str) -> crate::PyError {
+    let mut err = crate::PyError::value_error(msg.to_string());
+    if let Some(cls) = crate::builtins::lookup_exc_class("EOFError") {
+        let args = [cls, w_str_new(msg)];
+        if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            err.exc_object = exc;
+        }
+    }
+    err
+}
+
+// ── argument helpers ────────────────────────────────────────────────────
 
 fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     unsafe {
@@ -20,6 +87,39 @@ fn as_bytes(obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
         }
     }
 }
+
+/// Fetch an integer argument by keyword or position, `None`/missing → default.
+fn arg_int(
+    pos: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    name: &str,
+    index: usize,
+    default: i64,
+) -> Result<i64, crate::PyError> {
+    match crate::builtins::kwarg_get(kwargs, name).or_else(|| pos.get(index).copied()) {
+        Some(o) if unsafe { is_none(o) } => Ok(default),
+        Some(o) => crate::baseobjspace::int_w(o),
+        None => Ok(default),
+    }
+}
+
+/// Fetch an optional `zdict` bytes argument by keyword or position.
+fn arg_zdict(
+    pos: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    index: usize,
+) -> Result<Option<Vec<u8>>, crate::PyError> {
+    match crate::builtins::kwarg_get(kwargs, "zdict").or_else(|| pos.get(index).copied()) {
+        Some(o) if !unsafe { is_none(o) } => Ok(Some(as_bytes(o)?)),
+        _ => Ok(None),
+    }
+}
+
+fn to_wbits(v: i64) -> i8 {
+    v as i8
+}
+
+// ── checksums ───────────────────────────────────────────────────────────
 
 fn crc32_compute(buf: &[u8], start: u32) -> u32 {
     let mut crc = !start;
@@ -43,14 +143,287 @@ fn adler32_compute(buf: &[u8], start: u32) -> u32 {
     (b << 16) | a
 }
 
+// ── Compress (compressobj) ──────────────────────────────────────────────
+
+thread_local! {
+    static COMPRESS_TYPE: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
+    static DECOMPRESS_TYPE: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
+    static ZDECOMPRESS_TYPE: std::cell::OnceCell<PyObjectRef> = const { std::cell::OnceCell::new() };
+}
+
+fn compress_type() -> PyObjectRef {
+    COMPRESS_TYPE.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("Compress", init_compress_type);
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+fn init_compress_type(ns: &mut crate::DictStorage) {
+    crate::dict_storage_store(
+        ns,
+        "compress",
+        crate::make_builtin_function_with_arity(
+            "compress",
+            |args| {
+                if args.len() < 2 {
+                    return Err(crate::PyError::type_error("compress() missing data"));
+                }
+                let id = get_id(args[0]);
+                let data = as_bytes(args[1])?;
+                let mut reg = COMPRESSORS.lock().unwrap();
+                let c = reg
+                    .get_mut(&id)
+                    .ok_or_else(|| zlib_error("Error -2: inconsistent stream state"))?;
+                let out = c.compress(&data).map_err(zlib_error)?;
+                Ok(bytesobject::w_bytes_from_bytes(&out))
+            },
+            2,
+        ),
+    );
+    crate::dict_storage_store(
+        ns,
+        "flush",
+        crate::make_builtin_function("flush", |args| {
+            if args.is_empty() {
+                return Err(crate::PyError::type_error("flush() missing self"));
+            }
+            let id = get_id(args[0]);
+            let mode = match args.get(1).copied() {
+                Some(o) if !unsafe { is_none(o) } => crate::baseobjspace::int_w(o)? as i32,
+                _ => backend::Z_FINISH,
+            };
+            let mut reg = COMPRESSORS.lock().unwrap();
+            let c = reg
+                .get_mut(&id)
+                .ok_or_else(|| zlib_error("Error -2: inconsistent stream state"))?;
+            let out = c.flush(mode).map_err(zlib_error)?;
+            Ok(bytesobject::w_bytes_from_bytes(&out))
+        }),
+    );
+}
+
+fn make_compress(level: i32, wbits: i8, zdict: Option<Vec<u8>>) -> Result<PyObjectRef, crate::PyError> {
+    let c = backend::Compressor::new(level, wbits, zdict.as_deref()).map_err(zlib_error)?;
+    let id = next_id();
+    COMPRESSORS.lock().unwrap().insert(id, c);
+    let obj = w_instance_new(compress_type());
+    set_id(obj, id);
+    Ok(obj)
+}
+
+// ── Decompress (decompressobj) ──────────────────────────────────────────
+
+fn decompress_type() -> PyObjectRef {
+    DECOMPRESS_TYPE.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("Decompress", init_decompress_type);
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+fn decompress_getset(ns: &mut crate::DictStorage, name: &'static str, f: crate::gateway::BuiltinCodeFn) {
+    crate::dict_storage_store(
+        ns,
+        name,
+        crate::typedef::make_getset_descriptor_named(
+            crate::make_builtin_function_with_arity(name, f, 2),
+            name,
+        ),
+    );
+}
+
+fn init_decompress_type(ns: &mut crate::DictStorage) {
+    crate::dict_storage_store(
+        ns,
+        "decompress",
+        crate::make_builtin_function("decompress", |args| {
+            if args.len() < 2 {
+                return Err(crate::PyError::type_error("decompress() missing data"));
+            }
+            let id = get_id(args[0]);
+            let data = as_bytes(args[1])?;
+            let max_length = match args.get(2).copied() {
+                Some(o) if !unsafe { is_none(o) } => {
+                    let v = crate::baseobjspace::int_w(o)?;
+                    if v < 0 {
+                        return Err(crate::PyError::value_error("max_length must be non-negative"));
+                    }
+                    (v != 0).then_some(v as usize)
+                }
+                _ => None,
+            };
+            let mut reg = DECOMPRESSORS.lock().unwrap();
+            let d = reg
+                .get_mut(&id)
+                .ok_or_else(|| zlib_error("Error -2: inconsistent stream state"))?;
+            let out = d.decompress(&data, max_length).map_err(zlib_error)?;
+            Ok(bytesobject::w_bytes_from_bytes(&out))
+        }),
+    );
+    crate::dict_storage_store(
+        ns,
+        "flush",
+        crate::make_builtin_function("flush", |args| {
+            if args.is_empty() {
+                return Err(crate::PyError::type_error("flush() missing self"));
+            }
+            let id = get_id(args[0]);
+            let length = match args.get(1).copied() {
+                Some(o) if !unsafe { is_none(o) } => {
+                    let v = crate::baseobjspace::int_w(o)?;
+                    if v <= 0 {
+                        return Err(crate::PyError::value_error("length must be greater than zero"));
+                    }
+                    v as usize
+                }
+                _ => backend::DEF_BUF_SIZE,
+            };
+            let mut reg = DECOMPRESSORS.lock().unwrap();
+            let d = reg
+                .get_mut(&id)
+                .ok_or_else(|| zlib_error("Error -2: inconsistent stream state"))?;
+            let out = d.flush(length).map_err(zlib_error)?;
+            Ok(bytesobject::w_bytes_from_bytes(&out))
+        }),
+    );
+    decompress_getset(ns, "unused_data", |args| {
+        let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
+        let reg = DECOMPRESSORS.lock().unwrap();
+        let data = reg.get(&id).map(|d| d.unused_data().to_vec()).unwrap_or_default();
+        Ok(bytesobject::w_bytes_from_bytes(&data))
+    });
+    decompress_getset(ns, "unconsumed_tail", |args| {
+        let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
+        let reg = DECOMPRESSORS.lock().unwrap();
+        let data = reg
+            .get(&id)
+            .map(|d| d.unconsumed_tail().to_vec())
+            .unwrap_or_default();
+        Ok(bytesobject::w_bytes_from_bytes(&data))
+    });
+    decompress_getset(ns, "eof", |args| {
+        let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
+        let reg = DECOMPRESSORS.lock().unwrap();
+        Ok(w_bool_from(reg.get(&id).map(|d| d.eof()).unwrap_or(false)))
+    });
+}
+
+fn make_decompress(wbits: i8, zdict: Option<Vec<u8>>) -> Result<PyObjectRef, crate::PyError> {
+    let d = backend::Decompressor::new(wbits, zdict).map_err(zlib_error)?;
+    let id = next_id();
+    DECOMPRESSORS.lock().unwrap().insert(id, d);
+    let obj = w_instance_new(decompress_type());
+    set_id(obj, id);
+    Ok(obj)
+}
+
+// ── _ZlibDecompressor (buffered; used by gzip reading) ──────────────────
+
+fn zdecompress_type() -> PyObjectRef {
+    ZDECOMPRESS_TYPE.with(|c| {
+        *c.get_or_init(|| {
+            let tp = crate::typedef::make_builtin_type("_ZlibDecompressor", init_zdecompress_type);
+            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            tp
+        })
+    })
+}
+
+fn zdecompress_getset(
+    ns: &mut crate::DictStorage,
+    name: &'static str,
+    f: crate::gateway::BuiltinCodeFn,
+) {
+    crate::dict_storage_store(
+        ns,
+        name,
+        crate::typedef::make_getset_descriptor_named(
+            crate::make_builtin_function_with_arity(name, f, 2),
+            name,
+        ),
+    );
+}
+
+fn init_zdecompress_type(ns: &mut crate::DictStorage) {
+    // _ZlibDecompressor(wbits=MAX_WBITS, zdict=b'') — the DecompressReader
+    // factory gzip calls with wbits=-MAX_WBITS.
+    crate::dict_storage_store(
+        ns,
+        "__new__",
+        crate::make_builtin_function("__new__", |args| {
+            // args[0] is the type; the rest are the constructor arguments.
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+            let wbits = to_wbits(arg_int(pos, kwargs, "wbits", 0, backend::MAX_WBITS as i64)?);
+            let zdict = arg_zdict(pos, kwargs, 1)?;
+            let d = backend::ZlibDecompressor::new(wbits, zdict).map_err(zlib_error)?;
+            let id = next_id();
+            ZDECOMPRESSORS.lock().unwrap().insert(id, d);
+            let obj = w_instance_new(zdecompress_type());
+            set_id(obj, id);
+            Ok(obj)
+        }),
+    );
+    crate::dict_storage_store(
+        ns,
+        "decompress",
+        crate::make_builtin_function("decompress", |args| {
+            if args.len() < 2 {
+                return Err(crate::PyError::type_error("decompress() missing data"));
+            }
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let max_length = match crate::builtins::kwarg_get(kwargs, "max_length")
+                .or_else(|| pos.get(1).copied())
+            {
+                Some(o) if !unsafe { is_none(o) } => {
+                    let v = crate::baseobjspace::int_w(o)?;
+                    usize::try_from(v).ok()
+                }
+                _ => None,
+            };
+            let id = get_id(args[0]);
+            let mut reg = ZDECOMPRESSORS.lock().unwrap();
+            let d = reg
+                .get_mut(&id)
+                .ok_or_else(|| zlib_error("Error -2: inconsistent stream state"))?;
+            match d.decompress(&data, max_length) {
+                Ok(out) => Ok(bytesobject::w_bytes_from_bytes(&out)),
+                Err(backend::DecompressError::Zlib(m)) => Err(zlib_error(m)),
+                Err(backend::DecompressError::Eof) => {
+                    Err(eof_error("End of stream already reached"))
+                }
+            }
+        }),
+    );
+    zdecompress_getset(ns, "unused_data", |args| {
+        let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
+        let reg = ZDECOMPRESSORS.lock().unwrap();
+        let data = reg.get(&id).map(|d| d.unused_data().to_vec()).unwrap_or_default();
+        Ok(bytesobject::w_bytes_from_bytes(&data))
+    });
+    zdecompress_getset(ns, "eof", |args| {
+        let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
+        let reg = ZDECOMPRESSORS.lock().unwrap();
+        Ok(w_bool_from(reg.get(&id).map(|d| d.eof()).unwrap_or(false)))
+    });
+    zdecompress_getset(ns, "needs_input", |args| {
+        let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
+        let reg = ZDECOMPRESSORS.lock().unwrap();
+        Ok(w_bool_from(reg.get(&id).map(|d| d.needs_input()).unwrap_or(true)))
+    });
+}
+
 crate::py_module! {
     "zlib",
     interpleveldefs: {
         "ZLIB_VERSION" => w_str_new("1.3.1"),
         "ZLIB_RUNTIME_VERSION" => w_str_new("1.3.1"),
-        // Referenced as an attribute by gzip; a placeholder type keeps
-        // `import gzip` working (its use raises only when constructed).
-        "_ZlibDecompressor" => crate::typedef::w_object(),
+        "_ZlibDecompressor" => zdecompress_type(),
     },
     int_constants: {
         "DEFLATED" => 8,
@@ -88,9 +461,39 @@ crate::py_module! {
             let start = args.get(1).map(|&o| unsafe { w_int_get_value(o) } as u32).unwrap_or(1);
             Ok(w_int_new(adler32_compute(&data, start) as i64))
         },
-        "compress" / * = |_| Err(crate::PyError::not_implemented("zlib compression is unavailable")),
-        "decompress" / * = |_| Err(crate::PyError::not_implemented("zlib decompression is unavailable")),
-        "compressobj" / * = |_| Err(crate::PyError::not_implemented("zlib compression is unavailable")),
-        "decompressobj" / * = |_| Err(crate::PyError::not_implemented("zlib decompression is unavailable")),
+        "compress" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let level = arg_int(pos, kwargs, "level", 1, -1)? as i32;
+            let wbits = to_wbits(arg_int(pos, kwargs, "wbits", 2, backend::MAX_WBITS as i64)?);
+            let out = backend::compress(&data, level, wbits).map_err(zlib_error)?;
+            Ok(bytesobject::w_bytes_from_bytes(&out))
+        },
+        "decompress" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let data = as_bytes(pos.first().copied().unwrap_or(w_none()))?;
+            let wbits = to_wbits(arg_int(pos, kwargs, "wbits", 1, backend::MAX_WBITS as i64)?);
+            let bufsize = arg_int(pos, kwargs, "bufsize", 2, backend::DEF_BUF_SIZE as i64)?;
+            if bufsize < 0 {
+                return Err(crate::PyError::value_error("bufsize must be non-negative"));
+            }
+            let out = backend::decompress(&data, wbits, bufsize as usize).map_err(zlib_error)?;
+            Ok(bytesobject::w_bytes_from_bytes(&out))
+        },
+        "compressobj" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let level = arg_int(pos, kwargs, "level", 0, -1)? as i32;
+            // positions 1 (method) and 3 (memLevel) / 4 (strategy) are accepted
+            // but only level / wbits / zdict affect the stream.
+            let wbits = to_wbits(arg_int(pos, kwargs, "wbits", 2, backend::MAX_WBITS as i64)?);
+            let zdict = arg_zdict(pos, kwargs, 5)?;
+            make_compress(level, wbits, zdict)
+        },
+        "decompressobj" / * = |args| {
+            let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            let wbits = to_wbits(arg_int(pos, kwargs, "wbits", 0, backend::MAX_WBITS as i64)?);
+            let zdict = arg_zdict(pos, kwargs, 1)?;
+            make_decompress(wbits, zdict)
+        },
     },
 }

--- a/pyre/pyre-interpreter/src/module/zlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/zlib/mod.rs
@@ -11,8 +11,8 @@
 //! dropped by GC leaks its (post-finish, buffer-freed) registry entry; the
 //! heavy flate2 buffers are released by the backend at finish/eof.
 
-use pyre_object::*;
 use pyre_native::zlib as backend;
+use pyre_object::*;
 
 use std::collections::BTreeMap;
 use std::sync::Mutex;
@@ -23,7 +23,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 static COMPRESSORS: Mutex<BTreeMap<u64, backend::Compressor>> = Mutex::new(BTreeMap::new());
 static DECOMPRESSORS: Mutex<BTreeMap<u64, backend::Decompressor>> = Mutex::new(BTreeMap::new());
-static ZDECOMPRESSORS: Mutex<BTreeMap<u64, backend::ZlibDecompressor>> = Mutex::new(BTreeMap::new());
+static ZDECOMPRESSORS: Mutex<BTreeMap<u64, backend::ZlibDecompressor>> =
+    Mutex::new(BTreeMap::new());
 
 fn next_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)
@@ -205,7 +206,11 @@ fn init_compress_type(ns: &mut crate::DictStorage) {
     );
 }
 
-fn make_compress(level: i32, wbits: i8, zdict: Option<Vec<u8>>) -> Result<PyObjectRef, crate::PyError> {
+fn make_compress(
+    level: i32,
+    wbits: i8,
+    zdict: Option<Vec<u8>>,
+) -> Result<PyObjectRef, crate::PyError> {
     let c = backend::Compressor::new(level, wbits, zdict.as_deref()).map_err(zlib_error)?;
     let id = next_id();
     COMPRESSORS.lock().unwrap().insert(id, c);
@@ -226,7 +231,11 @@ fn decompress_type() -> PyObjectRef {
     })
 }
 
-fn decompress_getset(ns: &mut crate::DictStorage, name: &'static str, f: crate::gateway::BuiltinCodeFn) {
+fn decompress_getset(
+    ns: &mut crate::DictStorage,
+    name: &'static str,
+    f: crate::gateway::BuiltinCodeFn,
+) {
     crate::dict_storage_store(
         ns,
         name,
@@ -251,7 +260,9 @@ fn init_decompress_type(ns: &mut crate::DictStorage) {
                 Some(o) if !unsafe { is_none(o) } => {
                     let v = crate::baseobjspace::int_w(o)?;
                     if v < 0 {
-                        return Err(crate::PyError::value_error("max_length must be non-negative"));
+                        return Err(crate::PyError::value_error(
+                            "max_length must be non-negative",
+                        ));
                     }
                     (v != 0).then_some(v as usize)
                 }
@@ -277,7 +288,9 @@ fn init_decompress_type(ns: &mut crate::DictStorage) {
                 Some(o) if !unsafe { is_none(o) } => {
                     let v = crate::baseobjspace::int_w(o)?;
                     if v <= 0 {
-                        return Err(crate::PyError::value_error("length must be greater than zero"));
+                        return Err(crate::PyError::value_error(
+                            "length must be greater than zero",
+                        ));
                     }
                     v as usize
                 }
@@ -294,7 +307,10 @@ fn init_decompress_type(ns: &mut crate::DictStorage) {
     decompress_getset(ns, "unused_data", |args| {
         let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
         let reg = DECOMPRESSORS.lock().unwrap();
-        let data = reg.get(&id).map(|d| d.unused_data().to_vec()).unwrap_or_default();
+        let data = reg
+            .get(&id)
+            .map(|d| d.unused_data().to_vec())
+            .unwrap_or_default();
         Ok(bytesobject::w_bytes_from_bytes(&data))
     });
     decompress_getset(ns, "unconsumed_tail", |args| {
@@ -403,7 +419,10 @@ fn init_zdecompress_type(ns: &mut crate::DictStorage) {
     zdecompress_getset(ns, "unused_data", |args| {
         let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
         let reg = ZDECOMPRESSORS.lock().unwrap();
-        let data = reg.get(&id).map(|d| d.unused_data().to_vec()).unwrap_or_default();
+        let data = reg
+            .get(&id)
+            .map(|d| d.unused_data().to_vec())
+            .unwrap_or_default();
         Ok(bytesobject::w_bytes_from_bytes(&data))
     });
     zdecompress_getset(ns, "eof", |args| {
@@ -414,7 +433,9 @@ fn init_zdecompress_type(ns: &mut crate::DictStorage) {
     zdecompress_getset(ns, "needs_input", |args| {
         let id = get_id(args.get(1).copied().unwrap_or(PY_NULL));
         let reg = ZDECOMPRESSORS.lock().unwrap();
-        Ok(w_bool_from(reg.get(&id).map(|d| d.needs_input()).unwrap_or(true)))
+        Ok(w_bool_from(
+            reg.get(&id).map(|d| d.needs_input()).unwrap_or(true),
+        ))
     });
 }
 

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -373,6 +373,58 @@ pub(crate) fn format_g_like(abs: f64, prec: usize, upper: bool, alt_form: bool) 
     }
 }
 
+/// Format an absolute float for the empty presentation type with an explicit
+/// precision (or alt-form).  Like `%g` with `prec` significant digits, but the
+/// scientific cutoff is one lower (`exp >= prec - 1`) and a fixed result always
+/// shows a fractional part — a bare integer keeps a trailing `.0`, and alt-form
+/// retains the requested trailing zeros.
+pub(crate) fn format_no_type_prec(abs: f64, prec: usize, alt_form: bool) -> String {
+    if !abs.is_finite() {
+        return format!("{abs}");
+    }
+    let prec = prec.max(1);
+    // 0.0 has no `log10`; its decimal point sits one past the leading digit.
+    let exp = if abs == 0.0 {
+        0
+    } else {
+        abs.log10().floor() as i32
+    };
+    if exp < -4 || exp >= prec as i32 - 1 {
+        let raw = normalise_exponent(&format!("{:.*e}", prec - 1, abs), false);
+        let Some(epos) = raw.find('e') else {
+            return raw;
+        };
+        let (mantissa, exp_part) = raw.split_at(epos);
+        let mantissa = if alt_form {
+            mantissa.to_string()
+        } else {
+            trim_trailing_zeros(mantissa)
+        };
+        // Alt-form advertises the point even when the mantissa is a bare digit.
+        let mantissa = if alt_form && !mantissa.contains('.') {
+            format!("{mantissa}.")
+        } else {
+            mantissa
+        };
+        return format!("{mantissa}{exp_part}");
+    }
+    let dec = (prec as i32 - 1 - exp).max(0) as usize;
+    let raw = format!("{abs:.dec$}");
+    if alt_form {
+        return if raw.contains('.') { raw } else { format!("{raw}.") };
+    }
+    let body = if raw.contains('.') {
+        trim_trailing_zeros(&raw)
+    } else {
+        raw
+    };
+    if body.contains('.') {
+        body
+    } else {
+        format!("{body}.0")
+    }
+}
+
 /// Convert Rust's `{:e}` / `{:E}` exponent encoding (no sign, minimal
 /// width — `1.5e3` / `1.5e-3`) to PyPy / CPython `%e`-style
 /// (`1.5e+03` / `1.5e-03` — explicit sign, exponent zero-padded to at

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -26,8 +26,8 @@ use rustpython_wtf8::{CodePoint, Wtf8Buf};
 /// error only when the operand is not itself a mapping.
 pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> PyResult {
     let fmt_str = w_str_get_wtf8(fmt);
-    let format =
-        CFormatWtf8::parse_from_wtf8(fmt_str).map_err(|err| PyError::value_error(err.to_string()))?;
+    let format = CFormatWtf8::parse_from_wtf8(fmt_str)
+        .map_err(|err| PyError::value_error(err.to_string()))?;
 
     // `unicodeobject.c PyUnicode_Format` — the operand is usable as a
     // mapping (for `%(key)s` lookups) when it exposes `__getitem__` and is
@@ -41,7 +41,9 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     };
     let positional: Vec<PyObjectRef> = if args_is_tuple {
         let n = w_tuple_len(args);
-        (0..n).filter_map(|i| w_tuple_getitem(args, i as i64)).collect()
+        (0..n)
+            .filter_map(|i| w_tuple_getitem(args, i as i64))
+            .collect()
     } else {
         vec![args]
     };
@@ -53,7 +55,10 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     for (idx, part) in format {
         match part {
             CFormatPart::Literal(literal) => result.push_wtf8(&literal),
-            CFormatPart::Spec(CFormatSpecKeyed { mapping_key, mut spec }) => {
+            CFormatPart::Spec(CFormatSpecKeyed {
+                mapping_key,
+                mut spec,
+            }) => {
                 saw_specifier = true;
                 let value = if let Some(key) = mapping_key {
                     let Some(dict) = dict else {
@@ -65,10 +70,16 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
                     let _ = pos.next();
                     w_value
                 } else {
-                    update_quantity_from_tuple(&mut pos, &mut spec.min_field_width, &mut spec.flags)?;
+                    update_quantity_from_tuple(
+                        &mut pos,
+                        &mut spec.min_field_width,
+                        &mut spec.flags,
+                    )?;
                     update_precision_from_tuple(&mut pos, &mut spec.precision)?;
                     let Some(v) = pos.next() else {
-                        return Err(PyError::type_error("not enough arguments for format string"));
+                        return Err(PyError::type_error(
+                            "not enough arguments for format string",
+                        ));
                     };
                     v
                 };
@@ -172,7 +183,9 @@ unsafe fn number_arg_decimal(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Big
         return Ok(arg_to_bigint(pyint));
     }
     if has_dunder(obj, "__index__") {
-        return Ok(crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?));
+        return Ok(crate::builtins::obj_to_bigint(
+            crate::baseobjspace::space_index(obj)?,
+        ));
     }
     if let Some(method) = crate::baseobjspace::lookup(obj, "__int__") {
         let r = crate::builtins::call_and_check(method, &[obj])?;
@@ -190,7 +203,9 @@ unsafe fn number_arg_integer(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Big
         return Ok(arg_to_bigint(obj));
     }
     if has_dunder(obj, "__index__") {
-        return Ok(crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?));
+        return Ok(crate::builtins::obj_to_bigint(
+            crate::baseobjspace::space_index(obj)?,
+        ));
     }
     Err(number_type_error(spec, obj, "an integer is required"))
 }
@@ -230,7 +245,12 @@ unsafe fn char_arg(obj: PyObjectRef) -> Result<CodePoint, PyError> {
             crate::baseobjspace::object_functionstr_type_name(obj),
         )));
     };
-    let overflow = || PyError::new(PyErrorKind::OverflowError, "%c arg not in range(0x110000)".to_string());
+    let overflow = || {
+        PyError::new(
+            PyErrorKind::OverflowError,
+            "%c arg not in range(0x110000)".to_string(),
+        )
+    };
     let n = u32::try_from(&value).map_err(|_| overflow())?;
     CodePoint::from_u32(n).ok_or_else(overflow)
 }
@@ -283,187 +303,12 @@ unsafe fn update_precision_from_tuple(
 /// The `*` argument must be an int; consume it, matching `nextinputvalue`.
 unsafe fn star_int(arg: Option<PyObjectRef>) -> Result<i64, PyError> {
     let Some(arg) = arg else {
-        return Err(PyError::type_error("not enough arguments for format string"));
+        return Err(PyError::type_error(
+            "not enough arguments for format string",
+        ));
     };
     if !is_int_like(arg) {
         return Err(PyError::type_error("* wants int"));
     }
     Ok(int_value(arg))
-}
-
-/// `formatting.py fmt_g / fmt_G` parity helper — emits the `%g` body
-/// for an *absolute* float value.  CPython's `%g` rules:
-///   * precision ≤ 0 is treated as 1 (PyPy: `prec = max(prec, 1)`)
-///   * choose scientific when `exp < -4` or `exp >= prec`
-///     (`pypy/objspace/std/formatting.py:120 format_e_g_complex`)
-///   * scientific body uses (`prec - 1`) decimals
-///   * fixed body uses `(prec - 1 - exp)` decimals
-///   * trailing zeros (and the trailing '.') are stripped unless
-///     `#` (alt-form) was set; with alt-form the trailing zeros AND
-///     the dangling '.' survive so the output advertises the full
-///     requested precision.
-pub(crate) fn format_g_like(abs: f64, prec: usize, upper: bool, alt_form: bool) -> String {
-    if abs == 0.0 {
-        return if alt_form {
-            // `formatting.py:120-128` — alt-form `%#g` keeps `prec`
-            // significant digits even for 0.0, so `"%#.4g" % 0`
-            // renders as `"0.000"` (one digit before the dot, then
-            // `prec - 1` zeros after).
-            let after = prec.saturating_sub(1);
-            if after == 0 {
-                "0".to_string()
-            } else {
-                format!("0.{}", "0".repeat(after))
-            }
-        } else {
-            "0".to_string()
-        };
-    }
-    if !abs.is_finite() {
-        return if upper {
-            format!("{abs}").to_uppercase()
-        } else {
-            format!("{abs}")
-        };
-    }
-    let prec = prec.max(1);
-    let exp = abs.log10().floor() as i32;
-    let use_sci = exp < -4 || exp >= prec as i32;
-    let raw = if use_sci {
-        let rust_exp = format!("{:.*e}", prec - 1, abs);
-        normalise_exponent(&rust_exp, upper)
-    } else {
-        let dec = (prec as i32 - 1 - exp).max(0) as usize;
-        format!("{abs:.dec$}")
-    };
-    if alt_form {
-        // Alt-form preserves trailing zeros and the dangling '.';
-        // ensure a '.' is present even when the natural body has
-        // none (e.g. `"%#g" % 1` → `"1.00000"`).
-        if use_sci {
-            return raw;
-        }
-        return if raw.contains('.') {
-            raw
-        } else {
-            // `prec - 1 - exp` was 0, so the body has no decimals;
-            // re-render with the alt-form '.' suffix + trailing
-            // zeros to advertise the full precision.
-            let after = (prec as i32 - 1 - exp).max(0) as usize;
-            if after == 0 {
-                format!("{raw}.")
-            } else {
-                format!("{raw}.{}", "0".repeat(after))
-            }
-        };
-    }
-    // Strip trailing zeros from the mantissa (and a dangling '.').
-    if use_sci {
-        if let Some(epos) = raw.find(|c: char| c == 'e' || c == 'E') {
-            let (mantissa, exp_part) = raw.split_at(epos);
-            let trimmed = trim_trailing_zeros(mantissa);
-            format!("{trimmed}{exp_part}")
-        } else {
-            raw
-        }
-    } else if raw.contains('.') {
-        trim_trailing_zeros(&raw)
-    } else {
-        raw
-    }
-}
-
-/// Format an absolute float for the empty presentation type with an explicit
-/// precision (or alt-form).  Like `%g` with `prec` significant digits, but the
-/// scientific cutoff is one lower (`exp >= prec - 1`) and a fixed result always
-/// shows a fractional part — a bare integer keeps a trailing `.0`, and alt-form
-/// retains the requested trailing zeros.
-pub(crate) fn format_no_type_prec(abs: f64, prec: usize, alt_form: bool) -> String {
-    if !abs.is_finite() {
-        return format!("{abs}");
-    }
-    let prec = prec.max(1);
-    // 0.0 has no `log10`; its decimal point sits one past the leading digit.
-    let exp = if abs == 0.0 {
-        0
-    } else {
-        abs.log10().floor() as i32
-    };
-    if exp < -4 || exp >= prec as i32 - 1 {
-        let raw = normalise_exponent(&format!("{:.*e}", prec - 1, abs), false);
-        let Some(epos) = raw.find('e') else {
-            return raw;
-        };
-        let (mantissa, exp_part) = raw.split_at(epos);
-        let mantissa = if alt_form {
-            mantissa.to_string()
-        } else {
-            trim_trailing_zeros(mantissa)
-        };
-        // Alt-form advertises the point even when the mantissa is a bare digit.
-        let mantissa = if alt_form && !mantissa.contains('.') {
-            format!("{mantissa}.")
-        } else {
-            mantissa
-        };
-        return format!("{mantissa}{exp_part}");
-    }
-    let dec = (prec as i32 - 1 - exp).max(0) as usize;
-    let raw = format!("{abs:.dec$}");
-    if alt_form {
-        return if raw.contains('.') { raw } else { format!("{raw}.") };
-    }
-    let body = if raw.contains('.') {
-        trim_trailing_zeros(&raw)
-    } else {
-        raw
-    };
-    if body.contains('.') {
-        body
-    } else {
-        format!("{body}.0")
-    }
-}
-
-/// Convert Rust's `{:e}` / `{:E}` exponent encoding (no sign, minimal
-/// width — `1.5e3` / `1.5e-3`) to PyPy / CPython `%e`-style
-/// (`1.5e+03` / `1.5e-03` — explicit sign, exponent zero-padded to at
-/// least two digits).  Mirrors `pypy/objspace/std/formatting.py
-/// fmt_e` which delegates to `rfloat.formatd` with the C printf-style
-/// padding rules.
-pub(crate) fn normalise_exponent(raw: &str, upper: bool) -> String {
-    let marker = if upper { 'E' } else { 'e' };
-    let lower_marker = marker.to_ascii_lowercase();
-    let upper_marker = marker.to_ascii_uppercase();
-    let pos = match raw.find([lower_marker, upper_marker].as_ref()) {
-        Some(p) => p,
-        None => return raw.to_string(),
-    };
-    let (mantissa, exp_part) = raw.split_at(pos);
-    let exp_str = &exp_part[1..]; // skip the marker
-    let (sign_char, digits) = if let Some(rest) = exp_str.strip_prefix('-') {
-        ('-', rest)
-    } else if let Some(rest) = exp_str.strip_prefix('+') {
-        ('+', rest)
-    } else {
-        ('+', exp_str)
-    };
-    let padded = if digits.len() < 2 {
-        format!("0{digits}")
-    } else {
-        digits.to_string()
-    };
-    format!("{mantissa}{marker}{sign_char}{padded}")
-}
-
-fn trim_trailing_zeros(body: &str) -> String {
-    if !body.contains('.') {
-        return body.to_string();
-    }
-    let trimmed = body.trim_end_matches('0').trim_end_matches('.');
-    if trimmed.is_empty() {
-        "0".to_string()
-    } else {
-        trimmed.to_string()
-    }
 }

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -1,520 +1,294 @@
 //! pypy/objspace/std/formatting.py — printf-style string formatting.
 #![allow(non_camel_case_types, non_snake_case)]
 
+use malachite_bigint::BigInt;
+use rustpython_common::cformat::{
+    CConversionFlags, CFormatConversion, CFormatPart, CFormatPrecision, CFormatQuantity,
+    CFormatSpec, CFormatSpecKeyed, CFormatType, CFormatWtf8, CNumberType,
+};
+
 use crate::objspace::descroperation::{int_value, is_int_like};
 use crate::{PyError, PyErrorKind, PyResult};
 use pyre_object::*;
-use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
-
-/// Take the first `n` code points of a WTF-8 string (the `%`-format
-/// precision truncation, surrogate-aware).
-fn take_code_points(body: &Wtf8, n: usize) -> Wtf8Buf {
-    let mut out = Wtf8Buf::new();
-    let mut k = 0usize;
-    for cp in body.code_points() {
-        if k >= n {
-            break;
-        }
-        out.push(cp);
-        k += 1;
-    }
-    out
-}
+use rustpython_wtf8::{CodePoint, Wtf8Buf};
 
 /// `str % args` — printf-style string formatting.
-/// PyPy: unicodeobject.py mod__String_ANY → formatting.py
+///
+/// The format string is parsed by `rustpython_common::cformat` into a
+/// sequence of literal / conversion-spec parts; pyre supplies the value
+/// glue (fetching arguments from the tuple / mapping and coercing each
+/// `W_Root` to the number/float/str the spec's formatter consumes).
+///
+/// Argument dispatch mirrors CPython's `getnextarg`: a non-tuple right
+/// operand provides a single positional value, a keyed spec (`%(k)s`)
+/// looks the value up in the operand as a mapping and consumes one
+/// positional slot if any remains, and surplus positional values are an
+/// error only when the operand is not itself a mapping.
 pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> PyResult {
     let fmt_str = w_str_get_wtf8(fmt);
-    // `formatting.py:39-46 StringFormatter.__init__` — when `args`
-    // is a tuple, `values_w` is the unpacked positional list; for
-    // any other shape (mapping, single value), `values_w` stays
-    // None and `checkconsumed` is skipped.  Pyre tracks the same
-    // distinction via `args_is_tuple` so the trailing surplus-args
-    // check at the end fires only for tuple input — without it,
-    // `"%s"`-only formats against a mapping that exposes
-    // `__getitem__` would always trip "not all arguments converted"
-    // even when the mapping was the (single) intended value.
+    let format =
+        CFormatWtf8::parse_from_wtf8(fmt_str).map_err(|err| PyError::value_error(err.to_string()))?;
+
+    // `unicodeobject.c PyUnicode_Format` — the operand is usable as a
+    // mapping (for `%(key)s` lookups) when it exposes `__getitem__` and is
+    // neither a tuple nor a str. A tuple supplies positional values in
+    // order; any other operand is the single positional value.
     let args_is_tuple = is_tuple(args);
-    let arg_list: Vec<PyObjectRef> = if args_is_tuple {
+    let dict = if !args_is_tuple && !is_str(args) && has_getitem(args) {
+        Some(args)
+    } else {
+        None
+    };
+    let positional: Vec<PyObjectRef> = if args_is_tuple {
         let n = w_tuple_len(args);
-        (0..n)
-            .filter_map(|i| w_tuple_getitem(args, i as i64))
-            .collect()
+        (0..n).filter_map(|i| w_tuple_getitem(args, i as i64)).collect()
     } else {
         vec![args]
     };
+    let mut pos = positional.into_iter().peekable();
 
     let mut result = Wtf8Buf::new();
-    let mut arg_idx = 0;
-    let bytes = fmt_str.as_bytes();
-    let mut i = 0;
-    let take_next_arg =
-        |arg_idx: &mut usize, arg_list: &[PyObjectRef]| -> Result<PyObjectRef, PyError> {
-            // `formatting.py:574-582 nextinputvalue` — surfaces the
-            // canonical "not enough arguments" message when the
-            // positional pool runs dry.
-            if *arg_idx >= arg_list.len() {
-                return Err(PyError::type_error(
-                    "not enough arguments for format string",
-                ));
-            }
-            let a = arg_list[*arg_idx];
-            *arg_idx += 1;
-            Ok(a)
-        };
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 1 < bytes.len() {
-            i += 1;
-            // Named format: %(name)s — `formatting.py:174-195
-            // getmappingkey` scans up to the *balanced* closing
-            // `)` (paren-depth counting so `%(a(b)c)s` parses key
-            // `a(b)c`), then `space.getitem(args, w_key)` looks up
-            // the mapping value (mapping-like object, not just
-            // exact dict).
-            let named_arg = if i < bytes.len() && bytes[i] == b'(' {
-                i += 1; // skip the opening '('
-                let key_start = i;
-                let mut pcount: usize = 1;
-                while i < bytes.len() {
-                    let c = bytes[i];
-                    if c == b')' {
-                        pcount -= 1;
-                        if pcount == 0 {
-                            break;
-                        }
-                    } else if c == b'(' {
-                        pcount += 1;
-                    }
-                    i += 1;
-                }
-                if i >= bytes.len() {
-                    // `formatting.py:184-186 incomplete format key` —
-                    // ran off the end of the format string without
-                    // the matching `)`.
-                    return Err(PyError::new(
-                        PyErrorKind::ValueError,
-                        "incomplete format key".to_string(),
-                    ));
-                }
-                let key = String::from_utf8_lossy(&bytes[key_start..i]).into_owned();
-                i += 1; // skip the closing ')'
-                // Fast path for exact dict: avoid building a W_UnicodeObject
-                // when we can probe the dict storage directly.
-                if is_dict(args) {
-                    w_dict_getitem_str(args, &key)
+    let mut saw_specifier = false;
+
+    for (idx, part) in format {
+        match part {
+            CFormatPart::Literal(literal) => result.push_wtf8(&literal),
+            CFormatPart::Spec(CFormatSpecKeyed { mapping_key, mut spec }) => {
+                saw_specifier = true;
+                let value = if let Some(key) = mapping_key {
+                    let Some(dict) = dict else {
+                        return Err(PyError::type_error("format requires a mapping"));
+                    };
+                    let w_value = crate::baseobjspace::getitem(dict, w_str_from_wtf8(key))?;
+                    // A keyed spec still consumes a positional slot when one
+                    // is available (`%(k)s %s` leaves nothing for the `%s`).
+                    let _ = pos.next();
+                    w_value
                 } else {
-                    let w_key = pyre_object::w_str_new(&key);
-                    Some(crate::baseobjspace::getitem(args, w_key)?)
-                }
-            } else {
-                None
-            };
-            // `pypy/objspace/std/formatting.py StringFormatter._parse_spec`
-            // — flags (`-`, `+`, ` `, `0`, `#`), width digits, optional
-            // `.precision` digits, then conversion type.  pyre handles
-            // the common subset; the asterisk (`*`) form is left to a
-            // future round.
-            let mut left_align = false;
-            let mut zero_pad = false;
-            let mut explicit_sign = false;
-            let mut blank_sign = false;
-            let mut alt_form = false;
-            while i < bytes.len() {
-                match bytes[i] {
-                    b'-' => left_align = true,
-                    b'0' => zero_pad = true,
-                    b'+' => explicit_sign = true,
-                    b' ' => blank_sign = true,
-                    // `formatting.py:240-242` — `#` selects the
-                    // alternate form (0x/0o/0b prefix on integers).
-                    b'#' => alt_form = true,
-                    _ => break,
-                }
-                i += 1;
+                    update_quantity_from_tuple(&mut pos, &mut spec.min_field_width, &mut spec.flags)?;
+                    update_precision_from_tuple(&mut pos, &mut spec.precision)?;
+                    let Some(v) = pos.next() else {
+                        return Err(PyError::type_error("not enough arguments for format string"));
+                    };
+                    v
+                };
+                result.push_wtf8(&spec_format_string(&spec, value, idx)?);
             }
-            // `formatting.py:266-274 peel_num` — `*` reads width /
-            // precision from the next positional input.
-            let mut width = 0usize;
-            if i < bytes.len() && bytes[i] == b'*' {
-                i += 1;
-                let star_arg = take_next_arg(&mut arg_idx, &arg_list)?;
-                if !is_int_like(star_arg) {
-                    return Err(PyError::type_error("* wants int"));
-                }
-                let val = int_value(star_arg);
-                if val < 0 {
-                    // Negative star width acts like `-` flag with abs(width).
-                    left_align = true;
-                    width = (-val) as usize;
-                } else {
-                    width = val as usize;
-                }
-            } else {
-                while i < bytes.len() && bytes[i].is_ascii_digit() {
-                    width = width * 10 + (bytes[i] - b'0') as usize;
-                    i += 1;
-                }
-            }
-            let mut precision: Option<usize> = None;
-            if i < bytes.len() && bytes[i] == b'.' {
-                i += 1;
-                if i < bytes.len() && bytes[i] == b'*' {
-                    i += 1;
-                    let star_arg = take_next_arg(&mut arg_idx, &arg_list)?;
-                    if !is_int_like(star_arg) {
-                        return Err(PyError::type_error("* wants int"));
-                    }
-                    let v = int_value(star_arg);
-                    precision = Some(if v < 0 { 0 } else { v as usize });
-                } else {
-                    let mut p = 0usize;
-                    while i < bytes.len() && bytes[i].is_ascii_digit() {
-                        p = p * 10 + (bytes[i] - b'0') as usize;
-                        i += 1;
-                    }
-                    precision = Some(p);
-                }
-            }
-            if i >= bytes.len() {
-                return Err(PyError::value_error("incomplete format"));
-            }
-            let spec = bytes[i] as char;
-            i += 1;
-            if spec == '%' {
-                result.push_char('%');
-                continue;
-            }
-            let arg = if let Some(na) = named_arg {
-                na
-            } else {
-                take_next_arg(&mut arg_idx, &arg_list)?
-            };
-            // Helper closure: pad-and-emit body string respecting
-            // width/left-align (zero-pad only matters for numeric paths
-            // that build their own body with sign awareness).
-            let pad = |body: String| -> String {
-                if body.chars().count() >= width {
-                    return body;
-                }
-                let need = width - body.chars().count();
-                let mut s = String::with_capacity(width);
-                if left_align {
-                    s.push_str(&body);
-                    for _ in 0..need {
-                        s.push(' ');
-                    }
-                } else {
-                    for _ in 0..need {
-                        s.push(' ');
-                    }
-                    s.push_str(&body);
-                }
-                s
-            };
-            // WTF-8 counterpart of `pad` for the `%s` / `%c` bodies,
-            // which may carry a lone surrogate; pads to `width` code
-            // points with spaces.
-            let pad_wtf8 = |body: &Wtf8| -> Wtf8Buf {
-                let body_len = body.code_points().count();
-                if body_len >= width {
-                    return body.to_wtf8_buf();
-                }
-                let need = width - body_len;
-                let mut out = Wtf8Buf::with_capacity(body.len() + need);
-                if left_align {
-                    out.push_wtf8(body);
-                    for _ in 0..need {
-                        out.push_char(' ');
-                    }
-                } else {
-                    for _ in 0..need {
-                        out.push_char(' ');
-                    }
-                    out.push_wtf8(body);
-                }
-                out
-            };
-            let sign_prefix = |val: i64| -> &'static str {
-                if val < 0 {
-                    "-"
-                } else if explicit_sign {
-                    "+"
-                } else if blank_sign {
-                    " "
-                } else {
-                    ""
-                }
-            };
-            match spec {
-                's' => {
-                    // `%s` is `str(self)`, preserved in WTF-8 so a lone
-                    // surrogate (a str, or an exception whose single
-                    // argument is a str) survives.
-                    let body = crate::py_str_wtf8(arg)?;
-                    let body = match precision {
-                        Some(p) => take_code_points(&body, p),
-                        None => body,
-                    };
-                    result.push_wtf8(&pad_wtf8(&body));
-                }
-                'r' => {
-                    let mut body = crate::py_repr(arg)?;
-                    if let Some(p) = precision {
-                        body = body.chars().take(p).collect();
-                    }
-                    result.push_str(&pad(body));
-                }
-                // `formatting.py fmt_a` (CPython `%a`) — repr() force-
-                // ASCII-encoded.  Pyre's `py_repr` already produces
-                // ASCII-clean output for the types it covers, so the
-                // result matches PyPy `fmt_a` for the supported subset.
-                'a' => {
-                    let mut body = crate::py_repr(arg)?;
-                    if let Some(p) = precision {
-                        body = body.chars().take(p).collect();
-                    }
-                    result.push_str(&pad(body));
-                }
-                // `formatting.py:549-552 fmt_b` — `%b` is a *bytes-only*
-                // conversion (formats a `bytes`/`bytearray`/`__bytes__`
-                // object); for the unicode formatter PyPy calls
-                // `self.unknown_fmtchar()` which raises ValueError
-                // "unsupported format character 'b' (0x62) at index N".
-                'b' => {
-                    return Err(PyError::new(
-                        PyErrorKind::ValueError,
-                        format!("unsupported format character 'b' (0x62) at index {}", i - 1),
-                    ));
-                }
-                // `formatting.py fmt_u` is documented as a deprecated
-                // alias for `%d` and dispatches to the same body.
-                'd' | 'i' | 'u' | 'x' | 'X' | 'o' => {
-                    // `formatting.py:296-302 fmt_d / fmt_x ...` raises
-                    // TypeError when the argument is not int-like
-                    // (`%X format: an integer is required, not <type>`),
-                    // not silently coerce via str().
-                    if !is_int_like(arg) {
-                        return Err(PyError::type_error(format!(
-                            "%{spec} format: an integer is required, not {}",
-                            crate::baseobjspace::object_functionstr_type_name(arg),
-                        )));
-                    }
-                    let val = int_value(arg);
-                    let abs = val.unsigned_abs();
-                    let digits = match spec {
-                        'x' => format!("{abs:x}"),
-                        'X' => format!("{abs:X}"),
-                        'o' => format!("{abs:o}"),
-                        _ => format!("{abs}"),
-                    };
-                    // `formatting.py:240-242` — alt-form adds the
-                    // base prefix (`0x`, `0X`, `0o`) for the matching
-                    // radix; `%d/%i/%u` ignore it.  `%b` is not a
-                    // unicode-formatter conversion (rejected above
-                    // per `:549-552 fmt_b`).
-                    let prefix = if alt_form {
-                        match spec {
-                            'x' => "0x",
-                            'X' => "0X",
-                            'o' => "0o",
-                            _ => "",
-                        }
-                    } else {
-                        ""
-                    };
-                    let sign = sign_prefix(val);
-                    // Sign-aware zero pad (`%05d`, `%-5d` parity):
-                    // `formatting.py:_pad_string` reserves width for
-                    // sign + alt-prefix before padding zeros.
-                    // Left-align disables zero pad.
-                    if zero_pad && !left_align {
-                        let need = width.saturating_sub(sign.len() + prefix.len() + digits.len());
-                        let mut s = String::with_capacity(width);
-                        s.push_str(sign);
-                        s.push_str(prefix);
-                        for _ in 0..need {
-                            s.push('0');
-                        }
-                        s.push_str(&digits);
-                        result.push_str(&s);
-                    } else {
-                        result.push_str(&pad(format!("{sign}{prefix}{digits}")));
-                    }
-                }
-                // `formatting.py fmt_e / fmt_E / fmt_g / fmt_G` —
-                // scientific / general float formatting.  Default
-                // precision is 6 (CPython %e/%g), `%g` strips
-                // trailing zeros and chooses scientific vs fixed
-                // based on exponent magnitude (PyPy delegates to
-                // `rfloat.formatd` with the matching format char).
-                'e' | 'E' | 'g' | 'G' => {
-                    // `formatting.py:303-308 fmt_e / fmt_g ...` raises
-                    // TypeError when the argument is not numeric;
-                    // silently substituting 0.0 for non-numeric input
-                    // hid type bugs at the format site.
-                    let val = if is_float(arg) {
-                        pyre_object::floatobject::w_float_get_value(arg)
-                    } else if is_int_like(arg) {
-                        int_value(arg) as f64
-                    } else {
-                        return Err(PyError::type_error(format!(
-                            "must be real number, not {}",
-                            crate::baseobjspace::object_functionstr_type_name(arg),
-                        )));
-                    };
-                    let prec = precision.unwrap_or(6);
-                    let abs = val.abs();
-                    let body = match spec {
-                        'e' => normalise_exponent(&format!("{:.*e}", prec, abs), false),
-                        'E' => normalise_exponent(&format!("{:.*E}", prec, abs), true),
-                        // `%g` precision counts significant digits;
-                        // Rust has no built-in formatter that exactly
-                        // matches CPython's `%g` rules, so emit
-                        // scientific when |v| >= 10^prec or < 1e-4
-                        // (matching the CPython threshold), else
-                        // fixed with (prec - 1 - exponent) decimals
-                        // and trailing zero stripping.
-                        'g' | 'G' => format_g_like(abs, prec, spec == 'G', alt_form),
-                        _ => unreachable!(),
-                    };
-                    let sign = if val.is_sign_negative() && !val.is_nan() {
-                        "-"
-                    } else if explicit_sign {
-                        "+"
-                    } else if blank_sign {
-                        " "
-                    } else {
-                        ""
-                    };
-                    if zero_pad && !left_align {
-                        let need = width.saturating_sub(sign.len() + body.len());
-                        let mut s = String::with_capacity(width);
-                        s.push_str(sign);
-                        for _ in 0..need {
-                            s.push('0');
-                        }
-                        s.push_str(&body);
-                        result.push_str(&s);
-                    } else {
-                        result.push_str(&pad(format!("{sign}{body}")));
-                    }
-                }
-                'f' | 'F' => {
-                    // `formatting.py:303-308 fmt_f` — same TypeError as
-                    // `%e/%g` for non-numeric arguments.
-                    let val = if is_float(arg) {
-                        pyre_object::floatobject::w_float_get_value(arg)
-                    } else if is_int_like(arg) {
-                        int_value(arg) as f64
-                    } else {
-                        return Err(PyError::type_error(format!(
-                            "must be real number, not {}",
-                            crate::baseobjspace::object_functionstr_type_name(arg),
-                        )));
-                    };
-                    let prec = precision.unwrap_or(6);
-                    let abs_body = format!("{:.*}", prec, val.abs());
-                    let sign = if val.is_sign_negative() && !val.is_nan() {
-                        "-"
-                    } else if explicit_sign {
-                        "+"
-                    } else if blank_sign {
-                        " "
-                    } else {
-                        ""
-                    };
-                    if zero_pad && !left_align {
-                        let need = width.saturating_sub(sign.len() + abs_body.len());
-                        let mut s = String::with_capacity(width);
-                        s.push_str(sign);
-                        for _ in 0..need {
-                            s.push('0');
-                        }
-                        s.push_str(&abs_body);
-                        result.push_str(&s);
-                    } else {
-                        result.push_str(&pad(format!("{sign}{abs_body}")));
-                    }
-                }
-                'c' => {
-                    // `formatting.py:283-294 fmt_c` parity:
-                    //   - int branch: `if value < 0 or value > 0x10FFFF:
-                    //     OverflowError("%c arg not in range(0x110000)")`
-                    //   - str branch: `if len(s) != 1: TypeError(
-                    //     "%c requires int or single character")`
-                    //   - other types: same TypeError.
-                    if is_int_like(arg) {
-                        let v = int_value(arg);
-                        if v < 0 || v > 0x10FFFF {
-                            return Err(PyError::new(
-                                PyErrorKind::OverflowError,
-                                "%c arg not in range(0x110000)".to_string(),
-                            ));
-                        }
-                        // A surrogate ordinal (0xD800..=0xDFFF) is a valid
-                        // single character, so build the body from a
-                        // CodePoint rather than a `char` (which rejects
-                        // surrogates).
-                        let cp = CodePoint::from_u32(v as u32).ok_or_else(|| {
-                            PyError::new(
-                                PyErrorKind::OverflowError,
-                                "%c arg not in range(0x110000)".to_string(),
-                            )
-                        })?;
-                        let mut one = Wtf8Buf::with_capacity(4);
-                        one.push(cp);
-                        result.push_wtf8(&pad_wtf8(&one));
-                    } else if is_str(arg) {
-                        let s = w_str_get_wtf8(arg);
-                        if s.code_points().count() != 1 {
-                            return Err(PyError::type_error("%c requires int or single character"));
-                        }
-                        result.push_wtf8(&pad_wtf8(s));
-                    } else {
-                        return Err(PyError::type_error(format!(
-                            "%c requires int or char, not {}",
-                            crate::baseobjspace::object_functionstr_type_name(arg),
-                        )));
-                    }
-                }
-                // `formatting.py:328-329 unknown_fmtchar` raises
-                // ValueError on any spec char outside FORMATTER_CHARS.
-                _ => {
-                    return Err(PyError::value_error(format!(
-                        "unsupported format character '{spec}' (0x{:x}) at index {}",
-                        spec as u32,
-                        i.saturating_sub(1)
-                    )));
-                }
-            }
-        } else if bytes[i] == b'%' {
-            // Trailing lone `%` (no following byte) — emit literally.
-            result.push_char('%');
-            i += 1;
-        } else {
-            // Literal run up to the next `%`; `%` is a single ASCII byte
-            // that never occurs inside a multi-byte sequence, so the run
-            // is itself valid WTF-8 and copies whole (preserving any
-            // surrogate in the template and avoiding byte-at-a-time
-            // decoding).
-            let start = i;
-            while i < bytes.len() && bytes[i] != b'%' {
-                i += 1;
-            }
-            result.push_wtf8(unsafe { Wtf8::from_bytes_unchecked(&bytes[start..i]) });
         }
     }
-    // `formatting.py:572-580 checkconsumed` — surplus positional
-    // arguments are an error only when the input came as a tuple
-    // (PyPy's `values_w` invariant).  Mapping inputs (dict and any
-    // other shape) skip this check because every replacement field
-    // pulls from `args` by name, not by sequential index.
-    if args_is_tuple && arg_idx < arg_list.len() {
+
+    // `checkconsumed` — surplus positional values are converted to an error
+    // only when the operand is not a mapping. With no specifiers at all, an
+    // empty tuple / a mapping is allowed but any other non-empty operand is
+    // surplus.
+    let surplus = if saw_specifier {
+        pos.peek().is_some()
+    } else {
+        !(args_is_tuple && w_tuple_len(args) == 0)
+    };
+    if dict.is_none() && surplus {
         return Err(PyError::type_error(
             "not all arguments converted during string formatting",
         ));
     }
-    Ok(pyre_object::w_str_from_wtf8(result))
+
+    Ok(w_str_from_wtf8(result))
+}
+
+/// True when `obj`'s type carries `__getitem__` (`PyMapping_Check`), so a
+/// `%(key)s` spec can index it.
+unsafe fn has_getitem(obj: PyObjectRef) -> bool {
+    match crate::typedef::r#type(obj) {
+        Some(tp) => crate::baseobjspace::lookup_in_type(tp, "__getitem__").is_some(),
+        None => false,
+    }
+}
+
+/// Apply a parsed spec to one argument, producing the formatted fragment.
+/// `formatting.py fmt_s / fmt_d / fmt_f / ...` — the per-conversion value
+/// coercion and formatting.
+unsafe fn spec_format_string(
+    spec: &CFormatSpec,
+    obj: PyObjectRef,
+    idx: usize,
+) -> Result<Wtf8Buf, PyError> {
+    match &spec.format_type {
+        CFormatType::String(conversion) => {
+            let result = match conversion {
+                CFormatConversion::Str => crate::py_str_wtf8(obj)?,
+                CFormatConversion::Repr => crate::py_repr_wtf8(obj)?,
+                CFormatConversion::Ascii => Wtf8Buf::from_string(crate::builtins::py_ascii(obj)?),
+                // `%b` is a bytes-only conversion; the unicode formatter
+                // rejects it (`fmt_b` → `unknown_fmtchar`). `idx` is the
+                // position of the `%`, the message reports the `b`.
+                CFormatConversion::Bytes => {
+                    return Err(PyError::value_error(format!(
+                        "unsupported format character 'b' (0x62) at index {}",
+                        idx + 1
+                    )));
+                }
+            };
+            Ok(spec.format_string(result))
+        }
+        CFormatType::Number(number_type) => {
+            let value = match number_type {
+                CNumberType::DecimalD | CNumberType::DecimalI | CNumberType::DecimalU => {
+                    number_arg_decimal(spec, obj)?
+                }
+                _ => number_arg_integer(spec, obj)?,
+            };
+            Ok(Wtf8Buf::from_string(spec.format_number(&value)))
+        }
+        CFormatType::Float(_) => {
+            let value = crate::baseobjspace::float_w(obj)?;
+            Ok(Wtf8Buf::from_string(spec.format_float(value)))
+        }
+        CFormatType::Character(_) => Ok(spec.format_char(char_arg(obj)?)),
+    }
+}
+
+/// BigInt from an `int` / `bool` / `long`.
+unsafe fn arg_to_bigint(obj: PyObjectRef) -> BigInt {
+    if is_bool(obj) {
+        BigInt::from(w_bool_get_value(obj) as i64)
+    } else if is_int(obj) {
+        BigInt::from(w_int_get_value(obj))
+    } else {
+        w_long_get_value(obj).clone()
+    }
+}
+
+/// `fmt_d / fmt_i / fmt_u` argument coercion — `%d`/`%i`/`%u` accept any
+/// integer, a float (truncated), or an object with `__index__` / `__int__`.
+unsafe fn number_arg_decimal(spec: &CFormatSpec, obj: PyObjectRef) -> Result<BigInt, PyError> {
+    if is_int_like(obj) || is_long(obj) {
+        return Ok(arg_to_bigint(obj));
+    }
+    if is_float(obj) {
+        let pyint = crate::typedef::float_to_pyint(
+            floatobject::w_float_get_value(obj),
+            crate::typedef::FloatToIntMode::Trunc,
+        )?;
+        return Ok(arg_to_bigint(pyint));
+    }
+    if has_dunder(obj, "__index__") {
+        return Ok(crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?));
+    }
+    if let Some(method) = crate::baseobjspace::lookup(obj, "__int__") {
+        let r = crate::builtins::call_and_check(method, &[obj])?;
+        if is_int_like(r) || is_long(r) {
+            return Ok(arg_to_bigint(r));
+        }
+    }
+    Err(number_type_error(spec, obj, "a real number is required"))
+}
+
+/// `fmt_x / fmt_X / fmt_o` argument coercion — the radix conversions accept
+/// an integer or an `__index__` object, but not a float.
+unsafe fn number_arg_integer(spec: &CFormatSpec, obj: PyObjectRef) -> Result<BigInt, PyError> {
+    if is_int_like(obj) || is_long(obj) {
+        return Ok(arg_to_bigint(obj));
+    }
+    if has_dunder(obj, "__index__") {
+        return Ok(crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?));
+    }
+    Err(number_type_error(spec, obj, "an integer is required"))
+}
+
+/// `%{c} format: {what}, not {type}` for a non-numeric argument.
+unsafe fn number_type_error(spec: &CFormatSpec, obj: PyObjectRef, what: &str) -> PyError {
+    PyError::type_error(format!(
+        "%{} format: {what}, not {}",
+        spec.format_type.to_char(),
+        crate::baseobjspace::object_functionstr_type_name(obj),
+    ))
+}
+
+/// `fmt_c` argument coercion — a single-character str, or an integer /
+/// `__index__` in `range(0x110000)`.
+unsafe fn char_arg(obj: PyObjectRef) -> Result<CodePoint, PyError> {
+    if is_str(obj) {
+        let s = w_str_get_wtf8(obj);
+        let mut cps = s.code_points();
+        if let Some(cp) = cps.next() {
+            if cps.next().is_none() {
+                return Ok(cp);
+            }
+        }
+        let n = s.code_points().count();
+        return Err(PyError::type_error(format!(
+            "%c requires an int or a unicode character, not a string of length {n}"
+        )));
+    }
+    let value = if is_int_like(obj) || is_long(obj) {
+        arg_to_bigint(obj)
+    } else if has_dunder(obj, "__index__") {
+        crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?)
+    } else {
+        return Err(PyError::type_error(format!(
+            "%c requires an int or a unicode character, not {}",
+            crate::baseobjspace::object_functionstr_type_name(obj),
+        )));
+    };
+    let overflow = || PyError::new(PyErrorKind::OverflowError, "%c arg not in range(0x110000)".to_string());
+    let n = u32::try_from(&value).map_err(|_| overflow())?;
+    CodePoint::from_u32(n).ok_or_else(overflow)
+}
+
+/// True when `obj`'s type carries `name` above `object`'s default.
+unsafe fn has_dunder(obj: PyObjectRef, name: &str) -> bool {
+    match crate::typedef::r#type(obj) {
+        Some(tp) => crate::baseobjspace::lookup_in_type(tp, name).is_some(),
+        None => false,
+    }
+}
+
+/// `peel_num` — a `*` field width reads its value (and, when negative, the
+/// left-align flag) from the next positional argument.
+unsafe fn update_quantity_from_tuple(
+    pos: &mut std::iter::Peekable<std::vec::IntoIter<PyObjectRef>>,
+    quantity: &mut Option<CFormatQuantity>,
+    flags: &mut CConversionFlags,
+) -> Result<(), PyError> {
+    if !matches!(quantity, Some(CFormatQuantity::FromValuesTuple)) {
+        return Ok(());
+    }
+    let v = star_int(pos.next())?;
+    if v < 0 {
+        flags.insert(CConversionFlags::LEFT_ADJUST);
+    }
+    *quantity = Some(CFormatQuantity::Amount(v.unsigned_abs() as usize));
+    Ok(())
+}
+
+/// `peel_num` — a `*` precision reads its value from the next positional
+/// argument (a negative precision is treated as absent).
+unsafe fn update_precision_from_tuple(
+    pos: &mut std::iter::Peekable<std::vec::IntoIter<PyObjectRef>>,
+    precision: &mut Option<CFormatPrecision>,
+) -> Result<(), PyError> {
+    if !matches!(
+        precision,
+        Some(CFormatPrecision::Quantity(CFormatQuantity::FromValuesTuple))
+    ) {
+        return Ok(());
+    }
+    let v = star_int(pos.next())?;
+    *precision = Some(CFormatPrecision::Quantity(CFormatQuantity::Amount(
+        v.max(0) as usize,
+    )));
+    Ok(())
+}
+
+/// The `*` argument must be an int; consume it, matching `nextinputvalue`.
+unsafe fn star_int(arg: Option<PyObjectRef>) -> Result<i64, PyError> {
+    let Some(arg) = arg else {
+        return Err(PyError::type_error("not enough arguments for format string"));
+    };
+    if !is_int_like(arg) {
+        return Err(PyError::type_error("* wants int"));
+    }
+    Ok(int_value(arg))
 }
 
 /// `formatting.py fmt_g / fmt_G` parity helper — emits the `%g` body

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1086,10 +1086,7 @@ fn format_render(
 
 /// Fetch positional argument `idx`, raising the `str.format` IndexError for
 /// an out-of-range replacement index.
-fn index_positional(
-    positional: &[PyObjectRef],
-    idx: usize,
-) -> Result<PyObjectRef, crate::PyError> {
+fn index_positional(positional: &[PyObjectRef], idx: usize) -> Result<PyObjectRef, crate::PyError> {
     positional.get(idx).copied().ok_or_else(|| {
         crate::PyError::index_error(format!(
             "Replacement index {idx} out of range for positional args tuple"
@@ -1101,7 +1098,10 @@ fn index_positional(
 /// `FormatString` reports `UnmatchedBracket` for both a lone trailing `{`
 /// and an opened-but-unclosed field, so the trailing byte disambiguates the
 /// two CPython messages.
-fn format_parse_err(err: rustpython_common::format::FormatParseError, fmt: &Wtf8) -> crate::PyError {
+fn format_parse_err(
+    err: rustpython_common::format::FormatParseError,
+    fmt: &Wtf8,
+) -> crate::PyError {
     use rustpython_common::format::FormatParseError as E;
     let msg = match err {
         E::UnmatchedBracket => {
@@ -1206,74 +1206,6 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         precision,
         ty,
     }
-}
-
-/// Insert the thousands separator `sep` into a run of plain digits every
-/// `interval` positions counted from the right.
-fn group_digits(digits: &str, sep: char, interval: usize) -> String {
-    let chars: Vec<char> = digits.chars().collect();
-    let len = chars.len();
-    let mut out = String::with_capacity(len + len / interval);
-    for (idx, c) in chars.iter().enumerate() {
-        if idx > 0 && (len - idx) % interval == 0 {
-            out.push(sep);
-        }
-        out.push(*c);
-    }
-    out
-}
-
-/// Group only the leading integer run of a numeric body (the digits before
-/// any `.`, exponent, or `%`), leaving the fractional / suffix portion
-/// untouched.  Float groupings always use interval 3.
-fn group_integer_prefix(body: &str, sep: char) -> String {
-    let int_len = body.chars().take_while(|c| c.is_ascii_digit()).count();
-    if int_len <= 3 {
-        return body.to_string();
-    }
-    let (int_part, rest) = body.split_at(int_len);
-    format!("{}{}", group_digits(int_part, sep, 3), rest)
-}
-
-/// Group the leading integer run of `body` while sign-aware zero-padding it
-/// to `field` characters (the width less the sign).  Leading zeros are added
-/// to the integer run *before* grouping so the padding is itself grouped,
-/// matching the `0`-flag / `=`-alignment interaction.  Only the digit run is
-/// touched, so an exponent (`e+30`) or fractional tail is never separated.
-fn group_integer_zero_padded(body: &str, sep: char, field: usize) -> String {
-    let int_len = body.chars().take_while(|c| c.is_ascii_digit()).count();
-    let (int_part, tail) = body.split_at(int_len);
-    let disp = std::cmp::max(field as i32, body.len() as i32);
-    let int_digit_cnt = disp - tail.len() as i32;
-    format!("{}{tail}", separate_integer(int_part, 3, sep, int_digit_cnt))
-}
-
-/// Pad the digit string `int_str` with leading zeros to a display width of
-/// `disp_digit_cnt` and insert `sep` every `inter` digits.  The pad count is
-/// reduced by the separators that will occupy width, and a leading separator
-/// is avoided when the display width is an exact group boundary.
-fn separate_integer(int_str: &str, inter: i32, sep: char, disp_digit_cnt: i32) -> String {
-    let mag_len = int_str.len() as i32;
-    let offset = i32::from(disp_digit_cnt % (inter + 1) == 0);
-    let disp = disp_digit_cnt + offset;
-    let pad_cnt = disp - mag_len;
-    let sep_cnt = disp / (inter + 1);
-    if pad_cnt > 0 && pad_cnt - sep_cnt > 0 {
-        let padded = format!("{}{int_str}", "0".repeat((pad_cnt - sep_cnt) as usize));
-        insert_separator(padded, inter, sep, sep_cnt)
-    } else {
-        insert_separator(int_str.to_string(), inter, sep, (mag_len - 1) / inter)
-    }
-}
-
-/// Insert `sep` into `s` at every `inter`-digit boundary from the right,
-/// `sep_cnt` times.
-fn insert_separator(mut s: String, inter: i32, sep: char, sep_cnt: i32) -> String {
-    let len = s.len() as i32;
-    for i in 1..=sep_cnt {
-        s.insert((len - inter * i) as usize, sep);
-    }
-    s
 }
 
 /// Pad `body` to `width` characters with `fill`, honouring the numeric
@@ -1602,8 +1534,8 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
             // A valid-UTF-8 body goes through the shared string formatter,
             // which pads by code point.
             if let Ok(valid) = full.as_str() {
-                let parsed = FormatSpec::parse(spec)
-                    .map_err(|e| format_spec_err(e, spec, "str", false))?;
+                let parsed =
+                    FormatSpec::parse(spec).map_err(|e| format_spec_err(e, spec, "str", false))?;
                 let s = parsed
                     .format_string(&CharLenStr(valid, valid.chars().count()))
                     .map_err(|e| format_spec_err(e, spec, "str", false))?;
@@ -1832,89 +1764,19 @@ fn validate_float_spec(spec: &str, p: &ParsedSpec) -> Result<(), crate::PyError>
     Ok(())
 }
 
-/// Format a finite `f64` through `spec`.  Fixed-point (`f`/`F`) and
-/// locale-general (`n`) presentations pad and group exactly through the shared
-/// engine, so delegate them.  The exponent and general forms stay local: the
-/// shared grouping splits only on the decimal point (corrupting an exponent
-/// into `1e,+20`) and its empty-type precision picks exponent notation where a
-/// fixed form is required.
+/// Format a finite `f64` through `spec`.  Every presentation type
+/// (`\0`/`e`/`E`/`f`/`F`/`g`/`G`/`n`/`%`) pads, groups, and rounds through the
+/// shared engine.  `validate_float_spec` still supplies the type and
+/// grouping-with-`n` messages before delegating.
 fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
     let p = parse_spec(spec);
     validate_float_spec(spec, &p)?;
-    if matches!(p.ty, 'f' | 'F' | 'n') {
-        let parsed = rustpython_common::format::FormatSpec::parse(spec)
-            .map_err(|e| format_spec_err(e, spec, "float", false))?;
-        let s = parsed
-            .format_float(v)
-            .map_err(|e| format_spec_err(e, spec, "float", false))?;
-        return Ok(Wtf8Buf::from_string(s));
-    }
-    Ok(Wtf8Buf::from_string(format_float(v, &p)))
-}
-
-/// Format a finite float through the presentation-type `p.ty`, applying
-/// sign, alt-form trailing dot, integer-run grouping, and width padding.
-fn format_float(v: f64, p: &ParsedSpec) -> String {
-    let prec = p.precision.unwrap_or(6);
-    // Format on `v.abs()` so the sign is reattached exactly once below;
-    // Rust's `{:e}`/`{:E}` would otherwise emit it too.
-    let abs = v.abs();
-    let body = match p.ty {
-        // Rust's `{:e}` emits a sign-less, minimal exponent ("e2"); C-style
-        // formatting wants an explicit, two-digit exponent ("e+02").
-        'e' => crate::baseobjspace::normalise_exponent(&format!("{abs:.prec$e}"), false),
-        'E' => crate::baseobjspace::normalise_exponent(&format!("{abs:.prec$E}"), true),
-        'f' | 'F' => format!("{abs:.prec$}"),
-        // Percent type: scale by 100, format fixed, suffix `%`.
-        '%' => format!("{:.*}%", prec, abs * 100.0),
-        // `g`/`G` format general with trailing zeros trimmed unless alt-form
-        // keeps them; `n` matches `g` with locale grouping (none in C).
-        'g' | 'G' | 'n' => crate::baseobjspace::format_g_like(abs, prec, p.ty == 'G', p.alt_form),
-        '\0' => {
-            // No presentation type formats like `repr()`; an explicit precision
-            // switches to a `g`-like form with a lower scientific cutoff, while
-            // bare alt-form only guarantees the trailing dot (added below).
-            match p.precision {
-                Some(_) => crate::baseobjspace::format_no_type_prec(abs, prec, p.alt_form),
-                None => crate::display::format_float_repr(abs),
-            }
-        }
-        _ => format!("{abs}"),
-    };
-    let sign_char = if v.is_sign_negative() && !v.is_nan() {
-        "-"
-    } else {
-        match p.sign {
-            Some('+') => "+",
-            Some(' ') => " ",
-            _ => "",
-        }
-    };
-    // Alt-form `#` keeps the decimal point even when no fractional digits
-    // remain; it sits before the exponent (`e`) or percent (`%`) suffix.
-    let body = if p.alt_form
-        && !body.contains('.')
-        && matches!(p.ty, 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | '%' | '\0')
-    {
-        match body.find(['e', 'E', '%']) {
-            Some(pos) => format!("{}.{}", &body[..pos], &body[pos..]),
-            None => format!("{body}."),
-        }
-    } else {
-        body
-    };
-    let align = p.align.unwrap_or('>');
-    let body = match p.grouping {
-        // Sign-aware zero padding groups the pad zeros together with the
-        // digits, so the width must be threaded into the grouping step.
-        Some(sep) if align == '=' && p.fill == '0' => {
-            group_integer_zero_padded(&body, sep, p.width.saturating_sub(sign_char.len()))
-        }
-        Some(sep) => group_integer_prefix(&body, sep),
-        None => body,
-    };
-    let body = format!("{sign_char}{body}");
-    pad_to_width(body, p.fill, align, p.width)
+    let parsed = rustpython_common::format::FormatSpec::parse(spec)
+        .map_err(|e| format_spec_err(e, spec, "float", false))?;
+    let s = parsed
+        .format_float(v)
+        .map_err(|e| format_spec_err(e, spec, "float", false))?;
+    Ok(Wtf8Buf::from_string(s))
 }
 
 /// Pad a WTF-8 string body to `width` code points with `fill`,

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -9,6 +9,8 @@
 //! Separated from space.rs to avoid bloating the hot-path compilation
 //! unit. Method functions are registered into TypeDef at startup.
 
+use malachite_bigint::BigInt;
+use num_traits::ToPrimitive;
 use pyre_object::*;
 use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
@@ -915,7 +917,9 @@ fn str_method_format_core(
     kwargs_dict: Option<PyObjectRef>,
     mapping: Option<PyObjectRef>,
 ) -> Result<PyObjectRef, crate::PyError> {
-    let fmt = unsafe { pyre_object::w_str_get_value(fmt_obj) };
+    // Read the template as WTF-8 so a lone surrogate in a literal run (or a
+    // surrogate arg spliced in) survives instead of panicking.
+    let fmt = unsafe { pyre_object::w_str_get_wtf8(fmt_obj) };
     let mut auto_idx = 0usize;
     // `newformat.py` auto_numbering_state — `None` = ANS_INIT, `Some(true)`
     // = ANS_AUTO (empty `{}` fields), `Some(false)` = ANS_MANUAL (numbered
@@ -939,7 +943,7 @@ fn str_method_format_core(
 /// `"{:{}}".format(42, ">5")` consumes positional args 0 then 1.
 /// `depth` bounds that recursion (the markup recursion limit is 2).
 fn format_render(
-    fmt: &str,
+    fmt: &Wtf8,
     positional: &[PyObjectRef],
     kwargs_dict: Option<PyObjectRef>,
     mapping: Option<PyObjectRef>,
@@ -947,6 +951,9 @@ fn format_render(
     numbering: &mut Option<bool>,
     depth: u32,
 ) -> Result<Wtf8Buf, crate::PyError> {
+    use rustpython_common::format::{
+        FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
+    };
     let lookup_kwarg = |name: &str| -> Result<Option<PyObjectRef>, crate::PyError> {
         if let Some(m) = mapping {
             // `newformat.format_method(... w_mapping, True)` resolves
@@ -963,293 +970,171 @@ fn format_render(
         Ok(None)
     };
 
+    if depth == 0 {
+        return Err(crate::PyError::value_error("Max string recursion exceeded"));
+    }
+    let parsed = FormatString::from_str(fmt).map_err(|e| format_parse_err(e, fmt))?;
     let mut result = Wtf8Buf::new();
-    let bytes = fmt.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'{' {
-            if i + 1 < bytes.len() && bytes[i + 1] == b'{' {
-                result.push_char('{');
-                i += 2;
+    for part in &parsed.format_parts {
+        let (field_name, conversion_spec, format_spec) = match part {
+            FormatPart::Literal(literal) => {
+                result.push_wtf8(literal);
                 continue;
             }
-            i += 1;
-            let field_start = i;
-            // Track brace depth so a nested `{...}` inside the format
-            // spec is captured whole rather than ending the field at the
-            // spec's first `}`.
-            let mut brace_depth = 1;
-            while i < bytes.len() {
-                if bytes[i] == b'{' {
-                    brace_depth += 1;
-                } else if bytes[i] == b'}' {
-                    brace_depth -= 1;
-                    if brace_depth == 0 {
-                        break;
-                    }
-                }
-                i += 1;
-            }
-            let field_text = &fmt[field_start..i];
-            if i < bytes.len() {
-                i += 1;
-            }
+            FormatPart::Field {
+                field_name,
+                conversion_spec,
+                format_spec,
+            } => (field_name, conversion_spec, format_spec),
+        };
 
-            // `newformat.py:_parse_field` — split the replacement field
-            // into the argument name, an optional `!conversion`, and the
-            // trailing `:spec`.  A `:` or `!` inside `[...]` is part of an
-            // item key, not a separator, so brackets are skipped over.
-            let fb = field_text.as_bytes();
-            let mut p = 0;
-            let mut name_end = fb.len();
-            let mut conversion: Option<char> = None;
-            let mut spec = String::new();
-            while p < fb.len() {
-                let c = fb[p];
-                if c == b':' || c == b'!' {
-                    name_end = p;
-                    if c == b'!' {
-                        p += 1;
-                        if p < fb.len() {
-                            conversion = Some(fb[p] as char);
-                            p += 1;
-                        }
-                        if p < fb.len() && fb[p] == b':' {
-                            p += 1;
-                        }
-                    } else {
-                        p += 1;
-                    }
-                    spec = field_text.get(p..).unwrap_or("").to_string();
-                    break;
-                } else if c == b'[' {
-                    while p + 1 < fb.len() && fb[p + 1] != b']' {
-                        p += 1;
-                    }
-                }
-                p += 1;
-            }
-            let name = &field_text[..name_end];
-
-            // `newformat.py:_get_argument` — the argument name is the
-            // prefix up to the first `[` or `.`; the remainder is a chain
-            // of attribute / item lookups resolved by
-            // `resolve_format_lookups`.
-            let nb = name.as_bytes();
-            let mut k = 0;
-            while k < nb.len() && nb[k] != b'[' && nb[k] != b'.' {
-                k += 1;
-            }
-            let base = &name[..k];
-            let rest = &name[k..];
-
-            // pypy/objspace/std/newformat.py:1066-1071 Template.get_arg:
-            // missing positional → IndexError "Replacement index N out of
-            // range for positional args tuple"; missing keyword →
-            // KeyError(name).
-            let w_arg = if base.is_empty() {
+        // `_get_argument` — resolve the base argument named by the field,
+        // threading the auto-/manual-numbering state (`None` = uncommitted,
+        // `Some(true)` = automatic `{}`, `Some(false)` = manual `{0}`).
+        let FieldName { field_type, parts } =
+            FieldName::parse(field_name).map_err(|e| format_parse_err(e, fmt))?;
+        let mut val = match field_type {
+            FieldType::Auto => {
                 if let Some(false) = *numbering {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::ValueError,
+                    return Err(crate::PyError::value_error(
                         "cannot switch from manual field specification to automatic \
-                         field numbering"
-                            .to_string(),
+                         field numbering",
                     ));
                 }
                 *numbering = Some(true);
                 let idx = *auto_idx;
                 *auto_idx += 1;
-                match positional.get(idx).copied() {
-                    Some(v) => v,
-                    None => {
-                        return Err(crate::PyError::new(
-                            crate::PyErrorKind::IndexError,
-                            format!(
-                                "Replacement index {idx} out of range for positional args tuple"
-                            ),
-                        ));
-                    }
-                }
-            } else if let Ok(idx) = base.parse::<usize>() {
+                index_positional(positional, idx)?
+            }
+            FieldType::Index(idx) => {
                 if let Some(true) = *numbering {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::ValueError,
+                    return Err(crate::PyError::value_error(
                         "cannot switch from automatic field numbering to manual \
-                         field specification"
-                            .to_string(),
+                         field specification",
                     ));
                 }
                 *numbering = Some(false);
-                match positional.get(idx).copied() {
-                    Some(v) => v,
-                    None => {
-                        return Err(crate::PyError::new(
-                            crate::PyErrorKind::IndexError,
-                            format!(
-                                "Replacement index {idx} out of range for positional args tuple"
-                            ),
-                        ));
-                    }
-                }
-            } else {
-                match lookup_kwarg(base)? {
-                    Some(v) => v,
-                    None => {
-                        return Err(crate::PyError::new(
-                            crate::PyErrorKind::KeyError,
-                            format!("'{base}'"),
-                        ));
-                    }
-                }
-            };
-            let val = resolve_format_lookups(w_arg, rest)?;
-
-            // `newformat.py:_convert_field` — `!s`/`!r`/`!a` apply
-            // str / repr / ascii before the format spec.
-            let converted = match conversion {
-                None => val,
-                // `!s` is `str(self)`, preserved in WTF-8 so a lone
-                // surrogate (a str, or an exception with a str argument)
-                // passes through unchanged.
-                Some('s') => pyre_object::w_str_from_wtf8(unsafe { crate::py_str_wtf8(val)? }),
-                Some('r') => pyre_object::w_str_new(&unsafe { crate::py_repr(val)? }),
-                Some('a') => pyre_object::w_str_new(&crate::builtins::py_ascii(val)?),
-                Some(c) => {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::ValueError,
-                        format!("Unknown conversion specifier {c}"),
-                    ));
-                }
-            };
-            // A spec containing `{` is itself a template: render it
-            // (sharing the numbering state) before applying it.  A
-            // rendered spec is expected to be valid text (format specs
-            // do not carry surrogates).
-            let resolved_spec: String = if spec.bytes().any(|b| b == b'{') {
-                if depth == 0 {
-                    return Err(crate::PyError::new(
-                        crate::PyErrorKind::ValueError,
-                        "Max string recursion exceeded".to_string(),
-                    ));
-                }
-                let nested = format_render(
-                    &spec,
-                    positional,
-                    kwargs_dict,
-                    mapping,
-                    auto_idx,
-                    numbering,
-                    depth - 1,
-                )?;
-                match nested.as_str() {
-                    Ok(v) => v.to_string(),
-                    Err(_) => String::new(),
-                }
-            } else {
-                spec
-            };
-            let formatted = format_value_dispatch(converted, &resolved_spec)?;
-            result.push_wtf8(&formatted);
-        } else if bytes[i] == b'}' && i + 1 < bytes.len() && bytes[i + 1] == b'}' {
-            result.push_char('}');
-            i += 2;
-        } else if bytes[i] == b'}' {
-            // A lone `}` (not `}}`) is emitted literally.
-            result.push_char('}');
-            i += 1;
-        } else {
-            // Literal run up to the next brace; `{` / `}` are single
-            // ASCII bytes that never occur inside a multi-byte
-            // sequence, so the run is itself valid text and copies
-            // whole (a byte-at-a-time `as char` would mojibake
-            // non-ASCII literals).
-            let start = i;
-            while i < bytes.len() && bytes[i] != b'{' && bytes[i] != b'}' {
-                i += 1;
+                index_positional(positional, idx)?
             }
-            result.push_str(&fmt[start..i]);
+            FieldType::Keyword(name) => {
+                let name_str = name.as_str().unwrap_or("");
+                match lookup_kwarg(name_str)? {
+                    Some(v) => v,
+                    None => {
+                        return Err(crate::PyError::key_error_with_key(
+                            pyre_object::w_str_from_wtf8(name),
+                        ));
+                    }
+                }
+            }
+        };
+
+        // `_resolve_lookups` — walk the `.attr` / `[element]` chain; a
+        // bracketed all-digit element is an integer index, anything else a
+        // string key (already classified by `FieldNamePart`).
+        for name_part in &parts {
+            val = match name_part {
+                FieldNamePart::Attribute(attr) => {
+                    crate::baseobjspace::getattr_str(val, attr.as_str().unwrap_or(""))?
+                }
+                FieldNamePart::Index(idx) => {
+                    crate::baseobjspace::getitem(val, pyre_object::w_int_new(*idx as i64))?
+                }
+                FieldNamePart::StringIndex(key) => {
+                    crate::baseobjspace::getitem(val, pyre_object::w_str_from_wtf8(key.clone()))?
+                }
+            };
         }
+
+        // A spec containing `{` is itself a template: render it (sharing the
+        // numbering state and the recursion budget) before applying it.
+        let resolved_spec = if format_spec.as_bytes().contains(&b'{') {
+            format_render(
+                format_spec,
+                positional,
+                kwargs_dict,
+                mapping,
+                auto_idx,
+                numbering,
+                depth - 1,
+            )?
+        } else {
+            format_spec.clone()
+        };
+
+        // `_convert_field` — `!s`/`!r`/`!a` apply str / repr / ascii before
+        // the format spec; any other conversion char is an error.  `!s`
+        // preserves WTF-8 so a lone surrogate passes through unchanged.
+        let converted = match conversion_spec {
+            None => val,
+            Some(cp) => match cp.to_char_lossy() {
+                's' => pyre_object::w_str_from_wtf8(unsafe { crate::py_str_wtf8(val)? }),
+                'r' => pyre_object::w_str_new(&unsafe { crate::py_repr(val)? }),
+                'a' => pyre_object::w_str_new(&crate::builtins::py_ascii(val)?),
+                c => {
+                    return Err(crate::PyError::value_error(format!(
+                        "Unknown conversion specifier {c}"
+                    )));
+                }
+            },
+        };
+        let formatted = format_value_dispatch(converted, resolved_spec.as_str().unwrap_or(""))?;
+        result.push_wtf8(&formatted);
     }
     Ok(result)
 }
 
-/// `newformat.py:_resolve_lookups` — walk the `.attr` / `[element]`
-/// suffix of a replacement-field name, resolving each step against
-/// `w_obj` via `getattr` / `getitem`.  A bracketed element made only
-/// of decimal digits is an integer index; anything else is a string
-/// key (`_parse_int` returns -1 for non-numeric elements).
-fn resolve_format_lookups(w_obj: PyObjectRef, rest: &str) -> Result<PyObjectRef, crate::PyError> {
-    let rb = rest.as_bytes();
-    let mut w_obj = w_obj;
-    let mut i = 0;
-    while i < rb.len() {
-        let c = rb[i];
-        if c == b'.' {
-            i += 1;
-            let start = i;
-            while i < rb.len() && rb[i] != b'[' && rb[i] != b'.' {
-                i += 1;
-            }
-            if start == i {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::ValueError,
-                    "Empty attribute in format string".to_string(),
-                ));
-            }
-            w_obj = crate::baseobjspace::getattr_str(w_obj, &rest[start..i])?;
-        } else if c == b'[' {
-            i += 1;
-            let start = i;
-            let mut got_bracket = false;
-            while i < rb.len() {
-                if rb[i] == b']' {
-                    got_bracket = true;
-                    break;
-                }
-                i += 1;
-            }
-            if got_bracket {
-                let elem = &rest[start..i];
-                i += 1;
-                let numeric = elem.len() > 0 && elem.bytes().all(|b| b.is_ascii_digit());
-                let w_item = if numeric {
-                    match elem.parse::<i64>() {
-                        Ok(idx) => pyre_object::w_int_new(idx),
-                        Err(_) => pyre_object::w_str_new(elem),
-                    }
-                } else {
-                    pyre_object::w_str_new(elem)
-                };
-                w_obj = crate::baseobjspace::getitem(w_obj, w_item)?;
-            } else {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::ValueError,
-                    "Missing ']' in format string".to_string(),
-                ));
-            }
-        } else {
-            return Err(crate::PyError::new(
-                crate::PyErrorKind::ValueError,
-                "Only '[' and '.' may follow ']' in format string".to_string(),
-            ));
-        }
-    }
-    Ok(w_obj)
+/// Fetch positional argument `idx`, raising the `str.format` IndexError for
+/// an out-of-range replacement index.
+fn index_positional(
+    positional: &[PyObjectRef],
+    idx: usize,
+) -> Result<PyObjectRef, crate::PyError> {
+    positional.get(idx).copied().ok_or_else(|| {
+        crate::PyError::index_error(format!(
+            "Replacement index {idx} out of range for positional args tuple"
+        ))
+    })
 }
 
-/// Mini Python format-spec parser — `pypy/objspace/std/newformat.py
-/// _parse_spec`.  Recognises the subset pyre exercises today:
-/// `[fill][align][sign][#][0][width][grouping][.precision][type]`.
-/// `alt_form` (the `#` flag) is now stored on the parsed spec so int /
-/// float formatters can apply the base prefix or trailing-zero
-/// preservation per PyPy `newformat.py:454-468`.  `grouping` holds the
-/// thousands separator (`,` or `_`) parsed at `newformat.py:501-512`.
+/// Map a template parse error to the matching `str.format` ValueError.
+/// `FormatString` reports `UnmatchedBracket` for both a lone trailing `{`
+/// and an opened-but-unclosed field, so the trailing byte disambiguates the
+/// two CPython messages.
+fn format_parse_err(err: rustpython_common::format::FormatParseError, fmt: &Wtf8) -> crate::PyError {
+    use rustpython_common::format::FormatParseError as E;
+    let msg = match err {
+        E::UnmatchedBracket => {
+            if fmt.as_bytes().last() == Some(&b'{') {
+                "Single '{' encountered in format string"
+            } else {
+                "expected '}' before end of string"
+            }
+        }
+        E::MissingStartBracket => "Single '}' encountered in format string",
+        E::UnescapedStartBracketInLiteral => "Single '{' encountered in format string",
+        E::MissingRightBracket => "expected '}' before end of string",
+        E::EmptyAttribute => "Empty attribute in format string",
+        E::UnknownConversion => "expected ':' after conversion specifier",
+        // The template parser accepts only one bracket layer in a spec and
+        // reports a second as `InvalidFormatSpecifier`; that is the markup
+        // recursion limit being hit.
+        E::InvalidFormatSpecifier => "Max string recursion exceeded",
+        E::InvalidCharacterAfterRightBracket => "Only '[' and '.' may follow ']' in format string",
+        E::TooManyDecimalDigits => "Too many decimal digits in format string",
+    };
+    crate::PyError::value_error(msg)
+}
+
+/// Geometry of a format spec: `[fill][align][sign][#][0][width][grouping]
+/// [.precision][type]`.  Only the presentation types the shared engine
+/// cannot format correctly — integer `c` and non-finite floats — read
+/// this back; every other case parses through `FormatSpec` directly.
 struct ParsedSpec {
     fill: char,
     align: Option<char>,
     sign: Option<char>,
     alt_form: bool,
-    zero_pad: bool,
     width: usize,
     grouping: Option<char>,
     precision: Option<usize>,
@@ -1280,13 +1165,8 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         alt_form = true;
         i += 1;
     }
-    let mut zero_pad = false;
     if i < n && chars[i] == '0' {
-        zero_pad = true;
-        // `pypy/objspace/std/newformat.py:454-460` — the `0` flag
-        // implies `fill='0', align='='` when no explicit fill /
-        // align were provided.  Without this, `f"{-7:=05d}"`
-        // would left-fill with spaces instead of zeros.
+        // The `0` flag implies `fill='0', align='='` when neither was given.
         if align.is_none() {
             align = Some('=');
         }
@@ -1300,8 +1180,6 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         width = width * 10 + (chars[i] as u8 - b'0') as usize;
         i += 1;
     }
-    // `pypy/objspace/std/newformat.py:501-512` — the thousands
-    // separator (`,` or `_`) sits between width and `.precision`.
     let mut grouping: Option<char> = None;
     if i < n && matches!(chars[i], ',' | '_') {
         grouping = Some(chars[i]);
@@ -1323,7 +1201,6 @@ fn parse_spec(spec: &str) -> ParsedSpec {
         align,
         sign,
         alt_form,
-        zero_pad,
         width,
         grouping,
         precision,
@@ -1331,10 +1208,8 @@ fn parse_spec(spec: &str) -> ParsedSpec {
     }
 }
 
-/// `pypy/objspace/std/newformat.py:740 _group_digits` — insert the
-/// thousands separator `sep` into a run of plain digits every
-/// `interval` positions counted from the right (3 for decimal
-/// presentations, 4 for `_` on binary / octal / hex).
+/// Insert the thousands separator `sep` into a run of plain digits every
+/// `interval` positions counted from the right.
 fn group_digits(digits: &str, sep: char, interval: usize) -> String {
     let chars: Vec<char> = digits.chars().collect();
     let len = chars.len();
@@ -1348,9 +1223,9 @@ fn group_digits(digits: &str, sep: char, interval: usize) -> String {
     out
 }
 
-/// Group only the leading integer run of a numeric body (the digits
-/// before any `.`, exponent, or `%`), leaving the fractional / suffix
-/// portion untouched.  Float groupings always use interval 3.
+/// Group only the leading integer run of a numeric body (the digits before
+/// any `.`, exponent, or `%`), leaving the fractional / suffix portion
+/// untouched.  Float groupings always use interval 3.
 fn group_integer_prefix(body: &str, sep: char) -> String {
     let int_len = body.chars().take_while(|c| c.is_ascii_digit()).count();
     if int_len <= 3 {
@@ -1360,6 +1235,50 @@ fn group_integer_prefix(body: &str, sep: char) -> String {
     format!("{}{}", group_digits(int_part, sep, 3), rest)
 }
 
+/// Group the leading integer run of `body` while sign-aware zero-padding it
+/// to `field` characters (the width less the sign).  Leading zeros are added
+/// to the integer run *before* grouping so the padding is itself grouped,
+/// matching the `0`-flag / `=`-alignment interaction.  Only the digit run is
+/// touched, so an exponent (`e+30`) or fractional tail is never separated.
+fn group_integer_zero_padded(body: &str, sep: char, field: usize) -> String {
+    let int_len = body.chars().take_while(|c| c.is_ascii_digit()).count();
+    let (int_part, tail) = body.split_at(int_len);
+    let disp = std::cmp::max(field as i32, body.len() as i32);
+    let int_digit_cnt = disp - tail.len() as i32;
+    format!("{}{tail}", separate_integer(int_part, 3, sep, int_digit_cnt))
+}
+
+/// Pad the digit string `int_str` with leading zeros to a display width of
+/// `disp_digit_cnt` and insert `sep` every `inter` digits.  The pad count is
+/// reduced by the separators that will occupy width, and a leading separator
+/// is avoided when the display width is an exact group boundary.
+fn separate_integer(int_str: &str, inter: i32, sep: char, disp_digit_cnt: i32) -> String {
+    let mag_len = int_str.len() as i32;
+    let offset = i32::from(disp_digit_cnt % (inter + 1) == 0);
+    let disp = disp_digit_cnt + offset;
+    let pad_cnt = disp - mag_len;
+    let sep_cnt = disp / (inter + 1);
+    if pad_cnt > 0 && pad_cnt - sep_cnt > 0 {
+        let padded = format!("{}{int_str}", "0".repeat((pad_cnt - sep_cnt) as usize));
+        insert_separator(padded, inter, sep, sep_cnt)
+    } else {
+        insert_separator(int_str.to_string(), inter, sep, (mag_len - 1) / inter)
+    }
+}
+
+/// Insert `sep` into `s` at every `inter`-digit boundary from the right,
+/// `sep_cnt` times.
+fn insert_separator(mut s: String, inter: i32, sep: char, sep_cnt: i32) -> String {
+    let len = s.len() as i32;
+    for i in 1..=sep_cnt {
+        s.insert((len - inter * i) as usize, sep);
+    }
+    s
+}
+
+/// Pad `body` to `width` characters with `fill`, honouring the numeric
+/// alignments.  `=` splits a leading sign (and `0x`/`0o`/`0b` base prefix)
+/// from the digits and inserts the fill between them.
 fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
     if body.chars().count() >= width {
         return body;
@@ -1386,13 +1305,6 @@ fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
             }
             s
         }
-        // `pypy/objspace/std/newformat.py:454-468` — `=` alignment
-        // splits the leading sign / base prefix from the digit body
-        // and inserts fill BETWEEN them, so `f"{-7:=05d}"` renders
-        // as `"-0007"` (sign then zeros then digits) instead of
-        // `"000-7"`.  Numeric bodies the int / float paths emit
-        // start with at most one sign char (`-`/`+`/space) followed
-        // by an optional base prefix (`0x`/`0X`/`0o`/`0b`).
         '=' => {
             let mut chars = body.chars().peekable();
             let mut prefix = String::new();
@@ -1402,7 +1314,6 @@ fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
                     chars.next();
                 }
             }
-            // Optional alt-form base prefix: 0x / 0X / 0o / 0b.
             let rest_so_far: String = chars.clone().collect();
             if rest_so_far.len() >= 2 && rest_so_far.as_bytes()[0] == b'0' {
                 let next = rest_so_far.as_bytes()[1];
@@ -1423,7 +1334,6 @@ fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
             s
         }
         _ => {
-            // Default `>` (right-align) for any unknown sigil.
             let mut s = String::with_capacity(width);
             for _ in 0..need {
                 s.push(fill);
@@ -1431,6 +1341,91 @@ fn pad_to_width(body: String, fill: char, align: char, width: usize) -> String {
             s.push_str(&body);
             s
         }
+    }
+}
+
+/// A `&str` paired with its precomputed code-point count, adapting a
+/// str body to the `CharLen + Deref<str>` bound `FormatSpec::format_string`
+/// requires for width padding.
+struct CharLenStr<'a>(&'a str, usize);
+
+impl std::ops::Deref for CharLenStr<'_> {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.0
+    }
+}
+
+impl rustpython_common::format::CharLen for CharLenStr<'_> {
+    fn char_len(&self) -> usize {
+        self.1
+    }
+}
+
+/// Render a presentation-type code for the "Unknown format code" message:
+/// printable ASCII (`0x21..=0x7f`) verbatim, anything else as `\x{hex}`.
+fn unknown_code_display(c: char) -> String {
+    if ('\u{21}'..='\u{7f}').contains(&c) {
+        c.to_string()
+    } else {
+        format!("\\x{:x}", c as u32)
+    }
+}
+
+/// Map a `FormatSpec` engine error to the matching Python exception.
+/// `spec` and `type_name` supply the value's format spec and type for the
+/// messages that name them; `integer` selects the integer-specific text
+/// for the `z` presentation code.
+fn format_spec_err(
+    err: rustpython_common::format::FormatSpecError,
+    spec: &str,
+    type_name: &str,
+    integer: bool,
+) -> crate::PyError {
+    use rustpython_common::format::FormatSpecError as E;
+    match err {
+        E::DecimalDigitsTooMany => {
+            crate::PyError::value_error("Too many decimal digits in format string")
+        }
+        // An integer never accepts a precision, so its presence is reported
+        // before the value is range-checked — the size never surfaces.
+        E::PrecisionTooBig if integer => {
+            crate::PyError::value_error("Precision not allowed in integer format specifier")
+        }
+        E::PrecisionTooBig => crate::PyError::value_error("precision too big"),
+        E::InvalidFormatSpecifier => crate::PyError::value_error(format!(
+            "Invalid format specifier '{spec}' for object of type '{type_name}'"
+        )),
+        E::UnspecifiedFormat(c1, c2) => {
+            crate::PyError::value_error(format!("Cannot specify '{c1}' with '{c2}'."))
+        }
+        E::ExclusiveFormat(c1, c2) => {
+            crate::PyError::value_error(format!("Cannot specify both '{c1}' and '{c2}'."))
+        }
+        E::UnknownFormatCode(c, _) if integer && c == 'z' => crate::PyError::value_error(
+            "Negative zero coercion (z) not allowed in integer format specifier",
+        ),
+        E::UnknownFormatCode(c, _) => crate::PyError::value_error(format!(
+            "Unknown format code '{}' for object of type '{type_name}'",
+            unknown_code_display(c)
+        )),
+        E::PrecisionNotAllowed => {
+            crate::PyError::value_error("Precision not allowed in integer format specifier")
+        }
+        E::NotAllowed(s) => crate::PyError::value_error(format!(
+            "{s} not allowed with integer format specifier 'c'"
+        )),
+        E::UnableToConvert => crate::PyError::value_error("Unable to convert int to float"),
+        E::CodeNotInRange => crate::PyError::overflow_error("%c arg not in range(0x110000)"),
+        E::ZeroPadding => {
+            crate::PyError::value_error("Zero padding is not allowed in complex format specifier")
+        }
+        E::AlignmentFlag => crate::PyError::value_error(
+            "'=' alignment flag is not allowed in complex format specifier",
+        ),
+        E::NotImplemented(c, s) => crate::PyError::value_error(format!(
+            "Format code '{c}' for object of type '{s}' not implemented yet"
+        )),
     }
 }
 
@@ -1555,68 +1550,371 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
-    let p = parse_spec(spec);
+    use rustpython_common::format::FormatSpec;
     unsafe {
-        if pyre_object::is_int(val) || pyre_object::is_bool(val) {
-            let v = if pyre_object::is_bool(val) {
-                pyre_object::w_bool_get_value(val) as i64
+        // `int` / `bool` / `long` share the integer formatter.  The `c`
+        // character type is formatted here instead — the shared engine pads
+        // by byte length rather than code point — and the float presentation
+        // codes (`e`/`f`/`g`/`%`) format the `f64` conversion of the value.
+        if pyre_object::is_int(val) || pyre_object::is_bool(val) || pyre_object::is_long(val) {
+            let type_name = arg_type_name(val);
+            let big = if pyre_object::is_bool(val) {
+                BigInt::from(pyre_object::w_bool_get_value(val) as i64)
             } else {
-                pyre_object::w_int_get_value(val)
+                crate::builtins::obj_to_bigint(val)
             };
-            // `newformat.py:1018-1026` — the `c` presentation type
-            // formats the integer as the single Unicode character
-            // `chr(v)`, then pads as text (default left align).
-            if p.ty == 'c' {
-                let body = u32::try_from(v)
-                    .ok()
-                    .and_then(char::from_u32)
-                    .map_or_else(|| format!("{v}"), |c| c.to_string());
-                // `c` keeps the integer default alignment (right).
-                let align = p.align.unwrap_or('>');
-                return Ok(Wtf8Buf::from_string(pad_to_width(
-                    body, p.fill, align, p.width,
-                )));
+            let parsed = FormatSpec::parse(spec);
+            if spec.ends_with('c') && parsed.is_ok() {
+                return format_char(&big, spec);
             }
-            // Float-style spec on int: coerce to f64 (matches CPython
-            // `int.__format__('.3f')` behaviour).  `%` is a float-only
-            // presentation type, so route ints through it too.
-            if matches!(p.ty, 'f' | 'F' | 'e' | 'E' | 'g' | 'G' | '%') {
-                return Ok(Wtf8Buf::from_string(format_float(v as f64, &p)));
+            // A float presentation code formats the `f64` conversion (`n` and
+            // the integer bases keep full integer precision instead).
+            if matches!(parse_spec(spec).ty, 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | '%') {
+                let f = big.to_f64().unwrap_or(f64::INFINITY);
+                if f.is_infinite() {
+                    return Err(crate::PyError::overflow_error(
+                        "int too large to convert to float",
+                    ));
+                }
+                return format_finite_float(f, spec);
             }
-            return Ok(Wtf8Buf::from_string(format_int(v, &p)));
+            let parsed = parsed.map_err(|e| format_spec_err(e, spec, &type_name, true))?;
+            let s = parsed
+                .format_int(&big)
+                .map_err(|e| format_spec_err(e, spec, &type_name, true))?;
+            return Ok(Wtf8Buf::from_string(s));
         }
         if pyre_object::is_float(val) {
             let v = pyre_object::floatobject::w_float_get_value(val);
-            return Ok(Wtf8Buf::from_string(format_float(v, &p)));
+            // `inf` / `nan` go through the local formatter — the shared engine
+            // inserts the digit-grouping separator into their padding.
+            if v.is_nan() || v.is_infinite() {
+                return format_nonfinite(v, spec);
+            }
+            return format_finite_float(v, spec);
         }
         if pyre_object::is_str(val) {
-            // Read the WTF-8 view so a lone-surrogate body formats and
-            // pads by code point instead of panicking.
             let full = pyre_object::w_str_get_wtf8(val);
-            let body = if let Some(prec) = p.precision {
-                let mut t = Wtf8Buf::new();
-                let mut n = 0usize;
-                for cp in full.code_points() {
-                    if n >= prec {
-                        break;
-                    }
-                    t.push(cp);
-                    n += 1;
-                }
-                t
-            } else {
-                full.to_wtf8_buf()
-            };
-            let align = p.align.unwrap_or('<');
-            return Ok(pad_wtf8(&body, p.fill, align, p.width));
+            // The shared string formatter rejects grouping and numeric types
+            // but not a sign or `=` alignment, which are also disallowed for
+            // strings.
+            reject_string_sign_align(spec)?;
+            // A valid-UTF-8 body goes through the shared string formatter,
+            // which pads by code point.
+            if let Ok(valid) = full.as_str() {
+                let parsed = FormatSpec::parse(spec)
+                    .map_err(|e| format_spec_err(e, spec, "str", false))?;
+                let s = parsed
+                    .format_string(&CharLenStr(valid, valid.chars().count()))
+                    .map_err(|e| format_spec_err(e, spec, "str", false))?;
+                return Ok(Wtf8Buf::from_string(s));
+            }
+            // A body carrying a lone surrogate cannot be handed to the
+            // `&str`-typed formatter, so pad it by code point here.
+            return format_surrogate_str(full, spec);
         }
-        Ok(Wtf8Buf::from_string(pad_to_width(
-            crate::py_str(val)?,
-            p.fill,
-            p.align.unwrap_or('<'),
-            p.width,
-        )))
+        // Reached only for the rare builtin type whose `__format__` is the
+        // inherited default yet still routes here with a non-empty spec;
+        // format its `str()` through the shared string formatter.
+        let s = crate::py_str(val)?;
+        let parsed = FormatSpec::parse(spec)
+            .map_err(|e| format_spec_err(e, spec, &arg_type_name(val), false))?;
+        let out = parsed
+            .format_string(&CharLenStr(&s, s.chars().count()))
+            .map_err(|e| format_spec_err(e, spec, &arg_type_name(val), false))?;
+        Ok(Wtf8Buf::from_string(out))
     }
+}
+
+/// Reject a sign flag or `=` alignment in a string format spec — both are
+/// disallowed for `str` values but accepted by the shared formatter.  Only
+/// the *explicit* alignment is inspected: a leading `0` flag (which the
+/// shared parser normalises to `=`) is a zero fill and stays legal for text.
+fn reject_string_sign_align(spec: &str) -> Result<(), crate::PyError> {
+    let chars: Vec<char> = spec.chars().collect();
+    let n = chars.len();
+    let mut i = 0;
+    let mut align: Option<char> = None;
+    if n >= 2 && matches!(chars[1], '<' | '>' | '=' | '^') {
+        align = Some(chars[1]);
+        i = 2;
+    } else if n >= 1 && matches!(chars[0], '<' | '>' | '=' | '^') {
+        align = Some(chars[0]);
+        i = 1;
+    }
+    if align == Some('=') {
+        return Err(crate::PyError::value_error(
+            "'=' alignment not allowed in string format specifier",
+        ));
+    }
+    if i < n && matches!(chars[i], '+' | '-' | ' ') {
+        return Err(crate::PyError::value_error(if chars[i] == ' ' {
+            "Space not allowed in string format specifier"
+        } else {
+            "Sign not allowed in string format specifier"
+        }));
+    }
+    Ok(())
+}
+
+/// Format a `str` value whose WTF-8 body carries a lone surrogate, which
+/// the shared `&str`-typed formatter cannot accept.  Only the geometry
+/// codes that make sense for text — `[fill][align][width][.precision]`
+/// and an optional `s` type — are honoured; a numeric presentation type
+/// raises the same "unknown format code" error the valid-UTF-8 path does.
+/// A sign / `=` alignment is rejected by the caller.
+fn format_surrogate_str(body: &Wtf8, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+    let chars: Vec<char> = spec.chars().collect();
+    let n = chars.len();
+    let mut i = 0;
+    let mut fill = ' ';
+    let mut align = '<';
+    if n >= 2 && matches!(chars[1], '<' | '>' | '=' | '^') {
+        fill = chars[0];
+        align = chars[1];
+        i = 2;
+    } else if n >= 1 && matches!(chars[0], '<' | '>' | '=' | '^') {
+        align = chars[0];
+        i = 1;
+    }
+    let mut width = 0usize;
+    while i < n && chars[i].is_ascii_digit() {
+        width = width * 10 + (chars[i] as u8 - b'0') as usize;
+        i += 1;
+    }
+    let mut precision: Option<usize> = None;
+    if i < n && chars[i] == '.' {
+        i += 1;
+        let mut p = 0usize;
+        while i < n && chars[i].is_ascii_digit() {
+            p = p * 10 + (chars[i] as u8 - b'0') as usize;
+            i += 1;
+        }
+        precision = Some(p);
+    }
+    if i < n {
+        let ty = chars[i];
+        if ty != 's' {
+            return Err(crate::PyError::value_error(format!(
+                "Unknown format code '{ty}' for object of type 'str'"
+            )));
+        }
+        i += 1;
+    }
+    if i != n {
+        return Err(crate::PyError::value_error(format!(
+            "Invalid format specifier '{spec}' for object of type 'str'"
+        )));
+    }
+    let body = if let Some(prec) = precision {
+        let mut t = Wtf8Buf::new();
+        for (k, cp) in body.code_points().enumerate() {
+            if k >= prec {
+                break;
+            }
+            t.push(cp);
+        }
+        t
+    } else {
+        body.to_wtf8_buf()
+    };
+    Ok(pad_wtf8(&body, fill, align, width))
+}
+
+/// Format an integer through the `c` presentation type: reject the flags
+/// that make no sense for a single character, map the value to its code
+/// point, then pad by code point.  The caller has already confirmed the
+/// spec parses and ends in `c`.
+fn format_char(num: &BigInt, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+    let p = parse_spec(spec);
+    // Rejection order matches the reference: grouping, then precision, then
+    // sign, then alternate form — each beats the value range check.
+    if let Some(sep) = p.grouping {
+        return Err(crate::PyError::value_error(format!(
+            "Cannot specify '{sep}' with 'c'."
+        )));
+    }
+    if p.precision.is_some() {
+        return Err(crate::PyError::value_error(
+            "Precision not allowed in integer format specifier",
+        ));
+    }
+    if p.sign.is_some() {
+        return Err(crate::PyError::value_error(
+            "Sign not allowed with integer format specifier 'c'",
+        ));
+    }
+    if p.alt_form {
+        return Err(crate::PyError::value_error(
+            "Alternate form (#) not allowed with integer format specifier 'c'",
+        ));
+    }
+    let cp = match num.to_i64() {
+        None => {
+            return Err(crate::PyError::overflow_error(
+                "Python int too large to convert to C long",
+            ));
+        }
+        Some(n) => match u32::try_from(n).ok().and_then(CodePoint::from_u32) {
+            Some(cp) => cp,
+            None => {
+                return Err(crate::PyError::overflow_error(
+                    "%c arg not in range(0x110000)",
+                ));
+            }
+        },
+    };
+    let mut body = Wtf8Buf::new();
+    body.push(cp);
+    // `c` keeps the integer default alignment (right).
+    Ok(pad_wtf8(&body, p.fill, p.align.unwrap_or('>'), p.width))
+}
+
+/// Format `inf` / `nan`: validate the presentation type, then emit the
+/// signed word (`inf` / `nan`, upper-cased for `E`/`F`/`G`, `%`-suffixed
+/// for the percentage type) padded to width.  Grouping only validates
+/// here — a non-finite value has no digits to separate.
+fn format_nonfinite(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+    let p = parse_spec(spec);
+    validate_float_spec(spec, &p)?;
+    let upper = matches!(p.ty, 'E' | 'F' | 'G');
+    let word = match (v.is_nan(), upper) {
+        (true, false) => "nan",
+        (true, true) => "NAN",
+        (false, false) => "inf",
+        (false, true) => "INF",
+    };
+    let mut magnitude = String::from(word);
+    if p.ty == '%' {
+        magnitude.push('%');
+    }
+    // A NaN carries no meaningful sign, so it takes only an explicit sign
+    // flag; an infinity takes its own sign.
+    let sign = if v.is_sign_negative() && !v.is_nan() {
+        "-"
+    } else {
+        match p.sign {
+            Some('+') => "+",
+            Some(' ') => " ",
+            _ => "",
+        }
+    };
+    let body = format!("{sign}{magnitude}");
+    Ok(Wtf8Buf::from_string(pad_to_width(
+        body,
+        p.fill,
+        p.align.unwrap_or('>'),
+        p.width,
+    )))
+}
+
+/// Validate a float presentation spec against the reference rules,
+/// independent of the value.  Structural errors (bad flag order, a
+/// precision beyond `i32`, trailing garbage) come from the shared parser
+/// for their exact messages; the type and grouping-with-`n` checks are
+/// applied on top.
+fn validate_float_spec(spec: &str, p: &ParsedSpec) -> Result<(), crate::PyError> {
+    rustpython_common::format::FormatSpec::parse(spec)
+        .map_err(|e| format_spec_err(e, spec, "float", false))?;
+    if !matches!(p.ty, '\0' | 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | 'n' | '%') {
+        return Err(crate::PyError::value_error(format!(
+            "Unknown format code '{}' for object of type 'float'",
+            unknown_code_display(p.ty)
+        )));
+    }
+    if let Some(sep) = p.grouping
+        && p.ty == 'n'
+    {
+        return Err(crate::PyError::value_error(format!(
+            "Cannot specify '{sep}' with 'n'."
+        )));
+    }
+    Ok(())
+}
+
+/// Format a finite `f64` through `spec`.  Fixed-point (`f`/`F`) and
+/// locale-general (`n`) presentations pad and group exactly through the shared
+/// engine, so delegate them.  The exponent and general forms stay local: the
+/// shared grouping splits only on the decimal point (corrupting an exponent
+/// into `1e,+20`) and its empty-type precision picks exponent notation where a
+/// fixed form is required.
+fn format_finite_float(v: f64, spec: &str) -> Result<Wtf8Buf, crate::PyError> {
+    let p = parse_spec(spec);
+    validate_float_spec(spec, &p)?;
+    if matches!(p.ty, 'f' | 'F' | 'n') {
+        let parsed = rustpython_common::format::FormatSpec::parse(spec)
+            .map_err(|e| format_spec_err(e, spec, "float", false))?;
+        let s = parsed
+            .format_float(v)
+            .map_err(|e| format_spec_err(e, spec, "float", false))?;
+        return Ok(Wtf8Buf::from_string(s));
+    }
+    Ok(Wtf8Buf::from_string(format_float(v, &p)))
+}
+
+/// Format a finite float through the presentation-type `p.ty`, applying
+/// sign, alt-form trailing dot, integer-run grouping, and width padding.
+fn format_float(v: f64, p: &ParsedSpec) -> String {
+    let prec = p.precision.unwrap_or(6);
+    // Format on `v.abs()` so the sign is reattached exactly once below;
+    // Rust's `{:e}`/`{:E}` would otherwise emit it too.
+    let abs = v.abs();
+    let body = match p.ty {
+        // Rust's `{:e}` emits a sign-less, minimal exponent ("e2"); C-style
+        // formatting wants an explicit, two-digit exponent ("e+02").
+        'e' => crate::baseobjspace::normalise_exponent(&format!("{abs:.prec$e}"), false),
+        'E' => crate::baseobjspace::normalise_exponent(&format!("{abs:.prec$E}"), true),
+        'f' | 'F' => format!("{abs:.prec$}"),
+        // Percent type: scale by 100, format fixed, suffix `%`.
+        '%' => format!("{:.*}%", prec, abs * 100.0),
+        // `g`/`G` format general with trailing zeros trimmed unless alt-form
+        // keeps them; `n` matches `g` with locale grouping (none in C).
+        'g' | 'G' | 'n' => crate::baseobjspace::format_g_like(abs, prec, p.ty == 'G', p.alt_form),
+        '\0' => {
+            // No presentation type formats like `repr()`; an explicit precision
+            // switches to a `g`-like form with a lower scientific cutoff, while
+            // bare alt-form only guarantees the trailing dot (added below).
+            match p.precision {
+                Some(_) => crate::baseobjspace::format_no_type_prec(abs, prec, p.alt_form),
+                None => crate::display::format_float_repr(abs),
+            }
+        }
+        _ => format!("{abs}"),
+    };
+    let sign_char = if v.is_sign_negative() && !v.is_nan() {
+        "-"
+    } else {
+        match p.sign {
+            Some('+') => "+",
+            Some(' ') => " ",
+            _ => "",
+        }
+    };
+    // Alt-form `#` keeps the decimal point even when no fractional digits
+    // remain; it sits before the exponent (`e`) or percent (`%`) suffix.
+    let body = if p.alt_form
+        && !body.contains('.')
+        && matches!(p.ty, 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | '%' | '\0')
+    {
+        match body.find(['e', 'E', '%']) {
+            Some(pos) => format!("{}.{}", &body[..pos], &body[pos..]),
+            None => format!("{body}."),
+        }
+    } else {
+        body
+    };
+    let align = p.align.unwrap_or('>');
+    let body = match p.grouping {
+        // Sign-aware zero padding groups the pad zeros together with the
+        // digits, so the width must be threaded into the grouping step.
+        Some(sep) if align == '=' && p.fill == '0' => {
+            group_integer_zero_padded(&body, sep, p.width.saturating_sub(sign_char.len()))
+        }
+        Some(sep) => group_integer_prefix(&body, sep),
+        None => body,
+    };
+    let body = format!("{sign_char}{body}");
+    pad_to_width(body, p.fill, align, p.width)
 }
 
 /// Pad a WTF-8 string body to `width` code points with `fill`,
@@ -1648,127 +1946,6 @@ fn pad_wtf8(body: &Wtf8, fill: char, align: char, width: usize) -> Wtf8Buf {
         }
     }
     out
-}
-
-fn format_int(v: i64, p: &ParsedSpec) -> String {
-    let abs = v.unsigned_abs();
-    let digits = match p.ty {
-        'x' => format!("{abs:x}"),
-        'X' => format!("{abs:X}"),
-        'o' => format!("{abs:o}"),
-        'b' => format!("{abs:b}"),
-        _ => format!("{abs}"),
-    };
-    // `newformat.py:646-651` — `,` always groups by 3; `_` groups by 4
-    // for the bit presentations (b/o/x/X) and by 3 otherwise.
-    let digits = if let Some(sep) = p.grouping {
-        let interval = if sep == '_' && matches!(p.ty, 'x' | 'X' | 'o' | 'b') {
-            4
-        } else {
-            3
-        };
-        group_digits(&digits, sep, interval)
-    } else {
-        digits
-    };
-    let sign_char = if v < 0 {
-        "-"
-    } else {
-        match p.sign {
-            Some('+') => "+",
-            Some(' ') => " ",
-            _ => "",
-        }
-    };
-    // `pypy/objspace/std/newformat.py:454-460` — alt-form `#`
-    // prepends the matching base prefix for x/X/o/b; ignored for
-    // d / decimal.
-    let alt_prefix = if p.alt_form {
-        match p.ty {
-            'x' => "0x",
-            'X' => "0X",
-            'o' => "0o",
-            'b' => "0b",
-            _ => "",
-        }
-    } else {
-        ""
-    };
-    let body = format!("{sign_char}{alt_prefix}{digits}");
-    // `pypy/objspace/std/newformat.py:454-468` — when zero_pad is
-    // set, parse_spec already promoted `align = '='` and `fill =
-    // '0'` so `pad_to_width` performs the sign-aware insertion.
-    let align = p.align.unwrap_or('>');
-    pad_to_width(body, p.fill, align, p.width)
-}
-
-fn format_float(v: f64, p: &ParsedSpec) -> String {
-    let prec = p.precision.unwrap_or(6);
-    // Always format on `v.abs()` so the sign is reattached exactly
-    // once below.  Rust's `{:e}` / `{:E}` include the sign already,
-    // which previously duplicated `-` for negative values; using
-    // `abs()` consistently fixes that.
-    let abs = v.abs();
-    let body = match p.ty {
-        // `pypy/objspace/std/newformat.py` `format_e_g_complex`
-        // mirrors C printf — the exponent has an explicit sign and
-        // is zero-padded to two digits ("e+02", "E-04").  Rust's
-        // `{:e}` emits a sign-less, minimal exponent ("e2"), so
-        // route through `normalise_exponent` here.
-        'e' => crate::baseobjspace::normalise_exponent(&format!("{abs:.prec$e}"), false),
-        'E' => crate::baseobjspace::normalise_exponent(&format!("{abs:.prec$E}"), true),
-        'f' | 'F' => format!("{:.*}", prec, abs),
-        // `newformat.py` percent type: scale by 100, format fixed, suffix `%`.
-        '%' => format!("{:.*}%", prec, abs * 100.0),
-        // `g`/`G` always format `general`: default precision 6, trailing
-        // zeros trimmed unless alt-form keeps them.  `n` matches `g` but
-        // takes its digit grouping from the locale (none in the C locale).
-        'g' | 'G' | 'n' => crate::baseobjspace::format_g_like(abs, prec, p.ty == 'G', p.alt_form),
-        '\0' => {
-            // No presentation type formats like `repr()` — the shortest
-            // round-trip string, which keeps the trailing `.0` for whole
-            // values.  An explicit precision (or `#`) switches to `g`.
-            if p.precision.is_some() || p.alt_form {
-                crate::baseobjspace::format_g_like(abs, prec, false, p.alt_form)
-            } else {
-                crate::display::format_float_repr(abs)
-            }
-        }
-        _ => format!("{}", abs),
-    };
-    let sign_char = if v.is_sign_negative() && !v.is_nan() {
-        "-"
-    } else {
-        match p.sign {
-            Some('+') => "+",
-            Some(' ') => " ",
-            _ => "",
-        }
-    };
-    // `pypy/objspace/std/newformat.py:464-468` — alt-form `#` keeps
-    // the trailing dot (and trailing zeros) for floats so the
-    // requested precision is visible even when the value is whole.
-    // Cheapest expression: append `.` if missing.
-    let body = if p.alt_form
-        && !body.contains('.')
-        && matches!(p.ty, 'e' | 'E' | 'f' | 'F' | 'g' | 'G' | '\0')
-    {
-        format!("{body}.")
-    } else {
-        body
-    };
-    // `newformat.py:646-648` — float groupings always use interval 3,
-    // applied to the integer run only (the fractional / exponent / `%`
-    // suffix is left untouched).
-    let body = match p.grouping {
-        Some(sep) => group_integer_prefix(&body, sep),
-        None => body,
-    };
-    let body = format!("{sign_char}{body}");
-    // Same `=`/`'0'` promotion as `format_int`; pad_to_width does
-    // the sign-aware insertion.
-    let align = p.align.unwrap_or('>');
-    pad_to_width(body, p.fill, align, p.width)
 }
 
 /// runicode.py:333 unicode_encode_utf_8 + interp_codecs.py

--- a/pyre/pyre-native/Cargo.toml
+++ b/pyre/pyre-native/Cargo.toml
@@ -12,3 +12,4 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
 blake2 = { workspace = true }
+flate2 = { workspace = true, features = ["zlib-rs"] }

--- a/pyre/pyre-native/src/lib.rs
+++ b/pyre/pyre-native/src/lib.rs
@@ -5,3 +5,4 @@
 //! lowered into the meta-traceable `.ullbc`.
 
 pub mod hash;
+pub mod zlib;

--- a/pyre/pyre-native/src/zlib.rs
+++ b/pyre/pyre-native/src/zlib.rs
@@ -1,0 +1,607 @@
+//! zlib DEFLATE backend — deliberate duplication of RustPython's zlib
+//! machinery (`stdlib/src/zlib.rs` + the shared `compression.rs` state
+//! machine), stripped of the `vm`/`PyResult` layer and specialised to the
+//! `flate2` zlib-rs backend.  Errors surface as plain messages the
+//! interpreter maps onto `zlib.error`.  Kept outside the LLBC extraction so
+//! the native codec never lowers into the traceable graph.
+
+use flate2::{
+    Compress, Compression, Decompress, FlushCompress, FlushDecompress, Status, write::ZlibEncoder,
+};
+use std::io::Write;
+
+pub const MAX_WBITS: i8 = 15;
+pub const DEF_BUF_SIZE: usize = 16 * 1024;
+
+// flush modes (libz values); mirrored as module constants on the Python side.
+pub const Z_NO_FLUSH: i32 = 0;
+pub const Z_PARTIAL_FLUSH: i32 = 1;
+pub const Z_SYNC_FLUSH: i32 = 2;
+pub const Z_FULL_FLUSH: i32 = 3;
+pub const Z_FINISH: i32 = 4;
+
+const Z_DEFAULT_COMPRESSION: i32 = -1;
+const Z_NO_COMPRESSION: i32 = 0;
+const Z_BEST_COMPRESSION: i32 = 9;
+
+const CHUNKSIZE: usize = u32::MAX as usize;
+const USE_AFTER_FINISH_ERR: &str = "Error -2: inconsistent stream state";
+
+fn level_compression(level: i32) -> Option<Compression> {
+    match level {
+        Z_DEFAULT_COMPRESSION => Some(Compression::default()),
+        Z_NO_COMPRESSION..=Z_BEST_COMPRESSION => Some(Compression::new(level as u32)),
+        _ => None,
+    }
+}
+
+enum InitOptions {
+    Standard { header: bool, wbits: u8 },
+    Gzip { wbits: u8 },
+}
+
+impl InitOptions {
+    fn new(wbits: i8) -> Result<Self, String> {
+        let header = wbits > 0;
+        let wbits = wbits.unsigned_abs();
+        match wbits {
+            9..=15 => Ok(Self::Standard { header, wbits }),
+            25..=31 => Ok(Self::Gzip { wbits: wbits - 16 }),
+            _ => Err("Invalid initialization option".to_owned()),
+        }
+    }
+
+    fn decompress(self) -> Decompress {
+        match self {
+            Self::Standard { header, wbits } => Decompress::new_with_window_bits(header, wbits),
+            Self::Gzip { wbits } => Decompress::new_gzip(wbits),
+        }
+    }
+
+    fn compress(self, level: Compression) -> Compress {
+        match self {
+            Self::Standard { header, wbits } => Compress::new_with_window_bits(level, header, wbits),
+            Self::Gzip { wbits } => Compress::new_gzip(level, wbits),
+        }
+    }
+}
+
+// ── input chunker (compression.rs Chunker) ──────────────────────────────
+
+struct Chunker<'a> {
+    data1: &'a [u8],
+    data2: &'a [u8],
+}
+
+impl<'a> Chunker<'a> {
+    const fn new(data: &'a [u8]) -> Self {
+        Self {
+            data1: data,
+            data2: &[],
+        }
+    }
+    fn chain(data1: &'a [u8], data2: &'a [u8]) -> Self {
+        if data1.is_empty() {
+            Self {
+                data1: data2,
+                data2: &[],
+            }
+        } else {
+            Self { data1, data2 }
+        }
+    }
+    const fn len(&self) -> usize {
+        self.data1.len() + self.data2.len()
+    }
+    const fn is_empty(&self) -> bool {
+        self.data1.is_empty()
+    }
+    fn to_vec(&self) -> Vec<u8> {
+        [self.data1, self.data2].concat()
+    }
+    fn chunk(&self) -> &'a [u8] {
+        self.data1.get(..CHUNKSIZE).unwrap_or(self.data1)
+    }
+    fn advance(&mut self, consumed: usize) {
+        self.data1 = &self.data1[consumed..];
+        if self.data1.is_empty() {
+            self.data1 = core::mem::take(&mut self.data2);
+        }
+    }
+}
+
+/// compression.rs `_decompress_chunks`, specialised to `Decompress` with an
+/// optional dictionary retry (the `DecompressWithDict::maybe_set_dict` path).
+fn decompress_chunks(
+    data: &mut Chunker<'_>,
+    d: &mut Decompress,
+    zdict: Option<&[u8]>,
+    bufsize: usize,
+    max_length: Option<usize>,
+    calc_flush: impl Fn(bool) -> FlushDecompress,
+) -> Result<(Vec<u8>, bool), String> {
+    if data.is_empty() {
+        return Ok((Vec::new(), true));
+    }
+    let max_length = max_length.unwrap_or(usize::MAX);
+    let mut buf = Vec::new();
+
+    'outer: loop {
+        let chunk = data.chunk();
+        let flush = calc_flush(chunk.len() == data.len());
+        loop {
+            let additional = core::cmp::min(bufsize, max_length - buf.capacity());
+            if additional == 0 {
+                return Ok((buf, false));
+            }
+            buf.reserve_exact(additional);
+
+            let prev_in = d.total_in();
+            let res = d.decompress_vec(chunk, &mut buf, flush);
+            let consumed = d.total_in() - prev_in;
+
+            data.advance(consumed as usize);
+
+            match res {
+                Ok(status) => {
+                    let stream_end = status == Status::StreamEnd;
+                    if stream_end || data.is_empty() {
+                        buf.shrink_to_fit();
+                        return Ok((buf, stream_end));
+                    } else if !chunk.is_empty() && consumed == 0 {
+                        continue;
+                    }
+                    continue 'outer;
+                }
+                Err(e) => {
+                    // maybe_set_dict: retry once with the stored dictionary.
+                    match zdict.filter(|_| e.needs_dictionary().is_some()) {
+                        Some(zd) => {
+                            d.set_dictionary(zd).map_err(|e| e.to_string())?;
+                            continue 'outer;
+                        }
+                        None => return Err(e.to_string()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn decompress_all(
+    data: &[u8],
+    d: &mut Decompress,
+    zdict: Option<&[u8]>,
+    bufsize: usize,
+    max_length: Option<usize>,
+    calc_flush: impl Fn(bool) -> FlushDecompress,
+) -> Result<(Vec<u8>, bool), String> {
+    let mut chunker = Chunker::new(data);
+    decompress_chunks(&mut chunker, d, zdict, bufsize, max_length, calc_flush)
+}
+
+// ── one-shot entry points ───────────────────────────────────────────────
+
+/// `zlib.compress(data, level, wbits)`.
+#[inline(never)]
+pub fn compress(data: &[u8], level: i32, wbits: i8) -> Result<Vec<u8>, String> {
+    let level = level_compression(level).ok_or_else(|| "Bad compression level".to_owned())?;
+    let compress = InitOptions::new(wbits)?.compress(level);
+    let mut encoder = ZlibEncoder::new_with_compress(Vec::new(), compress);
+    encoder.write_all(data).unwrap();
+    Ok(encoder.finish().unwrap())
+}
+
+/// `zlib.decompress(data, wbits, bufsize)`.
+#[inline(never)]
+pub fn decompress(data: &[u8], wbits: i8, bufsize: usize) -> Result<Vec<u8>, String> {
+    let mut d = InitOptions::new(wbits)?.decompress();
+    let (buf, stream_end) = decompress_all(data, &mut d, None, bufsize, None, |_| {
+        FlushDecompress::Sync
+    })?;
+    if !stream_end {
+        return Err("Error -5 while decompressing data: incomplete or truncated stream".to_owned());
+    }
+    Ok(buf)
+}
+
+// ── streaming compressor (zlib.Compress) ────────────────────────────────
+
+pub struct Compressor {
+    compress: Option<Compress>,
+}
+
+impl Compressor {
+    #[inline(never)]
+    pub fn new(level: i32, wbits: i8, zdict: Option<&[u8]>) -> Result<Self, String> {
+        let level =
+            level_compression(level).ok_or_else(|| "invalid initialization option".to_owned())?;
+        let mut compress = InitOptions::new(wbits)?.compress(level);
+        if let Some(zdict) = zdict {
+            compress.set_dictionary(zdict).map_err(|e| e.to_string())?;
+        }
+        Ok(Self {
+            compress: Some(compress),
+        })
+    }
+
+    #[inline(never)]
+    pub fn compress(&mut self, data: &[u8]) -> Result<Vec<u8>, String> {
+        let compressor = self
+            .compress
+            .as_mut()
+            .ok_or_else(|| USE_AFTER_FINISH_ERR.to_owned())?;
+        let mut buf = Vec::new();
+        for mut chunk in data.chunks(CHUNKSIZE) {
+            while !chunk.is_empty() {
+                buf.reserve(DEF_BUF_SIZE);
+                let prev_in = compressor.total_in();
+                compressor
+                    .compress_vec(chunk, &mut buf, FlushCompress::None)
+                    .map_err(|_| "error while compressing".to_owned())?;
+                let consumed = (compressor.total_in() - prev_in) as usize;
+                chunk = &chunk[consumed..];
+            }
+        }
+        buf.shrink_to_fit();
+        Ok(buf)
+    }
+
+    /// Returns the flushed bytes; `finished` is true once a `Z_FINISH` flush
+    /// has consumed the stream (the object may no longer be used).
+    #[inline(never)]
+    pub fn flush(&mut self, mode: i32) -> Result<Vec<u8>, String> {
+        let flush = match mode {
+            Z_NO_FLUSH => return Ok(vec![]),
+            Z_PARTIAL_FLUSH => FlushCompress::Partial,
+            Z_SYNC_FLUSH => FlushCompress::Sync,
+            Z_FULL_FLUSH => FlushCompress::Full,
+            Z_FINISH => FlushCompress::Finish,
+            _ => return Err("invalid mode".to_owned()),
+        };
+        let compressor = self
+            .compress
+            .as_mut()
+            .ok_or_else(|| USE_AFTER_FINISH_ERR.to_owned())?;
+        let mut buf = Vec::new();
+        let status = loop {
+            if buf.len() == buf.capacity() {
+                buf.reserve(DEF_BUF_SIZE);
+            }
+            let status = compressor
+                .compress_vec(&[], &mut buf, flush)
+                .map_err(|_| "error while compressing".to_owned())?;
+            if buf.len() != buf.capacity() {
+                break status;
+            }
+        };
+        if status == Status::StreamEnd {
+            if mode == Z_FINISH {
+                self.compress = None;
+            } else {
+                return Err("unexpected eof".to_owned());
+            }
+        }
+        buf.shrink_to_fit();
+        Ok(buf)
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.compress.is_none()
+    }
+}
+
+// ── streaming decompressor (zlib.Decompress) ────────────────────────────
+
+pub struct Decompressor {
+    decompress: Option<Decompress>,
+    zdict: Option<Vec<u8>>,
+    eof: bool,
+    unused_data: Vec<u8>,
+    unconsumed_tail: Vec<u8>,
+}
+
+impl Decompressor {
+    #[inline(never)]
+    pub fn new(wbits: i8, zdict: Option<Vec<u8>>) -> Result<Self, String> {
+        let mut decompress = InitOptions::new(wbits)?.decompress();
+        if let Some(d) = &zdict
+            && wbits < 0
+        {
+            decompress
+                .set_dictionary(d)
+                .map_err(|_| "failed to set dictionary".to_owned())?;
+        }
+        Ok(Self {
+            decompress: Some(decompress),
+            zdict,
+            eof: false,
+            unused_data: Vec::new(),
+            unconsumed_tail: Vec::new(),
+        })
+    }
+
+    pub fn eof(&self) -> bool {
+        self.eof
+    }
+    pub fn unused_data(&self) -> &[u8] {
+        &self.unused_data
+    }
+    pub fn unconsumed_tail(&self) -> &[u8] {
+        &self.unconsumed_tail
+    }
+
+    /// zlib.rs `PyDecompress::decompress_inner`.
+    fn decompress_inner(
+        &mut self,
+        data: &[u8],
+        bufsize: usize,
+        max_length: Option<usize>,
+        is_flush: bool,
+    ) -> Result<(Result<Vec<u8>, String>, bool), String> {
+        let Self {
+            decompress,
+            zdict,
+            unused_data,
+            unconsumed_tail,
+            ..
+        } = self;
+        let Some(d) = decompress.as_mut() else {
+            return Err(USE_AFTER_FINISH_ERR.to_owned());
+        };
+
+        let prev_in = d.total_in();
+        let res = if is_flush {
+            // ignore zdict on a flush, finish on the final chunk
+            let calc_flush = |final_chunk| {
+                if final_chunk {
+                    FlushDecompress::Finish
+                } else {
+                    FlushDecompress::None
+                }
+            };
+            decompress_all(data, d, None, bufsize, max_length, calc_flush)
+        } else {
+            decompress_all(data, d, zdict.as_deref(), bufsize, max_length, |_| {
+                FlushDecompress::Sync
+            })
+        };
+        let (ret, stream_end) = match res {
+            Ok((buf, stream_end)) => (Ok(buf), stream_end),
+            Err(err) => (Err(err), false),
+        };
+        let consumed = (d.total_in() - prev_in) as usize;
+
+        // save unused input
+        let unconsumed = &data[consumed..];
+        if !unconsumed.is_empty() {
+            if stream_end {
+                unused_data.extend_from_slice(unconsumed);
+            } else {
+                *unconsumed_tail = unconsumed.to_vec();
+            }
+        } else if !unconsumed_tail.is_empty() {
+            unconsumed_tail.clear();
+        }
+
+        Ok((ret, stream_end))
+    }
+
+    /// `Decompress.decompress(data, max_length)`; `max_length` of `None` is
+    /// unlimited.
+    #[inline(never)]
+    pub fn decompress(
+        &mut self,
+        data: &[u8],
+        max_length: Option<usize>,
+    ) -> Result<Vec<u8>, String> {
+        let (ret, stream_end) = self.decompress_inner(data, DEF_BUF_SIZE, max_length, false)?;
+        self.eof |= stream_end;
+        ret
+    }
+
+    /// `Decompress.flush(length)`.
+    #[inline(never)]
+    pub fn flush(&mut self, length: usize) -> Result<Vec<u8>, String> {
+        let data = core::mem::take(&mut self.unconsumed_tail);
+        let (ret, _) = self.decompress_inner(&data, length, None, true)?;
+        if self.eof {
+            self.decompress = None;
+        }
+        ret
+    }
+}
+
+// ── buffered decompressor (zlib._ZlibDecompressor, DecompressState) ──────
+
+/// Error surface of [`ZlibDecompressor::decompress`]: `Zlib` maps to
+/// `zlib.error`, `Eof` to `EOFError` ("End of stream already reached").
+#[derive(Debug)]
+pub enum DecompressError {
+    Zlib(String),
+    Eof,
+}
+
+pub struct ZlibDecompressor {
+    decompress: Decompress,
+    zdict: Option<Vec<u8>>,
+    unused_data: Vec<u8>,
+    input_buffer: Vec<u8>,
+    eof: bool,
+    needs_input: bool,
+}
+
+impl ZlibDecompressor {
+    #[inline(never)]
+    pub fn new(wbits: i8, zdict: Option<Vec<u8>>) -> Result<Self, String> {
+        let mut decompress = InitOptions::new(wbits)?.decompress();
+        if let Some(d) = &zdict
+            && wbits < 0
+        {
+            decompress
+                .set_dictionary(d)
+                .map_err(|_| "failed to set dictionary".to_owned())?;
+        }
+        Ok(Self {
+            decompress,
+            zdict,
+            unused_data: Vec::new(),
+            input_buffer: Vec::new(),
+            eof: false,
+            needs_input: true,
+        })
+    }
+
+    pub fn eof(&self) -> bool {
+        self.eof
+    }
+    pub fn unused_data(&self) -> &[u8] {
+        &self.unused_data
+    }
+    pub fn needs_input(&self) -> bool {
+        self.needs_input
+    }
+
+    /// compression.rs `DecompressState::decompress`.
+    #[inline(never)]
+    pub fn decompress(
+        &mut self,
+        data: &[u8],
+        max_length: Option<usize>,
+    ) -> Result<Vec<u8>, DecompressError> {
+        if self.eof {
+            return Err(DecompressError::Eof);
+        }
+
+        let Self {
+            decompress,
+            zdict,
+            unused_data,
+            input_buffer,
+            eof,
+            needs_input,
+        } = self;
+
+        let mut chunks = Chunker::chain(input_buffer.as_slice(), data);
+
+        let prev_len = chunks.len();
+        let (ret, stream_end) = match decompress_chunks(
+            &mut chunks,
+            decompress,
+            zdict.as_deref(),
+            DEF_BUF_SIZE,
+            max_length,
+            |_| FlushDecompress::Sync,
+        ) {
+            Ok((buf, stream_end)) => (Ok(buf), stream_end),
+            Err(err) => (Err(err), false),
+        };
+        let consumed = prev_len - chunks.len();
+
+        *eof |= stream_end;
+
+        if *eof {
+            *needs_input = false;
+            if !chunks.is_empty() {
+                *unused_data = chunks.to_vec();
+            }
+        } else if chunks.is_empty() {
+            input_buffer.clear();
+            *needs_input = true;
+        } else {
+            *needs_input = false;
+            if let Some(n_consumed_from_data) = consumed.checked_sub(input_buffer.len()) {
+                input_buffer.clear();
+                input_buffer.extend_from_slice(&data[n_consumed_from_data..]);
+            } else {
+                input_buffer.drain(..consumed);
+                input_buffer.extend_from_slice(data);
+            }
+        }
+
+        ret.map_err(DecompressError::Zlib)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_default() {
+        let data = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit";
+        let c = compress(data, -1, MAX_WBITS).unwrap();
+        let d = decompress(&c, MAX_WBITS, DEF_BUF_SIZE).unwrap();
+        assert_eq!(d, data);
+    }
+
+    #[test]
+    fn roundtrip_all_levels_and_wbits() {
+        let data = b"the quick brown fox jumps over the lazy dog".repeat(20);
+        for level in 0..=9 {
+            for &wbits in &[15i8, 31, -15] {
+                let c = compress(&data, level, wbits).unwrap();
+                let d = decompress(&c, wbits, DEF_BUF_SIZE).unwrap();
+                assert_eq!(d, data, "level={level} wbits={wbits}");
+            }
+        }
+    }
+
+    #[test]
+    fn bad_level_rejected() {
+        assert!(compress(b"x", 10, MAX_WBITS).is_err());
+        assert!(compress(b"x", -40, MAX_WBITS).is_err());
+    }
+
+    #[test]
+    fn streaming_roundtrip() {
+        let mut co = Compressor::new(-1, MAX_WBITS, None).unwrap();
+        let mut out = co.compress(b"hello ").unwrap();
+        out.extend(co.compress(b"world").unwrap());
+        out.extend(co.flush(Z_FINISH).unwrap());
+        assert!(co.is_finished());
+
+        let mut do_ = Decompressor::new(MAX_WBITS, None).unwrap();
+        let got = do_.decompress(&out, None).unwrap();
+        assert_eq!(got, b"hello world");
+        assert!(do_.eof());
+    }
+
+    #[test]
+    fn buffered_decompressor_gzip_roundtrip() {
+        // gzip uses _ZlibDecompressor(wbits=-MAX_WBITS) over raw deflate.
+        let raw = compress(b"gzip payload contents", -1, -15).unwrap();
+        let mut d = ZlibDecompressor::new(-15, None).unwrap();
+        let got = d.decompress(&raw, None).unwrap();
+        assert_eq!(got, b"gzip payload contents");
+        assert!(d.eof());
+        // decompress after eof raises Eof
+        assert!(matches!(
+            d.decompress(b"", None),
+            Err(DecompressError::Eof)
+        ));
+    }
+
+    #[test]
+    fn buffered_decompressor_incremental_needs_input() {
+        let full = compress(&b"streamed content ".repeat(100), -1, MAX_WBITS).unwrap();
+        let mut d = ZlibDecompressor::new(MAX_WBITS, None).unwrap();
+        let mut out = Vec::new();
+        for byte in full.chunks(1) {
+            out.extend(d.decompress(byte, None).unwrap());
+        }
+        assert_eq!(out, b"streamed content ".repeat(100));
+        assert!(d.eof());
+    }
+
+    #[test]
+    fn streaming_max_length_unconsumed_tail() {
+        let full = compress(&b"abcdefghij".repeat(50), -1, MAX_WBITS).unwrap();
+        let mut d = Decompressor::new(MAX_WBITS, None).unwrap();
+        let first = d.decompress(&full, Some(5)).unwrap();
+        assert_eq!(first.len(), 5);
+        assert!(!d.unconsumed_tail().is_empty());
+        let rest = d.flush(DEF_BUF_SIZE).unwrap();
+        assert_eq!([first, rest].concat(), b"abcdefghij".repeat(50));
+    }
+}

--- a/pyre/pyre-native/src/zlib.rs
+++ b/pyre/pyre-native/src/zlib.rs
@@ -60,7 +60,9 @@ impl InitOptions {
 
     fn compress(self, level: Compression) -> Compress {
         match self {
-            Self::Standard { header, wbits } => Compress::new_with_window_bits(level, header, wbits),
+            Self::Standard { header, wbits } => {
+                Compress::new_with_window_bits(level, header, wbits)
+            }
             Self::Gzip { wbits } => Compress::new_gzip(level, wbits),
         }
     }
@@ -196,9 +198,8 @@ pub fn compress(data: &[u8], level: i32, wbits: i8) -> Result<Vec<u8>, String> {
 #[inline(never)]
 pub fn decompress(data: &[u8], wbits: i8, bufsize: usize) -> Result<Vec<u8>, String> {
     let mut d = InitOptions::new(wbits)?.decompress();
-    let (buf, stream_end) = decompress_all(data, &mut d, None, bufsize, None, |_| {
-        FlushDecompress::Sync
-    })?;
+    let (buf, stream_end) =
+        decompress_all(data, &mut d, None, bufsize, None, |_| FlushDecompress::Sync)?;
     if !stream_end {
         return Err("Error -5 while decompressing data: incomplete or truncated stream".to_owned());
     }
@@ -576,10 +577,7 @@ mod tests {
         assert_eq!(got, b"gzip payload contents");
         assert!(d.eof());
         // decompress after eof raises Eof
-        assert!(matches!(
-            d.decompress(b"", None),
-            Err(DecompressError::Eof)
-        ));
+        assert!(matches!(d.decompress(b"", None), Err(DecompressError::Eof)));
     }
 
     #[test]


### PR DESCRIPTION
Maximizes code shared with RustPython where it does not affect JIT performance: traced interpreter structure keeps PyPy parity, while runtime-independent value logic follows bit-exact CPython 3.14 behavior via shared RustPython crates. All delegated calls sit outside the trace boundary (external-crate calls are residual by the PyreCallRegistry rule), and the perf gate confirms neutrality.

## Shared-crate consumption (Tier 1)
- float repr / `str→float` parse → `rustpython-literal` (replaces an approximate local shortest-repr)
- str/bytes repr escaping → `rustpython-literal::escape`
- `str % args` → `rustpython-common::cformat`
- `str.format` template engine + int/str format specs → `rustpython-common::format`
- int hash → `rustpython-common::hash` (`mod_int`/`fix_sentinel`/`hash_bigint`); `hash("")` fixed to 0

## Module backends (Tier 2)
- mmap: map/unmap/flush/madvise and MAP_/PROT_/MADV_ constants through `host_env::mmap`
- zlib: full DEFLATE compress/decompress via a backend copied from RustPython (flate2 + zlib-rs), replacing raise-only stubs
- binascii: vendored runtime-independent transform core (base64/hex/crc32, CPython 3.14 error strings)

## Unicode + upstream pin
- rustpython crate pins move to upstream main `984cb5089` (unicode crate #8211, host_env mmap re-exports #8214, hash/format fixes #8232 — all merged upstream during this program)
- unicodedata: real implementation over `rustpython-unicode`, replacing a 46-line stub whose `category()` always returned `"Cn"`

## Unblocked by upstream #8232
- float hash → `common::hash::hash_float` (local frexp port deleted)
- **all** finite float presentation types (`''`/`e`/`E`/`f`/`F`/`g`/`G`/`n`/`%`) → `FormatSpec::format_float`; a 2,150,400-case differential against CPython 3.14 is byte-identical and this also fixes 14,636 divergences the previous local formatter had (g/G power-of-ten rounding, empty-type-with-precision, %-overflow alt-form)

## Deliberately kept local
- str/bytes hash: `common` frames data through the `Hash` impl + `mod_int`; pyre uses a raw siphash24 digest — different values, delegation blocked
- `unicodedb.rs` / `caseless` / `unicode-xid`: the unicode crate ships Unicode 17 data while CPython 3.14 is 16.0.0; pyre's local tables are proven bit-exact, so they stay
- float spec error-text mapping and nonfinite formatting (shared engine diverges from CPython messages/padding)

## Gates
- `pyre/check.py --backend dynasm,cranelift`: dynasm 183/183, cranelift 183/183, perf-neutral
- `cargo test -p pyre-interpreter --features dynasm`: 383/383; workspace `--all --features dynasm`: 101 suites, 0 failed
- format battery: 2.15M float-spec cases byte-identical to CPython 3.14; 262k int/float/str spec battery and error-path battery unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for compression/decompression features, including streaming objects and buffered decompression.
  * Improved Unicode data handling with real lookups, normalization, and character property queries.
  * Updated string, bytes, and float formatting to better match Python behavior.
  * Added more accurate hashing and numeric parsing behavior.
  * Expanded binary data utilities for hex, base64, quoted-printable, UU, and CRC operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->