### PR TITLE
#346: retire rtyper legacy walker — numeric boxing-tail residualization + is_null + foreign slices

### DIFF
--- a/majit/majit-translate/src/front/bigint_div_mod_floor.rs
+++ b/majit/majit-translate/src/front/bigint_div_mod_floor.rs
@@ -1,0 +1,321 @@
+//! `bigint::BigInt::div_mod_floor()` → modeled floored `(quotient, modulus)` tuple.
+//!
+//! ## Positioning
+//!
+//! num_integer's `BigInt::div_mod_floor(&self, &Self) -> (Self, Self)` returns a
+//! `(BigInt, BigInt)` tuple whose body is Opaque in the LLBC, so the caller
+//! emits a residual `div_mod_floor` FunctionPath call — an unregistered callee
+//! the rtyper census Skips.  The value flows into a downstream `let (q, m) = …`
+//! destructure the front lowers as `__pos_0` / `__pos_1` tuple field reads.
+//! This pass supplies that producer, sourcing each half from a
+//! `#[dont_look_inside]` residual and reassembling the pair as the same
+//! synthetic-`Tuple` aggregate `Rvalue::Aggregate` emits:
+//!
+//! ```text
+//!     t = num.div_mod_floor(&den)                 // residual `div_mod_floor` call
+//! becomes
+//!     q = jit_bigint_div_floor(num, den)          // floored quotient
+//!     m = jit_bigint_mod_floor(num, den)          // floored modulus
+//!     t = Tuple { __pos_0: q, __pos_1: m }
+//! ```
+//!
+//! `num` / `den` are the raw `*mut BigInt` the front models a `BigInt` value
+//! as (a classdef-less `SomeInstance` GcRef), matching both helpers' i64-over-
+//! `*mut BigInt` ABI; each helper allocates its result in the collecting
+//! nursery.  Sibling of [`crate::front::bigint_div_rem`] — the same branchless
+//! in-place splice, differing only in the floored (not truncated) leaf residuals.
+//!
+//! It is **fail-safe**: a site whose producer op is not the expected 2-arg
+//! residual call is left untouched, and the unregistered `div_mod_floor` callee
+//! keeps the rtyper census Skip (no regression vs the legacy walker).
+
+use crate::flowspace::model::Variable;
+use crate::model::{
+    CallTarget, FieldDescriptor, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType,
+};
+
+/// The `#[dont_look_inside]` residuals the synth calls, spelled to match their
+/// `jit_fnaddr` bindings.
+const DIV_PATH: [&str; 4] = [
+    "pyre_interpreter",
+    "objspace",
+    "descroperation",
+    "jit_bigint_div_floor",
+];
+const REM_PATH: [&str; 4] = [
+    "pyre_interpreter",
+    "objspace",
+    "descroperation",
+    "jit_bigint_mod_floor",
+];
+
+/// A recognized `bigint::BigInt::div_mod_floor()` call site captured during body
+/// lowering (`front::mir` recognizer arm).  The synthetic `Tuple` owner is a
+/// constant, so the site carries only the result var.
+#[derive(Clone)]
+pub(crate) struct BigIntDivModFloorSite {
+    /// The `div_mod_floor` call result (the `(BigInt, BigInt)` tuple) — locates
+    /// the producer op.
+    pub result_var: Variable,
+}
+
+/// Rewrite every recorded `bigint::BigInt::div_mod_floor()` call site into the
+/// modeled floored quotient/modulus tuple.  Fail-safe: a site whose producer op
+/// is not the expected 2-arg residual call is left untouched (Skip).  Returns
+/// the number of sites rewritten.
+pub(crate) fn rewire_bigint_div_mod_floor_call_sites(
+    graph: &mut FunctionGraph,
+    sites: &[BigIntDivModFloorSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        match rewire_one_bigint_div_mod_floor_site(graph, site) {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {
+                // Leave the residual `div_mod_floor` call; the unregistered
+                // callee keeps the rtyper census Skip for this graph.
+            }
+        }
+    }
+    rewritten
+}
+
+fn rewire_one_bigint_div_mod_floor_site(
+    graph: &mut FunctionGraph,
+    site: &BigIntDivModFloorSite,
+) -> Result<(), String> {
+    let name = graph.name.clone();
+    let (a, call_idx) = graph
+        .blocks
+        .iter()
+        .enumerate()
+        .find_map(|(bi, b)| {
+            b.operations
+                .iter()
+                .position(|op| op.result.as_ref() == Some(&site.result_var))
+                .map(|oi| (bi, oi))
+        })
+        .ok_or_else(|| format!("{name}: bigint div_mod_floor result var has no producer op"))?;
+
+    // The producer must be the 2-arg residual call (numerator, denominator).
+    let (num, den) = match &graph.blocks[a].operations[call_idx].kind {
+        OpKind::Call { args, .. } if args.len() == 2 => (args[0].clone(), args[1].clone()),
+        other => {
+            return Err(format!(
+                "{name}: bigint div_mod_floor producer op is not a 2-arg call: {other:?}"
+            ));
+        }
+    };
+
+    // --- Structural validation passed; splice the producer. ---
+    // Key the rebuilt tuple's `__pos_N` owner off the destructure reads so
+    // the writes land on the same (possibly per-shape-suffixed) classdef.
+    let owner = graph.tuple_owner_for_var(&site.result_var);
+    let q = graph.alloc_value_var();
+    let r = graph.alloc_value_var();
+    let inserts = build_div_mod_floor_tuple(&site.result_var, num, den, q, r, &owner);
+
+    let ops = &mut graph.blocks[a].operations;
+    ops.remove(call_idx);
+    for (offset, op) in inserts.into_iter().enumerate() {
+        ops.insert(call_idx + offset, op);
+    }
+    Ok(())
+}
+
+/// A residual `CallTarget::FunctionPath` for a `#[dont_look_inside]` helper.
+fn functionpath(segments: &[&str]) -> CallTarget {
+    CallTarget::FunctionPath {
+        segments: segments.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+/// A synthetic-`Tuple` `__pos_<idx>` `FieldWrite` of a `Ref` element, matching
+/// the `Rvalue::Aggregate` non-Adt tuple chain (owner_root `"Tuple"`, element
+/// ty `Ref(None)`).
+fn tuple_field_write(base: &Variable, idx: usize, value: Variable, owner: &str) -> SpaceOperation {
+    SpaceOperation {
+        result: None,
+        kind: OpKind::FieldWrite {
+            base: base.clone(),
+            field: FieldDescriptor {
+                name: format!("__pos_{idx}"),
+                owner_root: Some(owner.to_string()),
+                owner_id: None,
+            },
+            value: LinkArg::Value(value),
+            ty: ValueType::Ref(None),
+        },
+    }
+}
+
+/// Build the modeled floored quotient/modulus tuple bound to `result_var`: the
+/// two `#[dont_look_inside]` residuals + the synthetic-`Tuple` ctor + `__pos_0` /
+/// `__pos_1` writes, the same transparent-ctor + `FieldWrite` chain
+/// `Rvalue::Aggregate` emits for a non-Adt tuple.
+fn build_div_mod_floor_tuple(
+    result_var: &Variable,
+    num: Variable,
+    den: Variable,
+    q: Variable,
+    r: Variable,
+    owner: &str,
+) -> [SpaceOperation; 5] {
+    [
+        SpaceOperation {
+            result: Some(q.clone()),
+            kind: OpKind::Call {
+                target: functionpath(&DIV_PATH),
+                args: vec![num.clone(), den.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        },
+        SpaceOperation {
+            result: Some(r.clone()),
+            kind: OpKind::Call {
+                target: functionpath(&REM_PATH),
+                args: vec![num, den],
+                result_ty: ValueType::Ref(None),
+            },
+        },
+        SpaceOperation {
+            result: Some(result_var.clone()),
+            kind: OpKind::Call {
+                target: CallTarget::synthetic_transparent_ctor(owner.to_string()),
+                args: Vec::new(),
+                result_ty: ValueType::Ref(Some(owner.to_string())),
+            },
+        },
+        tuple_field_write(result_var, 0, q, owner),
+        tuple_field_write(result_var, 1, r, owner),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn div_mod_floor_target() -> CallTarget {
+        CallTarget::FunctionPath {
+            segments: ["bigint", "BigInt", "div_mod_floor"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        }
+    }
+
+    fn calls_to<'a>(g: &'a FunctionGraph, leaf: &'a str) -> usize {
+        g.blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.last().map(String::as_str) == Some(leaf)
+                )
+            })
+            .count()
+    }
+
+    /// Build `t = num.div_mod_floor(&den)` and assert the rewrite drops the
+    /// `div_mod_floor` call, emits the `jit_bigint_div_floor` /
+    /// `jit_bigint_mod_floor` residuals, and builds the
+    /// `Tuple { __pos_0, __pos_1 }` aggregate on the original result.
+    #[test]
+    fn rewrite_lifts_div_mod_floor_to_modeled_tuple() {
+        let mut g = FunctionGraph::new("test_bigint_div_mod_floor");
+        let a = g.startblock;
+        let num = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let den = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: div_mod_floor_target(),
+                    args: vec![num.clone(), den.clone()],
+                    result_ty: ValueType::Ref(Some("Tuple".into())),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(1);
+        g.set_return(b, None);
+        g.set_goto(a, b, vec![result.clone()]);
+
+        let rewritten = rewire_bigint_div_mod_floor_call_sites(
+            &mut g,
+            &[BigIntDivModFloorSite {
+                result_var: result.clone(),
+            }],
+        );
+        assert_eq!(rewritten, 1, "the div_mod_floor site must be rewritten");
+        assert_eq!(
+            calls_to(&g, "div_mod_floor"),
+            0,
+            "residual div_mod_floor call removed"
+        );
+        assert_eq!(
+            calls_to(&g, "jit_bigint_div_floor"),
+            1,
+            "quotient residual emitted"
+        );
+        assert_eq!(
+            calls_to(&g, "jit_bigint_mod_floor"),
+            1,
+            "modulus residual emitted"
+        );
+        // The aggregate: __pos_0 + __pos_1 writes on the result var.
+        let pos_writes: Vec<usize> = g
+            .blocks
+            .iter()
+            .flat_map(|blk| &blk.operations)
+            .filter_map(|op| match &op.kind {
+                OpKind::FieldWrite { field, .. } if field.name.starts_with("__pos_") => field
+                    .name
+                    .strip_prefix("__pos_")
+                    .and_then(|n| n.parse().ok()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(pos_writes, vec![0, 1], "two positional tuple writes");
+        let ctor_binds_result = g.blocks[a.0].operations.iter().any(|op| {
+            op.result.as_ref() == Some(&result)
+                && matches!(&op.kind, OpKind::Call { args, .. } if args.is_empty())
+        });
+        assert!(ctor_binds_result, "result var re-bound to the Tuple ctor");
+    }
+
+    /// A producer op that is not a 2-arg call declines (fail-safe).
+    #[test]
+    fn rewrite_declines_when_producer_not_binary_call() {
+        let mut g = FunctionGraph::new("test_bigint_div_mod_floor_decline");
+        let a = g.startblock;
+        let num = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let result = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: div_mod_floor_target(),
+                    args: vec![num],
+                    result_ty: ValueType::Ref(Some("Tuple".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.set_return(a, None);
+
+        let rewritten = rewire_bigint_div_mod_floor_call_sites(
+            &mut g,
+            &[BigIntDivModFloorSite { result_var: result }],
+        );
+        assert_eq!(rewritten, 0, "a non-binary producer declines");
+        assert_eq!(
+            calls_to(&g, "div_mod_floor"),
+            1,
+            "residual call survives on decline"
+        );
+    }
+}

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1703,6 +1703,19 @@ pub fn lower_fun_decl_with_static_addrs(
                 &lo.bigint_div_rem_sites,
             );
         }
+        // The `bigint::BigInt::div_mod_floor()` producer rewrite
+        // (`front::bigint_div_mod_floor`) splices the residual `div_mod_floor`
+        // call in place with `jit_bigint_div_floor` / `jit_bigint_mod_floor`
+        // residuals + a synthetic-`Tuple` floored `(quotient, modulus)`
+        // aggregate.  It touches no control flow (no fresh blocks, no detached
+        // edges), so it does not gate the reachability sweep; fail-safe, so a
+        // structural mismatch leaves the residual call (rtyper Skip).
+        if !lo.bigint_div_mod_floor_sites.is_empty() {
+            crate::front::bigint_div_mod_floor::rewire_bigint_div_mod_floor_call_sites(
+                &mut lo.graph,
+                &lo.bigint_div_mod_floor_sites,
+            );
+        }
         if !lo.result_exc_call_results.is_empty()
             || result_exc_callee
             || next_rewritten > 0
@@ -2057,6 +2070,11 @@ struct Lowering<'a> {
     /// post-pass synthesizes (see
     /// [`crate::front::bigint_div_rem::BigIntDivRemSite`]).
     bigint_div_rem_sites: Vec<crate::front::bigint_div_rem::BigIntDivRemSite>,
+    /// `bigint::BigInt::div_mod_floor()` call sites recorded for the modeled
+    /// floored `(quotient, modulus)` tuple producer the
+    /// `front::bigint_div_mod_floor` post-pass synthesizes (see
+    /// [`crate::front::bigint_div_mod_floor::BigIntDivModFloorSite`]).
+    bigint_div_mod_floor_sites: Vec<crate::front::bigint_div_mod_floor::BigIntDivModFloorSite>,
     /// `Option::unwrap_or(opt, default)` call sites recorded for the
     /// discriminant value-select the `front::option_unwrap_or` post-pass
     /// synthesizes after the body lowering completes.  Each carries the
@@ -2239,6 +2257,7 @@ impl<'a> Lowering<'a> {
             option_try_sites: Vec::new(),
             bool_then_sites: Vec::new(),
             bigint_div_rem_sites: Vec::new(),
+            bigint_div_mod_floor_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             unwrap_sites: Vec::new(),
             map_or_sites: Vec::new(),
@@ -6186,6 +6205,26 @@ impl<'a> Lowering<'a> {
                 .push(crate::front::bigint_div_rem::BigIntDivRemSite {
                     result_var: result_var.clone(),
                 });
+        }
+        // Capture `bigint::BigInt::div_mod_floor()` sites for the modeled floored
+        // `(quotient, modulus)` tuple producer `front::bigint_div_mod_floor`
+        // synthesizes.  Opaque foreign 2-arg FunctionPath (numerator,
+        // denominator); the `(BigInt, BigInt)` tuple owner is the synthetic
+        // `"Tuple"` constant, so only the result var is recorded.  A distinct
+        // leaf name from `div_rem`, so this arm coexists with it.
+        if let OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } = &op_kind
+            && args.len() == 2
+            && fmt_path_ends_with(segments, &["bigint", "BigInt", "div_mod_floor"])
+        {
+            self.bigint_div_mod_floor_sites.push(
+                crate::front::bigint_div_mod_floor::BigIntDivModFloorSite {
+                    result_var: result_var.clone(),
+                },
+            );
         }
         // Capture `Option::unwrap_or(opt, default)` /
         // `Result::unwrap_or(res, default)` sites for the discriminant

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -65,6 +65,7 @@
 //! treated as opaque ops.
 
 pub(crate) mod bigint_binop;
+pub(crate) mod bigint_div_mod_floor;
 pub(crate) mod bigint_div_rem;
 pub(crate) mod bool_then;
 pub(crate) mod checked_arith;

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2104,6 +2104,8 @@ pub(crate) fn register_unsafe_fn_stubs(
 ///
 /// - `core::mem::swap(&mut T, &mut T)` returns `()` — an in-place swap,
 ///   `Void` result.
+/// - `core::cell::Cell::<T>::set(&self, val)` returns `()` — an
+///   in-place store into the cell, `Void` result.
 /// - `core::f64::<Impl>::is_infinite` / `core::slice::<Impl>::is_empty`
 ///   return `bool` — `Bool` result.
 /// - `std::f64::<Impl>::floor` / `std::f64::<Impl>::powf` return `f64` —
@@ -2122,6 +2124,11 @@ pub(crate) fn register_unsafe_fn_stubs(
 /// "not registered" Skip until their result type can be modeled.
 const FOREIGN_STDLIB_EXTERNALS: &[(&[&str], &[&str], LowLevelType)] = &[
     (&["core", "mem", "swap"], &["x", "y"], LowLevelType::Void),
+    (
+        &["cell", "Cell", "set"],
+        &["self", "val"],
+        LowLevelType::Void,
+    ),
     (
         &["core", "f64", "<Impl>", "is_infinite"],
         &["self"],

--- a/majit/majit-translate/src/translator/rtyper/llannotation.rs
+++ b/majit/majit-translate/src/translator/rtyper/llannotation.rs
@@ -266,13 +266,13 @@ impl SomePtr {
                 // `SomeBool`.  Last-resort after both `_lookup_adtmeth` and
                 // the struct-field `getattr`, so a real `is_null` adt
                 // member or field is never shadowed.
-                Err(_) if attr == "is_null" => Ok(SomeValue::BuiltinMethod(
-                    SomeBuiltinMethod::new(
+                Err(_) if attr == "is_null" => {
+                    Ok(SomeValue::BuiltinMethod(SomeBuiltinMethod::new(
                         "ptr_method_is_null",
                         SomeValue::Ptr(self.clone()),
                         "is_null",
-                    ),
-                )),
+                    )))
+                }
                 Err(e) => Err(AnnotatorError::new(e)),
             },
             Ok(lltype::LowLevelAdtMember::Method { ll_ptrtype, func }) => {

--- a/majit/majit-translate/src/translator/rtyper/llannotation.rs
+++ b/majit/majit-translate/src/translator/rtyper/llannotation.rs
@@ -28,9 +28,9 @@ use super::lltypesystem::lltype;
 use crate::annotator::argument::ArgumentsForTranslation;
 use crate::annotator::bookkeeper;
 use crate::annotator::model::{
-    AnnotatorError, KnownType, SomeAddress, SomeBool, SomeChar, SomeFloat, SomeInteger,
-    SomeLongFloat, SomeObject, SomeObjectTrait, SomePtr, SomeSingleFloat, SomeUnicodeCodePoint,
-    SomeValue, SomeValueTag, s_bool, s_none,
+    AnnotatorError, KnownType, SomeAddress, SomeBool, SomeBuiltinMethod, SomeChar, SomeFloat,
+    SomeInteger, SomeLongFloat, SomeObject, SomeObjectTrait, SomePtr, SomeSingleFloat,
+    SomeUnicodeCodePoint, SomeValue, SomeValueTag, s_bool, s_none,
 };
 use crate::flowspace::model::{ConstValue, Constant};
 use crate::flowspace::operation::{CanOnlyThrow, HLOperation, OpKind, Specialization, pure};
@@ -251,10 +251,30 @@ impl SomePtr {
         };
         let example = self.ll_ptrtype._example();
         match example._lookup_adtmeth(attr) {
-            Err(lltype::AttributeError) => {
-                let v = example.getattr(attr).map_err(AnnotatorError::new)?;
-                Ok(ll_to_annotation(v))
-            }
+            Err(lltype::AttributeError) => match example.getattr(attr) {
+                Ok(v) => Ok(ll_to_annotation(v)),
+                // A raw-pointer `p.is_null()` whose receiver keeps its
+                // `SomePtr` tag (e.g. the `*mut u8` opaque GCREF from
+                // `try_gc_alloc_stable_raw`, `TO: Opaque(GCREF)`) reaches
+                // this `SomePtr.getattr` rather than the `SomeObject` /
+                // `SomeInstance` `is_null` arms.  `front::mir` already
+                // routed it as `CallTarget::Method { name: "is_null",
+                // receiver_root: "mut_ptr"/"const_ptr" }`, which
+                // `jtransform` lowers to `ptr_iszero` regardless of the
+                // receiver repr; answer the getattr with the same
+                // `ptr_method_is_null` bound method so the result types as
+                // `SomeBool`.  Last-resort after both `_lookup_adtmeth` and
+                // the struct-field `getattr`, so a real `is_null` adt
+                // member or field is never shadowed.
+                Err(_) if attr == "is_null" => Ok(SomeValue::BuiltinMethod(
+                    SomeBuiltinMethod::new(
+                        "ptr_method_is_null",
+                        SomeValue::Ptr(self.clone()),
+                        "is_null",
+                    ),
+                )),
+                Err(e) => Err(AnnotatorError::new(e)),
+            },
             Ok(lltype::LowLevelAdtMember::Method { ll_ptrtype, func }) => {
                 Ok(SomeValue::LLADTMeth(SomeLLADTMeth::new(ll_ptrtype, func)))
             }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -611,6 +611,21 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::objspace::descroperation::jit_bigint_rem",
         crate::objspace::descroperation::jit_bigint_rem as *const (),
     );
+    // `jit_bigint_div_floor` / `jit_bigint_mod_floor` residualize the
+    // `div_mod_floor()` tuple synth (`front::bigint_div_mod_floor`): the foreign
+    // malachite `div_mod_floor` returns a floored `(BigInt, BigInt)` the tracer
+    // models as a `__pos_0`/`__pos_1` tuple sourced from these two
+    // `#[dont_look_inside]` calls, bound by path.
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_div_floor",
+        crate::objspace::descroperation::jit_bigint_div_floor as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_mod_floor",
+        crate::objspace::descroperation::jit_bigint_mod_floor as *const (),
+    );
     // `jit_bigint_{and,or,xor,sub,mul}` residualize the foreign BigInt binary
     // operators (`<BigInt as BitAnd>::bitand`, …) the `front::mir` retarget
     // (`front::bigint_binop`) redirects when both operands are the opaque

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -522,6 +522,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::module::w_module_new_aliasing_dict",
+        "pyre_object::w_module_new_aliasing_dict",
+        pyre_object::module::w_module_new_aliasing_dict as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_interpreter::function::function_new_impl",
         "pyre_interpreter::function_new_impl",
         crate::function::function_new_impl as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -547,6 +547,24 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_alloc_stable_raw",
         pyre_object::gc_hook::try_gc_alloc_stable_raw as *const (),
     );
+    // The interp-alloc boxing tail's two GC-hook toucher residuals: `note_alloc`
+    // bumps the runtime-mutable `ALLOC_SINCE_GC` atomic, and
+    // `try_gc_charge_oldgen_external` dispatches through a thread-local `Cell`.
+    // Neither is a build-time constant, so both carry `#[dont_look_inside]` and
+    // bind their `()`-returning `fn` directly by qualified path (siblings of
+    // `try_gc_alloc_stable_raw` / `gc_interp::enabled`).
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_interp::note_alloc",
+        "pyre_object::note_alloc",
+        pyre_object::gc_interp::note_alloc as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_hook::try_gc_charge_oldgen_external",
+        "pyre_object::try_gc_charge_oldgen_external",
+        pyre_object::gc_hook::try_gc_charge_oldgen_external as *const (),
+    );
     push_fnaddr(
         &mut entries,
         "pyre_interpreter::module::_weakref::interp__weakref::dereference",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -488,6 +488,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::unicodeobject::w_str_new",
+        "pyre_object::w_str_new",
+        pyre_object::unicodeobject::w_str_new as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::gc_hook::try_gc_add_root",
         "pyre_object::try_gc_add_root",
         pyre_object::gc_hook::try_gc_add_root as *const (),

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -116,6 +116,32 @@ pub extern "C" fn jit_bigint_rem(a: i64, b: i64) -> *mut BigInt {
     unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_rem(&*b).1) }
 }
 
+/// `rbigint.floordiv`'s floored quotient — the `.0` of `num_integer::div_mod_floor`
+/// on two bare `*const BigInt` payloads. The foreign malachite `div_mod_floor`
+/// returns a `(BigInt, BigInt)` tuple the tracer cannot model, so the front
+/// `div_mod_floor` synth (`front::bigint_div_mod_floor`) replaces the call with
+/// the floored quotient (this) + floored modulus ([`jit_bigint_mod_floor`])
+/// sourcing a modeled 2-tuple. Allocates the result via the COLLECTING nursery
+/// (a gcmap-rooted residual, its operand pointers rooted across the alloc),
+/// matching the arithmetic residuals. Returns a freshly heap-allocated
+/// `*mut BigInt` — a `ref`-token return so the CodeWriter models the result as
+/// a traced GcRef.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_div_floor(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_mod_floor(&*b).0) }
+}
+
+/// `rbigint.mod`'s floored modulus — the `.1` of `num_integer::div_mod_floor`.
+/// See [`jit_bigint_div_floor`]; the two share the `(BigInt, BigInt)` floored
+/// semantics the `front::bigint_div_mod_floor` synth reassembles into a modeled
+/// tuple.
+#[majit_macros::dont_look_inside]
+pub extern "C" fn jit_bigint_mod_floor(a: i64, b: i64) -> *mut BigInt {
+    let (a, b) = (a as *const BigInt, b as *const BigInt);
+    unsafe { pyre_object::longobject::alloc_bigint_nursery_collecting((&*a).div_mod_floor(&*b).1) }
+}
+
 // ── BigInt binary-operator residuals ─────────────────────────────────
 // The foreign malachite operator impls (`<BigInt as BitAnd>::bitand`, …)
 // are Opaque in the LLBC, so a traced-into caller (`bigint_truediv`) emits

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -177,7 +177,11 @@ pub fn clear_gc_charge_oldgen_external_hook() {
 /// minor, so it is safe after allocating an unrooted payload: a directly-old-gen
 /// bignum's limb `Vec` would otherwise stay invisible to the threshold until
 /// the next major's `recompute_oldgen_external_bytes`.
-#[inline]
+// `dont_look_inside`: host hook dispatch (`thread_local!` `Cell` indirection)
+// stays opaque to the JIT — the `try_gc_add_root` / `try_gc_remove_root` /
+// `try_gc_write_barrier` twins; calls residualize via the registered fnaddr
+// (`rlib/jit.py:139`). A `()` return has no discriminant to erase.
+#[majit_macros::dont_look_inside]
 pub fn try_gc_charge_oldgen_external(obj_addr: usize, bytes: usize) {
     GC_CHARGE_OLDGEN_EXTERNAL_HOOK.with(|cell| {
         if let Some(f) = cell.get() {

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -126,7 +126,12 @@ pub fn enabled() -> bool {
 
 /// Account for one interpreter-routed allocation. Called from `w_int_new` /
 /// `w_float_new` after a successful `try_gc_alloc_stable`.
-#[inline]
+///
+/// Touches the runtime-mutable `ALLOC_SINCE_GC` atomic; the value is not a
+/// build-time constant, so the JIT residualises the call instead of tracing
+/// into it (`@dont_look_inside`, the [`enabled`] sibling). A `()` return has no
+/// discriminant to erase.
+#[majit_macros::dont_look_inside]
 pub fn note_alloc() {
     ALLOC_SINCE_GC.fetch_add(1, Ordering::Relaxed);
 }

--- a/pyre/pyre-object/src/module.rs
+++ b/pyre/pyre-object/src/module.rs
@@ -127,6 +127,15 @@ pub fn w_module_new(name: &str, dict_ptr: *mut u8) -> PyObjectRef {
 /// setitem is skipped — the subclass's own `__init__` is responsible
 /// for seeding `__name__` (matching PyPy `moduledef.py:102-103
 /// Module(space, None, w_builtin)` where `w_name=None`).
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`):
+/// the body performs an unported `lltype::malloc_typed` NewWithVtable
+/// (`Module`) that survives `fuse_boxing_alloc` unfused, so the JIT
+/// residualises the whole call to a stable runtime fnaddr instead of
+/// tracing the allocation — the `w_module_dict_new_with_storage_proxy`
+/// twin.  The `-> PyObjectRef` result is a plain GCREF with no
+/// discriminant to erase.
+#[majit_macros::dont_look_inside]
 pub fn w_module_new_aliasing_dict(
     name: &str,
     _dict_ptr: *mut u8,

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -61,6 +61,14 @@ impl crate::lltype::GcType for W_UnicodeObject {
 /// The inner `Wtf8Buf` is also `Box::into_raw`'d so it can be recovered.
 /// `from_string` takes ownership of the bytes with no copy or
 /// re-validation (every `&str` is already valid WTF-8).
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`), the
+/// `box_str_constant` twin: the body runs a `str::chars` count plus an
+/// unfused `malloc_typed` NewWithVtable (`W_UnicodeObject`), so the JIT
+/// residualises the whole `&str -> W_UnicodeObject` construction to a
+/// stable fnaddr instead of tracing it.  The `-> PyObjectRef` result is a
+/// plain GCREF with no discriminant to erase.
+#[majit_macros::dont_look_inside]
 pub fn w_str_new(s: &str) -> PyObjectRef {
     let value = crate::lltype::malloc_raw(Wtf8Buf::from_string(s.to_string()));
     let byte_len = s.len();


### PR DESCRIPTION
(untracked)

## Summary

A series of slices toward gh #346 (retire the rtyper legacy walker). Each makes the two-phase (annotate → rtype) prepass lift graphs the legacy walker currently covers, by residualizing foreign/opaque calls and widening annotator coverage. Every slice keeps `pyre/check.py` green (dynasm / cranelift / wasm 183/183, 3/3 backend runs).

## Slices

1. **Cell::set + w_module_new_aliasing_dict** (`e27f9ad1b8`) — register `core::cell::Cell::set` as a `Void` FOREIGN_STDLIB_EXTERNALS row; `#[dont_look_inside]` residualize `w_module_new_aliasing_dict`.
2. **w_str_new** (`b9eb555540`) — `#[dont_look_inside]` residualize (the `box_str_constant` twin: `str::chars` count + unfused `malloc_typed`). Census 36→35.
3. **is_null on any SomePtr receiver** (`9401ed1e0e`) — `SomePtr::getattr` answers `is_null` for Opaque-GCREF pointers (`*mut u8` from `try_gc_alloc_stable_raw`) via `ptr_method_is_null`→`SomeBool`, as a last-resort after `_lookup_adtmeth` and the struct-field `getattr`, so a real member is never shadowed. Widens the prior List/Dict-only gate; unblocks the numeric boxing tail's `is_null`.
4. **GC-hook keystone** (`e2364002b4`) — `#[dont_look_inside]` `note_alloc` + `try_gc_charge_oldgen_external`. Both touch runtime-mutable GC statics the tracer walked into as unregistered FunctionPaths (`ALLOC_SINCE_GC`, `GC_CHARGE_OLDGEN_EXTERNAL_HOOK`), failing the whole numeric family's boxing tail with an empty `compute_at_fixpoint` panic. Census cat1 38→35; `int_mod` / `int_bitand` / `int_rshift` / `long_mul` lift to CodeWriter.
5. **div_mod_floor front tuple-splice** (`91d4bef482`) — mirror of the `div_rem` splice for the floored `(quotient, modulus)` pair: `#[dont_look_inside]` `jit_bigint_div_floor` / `jit_bigint_mod_floor` residuals + a `front::bigint_div_mod_floor` recognizer/rewrite.

## Remaining

After these, the numeric descroperation family advances to the generic-ADT-collapse phi-merge wall (`cannot unify instances with no common base class`, `cutover.rs:1281`) — the next and largest lever (per-instantiation classdef specialization), scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
