### PR TITLE
majit: opt-in trait-family method dispatch + census follow-ups

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -1801,6 +1801,74 @@ impl Bookkeeper {
         self.getuniqueclassdef(&variant_host)
     }
 
+    /// Register a trait family for receiver-driven method dispatch: a base
+    /// `ClassDef` `base_root` with each `(impl_root, members)` interned as a
+    /// subclass, carrying method MEMBERS so `getattr(instance, method)`
+    /// resolves to a `MethodDesc` PBC family — the RPython instance-method
+    /// [`MethodsPBCRepr`](crate::translator::rtyper::rpbc::MethodsPBCRepr)
+    /// dispatch path.
+    ///
+    /// Mirrors [`Self::getuniqueclassdef_for_enum_variant`] (a base plus
+    /// subclasses interned WITH that base as their sole `__bases__`, so
+    /// `ClassDef.basedef`/`subdefs`/`getmro` chain), but seeds method members
+    /// through [`HostObject::new_class_with_members`].  Plain pyre struct
+    /// classdefs are minted member-less by
+    /// [`Self::intern_class_by_qualname`] (`HostObject::new_class`) and carry
+    /// only fields (`project_struct_rows`); a `dyn Trait` receiver therefore
+    /// annotates to a classdef-less shell and every `getattr` on it fails.
+    /// The members seeded here are what `ClassDesc::find_source_for` reads via
+    /// `pyobj.class_get(name)` → `add_source_attribute`, so the trait methods
+    /// become classdict attributes and `s_getattr` yields the PBC family.
+    ///
+    /// `base_members` (trait default-body methods) attach to the base;
+    /// each impl's `members` (its required-method overrides) attach to that
+    /// subclass — mirroring the trait's default-vs-required split, so the MRO
+    /// getattr binds each method to its correct owner.
+    ///
+    /// OPT-IN: only a trait registered through this entry point gets a
+    /// member-carrying host in `pyre_struct_root_classes`.  Every other
+    /// (unregistered) multi-impl trait keeps its current classdef-less /
+    /// fail-loud disposition, so this cannot perturb the annotation of pyre
+    /// production dispatch that was never registered.
+    ///
+    /// Returns the base `ClassDef`.
+    pub fn register_trait_family(
+        self: &Rc<Self>,
+        base_root: &str,
+        base_members: HashMap<String, ConstValue>,
+        impls: Vec<(String, HashMap<String, ConstValue>)>,
+    ) -> Result<Rc<RefCell<ClassDef>>, AnnotatorError> {
+        // Base first — its identity-keyed HostObject must be published in
+        // `pyre_struct_root_classes` before the subclasses intern, so each
+        // subclass's `__bases__` resolves to this exact base host (the same
+        // discipline `getuniqueclassdef_for_enum_variant` relies on).
+        let base_key = majit_ir::descr::canonical_struct_name(base_root);
+        let base_host = crate::flowspace::model::HostObject::new_class_with_members(
+            base_key.clone(),
+            Vec::new(),
+            base_members,
+        );
+        self.pyre_struct_root_classes
+            .borrow_mut()
+            .insert(base_key, base_host.clone());
+        let base_cd = self.getuniqueclassdef(&base_host)?;
+        // Subclasses — interned WITH the base host so `ClassDesc::new` wires
+        // `basedef` and `_init_classdef` pushes each into `base.subdefs`.
+        for (impl_root, members) in impls {
+            let impl_key = majit_ir::descr::canonical_struct_name(&impl_root);
+            let impl_host = crate::flowspace::model::HostObject::new_class_with_members(
+                impl_key.clone(),
+                vec![base_host.clone()],
+                members,
+            );
+            self.pyre_struct_root_classes
+                .borrow_mut()
+                .insert(impl_key, impl_host.clone());
+            self.getuniqueclassdef(&impl_host)?;
+        }
+        Ok(base_cd)
+    }
+
     /// Intern (first-mint-wins) and return the canonical variant-subclass
     /// `HostObject` for `{enum_root}::{variant_name}`, wiring the enum's
     /// discriminant-only base as its sole `__bases__` (`rclass.py:82-88`).
