### PR TITLE
float.fromhex: delegate to rustpython_common::float_ops::from_hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +659,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "dualtape"
 version = "0.0.2"
 dependencies = [
@@ -716,6 +744,12 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "endian-type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equivalent"
@@ -906,6 +940,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "ordermap",
  "smallvec",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -1416,6 +1460,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1791,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2273,7 +2340,7 @@ dependencies = [
  "pyre-object",
  "pyre-sandbox",
  "rustpython-compiler",
- "rustyline",
+ "rustyline 17.0.2",
 ]
 
 [[package]]
@@ -2334,7 +2401,17 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
- "endian-type",
+ "endian-type 0.1.2",
+ "nibble_vec",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
+dependencies = [
+ "endian-type 0.2.0",
  "nibble_vec",
 ]
 
@@ -2508,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap",
@@ -2531,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "ascii",
  "bitflags 2.11.1",
@@ -2554,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -2568,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "bitflags 2.11.1",
  "bitflagset",
@@ -2584,14 +2661,17 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "bitflags 2.11.1",
+ "dns-lookup",
+ "gethostname",
  "getrandom 0.4.2",
  "junction",
  "libc",
  "libffi",
  "libloading",
+ "mac_address",
  "memmap2 0.9.10",
  "nix 0.31.3",
  "num-traits",
@@ -2600,8 +2680,12 @@ dependencies = [
  "paste",
  "rustix",
  "rustpython-wtf8",
+ "rustyline 18.0.1",
  "schannel",
+ "socket2",
+ "system-configuration",
  "termios",
+ "which",
  "widestring",
  "windows-sys 0.61.2",
 ]
@@ -2609,7 +2693,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2688,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "bitflags 2.11.1",
  "num_enum",
@@ -2700,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "icu_casemap",
  "icu_normalizer",
@@ -2713,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=984cb5089ebb04ce22c37c467c0fc001af2a2f36#984cb5089ebb04ce22c37c467c0fc001af2a2f36"
+source = "git+https://github.com/RustPython/RustPython.git?rev=a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a#a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a"
 dependencies = [
  "ascii",
  "bstr",
@@ -2742,11 +2826,32 @@ dependencies = [
  "log",
  "memchr",
  "nix 0.30.1",
- "radix_trie",
+ "radix_trie 0.2.1",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustyline"
+version = "18.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "clipboard-win",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.31.3",
+ "radix_trie 0.3.0",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2922,6 +3027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3103,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3866,6 +4002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,16 @@ pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
 # Pinned to upstream main, which now carries the rustpython-unicode crate,
-# the host_env mmap re-exports, and the float hash/format fixes (#8232).
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "984cb5089ebb04ce22c37c467c0fc001af2a2f36" }
+# the host_env mmap re-exports, and the round-half-even float_ops::from_hex
+# hex-float parser (#8234).
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8739,60 +8739,27 @@ fn init_float_type(ns: &mut DictStorage) {
                 .ok_or_else(|| {
                     crate::PyError::type_error("fromhex() requires a string argument")
                 })?;
-            let s = s_arg.trim();
-            let lower = s.to_ascii_lowercase();
-            match lower.as_str() {
-                "inf" | "infinity" | "+inf" | "+infinity" => {
-                    return Ok(pyre_object::w_float_new(f64::INFINITY));
+            // Delegate parsing to the shared hex-float reader, which rounds
+            // round-half-even over the full exponent range (subnormals down to
+            // 0x1p-1074), accepts the inf/nan spellings, handles surrounding
+            // ASCII whitespace itself, and flags overflow distinctly.
+            match rustpython_common::float_ops::from_hex(&s_arg) {
+                Ok(v) => Ok(pyre_object::w_float_new(v)),
+                Err(e) => {
+                    use rustpython_common::float_ops::HexFloatError;
+                    Err(match e {
+                        HexFloatError::Overflow => crate::PyError::overflow_error(
+                            "hexadecimal value too large to represent as a float",
+                        ),
+                        HexFloatError::TooLong => {
+                            crate::PyError::value_error("hexadecimal string too long to convert")
+                        }
+                        HexFloatError::Invalid => {
+                            crate::PyError::value_error("invalid hexadecimal floating-point string")
+                        }
+                    })
                 }
-                "-inf" | "-infinity" => {
-                    return Ok(pyre_object::w_float_new(f64::NEG_INFINITY));
-                }
-                "nan" | "+nan" | "-nan" => {
-                    return Ok(pyre_object::w_float_new(f64::NAN));
-                }
-                _ => {}
             }
-            let (sign_s, rest) = if let Some(r) = s.strip_prefix('-') {
-                (-1.0f64, r)
-            } else if let Some(r) = s.strip_prefix('+') {
-                (1.0f64, r)
-            } else {
-                (1.0f64, s)
-            };
-            let rest = rest
-                .strip_prefix("0x")
-                .or_else(|| rest.strip_prefix("0X"))
-                .unwrap_or(rest);
-            let (body, exp_str) = if let Some(i) = rest.find(|c| c == 'p' || c == 'P') {
-                (&rest[..i], &rest[i + 1..])
-            } else {
-                (rest, "0")
-            };
-            let (int_part, frac_part) = if let Some(i) = body.find('.') {
-                (&body[..i], &body[i + 1..])
-            } else {
-                (body, "")
-            };
-            let int_val = if int_part.is_empty() {
-                0u64
-            } else {
-                u64::from_str_radix(int_part, 16).map_err(|_| {
-                    crate::PyError::value_error("invalid hexadecimal floating-point literal")
-                })?
-            };
-            let mut frac_val = 0f64;
-            for (i, ch) in frac_part.chars().enumerate() {
-                let d = ch.to_digit(16).ok_or_else(|| {
-                    crate::PyError::value_error("invalid hexadecimal floating-point literal")
-                })? as f64;
-                frac_val += d / 16f64.powi(i as i32 + 1);
-            }
-            let exp: i32 = exp_str.parse().map_err(|_| {
-                crate::PyError::value_error("invalid hexadecimal floating-point literal")
-            })?;
-            let mantissa = int_val as f64 + frac_val;
-            Ok(pyre_object::w_float_new(sign_s * mantissa * 2f64.powi(exp)))
         }),
     );
     dict_storage_store(


### PR DESCRIPTION
## Summary

Retire the hand-rolled `float.fromhex` parser in `init_float_type` and delegate to the shared `rustpython_common::float_ops::from_hex`, landed upstream in RustPython/RustPython#8234.

- Bump the RustPython pin `984cb5089…` → `a5eecb5ebfd48dc62fc05913d16a556d6b0ccd3a` (carries #8234; also #8233 c-api move + #7932 hostenv isolation — 3 commits total).
- Replace the parser: the old code built `sign * mantissa * 2f64.powi(exp)`, which overflowed to `0` across the whole subnormal range and neither rounded round-half-even nor reported overflow. `float_ops::from_hex` rounds round-half-even over the full exponent range (subnormals down to `0x1p-1074`), accepts the inf/nan spellings, handles surrounding ASCII whitespace itself, and returns `HexFloatError::{Overflow,TooLong,Invalid}` — mapped here to `OverflowError` / `ValueError`.

The upstream parser is a faithful port of `float_fromhex`, verified bit-exact against 125,000 comparison cases (0 mismatches).

## Verification

`pyre -m unittest -v test.test_float.HexFloatTestCase`:

| test | result |
|---|---|
| `test_from_hex` | ok |
| `test_ends` | ok |
| `test_invalid_inputs` | ok |
| `test_whitespace` | ok |
| `test_roundtrip` | ERROR — pre-existing, orthogonal (see below) |
| `test_subclass` | FAIL — pre-existing, orthogonal (see below) |

The previously-buggy subnormal case now round-trips (`float.fromhex((1.5).hex()) == 1.5`, etc.).

## The two remaining failures are pre-existing and unrelated to this change

Both live outside the fromhex path; this PR touches only `Cargo.toml`, `Cargo.lock`, and the fromhex block in `typedef.rs`.

- **`test_roundtrip`** errors in its *scaffolding*: it constructs inputs with `math.ldexp(m, e)`, and pyre's `math.ldexp` raises `ValueError: math domain error: ERANGE` on overflow instead of `OverflowError`, so the test's `except OverflowError` misses it. `math.ldexp` lives in `module/math/mod.rs`, untouched here; the bug is deterministic (`math.ldexp(0.5, 1100)` reproduces it), so it fails identically on `main`. Separate follow-up.
- **`test_subclass`** exercises `F.fromhex(...)` on a `float` subclass. `fromhex` is registered as a plain builtin that ignores `cls`, so it returns a base `float` rather than constructing via `cls`. Orthogonal to parsing; separate follow-up.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hexadecimal floating-point parsing so `float.fromhex()` handles more cases consistently and returns clearer errors for invalid or oversized inputs.
  * Updated the app’s Rust dependencies to a newer upstream revision, bringing in the latest fixes and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->