### PR TITLE
math: raise OverflowError (not ValueError) on pymath range errors

### DIFF
--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -65,9 +65,8 @@ type PyResult = Result<PyObjectRef, crate::PyError>;
 fn map_err(r: pymath::Result<f64>) -> PyResult {
     match r {
         Ok(v) => Ok(floatobject::w_float_new(v)),
-        Err(e) => Err(crate::PyError::value_error(format!(
-            "math domain error: {e:?}"
-        ))),
+        Err(pymath::Error::EDOM) => Err(crate::PyError::value_error("math domain error")),
+        Err(pymath::Error::ERANGE) => Err(crate::PyError::overflow_error("math range error")),
     }
 }
 


### PR DESCRIPTION
## Summary

`interp_math::map_err` collapsed **every** `pymath` error into `ValueError` with the message `"math domain error: {e:?}"`, so range errors (`errno == ERANGE`) surfaced as `ValueError` instead of `OverflowError`.

Split the mapping to match the reference:

| pymath | exception | message |
|---|---|---|
| `Error::EDOM` | `ValueError` | `math domain error` |
| `Error::ERANGE` | `OverflowError` | `math range error` |

`map_err` is the shared error path for all pymath-delegated functions (`sin`/`cos`/`exp`/`log`/`sqrt`/`sinh`/`cosh`/`ldexp`/`atan2`/`fma`/…), so this corrects the whole family at once. It also drops the non-standard `: EDOM`/`: ERANGE` suffix the old `{e:?}` format appended.

### Before / after

```
math.ldexp(1.0, 100000)  ValueError: math domain error: ERANGE   →  OverflowError: math range error
math.exp(10000)          ValueError: math domain error: ERANGE   →  OverflowError: math range error
math.sinh(1000)          ValueError: math domain error: ERANGE   →  OverflowError: math range error
math.log(-1)             ValueError: math domain error: EDOM     →  ValueError:    math domain error
math.sqrt(-1)            ValueError: math domain error: EDOM     →  ValueError:    math domain error
```

## Verification

- `test.test_float.HexFloatTestCase.test_roundtrip` now **passes** — its scaffolding builds inputs with `math.ldexp(m, e)` and relies on the `OverflowError` it raises on overflow.
- All `map_err`-routed function tests in `test_math` pass (none of `testSin`/`testExp`/`testLog`/`testSqrt`/`testSinh`/`testCosh`/`testLdexp`/`testAtan2`/… appear in the failure set).
- No regression: the change only rewrites the error arm, and moves strictly toward reference behavior for both error kinds.

### Pre-existing, out of scope

`test_math`'s remaining failures are unrelated to this change: unimplemented/partial functions (`remainder`, `sumprod`, `isqrt`, `gcd`/`lcm`/`comb`/`perm`, `fsum`, `hypot`, `dist`, `isclose` with `Decimal`/`Fraction`, `ceil`/`floor`/`trunc`). In particular `test_exception_messages` fails both before and after — it expects the 3.14 *descriptive* messages (`"expected a nonnegative input, got -1.1"` for `sqrt(-1.1)`), a separate parity task; this PR keeps the classic `"math domain error"` / adds correct `"math range error"`.

Assisted-by: Claude