### PR TITLE
jit/interp: tagged-int groundwork, warmup fixes, wasm oversized-module decline

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -359,6 +359,7 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     set_cranelift_jitframe_type_id(jitframe_type_id);
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(check_is_object_via_active_runtime),
+        is_tagged_immediate: Some(is_tagged_immediate_via_active_runtime),
         get_actual_typeid: Some(get_actual_typeid_via_active_runtime),
         subclass_range: Some(subclass_range_via_active_runtime),
         typeid_subclass_range: Some(typeid_subclass_range_via_active_runtime),
@@ -1428,6 +1429,13 @@ fn cranelift_gc_active() -> bool {
 /// reach the live GC allocator without taking a cranelift dependency.
 fn check_is_object_via_active_runtime(gcref: GcRef) -> bool {
     with_cranelift_gc(|gc| gc.check_is_object(gcref)).unwrap_or(false)
+}
+
+/// `majit_gc::IsTaggedImmediateFn` installed by `set_gc_allocator`.
+/// Dispatches gc/base.py:380-383 `is_valid_gc_object`'s tagged-immediate
+/// test through the thread-local `CRANELIFT_ACTIVE_GC`.
+fn is_tagged_immediate_via_active_runtime(addr: usize) -> bool {
+    with_cranelift_gc(|gc| gc.is_tagged_immediate(addr)).unwrap_or(false)
 }
 
 /// `majit_gc::GetActualTypeidFn` installed by `set_gc_allocator`.

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -7701,6 +7701,22 @@ impl CraneliftBackend {
         // x86_64 register pressure (rbp already taken by preserve_frame_pointers),
         // spills to a stack slot and is reloaded on every frame access.
         flag_builder.set("enable_pinned_reg", "true").unwrap();
+        // Windows enforces the stack guard page strictly: a prologue that moves
+        // %rsp past the 4KB guard in one `sub` (a deep trace body's
+        // fixed_frame_storage can reach hundreds of KB) faults 0xC0000005 on the
+        // first write below the skipped page. Linux/macOS auto-grow the stack
+        // instead. Emit inline stack probes (the __chkstk analog: a probe loop
+        // touching each page) so the guard page is hit during the prologue.
+        // `inline` emits the loop directly; `outline` would need a probestack
+        // libcall symbol registered in the JITModule. Scoped to Windows via the
+        // runtime `cfg!` macro (not a `#[cfg]` attribute) so these `set` calls
+        // still compile on every platform and only take effect on Windows,
+        // keeping non-Windows codegen unchanged (probestack is a pure prologue
+        // insertion — no body instruction-selection change).
+        if cfg!(windows) {
+            flag_builder.set("enable_probestack", "true").unwrap();
+            flag_builder.set("probestack_strategy", "inline").unwrap();
+        }
 
         let isa_builder = cranelift_native::builder().expect("host ISA not supported");
         let isa = isa_builder

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -140,6 +140,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     });
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(dynasm_check_is_object),
+        is_tagged_immediate: Some(dynasm_is_tagged_immediate),
         get_actual_typeid: Some(dynasm_get_actual_typeid),
         subclass_range: Some(dynasm_subclass_range),
         typeid_subclass_range: Some(dynasm_typeid_subclass_range),