@@ -5846,6 +5914,160 @@ mod tests {
             matches!(varnames.s_value, SomeValue::List(_)),
             "varnames must project to SomeList, got {:?}",
             varnames.s_value
+        );
+    }
+
+    /// Fixture for the methods-on-classdef capability that `dyn Trait`
+    /// receiver-driven dispatch (issue #346, aheui LinkedList) needs.
+    ///
+    /// A ≥2-impl trait family registered through `register_trait_family`
+    /// must (a) link a base ClassDef to its impl subclasses, (b) carry the
+    /// trait methods as members so `getattr(instance, method)` annotates to
+    /// a `MethodDesc` PBC family instead of a classdef-less shell, and
+    /// (c) let the existing `MethodsPBCRepr` port lower that family to a
+    /// vtable/method dispatch.  Plain pyre struct classdefs carry fields
+    /// only, so this method-member path is exercised here for the first time.
+    #[test]
+    fn register_trait_family_getattr_yields_method_pbc_and_rtypes_via_methods_pbc_repr() {
+        use crate::annotator::classdesc::ClassDef;
+        use crate::annotator::model::SomeValue;
+        use crate::translator::rtyper::rpbc::MethodsPBCRepr;
+        use crate::translator::rtyper::rtyper::RPythonTyper;
+        use std::collections::HashMap;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let bk = ann.bookkeeper.clone();
+
+        // A method member is a user function backed by a GraphFunc — the
+        // same shape `HostObject::new_class`'s `__dict__` would carry, and
+        // what `add_source_attribute` turns into a MethodDesc.
+        let member = |name: &str| -> ConstValue {
+            ConstValue::HostObject(HostObject::new_user_function(GraphFunc::new(
+                name.to_string(),
+                Constant::new(ConstValue::Dict(Default::default())),
+            )))
+        };
+
+        // Base trait `T` with a default-body method `shared`; three impls
+        // A/B/C each override `shared`.  This is the ≥2-impl multi-impl
+        // family shape that annotates classdef-less today.
+        let mut base_members = HashMap::new();
+        base_members.insert("shared".to_string(), member("T::shared"));
+        let mut impls = Vec::new();
+        for impl_name in ["A", "B", "C"] {
+            let mut m = HashMap::new();
+            m.insert(
+                "shared".to_string(),
+                member(&format!("{impl_name}::shared")),
+            );
+            impls.push((impl_name.to_string(), m));
+        }
+        let base_cd = bk
+            .register_trait_family("T", base_members, impls)
+            .expect("register_trait_family must succeed");
+
+        // (a) base ↔ subclass links.
+        assert_eq!(
+            base_cd.borrow().subdefs.len(),
+            3,
+            "base classdef must link 3 impl subclasses"
+        );
+
+        // (b) getattr(instance_of_T, "shared") resolves to a MethodDesc PBC
+        // family — NOT `SomeInstance(classdef=None)`, NOT "attribute not
+        // found".  `s_getattr` on the base ClassDef is exactly what
+        // `SomeInstance.getattr` (unaryop.rs:4143) calls for an instance of
+        // that classdef; populate the attr across the tree first (the
+        // fixpoint analog).
+        ClassDef::check_missing_attribute_update(&base_cd, "shared")
+            .expect("attr population must succeed");
+        let s_shared = ClassDef::s_getattr(&base_cd, "shared", &std::collections::BTreeMap::new())
+            .expect("s_getattr(shared) must resolve");
+        let pbc = match &s_shared {
+            SomeValue::PBC(p) => p.clone(),
+            other => panic!("expected a method PBC for `shared`, got {other:?}"),
+        };
+        let n_methods = pbc
+            .descriptions
+            .values()
+            .filter(|d| d.as_method().is_some())
+            .count();
+        assert!(
+            n_methods >= 3,
+            "expected >=3 MethodDescs in the `shared` family (the subclass \
+             overrides), got {n_methods}: {pbc:?}"
+        );
+
+        // (c) the `MethodsPBCRepr` port — possibly never exercised on a
+        // pyre-synthesized method PBC — must accept the family and resolve
+        // its owner + bound-`self` InstanceRepr (the vtable dispatch seed).
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        let repr = MethodsPBCRepr::new(&rtyper, pbc)
+            .expect("MethodsPBCRepr must accept the pyre-synthesized method family");
+        assert_eq!(repr.methodname, "shared");
+        assert!(
+            Rc::ptr_eq(&repr.classdef, &base_cd),
+            "MethodsPBCRepr must fold the family's owner to the base classdef"
+        );
+    }
+
+    /// Diagnostic for the LinkedList wiring: the real dispatch blockers
+    /// (`_get_2_values` / `head` / `dup`) are trait REQUIRED methods —
+    /// declared on the trait, bodied only on the impl subclasses.  This
+    /// probes a base-instance `getattr` of a method that exists ONLY on the
+    /// subclasses (absent from the base member map).
+    ///
+    /// FINDING: it resolves to the full impl family anyway.  RPython's
+    /// attrfamily merge homes a same-named attribute defined across sibling
+    /// subclasses onto their common base, so `s_getattr(base, "req")` returns
+    /// the {A,B,C}::req MethodDesc PBC even though the base declares no `req`.
+    /// => piece-3 registration can seed the impls ONLY; it need NOT synthesize
+    /// a base declaration for required (default-body-less) trait methods.
+    #[test]
+    fn register_trait_family_subclass_only_method_surfaces_on_base() {
+        use crate::annotator::classdesc::ClassDef;
+        use crate::annotator::model::SomeValue;
+        use std::collections::HashMap;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let bk = ann.bookkeeper.clone();
+        let member = |name: &str| -> ConstValue {
+            ConstValue::HostObject(HostObject::new_user_function(GraphFunc::new(
+                name.to_string(),
+                Constant::new(ConstValue::Dict(Default::default())),
+            )))
+        };
+
+        // Base `T` declares NO `req`; each impl bodies `req` — the
+        // required-method-with-no-default-body shape.
+        let mut impls = Vec::new();
+        for impl_name in ["A", "B", "C"] {
+            let mut m = HashMap::new();
+            m.insert("req".to_string(), member(&format!("{impl_name}::req")));
+            impls.push((impl_name.to_string(), m));
+        }
+        let base_cd = bk
+            .register_trait_family("T", HashMap::new(), impls)
+            .expect("register_trait_family must succeed");
+
+        ClassDef::check_missing_attribute_update(&base_cd, "req").expect("attr population");
+        let s_req = ClassDef::s_getattr(&base_cd, "req", &std::collections::BTreeMap::new())
+            .expect("s_getattr(req) must not error");
+        let n_methods = match &s_req {
+            SomeValue::PBC(p) => p
+                .descriptions
+                .values()
+                .filter(|d| d.as_method().is_some())
+                .count(),
+            other => panic!("expected a method PBC for subclass-only `req`, got {other:?}"),
+        };
+        // The attrfamily merge surfaces the subclass-only method on the base:
+        // one MethodDesc per impl, so a base-typed / trait-object receiver
+        // dispatches across all impls without a base declaration.
+        assert_eq!(
+            n_methods, 3,
+            "subclass-only `req` must surface all 3 impl MethodDescs on the \
+             base via attrfamily merge, got {n_methods}: {s_req:?}"
         );
     }
 }

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -350,6 +350,16 @@ pub struct Bookkeeper {
     /// RPython's annotator never needs this: it sees the concrete
     /// receiver class at every call site (`classdesc.py:749 lookup`).
     pub pyre_trait_unique_impls: RefCell<HashMap<String, String>>,
+    /// Trait qualified-path (`name_path()`) → base `HostObject` for a
+    /// receiver-driven method-dispatch family registered through
+    /// [`Self::register_trait_family`] (issue #346).
+    /// `derive_subject_inputcells` seeds a `dyn Trait` receiver whose
+    /// `class_root` is a key here with the base `ClassDef`, so
+    /// `getattr(receiver, method)` resolves the impl-subclass
+    /// `MethodDesc` family (attrfamily merge) rather than blocking on
+    /// the classdef-less shell.  Empty unless a consumer opts a trait
+    /// in; pyre production registers none.
+    pub pyre_trait_family_bases: RefCell<HashMap<String, HostObject>>,
     /// TODO: no upstream equivalent.  Struct names first interned by
     /// [`Self::project_pyre_field_type`]'s bare-name arm whose
     /// registry rows have not been projected yet — drained at the end
@@ -538,6 +548,7 @@ impl Bookkeeper {
             pyre_enum_variant_by_discriminant: RefCell::new(None),
             pyre_struct_root_classes: RefCell::new(HashMap::new()),
             pyre_trait_unique_impls: RefCell::new(HashMap::new()),
+            pyre_trait_family_bases: RefCell::new(HashMap::new()),
             pending_struct_row_projection: RefCell::new(Vec::new()),
             projected_struct_rows: RefCell::new(std::collections::HashSet::new()),
         }
@@ -594,6 +605,20 @@ impl Bookkeeper {
             .as_ref()
             .map(|reg| reg.fields.keys().cloned().collect())
             .unwrap_or_default()
+    }
+
+    /// True when `leaf` is the trait-leaf of a registered dispatch family
+    /// ([`Self::pyre_trait_family_bases`], keyed by the trait's full
+    /// `name_path()`).  A method call lowered as `FunctionPath [<leaf>,
+    /// method]` (`front::mir`'s `CallKind::Trait` arm spells the trait by
+    /// leaf) routes through the receiver's getattr when this matches and
+    /// the direct-path registry has no entry (the required-method,
+    /// `>=2`-impl case).  Empty unless a consumer opts a trait in.
+    pub fn is_registered_trait_family_leaf(&self, leaf: &str) -> bool {
+        self.pyre_trait_family_bases
+            .borrow()
+            .keys()
+            .any(|path| path.rsplit("::").next().unwrap_or(path) == leaf)
     }
 
     /// No upstream equivalent — forced by pyre's numbering order, not a
@@ -1851,6 +1876,13 @@ impl Bookkeeper {
         self.pyre_struct_root_classes
             .borrow_mut()
             .insert(base_key, base_host.clone());
+        // Index the base by the raw `base_root` spelling too, so the
+        // receiver seed (`derive_subject_inputcells`) can match a
+        // `dyn Trait` receiver's `class_root` (the trait's `name_path()`)
+        // directly without re-canonicalising.
+        self.pyre_trait_family_bases
+            .borrow_mut()
+            .insert(base_root.to_string(), base_host.clone());
         let base_cd = self.getuniqueclassdef(&base_host)?;
         // Subclasses — interned WITH the base host so `ClassDesc::new` wires
         // `basedef` and `_init_classdef` pushes each into `base.subdefs`.

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -562,6 +562,20 @@ impl GraphStore {
     }
 }
 
+/// Opt-in receiver-driven method-dispatch family (issue #346).  A
+/// consumer names a `>=2`-impl trait whose `dyn Trait` receivers should
+/// annotate to a base `ClassDef` linking the impl subclasses, so a
+/// method getattr on the receiver resolves the impl `MethodDesc` family
+/// (attrfamily merge) instead of blocking on the classdef-less shell.
+/// `base_root` is the trait's qualified `name_path()` — the same
+/// spelling `tyref_generic_trait_bound_root` stamps as a receiver's
+/// `class_root`; `impl_roots` are its concrete impl owner roots.
+#[derive(Debug, Clone)]
+pub struct TraitFamilyRegistration {
+    pub base_root: String,
+    pub impl_roots: Vec<String>,
+}
+
 /// Call control — decides inline vs residual for each call target.
 ///
 /// RPython: `call.py::CallControl`.
@@ -811,6 +825,13 @@ pub struct CallControl {
     /// while a subject graph annotated standalone only knows the
     /// trait bound.
     trait_unique_impls: HashMap<String, String>,
+
+    /// Opt-in receiver-driven method-dispatch families (see
+    /// [`TraitFamilyRegistration`]).  Empty for pyre production — its
+    /// multi-impl traits keep their classdef-less / fail-loud
+    /// disposition; a consumer (e.g. the aheui census) opts specific
+    /// traits in through [`Self::set_trait_family_registrations`].
+    trait_family_registrations: Vec<TraitFamilyRegistration>,
 
     /// RPython: `symbolic.get_array_token(ARRAY, tsc)[0]` — array base size.
     /// Offset from the array object pointer to the first element.
@@ -1256,6 +1277,7 @@ impl CallControl {
             struct_fields: crate::front::StructFieldRegistry::default(),
             enum_variant_by_discriminant: HashMap::new(),
             trait_unique_impls: HashMap::new(),
+            trait_family_registrations: Vec::new(),
             // RPython: symbolic.get_array_token(GcArray(T))[0] = carray.items.offset
             // = sizeof(Signed) = WORD. Standard GcArray has a length field before items.
             //
@@ -1350,6 +1372,19 @@ impl CallControl {
     /// bookkeeper alongside [`Self::struct_fields`].
     pub fn trait_unique_impls(&self) -> &HashMap<String, String> {
         &self.trait_unique_impls
+    }
+
+    /// Register the opt-in receiver-driven method-dispatch families (see
+    /// [`TraitFamilyRegistration`]).  Consumed by
+    /// `CodeWriter::dual_gate_registry` before the class-method seeding
+    /// so each family's base + impl subclasses are minted first.
+    pub fn set_trait_family_registrations(&mut self, families: Vec<TraitFamilyRegistration>) {
+        self.trait_family_registrations = families;
+    }
+
+    /// The opt-in receiver-driven method-dispatch families.
+    pub fn trait_family_registrations(&self) -> &[TraitFamilyRegistration] {
+        &self.trait_family_registrations
     }
 
     /// RPython: isinstance(TYPE, lltype.Struct) check.

--- a/majit/majit-translate/src/codewriter/codewriter.rs
+++ b/majit/majit-translate/src/codewriter/codewriter.rs
@@ -149,6 +149,13 @@ impl CodeWriter {
         // path (`derive_subject_inputcells` resolves a bound-trait
         // `class_root` through it before the struct-root lookup).
         registry.set_pyre_trait_unique_impls(callcontrol.trait_unique_impls().clone());
+        // Opt-in receiver-driven dispatch families (issue #346): mint
+        // each registered trait's base ClassDef + impl subclasses BEFORE
+        // `seed_struct_root_method_members` below, so the method seeding
+        // attaches the impl methods onto the base-linked subclass and a
+        // `dyn Trait` receiver getattr resolves the impl MethodDesc
+        // family (attrfamily merge).  Empty for pyre production.
+        registry.register_trait_families(callcontrol.trait_family_registrations());
         // PyPy's `Bookkeeper.compute_at_fixpoint` raises through to
         // the caller (`bookkeeper.py:108-127`); pyre's dual-gate
         // mirrors that propagation by routing the populate `TyperError`
@@ -186,6 +193,11 @@ impl CodeWriter {
         // instead of blocking.  AFTER populate (which seeds the unsafe-fn
         // stubs internally) so the entry set is complete.
         registry.seed_struct_root_method_members();
+        // Issue #346: register the just-seeded impl-subclass methods into
+        // their ClassDef attr sources so a family-base / `dyn Trait`
+        // receiver getattr resolves the impl MethodDesc family via the
+        // attrfamily merge.  No-op for pyre production (no families).
+        registry.populate_trait_family_base_attrs(callcontrol.trait_family_registrations());
         // RPython parity: `Translator.buildannotator()` /
         // `Translator.buildrtyper()` (`translator.py:69-83`) construct
         // exactly one annotator and one rtyper per Translator and assert

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4778,8 +4778,7 @@ impl<'a> Lowering<'a> {
                             let Operand::Const(value) = op else {
                                 return None;
                             };
-                            let DecodedConst::Int(n) =
-                                decode_constant(self.llbc, value).ok()?
+                            let DecodedConst::Int(n) = decode_constant(self.llbc, value).ok()?
                             else {
                                 return None;
                             };
@@ -12370,6 +12369,17 @@ fn operator_name(kind: &serde_json::Value) -> Option<&str> {
     }
 }
 
+/// The overflow mode string of an operator object (`{"Add": "Wrap"}` →
+/// `Some("Wrap")`). Atom operators (`"Add"`) and payloads that are not a
+/// bare string (cast targets, multi-key objects) yield `None`.
+fn operator_mode(kind: &serde_json::Value) -> Option<&str> {
+    let obj = kind.as_object()?;
+    if obj.len() != 1 {
+        return None;
+    }
+    obj.values().next()?.as_str()
+}
+
 /// Decode a `Field` projection on a tuple container —
 /// `{"Field": [{"Tuple": N}, idx]}` — to its element index.
 fn const_tuple_field_index(elem: &ProjectionElem) -> Option<u64> {
@@ -12429,9 +12439,13 @@ fn const_eval_binop(kind: &serde_json::Value, lhs: ConstLit, rhs: ConstLit) -> O
     let name = operator_name(kind)?;
     match (lhs, rhs) {
         (ConstLit::Int(a), ConstLit::Int(b)) => match name {
-            // checked_* also on the Wrap-mode forms: a genuinely
-            // wrapping fold would need the operand width, so bail to
-            // the residual Call instead of folding wrong.
+            // Wrapping Add/Sub/Mul: the correct result depends on the
+            // operand width the i64 carrier has dropped (`255u8 + 1`
+            // wraps to 0, not 256), so residualize instead of folding
+            // at 64-bit width. Non-wrapping (panic-checked) forms reach
+            // the arms below, where checked_* is exact because a valid
+            // const initializer never overflows.
+            "Add" | "Sub" | "Mul" if operator_mode(kind) == Some("Wrap") => None,
             "Add" => a.checked_add(b).map(ConstLit::Int),
             "Sub" => a.checked_sub(b).map(ConstLit::Int),
             "Mul" => a.checked_mul(b).map(ConstLit::Int),
@@ -12441,6 +12455,12 @@ fn const_eval_binop(kind: &serde_json::Value, lhs: ConstLit, rhs: ConstLit) -> O
                 .ok()
                 .and_then(|s| a.checked_shl(s))
                 .map(ConstLit::Int),
+            // Right shift: the carrier lost the operand's signedness, so
+            // a negative `a` is ambiguous between a signed value (which
+            // wants an arithmetic shift) and an unsigned value past
+            // i64::MAX (which wants a logical shift). Fold only for
+            // `a >= 0`, where both shifts agree; residualize otherwise.
+            "Shr" if a < 0 => None,
             "Shr" => u32::try_from(b)
                 .ok()
                 .and_then(|s| a.checked_shr(s))
@@ -14263,6 +14283,84 @@ mod tests {
         for p in ["f32", "f64", "()", ""] {
             assert!(!type_arg_splits_per_instantiation(p), "{p} must not split");
         }
+    }
+
+    #[test]
+    fn const_eval_binop_declines_width_and_sign_ambiguous_folds() {
+        use super::{ConstLit, const_eval_binop};
+        use serde_json::json;
+
+        // Wrapping Add/Sub/Mul: the i64 carrier has no operand width, so
+        // `255u8 + 1` (wraps to 0, not 256) must residualize.
+        assert!(
+            const_eval_binop(
+                &json!({ "Add": "Wrap" }),
+                ConstLit::Int(255),
+                ConstLit::Int(1)
+            )
+            .is_none()
+        );
+        assert!(
+            const_eval_binop(
+                &json!({ "Sub": "Wrap" }),
+                ConstLit::Int(0),
+                ConstLit::Int(1)
+            )
+            .is_none()
+        );
+        assert!(
+            const_eval_binop(
+                &json!({ "Mul": "Wrap" }),
+                ConstLit::Int(16),
+                ConstLit::Int(16)
+            )
+            .is_none()
+        );
+        // Non-wrapping (panic-checked) forms still fold: a valid const
+        // initializer never overflows, so checked_* is exact.
+        assert!(matches!(
+            const_eval_binop(
+                &json!({ "Add": "Panic" }),
+                ConstLit::Int(255),
+                ConstLit::Int(1)
+            ),
+            Some(ConstLit::Int(256))
+        ));
+
+        // Right shift with a negative carrier is signedness-ambiguous
+        // (`u64::MAX >> 1` collapsed to `-1 >> 1`) — decline.
+        assert!(
+            const_eval_binop(
+                &json!({ "Shr": "Wrap" }),
+                ConstLit::Int(-1),
+                ConstLit::Int(1)
+            )
+            .is_none()
+        );
+        // A non-negative left operand shifts identically signed/unsigned.
+        assert!(matches!(
+            const_eval_binop(
+                &json!({ "Shr": "Wrap" }),
+                ConstLit::Int(0x7fff_ffff),
+                ConstLit::Int(1)
+            ),
+            Some(ConstLit::Int(0x3fff_ffff))
+        ));
+
+        // Census fold targets survive: SMALL_MAX = `(1i64<<62)-1` builds
+        // from a Shl and a SubChecked; SMALL_MIN negates the same Shl.
+        assert!(matches!(
+            const_eval_binop(&json!({ "Shl": "Panic" }), ConstLit::Int(1), ConstLit::Int(62)),
+            Some(ConstLit::Int(v)) if v == 1i64 << 62
+        ));
+        assert!(matches!(
+            const_eval_binop(&json!("SubChecked"), ConstLit::Int(1i64 << 62), ConstLit::Int(1)),
+            Some(ConstLit::Checked(v, false)) if v == (1i64 << 62) - 1
+        ));
+        assert!(matches!(
+            const_eval_binop(&json!("AddChecked"), ConstLit::Int(1i64 << 62), ConstLit::Int(1)),
+            Some(ConstLit::Checked(v, false)) if v == (1i64 << 62) + 1
+        ));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4356,6 +4356,7 @@ impl<'a> Lowering<'a> {
                     .or_else(|| self.static_int_value_op(&segments))
                     .or_else(|| self.const_eval_global(id))
                     .or_else(|| self.fold_size_const_global(id))
+                    .or_else(|| self.fold_named_const_int_array_global(id))
                     .or_else(|| primitive_float_const(&segments))
                     .unwrap_or_else(|| OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
@@ -4724,6 +4725,96 @@ impl<'a> Lowering<'a> {
             }),
             _ => None,
         }
+    }
+
+    /// Fold a `NamedConst` global whose initializer builds a fixed-size
+    /// array of integer literals (`OP_STACKDEL: [i32; N] = [c0, c1, …]`)
+    /// into the synthetic prebuilt-constant-array define-op the adapter
+    /// re-folds to `Constant(list)`
+    /// (`flowspace_adapter.rs::is_const_int_array_define`).  A
+    /// module-level constant array is a prebuilt `Constant(ll_array)`
+    /// whose `arr[i]` runtime-index read is a foldable `getarrayitem`
+    /// (the `ArrayRead` the `Index` projection arm emits); baking the
+    /// literals here lets that read resolve against a constant base
+    /// instead of a residual accessor `Call` no registry can bind.
+    ///
+    /// Accepts only the exact `_0 = [c0, c1, …]; return` shape: a single
+    /// `Array` aggregate assigned to `_0` whose operands are all integer
+    /// literals, over linear `Goto`s to a `Return`.  Anything richer
+    /// (computed elements, non-integer items, a `Repeat` fill, a second
+    /// `_0` write) returns `None` and keeps the residual accessor path;
+    /// so does a foreign const whose init body Charon left opaque (no
+    /// readable body to bake).
+    fn fold_named_const_int_array_global(&self, def_id: u64) -> Option<OpKind> {
+        let gd = self.llbc.global_by_id(def_id)?;
+        if gd
+            .rest
+            .get("global_kind")
+            .and_then(serde_json::Value::as_str)
+            != Some("NamedConst")
+        {
+            return None;
+        }
+        let init_id = gd.rest.get("init")?.as_u64()?;
+        let body = self.llbc.fn_by_id(init_id)?.unstructured()?;
+        let mut items: Option<Vec<i64>> = None;
+        for block in &body.body {
+            for stmt in &block.statements {
+                match stmt.stmt_kind() {
+                    Ok(StmtKind::StorageLive(_))
+                    | Ok(StmtKind::StorageDead(_))
+                    | Ok(StmtKind::PlaceMention(_)) => {}
+                    Ok(StmtKind::Assign(place, Rvalue::Aggregate(kind, operands)))
+                        if matches!(place.kind, PlaceKind::Local(0)) =>
+                    {
+                        // Only a fixed-size `Array` aggregate of integer
+                        // literals; a `Repeat` fill or an Adt aggregate is
+                        // out of scope, as is a second `_0`-defining assign.
+                        if aggregate_ctor_name(&kind) != "Array" || items.is_some() {
+                            return None;
+                        }
+                        let mut vals = Vec::with_capacity(operands.len());
+                        for op in &operands {
+                            let Operand::Const(value) = op else {
+                                return None;
+                            };
+                            let DecodedConst::Int(n) =
+                                decode_constant(self.llbc, value).ok()?
+                            else {
+                                return None;
+                            };
+                            vals.push(n);
+                        }
+                        items = Some(vals);
+                    }
+                    // Any other statement (a write to a temporary or a
+                    // richer `_0` definition) means the array is computed,
+                    // not a literal aggregate.
+                    _ => return None,
+                }
+            }
+            match block.term() {
+                Ok(TermKind::Return) | Ok(TermKind::Goto { .. }) => {}
+                _ => return None,
+            }
+        }
+        let items = items?;
+        // The annotator infers the list's element type from the baked
+        // literals, so an empty array carries no element type; leave it
+        // to the residual path.
+        if items.is_empty() {
+            return None;
+        }
+        let mut segments = Vec::with_capacity(items.len() + 1);
+        segments.push("__const_int_array".to_string());
+        for n in items {
+            segments.push(n.to_string());
+        }
+        Some(OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args: Vec::new(),
+            result_ty: ValueType::Ref(None),
+        })
     }
 
     fn static_addr_op(&self, segments: &[String]) -> Option<OpKind> {

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1203,10 +1203,32 @@ fn analyze_pipeline_from_module_paths(
                         .iter()
                         .map(|owner| owner.rsplit("::").next().unwrap_or(owner).to_string())
                         .collect();
-                    Some(call::TraitFamilyRegistration {
-                        base_root: trait_qualified.clone(),
-                        impl_roots,
-                    })
+                    // The family interning + method seeding key impl
+                    // subclasses by leaf (`canonical_struct_name`), so two
+                    // impls whose qualified owners share a leaf across
+                    // modules would collapse to one classdef and silently
+                    // drop a member. Skip such a family — leaving the
+                    // trait's classdef-less / fail-loud disposition — rather
+                    // than mis-seed it; a same-leaf consumer needs
+                    // qualified-root interning end-to-end (the leaf-keyed
+                    // struct registry and receiver match are pre-existing).
+                    // Mirrors the `struct_leaf_counts` bail on the
+                    // single-impl path below.
+                    let mut seen = std::collections::HashSet::new();
+                    let dup_leaf = impl_roots.iter().find(|leaf| !seen.insert(leaf.as_str()));
+                    if let Some(dup) = dup_leaf {
+                        eprintln!(
+                            "register_trait_families: {trait_qualified:?} has impls sharing \
+                             leaf {dup:?} across modules ({owners:?}); skipping — leaf-keyed \
+                             seeding cannot disambiguate them"
+                        );
+                        None
+                    } else {
+                        Some(call::TraitFamilyRegistration {
+                            base_root: trait_qualified.clone(),
+                            impl_roots,
+                        })
+                    }
                 }
                 None => {
                     // Config validation: a named family that matches no

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1182,6 +1182,53 @@ fn analyze_pipeline_from_module_paths(
             *struct_leaf_counts.entry(leaf).or_default() += 1;
         }
     }
+    // Opt-in receiver-driven dispatch families (issue #346): a consumer
+    // (e.g. the aheui census) names `>=2`-impl trait qualified paths
+    // whose `dyn Trait` receivers should annotate to a base ClassDef
+    // linking the impl subclasses, so a method getattr on the receiver
+    // resolves the impl MethodDesc family.  Pyre production names none,
+    // so its multi-impl traits keep their classdef-less / fail-loud
+    // disposition unchanged.  Built from `trait_impl_owners` (before it
+    // is consumed below) and forwarded through `CallControl` to
+    // `dual_gate_registry`, which mints each family before the
+    // class-method seeding.
+    let trait_family_registrations: Vec<call::TraitFamilyRegistration> = config
+        .pipeline
+        .register_trait_families
+        .iter()
+        .filter_map(
+            |trait_qualified| match trait_impl_owners.get(trait_qualified) {
+                Some(owners) => {
+                    let impl_roots: Vec<String> = owners
+                        .iter()
+                        .map(|owner| owner.rsplit("::").next().unwrap_or(owner).to_string())
+                        .collect();
+                    Some(call::TraitFamilyRegistration {
+                        base_root: trait_qualified.clone(),
+                        impl_roots,
+                    })
+                }
+                None => {
+                    // Config validation: a named family that matches no
+                    // harvested trait is almost always a spelling mismatch
+                    // (the key is the trait's full `name_path()`).  List the
+                    // available multi-impl trait paths so the consumer can
+                    // correct it.
+                    let candidates: Vec<&String> = trait_impl_owners
+                        .iter()
+                        .filter(|(_, owners)| owners.len() >= 2)
+                        .map(|(path, _)| path)
+                        .collect();
+                    eprintln!(
+                        "register_trait_families: no harvested trait matches {trait_qualified:?}; \
+                     known multi-impl trait paths: {candidates:?}"
+                    );
+                    None
+                }
+            },
+        )
+        .collect();
+    call_control.set_trait_family_registrations(trait_family_registrations);
     let trait_unique_impls: std::collections::HashMap<String, String> = trait_impl_owners
         .into_iter()
         .filter_map(|(trait_qualified, owners)| {

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -47,6 +47,15 @@ pub struct PipelineConfig {
     /// (`execute_opcode_step`) for backwards compatibility with the
     /// pyre-specific entry path.
     pub portal: Option<PortalSpec>,
+    /// Opt-in receiver-driven method-dispatch families (issue #346):
+    /// qualified `name_path()`s of `>=2`-impl traits whose `dyn Trait`
+    /// receivers should annotate to a base `ClassDef` linking the impl
+    /// subclasses (so a method getattr resolves the impl `MethodDesc`
+    /// family via the attrfamily merge).  Empty for pyre production — its
+    /// multi-impl traits keep their classdef-less / fail-loud
+    /// disposition; the aheui census opts `LinkedList` in.
+    #[serde(default)]
+    pub register_trait_families: Vec<String>,
 }
 
 /// Result of running the full pipeline on a single function.

--- a/majit/majit-translate/src/test_support.rs
+++ b/majit/majit-translate/src/test_support.rs
@@ -48,5 +48,6 @@ pub(crate) fn pyre_pipeline_config() -> crate::PipelineConfig {
             ..Default::default()
         },
         portal: None,
+        register_trait_families: Vec::new(),
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1709,6 +1709,54 @@ pub fn translate_op(
                         crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments(
                             segments.iter().cloned(),
                         );
+                    // Method-routing for a registered dispatch family
+                    // (issue #346).  `front::mir`'s `CallKind::Trait` arm
+                    // lowers `<Trait>::method(receiver, …)` to a
+                    // `FunctionPath [<trait leaf>, method]`.  The
+                    // direct-path binder (`lib.rs`) registers only trait
+                    // default bodies and single-impl devirtualizations; a
+                    // REQUIRED method with `>=2` impls is intentionally
+                    // left unregistered ("keep failing loud until
+                    // receiver-driven resolution lands").  When the trait
+                    // is an opted-in family and the receiver carries the
+                    // family base `ClassDef` (seeded by
+                    // `derive_subject_inputcells`), lower the call as a
+                    // `getattr` + `simple_call` so the attrfamily merge
+                    // resolves the impl `MethodDesc` family — exactly as
+                    // `CallTarget::Method`.  Gated on an exact registry
+                    // miss so default bodies and single-impl devirt (both
+                    // registered) keep their direct FunctionPath.
+                    if segments.len() == 2
+                        && call_registry.lookup(&key).is_none()
+                        && call_registry
+                            .bookkeeper()
+                            .is_registered_trait_family_leaf(&segments[0])
+                    {
+                        let mut iter = arg_hls.into_iter();
+                        let receiver = iter.next().ok_or_else(|| {
+                            TyperError::message(format!(
+                                "translate_op: family method call {segments:?} \
+                                 has no receiver arg (receiver must be args[0])"
+                            ))
+                        })?;
+                        let bound_method = Hlvalue::Variable(Variable::new());
+                        let mut call_args = Vec::with_capacity(iter.size_hint().0 + 1);
+                        call_args.push(bound_method.clone());
+                        call_args.extend(iter);
+                        return Ok(vec![
+                            FlowspaceOp::new(
+                                "getattr",
+                                vec![
+                                    receiver,
+                                    Hlvalue::Constant(Constant::new(ConstValue::byte_str(
+                                        &segments[1],
+                                    ))),
+                                ],
+                                bound_method,
+                            ),
+                            FlowspaceOp::new("simple_call", call_args, result),
+                        ]);
+                    }
                     // Three resolution layers, matching upstream's three
                     // dispatch shapes for a dotted call site:
                     //
@@ -2641,6 +2689,38 @@ pub(crate) fn derive_subject_inputcells(
                     continue;
                 }
                 if let (Some(root), Some(bk)) = (class_root.as_ref(), bookkeeper) {
+                    // A registered receiver-driven dispatch family (issue
+                    // #346): a `dyn Trait` receiver whose bound-trait
+                    // `class_root` names a family opted in through
+                    // `register_trait_families` seeds the family base
+                    // `ClassDef`.  Its impl subclasses carry the methods
+                    // (attrfamily merge), so a method getattr on the
+                    // receiver resolves the impl `MethodDesc` family
+                    // instead of blocking on the classdef-less shell.
+                    // Checked before the unique-impl substitution below —
+                    // a multi-impl family has no unique impl to fold to.
+                    let family_base = bk
+                        .pyre_trait_family_bases
+                        .borrow()
+                        .get(root.as_str())
+                        .cloned();
+                    if let Some(base_host) = family_base {
+                        let cd = bk.getuniqueclassdef(&base_host).map_err(|e| {
+                            TyperError::message(format!(
+                                "derive_subject_inputcells: startblock.inputargs[{idx}] \
+                                 ({var:?}) trait-family base for {root:?} failed \
+                                 ClassDef registration: {e:?}"
+                            ))
+                        })?;
+                        cells.push(crate::annotator::model::SomeValue::Instance(
+                            crate::annotator::model::SomeInstance::new(
+                                Some(cd),
+                                false,
+                                std::collections::BTreeMap::new(),
+                            ),
+                        ));
+                        continue;
+                    }
                     // A generic param (`&T` where `T: Trait`, incl. a
                     // trait default body's `&Self`) carries the bound
                     // trait's qualified path as `class_root`

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -626,6 +626,44 @@ fn is_str_const_define(kind: &OpKind) -> bool {
     )
 }
 
+/// `true` iff `kind` is `front::mir`'s synthetic prebuilt-constant-array
+/// define-op (`Call(["__const_int_array", <i0>, <i1>, …])`,
+/// `fold_named_const_int_array_global`).  A module-level constant array
+/// is carried as a bare `Constant(list)` SSA value, so the pre-pass
+/// ([`legacy_const_define_hlvalue`]) folds the op to that Constant and
+/// [`translate_op`] emits nothing — same contract as
+/// [`is_str_const_define`].
+fn is_const_int_array_define(kind: &OpKind) -> bool {
+    matches!(
+        kind,
+        OpKind::Call {
+            target: crate::model::CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if args.is_empty() && segments.len() >= 2 && segments[0] == "__const_int_array"
+    )
+}
+
+/// Decode the baked integers of a `__const_int_array` define-op's
+/// segments (`["__const_int_array", "0", "2", …]`) into the
+/// `ConstValue::Int` element list.  `None` if any segment past the tag
+/// fails to parse (a malformed synthesis) or the op is not the
+/// define-op shape.
+fn const_int_array_items(kind: &OpKind) -> Option<Vec<ConstValue>> {
+    let OpKind::Call {
+        target: crate::model::CallTarget::FunctionPath { segments },
+        ..
+    } = kind
+    else {
+        return None;
+    };
+    segments
+        .get(1..)?
+        .iter()
+        .map(|s| s.parse::<i64>().ok().map(ConstValue::Int))
+        .collect()
+}
+
 /// The pure, non-raising flowspace opname a `core::<family>::<leaf>`
 /// method-call bridge lowers to in [`translate_op`], or `None` when the
 /// path is not such a bridge.  The single source of truth shared by
@@ -745,6 +783,10 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         // and emits no op — a Constant raises nothing.  Matched before
         // the general `Call` arm, same as the unit-variant elision.
         kind if is_str_const_define(kind) => false,
+        // A prebuilt-constant-array define-op pre-folds to `Constant(list)`
+        // and emits no op — a Constant raises nothing.  Matched before the
+        // general `Call` arm, same as the string-literal elision.
+        kind if is_const_int_array_define(kind) => false,
         // A `hint(x, **kwds)` op (`OpKind::Hint`) lowers to a non-raising
         // `same_as(value)` (`rtyper.py:478-481` internal renaming) in
         // `translate_op` — it emits no raising op.  Matched before the
@@ -866,6 +908,12 @@ pub fn translate_op(
     // way (see `is_str_const_define`); the pre-pass owns the slot's
     // `Hlvalue::Constant`, translate_op emits no FlowspaceOp.
     if is_str_const_define(&op.kind) {
+        return Ok(Vec::new());
+    }
+    // Prebuilt-constant-array define-ops pre-fold to `Constant(list)` the
+    // same way (see `is_const_int_array_define`); the pre-pass owns the
+    // slot's `Hlvalue::Constant`, translate_op emits no FlowspaceOp.
+    if is_const_int_array_define(&op.kind) {
         return Ok(Vec::new());
     }
     match &op.kind {
@@ -2283,6 +2331,17 @@ fn legacy_const_define_hlvalue(op: &SpaceOperation) -> Option<Hlvalue> {
         OpKind::ConstRefAddr(addr) => {
             Some(Hlvalue::Constant(const_ref_gcref_constant(Some(*addr))))
         }
+        // Prebuilt-constant-array define-op.  A module-level constant
+        // array (`OP_STACKDEL: [i32; N]`) is carried as a bare immutable
+        // `Constant(list)`; `immutableconstant` annotates it `SomeList`
+        // and its `arr[i]` read is a foldable getarrayitem.  `front::mir`
+        // has no ConstList opkind and synthesises a 0-arg
+        // `Call(["__const_int_array", <i0>, …])` instead
+        // (`fold_named_const_int_array_global`); re-fold that define-op to
+        // the upstream Constant shape here, the same way the
+        // `__str_const` arm below re-folds a string literal.
+        kind if is_const_int_array_define(kind) => const_int_array_items(kind)
+            .map(|items| Hlvalue::Constant(Constant::new(ConstValue::List(items)))),
         // String-literal constant.  Upstream flowspace carries a string
         // literal as a bare `Constant('text')` SSA value (annotated
         // `SomeString` by `immutablevalue`); `front::mir` has no
@@ -5150,5 +5209,70 @@ mod tests {
             }),
             "Input"
         );
+    }
+
+    /// The prebuilt-constant-array define-op (`front::mir`'s
+    /// `__const_int_array` synthetic Call) is recognized, decodes to its
+    /// baked integer list, and pre-folds to a `Constant(List)` the same
+    /// way `__str_const` folds to `Constant(ByteStr)` — so `translate_op`
+    /// emits nothing and the slot carries the prebuilt list constant.
+    #[test]
+    fn const_int_array_define_folds_to_list_constant() {
+        use crate::model::CallTarget;
+
+        let define = OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec![
+                    "__const_int_array".to_string(),
+                    "0".to_string(),
+                    "2".to_string(),
+                    "-3".to_string(),
+                ],
+            },
+            args: Vec::new(),
+            result_ty: ValueType::Ref(None),
+        };
+        assert!(is_const_int_array_define(&define));
+        assert_eq!(
+            const_int_array_items(&define),
+            Some(vec![
+                ConstValue::Int(0),
+                ConstValue::Int(2),
+                ConstValue::Int(-3),
+            ])
+        );
+
+        let op = SpaceOperation {
+            result: Some(Variable::new()),
+            kind: define,
+        };
+        // `translate_op` emits no FlowspaceOp — the pre-pass owns the slot.
+        assert!(
+            translate_op(&op, &HashMap::new(), &empty_call_registry())
+                .expect("const-array define translates")
+                .is_empty()
+        );
+        // The pre-pass folds the define to the prebuilt list constant.
+        match legacy_const_define_hlvalue(&op) {
+            Some(Hlvalue::Constant(c)) => assert_eq!(
+                c.value,
+                ConstValue::List(vec![
+                    ConstValue::Int(0),
+                    ConstValue::Int(2),
+                    ConstValue::Int(-3),
+                ])
+            ),
+            other => panic!("expected Constant(List), got {other:?}"),
+        }
+
+        // A `__str_const` call and an ordinary path are not mistaken for it.
+        let str_const = OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__str_const".to_string(), "hi".to_string()],
+            },
+            args: Vec::new(),
+            result_ty: ValueType::Ref(None),
+        };
+        assert!(!is_const_int_array_define(&str_const));
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -271,6 +271,40 @@ impl PyreCallRegistry {
         self.bookkeeper.set_pyre_trait_unique_impls(map);
     }
 
+    /// Mint each opt-in receiver-driven dispatch family's base
+    /// `ClassDef` + impl subclasses (issue #346).  Called from
+    /// `dual_gate_registry` BEFORE
+    /// [`Self::seed_struct_root_method_members`], so that method seeding's
+    /// `intern_class_by_qualname(owner)` hits the subclass host minted
+    /// here (first-mint wins) and attaches the impl methods onto the
+    /// base-linked subclass; the attrfamily merge then surfaces them on
+    /// the base for a `dyn Trait` receiver getattr.  The impl subclasses
+    /// are minted member-less — `seed_struct_root_method_members`
+    /// installs their methods.  A per-family registration error is
+    /// reported and skipped (the block stays census-visible / fail-loud)
+    /// rather than aborting the whole build.
+    pub fn register_trait_families(
+        &self,
+        families: &[crate::codewriter::call::TraitFamilyRegistration],
+    ) {
+        for family in families {
+            let impls: Vec<(String, HashMap<String, ConstValue>)> = family
+                .impl_roots
+                .iter()
+                .map(|root| (root.clone(), HashMap::new()))
+                .collect();
+            if let Err(e) =
+                self.bookkeeper
+                    .register_trait_family(&family.base_root, HashMap::new(), impls)
+            {
+                eprintln!(
+                    "register_trait_families: base {:?} failed: {e:?}",
+                    family.base_root
+                );
+            }
+        }
+    }
+
     /// Thread the enum `discriminant → variant` tables into the shared
     /// bookkeeper so the `__discriminant` getattr can attach
     /// discriminant→variant narrowing `knowntypedata`.  Called once from
@@ -378,6 +412,48 @@ impl PyreCallRegistry {
                 method.clone(),
                 ConstValue::HostObject(entry.host_object.clone()),
             );
+        }
+    }
+
+    /// Populate each registered dispatch family's impl-subclass
+    /// `ClassDef` attr sources from the method members seeded by
+    /// [`Self::seed_struct_root_method_members`] (issue #346).
+    ///
+    /// A raw `class_set` on the subclass host (what the method seeding
+    /// does) puts the method in the host `__dict__` but does NOT register
+    /// it in the subclass `ClassDef`'s `attr_sources` — only
+    /// `check_missing_attribute_update` → `check_attr_here` →
+    /// `find_source_for` reads the host dict and records the source.
+    /// Without that, a `getattr` on the FAMILY BASE
+    /// (`ClassDef::generalize_attr` at `locate_attribute`) finds no
+    /// subclass `attr_sources` to merge up and the block stays blocked
+    /// ("no source").  Run the update for every seeded subclass method so
+    /// a base-instance / `dyn Trait` receiver getattr resolves the impl
+    /// `MethodDesc` family via the attrfamily merge.  Called from
+    /// `dual_gate_registry` AFTER `seed_struct_root_method_members`.
+    pub fn populate_trait_family_base_attrs(
+        &self,
+        families: &[crate::codewriter::call::TraitFamilyRegistration],
+    ) {
+        for family in families {
+            for impl_root in &family.impl_roots {
+                let key = majit_ir::descr::canonical_struct_name(impl_root);
+                let host = self
+                    .bookkeeper
+                    .pyre_struct_root_classes
+                    .borrow()
+                    .get(&key)
+                    .cloned();
+                let Some(host) = host else { continue };
+                let Ok(cd) = self.bookkeeper.getuniqueclassdef(&host) else {
+                    continue;
+                };
+                for method in host.class_dict_keys() {
+                    let _ = crate::annotator::classdesc::ClassDef::check_missing_attribute_update(
+                        &cd, &method,
+                    );
+                }
+            }
         }
     }
 

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -4895,6 +4895,13 @@ impl Repr for MultipleFrozenPBCRepr {
         // frozendesc not in self.access_set.descs)` — the membership
         // check is skipped in the `None` (no-attrs) arm.
         //
+        // upstream's `convert_desc` does not require a FrozenDesc: in the
+        // `access_set is None` arm the fieldmap is empty and the desc is
+        // consumed only as a cache key, so an uncallable FunctionDesc
+        // routed here by `getFrozenPBCRepr` is accepted and materialises
+        // an empty zero-field instance. Only the `access_set is Some` arm
+        // reads `attrcache`, so a FrozenDesc is required there.
+        //
         // PRE-EXISTING-DEVIATION: pyre keys
         // `FrozenAttrFamily.descs` on `FrozenDesc.base.identity`
         // (counter-based DescKey) because that is the key
@@ -4902,12 +4909,17 @@ impl Repr for MultipleFrozenPBCRepr {
         // `DescEntry::desc_key()` returns the `Rc::as_ptr`-based
         // identity used elsewhere. Look up by `base.identity` so
         // membership matches what `mergeattrfamilies` populated.
-        let crate::annotator::description::DescEntry::Frozen(fd_rc) = desc else {
-            return Err(TyperError::message(format!(
-                "MultipleFrozenPBCRepr.convert_desc: non-Frozen desc {desc:?}"
-            )));
+        let fd_rc = match desc {
+            crate::annotator::description::DescEntry::Frozen(fd_rc) => Some(fd_rc),
+            _ => None,
         };
         if let Some(access_set) = &self.access_set {
+            let fd_rc = fd_rc.ok_or_else(|| {
+                TyperError::message(format!(
+                    "MultipleFrozenPBCRepr.convert_desc: access_set=Some requires a \
+                     Frozen desc, got {desc:?}"
+                ))
+            })?;
             let identity_key = fd_rc.borrow().base.identity;
             if !access_set.borrow().descs.contains_key(&identity_key) {
                 return Err(TyperError::message(format!(
@@ -4934,7 +4946,10 @@ impl Repr for MultipleFrozenPBCRepr {
 
         // upstream loop over fieldmap, writing each attr's converted
         // value into the cached pointer through brief borrow_mut bursts.
-        let frozendesc = fd_rc.clone();
+        // `fieldmap` is non-empty only in the `access_set is Some` arm,
+        // where the desc is a FrozenDesc (guarded above); `None` when
+        // access_set is None so the loop below never runs.
+        let frozendesc = fd_rc.cloned();
         let fieldmap_snapshot: Vec<(String, String, Arc<dyn Repr>)> = self
             .fieldmap
             .borrow()
@@ -4945,6 +4960,13 @@ impl Repr for MultipleFrozenPBCRepr {
             if matches!(r_value.lowleveltype(), LowLevelType::Void) {
                 continue;
             }
+            // A non-empty fieldmap only occurs on the `access_set is Some`
+            // arm, where `desc` was validated as a FrozenDesc above.
+            let frozendesc = frozendesc.as_ref().ok_or_else(|| {
+                TyperError::message(
+                    "MultipleFrozenPBCRepr.convert_desc: non-empty fieldmap requires a Frozen desc",
+                )
+            })?;
             // upstream `frozendesc.attrcache[attr]`; missing attrs
             // consult `warn_missing_attribute` and emit the same rtyper
             // warning before leaving the field unset.
@@ -7997,6 +8019,31 @@ mod pbc_repr_tests {
         assert!(
             std::sync::Arc::ptr_eq(&r1, &r2),
             "the None-access MultipleFrozenPBCRepr must be a cached singleton"
+        );
+    }
+
+    #[test]
+    fn multiple_frozen_pbc_repr_none_access_convert_desc_accepts_function_desc() {
+        // An uncallable multi-FunctionDesc PBC (each `queryattrfamily() ==
+        // None`) is routed by `getFrozenPBCRepr` to the zero-field
+        // None-access arm. upstream `MultipleFrozenPBCRepr.convert_desc`
+        // (rpbc.py:769) does not require a FrozenDesc, so converting a
+        // FunctionDesc there must succeed: the fieldmap is empty, so nothing
+        // is read off the desc and an empty `pbc` instance is materialised.
+        let (ann, rtyper) = make_rtyper();
+        let f = function_entry(&ann.bookkeeper, "func0");
+        let g = function_entry(&ann.bookkeeper, "func1");
+        let s_pbc = SomePBC::new(vec![f.clone(), g], false);
+        let r = getFrozenPBCRepr(&rtyper, &s_pbc).unwrap();
+        assert_eq!(r.class_name(), "MultipleFrozenPBCRepr");
+        Repr::setup(r.as_ref()).expect("setup");
+        let c = r
+            .convert_desc(&f)
+            .expect("None-access convert_desc must accept a FunctionDesc");
+        assert!(
+            matches!(c.value, ConstValue::LLPtr(_)),
+            "expected a zero-field pbc instance pointer, got {:?}",
+            c.value
         );
     }
 

--- a/majit/majit-translate/src/translator/rtyper/rpbc.rs
+++ b/majit/majit-translate/src/translator/rtyper/rpbc.rs
@@ -4621,8 +4621,11 @@ pub fn pair_function_repr_base_rtype_is_(
 pub struct MultipleFrozenPBCRepr {
     /// RPython `self.rtyper = rtyper` (rpbc.py:732).
     pub rtyper: Weak<RPythonTyper>,
-    /// RPython `self.access_set = access_set` (rpbc.py:733).
-    pub access_set: Rc<RefCell<crate::annotator::description::FrozenAttrFamily>>,
+    /// RPython `self.access_set = access_set` (rpbc.py:733). `None` is the
+    /// no-attrs arm (`getFrozenPBCRepr`'s `access is None` case): a
+    /// zero-field `Struct('pbc')` with no per-attr membership check
+    /// (rpbc.py:758, 770).
+    pub access_set: Option<Rc<RefCell<crate::annotator::description::FrozenAttrFamily>>>,
     /// RPython `self.pbc_type = ForwardReference()` (rpbc.py:734).
     /// Stored as a clone alongside [`Self::lltype`] so callers can
     /// observe the resolved struct after `_setup_repr` runs `become`
@@ -4648,7 +4651,7 @@ impl MultipleFrozenPBCRepr {
     /// (rpbc.py:731-736).
     pub fn new(
         rtyper: &Rc<RPythonTyper>,
-        access_set: Rc<RefCell<crate::annotator::description::FrozenAttrFamily>>,
+        access_set: Option<Rc<RefCell<crate::annotator::description::FrozenAttrFamily>>>,
     ) -> Self {
         let pbc_type = crate::translator::rtyper::lltypesystem::lltype::ForwardReference::new();
         let pbc_type_clone = pbc_type.clone();
@@ -4692,9 +4695,16 @@ impl MultipleFrozenPBCRepr {
         let rtyper = self.rtyper.upgrade().ok_or_else(|| {
             TyperError::message("MultipleFrozenPBCRepr._setup_repr_fields: rtyper weak ref dropped")
         })?;
+        // upstream `if self.access_set is not None:` (rpbc.py:758) — the
+        // no-attrs arm leaves `fields`/`fieldmap` empty, giving a
+        // zero-field `Struct('pbc')`.
+        let Some(access_set) = &self.access_set else {
+            self.fieldmap.borrow_mut().clear();
+            return Ok(Vec::new());
+        };
         // upstream `attrlist = self.access_set.attrs.keys(); attrlist.sort()`.
         let attrs_snapshot: Vec<(String, crate::annotator::model::SomeValue)> = {
-            let caf = self.access_set.borrow();
+            let caf = access_set.borrow();
             let mut attrs: Vec<(String, crate::annotator::model::SomeValue)> = caf
                 .attrs
                 .iter()
@@ -4882,11 +4892,8 @@ impl Repr for MultipleFrozenPBCRepr {
         desc: &crate::annotator::description::DescEntry,
     ) -> Result<Constant, TyperError> {
         // upstream `if (self.access_set is not None and
-        // frozendesc not in self.access_set.descs)` — pyre's
-        // `access_set` is always Some on this concrete repr (the
-        // `None` arm in upstream describes the abstract base class
-        // before the per-attr family is known), so the membership
-        // check is unconditional here.
+        // frozendesc not in self.access_set.descs)` — the membership
+        // check is skipped in the `None` (no-attrs) arm.
         //
         // PRE-EXISTING-DEVIATION: pyre keys
         // `FrozenAttrFamily.descs` on `FrozenDesc.base.identity`
@@ -4900,11 +4907,13 @@ impl Repr for MultipleFrozenPBCRepr {
                 "MultipleFrozenPBCRepr.convert_desc: non-Frozen desc {desc:?}"
             )));
         };
-        let identity_key = fd_rc.borrow().base.identity;
-        if !self.access_set.borrow().descs.contains_key(&identity_key) {
-            return Err(TyperError::message(format!(
-                "MultipleFrozenPBCRepr.convert_desc: {desc:?} not found in PBC access set"
-            )));
+        if let Some(access_set) = &self.access_set {
+            let identity_key = fd_rc.borrow().base.identity;
+            if !access_set.borrow().descs.contains_key(&identity_key) {
+                return Err(TyperError::message(format!(
+                    "MultipleFrozenPBCRepr.convert_desc: {desc:?} not found in PBC access set"
+                )));
+            }
         }
         let desc_key = desc.desc_key();
 
@@ -6260,18 +6269,16 @@ impl Repr for ClassesPBCRepr {
 /// * multi-desc with a common `Some(access)` set →
 ///   [`MultipleFrozenPBCRepr`] keyed in
 ///   `rtyper.pbc_reprs[PbcReprKey::Access(access_key)]`, registered
-///   via `rtyper.add_pendingsetup`.
-///
-/// The `None`-access edge case (every desc has no attrfamily) still
-/// surfaces `MissingRTypeOperation`: upstream constructs
-/// `MultipleFrozenPBCRepr(rtyper, access_set=None)` to materialise a
-/// zero-field struct PBC; pyre defers the body because no current
-/// consumer reaches it.
+///   via `rtyper.add_pendingsetup`,
+/// * multi-desc whose common access set is `None` (every desc has no
+///   attrfamily) → [`MultipleFrozenPBCRepr`] with `access_set = None`,
+///   a zero-field `Struct('pbc')` keyed in
+///   `rtyper.pbc_reprs[PbcReprKey::AccessNone]` (rpbc.py:626-632 + 758).
 ///
 /// Called from both `somepbc_rtyper_makerepr` DescKind::Frozen and the
 /// Function-kind uncallable branch — `FunctionDesc.queryattrfamily` is
 /// the base `None` stub, so multi-FunctionDesc always appears "common
-/// access set = None" and routes to the still-pending `MultipleFrozenPBCRepr`
+/// access set = None" and routes to the `None`-access `MultipleFrozenPBCRepr`
 /// arm.
 #[allow(non_snake_case)]
 pub fn getFrozenPBCRepr(
@@ -6340,49 +6347,47 @@ pub fn getFrozenPBCRepr(
     //     return result
     // ```
     //
-    // All descs share `first` (verified above) — the access family is
-    // either `Some(usize)` or `None`. None means every desc has no
-    // attrfamily; upstream still routes to `MultipleFrozenPBCRepr` with
-    // `access_set=None`, but the Rust port requires a live family Rc to
-    // construct the repr. Resolve the family from the first frozen
-    // desc's `queryattrfamily()` so the repr can read its `attrs`.
-    let Some(access_key) = first else {
-        return Err(TyperError::missing_rtype_operation(
-            "getFrozenPBCRepr: MultipleFrozenPBCRepr with access_set=None \
-             (rpbc.py:626-632 + 758) is upstream's no-attrs path — pyre \
-             defers it because no current consumer needs a zero-field \
-             struct PBC",
-        ));
-    };
+    // All descs share `first` (verified above): the access family is
+    // either `Some(usize)` or `None`. `None` means every desc has no
+    // attrfamily (uncallable multi-desc function/frozen PBCs) —
+    // `MultipleFrozenPBCRepr(rtyper, None)` lowers to a zero-field
+    // `Struct('pbc')` (`_setup_repr_fields` returns `[]`, rpbc.py:758),
+    // cached under the `pbc_reprs[None]` singleton slot.
     use crate::translator::rtyper::rtyper::PbcReprKey;
-    if let Some(cached) = rtyper
-        .pbc_reprs
-        .borrow()
-        .get(&PbcReprKey::Access(access_key))
-    {
+    let repr_key = match first {
+        Some(access_key) => PbcReprKey::Access(access_key),
+        None => PbcReprKey::AccessNone,
+    };
+    if let Some(cached) = rtyper.pbc_reprs.borrow().get(&repr_key) {
         return Ok(cached.clone());
     }
-    // Fetch the live FrozenAttrFamily — every desc shared the same key
-    // so any of them yields the same family.
-    let access_family = s_pbc
-        .descriptions
-        .values()
-        .find_map(|d| match d {
-            DescEntry::Frozen(fd) => fd.borrow().queryattrfamily(),
-            _ => None,
-        })
-        .ok_or_else(|| {
-            TyperError::message(
-                "getFrozenPBCRepr: invariant — first desc's queryattrfamily \
-                 returned Some(key) but no descs surface a family",
-            )
-        })?;
+    // Fetch the live FrozenAttrFamily shared by all descs (verified via
+    // `first`). `None` when the shared access set is absent — the
+    // zero-field `access_set=None` arm.
+    let access_family = match first {
+        Some(_) => Some(
+            s_pbc
+                .descriptions
+                .values()
+                .find_map(|d| match d {
+                    DescEntry::Frozen(fd) => fd.borrow().queryattrfamily(),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    TyperError::message(
+                        "getFrozenPBCRepr: invariant — first desc's queryattrfamily \
+                         returned Some(key) but no descs surface a family",
+                    )
+                })?,
+        ),
+        None => None,
+    };
     let fresh: std::sync::Arc<dyn Repr> =
         std::sync::Arc::new(MultipleFrozenPBCRepr::new(rtyper, access_family));
     rtyper
         .pbc_reprs
         .borrow_mut()
-        .insert(PbcReprKey::Access(access_key), fresh.clone());
+        .insert(repr_key, fresh.clone());
     rtyper.add_pendingsetup(fresh.clone());
     Ok(fresh)
 }
@@ -7043,12 +7048,11 @@ pub fn somepbc_rtyper_makerepr(
                     // through `getFrozenPBCRepr`. The factory dispatches
                     // to `SingleFrozenPBCRepr` (single-desc + !can_be_None),
                     // `MultipleUnrelatedFrozenPBCRepr` (cached at
-                    // `pbc_reprs[Unrelated]`), or `MultipleFrozenPBCRepr`
-                    // (cached at `pbc_reprs[Access(_)]`). The remaining
-                    // `MissingRTypeOperation` path is the `None`-access
-                    // edge case (every desc has no attrfamily — upstream's
-                    // zero-field struct PBC), deferred until a consumer
-                    // reaches it.
+                    // `pbc_reprs[Unrelated]`), `MultipleFrozenPBCRepr`
+                    // (cached at `pbc_reprs[Access(_)]`), or — when every
+                    // desc has no attrfamily — the `None`-access
+                    // `MultipleFrozenPBCRepr` zero-field struct PBC
+                    // (cached at `pbc_reprs[AccessNone]`).
                     getFrozenPBCRepr(rtyper, s_pbc)
                 }
             }
@@ -7129,33 +7133,29 @@ mod pbc_repr_tests {
     }
 
     #[test]
-    fn somepbc_rtyper_makerepr_single_function_desc_with_can_be_none_surfaces_pending() {
-        // Uncallable (no callfamily wired) → getFrozenPBCRepr branch.
+    fn somepbc_rtyper_makerepr_single_function_desc_with_can_be_none_returns_multiple_frozen() {
+        // Uncallable (no callfamily wired), `can_be_None=true` drops out of
+        // the SingleFrozenPBCRepr fast-path → getFrozenPBCRepr multi-desc
+        // branch → the `access is None` no-attrs arm builds a zero-field
+        // MultipleFrozenPBCRepr (rpbc.py:626-632 + 758).
         let (ann, rtyper) = make_rtyper();
         let f = function_entry(&ann.bookkeeper, "f");
         let s_pbc = SomePBC::new(vec![f], true);
-        let err = somepbc_rtyper_makerepr(&s_pbc, &rtyper).unwrap_err();
-        assert!(
-            err.to_string().contains("getFrozenPBCRepr"),
-            "unexpected: {}",
-            err
-        );
+        let r = somepbc_rtyper_makerepr(&s_pbc, &rtyper).unwrap();
+        assert_eq!(r.class_name(), "MultipleFrozenPBCRepr");
     }
 
     #[test]
     fn somepbc_rtyper_makerepr_multi_function_descs_without_callfamily_uses_getfrozenpbcrepr() {
         // Multi-FunctionDesc PBC without an attached callfamily → upstream
-        // rpbc.py:49 routes to getFrozenPBCRepr.
+        // rpbc.py:49 routes to getFrozenPBCRepr, whose no-attrs
+        // (`access is None`) arm yields a zero-field MultipleFrozenPBCRepr.
         let (ann, rtyper) = make_rtyper();
         let f = function_entry(&ann.bookkeeper, "f");
         let g = function_entry(&ann.bookkeeper, "g");
         let s_pbc = SomePBC::new(vec![f, g], false);
-        let err = somepbc_rtyper_makerepr(&s_pbc, &rtyper).unwrap_err();
-        assert!(
-            err.to_string().contains("getFrozenPBCRepr"),
-            "unexpected: {}",
-            err
-        );
+        let r = somepbc_rtyper_makerepr(&s_pbc, &rtyper).unwrap();
+        assert_eq!(r.class_name(), "MultipleFrozenPBCRepr");
     }
 
     #[test]
@@ -7981,17 +7981,23 @@ mod pbc_repr_tests {
     }
 
     #[test]
-    fn getFrozenPBCRepr_multi_desc_common_access_set_surfaces_pending() {
+    fn getFrozenPBCRepr_multi_desc_common_none_access_set_returns_multiple_frozen() {
         // Two FrozenDescs without any `getattrfamily` touch share the
-        // same `queryattrfamily() == None` result, so upstream routes
-        // them to MultipleFrozenPBCRepr (still pending).
+        // same `queryattrfamily() == None` result, so upstream routes them
+        // to the `access is None` arm — a zero-field MultipleFrozenPBCRepr
+        // (rpbc.py:626-632 + 758). The None arm is a singleton cached at
+        // `pbc_reprs[None]`.
         let (ann, rtyper) = make_rtyper();
         let f = frozen_entry(&ann.bookkeeper, "frozen0");
         let g = frozen_entry(&ann.bookkeeper, "frozen1");
         let s_pbc = SomePBC::new(vec![f, g], false);
-        let err = getFrozenPBCRepr(&rtyper, &s_pbc).unwrap_err();
-        assert!(err.is_missing_rtype_operation());
-        assert!(err.to_string().contains("MultipleFrozenPBCRepr"));
+        let r1 = getFrozenPBCRepr(&rtyper, &s_pbc).unwrap();
+        assert_eq!(r1.class_name(), "MultipleFrozenPBCRepr");
+        let r2 = getFrozenPBCRepr(&rtyper, &s_pbc).unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&r1, &r2),
+            "the None-access MultipleFrozenPBCRepr must be a cached singleton"
+        );
     }
 
     #[test]
@@ -8777,17 +8783,16 @@ mod pbc_repr_tests {
     }
 
     #[test]
-    fn somepbc_rtyper_makerepr_single_frozen_desc_with_can_be_none_surfaces_pending() {
+    fn somepbc_rtyper_makerepr_single_frozen_desc_with_can_be_none_returns_multiple_frozen() {
         // Single FrozenDesc with `can_be_None=true` falls out of the
-        // SingleFrozenPBCRepr fast-path, hits getFrozenPBCRepr's
-        // multi-desc branch, and — with only one access-set (None) —
-        // routes to the still-pending MultipleFrozenPBCRepr arm.
+        // SingleFrozenPBCRepr fast-path, hits getFrozenPBCRepr's multi-desc
+        // branch, and — with only one access-set (None) — routes to the
+        // zero-field MultipleFrozenPBCRepr no-attrs arm.
         let (ann, rtyper) = make_rtyper();
         let f = frozen_entry(&ann.bookkeeper, "frozen0");
         let s_pbc = SomePBC::new(vec![f], true);
-        let err = somepbc_rtyper_makerepr(&s_pbc, &rtyper).unwrap_err();
-        assert!(err.is_missing_rtype_operation());
-        assert!(err.to_string().contains("MultipleFrozenPBCRepr"));
+        let r = somepbc_rtyper_makerepr(&s_pbc, &rtyper).unwrap();
+        assert_eq!(r.class_name(), "MultipleFrozenPBCRepr");
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -334,10 +334,13 @@ pub(crate) enum PbcReprKey {
     /// `rtyper.pbc_reprs['unrelated']` (rpbc.py:621).
     Unrelated,
     /// `rtyper.pbc_reprs[access_set]` (rpbc.py:627) — keyed by the
-    /// `FrozenAttrFamily` pointer identity. Reserved for
-    /// MultipleFrozenPBCRepr caching when that repr lands; currently
-    /// unused.
+    /// `FrozenAttrFamily` pointer identity, for a `MultipleFrozenPBCRepr`
+    /// with a concrete access set.
     Access(usize),
+    /// `rtyper.pbc_reprs[None]` (rpbc.py:627) — the singleton
+    /// `MultipleFrozenPBCRepr` for the no-attrs arm (`access is None`),
+    /// a zero-field `Struct('pbc')`.
+    AccessNone,
 }
 
 /// RPython `class RTyperBackend(object): pass` (`rtyper.py:30-31`).

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -253,6 +253,8 @@ fn real_main() {
                 ..Default::default()
             },
             portal: None,
+            // pyre production registers no trait-dispatch families (#346).
+            register_trait_families: Vec::new(),
         },
     };
     // warmspot.py:516 `vinfos[VTYPEPTR] = VirtualizableInfo(self, VTYPEPTR)` —

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -101,12 +101,25 @@ def platform_info() -> tuple[str, str]:
     raise SystemExit(f"extract-llbc.py: unsupported platform {system}-{machine}")
 
 
+def expand_features(arg: str, cargo_features: str) -> str:
+    features = [f.strip() for f in cargo_features.split(",") if f.strip()]
+    if "{features}" not in arg or len(features) <= 1:
+        # No placeholder, or a single/absent feature: whole-string
+        # substitution already yields the right flag.
+        return arg.format(features=cargo_features)
+    # Multiple features: a template like `crate/{features}` prefixes the
+    # placeholder, so splicing the raw `a,b` list into one slot only
+    # prefixes the first feature. Expand the template per feature and
+    # rejoin so each feature keeps the prefix.
+    return ",".join(arg.format(features=feature) for feature in features)
+
+
 def crate_flags(spec: CrateSpec, cargo_features: str) -> list[str]:
-    return [arg.format(features=cargo_features) for arg in spec.cargo_args]
+    return [expand_features(arg, cargo_features) for arg in spec.cargo_args]
 
 
 def charon_crate_flags(spec: CrateSpec, cargo_features: str) -> list[str]:
-    return [arg.format(features=cargo_features) for arg in spec.charon_args]
+    return [expand_features(arg, cargo_features) for arg in spec.charon_args]
 
 
 def run_capture(args: list[str], *, cwd: Path) -> str:
@@ -193,7 +206,10 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
             closure.append(package)
 
             for dep in resolve_nodes.get(package_id, {}).get("deps", []):
-                if all(kind.get("kind") == "dev" for kind in dep.get("dep_kinds", [])):
+                dep_kinds = dep.get("dep_kinds", [])
+                # An empty `dep_kinds` is a normal (non-dev) edge; only
+                # drop deps whose every listed kind is `dev`.
+                if dep_kinds and all(kind.get("kind") == "dev" for kind in dep_kinds):
                     continue
                 dep_package = by_id.get(dep["pkg"])
                 if dep_package is not None and dep_package.get("source") is None:
@@ -203,8 +219,9 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
             if package["name"] in exclude:
                 continue
             package_dir = Path(package["manifest_path"]).resolve().parent
-            rel_dir = package_dir.relative_to(root).as_posix()
-            pathspecs.append(f"{rel_dir}/Cargo.toml")
+            if package_dir.is_relative_to(root):
+                rel_dir = package_dir.relative_to(root).as_posix()
+                pathspecs.append(f"{rel_dir}/Cargo.toml")
             for target in package["targets"]:
                 kinds = set(target["kind"])
                 if not ({"lib", "bin", "custom-build"} & kinds):

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -30,6 +30,10 @@ class CrateSpec:
     - `cargo_args`: extra flags passed after `--`; each arg may contain the
       `{features}` placeholder, substituted with the active cargo feature set
       (e.g. `["--features", "{features}"]` or `["--no-default-features"]`).
+    - `charon_args`: extra flags passed to Charon itself, before the `--`
+      separator (e.g. `["--include", "somecrate::module::_"]` to translate the
+      bodies of items in a foreign dependency instead of keeping them opaque).
+      Same `{features}` placeholder substitution as `cargo_args`.
     - `fingerprint_pathspecs`: explicit git pathspecs (relative to the driver's
       `root`) that fingerprint this crate's sources. `None` derives them from a
       `cargo metadata` dependency walk instead.
@@ -42,6 +46,7 @@ class CrateSpec:
     crate_dir: Path
     output_name: str
     cargo_args: list[str] = field(default_factory=list)
+    charon_args: list[str] = field(default_factory=list)
     fingerprint_pathspecs: list[str] | None = None
     excluded_deps: set[str] = field(default_factory=set)
 
@@ -98,6 +103,10 @@ def platform_info() -> tuple[str, str]:
 
 def crate_flags(spec: CrateSpec, cargo_features: str) -> list[str]:
     return [arg.format(features=cargo_features) for arg in spec.cargo_args]
+
+
+def charon_crate_flags(spec: CrateSpec, cargo_features: str) -> list[str]:
+    return [arg.format(features=cargo_features) for arg in spec.charon_args]
 
 
 def run_capture(args: list[str], *, cwd: Path) -> str:
@@ -308,6 +317,7 @@ def stamp_for(
     charon_stamp: str,
     cargo_features: str,
     flags: list[str],
+    charon_flags: list[str],
 ) -> str:
     return "\n".join(
         [
@@ -316,6 +326,7 @@ def stamp_for(
             f"charon={charon_stamp}",
             f"features={cargo_features}",
             f"flags={' '.join(flags)}",
+            f"charon_flags={' '.join(charon_flags)}",
             f"source={source_fingerprint(eng, [crate], cargo_features)}",
         ]
     )
@@ -359,6 +370,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         spec = eng.spec(crate)
         path = spec.crate_dir
         flags = crate_flags(spec, cargo_features)
+        charon_flags = charon_crate_flags(spec, cargo_features)
         if not path.is_dir():
             raise SystemExit(f"extract-llbc.py: missing crate dir for '{crate}' at {path}")
 
@@ -371,6 +383,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             charon_stamp=charon_stamp,
             cargo_features=cargo_features,
             flags=flags,
+            charon_flags=charon_flags,
         )
 
         if (
@@ -404,6 +417,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             "--ullbc",
             "--dest-file",
             str(dest),
+            *charon_flags,
             "--",
             *flags,
             *host_config,


### PR DESCRIPTION
## Summary

Accumulated aheui-census (M2–M3) work on the majit translator, on top of #403.

**Receiver-driven trait-family method dispatch (opt-in, #346).** A ≥2-impl trait's `dyn Trait` receivers can be annotated to a base ClassDef that links the impl subclasses; `getattr` on the base resolves the impl `MethodDesc` family via attrfamily merge, so a trait method call decomposes into JIT primitive dispatch instead of an opaque `CallPureI`. Opt-in per consumer via `register_trait_family`; an empty family is a no-op, so existing production paths are unaffected.

- **annotator: register_trait_family method-member seeding** — seeds the base classdef's method members and merges the impl attrfamilies so a subclass-only method surfaces on the base.
- **majit: opt-in receiver-driven trait-family dispatch** — wires the dispatch through the flowspace adapter / pyre call registry.
- **rtyper: implement access_set=None MultipleFrozenPBCRepr** — implements upstream's `access_set=None` frozen-PBC path (rpbc.py:626–632 + 755–772) that pyre had stubbed as `MissingRTypeOperation`. A base classdef accumulates trait-family method attrs that are uncalled in a partial closure (funcdesc callfamily=None → uncallable Function-kind → `getFrozenPBCRepr`), and the multi-desc no-attrs arm now builds a zero-field `Struct('pbc')` repr cached under a singleton `PbcReprKey::AccessNone`. Purely additive: called production methods still route to `FunctionsPBCRepr`.

**Front-end / scripts follow-ups (post-#403).**
- **front: decline width/sign-ambiguous const binop folds** — narrow-wrap Add/Sub/Mul and unsigned-Shr const folds could yield wrong values; residualize instead of misfolding.
- **front: fold const int-array runtime-index read**
- **scripts: add CrateSpec.charon_args pre-`--` flags**
- **scripts: harden llbc_extract fingerprint edge cases**

## Testing

- `cargo test -p majit-translate --lib`: **2950 passed, 0 failed** (incl. both `register_trait_family_*` tests and the reworked `access_set=None` repr tests).
- aheui census `aheui_census_m0` (aheui-rust `1fc5c34`): phaseB failures **4 → 0**; `LinkedList::swap` reaches the code writer; 23 jitcodes emitted. Remaining blockers are all phaseA (NURSERY static, `__array_repeat`, `bigint::from`, numeric-family `compute_at_fixpoint`) and tracked separately.

Refs #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
