### PR TITLE
#346: resolve dot-joined constructor base, residualize w_long_new, name colliding classdefs

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2041,6 +2041,17 @@ impl Bookkeeper {
             seen.insert(cur.rsplit("::").next().unwrap_or(&cur).to_string());
             chain.push(cur.clone());
             let next = self.pyre_struct_fields.borrow().as_ref().and_then(|reg| {
+                // A constructor mints its class under the dot-joined,
+                // crate-included qualname (`pyre_object.intobject.
+                // W_IntObject`, flowspace_adapter `SyntheticTransparentCtor`
+                // arm), but `struct_fields` is keyed by the `::` `name_path`
+                // (`pyre_object::intobject::W_IntObject`) and the bare leaf.
+                // Reduce `.`→`::` for the registry lookups ONLY, so the
+                // header chain resolves the base for a dot-joined ctor
+                // qualname too — the classdef cache key (`key` above) keeps
+                // the raw spelling, so this seeds the base without collapsing
+                // the ctor class onto the `::`-spelled field-read class.
+                let lookup = cur.replace('.', "::");
                 // An enum-variant key `{enum_base}::{variant}` subclasses its
                 // enum base — the discriminant-only sum-type root
                 // (`rclass.py:82-88`).  Checked before the header convention
@@ -2050,13 +2061,13 @@ impl Bookkeeper {
                 // `struct_fields` key including the variant keys, would mint
                 // the variant base-less, and first-mint-wins would freeze
                 // that, dropping the subclass link the narrowing relies on.
-                if let Some((parent, _variant)) = cur.rsplit_once("::") {
+                if let Some((parent, _variant)) = lookup.rsplit_once("::") {
                     let parent_leaf = parent.rsplit("::").next().unwrap_or(parent);
                     if reg.is_enum_base(parent) && !seen.contains(parent_leaf) {
                         return Some(parent.to_string());
                     }
                 }
-                let (first_name, first_ty) = reg.fields.get(&cur)?.first()?;
+                let (first_name, first_ty) = reg.fields.get(&lookup)?.first()?;
                 // Only header-conventional first fields mark subclassing
                 // (`ob_header: PyObject` / `base: FrameBlock`).  A
                 // by-value first field of another registered type is

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -2981,12 +2981,21 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
                 (Some(ca), Some(cb)) => match ClassDef::commonbase(ca, cb) {
                     Some(base) => Some(base),
                     None => {
+                        // Name the two colliding classdefs so the
+                        // skip-classified panic path is diagnosable
+                        // instead of a blind `<other> ∪ <other>`.  The
+                        // "cannot unify instances with no common base
+                        // class" phrase is preserved verbatim so the
+                        // dual-gate skip classifier still matches.
                         return Err(UnionError {
                             lhs: s1.clone(),
                             rhs: s2.clone(),
-                            msg: "RPython cannot unify instances with no \
-                                  common base class"
-                                .to_string(),
+                            msg: format!(
+                                "RPython cannot unify instances with no \
+                                 common base class: {} ∪ {}",
+                                ca.borrow().name,
+                                cb.borrow().name
+                            ),
                         });
                     }
                 },
@@ -3156,17 +3165,25 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         // SomeWeakRef ∪ SomeWeakRef — upstream widens the classdef to
         // the common base when both sides carry one.
         (SomeValue::WeakRef(a), SomeValue::WeakRef(b)) => {
-            let merged_classdef = match (&a.classdef, &b.classdef) {
-                (None, _) | (_, None) => Some(None),
-                (Some(ca), Some(cb)) => ClassDef::commonbase(ca, cb).map(Some),
-            };
-            let Some(merged_classdef) = merged_classdef else {
-                return Err(UnionError {
-                    lhs: s1.clone(),
-                    rhs: s2.clone(),
-                    msg: "RPython cannot unify weakrefs with no common base class".into(),
-                });
-            };
+            let merged_classdef: Option<Rc<RefCell<ClassDef>>> =
+                match (&a.classdef, &b.classdef) {
+                    (None, _) | (_, None) => None,
+                    (Some(ca), Some(cb)) => match ClassDef::commonbase(ca, cb) {
+                        Some(base) => Some(base),
+                        None => {
+                            return Err(UnionError {
+                                lhs: s1.clone(),
+                                rhs: s2.clone(),
+                                msg: format!(
+                                    "RPython cannot unify weakrefs with no \
+                                     common base class: {} ∪ {}",
+                                    ca.borrow().name,
+                                    cb.borrow().name
+                                ),
+                            });
+                        }
+                    },
+                };
             Ok(SomeValue::WeakRef(SomeWeakRef::new(merged_classdef)))
         }
 

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -3165,25 +3165,24 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         // SomeWeakRef ∪ SomeWeakRef — upstream widens the classdef to
         // the common base when both sides carry one.
         (SomeValue::WeakRef(a), SomeValue::WeakRef(b)) => {
-            let merged_classdef: Option<Rc<RefCell<ClassDef>>> =
-                match (&a.classdef, &b.classdef) {
-                    (None, _) | (_, None) => None,
-                    (Some(ca), Some(cb)) => match ClassDef::commonbase(ca, cb) {
-                        Some(base) => Some(base),
-                        None => {
-                            return Err(UnionError {
-                                lhs: s1.clone(),
-                                rhs: s2.clone(),
-                                msg: format!(
-                                    "RPython cannot unify weakrefs with no \
+            let merged_classdef: Option<Rc<RefCell<ClassDef>>> = match (&a.classdef, &b.classdef) {
+                (None, _) | (_, None) => None,
+                (Some(ca), Some(cb)) => match ClassDef::commonbase(ca, cb) {
+                    Some(base) => Some(base),
+                    None => {
+                        return Err(UnionError {
+                            lhs: s1.clone(),
+                            rhs: s2.clone(),
+                            msg: format!(
+                                "RPython cannot unify weakrefs with no \
                                      common base class: {} ∪ {}",
-                                    ca.borrow().name,
-                                    cb.borrow().name
-                                ),
-                            });
-                        }
-                    },
-                };
+                                ca.borrow().name,
+                                cb.borrow().name
+                            ),
+                        });
+                    }
+                },
+            };
             Ok(SomeValue::WeakRef(SomeWeakRef::new(merged_classdef)))
         }
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -494,6 +494,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::longobject::w_long_new",
+        "pyre_object::w_long_new",
+        pyre_object::longobject::w_long_new as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::gc_hook::try_gc_add_root",
         "pyre_object::try_gc_add_root",
         pyre_object::gc_hook::try_gc_add_root as *const (),

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -263,6 +263,14 @@ pub fn w_long_from_raw(value: *mut BigInt) -> PyObjectRef {
 /// payload is GC-managed at a stable address (held on the Rust stack by host
 /// callers without rooting), and the wrapper traces it via the registered
 /// `LONG_VALUE_OFFSET` gc-pointer.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the body
+/// delegates through `alloc_bigint_stable -> *mut BigInt`, so tracing into it
+/// leaks the raw `BigInt` pointee into the return model and unifies against the
+/// `w_int_new` fast path as `PyObject ∪ BigInt`. Residualising the whole box
+/// tail models it by signature — a plain `PyObjectRef` GCREF with no
+/// discriminant to erase — the `w_str_new`/`box_bigint_constant` twin.
+#[majit_macros::dont_look_inside]
 pub fn w_long_new(value: BigInt) -> PyObjectRef {
     w_long_from_raw(alloc_bigint_stable(value))
 }


### PR DESCRIPTION
(untracked)

Follow-on slices to #405, reducing two-phase rtyper prepass lift failures by wiring classdef common bases and residualizing the numeric boxing tail. Toward gh#346 (retire the rtyper legacy walker): as classdef unification succeeds and boxing tails residualize, more graphs lift through the two-phase CodeWriter path and `cutover::is_known_unported` shrinks.

## Commits

- **name colliding classdefs in the no-common-base UnionError** — enrich both no-common-base `UnionError` arms (`SomeInstance`, `SomeWeakRef`) with the two colliding classdef names so the failure identifies the exact pair; the skip substring is preserved. `SomeWeakRef` merge flattened to a single `Option<classdef>` match.
- **resolve header base for dot-joined constructor qualnames** — `intern_class_by_qualname`'s header-chain walk resolves the enum-base check and field lookup through a `::`-normalized spelling while keeping the classdef cache key raw, so a boxed subtype and its base unify via their shared base instead of raising no-common-base.
- **residualize w_long_new via dont_look_inside** — annotate `w_long_new` `#[dont_look_inside]` (with the fnaddr bind) so the annotator models it by signature (`PyObjectRef` return) instead of tracing into the `BigInt` boxing tail; `alloc_bigint_stable` / `w_long_from_raw` return `*mut BigInt`. Closes the `PyObject ∪ BigInt` collision.

## Effect

Measured over these three slices: no-common-base `cannot unify` occurrences 106→60, two-phase prepass phaseA failures 323→307. `check.py` 3/3 bit-exact (dynasm / cranelift / wasm, 183/183 each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT tracing support for long-integer construction, including an additional function mapping and clearer handling of the allocation path.

* **Bug Fixes**
  * Fixed type-name matching for constructor-qualified names with dot notation, reducing lookup mismatches.
  * Error messages for failed type unification now include the conflicting class names, making issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->