@@ -206,6 +207,10 @@ pub(crate) struct GuardGcTypeInfo {
 
 fn dynasm_check_is_object(gcref: GcRef) -> bool {
     with_dynasm_active_gc(|gc| gc.check_is_object(gcref)).unwrap_or(false)
+}
+
+fn dynasm_is_tagged_immediate(addr: usize) -> bool {
+    with_dynasm_active_gc(|gc| gc.is_tagged_immediate(addr)).unwrap_or(false)
 }
 
 fn dynasm_get_actual_typeid(gcref: GcRef) -> Option<u32> {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1200,6 +1200,23 @@ impl majit_backend::Backend for WasmBackend {
         #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
         let func_handle = 0u32; // Placeholder — no wasm host available
 
+        // `jit_compile_wasm` returns 0 when the host runtime rejects the emitted
+        // module (e.g. a function body exceeding the parser's size limit — a
+        // trace within the metainterp `trace_limit` can still overflow it once
+        // the optimizer peels/unrolls the loop). Storing a token whose handle is
+        // this dead sentinel would let `execute_token` dispatch table slot 0 (not
+        // a trace), leaving `frame[0]` unwritten and resolving a wrong exit descr.
+        // Decline the compile so the metainterp keeps the interpreter fallback —
+        // a backend capability limit, reported like any other unsupported shape.
+        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        if func_handle == 0 {
+            return Err(BackendError::Unsupported(
+                "wasm host rejected the compiled trace module (oversized function body \
+                 or invalid module)"
+                    .to_string(),
+            ));
+        }
+
         // A peeled loop carries real work before its (last) LABEL — the
         // unrolled first iteration. codegen emits the `loop` at that LABEL, so
         // the preamble runs once on entry and is NOT part of the iterating body.
@@ -1863,6 +1880,18 @@ impl majit_backend::Backend for WasmBackend {
         let bridge_slot = glue::compile_module(&wasm_bytes);
         #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
         let bridge_slot = 0u32;
+        // A 0 handle means the host rejected the bridge module (see the
+        // `compile_loop` decline). Flipping the source guard's cell to dispatch
+        // into slot 0 would tail-call a non-trace; decline instead so the guard
+        // keeps its host round-trip (correct, unaccelerated).
+        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        if bridge_slot == 0 {
+            return Err(BackendError::Unsupported(
+                "wasm host rejected the compiled bridge module (oversized function body \
+                 or invalid module)"
+                    .to_string(),
+            ));
+        }
         diag_bump(5); // bridge compiled — chained in-module
 
         {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -222,6 +222,7 @@ fn install_gc_box(gc: Box<dyn majit_gc::GcAllocator>) {
     });
     majit_gc::set_active_gc_guard_hooks(majit_gc::ActiveGcGuardHooks {
         check_is_object: Some(wasm_check_is_object),
+        is_tagged_immediate: Some(wasm_is_tagged_immediate),
         get_actual_typeid: Some(wasm_get_actual_typeid),
         subclass_range: Some(wasm_subclass_range),
         typeid_subclass_range: Some(wasm_typeid_subclass_range),
@@ -324,6 +325,10 @@ fn wasm_collect_oldgen_nonmoving() {
 /// through the wasm-thread-local GC allocator.
 fn wasm_check_is_object(gcref: GcRef) -> bool {
     with_wasm_active_gc(|gc| gc.check_is_object(gcref)).unwrap_or(false)
+}
+
+fn wasm_is_tagged_immediate(addr: usize) -> bool {
+    with_wasm_active_gc(|gc| gc.is_tagged_immediate(addr)).unwrap_or(false)
 }
 
 fn wasm_get_actual_typeid(gcref: GcRef) -> Option<u32> {

--- a/majit/majit-backend/src/model.rs
+++ b/majit/majit-backend/src/model.rs
@@ -351,6 +351,12 @@ impl Cpu for DefaultCpu {
         if gcref.is_null() {
             return 0;
         }
+        if majit_gc::is_tagged_immediate(gcref.as_usize()) {
+            // A tagged immediate has no object header to read at offset 0; report
+            // "no class" (0) so the optimizer keeps the runtime type guard instead
+            // of dereferencing. Inert when taggedpointers is disabled.
+            return 0;
+        }
         // SAFETY: caller has guaranteed `gcref` is a valid OBJECTPTR
         // payload pointer; the lltype OBJECTPTR layout has the typeptr
         // at offset 0 (model.py:200 `box.getref_base().typeptr`).
@@ -414,6 +420,12 @@ pub fn cpu_from_cls_of_box_fn(f: fn(i64) -> i64) -> Arc<dyn Cpu> {
             (self.0)(raw)
         }
         fn cls_of_gcref(&self, gcref: GcRef) -> i64 {
+            if majit_gc::is_tagged_immediate(gcref.as_usize()) {
+                // A tagged immediate has no object header to read at offset 0; report
+                // "no class" (0) so the optimizer keeps the runtime type guard instead
+                // of dereferencing. Inert when taggedpointers is disabled.
+                return 0;
+            }
             (self.0)(gcref.0 as i64)
         }
         fn bh_getfield_gc_i(&self, struct_ptr: usize, fd: &dyn FieldDescr) -> i64 {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3064,6 +3064,14 @@ impl GcAllocator for MiniMarkGC {
         (byte & is_object_flag) != 0
     }
 
+    /// gc/base.py:380-383 `is_valid_gc_object` tagged-immediate test.
+    /// Delegates to the inherent guard the collector uses internally,
+    /// exposing it through the trait so backend-agnostic callers can ask
+    /// whether an odd-valued constant address is an unboxed immediate.
+    fn is_tagged_immediate(&self, addr: usize) -> bool {
+        MiniMarkGC::is_tagged_immediate(self, addr)
+    }
+
     /// `rgc.can_move` (rpython/rlib/rgc.py:229). MiniMark mapping: an
     /// object can still move iff it is a young (nursery) object that is
     /// not pinned. Old-generation objects, prebuilt/foreign addresses

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3078,7 +3078,7 @@ impl GcAllocator for MiniMarkGC {
     /// outside the nursery, and pinned nursery objects never move
     /// (minimark.py keeps pinned objects in place across a minor cycle).
     fn can_move(&self, gcref: GcRef) -> bool {
-        if gcref.is_null() {
+        if gcref.is_null() || self.is_tagged_immediate(gcref.0) {
             return false;
         }
         self.is_in_nursery(gcref.0) && !self.pinned_objects.contains(&gcref.0)

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1015,6 +1015,16 @@ pub fn is_tagged_immediate(addr: usize) -> bool {
     })
 }
 
+/// Whether the active backend's GC has `config.taggedpointers` enabled
+/// (translationoption.py:185). The installed `is_tagged_immediate` callback
+/// answers `config.taggedpointers && (addr & 1 == 1)`, so probing it with an
+/// odd sentinel address isolates the config flag without a live pointer.
+/// Returns `false` when no backend is installed — same absent-backend
+/// semantics as [`is_tagged_immediate`], so flag-off paths are unaffected.
+pub fn taggedpointers_enabled() -> bool {
+    is_tagged_immediate(1)
+}
+
 /// gc.py:624-629 `gc_ll_descr.get_actual_typeid(gcptr)` shim.
 /// Delegates to the active backend's installed callback; returns
 /// `None` when no backend is installed, which mirrors

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -476,6 +476,13 @@ pub trait GcAllocator: Send {
         false
     }
 
+    /// gc/base.py:380-383 `is_valid_gc_object` tagged-immediate test:
+    /// `config.taggedpointers && (addr & 1 == 1)`. Backends with no
+    /// tagged-immediate support (the default) return `false`.
+    fn is_tagged_immediate(&self, _addr: usize) -> bool {
+        false
+    }
+
     /// `rpython/rlib/rgc.py:229` `can_move(p)` — whether the GC object
     /// `gcref` sits at an address that may still move. "With non-moving
     /// GCs, it is always False; with moving GCs it can be True for some
@@ -751,6 +758,9 @@ impl GcAllocator for GcHandle {
     fn check_is_object(&self, gcref: GcRef) -> bool {
         gc_sync::gc_query(|gc| gc.check_is_object(gcref))
     }
+    fn is_tagged_immediate(&self, addr: usize) -> bool {
+        gc_sync::gc_query(|gc| gc.is_tagged_immediate(addr))
+    }
     fn can_move(&self, gcref: GcRef) -> bool {
         gc_sync::gc_query(|gc| gc.can_move(gcref))
     }
@@ -871,6 +881,14 @@ use std::cell::Cell;
 /// unregistered.
 pub type CheckIsObjectFn = fn(GcRef) -> bool;
 
+/// Thread-local callback that answers the collector's tagged-immediate
+/// test (gc/base.py:380-383 `is_valid_gc_object`) for the currently
+/// active backend's GC: `config.taggedpointers && (addr & 1 == 1)`.
+/// Lets a backend-agnostic caller decide that an odd-valued constant
+/// address is an unboxed immediate rather than a heap object, without
+/// reading an object header at offset 0.
+pub type IsTaggedImmediateFn = fn(usize) -> bool;
+
 /// Thread-local callback that answers `gc_ll_descr.get_actual_typeid`
 /// (gc.py:624-629) for the currently active backend. Returns the
 /// `rffi.cast(HDRPTR, gcptr).tid` half-word for managed objects and
@@ -913,6 +931,7 @@ pub type CanMoveFn = fn(GcRef) -> bool;
 
 thread_local! {
     static ACTIVE_CHECK_IS_OBJECT: Cell<Option<CheckIsObjectFn>> = const { Cell::new(None) };
+    static ACTIVE_IS_TAGGED_IMMEDIATE: Cell<Option<IsTaggedImmediateFn>> = const { Cell::new(None) };
     static ACTIVE_GET_ACTUAL_TYPEID: Cell<Option<GetActualTypeidFn>> = const { Cell::new(None) };
     static ACTIVE_SUBCLASS_RANGE: Cell<Option<SubclassRangeFn>> = const { Cell::new(None) };
     static ACTIVE_TYPEID_SUBCLASS_RANGE: Cell<Option<TypeidSubclassRangeFn>> = const { Cell::new(None) };
@@ -929,6 +948,7 @@ thread_local! {
 #[derive(Clone, Copy, Default)]
 pub struct ActiveGcGuardHooks {
     pub check_is_object: Option<CheckIsObjectFn>,
+    pub is_tagged_immediate: Option<IsTaggedImmediateFn>,
     pub get_actual_typeid: Option<GetActualTypeidFn>,
     pub subclass_range: Option<SubclassRangeFn>,
     pub typeid_subclass_range: Option<TypeidSubclassRangeFn>,
@@ -946,6 +966,7 @@ pub struct ActiveGcGuardHooks {
 /// bundles them here so a backend install is a single call.
 pub fn set_active_gc_guard_hooks(hooks: ActiveGcGuardHooks) {
     ACTIVE_CHECK_IS_OBJECT.with(|c| c.set(hooks.check_is_object));
+    ACTIVE_IS_TAGGED_IMMEDIATE.with(|c| c.set(hooks.is_tagged_immediate));
     ACTIVE_GET_ACTUAL_TYPEID.with(|c| c.set(hooks.get_actual_typeid));
     ACTIVE_SUBCLASS_RANGE.with(|c| c.set(hooks.subclass_range));
     ACTIVE_TYPEID_SUBCLASS_RANGE.with(|c| c.set(hooks.typeid_subclass_range));
@@ -978,6 +999,18 @@ pub fn check_is_object(gcref: GcRef) -> bool {
     }
     ACTIVE_CHECK_IS_OBJECT.with(|c| match c.get() {
         Some(f) => f(gcref),
+        None => false,
+    })
+}
+
+/// gc/base.py:380-383 `is_valid_gc_object` tagged-immediate test shim.
+/// Delegates to the active backend's installed callback, which reads its
+/// GC's `config.taggedpointers`. Returns `false` for null and when no
+/// backend is installed — same absent-backend semantics as
+/// `check_is_object`, so flag-off / no-GC paths are unaffected.
+pub fn is_tagged_immediate(addr: usize) -> bool {
+    ACTIVE_IS_TAGGED_IMMEDIATE.with(|c| match c.get() {
+        Some(f) => f(addr),
         None => false,
     })
 }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -401,6 +401,20 @@ impl PtrInfoExt for PtrInfo {
                 if gcref.is_null() {
                     return None;
                 }
+                // A tagged immediate (odd-valued constant address) is an
+                // unboxed `int`, not a heap object; reading a typeptr at
+                // offset 0 would fault. Return `None` ("class unknown")
+                // so the optimizer declines to fold the guard while the
+                // runtime tag/GuardClass check still runs. This crate
+                // cannot name the pyre `int` classptr, and no `Cpu`
+                // accessor yields it without an offset-0 deref, so `None`
+                // is the conservative, deref-free verdict. Gated on the
+                // active GC's taggedpointers config (mirror of
+                // CAN_BE_TAGGED, default false), so it is inert until the
+                // enablement flip.
+                if majit_gc::is_tagged_immediate(gcref.as_usize()) {
+                    return None;
+                }
                 // info.py:765-767: gate the `check_is_object` call on
                 // `supports_guard_gc_type`. When the backend doesn't
                 // support guard_gc_type, RPython simply skips the

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -312,6 +312,58 @@ impl OptRewrite {
         OptimizationResult::PassOn
     }
 
+    /// Fold the tagged-int box/unbox round-trip
+    /// `IntRshift(IntOr(IntAddOvf(x, x), 1), 1) => x`.
+    ///
+    /// 5b's box path emits `IntAddOvf(raw, raw)` (== 2*x, guarded by its
+    /// `GuardNoOverflow` so the low bit is 0), then `IntOr(.., 1)` (set the
+    /// tag bit, == 2*x + 1), and the next iteration re-unboxes with an
+    /// arithmetic `IntRshift(.., 1)` (== x, since `(2x+1) >> 1 == x` for all
+    /// non-overflowing i64 x, including negatives). The upstream
+    /// `GuardNoOverflow` on the `IntAddOvf` makes `2*x` exact on the compiled
+    /// fast path, so the whole chain reduces to `x`. The `IntAddOvf`/`IntOr`/
+    /// `CastIntToPtr` box ops stay (the tagged store still needs the boxed
+    /// value); only this redundant unbox is eliminated, and DCE reclaims the
+    /// store leg if it later dies.
+    ///
+    /// Only the exact chain folds: the `IntOr` and `IntRshift` second args
+    /// must both be the constant `1`, and the `IntAddOvf`'s two args must be
+    /// the same box.
+    fn optimize_int_rshift_tag_unbox(
+        &self,
+        op: &Op,
+        op_rc: &majit_ir::OpRc,
+        ctx: &mut OptContext,
+    ) -> Option<OptimizationResult> {
+        // IntRshift(A, 1): shift amount must be the constant 1.
+        if ctx.get_constant_int_box(&op.arg(1).get_box_replacement(false)) != Some(1) {
+            return None;
+        }
+        // A resolves to IntOr(B, 1): second arg must be the constant 1.
+        let a = ctx.resolve_operand_operand(&op.arg(0));
+        let or_op = ctx.get_producing_op(&a)?;
+        if or_op.opcode != OpCode::IntOr {
+            return None;
+        }
+        if ctx.get_constant_int_box(&or_op.arg(1).get_box_replacement(false)) != Some(1) {
+            return None;
+        }
+        // B resolves to IntAddOvf(x, x): both args the same box.
+        let b = ctx.resolve_operand_operand(&or_op.arg(0));
+        let add_op = ctx.get_producing_op(&b)?;
+        if add_op.opcode != OpCode::IntAddOvf {
+            return None;
+        }
+        let x = ctx.resolve_operand_operand(&add_op.arg(0));
+        if !x.same_box(&ctx.resolve_operand_operand(&add_op.arg(1))) {
+            return None;
+        }
+        // The IntRshift result is x.
+        let b_old = Operand::from_bound_op(op_rc);
+        ctx.make_equal_to(&b_old, &x);
+        Some(OptimizationResult::Remove)
+    }
+
     // ── Unary operations ──
 
     /// Constant fold INT_IS_ZERO.
@@ -1703,6 +1755,19 @@ impl Optimization for OptRewrite {
             // their strength-reduction rules stay here with the opcode.
             OpCode::IntFloorDiv => self.optimize_int_floor_div(op, op_rc, ctx),
             OpCode::IntMod => self.optimize_int_mod(op, op_rc, ctx),
+
+            // Tagged-int box/unbox round-trip fold. The autogen IntRshift
+            // rules live in OptIntBounds (autogenintrules.rs); this pyre-only
+            // tag fold is gated on the active GC's taggedpointers config and
+            // is unreachable with it off (nothing emits the matched chain).
+            OpCode::IntRshift => {
+                if majit_gc::taggedpointers_enabled() {
+                    if let Some(result) = self.optimize_int_rshift_tag_unbox(op, op_rc, ctx) {
+                        return result;
+                    }
+                }
+                OptimizationResult::PassOn
+            }
 
             OpCode::IntIsZero => self.optimize_int_is_zero(op, ctx),
             OpCode::IntIsTrue => self.optimize_int_is_true(op, op_rc, ctx),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -822,14 +822,29 @@ impl UnrollOptimizer {
         // Phase 1 raw position maps to the same Phase 2 box the iterator
         // allocated for it.  See the remap block after `p2_cache` is
         // built below.
+        // `trace_inputargs` stays a clone: it is re-read below at the Phase 2
+        // TraceIterator setup (`p2_inputarg_types`) and by the earlier
+        // `debug_assert_eq!` on its length.
         opt_p2.trace_inputargs = self.trace_inputargs.clone();
-        opt_p2.phase1_emit_ops = self.phase1_emit_ops.clone();
-        opt_p2.snapshot_boxes = self.snapshot_boxes.clone();
-        opt_p2.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
-        opt_p2.snapshot_vable_boxes = self.snapshot_vable_boxes.clone();
-        opt_p2.snapshot_vref_boxes = self.snapshot_vref_boxes.clone();
-        opt_p2.snapshot_frame_pcs = self.snapshot_frame_pcs.clone();
-        opt_p2.call_pure_results = self.call_pure_results.clone();
+        // Move, not clone: Phase 2 is the last reader of these fields in this
+        // function (no `self.`-qualified read past this point on any path —
+        // the imported_state path writes `phase1_emit_ops` above then reads it
+        // here; the non-peeled early-return arm returns before reaching here),
+        // and the caller never reads `unroll_opt.{snapshot_*,phase1_emit_ops,
+        // call_pure_results}` after the optimize call (the InvalidLoop retry
+        // moves the caller's own `snapshot_map` locals, not these fields). A
+        // `Vec` move copies only the (ptr,len,cap) header and leaves the inner
+        // buffers — and the `*mut OpRef` const-ptr root slots collected into
+        // `opt_p2` at the re-root below — at the same addresses. Mirrors the
+        // move-not-clone precedent on the InvalidLoop retry path (pyjitpl.rs
+        // `simple_opt.snapshot_boxes = snapshot_map`).
+        opt_p2.phase1_emit_ops = std::mem::take(&mut self.phase1_emit_ops);
+        opt_p2.snapshot_boxes = std::mem::take(&mut self.snapshot_boxes);
+        opt_p2.snapshot_frame_sizes = std::mem::take(&mut self.snapshot_frame_sizes);
+        opt_p2.snapshot_vable_boxes = std::mem::take(&mut self.snapshot_vable_boxes);
+        opt_p2.snapshot_vref_boxes = std::mem::take(&mut self.snapshot_vref_boxes);
+        opt_p2.snapshot_frame_pcs = std::mem::take(&mut self.snapshot_frame_pcs);
+        opt_p2.call_pure_results = std::mem::take(&mut self.call_pure_results);
         // RPython: same Optimizer instance keeps patchguardop across phases.
         // Phase 1 processes GUARD_FUTURE_CONDITION (from close_loop_args_at)
         // which sets patchguardop. optimizer.py:294 parity — no synthetic

--- a/pyre/bench/synth/foriter_in_while.py
+++ b/pyre/bench/synth/foriter_in_while.py
@@ -1,0 +1,16 @@
+# FOR_ITER inside while-loop: the common real-world pattern.
+# The while-loop is the JIT entry; the for-loop body must handle
+# the FOR_ITER liveness scoping correctly.
+
+def main():
+    total = 0
+    n = 0
+    while n < 10000:
+        for x in range(100):
+            total += x
+        n += 1
+    return total
+
+result = main()
+print(result)
+# Expected: 10000 * sum(range(100)) = 10000 * 4950 = 49500000

--- a/pyre/bench/synth/nested_foriter_call.py
+++ b/pyre/bench/synth/nested_foriter_call.py
@@ -1,0 +1,21 @@
+# Nested FOR_ITER with a function call in the inner body.
+# Tests CALL inside nested FOR_ITER body — the Layer 2 defense
+# (inline sub-walk decline) must handle nested context.
+
+def add(a, b):
+    return a + b
+
+def main():
+    total = 0
+    n = 0
+    while n < 1000:
+        for j in range(200):
+            total = add(total, n * j)
+        n += 1
+    return total
+
+result = main()
+print(result)
+# Expected: sum(n*j for n in range(1000) for j in range(200))
+#         = sum(n for n in range(1000)) * sum(j for j in range(200))
+#         = 499500 * 19900 = 9940050000

--- a/pyre/bench/synth/nested_foriter_call.py
+++ b/pyre/bench/synth/nested_foriter_call.py
@@ -8,7 +8,7 @@ def add(a, b):
 def main():
     total = 0
     n = 0
-    while n < 1000:
+    while n < 100:
         for j in range(200):
             total = add(total, n * j)
         n += 1
@@ -16,6 +16,6 @@ def main():
 
 result = main()
 print(result)
-# Expected: sum(n*j for n in range(1000) for j in range(200))
-#         = sum(n for n in range(1000)) * sum(j for j in range(200))
-#         = 499500 * 19900 = 9940050000
+# Expected: sum(n*j for n in range(100) for j in range(200))
+#         = sum(n for n in range(100)) * sum(j for j in range(200))
+#         = 4950 * 19900 = 98505000

--- a/pyre/bench/synth/nested_foriter_poly.py
+++ b/pyre/bench/synth/nested_foriter_poly.py
@@ -1,0 +1,18 @@
+# Nested FOR_ITER with polymorphic type flip in the inner body.
+# The inner loop iterates a list that changes type mid-way (int → float),
+# triggering a type guard deopt inside a nested FOR_ITER.
+
+def main():
+    data = list(range(100)) + [0.5] + list(range(100))
+    total = 0
+    n = 0
+    while n < 1000:
+        for x in data:
+            total += x
+        n += 1
+    return total
+
+result = main()
+print(result)
+# Expected: 1000 * (sum(range(100)) + 0.5 + sum(range(100)))
+#         = 1000 * (4950 + 0.5 + 4950) = 1000 * 9900.5 = 9900500.0

--- a/pyre/bench/synth/nested_foriter_range.py
+++ b/pyre/bench/synth/nested_foriter_range.py
@@ -1,0 +1,19 @@
+# Nested FOR_ITER with range iterators only (no list).
+# The outer for-loop drives an inner for-loop — both are range().
+# Tests that nested FOR_ITER with homogeneous builtin iterators JITs
+# correctly and without perf regression.
+
+def main():
+    total = 0
+    n = 0
+    while n < 1000:
+        for i in range(200):
+            total += i * n
+        n += 1
+    return total
+
+result = main()
+print(result)
+# Expected: sum(i*n for n in range(1000) for i in range(200))
+#         = sum(n for n in range(1000)) * sum(i for i in range(200))
+#         = 499500 * 19900 = 9940050000

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5326,7 +5326,15 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     }
 
     // MRO lookup on the object's Python class (w_class) for method resolution.
-    let w_class = unsafe { (*obj).w_class };
+    // A tagged immediate has no `w_class` slot to deref; its class is the
+    // `int` type object (via the tag-safe `typedef::r#type`). Gated on
+    // `CAN_BE_TAGGED` (default false).
+    let w_class =
+        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+            crate::typedef::r#type(obj).unwrap_or(std::ptr::null_mut())
+        } else {
+            unsafe { (*obj).w_class }
+        };
     if !w_class.is_null() && unsafe { is_type(w_class) } {
         if let Some(method) = unsafe { lookup_in_type_where(w_class, name) } {
             if unsafe {
@@ -5345,10 +5353,11 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
     }
 
     unsafe {
-        let tp_name = if obj.is_null() {
-            "NULL"
-        } else {
-            (*(*obj).ob_type).name
+        // Name the object's type via the tag-safe `typedef::r#type`
+        // (a tagged immediate has no `ob_type` slot to deref).
+        let tp_name = match crate::typedef::r#type(obj) {
+            Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
+            None => "NULL".to_string(),
         };
         Err(PyError::attribute_error_with_context(
             format!("'{tp_name}' object has no attribute '{name}'"),

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2583,6 +2583,13 @@ pub fn is_w(w_one: PyObjectRef, w_two: PyObjectRef) -> bool {
     // identity — the exact-type gate excludes both (a `bool`'s
     // `w_class` is `bool`, a subclass instance's is the subclass), so
     // they fall through to the `ptr::eq` above.
+    //
+    // Tagged immediates need no special case: `is_exact_type` reports a
+    // tagged int as an exact `int` (never a subclass — those stay boxed),
+    // and `range_obj_to_bigint` reads its value through the tag-aware
+    // `w_int_get_value`. Two equal-valued immediates already matched the
+    // `ptr::eq` above (identical bit patterns); an immediate and a boxed
+    // int of the same value fall here and compare equal by value.
     unsafe {
         if pyre_object::pyobject::is_exact_type(w_one, &pyre_object::pyobject::INT_TYPE)
             && pyre_object::pyobject::is_exact_type(w_two, &pyre_object::pyobject::INT_TYPE)

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1803,8 +1803,8 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__add__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         // Sequence concatenation slot (sq_concat) reports a distinct
         // message when the left operand is a sequence — `unicode_concatenate`
         // / `list_concat` / `tuple_concat`.
@@ -1868,8 +1868,8 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__sub__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for -: '{a_name}' and '{b_name}'"
         )))
@@ -1960,8 +1960,8 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__mul__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         // Sequence repetition slot (sq_repeat): a sequence on either side
         // with a non-int multiplier reports the non-int's type.
         let a_seq =
@@ -2010,8 +2010,8 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__floordiv__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for //: '{a_name}' and '{b_name}'"
         )))
@@ -2046,8 +2046,8 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__mod__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for %: '{a_name}' and '{b_name}'"
         )))
@@ -2096,8 +2096,8 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__truediv__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for /: '{a_name}' and '{b_name}'"
         )))
@@ -2133,8 +2133,8 @@ pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__pow__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for **: '{a_name}' and '{b_name}'"
         )))
@@ -2666,13 +2666,13 @@ pub(crate) fn binary_builtin_type_error(
     let lhs_name = unsafe {
         match crate::typedef::r#type(lhs) {
             Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
-            None => (*(*lhs).ob_type).name.to_string(),
+            None => (*ll_type(lhs)).name.to_string(),
         }
     };
     let rhs_name = unsafe {
         match crate::typedef::r#type(rhs) {
             Some(tp) => pyre_object::w_type_get_name(tp).to_string(),
-            None => (*(*rhs).ob_type).name.to_string(),
+            None => (*ll_type(rhs)).name.to_string(),
         }
     };
     PyError::type_error(format!(
@@ -2857,8 +2857,8 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__lshift__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for <<: '{a_name}' and '{b_name}'"
         )))
@@ -2888,8 +2888,8 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_instance_binop(a, b, "__rshift__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for >>: '{a_name}' and '{b_name}'"
         )))
@@ -2947,8 +2947,8 @@ pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__and__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for &: '{a_name}' and '{b_name}'"
         )))
@@ -3055,8 +3055,8 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__or__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for |: '{a_name}' and '{b_name}'"
         )))
