### PR TITLE
jit: decline wasm bridges with CallMayForce re-entry (real fix for the #404 workaround)

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1380,6 +1380,20 @@ impl majit_backend::Backend for WasmBackend {
             return Err(BackendError::Unsupported(reason));
         }
 
+        // Decline bridges that re-enter the interpreter through a may-force
+        // residual call. Such a bridge reconstructs the interpreter value stack
+        // from its inputargs before the CallMayForce; on wasm a float-const
+        // dividend materialises as NULL through that inputarg path, so the
+        // re-entered interpreter runs `truediv(NULL, int)` and raises a spurious
+        // `unsupported operand type(s) for /`. Native never compiles this
+        // side-trace — it blackholes the deopt instead. Declining here routes
+        // the deopt back through the blackhole interpreter, matching native.
+        if ops.iter().any(|op| op.opcode.is_call_may_force()) {
+            return Err(BackendError::Unsupported(
+                "wasm backend: bridge with CallMayForce interpreter re-entry".into(),
+            ));
+        }
+
         // The source guard this bridge attaches to. `fail_index` is its index in
         // the source loop's `fail_descrs` / cell array; `trace_id` identifies the
         // owning trace.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7256,24 +7256,7 @@ pub(crate) fn fbw_loop_callee_ca_enabled() -> bool {
 /// avoids that.  Default ON — corpus-wide OFF/ON byte-equality validated on
 /// both backends (171/171 dynasm + cranelift); opt out with
 /// `PYRE_M366_NONBRANCH_PC=0`.
-///
-/// The OFF/ON byte-equality was validated on dynasm + cranelift only; those
-/// backends decode a guard exit through the bridge / re-trace path, which
-/// reads the same carried-coordinate liveness twin
-/// (`frame_liveness_reg_indices_by_bank_at_with_jitcode_pc`) the encoder
-/// (`collect_outer_active_boxes`) uses, so encoder and decoder stay symmetric.
-/// wasm re-enters `blackhole_from_resumedata` on every guard exit (no bridge
-/// chaining, #62) and enumerates the raw `-live-` record at the resolved
-/// offset instead of that twin; the two disagree for the carried coordinate,
-/// so the resumed frame materialises the wrong slot value (e.g. a `float /`
-/// dividend reconstructs as a typeless object → `unsupported operand type(s)
-/// for /: '' and ...`). wasm gains nothing from the direct-pc carry — the hot
-/// loop still runs interpreter-bound there — so disable on wasm; keep it on
-/// natively.
 pub(crate) fn m366_nonbranch_pc_enabled() -> bool {
-    if cfg!(target_arch = "wasm32") {
-        return false;
-    }
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var_os("PYRE_M366_NONBRANCH_PC") {
         Some(v) => {


### PR DESCRIPTION
## Summary

Real fix for the wasm `float_div_zero_caught_loop` failure that #404 worked around by gating the #366 non-branch direct-pc carry off on wasm.

**Root cause.** Under the m366 carry, the checked-float-truediv deopt (`float_eq(rhs,0.0) -> guard_false`, every 5th iteration) gets a guard side-trace (**bridge**) compiled for it on wasm only. That bridge does `NewWithVtable` + `SetfieldGc` + `CallMayForceR(...1.5-float-const..., v80, 5)` — it re-enters the plain interpreter through a may-force residual call. On wasm the reconstructed interpreter value stack has the `1.5` dividend as NULL, so the re-entered interpreter runs `truediv(NULL, int)` → `TypeError: unsupported operand type(s) for /: '' and 'int'`. **Native never compiles this bridge — it blackholes the deopt** and prints `37500.0`.

The earlier "wasm liveness twin ≠ raw `-live-` decode" (#404) and a later "wasm32 32-bit object-layout corruption" hypothesis were both wrong; the latter was a stale-wasm-module measurement artifact. The blackhole path runs byte-identically on wasm and native — the divergence is native-blackhole vs wasm-bridge.

## Fix

1. **`majit-backend-wasm` `compile_bridge`** — decline any bridge whose ops contain a may-force call, so the deopt routes back through the blackhole interpreter, matching native.
2. **`jitcode_dispatch.rs`** — with the deopt handled, the m366 carry resumes correctly on wasm, so the wasm-only gate in `m366_nonbranch_pc_enabled` (added in #404) and its stale doc-comment are removed. m366 is now ON on all backends (parity).

dynasm/cranelift codegen is unaffected by construction: the lib.rs change is wasm-backend-only, and the removed jitcode gate branch was never taken on native.

## Verification

- `wasm synth/float_div_zero_caught_loop` → `37500.0`
- wasm synthetic suite **173/173**
- dynasm synthetic suite **173/173**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge handling to avoid a runtime path that could surface division-related interpreter errors, matching native behavior more closely.
  * Fixed feature flag behavior so the non-branch PC setting now respects the environment variable consistently across platforms.
  
* **Documentation**
  * Updated feature notes to clarify the default behavior and how to disable it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->