### PR TITLE
#346: dedup MRO subtype scan into w_type_issubtype

### DIFF
--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2344,13 +2344,10 @@ fn type_call_init_type(instance: PyObjectRef, w_type: PyObjectRef) -> Option<PyO
     }
 }
 
-/// Pointer-based subtype check for descr_call __init__ guard.
+/// Pointer-based subtype check for descr_call __init__ guard — the MRO
+/// membership scan lives in `pyre_object::w_type_issubtype`.
 fn issubtype_ptr(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
-    let mro_ptr = unsafe { pyre_object::w_type_get_mro(w_type) };
-    if mro_ptr.is_null() {
-        return false;
-    }
-    unsafe { (*mro_ptr).iter().any(|&t| std::ptr::eq(t, cls)) }
+    unsafe { pyre_object::w_type_issubtype(w_type, cls) }
 }
 
 /// Helper: call a user function with arbitrary args from descriptor context.

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1408,13 +1408,10 @@ unsafe fn try_typedef_binop(a: PyObjectRef, b: PyObjectRef, dunder: &str) -> Opt
     None
 }
 
-/// Check if w_type is a subtype of cls using cached MRO.
+/// Check if w_type is a subtype of cls — delegates to the single MRO
+/// membership scan in `pyre_object::w_type_issubtype`.
 unsafe fn issubtype_cached(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
-    let mro_ptr = w_type_get_mro(w_type);
-    if !mro_ptr.is_null() {
-        return (*mro_ptr).iter().any(|&t| std::ptr::eq(t, cls));
-    }
-    false
+    pyre_object::w_type_issubtype(w_type, cls)
 }
 
 /// Builtin-subclass comparison override dispatch.

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -698,6 +698,19 @@ pub unsafe fn w_type_get_mro(obj: PyObjectRef) -> *mut Vec<PyObjectRef> {
     (*(obj as *const W_TypeObject)).mro_w
 }
 
+/// True when `cls` occurs in `w_type`'s MRO — the pointer-identity subtype
+/// membership scan `W_TypeObject.issubtype` / `_issubtype` performs
+/// (typeobject.py:603/1640).  The single home for the MRO subtype check;
+/// interpreter-level subtype guards and reflected-binop dispatch delegate
+/// here rather than each re-scanning the MRO.
+pub unsafe fn w_type_issubtype(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
+    let mro_ptr = w_type_get_mro(w_type);
+    if mro_ptr.is_null() {
+        return false;
+    }
+    (*mro_ptr).iter().any(|&t| std::ptr::eq(t, cls))
+}
+
 /// Set the cached MRO.
 ///
 /// Construction installs the MRO here (rather than in `__init__`


### PR DESCRIPTION
Follow-on #346 slice (after #411). Removes a genuine duplication and clears a rtyper prepass no-common-base collision.

`issubtype_ptr` (call.rs) and `issubtype_cached` (descroperation.rs) held byte-identical MRO pointer-identity subtype scans. Move the scan into a single `pyre_object::w_type_issubtype` — the `W_TypeObject.issubtype` / `_issubtype` MRO-membership check (typeobject.py:603/1640), living where `w_type_get_mro` already does; both callers now delegate.

Beyond removing the copy-paste, this collapses the two per-closure classdefs the annotator interned under distinct `module::fn::closure` paths, so the binop-dispatch `mergeinputargs` phi no longer fails to unify them. Measured over the slice: no-common-base `cannot unify` occurrences −8 (the `issubtype_ptr::closure ∪ issubtype_cached::closure` pair goes to zero), prepass phaseA failures −1 (`issubtype_cached` lifts). The three binop-dispatch graphs (lshift/rshift/try_instance_binop) that previously failed at this closure phi now reach the already-deferred generic-ADT-collapse frontier (unaryop.rs `compute_at_fixpoint`) — the same #346 sub-epic wall documented as out of scope; they were failing before and remain behind that wall, not newly broken.

check.py 3/3 bit-exact (dynasm / cranelift / wasm, 183/183 each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how type relationships are checked internally, making `__init__`-related behavior and subtype handling more consistent and reliable.
  * Reduced the chance of mismatched type comparisons by using a single, centralized check path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->