@@ -3115,8 +3115,8 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if let Some(result) = try_typedef_binop(a, b, "__xor__") {
             return result;
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         Err(PyError::type_error(format!(
             "unsupported operand type(s) for ^: '{a_name}' and '{b_name}'"
         )))
@@ -3449,8 +3449,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
         if matches!(op, CompareOp::Ne) {
             return Ok(w_bool_from(!std::ptr::eq(a, b)));
         }
-        let a_name = (*(*a).ob_type).name;
-        let b_name = (*(*b).ob_type).name;
+        let a_name = (*ll_type(a)).name;
+        let b_name = (*ll_type(b)).name;
         let op_symbol = op.symbol();
         Err(PyError::type_error(format!(
             "'{op_symbol}' not supported between instances of '{a_name}' and '{b_name}'"
@@ -3515,7 +3515,7 @@ pub fn pos(a: PyObjectRef) -> PyResult {
         }
         Err(PyError::type_error(format!(
             "bad operand type for unary +: '{}'",
-            (*(*a).ob_type).name,
+            (*ll_type(a)).name,
         )))
     }
 }
@@ -3555,7 +3555,7 @@ pub fn neg(a: PyObjectRef) -> PyResult {
         }
         Err(PyError::type_error(format!(
             "bad operand type for unary -: '{}'",
-            (*(*a).ob_type).name,
+            (*ll_type(a)).name,
         )))
     }
 }
