### PR TITLE
jit: disable the #366 non-branch direct-pc carry on wasm

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7256,7 +7256,24 @@ pub(crate) fn fbw_loop_callee_ca_enabled() -> bool {
 /// avoids that.  Default ON — corpus-wide OFF/ON byte-equality validated on
 /// both backends (171/171 dynasm + cranelift); opt out with
 /// `PYRE_M366_NONBRANCH_PC=0`.
+///
+/// The OFF/ON byte-equality was validated on dynasm + cranelift only; those
+/// backends decode a guard exit through the bridge / re-trace path, which
+/// reads the same carried-coordinate liveness twin
+/// (`frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`) the encoder
+/// (`collect_outer_active_boxes`) uses, so encoder and decoder stay symmetric.
+/// wasm re-enters `blackhole_from_resumedata` on every guard exit (no bridge
+/// chaining, #62) and enumerates the raw `-live-` record at the resolved
+/// offset instead of that twin; the two disagree for the carried coordinate,
+/// so the resumed frame materialises the wrong slot value (e.g. a `float /`
+/// dividend reconstructs as a typeless object → `unsupported operand type(s)
+/// for /: '' and ...`). wasm gains nothing from the direct-pc carry — the hot
+/// loop still runs interpreter-bound there — so disable on wasm; keep it on
+/// natively.
 pub(crate) fn m366_nonbranch_pc_enabled() -> bool {
+    if cfg!(target_arch = "wasm32") {
+        return false;
+    }
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M366_NONBRANCH_PC") {
         Some(v) => {


### PR DESCRIPTION
## Problem

`main` is red on `pyre/check.py (ubuntu-24.04)`: the wasm backend fails `synth/float_div_zero_caught_loop` with `TypeError: unsupported operand type(s) for /: '' and 'int'` instead of `37500.0`. Every green PR since #400 inherits this (surfaced most recently on #403). Only the ubuntu leg builds the wasm32 backend, so it is the only failing check.

## Root cause

Regression from #400 (`f3cd5b3ff1`), which flipped `PYRE_M366_NONBRANCH_PC` default **on**. That gate carries a direct JitCode resume pc for the non-branch specialization guards (`GuardValue`/`GuardClass`/`GuardTrue`/`GuardFalse`) instead of the `NO_JITCODE_PC` sentinel. The zero-divisor guard (`float_eq(rhs,0.0) -> guard_false`) deopts every 5th iteration.

`collect_outer_active_boxes` selects the encoder's live-box banks through the carried-coordinate liveness twin (`frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`). Native decodes a guard exit through the bridge / re-trace path, which reads that **same** twin, so encoder and decoder stay symmetric. wasm re-enters `blackhole_from_resumedata` on every guard exit (no bridge chaining, #62) and enumerates the **raw `-live-` record** at the resolved offset instead; the two disagree for the carried coordinate, so the resumed frame materialises the wrong slot value and the float dividend reconstructs as a typeless object.

The #400 carry was byte-equality validated on dynasm + cranelift only, never on wasm, so this decode asymmetry was never exercised.

## Fix

Gate `m366_nonbranch_pc_enabled` off on wasm32, mirroring the existing LOAD_ATTR fold gate (`c4ba73d769`). It is a compile-time `cfg!(target_arch = "wasm32")`, so native machine code is bit-identical — no native regression is possible. The direct-pc carry buys nothing on wasm (interpreter-bound hot loop).

## Verification

- wasm: `float_div_zero_caught_loop` → `37500.0` (was the TypeError).
- native dynasm synth suite: 173/173 pass.