### PR TITLE
jit: narrow the wasm bridge decline to exception-resume (GuardException)

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1380,17 +1380,28 @@ impl majit_backend::Backend for WasmBackend {
             return Err(BackendError::Unsupported(reason));
         }
 
-        // Decline bridges that re-enter the interpreter through a may-force
-        // residual call. Such a bridge reconstructs the interpreter value stack
-        // from its inputargs before the CallMayForce; on wasm a float-const
-        // dividend materialises as NULL through that inputarg path, so the
-        // re-entered interpreter runs `truediv(NULL, int)` and raises a spurious
-        // `unsupported operand type(s) for /`. Native never compiles this
-        // side-trace — it blackholes the deopt instead. Declining here routes
-        // the deopt back through the blackhole interpreter, matching native.
-        if ops.iter().any(|op| op.opcode.is_call_may_force()) {
+        // Decline exception-resume bridges (`GuardException`): the guarded call
+        // raised, so the bridge resumes into the exception handler by re-entering
+        // the interpreter at the raising bytecode. That re-entry reads the
+        // pre-call operand stack, whose constant entries (e.g. a float dividend)
+        // live only in the guard's `rd_consts` resume data, not in a spilled
+        // frame slot. The compiled bridge reconstructs its state from inputargs
+        // (spilled slots) alone and cannot see `rd_consts`, so such a constant
+        // materialises as NULL and the re-entered interpreter runs e.g.
+        // `truediv(NULL, int)`, raising a spurious `unsupported operand type(s)
+        // for /`. Declining routes the deopt through the blackhole interpreter,
+        // which rematerialises constants from `rd_consts` (the native path).
+        // Non-raising (`GuardNoException`) loop-closing bridges keep their
+        // compiled fast path — the CallMayForce bridges wasm relies on for speed
+        // are unaffected, so this does not regress them.
+        if ops
+            .iter()
+            .any(|op| op.opcode == majit_ir::OpCode::GuardException)
+        {
             return Err(BackendError::Unsupported(
-                "wasm backend: bridge with CallMayForce interpreter re-entry".into(),
+                "wasm backend: exception-resume bridge (GuardException) re-enters \
+                 the interpreter with unreconstructable rd_consts stack entries"
+                    .into(),
             ));
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #407. #407 declined **every** `CallMayForce` bridge on wasm, which also dropped the non-raising loop-closing bridges wasm relies on for speed — `bool_arithmetic` ~6× slower, ~+11% on the synthetic suite. This narrows the decline to only the bridges that are actually broken.

## Root cause (pinned via in-guest instrumentation)

Only **exception-resume** bridges are broken. A bridge containing `GuardException` resumes into the exception handler by re-entering the interpreter at the raising bytecode, reading the **pre-call operand stack**. Constant stack entries (e.g. a `float` dividend `1.5`) live only in the guard's `rd_consts` resume data, not in a spilled frame slot. The compiled bridge reconstructs its state from inputargs (spilled slots) alone and cannot see `rd_consts`, so the constant materialises as **NULL** and the re-entered interpreter runs `truediv(NULL, int)` → spurious `unsupported operand type(s) for /`.

Dumping every `CallMayForce` bridge gave a crisp discriminator:

| bench | guard | tail | status |
|---|---|---|---|
| `float_div_zero_caught_loop` | **`GuardException`** | `Finish` (interp re-entry) | broken |
| `bool_arithmetic` / `is_op` / `string_ops` | `GuardNoException` | `Jump` (loop-closing) | fast, correct |

## Fix

Decline only bridges containing `OpCode::GuardException` (was `is_call_may_force()`). The broken shape blackholes — rematerialising constants from `rd_consts`, the native path — while `GuardNoException` loop-closing bridges keep their compiled fast path.

## Verification (on current `main` base)

- wasm synthetic suite **173/173** (`float_div_zero_caught_loop` → `37500.0`, 0.41s)
- `bool_arithmetic` **2.77s** (was 15.84s under the #407 blanket decline) — regression removed
- dynasm synthetic suite **173/173** (lib.rs change is wasm-backend-only)
- suite total **~119s**, faster than both the #407 blanket decline (~139s) and the #404 workaround (~125s): loop-closing bridges are kept and m366 stays on (its ~4% wasm benefit).