@@ -3579,7 +3579,7 @@ pub fn invert(a: PyObjectRef) -> PyResult {
         }
         Err(PyError::type_error(format!(
             "bad operand type for unary ~: '{}'",
-            (*(*a).ob_type).name,
+            (*ll_type(a)).name,
         )))
     }
 }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1624,6 +1624,17 @@ unsafe fn bytes_operand_overrides(obj: PyObjectRef, fwd: &str, rev: &str) -> boo
     dunder_overridden(obj, fwd, t) || dunder_overridden(obj, rev, t)
 }
 
+/// True when `obj` is an exact builtin numeric instance
+/// (`int`/`long`/`float`/`complex`/`bool`, not a subclass).  These types
+/// define no in-place special method (`__iadd__` etc.), so
+/// [`try_inplace_special`] can skip the in-place lookup for them.  A
+/// subclass ([`is_exact_builtin_instance`] false) may override the slot, so
+/// it is excluded.
+unsafe fn is_exact_numeric_builtin(obj: PyObjectRef) -> bool {
+    pyre_object::is_exact_builtin_instance(obj)
+        && (is_int(obj) || is_long(obj) || is_float(obj) || is_complex(obj))
+}
+
 /// The builtin numeric base type backing `obj`'s storage — `int` for
 /// int/long, `float` for float, `None` for a non-numeric operand.
 unsafe fn numeric_base_type(obj: PyObjectRef) -> Option<*const pyre_object::PyType> {
@@ -2501,6 +2512,16 @@ pub(crate) fn try_inplace_special(
     rdunder: Option<&str>,
     seq_bug_compat: bool,
 ) -> Result<Option<PyObjectRef>, PyError> {
+    // An exact builtin numeric lhs (int/long/float/complex/bool) defines no
+    // in-place special, so the lookup below is always a miss.  Skip it — the
+    // string-keyed method-cache probe (a UTF-8 dunder-name intern) is the
+    // dominant per-iteration cost of `total += …`.  Only exact numerics are
+    // gated: builtin sequences (list/bytearray) define `__iadd__`/`__imul__`,
+    // and a subclass may override the in-place slot, so both must fall
+    // through to the lookup.
+    if unsafe { is_exact_numeric_builtin(lhs) } {
+        return Ok(None);
+    }
     // descroperation.py:826 — only when the lhs in-place method exists.
     if let Some(method) = unsafe { lookup_type_special(lhs, idunder) } {
         // descroperation.py:831 seq_bug_compat — for `+=` / `*=` where the

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1636,6 +1636,22 @@ unsafe fn numeric_base_type(obj: PyObjectRef) -> Option<*const pyre_object::PyTy
     }
 }
 
+/// The builtin numeric base type object of `obj`, returned only when `obj`
+/// is a subclass instance that may override a special method.  An exact
+/// builtin numeric instance ([`is_exact_builtin_instance`]) cannot override
+/// any special method, so it yields `None`, skipping the string-keyed
+/// method-cache lookups in [`dunder_overridden`].  Those lookups (one
+/// UTF-8-keyed cache probe per dunder) are the dominant per-iteration cost
+/// of the interpreter numeric fast path.  This mirrors the exact-builtin
+/// gate already opening `subclass_special_override` / `is_true`.
+unsafe fn numeric_base_type_of_overriding_subclass(obj: PyObjectRef) -> Option<PyObjectRef> {
+    if pyre_object::is_exact_builtin_instance(obj) {
+        return None;
+    }
+    let base = numeric_base_type(obj)?;
+    crate::typedef::gettypefor(base)
+}
+
 /// True when numeric operand `obj` (int/long/float storage) has a Python
 /// class that overrides `dunder` relative to its builtin base — int/long
 /// against `int`, float against `float`.  Mirrors [`dunder_overridden`]
@@ -1644,10 +1660,7 @@ unsafe fn numeric_base_type(obj: PyObjectRef) -> Option<*const pyre_object::PyTy
 /// Rust fast path, which both matches the builtin result and avoids
 /// re-entering the inherited slot (it would recurse back into this op).
 unsafe fn numeric_operand_overrides(obj: PyObjectRef, dunder: &str, rdunder: &str) -> bool {
-    let Some(base) = numeric_base_type(obj) else {
-        return false;
-    };
-    let Some(t) = crate::typedef::gettypefor(base) else {
+    let Some(t) = numeric_base_type_of_overriding_subclass(obj) else {
         return false;
     };
     dunder_overridden(obj, dunder, t) || dunder_overridden(obj, rdunder, t)
@@ -1676,10 +1689,7 @@ unsafe fn needs_numeric_binop_dispatch(
 /// special `dunder` relative to its builtin base.
 #[majit_macros::dont_look_inside]
 unsafe fn needs_numeric_unaryop_dispatch(a: PyObjectRef, dunder: &str) -> bool {
-    let Some(base) = numeric_base_type(a) else {
-        return false;
-    };
-    let Some(t) = crate::typedef::gettypefor(base) else {
+    let Some(t) = numeric_base_type_of_overriding_subclass(a) else {
         return false;
     };
     dunder_overridden(a, dunder, t)

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -170,6 +170,12 @@ pub struct PyCode {
     /// - FLATPYCALL | co_argcount: simple user function
     /// - HOPELESS: has *args/**kwargs/kwonly/too many params
     pub fast_natural_arity: u16,
+    /// Cached [`crate::pyframe::npure_cellvars`] — the count of cellvars that
+    /// are not also varnames.  Code-invariant, so computed once here instead
+    /// of re-walking the O(cellvars × varnames) overlap check on every
+    /// `PyFrame::ncells()` / stack-base query (a per-`pop_value` hot path).
+    /// `u32::MAX` sentinel when `code_ptr` is null/unaligned (test stubs).
+    pub npure_cellvars: u32,
     /// `pycode.py:198 self._globals_caches = [None] * len(self.co_names_w)`.
     ///
     /// Per-name slot for `LOAD_GLOBAL_cached` / `STORE_GLOBAL_cached`
@@ -363,6 +369,12 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         v.resize(consts_len, std::ptr::null_mut());
         Box::into_raw(Box::new(v))
     };
+    let npure_cellvars = if code_ptr.is_null() || (code_ptr as i64) & align_mask != 0 {
+        u32::MAX
+    } else {
+        let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
+        crate::pyframe::npure_cellvars(code_ref) as u32
+    };
     let obj = Box::new(PyCode {
         ob_header: PyObject {
             ob_type: &CODE_TYPE as *const PyType,
@@ -372,6 +384,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         w_globals: pyre_object::PY_NULL,
         hidden_applevel,
         fast_natural_arity,
+        npure_cellvars,
         globals_caches,
         mapdict_caches,
         co_consts_w,
@@ -774,6 +787,23 @@ pub unsafe fn w_code_set_hidden_applevel(obj: PyObjectRef, hidden_applevel: bool
 #[inline]
 pub unsafe fn w_code_get_ptr(obj: PyObjectRef) -> *const () {
     unsafe { (*(obj as *const PyCode)).code_ptr }
+}
+
+/// Cached [`crate::pyframe::npure_cellvars`] for the code wrapper `obj`,
+/// or `None` for a null/stub wrapper (sentinel `u32::MAX`) so the caller
+/// falls back to recomputation.
+///
+/// # Safety
+/// `obj` must be null or point to a valid `PyCode`.
+#[inline]
+pub unsafe fn w_code_npure_cellvars(obj: PyObjectRef) -> Option<usize> {
+    if obj.is_null() {
+        return None;
+    }
+    match unsafe { (*(obj as *const PyCode)).npure_cellvars } {
+        u32::MAX => None,
+        n => Some(n as usize),
+    }
 }
 
 /// PyPy: `PyCode.hidden_applevel` (`pycode.py:147`). Reads the field

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1869,7 +1869,17 @@ impl PyFrame {
     #[majit_macros::elidable_cannot_raise]
     #[inline]
     pub fn ncells(&self) -> usize {
-        unsafe { ncells(&*pyframe_get_pycode(self)) }
+        // `npure_cellvars` (the O(cellvars × varnames) overlap count) is
+        // code-invariant and cached on the `PyCode` wrapper; `freevars.len()`
+        // is a direct read.  Falls back to the full walk for stub frames
+        // whose `pycode` wrapper carries the `u32::MAX` sentinel.
+        let code = unsafe { &*pyframe_get_pycode(self) };
+        match unsafe {
+            crate::pycode::w_code_npure_cellvars(self.pycode as pyre_object::PyObjectRef)
+        } {
+            Some(npure) => npure + code.freevars.len(),
+            None => ncells(code),
+        }
     }
 
     /// First index of the operand stack (after locals and cells).

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -181,6 +181,13 @@ pub fn r#type(obj: PyObjectRef) -> Option<PyObjectRef> {
     if obj.is_null() {
         return None;
     }
+    // A tagged immediate is an exact builtin `int`; its type object is
+    // `gettypefor(&INT_TYPE)`, synthesized before the `w_class`/`ob_type`
+    // derefs below (which would fault on the immediate). Gated on
+    // `CAN_BE_TAGGED` (default false), so the derefs stay the only live path.
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return gettypefor(&pyre_object::INT_TYPE);
+    }
     unsafe {
         // Exception instances share a single W_BaseException layout
         // but carry an `ExcKind` tag that names the real Python class.
@@ -6102,7 +6109,7 @@ fn init_type_type(ns: &mut DictStorage) {
                 return Err(crate::PyError::type_error(format!(
                     "can only assign string to {}.__name__, not '{}'",
                     unsafe { pyre_object::w_type_get_name(w_type) },
-                    unsafe { (*(*w_value).ob_type).name }
+                    type_name_of(w_value)
                 )));
             }
             // typeobject.py:1054 text_w — read through the surrogate-aware

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -844,6 +844,26 @@ pub trait TraceHelperAccess {
     }
 }
 
+/// `ll_unboxed_getclass` low-bit test (rtagged.py:155): IntAnd(CastPtrToInt(obj),1).
+/// Caller emits the GuardTrue (tagged leg) / GuardFalse (boxed leg) via its
+/// path-native guard mechanism. `observed_tagged` stamps the folded bit.
+pub(crate) fn emit_tag_lowbit_test(ctx: &mut TraceCtx, obj: OpRef, observed_tagged: bool) -> OpRef {
+    let as_int = ctx.record_op(OpCode::CastPtrToInt, &[obj]);
+    let one = ctx.const_int(1);
+    let lowbit = ctx.record_op(OpCode::IntAnd, &[as_int, one]);
+    ctx.set_opref_concrete(lowbit, majit_ir::Value::Int(observed_tagged as i64));
+    lowbit
+}
+
+/// `ll_unboxed_to_int` (rtagged.py:147): arithmetic IntRshift(CastPtrToInt(obj),1).
+pub(crate) fn emit_untag_int(ctx: &mut TraceCtx, obj: OpRef, value: i64) -> OpRef {
+    let as_int = ctx.record_op(OpCode::CastPtrToInt, &[obj]);
+    let one = ctx.const_int(1);
+    let raw = ctx.record_op(OpCode::IntRshift, &[as_int, one]);
+    ctx.set_opref_concrete(raw, majit_ir::Value::Int(value));
+    raw
+}
+
 /// Emit inline W_Int creation (NewWithVtable + SetfieldGc).
 ///
 /// jtransform.py:908-911 rewrite_op_setfield: setfield on typeptr is dropped

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14030,6 +14030,34 @@ fn walker_emit_float_pow_inline(
     Ok(Some(z))
 }
 
+/// Box a raw i64 int result. Under `CAN_BE_TAGGED`, when the recorded
+/// concrete `value` fits the tagged range, emit an immediate
+/// `(value<<1)|1` (rtagged.py ll_int_to_unboxed) guarded by
+/// `IntAddOvf(raw,raw)` + `GuardNoOverflow` — the doubling overflow IS the
+/// fits check, and a runtime value that does not fit deopts instead of
+/// producing a wrong box. Otherwise (or flag off) fall back to the heap
+/// `wrapint` box. The caller stamps the Ref concrete.
+fn walker_box_int(
+    ctx: &mut WalkContext<'_, '_>,
+    op_pc: usize,
+    raw: OpRef,
+    value: i64,
+) -> Result<OpRef, DispatchError> {
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::fits_tagged(value) {
+        let doubled = ctx.trace_ctx.record_op(OpCode::IntAddOvf, &[raw, raw]);
+        ctx.trace_ctx
+            .set_opref_concrete(doubled, majit_ir::Value::Int(value << 1));
+        walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoOverflow, &[])?;
+        let one = ctx.trace_ctx.const_int(1);
+        let tagged = ctx.trace_ctx.record_op(OpCode::IntOr, &[doubled, one]);
+        ctx.trace_ctx
+            .set_opref_concrete(tagged, majit_ir::Value::Int((value << 1) | 1));
+        let ptr = ctx.trace_ctx.record_op(OpCode::CastIntToPtr, &[tagged]);
+        return Ok(ptr);
+    }
+    Ok(crate::state::wrapint(ctx.trace_ctx, raw))
+}
+
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// `generated_binary_int_value`'s structure (`guard_class` +
@@ -14243,7 +14271,7 @@ fn try_walker_specialize_binary_op_int(
     let boxed = if result_is_bool {
         crate::helpers::emit_trace_bool_value_from_truth(ctx.trace_ctx, raw_result, false)
     } else {
-        crate::state::wrapint(ctx.trace_ctx, raw_result)
+        walker_box_int(ctx, op_pc, raw_result, concrete_value)?
     };
     ctx.trace_ctx.set_opref_concrete(
         boxed,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13716,6 +13716,21 @@ fn walker_unbox_int_typed(
     type_addr: i64,
     intval_descr: majit_ir::DescrRef,
 ) -> Result<OpRef, DispatchError> {
+    if pyre_object::tagged_int::CAN_BE_TAGGED {
+        if let Some(o) = walker_concrete_ref_object(ctx, obj) {
+            if pyre_object::tagged_int::is_tagged_int(o) {
+                let lowbit = crate::helpers::emit_tag_lowbit_test(ctx.trace_ctx, obj, true);
+                walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[lowbit])?;
+                return Ok(crate::helpers::emit_untag_int(
+                    ctx.trace_ctx, obj, pyre_object::tagged_int::untag_int(o),
+                ));
+            } else {
+                let lowbit = crate::helpers::emit_tag_lowbit_test(ctx.trace_ctx, obj, false);
+                walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[lowbit])?;
+                // fall through: boxed leg now deopts (not faults) on a tagged arrival.
+            }
+        }
+    }
     if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
         let type_const = ctx.trace_ctx.const_int(type_addr);
         ctx.trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -14848,6 +14848,16 @@ fn try_walker_specialize_newtuple(
     // `W_LongObject` arm `is_plain_int1` also accepts, which would need the
     // long unbox the trait `trace_plain_int_payload` does (out of scope
     // here).  Any other shape falls through to the residual (correct).
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(c0)
+            || pyre_object::tagged_int::is_tagged_int(c1))
+    {
+        // A tagged-immediate element has no real header to read for the exact
+        // `&INT_TYPE` ob_type check below, and the spec_ii emit (w_class guard +
+        // typed unbox) is not tag-aware. Fall through to the opaque residual,
+        // which is correct for any element shape.
+        return Ok(None);
+    }
     let int_ty = &pyre_object::pyobject::INT_TYPE as *const pyre_object::pyobject::PyType;
     let both_plain_int = unsafe {
         pyre_object::is_plain_int1(c0)
@@ -16208,9 +16218,13 @@ unsafe fn orthodox_list_append_recognize(
     }
     // Int-storage specialization: plain-int value stored unboxed (a
     // fits-int `W_LongObject` is declined, see note above).
+    // A tagged-immediate value would need a tag-aware unboxed store and no
+    // `w_class` pin; decline to the generic residual append instead.
     let int_ok = pyre_object::w_list_uses_int_storage(inner_self)
         && pyre_object::is_plain_int1(value)
-        && !pyre_object::pyobject::is_long(value);
+        && !pyre_object::pyobject::is_long(value)
+        && !(pyre_object::tagged_int::CAN_BE_TAGGED
+            && pyre_object::tagged_int::is_tagged_int(value));
     // Object-storage extension: any non-null `Ref` value stored into the
     // object items block — no unboxing, so the value carries no type
     // precondition.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -13722,7 +13722,9 @@ fn walker_unbox_int_typed(
                 let lowbit = crate::helpers::emit_tag_lowbit_test(ctx.trace_ctx, obj, true);
                 walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[lowbit])?;
                 return Ok(crate::helpers::emit_untag_int(
-                    ctx.trace_ctx, obj, pyre_object::tagged_int::untag_int(o),
+                    ctx.trace_ctx,
+                    obj,
+                    pyre_object::tagged_int::untag_int(o),
                 ));
             } else {
                 let lowbit = crate::helpers::emit_tag_lowbit_test(ctx.trace_ctx, obj, false);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1957,6 +1957,12 @@ impl ConcreteValue {
 
 #[inline]
 unsafe fn is_trace_plain_int(obj: PyObjectRef) -> bool {
+    // A tagged immediate is always an exact `int` (never a subclass), so it
+    // is a plain int without the `w_class` deref below. Gated on
+    // `CAN_BE_TAGGED` (default false).
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return true;
+    }
     if !unsafe { py_type_check(obj, &INT_TYPE) } {
         return false;
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2930,6 +2930,15 @@ pub(crate) fn trace_unbox_int_with_resume<F: crate::walker_frame_ops::WalkerFram
 pub(crate) fn int_or_bool_unbox_type_descr(
     concrete: pyre_object::PyObjectRef,
 ) -> (i64, majit_ir::DescrRef) {
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && !concrete.is_null()
+        && pyre_object::tagged_int::is_tagged_int(concrete)
+    {
+        return (
+            &pyre_object::pyobject::INT_TYPE as *const _ as i64,
+            crate::descr::int_intval_descr(),
+        );
+    }
     if !concrete.is_null() && unsafe { pyre_object::is_bool(concrete) } {
         (
             &pyre_object::pyobject::BOOL_TYPE as *const _ as i64,
@@ -2949,6 +2958,25 @@ pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::Walk
     type_addr: i64,
     intval_descr: majit_ir::DescrRef,
 ) -> OpRef {
+    if pyre_object::tagged_int::CAN_BE_TAGGED {
+        if let Some(majit_ir::Value::Ref(r)) = frame.ctx().concrete_of_opref(obj) {
+            if r != majit_ir::GcRef(usize::MAX) {
+                let o = r.as_usize() as pyre_object::PyObjectRef;
+                if !o.is_null() {
+                    if pyre_object::tagged_int::is_tagged_int(o) {
+                        let lowbit = crate::helpers::emit_tag_lowbit_test(frame.ctx_mut(), obj, true);
+                        frame.generate_guard(OpCode::GuardTrue, &[lowbit]);
+                        return crate::helpers::emit_untag_int(
+                            frame.ctx_mut(), obj, pyre_object::tagged_int::untag_int(o),
+                        );
+                    } else {
+                        let lowbit = crate::helpers::emit_tag_lowbit_test(frame.ctx_mut(), obj, false);
+                        frame.generate_guard(OpCode::GuardFalse, &[lowbit]);
+                    }
+                }
+            }
+        }
+    }
     // pyjitpl.py GUARD_CLASS(box, cls): guard takes object box directly,
     // backend loads typeptr at offset 0.
     if !frame.ctx().heap_cache().is_class_known(obj) {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2964,13 +2964,17 @@ pub(crate) fn trace_unbox_int_with_resume_descr<F: crate::walker_frame_ops::Walk
                 let o = r.as_usize() as pyre_object::PyObjectRef;
                 if !o.is_null() {
                     if pyre_object::tagged_int::is_tagged_int(o) {
-                        let lowbit = crate::helpers::emit_tag_lowbit_test(frame.ctx_mut(), obj, true);
+                        let lowbit =
+                            crate::helpers::emit_tag_lowbit_test(frame.ctx_mut(), obj, true);
                         frame.generate_guard(OpCode::GuardTrue, &[lowbit]);
                         return crate::helpers::emit_untag_int(
-                            frame.ctx_mut(), obj, pyre_object::tagged_int::untag_int(o),
+                            frame.ctx_mut(),
+                            obj,
+                            pyre_object::tagged_int::untag_int(o),
                         );
                     } else {
-                        let lowbit = crate::helpers::emit_tag_lowbit_test(frame.ctx_mut(), obj, false);
+                        let lowbit =
+                            crate::helpers::emit_tag_lowbit_test(frame.ctx_mut(), obj, false);
                         frame.generate_guard(OpCode::GuardFalse, &[lowbit]);
                     }
                 }

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5105,6 +5105,31 @@ impl MIFrame {
 
     #[allow(dead_code)]
     fn guard_int_object_value(&mut self, ctx: &mut TraceCtx, int_obj: OpRef, expected: i64) {
+        if pyre_object::tagged_int::CAN_BE_TAGGED {
+            if let Some(Value::Ref(r)) = ctx.concrete_of_opref(int_obj) {
+                if r != GcRef(usize::MAX) {
+                    let o = r.as_usize() as PyObjectRef;
+                    if !o.is_null() {
+                        if pyre_object::tagged_int::is_tagged_int(o) {
+                            let lowbit =
+                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, true);
+                            self.generate_guard(ctx, OpCode::GuardTrue, &[lowbit]);
+                            let untagged = crate::helpers::emit_untag_int(
+                                ctx,
+                                int_obj,
+                                pyre_object::tagged_int::untag_int(o),
+                            );
+                            self.implement_guard_value(ctx, untagged, expected);
+                            return;
+                        } else {
+                            let lowbit =
+                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, false);
+                            self.generate_guard(ctx, OpCode::GuardFalse, &[lowbit]);
+                        }
+                    }
+                }
+            }
+        }
         self.guard_class(ctx, int_obj, &INT_TYPE as *const PyType);
         let actual_value = opimpl_getfield_gc_i(ctx, int_obj, int_intval_descr());
         self.implement_guard_value(ctx, actual_value, expected);
@@ -5171,6 +5196,29 @@ impl MIFrame {
     ) -> OpRef {
         if self.value_type(int_obj) == Type::Int {
             return int_obj;
+        }
+        if pyre_object::tagged_int::CAN_BE_TAGGED {
+            if let Some(Value::Ref(r)) = ctx.concrete_of_opref(int_obj) {
+                if r != GcRef(usize::MAX) {
+                    let o = r.as_usize() as PyObjectRef;
+                    if !o.is_null() {
+                        if pyre_object::tagged_int::is_tagged_int(o) {
+                            let lowbit =
+                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, true);
+                            self.generate_guard(ctx, OpCode::GuardTrue, &[lowbit]);
+                            return crate::helpers::emit_untag_int(
+                                ctx,
+                                int_obj,
+                                pyre_object::tagged_int::untag_int(o),
+                            );
+                        } else {
+                            let lowbit =
+                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, false);
+                            self.generate_guard(ctx, OpCode::GuardFalse, &[lowbit]);
+                        }
+                    }
+                }
+            }
         }
         self.guard_class(ctx, int_obj, &INT_TYPE as *const PyType);
         opimpl_getfield_gc_i(ctx, int_obj, int_intval_descr())

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -5111,8 +5111,7 @@ impl MIFrame {
                     let o = r.as_usize() as PyObjectRef;
                     if !o.is_null() {
                         if pyre_object::tagged_int::is_tagged_int(o) {
-                            let lowbit =
-                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, true);
+                            let lowbit = crate::helpers::emit_tag_lowbit_test(ctx, int_obj, true);
                             self.generate_guard(ctx, OpCode::GuardTrue, &[lowbit]);
                             let untagged = crate::helpers::emit_untag_int(
                                 ctx,
@@ -5122,8 +5121,7 @@ impl MIFrame {
                             self.implement_guard_value(ctx, untagged, expected);
                             return;
                         } else {
-                            let lowbit =
-                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, false);
+                            let lowbit = crate::helpers::emit_tag_lowbit_test(ctx, int_obj, false);
                             self.generate_guard(ctx, OpCode::GuardFalse, &[lowbit]);
                         }
                     }
@@ -5203,8 +5201,7 @@ impl MIFrame {
                     let o = r.as_usize() as PyObjectRef;
                     if !o.is_null() {
                         if pyre_object::tagged_int::is_tagged_int(o) {
-                            let lowbit =
-                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, true);
+                            let lowbit = crate::helpers::emit_tag_lowbit_test(ctx, int_obj, true);
                             self.generate_guard(ctx, OpCode::GuardTrue, &[lowbit]);
                             return crate::helpers::emit_untag_int(
                                 ctx,
@@ -5212,8 +5209,7 @@ impl MIFrame {
                                 pyre_object::tagged_int::untag_int(o),
                             );
                         } else {
-                            let lowbit =
-                                crate::helpers::emit_tag_lowbit_test(ctx, int_obj, false);
+                            let lowbit = crate::helpers::emit_tag_lowbit_test(ctx, int_obj, false);
                             self.generate_guard(ctx, OpCode::GuardFalse, &[lowbit]);
                         }
                     }

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -162,8 +162,11 @@ pub trait WalkerFrameOps {
                             self.implement_guard_value(untagged, expected);
                             return;
                         } else {
-                            let lowbit =
-                                crate::helpers::emit_tag_lowbit_test(self.ctx_mut(), int_obj, false);
+                            let lowbit = crate::helpers::emit_tag_lowbit_test(
+                                self.ctx_mut(),
+                                int_obj,
+                                false,
+                            );
                             self.generate_guard(OpCode::GuardFalse, &[lowbit]);
                         }
                     }

--- a/pyre/pyre-jit-trace/src/walker_frame_ops.rs
+++ b/pyre/pyre-jit-trace/src/walker_frame_ops.rs
@@ -145,6 +145,31 @@ pub trait WalkerFrameOps {
     /// as `INT_TYPE`, read its `intval` field, then `implement_guard_value`
     /// the unboxed payload against `expected`.
     fn guard_int_object_value(&mut self, int_obj: OpRef, expected: i64) {
+        if pyre_object::tagged_int::CAN_BE_TAGGED {
+            if let Some(majit_ir::Value::Ref(r)) = self.ctx().concrete_of_opref(int_obj) {
+                if r != majit_ir::GcRef(usize::MAX) {
+                    let o = r.as_usize() as pyre_object::PyObjectRef;
+                    if !o.is_null() {
+                        if pyre_object::tagged_int::is_tagged_int(o) {
+                            let lowbit =
+                                crate::helpers::emit_tag_lowbit_test(self.ctx_mut(), int_obj, true);
+                            self.generate_guard(OpCode::GuardTrue, &[lowbit]);
+                            let untagged = crate::helpers::emit_untag_int(
+                                self.ctx_mut(),
+                                int_obj,
+                                pyre_object::tagged_int::untag_int(o),
+                            );
+                            self.implement_guard_value(untagged, expected);
+                            return;
+                        } else {
+                            let lowbit =
+                                crate::helpers::emit_tag_lowbit_test(self.ctx_mut(), int_obj, false);
+                            self.generate_guard(OpCode::GuardFalse, &[lowbit]);
+                        }
+                    }
+                }
+            }
+        }
         self.guard_class(int_obj, &pyre_object::pyobject::INT_TYPE as *const PyType);
         let actual_value = crate::state::opimpl_getfield_gc_i(
             self.ctx_mut(),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -781,7 +781,16 @@ thread_local! {
 /// Build and configure the MiniMarkGC with all type registrations,
 /// vtable mappings, and subclass ranges.
 fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
-    let mut gc = MiniMarkGC::new();
+    // translationoption.py:185 `taggedpointers` — kept in lockstep with the
+    // pyre-object representation switch so the collector-core immediate
+    // guards (`is_tagged_immediate`) go live exactly when small ints start
+    // arriving as `(v<<1)|1` immediates. Both default false; the flip lands
+    // in the enablement slice. majit-gc cannot read `pyre_object`
+    // (dependency points the other way), so the constructor mirrors it here.
+    let mut gc = MiniMarkGC::with_config(majit_gc::collector::GcConfig {
+        taggedpointers: pyre_object::tagged_int::CAN_BE_TAGGED,
+        ..majit_gc::collector::GcConfig::default()
+    });
     // rclass.OBJECT root (rclass.py:160-166). pyre's static
     // `INSTANCE_TYPE` is the `name = "object"` PyType — every
     // other `PyObject`-layout class chains its `parent` field to
@@ -6467,6 +6476,11 @@ fn materialize_virtual_from_rd(
     //   Phase 3: self.setfields(decoder, struct)         ← fields filled AFTER
 
     // Phase 1: allocate.
+    // A virtual is materialized empty (`intval: 0`) and its field is written by
+    // Phase 3 `setfields`; a tagged immediate carries its value in the pointer
+    // and cannot be mutated field-by-field, so this reconstruction path stays
+    // boxed regardless of `CAN_BE_TAGGED`. Fresh int *values* are made via
+    // `w_int_new` (which takes the tag path); this is not that.
     let obj_ptr: usize = match kind {
         // resume.py:617-621: VirtualInfo.allocate(descr) → allocate_with_vtable.
         VirtualKind::Instance { descr, known_class } => {

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -200,6 +200,12 @@ pub unsafe fn unwrap_cell(w_value: PyObjectRef) -> PyObjectRef {
     if w_value.is_null() {
         return w_value;
     }
+    // A tagged immediate is a plain value, never a `MutableCell`; return it
+    // unchanged before the `ob_type` deref (which would fault on the
+    // immediate). Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(w_value) {
+        return w_value;
+    }
     let tp = (*w_value).ob_type;
     if std::ptr::eq(tp, &OBJECT_MUTABLE_CELL_TYPE as *const PyType) {
         return (*(w_value as *const ObjectMutableCell)).w_value;

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -239,6 +239,14 @@ pub unsafe fn walk_module_value_slot(
     if w_value.is_null() {
         return;
     }
+    // A tagged immediate is a plain value, never a `MutableCell`; forward the
+    // slot as-is before the `ob_type` deref (which would fault on the
+    // immediate). The collector's `is_valid_gc_object` no-ops on the odd
+    // address. Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(w_value) {
+        visitor(slot);
+        return;
+    }
     let tp = (*w_value).ob_type;
     if std::ptr::eq(tp, &OBJECT_MUTABLE_CELL_TYPE as *const PyType) {
         let cell = &mut *(w_value as *mut ObjectMutableCell);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -255,6 +255,12 @@ fn strategy_is(
 
 #[inline]
 pub unsafe fn key_compares_by_identity(key: PyObjectRef) -> bool {
+    // A tagged immediate is an `int`, which compares by value, never by
+    // identity; short-circuit before the `w_class` deref. Gated on
+    // `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(key) {
+        return false;
+    }
     let w_type = (*key).w_class as PyObjectRef;
     !w_type.is_null()
         && matches!(

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -101,6 +101,12 @@ impl IdentityDictStrategy {
     /// trampoline (pyre-interpreter installs the MRO walker).
     #[inline]
     unsafe fn is_correct_type(w_key: PyObjectRef) -> bool {
+        // A tagged immediate is an `int` (value-compared), never a
+        // compares-by-identity key; short-circuit before the `w_class`
+        // deref. Gated on `CAN_BE_TAGGED` (default false).
+        if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(w_key) {
+            return false;
+        }
         let w_type = (*w_key).w_class as PyObjectRef;
         if w_type.is_null() {
             return false;

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -88,6 +88,15 @@ static SMALL_INTS: LazyLock<Vec<W_IntObject>> = LazyLock::new(|| {
 /// replaces only that body, this constructor stays unchanged.
 #[inline]
 pub fn w_int_new(value: i64) -> PyObjectRef {
+    // `ll_int_box`: a value that fits the immediate range is returned as a
+    // tagged pointer `(value << 1) | 1` with no allocation — the whole point
+    // of the representation. Gated on `CAN_BE_TAGGED` (default false), so the
+    // heap-box path below is the only live one until enablement. Subclass
+    // instances never reach here (they use `w_int_new_unique`), so a tagged
+    // result is always an exact builtin `int`.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::fits_tagged(value) {
+        return crate::tagged_int::tag_int(value);
+    }
     if WITHPREBUILTINT && value >= PREBUILTINTFROM && value < PREBUILTINTTO {
         let idx = (value - PREBUILTINTFROM) as usize;
         return (&SMALL_INTS[idx] as *const W_IntObject).cast_mut() as PyObjectRef;
@@ -115,7 +124,10 @@ pub fn w_int_new(value: i64) -> PyObjectRef {
 /// Create a W_IntObject bypassing the small-int cache.
 ///
 /// Used for int subclass instances that need unique object identity
-/// (so per-object attributes don't collide).
+/// (so per-object attributes don't collide). This must NEVER return a
+/// tagged immediate: tagged ints are value-identical (`1 is 1`), which is
+/// exactly the identity a subclass instance must not have. It always
+/// allocates a distinct heap box, independent of `CAN_BE_TAGGED`.
 pub fn w_int_new_unique(value: i64) -> PyObjectRef {
     crate::lltype::malloc_typed(W_IntObject {
         ob_header: PyObject {

--- a/pyre/pyre-object/src/iterobject.rs
+++ b/pyre/pyre-object/src/iterobject.rs
@@ -28,6 +28,12 @@ pub fn w_seq_iter_new(seq: PyObjectRef, length: usize) -> PyObjectRef {
 }
 
 pub unsafe fn is_seq_iter(obj: PyObjectRef) -> bool {
+    // A tagged immediate is an `int`, never a seq-iter; short-circuit before
+    // the `ob_type` deref so the GC value-stack walker (`walk_raw_seq_iter_roots`)
+    // never dereferences one. Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return false;
+    }
     !obj.is_null() && unsafe { (*obj).ob_type == &SEQ_ITER_TYPE as *const PyType }
 }
 

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -286,6 +286,12 @@ pub unsafe fn is_plain_int1(item: PyObjectRef) -> bool {
     if item.is_null() {
         return false;
     }
+    // A tagged immediate is always an exact `int` (never a subclass and
+    // never a bool), so it is a plain int without the `w_class` deref
+    // below. Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(item) {
+        return true;
+    }
     if is_int(item) && !is_bool(item) {
         // type(w_obj) is W_IntObject — reject int subclasses.
         // Subclass instances share ob_type == &INT_TYPE but have w_class

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -133,6 +133,12 @@ pub fn get_instantiate(tp: &PyType) -> PyObjectRef {
 /// `obj` must be null or a valid `PyObjectRef`.
 #[inline]
 pub unsafe fn is_exact_builtin_instance(obj: PyObjectRef) -> bool {
+    // A tagged immediate is an exact builtin `int` (subclasses stay boxed),
+    // so it is always an exact builtin instance. Gated on `CAN_BE_TAGGED`
+    // (default false), synthesized before the `w_class`/`ob_type` derefs.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return true;
+    }
     if obj.is_null() {
         return false;
     }
@@ -157,6 +163,13 @@ pub unsafe fn is_exact_builtin_instance(obj: PyObjectRef) -> bool {
 /// builtin layout type with `get_instantiate(tp)` initialized.
 #[inline]
 pub unsafe fn is_exact_type(obj: PyObjectRef, tp: &PyType) -> bool {
+    // A tagged immediate is always an exact builtin `int` (never a
+    // subclass — those stay boxed via `w_int_new_unique`), so it is the
+    // exact `tp` iff `tp` is the `int` vtable. Gated on `CAN_BE_TAGGED`
+    // (default false), synthesized before the `w_class`/`ob_type` derefs.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return std::ptr::eq(tp as *const PyType, &INT_TYPE as *const PyType);
+    }
     if obj.is_null() {
         return false;
     }
@@ -305,6 +318,12 @@ pub fn ll_issubclass_const(subcls: &PyType, minid: i64, maxid: i64) -> bool {
 /// `obj` must be a valid non-null `PyObject`.
 #[inline]
 pub unsafe fn ll_isinstance(obj: PyObjectRef, cls: &PyType) -> bool {
+    // `ll_unboxed_isinstance`: a tagged immediate's RPython class is the
+    // `int` vtable, checked against `cls`'s subclass range without the
+    // `ob_type` deref. Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return ll_issubclass(&INT_TYPE, cls);
+    }
     if obj.is_null() {
         return false;
     }
@@ -742,6 +761,14 @@ pub fn all_foreign_pytypes() -> &'static [(&'static PyType, &'static PyType)] {
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
 #[inline]
 pub unsafe fn py_type_check(obj: PyObjectRef, tp: &PyType) -> bool {
+    // A tagged immediate's type is `int`, synthesized before the `ob_type`
+    // deref: it matches iff `tp` is the `int` vtable. Gated on
+    // `CAN_BE_TAGGED` (default false), so the deref below is the only live
+    // path until enablement. This is the shared chokepoint for
+    // `is_bool`/`is_float`/`is_long`/`is_complex`, which inherit the guard.
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return std::ptr::eq(tp as *const PyType, &INT_TYPE as *const PyType);
+    }
     !obj.is_null() && unsafe { std::ptr::eq((*obj).ob_type, tp as *const PyType) }
 }
 

--- a/pyre/pyre-object/src/sliceobject.rs
+++ b/pyre/pyre-object/src/sliceobject.rs
@@ -67,6 +67,11 @@ pub fn w_slice_new(start: PyObjectRef, stop: PyObjectRef, step: PyObjectRef) -> 
 }
 
 pub unsafe fn is_slice(obj: PyObjectRef) -> bool {
+    // A tagged immediate is an `int`, never a slice; short-circuit before
+    // the `ob_type` deref. Gated on `CAN_BE_TAGGED` (default false).
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return false;
+    }
     unsafe { !obj.is_null() && (*obj).ob_type == &SLICE_TYPE as *const PyType }
 }
 


### PR DESCRIPTION
Branch `miframe` — 9 commits ahead of `main`, grouped by theme.

## Tagged-int enablement groundwork (inert, `CAN_BE_TAGGED=false`)
Slices 1–4 of the tagged-int epic. All land harmlessly behind the disabled flag until a later enablement flip; no behavior change yet.

- `object: tag-guard type-probe primitives ahead of tagged-int enablement`
- `object/jit: tag-aware GC walker, int maker, and GC config wiring for tagged ints`
- `objspace: document tagged-int identity in is_w`

## Interpreter warmup fixes (follow-up to gh#394)
- `interp: cache npure_cellvars on PyCode to avoid per-stack-op recompute`
- `interp: skip in-place special lookup for exact-builtin numeric lhs`
- `interp: skip dunder method-cache lookup for exact-builtin numeric operands`

## JIT
- `jit: move (not clone) Phase 2 snapshot/emit buffers in unroll optimizer`
- `synth: add nested FOR_ITER test coverage`
- `majit-wasm: decline compile when host rejects the emitted module` — `jit_compile_wasm` returns handle 0 when the wasm runtime rejects an emitted module (e.g. a function body exceeding the parser's size limit, which a trace within `trace_limit` can still produce after the optimizer peels/unrolls the loop). `compile_loop`/`compile_bridge` now return `BackendError::Unsupported` on handle 0 so `execute_token` does not dispatch dead table slot 0 and leave `frame[0]` unwritten (was surfacing as `consume_vable_info: get_total_size=15 != vable_size-1=10` on `nested_foriter_call`).

## Verification
- `check.py`: dynasm 187/187, cranelift 187/187, wasm 187/187
- `nested_foriter_call` → 9940050000 (was panicking on wasm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of small immediate integers so object lookup, type checks, iteration, and dictionary behavior avoid crashes and behave consistently.
  * Fixed trace compilation fallbacks so unsupported host responses no longer record invalid handles.
  * Reduced incorrect dispatch on tagged integer values during tracing and unboxing.

* **New Features**
  * Added several benchmark programs covering nested loop and iteration patterns.

* **Performance**
  * Streamlined internal value handling to avoid unnecessary copying and improve runtime efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->