### PR TITLE
test_math: full pass — comb/perm, domain messages, displayhook, lazy itertools.chain, int.bit_count, float pow

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5667,6 +5667,29 @@ pub unsafe fn lookup(obj: PyObjectRef, name: &str) -> Option<PyObjectRef> {
     lookup_in_type(w_type, name)
 }
 
+/// `_PyObject_LookupSpecial(obj, name)` — resolve a special method on the
+/// **type** only, ignoring the instance dict, then bind it through the
+/// descriptor `__get__` protocol.
+///
+/// Returns `Ok(None)` when the type MRO does not define `name`, `Ok(Some(m))`
+/// with the bound method otherwise, and propagates a descriptor `__get__`
+/// error (e.g. a `__get__` that raises `ValueError`).
+pub unsafe fn lookup_special(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    let Some(descr) = lookup(obj, name) else {
+        return Ok(None);
+    };
+    let Some(w_type) = crate::typedef::r#type(obj) else {
+        return Ok(Some(descr));
+    };
+    match get(descr, obj, w_type)? {
+        Some(bound) => Ok(Some(bound)),
+        None => Ok(Some(descr)),
+    }
+}
+
 /// Look up a name on a type by walking the C3 MRO.
 ///
 /// PyPy equivalent: `space.lookup_in_type(w_type, name)`.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3376,6 +3376,12 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
                 "__setstate__" if pyre_object::interp_itertools::is_cycle(obj) => {
                     Some((cycle_setstate_method, "__setstate__", 2))
                 }
+                "__reduce__" if pyre_object::interp_itertools::is_chain(obj) => {
+                    Some((chain_reduce_method, "__reduce__", 1))
+                }
+                "__setstate__" if pyre_object::interp_itertools::is_chain(obj) => {
+                    Some((chain_setstate_method, "__setstate__", 2))
+                }
                 "__reduce__" if pyre_object::interp_itertools::is_takewhile(obj) => {
                     Some((takewhile_reduce_method, "__reduce__", 1))
                 }
@@ -9937,10 +9943,24 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             let it = &mut *(obj as *mut pyre_object::interp_itertools::W_Chain);
             loop {
                 if it.w_it.is_null() {
-                    // `_advance`: fetch the next source iterable and take its
-                    // iterator.  StopIteration from `w_iterables` means the
-                    // whole chain is exhausted — propagate.
-                    let w_iterable = next(it.w_iterables)?;
+                    // `_advance`: `if self.w_iterables is None: raise
+                    // StopIteration` — once the outer iterator is spent it is
+                    // cleared to None and the chain stays exhausted.
+                    if it.w_iterables.is_null() {
+                        return Err(PyError::stop_iteration());
+                    }
+                    // Fetch the next source iterable and take its iterator.
+                    // StopIteration from `w_iterables` means the outer
+                    // iterator is exhausted — `_handle_error` sets
+                    // `w_iterables = None` before re-raising.
+                    let w_iterable = match next(it.w_iterables) {
+                        Ok(w) => w,
+                        Err(e) if e.kind == PyErrorKind::StopIteration => {
+                            it.w_iterables = std::ptr::null_mut();
+                            return Err(e);
+                        }
+                        Err(e) => return Err(e),
+                    };
                     it.w_it = iter(w_iterable)?;
                 }
                 match next(it.w_it) {
@@ -10655,6 +10675,70 @@ fn cycle_setstate_method(args: &[PyObjectRef]) -> PyResult {
     it.saved = w_saved;
     pyre_object::gc_hook::try_gc_write_barrier(w_self as *mut u8);
     it.index = index;
+    Ok(w_none())
+}
+
+/// `chain.__reduce__` — `interp_itertools.py W_Chain.descr_reduce`.  While
+/// the chain still has a live `w_iterables` the state carries `(w_iterables,)`
+/// or `(w_iterables, w_it)` so `__setstate__` can restore both; the args
+/// tuple is empty because `chain()` takes no positional arguments (the
+/// iterables come back through `__setstate__`).  A spent chain
+/// (`w_iterables is None`) reduces to just `(type, ())`.
+fn chain_reduce_method(args: &[PyObjectRef]) -> PyResult {
+    // Read the pointer fields before any allocation (`w_tuple_new` may
+    // collect); `w_type` mirrors `space.type(self)`.
+    let w_type = crate::typedef::r#type(args[0]).unwrap_or(PY_NULL);
+    let w_iterables = unsafe { pyre_object::interp_itertools::w_chain_get_iterables(args[0]) };
+    let w_it = unsafe { pyre_object::interp_itertools::w_chain_get_it(args[0]) };
+    if !w_iterables.is_null() {
+        let inner = if !w_it.is_null() {
+            vec![w_iterables, w_it]
+        } else {
+            vec![w_iterables]
+        };
+        Ok(w_tuple_new(vec![
+            w_type,
+            w_tuple_new(vec![]),
+            w_tuple_new(inner),
+        ]))
+    } else {
+        Ok(w_tuple_new(vec![w_type, w_tuple_new(vec![])]))
+    }
+}
+
+/// `chain.__setstate__` — `interp_itertools.py W_Chain.descr_setstate`:
+/// unpack the pickled state and restore `w_iterables` (and, with two
+/// elements, `w_it`).  Reassigning the pointer fields records an old→young
+/// edge, so the setters run the GC write barrier.
+fn chain_setstate_method(args: &[PyObjectRef]) -> PyResult {
+    // `unpackiterable` iterates the pickled state and may collect; pin the
+    // receiver and the state so they (and, transitively, the unpacked
+    // elements) survive each iteration.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let w_self = args[0];
+    let w_state = args.get(1).copied().unwrap_or(w_none());
+    pyre_object::gc_roots::pin_root(w_self);
+    pyre_object::gc_roots::pin_root(w_state);
+    let state = unpackiterable(w_state, -1)?;
+    let n = state.len();
+    if n < 1 {
+        return Err(PyError::type_error(format!(
+            "function takes at least 1 argument ({n} given)"
+        )));
+    } else if n == 1 {
+        unsafe {
+            pyre_object::interp_itertools::w_chain_set_iterables(w_self, state[0]);
+        }
+    } else if n == 2 {
+        unsafe {
+            pyre_object::interp_itertools::w_chain_set_iterables(w_self, state[0]);
+            pyre_object::interp_itertools::w_chain_set_it(w_self, state[1]);
+        }
+    } else {
+        return Err(PyError::type_error(format!(
+            "function takes at most 2 arguments ({n} given)"
+        )));
+    }
     Ok(w_none())
 }
 

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3353,6 +3353,7 @@ fn getattr_str_impl(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyResul
             || pyre_object::interp_itertools::is_filterfalse(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
+            || pyre_object::interp_itertools::is_chain(obj)
         {
             let entry: Option<(fn(&[PyObjectRef]) -> PyResult, &str, u16)> = match name {
                 "__next__" => Some((iter_next_method, "__next__", 1)),
@@ -9148,6 +9149,7 @@ pub fn is_iterable(w_obj: PyObjectRef) -> bool {
             || pyre_object::interp_itertools::is_filterfalse(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
+            || pyre_object::interp_itertools::is_chain(obj)
         {
             return true;
         }
@@ -9390,6 +9392,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             || pyre_object::interp_itertools::is_filterfalse(obj)
             || pyre_object::interp_itertools::is_pairwise(obj)
             || pyre_object::interp_itertools::is_cycle(obj)
+            || pyre_object::interp_itertools::is_chain(obj)
         {
             return Ok(obj);
         }
@@ -9911,6 +9914,44 @@ pub fn next(obj: PyObjectRef) -> PyResult {
                     );
                 }
                 Err(e) => return Err(e),
+            }
+        }
+        // itertools.chain — interp_itertools.py W_Chain.next_w
+        //
+        //     def _advance(self):
+        //         self.w_it = self.space.iter(self.space.next(self.w_iterables))
+        //
+        //     def next_w(self):
+        //         if not self.w_it:
+        //             self._advance()     # may raise StopIteration
+        //         while True:
+        //             try:
+        //                 return self.space.next(self.w_it)
+        //             except OperationError as e:
+        //                 if e.match(self.space, self.space.w_StopIteration):
+        //                     self.w_it = None
+        //                     self._advance()
+        //                 else:
+        //                     raise
+        if pyre_object::interp_itertools::is_chain(obj) {
+            let it = &mut *(obj as *mut pyre_object::interp_itertools::W_Chain);
+            loop {
+                if it.w_it.is_null() {
+                    // `_advance`: fetch the next source iterable and take its
+                    // iterator.  StopIteration from `w_iterables` means the
+                    // whole chain is exhausted — propagate.
+                    let w_iterable = next(it.w_iterables)?;
+                    it.w_it = iter(w_iterable)?;
+                }
+                match next(it.w_it) {
+                    Ok(w_obj) => return Ok(w_obj),
+                    Err(e) if e.kind == PyErrorKind::StopIteration => {
+                        // Sub-iterator exhausted — advance to the next iterable.
+                        it.w_it = std::ptr::null_mut();
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
         // `pypy/objspace/std/dictmultiobject.py:809-845 _new_next`

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5059,9 +5059,15 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
             }));
         }
         if pyre_object::is_long(obj) {
-            return Ok(floatobject::w_float_new(
-                pyre_object::jit_bigint_to_f64_or_nan(pyre_object::w_long_get_value(obj)),
-            ));
+            // A Python int is finite, so a non-finite conversion means the
+            // magnitude exceeds f64 range.
+            let v = pyre_object::jit_bigint_to_f64_or_nan(pyre_object::w_long_get_value(obj));
+            if !v.is_finite() {
+                return Err(crate::PyError::overflow_error(
+                    "int too large to convert to float",
+                ));
+            }
+            return Ok(floatobject::w_float_new(v));
         }
         if is_str(obj) {
             let raw = w_str_get_value(obj);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2328,6 +2328,49 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_none())
 }
 
+/// Bind `builtins._` best-effort; a missing `builtins` module (early
+/// bootstrap) is ignored.
+fn set_builtins_underscore(value: PyObjectRef) {
+    if let Some(b) = crate::importing::get_sys_module("builtins") {
+        let _ = crate::baseobjspace::setattr_str(b, "_", value);
+    }
+}
+
+/// `sys.displayhook(value)` — print `repr(value)` followed by a newline to
+/// the live `sys.stdout` and bind `builtins._` to the value. A `None` value
+/// prints nothing and leaves `_` unchanged (`sys_displayhook` in sysmodule.c).
+pub(crate) fn sys_displayhook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let value = args.first().copied().unwrap_or_else(w_none);
+    if unsafe { pyre_object::is_none(value) } {
+        return Ok(w_none());
+    }
+    // `_` is cleared before rendering so a failing repr does not leave a
+    // stale binding, then set to the value once the write succeeds.
+    set_builtins_underscore(w_none());
+    let repr = pyre_object::w_str_from_wtf8(unsafe { crate::display::py_repr_wtf8(value)? });
+    let newline = w_str_new("\n");
+    match resolve_default_print_target()? {
+        DefaultPrintTarget::Native => {
+            let s = unsafe { print_render(repr)? };
+            crate::print_output(&s);
+            crate::print_output("\n");
+        }
+        DefaultPrintTarget::Rebound(fp) => {
+            for part in [repr, newline] {
+                let r = crate::baseobjspace::call_method(fp, "write", &[part]);
+                if r.is_null() {
+                    return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                        crate::PyError::runtime_error("displayhook: file.write() failed")
+                    }));
+                }
+            }
+        }
+        DefaultPrintTarget::Silent => return Ok(w_none()),
+    }
+    set_builtins_underscore(value);
+    Ok(w_none())
+}
+
 /// `space.index` re-wraps a result whose type is not exactly `int` (a
 /// bool, or a strict int subclass) as a plain int (descroperation.py:622
 /// `index`).  A range stores its bounds wrapped, so normalize each here —

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1866,6 +1866,7 @@ impl IterOpcodeHandler for PyFrame {
                 || pyre_object::interp_itertools::is_filterfalse(iter)
                 || pyre_object::interp_itertools::is_pairwise(iter)
                 || pyre_object::interp_itertools::is_cycle(iter)
+                || pyre_object::interp_itertools::is_chain(iter)
                 || pyre_object::dictmultiobject::is_dict_view_iterator(iter)
                 || pyre_object::functional::is_enumerate(iter)
                 || pyre_object::functional::is_reversed(iter)

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3331,8 +3331,28 @@ impl OpcodeStepExecutor for PyFrame {
     }
 
     // ── print_expr ──
-    // PyPy: PRINT_EXPR → sys.displayhook(value)
+    // PRINT_EXPR → sys.displayhook(value). Routing through the live hook lets
+    // a rebound displayhook (doctest, IDLE) and a redirected sys.stdout take
+    // effect instead of writing straight to the native stream.
     fn print_expr(&mut self, val: PyObjectRef) -> Result<(), PyError> {
+        if let Some(sys_mod) = crate::importing::get_sys_module("sys") {
+            match crate::baseobjspace::getattr_str(sys_mod, "displayhook") {
+                Ok(hook) => {
+                    let r = crate::call_function(hook, &[val]);
+                    if r.is_null() {
+                        return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                            PyError::runtime_error("displayhook raised an exception")
+                        }));
+                    }
+                    return Ok(());
+                }
+                Err(e) if e.kind == PyErrorKind::AttributeError => {
+                    return Err(PyError::runtime_error("lost sys.displayhook"));
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        // No `sys` yet (early bootstrap) — native repr print.
         if !unsafe { pyre_object::is_none(val) } {
             let s = unsafe { crate::py_repr(val)? };
             crate::host_seam::emit_stdout(format!("{s}\n").as_bytes());

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -8,6 +8,14 @@
 //! lookups, no negative cache).
 
 use pyre_object::*;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// `abc_invalidation_counter` (`_abcmodule.c`): bumped by every successful
+// `_abc_register` and by `_reset_caches`, and read by `get_cache_token`.
+// The positive/negative object caches themselves remain omitted as an
+// optimisation — only this token is tracked, so a bump makes any cached
+// token stale.
+static INVALIDATION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 // `_py_abc.ABCMeta.__new__` (`_py_abc.py:48`) gives every ABC its OWN
 // `_abc_registry`. Create it here as a per-class list so the registry is not
@@ -23,9 +31,9 @@ fn abc_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_none())
 }
 
-// `app_abc.py:_abc_register` — `cls._abc_registry.add(subclass)`.
-// Pyre stores the registry as a list attribute (no WeakSet); duplicates
-// are skipped to keep the list bounded.
+// `_abc_register` (`_abcmodule.c:_abc__abc_register_impl`) —
+// `cls._abc_registry.add(subclass)`.  Pyre stores the registry as a list
+// attribute (no WeakSet).
 fn register(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() < 2 {
         return Err(crate::PyError::type_error(
@@ -34,6 +42,30 @@ fn register(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let cls = args[0];
     let subclass = args[1];
+    // `subclass` must be a class (`PyType_Check`).  Pyre's stdlib stubs
+    // register callable non-type shells to ABCs — `_contextvars.Context` is a
+    // builtin function here, yet `contextvars` runs `Mapping.register(Context)`
+    // at import.  `__subclasscheck__` already tolerates such members by
+    // skipping non-type registry entries (see `subclass_of`), so the
+    // `PyObject_IsSubclass` guards below (which reject non-type args) only run
+    // for real types; a callable stub falls straight through to the append,
+    // and only a genuine non-class value (`register(42)`) is rejected.
+    if unsafe { is_type(subclass) } {
+        // Already a subclass (`PyObject_IsSubclass(subclass, cls) > 0`) —
+        // nothing to register.  This also dedups: a previously registered
+        // `subclass` resolves through `__subclasscheck__`'s registry walk.
+        if crate::baseobjspace::issubclass(subclass, cls)? {
+            return Ok(subclass);
+        }
+        // Registering `subclass` would also make `cls` its subclass.
+        if crate::baseobjspace::issubclass(cls, subclass)? {
+            return Err(crate::PyError::runtime_error(
+                "Refusing to create an inheritance cycle",
+            ));
+        }
+    } else if !crate::baseobjspace::callable_w(subclass) {
+        return Err(crate::PyError::type_error("Can only register classes"));
+    }
     let registry = match crate::baseobjspace::getattr_str(cls, "_abc_registry") {
         Ok(r) if !unsafe { is_none(r) } => r,
         _ => {
@@ -43,16 +75,10 @@ fn register(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         }
     };
     unsafe {
-        let n = w_list_len(registry);
-        for i in 0..n {
-            if let Some(item) = w_list_getitem(registry, i as i64) {
-                if std::ptr::eq(item, subclass) {
-                    return Ok(subclass);
-                }
-            }
-        }
         w_list_append(registry, subclass);
     }
+    // Invalidate any outstanding cache token.
+    INVALIDATION_COUNTER.fetch_add(1, Ordering::Relaxed);
     Ok(subclass)
 }
 
@@ -152,13 +178,15 @@ fn subclasscheck(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 crate::py_module! {
     "_abc",
     functions: {
-        "get_cache_token"     / 0 = |_| Ok(w_int_new(0)),
+        "get_cache_token"     / 0 = |_| Ok(w_int_new(INVALIDATION_COUNTER.load(Ordering::Relaxed) as i64)),
         "_abc_init"           / 1 = abc_init,
         "_abc_register"       / 2 = register,
         "_abc_instancecheck"  / 2 = instancecheck,
         "_abc_subclasscheck"  / 2 = subclasscheck,
         "_get_dump"           / 1 = |_| Ok(w_tuple_new(vec![])),
         "_reset_registry"     / 1 = |_| Ok(w_none()),
-        "_reset_caches"       / 1 = |_| Ok(w_none()),
+        // Pyre keeps no object caches to clear; bumping the token invalidates
+        // any outstanding `get_cache_token` value.
+        "_reset_caches"       / 1 = |_| { INVALIDATION_COUNTER.fetch_add(1, Ordering::Relaxed); Ok(w_none()) },
     },
 }

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -9,6 +9,20 @@
 
 use pyre_object::*;
 
+// `_py_abc.ABCMeta.__new__` (`_py_abc.py:48`) gives every ABC its OWN
+// `_abc_registry`. Create it here as a per-class list so the registry is not
+// inherited: without an own entry `register`/`subclass_of` would resolve
+// `_abc_registry` up the MRO and share one base class's list across every
+// descendant ABC (e.g. Complex/Real/Rational/Integral all collapsing to a
+// single registry).
+fn abc_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if let Some(&cls) = args.first() {
+        let fresh = w_list_new(vec![]);
+        crate::baseobjspace::setattr_str(cls, "_abc_registry", fresh)?;
+    }
+    Ok(w_none())
+}
+
 // `app_abc.py:_abc_register` — `cls._abc_registry.add(subclass)`.
 // Pyre stores the registry as a list attribute (no WeakSet); duplicates
 // are skipped to keep the list bounded.
@@ -139,7 +153,7 @@ crate::py_module! {
     "_abc",
     functions: {
         "get_cache_token"     / 0 = |_| Ok(w_int_new(0)),
-        "_abc_init"           / 1 = |_| Ok(w_none()),
+        "_abc_init"           / 1 = abc_init,
         "_abc_register"       / 2 = register,
         "_abc_instancecheck"  / 2 = instancecheck,
         "_abc_subclasscheck"  / 2 = subclasscheck,

--- a/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
+++ b/pyre/pyre-interpreter/src/module/itertools/interp_itertools.rs
@@ -6,33 +6,26 @@ use crate::DictStorage;
 
 /// itertools stub
 pub fn register_module(ns: &mut DictStorage) {
-    // chain(*iterables) → flat iterator
+    // chain(*iterables) — W_Chain___new__: store `iter(newtuple(args))` as
+    // the source-iterables iterator.  W_Chain.next_w (baseobjspace::next)
+    // lazily draws each sub-iterable's iterator on demand, so infinite
+    // arguments (e.g. `chain([3], repeat(3))`) do not hang at construction.
     let chain_fn = crate::make_builtin_function("chain", |args| {
-        let mut items = Vec::new();
-        for &arg in args {
-            items.extend(crate::builtins::collect_iterable(arg)?);
-        }
-        let n = items.len();
-        let list = pyre_object::w_list_new(items);
-        Ok(pyre_object::w_seq_iter_new(list, n))
+        let tup = pyre_object::w_tuple_new(args.to_vec());
+        let iterables = crate::baseobjspace::iter(tup)?;
+        Ok(pyre_object::interp_itertools::w_chain_new(iterables))
     });
-    // chain.from_iterable(iterable) — flatten a single iterable of iterables.
-    // Attached as an attribute on the `chain` callable (the classmethod is
-    // read straight off the function object, so it is called with just the
-    // outer iterable).
-    let from_iterable_fn =
-        crate::make_builtin_function("from_iterable", |args| {
-            let outer = args.first().copied().ok_or_else(|| {
-                crate::PyError::type_error("from_iterable() missing 1 required positional argument")
-            })?;
-            let mut items = Vec::new();
-            for inner in crate::builtins::collect_iterable(outer)? {
-                items.extend(crate::builtins::collect_iterable(inner)?);
-            }
-            let n = items.len();
-            let list = pyre_object::w_list_new(items);
-            Ok(pyre_object::w_seq_iter_new(list, n))
-        });
+    // chain.from_iterable(iterable) — W_Chain.descr_from_iterable: flatten a
+    // single iterable of iterables.  Attached as an attribute on the `chain`
+    // callable (the classmethod is read straight off the function object, so
+    // it is called with just the outer iterable).
+    let from_iterable_fn = crate::make_builtin_function("from_iterable", |args| {
+        let outer = args.first().copied().ok_or_else(|| {
+            crate::PyError::type_error("from_iterable() missing 1 required positional argument")
+        })?;
+        let iterables = crate::baseobjspace::iter(outer)?;
+        Ok(pyre_object::interp_itertools::w_chain_new(iterables))
+    });
     crate::setattr_str(chain_fn, "from_iterable", from_iterable_fn)
         .expect("attach itertools.chain.from_iterable");
     crate::dict_storage_store(ns, "chain", chain_fn);

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -6,11 +6,10 @@
 
 use pyre_object::*;
 
-/// Extract f64 from an int, float, or long object.
-/// PyPy: `_get_double(space, w_x)` — falls back to `__float__` for
-/// Fraction/Decimal/custom number types. Infallible callers should
-/// use `get_double_or_default` which retains the legacy 0.0 fallback
-/// for backward compatibility.
+/// Infallible f64 extraction with a `0.0` fallback for a non-convertible
+/// argument. Retained for `cmath`, whose flat gateway does not thread the
+/// error path; the `math` module uses [`try_get_double`] directly so a
+/// non-number raises `TypeError`.
 pub fn get_double(obj: PyObjectRef) -> f64 {
     try_get_double(obj).unwrap_or(0.0)
 }
@@ -42,31 +41,39 @@ pub fn try_get_double(obj: PyObjectRef) -> Result<f64, crate::PyError> {
             return Ok(if w_bool_get_value(obj) { 1.0 } else { 0.0 });
         }
     }
-    // A raising `__float__`/`__index__` (descriptor `__get__` or the call
-    // itself) propagates instead of being reported as "must be real number".
-    match crate::baseobjspace::getattr_str(obj, "__float__") {
-        Ok(method) => {
+    // `__float__` is a type-only special-method lookup (`space.lookup`); an
+    // instance attribute named `__float__` is not consulted. A raising
+    // `__float__` (descriptor `__get__` or the call itself) propagates
+    // instead of being reported as "must be real number".
+    match unsafe { crate::baseobjspace::lookup_special(obj, "__float__") } {
+        Ok(Some(method)) => {
             let result = crate::builtins::call_and_check(method, &[])?;
             unsafe {
                 if is_float(result) {
-                    return Ok(floatobject::w_float_get_value(result));
-                }
-                if is_int(result) {
-                    return Ok(w_int_get_value(result) as f64);
-                }
-                if is_long(result) {
-                    let v = jit_bigint_to_f64_or_nan(w_long_get_value(result));
-                    if !v.is_finite() {
-                        return Err(crate::PyError::overflow_error(
-                            "int too large to convert to float",
+                    // A strict `float` subclass is accepted but deprecated;
+                    // an exact `float` is used as-is.
+                    if !is_exact_type(result, &FLOAT_TYPE) {
+                        let value_type = crate::type_methods::arg_type_name(obj);
+                        let result_type = crate::type_methods::arg_type_name(result);
+                        crate::warn::warn_deprecation(&format!(
+                            "{value_type}.__float__ returned non-float (type {result_type}).  \
+                             The ability to return an instance of a strict subclass of \
+                             float is deprecated, and may be removed in a future version \
+                             of Python."
                         ));
                     }
-                    return Ok(v);
+                    return Ok(floatobject::w_float_get_value(result));
                 }
             }
+            // descroperation.py:891 — a non-float result (including int/long)
+            // is rejected rather than coerced.
+            let result_type = unsafe { (*(*result).ob_type).name };
+            return Err(crate::PyError::type_error(format!(
+                "__float__ returned non-float (type '{result_type}')",
+            )));
         }
-        Err(err) if err.kind != crate::PyErrorKind::AttributeError => return Err(err),
-        Err(_) => {}
+        Ok(None) => {}
+        Err(err) => return Err(err),
     }
     match crate::baseobjspace::getattr_str(obj, "__index__") {
         Ok(method) => {
@@ -484,9 +491,9 @@ pub fn degrees(args: &[PyObjectRef]) -> PyResult {
             "degrees() takes exactly 1 argument",
         ));
     }
-    Ok(floatobject::w_float_new(pymath::math::degrees(get_double(
-        args[0],
-    ))))
+    Ok(floatobject::w_float_new(pymath::math::degrees(
+        try_get_double(args[0])?,
+    )))
 }
 
 pub fn radians(args: &[PyObjectRef]) -> PyResult {
@@ -495,9 +502,9 @@ pub fn radians(args: &[PyObjectRef]) -> PyResult {
             "radians() takes exactly 1 argument",
         ));
     }
-    Ok(floatobject::w_float_new(pymath::math::radians(get_double(
-        args[0],
-    ))))
+    Ok(floatobject::w_float_new(pymath::math::radians(
+        try_get_double(args[0])?,
+    )))
 }
 
 pub fn isinf(args: &[PyObjectRef]) -> PyResult {
@@ -506,7 +513,7 @@ pub fn isinf(args: &[PyObjectRef]) -> PyResult {
             "isinf() takes exactly 1 argument",
         ));
     }
-    Ok(w_bool_from(pymath::math::isinf(get_double(args[0]))))
+    Ok(w_bool_from(pymath::math::isinf(try_get_double(args[0])?)))
 }
 
 pub fn isnan(args: &[PyObjectRef]) -> PyResult {
@@ -515,7 +522,7 @@ pub fn isnan(args: &[PyObjectRef]) -> PyResult {
             "isnan() takes exactly 1 argument",
         ));
     }
-    Ok(w_bool_from(pymath::math::isnan(get_double(args[0]))))
+    Ok(w_bool_from(pymath::math::isnan(try_get_double(args[0])?)))
 }
 
 pub fn isfinite(args: &[PyObjectRef]) -> PyResult {
@@ -524,34 +531,32 @@ pub fn isfinite(args: &[PyObjectRef]) -> PyResult {
             "isfinite() takes exactly 1 argument",
         ));
     }
-    Ok(w_bool_from(pymath::math::isfinite(get_double(args[0]))))
+    Ok(w_bool_from(pymath::math::isfinite(try_get_double(args[0])?)))
 }
 
 pub fn isclose(args: &[PyObjectRef]) -> PyResult {
-    let is_kwargs = !args.is_empty()
-        && unsafe {
-            let last = *args.last().unwrap();
-            pyre_object::is_dict(last)
-                && pyre_object::w_dict_lookup(last, pyre_object::w_str_new("__pyre_kw__")).is_some()
-        };
-    let (pos, kwargs) = if is_kwargs {
-        (&args[..args.len() - 1], Some(*args.last().unwrap()))
-    } else {
-        (&args[..], None)
-    };
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
     if pos.len() != 2 {
         return Err(crate::PyError::type_error(
             "isclose() takes exactly 2 positional arguments",
         ));
     }
-    let read = |name: &str| -> Option<f64> {
-        kwargs
-            .and_then(|kw| unsafe { pyre_object::w_dict_lookup(kw, pyre_object::w_str_new(name)) })
-            .map(get_double)
+    // `rel_tol` and `abs_tol` are the only (keyword-only) parameters.
+    crate::builtins::kwarg_reject_unknown(kwargs, &["rel_tol", "abs_tol"], "isclose")?;
+    let read = |name: &str| -> Result<Option<f64>, crate::PyError> {
+        match crate::builtins::kwarg_get(kwargs, name) {
+            Some(v) => Ok(Some(try_get_double(v)?)),
+            None => Ok(None),
+        }
     };
-    let rel_tol = read("rel_tol");
-    let abs_tol = read("abs_tol");
-    match pymath::math::isclose(get_double(pos[0]), get_double(pos[1]), rel_tol, abs_tol) {
+    let rel_tol = read("rel_tol")?;
+    let abs_tol = read("abs_tol")?;
+    match pymath::math::isclose(
+        try_get_double(pos[0])?,
+        try_get_double(pos[1])?,
+        rel_tol,
+        abs_tol,
+    ) {
         Ok(v) => Ok(w_bool_from(v)),
         Err(e) => Err(map_int_err(e)),
     }
@@ -629,10 +634,12 @@ fn get_bigint(obj: PyObjectRef) -> Result<malachite_bigint::BigInt, crate::PyErr
             ));
         }
     }
-    // __index__ dunder — PyPy: descroperation.py space.index.
-    if let Ok(method) = crate::baseobjspace::getattr_str(obj, "__index__") {
-        let result = crate::call_function(method, &[]);
-        if !result.is_null() {
+    // __index__ dunder — descroperation.py `_index`: type-only special-method
+    // lookup, then propagate a raising `__index__` instead of masking it with
+    // the generic "object cannot be interpreted as an integer".
+    match unsafe { crate::baseobjspace::lookup_special(obj, "__index__") } {
+        Ok(Some(method)) => {
+            let result = crate::builtins::call_and_check(method, &[])?;
             unsafe {
                 if pyre_object::is_int(result) {
                     return Ok(BigInt::from(pyre_object::w_int_get_value(result)));
@@ -641,7 +648,14 @@ fn get_bigint(obj: PyObjectRef) -> Result<malachite_bigint::BigInt, crate::PyErr
                     return Ok(pyre_object::w_long_get_value(result).clone());
                 }
             }
+            // descroperation.py:612 — __index__ returned non-int (type %T)
+            let result_type = unsafe { (*(*result).ob_type).name };
+            return Err(crate::PyError::type_error(format!(
+                "__index__ returned non-int (type '{result_type}')",
+            )));
         }
+        Ok(None) => {}
+        Err(err) => return Err(err),
     }
     Err(crate::PyError::type_error(
         "object cannot be interpreted as an integer",
@@ -933,7 +947,7 @@ pub fn frexp(args: &[PyObjectRef]) -> PyResult {
             "frexp() takes exactly 1 argument",
         ));
     }
-    let (m, e) = pymath::math::frexp(get_double(args[0]));
+    let (m, e) = pymath::math::frexp(try_get_double(args[0])?);
     Ok(w_tuple_new(vec![
         floatobject::w_float_new(m),
         w_int_new(e as i64),
@@ -950,7 +964,7 @@ pub fn ldexp(args: &[PyObjectRef]) -> PyResult {
     // PyPy: pypy/module/math/interp_math.py::ldexp — second argument
     // must be an integer (via `__index__`), not a float.
     let exp_big = get_bigint(args[1])?;
-    let x = get_double(args[0]);
+    let x = try_get_double(args[0])?;
     // Short-circuit special cases so an overflowing exponent doesn't
     // mask inf/nan propagation.
     if x.is_nan() {
@@ -981,7 +995,7 @@ pub fn modf(args: &[PyObjectRef]) -> PyResult {
             "modf() takes exactly 1 argument",
         ));
     }
-    let (frac, integer) = pymath::math::modf(get_double(args[0]));
+    let (frac, integer) = pymath::math::modf(try_get_double(args[0])?);
     Ok(w_tuple_new(vec![
         floatobject::w_float_new(frac),
         floatobject::w_float_new(integer),
@@ -1021,8 +1035,8 @@ pub fn nextafter(args: &[PyObjectRef]) -> PyResult {
         None => None,
     };
     Ok(floatobject::w_float_new(pymath::math::nextafter(
-        get_double(pos[0]),
-        get_double(pos[1]),
+        try_get_double(pos[0])?,
+        try_get_double(pos[1])?,
         steps,
     )))
 }
@@ -1034,8 +1048,8 @@ pub fn fma(args: &[PyObjectRef]) -> PyResult {
         ));
     }
     map_err(pymath::math::fma(
-        get_double(args[0]),
-        get_double(args[1]),
-        get_double(args[2]),
+        try_get_double(args[0])?,
+        try_get_double(args[1])?,
+        try_get_double(args[2])?,
     ))
 }

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -743,6 +743,9 @@ pub fn comb(args: &[PyObjectRef]) -> PyResult {
     } else {
         &k_big
     };
+    // `comb_bigint` takes the smaller factor as a `u64`; a value past
+    // `u64::MAX` is unreachable for any computable input (the product would
+    // need >2**64 multiplications) and is rejected rather than truncated.
     let ki: u64 = match effective_k.to_u64() {
         Some(k) => k,
         None => {

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -28,15 +28,25 @@ pub fn try_get_double(obj: PyObjectRef) -> Result<f64, crate::PyError> {
             return Ok(floatobject::w_float_get_value(obj));
         }
         if is_long(obj) {
-            return Ok(jit_bigint_to_f64_or_nan(w_long_get_value(obj)));
+            // A Python int is always finite, so a non-finite conversion means
+            // the magnitude exceeds f64 range — PyFloat_AsDouble raises here.
+            let v = jit_bigint_to_f64_or_nan(w_long_get_value(obj));
+            if !v.is_finite() {
+                return Err(crate::PyError::overflow_error(
+                    "int too large to convert to float",
+                ));
+            }
+            return Ok(v);
         }
         if is_bool(obj) {
             return Ok(if w_bool_get_value(obj) { 1.0 } else { 0.0 });
         }
     }
-    if let Ok(method) = crate::baseobjspace::getattr_str(obj, "__float__") {
-        let result = crate::call_function(method, &[obj]);
-        if !result.is_null() {
+    // A raising `__float__`/`__index__` (descriptor `__get__` or the call
+    // itself) propagates instead of being reported as "must be real number".
+    match crate::baseobjspace::getattr_str(obj, "__float__") {
+        Ok(method) => {
+            let result = crate::builtins::call_and_check(method, &[])?;
             unsafe {
                 if is_float(result) {
                     return Ok(floatobject::w_float_get_value(result));
@@ -44,18 +54,40 @@ pub fn try_get_double(obj: PyObjectRef) -> Result<f64, crate::PyError> {
                 if is_int(result) {
                     return Ok(w_int_get_value(result) as f64);
                 }
+                if is_long(result) {
+                    let v = jit_bigint_to_f64_or_nan(w_long_get_value(result));
+                    if !v.is_finite() {
+                        return Err(crate::PyError::overflow_error(
+                            "int too large to convert to float",
+                        ));
+                    }
+                    return Ok(v);
+                }
             }
         }
+        Err(err) if err.kind != crate::PyErrorKind::AttributeError => return Err(err),
+        Err(_) => {}
     }
-    if let Ok(method) = crate::baseobjspace::getattr_str(obj, "__index__") {
-        let result = crate::call_function(method, &[obj]);
-        if !result.is_null() {
+    match crate::baseobjspace::getattr_str(obj, "__index__") {
+        Ok(method) => {
+            let result = crate::builtins::call_and_check(method, &[])?;
             unsafe {
                 if is_int(result) {
                     return Ok(w_int_get_value(result) as f64);
                 }
+                if is_long(result) {
+                    let v = jit_bigint_to_f64_or_nan(w_long_get_value(result));
+                    if !v.is_finite() {
+                        return Err(crate::PyError::overflow_error(
+                            "int too large to convert to float",
+                        ));
+                    }
+                    return Ok(v);
+                }
             }
         }
+        Err(err) if err.kind != crate::PyErrorKind::AttributeError => return Err(err),
+        Err(_) => {}
     }
     Err(crate::PyError::type_error("must be real number"))
 }
@@ -67,6 +99,29 @@ fn map_err(r: pymath::Result<f64>) -> PyResult {
         Ok(v) => Ok(floatobject::w_float_new(v)),
         Err(pymath::Error::EDOM) => Err(crate::PyError::value_error("math domain error")),
         Err(pymath::Error::ERANGE) => Err(crate::PyError::overflow_error("math range error")),
+    }
+}
+
+fn map_int_err(e: pymath::Error) -> crate::PyError {
+    match e {
+        pymath::Error::EDOM => crate::PyError::value_error("math domain error"),
+        pymath::Error::ERANGE => crate::PyError::overflow_error("math range error"),
+    }
+}
+
+/// `float.__repr__` of a finite value, used to embed the offending operand
+/// in a domain-error message.
+fn float_repr(val: f64) -> String {
+    if val.is_nan() {
+        "nan".to_owned()
+    } else if val.is_infinite() {
+        if val.is_sign_positive() {
+            "inf".to_owned()
+        } else {
+            "-inf".to_owned()
+        }
+    } else {
+        crate::display::format_float_repr(val)
     }
 }
 
@@ -82,6 +137,32 @@ macro_rules! pm1 {
                 )));
             }
             map_err(pymath::math::$name(try_get_double(args[0])?))
+        }
+    };
+}
+
+/// Like `pm1!`, but an `EDOM` result becomes a value-carrying message
+/// ("<prefix>, got <repr>") instead of the generic "math domain error".
+macro_rules! pm1_edom {
+    ($name:ident, $prefix:literal) => {
+        pub fn $name(args: &[PyObjectRef]) -> PyResult {
+            if args.len() != 1 {
+                return Err(crate::PyError::type_error(concat!(
+                    stringify!($name),
+                    "() takes exactly one argument"
+                )));
+            }
+            let val = try_get_double(args[0])?;
+            match pymath::math::$name(val) {
+                Ok(v) => Ok(floatobject::w_float_new(v)),
+                Err(pymath::Error::EDOM) => Err(crate::PyError::value_error(format!(
+                    concat!($prefix, ", got {}"),
+                    float_repr(val)
+                ))),
+                Err(pymath::Error::ERANGE) => {
+                    Err(crate::PyError::overflow_error("math range error"))
+                }
+            }
         }
     };
 }
@@ -103,21 +184,21 @@ macro_rules! pm1_plain {
 }
 
 // Trigonometric
-pm1!(sin);
-pm1!(cos);
-pm1!(tan);
-pm1!(asin);
-pm1!(acos);
+pm1_edom!(sin, "expected a finite input");
+pm1_edom!(cos, "expected a finite input");
+pm1_edom!(tan, "expected a finite input");
+pm1_edom!(asin, "expected a number in range from -1 up to 1");
+pm1_edom!(acos, "expected a number in range from -1 up to 1");
 pm1!(atan);
 pm1!(sinh);
 pm1!(cosh);
 pm1!(tanh);
 pm1!(asinh);
 pm1!(acosh);
-pm1!(atanh);
+pm1_edom!(atanh, "expected a number between -1 and 1");
 
 // Exponential / logarithmic
-pm1!(sqrt);
+pm1_edom!(sqrt, "expected a nonnegative input");
 pm1!(cbrt);
 pm1!(exp);
 pm1!(exp2);
@@ -127,7 +208,7 @@ pm1!(log1p);
 // Gamma / error
 pm1!(erf);
 pm1!(erfc);
-pm1!(gamma);
+pm1_edom!(gamma, "expected a noninteger or positive integer");
 pm1!(lgamma);
 
 // Misc
@@ -169,22 +250,27 @@ pub fn atan2(args: &[PyObjectRef]) -> PyResult {
 }
 
 pub fn hypot(args: &[PyObjectRef]) -> PyResult {
-    let coords: Vec<f64> = args.iter().map(|&a| get_double(a)).collect();
+    let coords: Vec<f64> = args
+        .iter()
+        .map(|&a| try_get_double(a))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(floatobject::w_float_new(pymath::math::hypot(&coords)))
 }
 
 pub fn dist(args: &[PyObjectRef]) -> PyResult {
-    if args.len() < 2 {
-        return Err(crate::PyError::type_error("dist requires 2 arguments"));
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(
+            "dist() takes exactly 2 arguments",
+        ));
     }
     let p: Vec<f64> = crate::builtins::collect_iterable(args[0])?
         .iter()
-        .map(|&a| get_double(a))
-        .collect();
+        .map(|&a| try_get_double(a))
+        .collect::<Result<Vec<_>, _>>()?;
     let q: Vec<f64> = crate::builtins::collect_iterable(args[1])?
         .iter()
-        .map(|&a| get_double(a))
-        .collect();
+        .map(|&a| try_get_double(a))
+        .collect::<Result<Vec<_>, _>>()?;
     if p.len() != q.len() {
         return Err(crate::PyError::value_error(
             "both points must have the same number of dimensions",
@@ -195,24 +281,29 @@ pub fn dist(args: &[PyObjectRef]) -> PyResult {
 
 // ── Integer-returning functions ──────────────────────────────────────
 
-/// Invoke `__ceil__`/`__floor__`/`__trunc__` or fall back to converting
-/// the argument to a float via `__float__`. Raises TypeError when the
-/// argument has no numeric interpretation — PyPy: mathmodule.c
-/// math_1_impl's `double_from_object` routine.
-fn math_unary_int(args: &[PyObjectRef], dunder: &str, fname: &str) -> PyResult {
+/// Invoke `__ceil__`/`__floor__`/`__trunc__` looked up on the argument's
+/// type (special-method semantics, so an instance attribute is ignored).
+///
+/// `math.ceil`/`math.floor` fall back to `__float__` coercion when the
+/// dunder is absent, so `ceil(FloatLike(...))` works; `math.trunc` has no
+/// such fallback and requires `__trunc__`.
+fn math_unary_int(
+    args: &[PyObjectRef],
+    dunder: &str,
+    fname: &str,
+    fallback_float: bool,
+) -> PyResult {
     if args.len() != 1 {
         return Err(crate::PyError::type_error(format!(
             "{fname}() takes exactly 1 argument",
         )));
     }
-    // Prefer the dunder so subclasses of float with `__ceil__` use their
-    // override even when the parent float path would also succeed. If the
-    // descriptor itself raises (e.g. BadDescr.__get__ → ValueError),
+    // If the descriptor itself raises (e.g. BadDescr.__get__ → ValueError),
     // propagate that error rather than silently falling back to float.
-    match crate::baseobjspace::getattr_str(args[0], dunder) {
-        Ok(method) => {
+    match unsafe { crate::baseobjspace::lookup_special(args[0], dunder) } {
+        Ok(Some(method)) => {
             crate::call::clear_call_error();
-            let result = crate::call_function(method, &[args[0]]);
+            let result = crate::call_function(method, &[]);
             if !result.is_null() {
                 return Ok(result);
             }
@@ -220,13 +311,16 @@ fn math_unary_int(args: &[PyObjectRef], dunder: &str, fname: &str) -> PyResult {
                 return Err(err);
             }
         }
-        Err(err) if err.kind != crate::PyErrorKind::AttributeError => {
-            return Err(err);
-        }
-        _ => {}
+        Ok(None) => {}
+        Err(err) => return Err(err),
     }
-    // Fall back to `__float__` coercion — mathmodule.c uses PyNumber_Float
-    // in math_1_impl for this role. `try_get_double` raises TypeError
+    if !fallback_float {
+        return Err(crate::PyError::type_error(format!(
+            "type {} doesn't define {fname}() method",
+            crate::baseobjspace::object_functionstr_type_name(args[0])
+        )));
+    }
+    // Fall back to `__float__` coercion — `try_get_double` raises TypeError
     // when the operand has no numeric interpretation.
     let v = try_get_double(args[0])
         .map_err(|_| crate::PyError::type_error(format!("type has no {fname}() method")))?;
@@ -238,15 +332,15 @@ fn math_unary_int(args: &[PyObjectRef], dunder: &str, fname: &str) -> PyResult {
 }
 
 pub fn floor(args: &[PyObjectRef]) -> PyResult {
-    math_unary_int(args, "__floor__", "floor")
+    math_unary_int(args, "__floor__", "floor", true)
 }
 
 pub fn ceil(args: &[PyObjectRef]) -> PyResult {
-    math_unary_int(args, "__ceil__", "ceil")
+    math_unary_int(args, "__ceil__", "ceil", true)
 }
 
 pub fn trunc(args: &[PyObjectRef]) -> PyResult {
-    math_unary_int(args, "__trunc__", "trunc")
+    math_unary_int(args, "__trunc__", "trunc", false)
 }
 
 // ── Special signatures ──────────────────────────────────────────────
@@ -295,29 +389,41 @@ fn bigint_log(n: &malachite_bigint::BigInt, base: f64) -> Result<f64, crate::PyE
     Ok(result)
 }
 
-/// PyPy: pypy/module/math/interp_math.py::_log_any —
-/// special-case long arguments to avoid overflow in `get_double`.
+/// Special-case integer arguments to avoid overflow, and give the domain
+/// error the value-carrying message except for an int argument, whose error
+/// carries no value.
 fn log_any(w_x: PyObjectRef, base: f64) -> PyResult {
+    use num_traits::Signed;
     unsafe {
-        if pyre_object::is_long(w_x) {
-            let num = pyre_object::w_long_get_value(w_x);
-            let r = bigint_log(num, base)?;
-            if base != 0.0 && base != 10.0 && base != 2.0 {
-                if base <= 0.0 || base.is_nan() {
-                    return Err(crate::PyError::value_error("math domain error"));
-                }
+        if pyre_object::is_bool(w_x) || pyre_object::is_int(w_x) || pyre_object::is_long(w_x) {
+            let num_owned;
+            let num: &malachite_bigint::BigInt = if pyre_object::is_long(w_x) {
+                pyre_object::w_long_get_value(w_x)
+            } else if pyre_object::is_bool(w_x) {
+                num_owned =
+                    malachite_bigint::BigInt::from(pyre_object::w_bool_get_value(w_x) as i64);
+                &num_owned
+            } else {
+                num_owned = malachite_bigint::BigInt::from(pyre_object::w_int_get_value(w_x));
+                &num_owned
+            };
+            if !num.is_positive() {
+                return Err(crate::PyError::value_error("expected a positive input"));
             }
-            return Ok(floatobject::w_float_new(r));
+            return Ok(floatobject::w_float_new(bigint_log(num, base)?));
         }
     }
-    let x = get_double(w_x);
+    let x = try_get_double(w_x)?;
     // NaN propagates through log.
     if x.is_nan() {
         return Ok(floatobject::w_float_new(f64::NAN));
     }
-    // CPython: domain error for x <= 0 (but x == +inf is fine).
+    // Domain error for x <= 0 (but x == +inf is fine).
     if x <= 0.0 {
-        return Err(crate::PyError::value_error("math domain error"));
+        return Err(crate::PyError::value_error(format!(
+            "expected a positive input, got {}",
+            float_repr(x)
+        )));
     }
     if base == 10.0 {
         Ok(floatobject::w_float_new(x.log10()))
@@ -326,9 +432,6 @@ fn log_any(w_x: PyObjectRef, base: f64) -> PyResult {
     } else if base == 0.0 {
         Ok(floatobject::w_float_new(x.ln()))
     } else {
-        if base <= 0.0 || base.is_nan() {
-            return Err(crate::PyError::value_error("math domain error"));
-        }
         Ok(floatobject::w_float_new(x.ln() / base.ln()))
     }
 }
@@ -338,7 +441,19 @@ pub fn log(args: &[PyObjectRef]) -> PyResult {
         return Err(crate::PyError::type_error("log() takes 1 or 2 arguments"));
     }
     let base = if args.len() >= 2 {
-        get_double(args[1])
+        // The base is validated before the argument, so log(x, base) with a
+        // non-positive base reports the base rather than the argument.
+        let b = try_get_double(args[1])?;
+        if b <= 0.0 {
+            return Err(crate::PyError::value_error(format!(
+                "expected a positive input, got {}",
+                float_repr(b)
+            )));
+        }
+        if b == 1.0 {
+            return Err(crate::PyError::value_error("math domain error"));
+        }
+        b
     } else {
         0.0
     };
@@ -413,14 +528,32 @@ pub fn isfinite(args: &[PyObjectRef]) -> PyResult {
 }
 
 pub fn isclose(args: &[PyObjectRef]) -> PyResult {
-    if args.len() < 2 {
-        return Err(crate::PyError::type_error("isclose requires 2 arguments"));
+    let is_kwargs = !args.is_empty()
+        && unsafe {
+            let last = *args.last().unwrap();
+            pyre_object::is_dict(last)
+                && pyre_object::w_dict_lookup(last, pyre_object::w_str_new("__pyre_kw__")).is_some()
+        };
+    let (pos, kwargs) = if is_kwargs {
+        (&args[..args.len() - 1], Some(*args.last().unwrap()))
+    } else {
+        (&args[..], None)
+    };
+    if pos.len() != 2 {
+        return Err(crate::PyError::type_error(
+            "isclose() takes exactly 2 positional arguments",
+        ));
     }
-    let rel_tol = args.get(2).map(|&a| get_double(a));
-    let abs_tol = args.get(3).map(|&a| get_double(a));
-    match pymath::math::isclose(get_double(args[0]), get_double(args[1]), rel_tol, abs_tol) {
+    let read = |name: &str| -> Option<f64> {
+        kwargs
+            .and_then(|kw| unsafe { pyre_object::w_dict_lookup(kw, pyre_object::w_str_new(name)) })
+            .map(get_double)
+    };
+    let rel_tol = read("rel_tol");
+    let abs_tol = read("abs_tol");
+    match pymath::math::isclose(get_double(pos[0]), get_double(pos[1]), rel_tol, abs_tol) {
         Ok(v) => Ok(w_bool_from(v)),
-        Err(e) => Err(crate::PyError::value_error(format!("{e:?}"))),
+        Err(e) => Err(map_int_err(e)),
     }
 }
 
@@ -441,6 +574,12 @@ pub fn factorial(args: &[PyObjectRef]) -> PyResult {
         }
     }
     let n_big = get_bigint(args[0])?;
+    use num_traits::Signed;
+    if n_big.is_negative() {
+        return Err(crate::PyError::value_error(
+            "factorial() not defined for negative values",
+        ));
+    }
     let n = if jit_bigint_to_i64_fits(&n_big) != 0 {
         jit_bigint_to_i64_value(&n_big)
     } else {
@@ -448,11 +587,6 @@ pub fn factorial(args: &[PyObjectRef]) -> PyResult {
             "factorial() argument should not exceed i64::MAX",
         ));
     };
-    if n < 0 {
-        return Err(crate::PyError::value_error(
-            "factorial() not defined for negative values",
-        ));
-    }
     // Straightforward BigInt multiplication; overflow impossible with
     // arbitrary precision. Faster algorithms (binary split) exist in
     // pypy/module/math/app_math.py but structural correctness is what
@@ -497,7 +631,7 @@ fn get_bigint(obj: PyObjectRef) -> Result<malachite_bigint::BigInt, crate::PyErr
     }
     // __index__ dunder — PyPy: descroperation.py space.index.
     if let Ok(method) = crate::baseobjspace::getattr_str(obj, "__index__") {
-        let result = crate::call_function(method, &[obj]);
+        let result = crate::call_function(method, &[]);
         if !result.is_null() {
             unsafe {
                 if pyre_object::is_int(result) {
@@ -544,73 +678,135 @@ pub fn lcm(args: &[PyObjectRef]) -> PyResult {
     }
 }
 
-pub fn comb(args: &[PyObjectRef]) -> PyResult {
+/// `w_int_new` when the value fits an i64, else `w_long_new`.
+fn bigint_to_pyint(b: malachite_bigint::BigInt) -> PyObjectRef {
     use num_traits::ToPrimitive;
-
-    if args.len() < 2 {
-        return Err(crate::PyError::type_error("comb() takes 2 arguments"));
-    }
-    let n_big = get_bigint(args[0])?;
-    let k_big = get_bigint(args[1])?;
-    let n = if jit_bigint_to_i64_fits(&n_big) != 0 {
-        jit_bigint_to_i64_value(&n_big)
-    } else {
-        return Err(crate::PyError::overflow_error(
-            "comb() argument should not exceed i64::MAX",
-        ));
-    };
-    let k = if jit_bigint_to_i64_fits(&k_big) != 0 {
-        jit_bigint_to_i64_value(&k_big)
-    } else {
-        return Err(crate::PyError::overflow_error(
-            "comb() argument should not exceed i64::MAX",
-        ));
-    };
-    match pymath::math::integer::comb(n, k) {
-        Ok(v) => match v.to_i64() {
-            Some(i) => Ok(w_int_new(i)),
-            None => Ok(w_long_new(malachite_bigint::BigInt::from(v))),
-        },
-        Err(e) => Err(crate::PyError::value_error(format!("{e:?}"))),
+    match b.to_i64() {
+        Some(i) => w_int_new(i),
+        None => w_long_new(b),
     }
 }
 
+fn biguint_to_pyint(b: malachite_bigint::BigUint) -> PyObjectRef {
+    bigint_to_pyint(malachite_bigint::BigInt::from(b))
+}
+
+pub fn comb(args: &[PyObjectRef]) -> PyResult {
+    use num_traits::{Signed, ToPrimitive};
+
+    if args.len() != 2 {
+        return Err(crate::PyError::type_error(
+            "comb() takes exactly two arguments",
+        ));
+    }
+    let n_big = get_bigint(args[0])?;
+    let k_big = get_bigint(args[1])?;
+
+    if n_big.is_negative() {
+        return Err(crate::PyError::value_error(
+            "n must be a non-negative integer",
+        ));
+    }
+    if k_big.is_negative() {
+        return Err(crate::PyError::value_error(
+            "k must be a non-negative integer",
+        ));
+    }
+
+    // Fast path: n fits in i64.
+    if let Some(ni) = n_big.to_i64() {
+        // k out of range [0, n] means the result is 0.
+        let ki = match k_big.to_i64() {
+            Some(k) if (0..=ni).contains(&k) => k,
+            _ => return Ok(w_int_new(0)),
+        };
+        // Symmetry C(n, k) == C(n, n-k): compute with the smaller index.
+        let ki = ki.min(ni - ki);
+        if ki > 1 {
+            let v = pymath::math::integer::comb(ni, ki).map_err(map_int_err)?;
+            return Ok(biguint_to_pyint(v));
+        }
+        if ki == 0 {
+            return Ok(w_int_new(1));
+        }
+        return Ok(bigint_to_pyint(n_big)); // ki == 1
+    }
+
+    // BigInt path: n does not fit i64. Reduce by symmetry, then the smaller
+    // index must fit u64 for the divide-and-conquer product.
+    let n_minus_k = &n_big - &k_big;
+    if n_minus_k.is_negative() {
+        return Ok(w_int_new(0));
+    }
+    let effective_k = if n_minus_k < k_big {
+        &n_minus_k
+    } else {
+        &k_big
+    };
+    let ki: u64 = match effective_k.to_u64() {
+        Some(k) => k,
+        None => {
+            return Err(crate::PyError::overflow_error(format!(
+                "min(n - k, k) must not exceed {}",
+                u64::MAX
+            )));
+        }
+    };
+    Ok(biguint_to_pyint(pymath::math::comb_bigint(&n_big, ki)))
+}
+
 pub fn perm(args: &[PyObjectRef]) -> PyResult {
-    use num_traits::ToPrimitive;
+    use num_traits::{Signed, ToPrimitive};
 
     if args.is_empty() {
         return Err(crate::PyError::type_error(
             "perm() takes at least 1 argument",
         ));
     }
-    let n_big = get_bigint(args[0])?;
-    let n = if jit_bigint_to_i64_fits(&n_big) != 0 {
-        jit_bigint_to_i64_value(&n_big)
-    } else {
-        return Err(crate::PyError::overflow_error(
-            "perm() argument should not exceed i64::MAX",
+    if args.len() > 2 {
+        return Err(crate::PyError::type_error(
+            "perm() takes at most 2 arguments",
         ));
-    };
-    // perm(n, None) means "unlimited" — treat as perm(n).
-    let k = if args.len() >= 2 && !unsafe { pyre_object::is_none(args[1]) } {
-        let k_big = get_bigint(args[1])?;
-        if jit_bigint_to_i64_fits(&k_big) != 0 {
-            Some(jit_bigint_to_i64_value(&k_big))
-        } else {
-            return Err(crate::PyError::overflow_error(
-                "perm() argument should not exceed i64::MAX",
-            ));
-        }
+    }
+    let n_big = get_bigint(args[0])?;
+    if n_big.is_negative() {
+        return Err(crate::PyError::value_error(
+            "n must be a non-negative integer",
+        ));
+    }
+    // perm(n, None) means k = n (factorial).
+    let k_big = if args.len() >= 2 && !unsafe { pyre_object::is_none(args[1]) } {
+        Some(get_bigint(args[1])?)
     } else {
         None
     };
-    match pymath::math::integer::perm(n, k) {
-        Ok(v) => match v.to_i64() {
-            Some(i) => Ok(w_int_new(i)),
-            None => Ok(w_long_new(malachite_bigint::BigInt::from(v))),
-        },
-        Err(e) => Err(crate::PyError::value_error(format!("{e:?}"))),
+    if let Some(ref k_val) = k_big {
+        if k_val.is_negative() {
+            return Err(crate::PyError::value_error(
+                "k must be a non-negative integer",
+            ));
+        }
+        if k_val > &n_big {
+            return Ok(w_int_new(0));
+        }
     }
+    // k (falling-factorial length) must fit u64 for the product.
+    let ki: u64 = match &k_big {
+        None => n_big.to_u64().ok_or_else(|| {
+            crate::PyError::overflow_error(format!("n must not exceed {}", u64::MAX))
+        })?,
+        Some(k_val) => k_val.to_u64().ok_or_else(|| {
+            crate::PyError::overflow_error(format!("k must not exceed {}", u64::MAX))
+        })?,
+    };
+    // Fast path: n fits in i64 and k > 1 uses the i64 kernel.
+    if let Some(ni) = n_big.to_i64() {
+        if ni >= 0 && ki > 1 {
+            let v = pymath::math::integer::perm(ni, Some(ki as i64)).map_err(map_int_err)?;
+            return Ok(biguint_to_pyint(v));
+        }
+    }
+    Ok(biguint_to_pyint(pymath::math::perm_bigint(&n_big, ki)))
 }
 
 pub fn isqrt(args: &[PyObjectRef]) -> PyResult {
@@ -628,17 +824,17 @@ pub fn isqrt(args: &[PyObjectRef]) -> PyResult {
                 None => Ok(w_long_new(v)),
             }
         }
-        Err(e) => Err(crate::PyError::value_error(format!("{e:?}"))),
+        Err(e) => Err(map_int_err(e)),
     }
 }
 
 pub fn fsum(args: &[PyObjectRef]) -> PyResult {
     let items = crate::builtins::collect_iterable(args[0])?;
-    let floats: Vec<f64> = items.iter().map(|&a| get_double(a)).collect();
-    match pymath::math::fsum(floats) {
-        Ok(v) => Ok(floatobject::w_float_new(v)),
-        Err(e) => Err(crate::PyError::value_error(format!("{e:?}"))),
-    }
+    let floats: Vec<f64> = items
+        .iter()
+        .map(|&a| try_get_double(a))
+        .collect::<Result<Vec<_>, _>>()?;
+    map_err(pymath::math::fsum(floats))
 }
 
 pub fn prod(args: &[PyObjectRef]) -> PyResult {
@@ -705,7 +901,7 @@ pub fn prod(args: &[PyObjectRef]) -> PyResult {
 /// mathmodule.c `math_sumprod_impl` semantics using the generic
 /// `space.mul` + `space.add` loop.
 pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
-    if args.len() < 2 {
+    if args.len() != 2 {
         return Err(crate::PyError::type_error(
             "sumprod() takes exactly 2 arguments",
         ));
@@ -717,21 +913,10 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
             "Inputs are not the same length",
         ));
     }
-    let mut acc: PyObjectRef = floatobject::w_float_new(0.0);
-    let mut all_int = true;
-    for (a, b) in p.iter().zip(q.iter()) {
-        unsafe {
-            if !(pyre_object::is_int(*a) || pyre_object::is_long(*a))
-                || !(pyre_object::is_int(*b) || pyre_object::is_long(*b))
-            {
-                all_int = false;
-                break;
-            }
-        }
-    }
-    if all_int {
-        acc = w_int_new(0);
-    }
+    // The accumulator starts as int 0 so type coercion follows the pure
+    // Python `total = 0; total += p_i * q_i` recipe: int stays int, and a
+    // Decimal/Fraction/float product widens the running total on first add.
+    let mut acc: PyObjectRef = w_int_new(0);
     for (a, b) in p.iter().zip(q.iter()) {
         let prod = crate::baseobjspace::mul(*a, *b)?;
         acc = crate::baseobjspace::add(acc, prod)?;
@@ -801,15 +986,41 @@ pub fn modf(args: &[PyObjectRef]) -> PyResult {
 }
 
 pub fn nextafter(args: &[PyObjectRef]) -> PyResult {
-    if args.len() < 2 {
+    let is_kwargs = !args.is_empty()
+        && unsafe {
+            let last = *args.last().unwrap();
+            pyre_object::is_dict(last)
+                && pyre_object::w_dict_lookup(last, pyre_object::w_str_new("__pyre_kw__")).is_some()
+        };
+    let (pos, kwargs) = if is_kwargs {
+        (&args[..args.len() - 1], Some(*args.last().unwrap()))
+    } else {
+        (&args[..], None)
+    };
+    if pos.len() != 2 {
         return Err(crate::PyError::type_error(
-            "nextafter() takes at least 2 arguments",
+            "nextafter() takes exactly 2 positional arguments",
         ));
     }
+    let steps = match kwargs
+        .and_then(|kw| unsafe { pyre_object::w_dict_lookup(kw, pyre_object::w_str_new("steps")) })
+    {
+        Some(s) => {
+            use num_traits::ToPrimitive;
+            let b = get_bigint(s)?;
+            if b.sign() == malachite_bigint::Sign::Minus {
+                return Err(crate::PyError::value_error(
+                    "steps must be a non-negative integer",
+                ));
+            }
+            Some(b.to_u64().unwrap_or(u64::MAX))
+        }
+        None => None,
+    };
     Ok(floatobject::w_float_new(pymath::math::nextafter(
-        get_double(args[0]),
-        get_double(args[1]),
-        None,
+        get_double(pos[0]),
+        get_double(pos[1]),
+        steps,
     )))
 }
 

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -531,7 +531,9 @@ pub fn isfinite(args: &[PyObjectRef]) -> PyResult {
             "isfinite() takes exactly 1 argument",
         ));
     }
-    Ok(w_bool_from(pymath::math::isfinite(try_get_double(args[0])?)))
+    Ok(w_bool_from(pymath::math::isfinite(try_get_double(
+        args[0],
+    )?)))
 }
 
 pub fn isclose(args: &[PyObjectRef]) -> PyResult {

--- a/pyre/pyre-interpreter/src/module/math/mod.rs
+++ b/pyre/pyre-interpreter/src/module/math/mod.rs
@@ -16,7 +16,7 @@ crate::py_module! {
         "inf" => pyre_object::floatobject::w_float_new(pymath::math::INF),
         "nan" => pyre_object::floatobject::w_float_new(pymath::math::NAN),
     },
-    functions: {
+    module_functions: {
         // Trigonometric
         "sin"   / 1 = m::sin,
         "cos"   / 1 = m::cos,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -869,11 +869,17 @@ pub fn register_module(ns: &mut DictStorage) {
         "is_finalizing",
         make_builtin_function_with_arity("is_finalizing", |_| Ok(w_bool_from(false)), 0),
     );
-    // sys.displayhook / excepthook
+    // sys.displayhook / excepthook. `__displayhook__` keeps the original so
+    // code (e.g. doctest) can save and restore the hook.
     dict_storage_store(
         ns,
         "displayhook",
-        make_builtin_function_with_arity("displayhook", |_| Ok(w_none()), 1),
+        make_builtin_function_with_arity("displayhook", crate::builtins::sys_displayhook, 1),
+    );
+    dict_storage_store(
+        ns,
+        "__displayhook__",
+        make_builtin_function_with_arity("displayhook", crate::builtins::sys_displayhook, 1),
     );
     dict_storage_store(
         ns,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -698,6 +698,18 @@ unsafe fn as_float(obj: PyObjectRef) -> f64 {
     }
 }
 
+/// Coerce an operand to f64 for a value-producing float operator, reporting
+/// an over-range int as `OverflowError` (`PyFloat_AsDouble`). A genuine
+/// float infinity is preserved; only an `int` whose magnitude exceeds f64
+/// range raises.
+unsafe fn as_float_arith(obj: PyObjectRef) -> Result<f64, PyError> {
+    let v = as_float(obj);
+    if is_long(obj) && !v.is_finite() {
+        return Err(PyError::overflow_error("int too large to convert to float"));
+    }
+    Ok(v)
+}
+
 /// True if both operands are numeric and at least one is float.
 
 unsafe fn is_float_pair(a: PyObjectRef, b: PyObjectRef) -> bool {
@@ -707,35 +719,35 @@ unsafe fn is_float_pair(a: PyObjectRef, b: PyObjectRef) -> bool {
 }
 
 unsafe fn float_add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_float_new(as_float(a) + as_float(b)))
+    Ok(w_float_new(as_float_arith(a)? + as_float_arith(b)?))
 }
 
 unsafe fn float_sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_float_new(as_float(a) - as_float(b)))
+    Ok(w_float_new(as_float_arith(a)? - as_float_arith(b)?))
 }
 
 unsafe fn float_mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_float_new(as_float(a) * as_float(b)))
+    Ok(w_float_new(as_float_arith(a)? * as_float_arith(b)?))
 }
 
 unsafe fn float_truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let vb = as_float(b);
+    let vb = as_float_arith(b)?;
     if vb == 0.0 {
         return Err(PyError::zero_division("float division by zero"));
     }
-    Ok(w_float_new(as_float(a) / vb))
+    Ok(w_float_new(as_float_arith(a)? / vb))
 }
 
 /// floatobject.py:508-512: descr_floordiv → _divmod_w()[0].
 unsafe fn float_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let (floordiv, _mod) = float_divmod_w(as_float(a), as_float(b))?;
+    let (floordiv, _mod) = float_divmod_w(as_float_arith(a)?, as_float_arith(b)?)?;
     Ok(w_float_new(floordiv))
 }
 
 /// floatobject.py:520-540: descr_mod with math_fmod + sign correction.
 unsafe fn float_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let x = as_float(a);
-    let y = as_float(b);
+    let x = as_float_arith(a)?;
+    let y = as_float_arith(b)?;
     if y == 0.0 {
         // floatobject.py:526
         return Err(PyError::zero_division("float modulo"));

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -698,16 +698,20 @@ unsafe fn as_float(obj: PyObjectRef) -> f64 {
     }
 }
 
-/// Coerce an operand to f64 for a value-producing float operator, reporting
-/// an over-range int as `OverflowError` (`PyFloat_AsDouble`). A genuine
-/// float infinity is preserved; only an `int` whose magnitude exceeds f64
-/// range raises.
-unsafe fn as_float_arith(obj: PyObjectRef) -> Result<f64, PyError> {
-    let v = as_float(obj);
+/// Reject an over-range `int` operand of a value-producing float operator:
+/// `PyFloat_AsDouble` raises `OverflowError` when an `int`'s magnitude
+/// exceeds f64 range. `v` is the already-extracted [`as_float`] value; a
+/// genuine float infinity is preserved, only an over-range `int` raises.
+///
+/// Split from the f64 extraction so the operator bodies pass plain `f64`
+/// values — never a `Result<f64, _>` — into the arithmetic. A `Result`
+/// payload mixing `Float` (`Ok`) and `Ref` (`Err`) has no single register
+/// kind, so the JIT codewriter cannot flatten it (`emit_list_of_kind`).
+unsafe fn reject_float_coercion_overflow(obj: PyObjectRef, v: f64) -> Result<(), PyError> {
     if is_long(obj) && !v.is_finite() {
         return Err(PyError::overflow_error("int too large to convert to float"));
     }
-    Ok(v)
+    Ok(())
 }
 
 /// True if both operands are numeric and at least one is float.
@@ -719,35 +723,56 @@ unsafe fn is_float_pair(a: PyObjectRef, b: PyObjectRef) -> bool {
 }
 
 unsafe fn float_add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_float_new(as_float_arith(a)? + as_float_arith(b)?))
+    let va = as_float(a);
+    reject_float_coercion_overflow(a, va)?;
+    let vb = as_float(b);
+    reject_float_coercion_overflow(b, vb)?;
+    Ok(w_float_new(va + vb))
 }
 
 unsafe fn float_sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_float_new(as_float_arith(a)? - as_float_arith(b)?))
+    let va = as_float(a);
+    reject_float_coercion_overflow(a, va)?;
+    let vb = as_float(b);
+    reject_float_coercion_overflow(b, vb)?;
+    Ok(w_float_new(va - vb))
 }
 
 unsafe fn float_mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    Ok(w_float_new(as_float_arith(a)? * as_float_arith(b)?))
+    let va = as_float(a);
+    reject_float_coercion_overflow(a, va)?;
+    let vb = as_float(b);
+    reject_float_coercion_overflow(b, vb)?;
+    Ok(w_float_new(va * vb))
 }
 
 unsafe fn float_truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let vb = as_float_arith(b)?;
+    let vb = as_float(b);
+    reject_float_coercion_overflow(b, vb)?;
     if vb == 0.0 {
         return Err(PyError::zero_division("float division by zero"));
     }
-    Ok(w_float_new(as_float_arith(a)? / vb))
+    let va = as_float(a);
+    reject_float_coercion_overflow(a, va)?;
+    Ok(w_float_new(va / vb))
 }
 
 /// floatobject.py:508-512: descr_floordiv → _divmod_w()[0].
 unsafe fn float_floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let (floordiv, _mod) = float_divmod_w(as_float_arith(a)?, as_float_arith(b)?)?;
+    let x = as_float(a);
+    reject_float_coercion_overflow(a, x)?;
+    let y = as_float(b);
+    reject_float_coercion_overflow(b, y)?;
+    let (floordiv, _mod) = float_divmod_w(x, y)?;
     Ok(w_float_new(floordiv))
 }
 
 /// floatobject.py:520-540: descr_mod with math_fmod + sign correction.
 unsafe fn float_mod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    let x = as_float_arith(a)?;
-    let y = as_float_arith(b)?;
+    let x = as_float(a);
+    reject_float_coercion_overflow(a, x)?;
+    let y = as_float(b);
+    reject_float_coercion_overflow(b, y)?;
     if y == 0.0 {
         // floatobject.py:526
         return Err(PyError::zero_division("float modulo"));

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2728,7 +2728,7 @@ fn float_pow_inner(x: f64, y: f64) -> Result<f64, FloatPowError> {
     // floatobject.py:844-847
     if x == 0.0 && y < 0.0 {
         return Err(FloatPowError::Py(PyError::zero_division(
-            "0.0 cannot be raised to a negative power",
+            "zero to a negative power",
         )));
     }
     // floatobject.py:849-862

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1392,6 +1392,7 @@ pub fn via_space_next(iter: PyObjectRef) -> bool {
             || pyre_object::interp_itertools::is_filterfalse(iter)
             || pyre_object::interp_itertools::is_pairwise(iter)
             || pyre_object::interp_itertools::is_cycle(iter)
+            || pyre_object::interp_itertools::is_chain(iter)
             || pyre_object::functional::is_enumerate(iter)
             || pyre_object::functional::is_reversed(iter)
             || pyre_object::functional::is_filter(iter)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8837,33 +8837,26 @@ fn init_float_type(ns: &mut DictStorage) {
                     ));
                 }
                 let v = unsafe { pyre_object::w_float_get_value(args[0]) };
-                if v.is_nan() || v.is_infinite() {
-                    return Err(crate::PyError::value_error(
-                        "cannot convert NaN/Infinity to integer ratio",
-                    ));
-                }
-                // Decompose f = m * 2^e with an integer mantissa, then
-                // reduce to lowest terms (the mantissa carries trailing
-                // zero bits for values like 0.5, so the raw ratio is not
-                // yet reduced).
-                let (mantissa, exponent, sign) = integer_decode(v);
-                let m = mantissa as i64 * sign as i64;
-                let (num, denom) = if exponent >= 0 {
-                    (m.saturating_mul(1i64 << exponent.min(62)), 1i64)
-                } else {
-                    (m, 1i64 << (-exponent).min(62))
-                };
-                fn gcd(mut a: i64, mut b: i64) -> i64 {
-                    while b != 0 {
-                        (a, b) = (b, a % b);
+                // Exact numerator/denominator via the shared rational
+                // decomposition (full exponent range, reduced to lowest terms).
+                let (numer, denom) =
+                    rustpython_common::int::float_to_ratio(v).ok_or_else(|| {
+                        if v.is_infinite() {
+                            crate::PyError::overflow_error(
+                                "cannot convert Infinity to integer ratio",
+                            )
+                        } else {
+                            crate::PyError::value_error("cannot convert NaN to integer ratio")
+                        }
+                    })?;
+                let to_pyint = |b: malachite_bigint::BigInt| {
+                    if pyre_object::jit_bigint_to_i64_fits(&b) != 0 {
+                        pyre_object::w_int_new(pyre_object::jit_bigint_to_i64_value(&b))
+                    } else {
+                        pyre_object::w_long_new(b)
                     }
-                    a.abs()
-                }
-                let g = gcd(num, denom).max(1);
-                Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_int_new(num / g),
-                    pyre_object::w_int_new(denom / g),
-                ]))
+                };
+                Ok(pyre_object::w_tuple_new(vec![to_pyint(numer), to_pyint(denom)]))
             },
             1,
         ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -838,6 +838,10 @@ pub fn init_typeobjects() {
             &pyre_object::interp_itertools::CYCLE_TYPE as *const PyType as usize,
             new_typeobject_with_base("itertools.cycle", |_| {}, object_type) as usize,
         );
+        reg.insert(
+            &pyre_object::interp_itertools::CHAIN_TYPE as *const PyType as usize,
+            new_typeobject_with_base("itertools.chain", |_| {}, object_type) as usize,
+        );
         // `pypy/objspace/std/specialisedtupleobject.py` — three SpecialisedTuple
         // variants share the public `tuple` PyType name, so all three
         // foreign statics map to a "tuple" typedef.  `gettypefor` keys
@@ -8130,12 +8134,25 @@ fn init_int_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "bit_count",
             |args| {
-                let val = if !args.is_empty() && unsafe { pyre_object::is_int(args[0]) } {
-                    unsafe { pyre_object::w_int_get_value(args[0]) }
+                let count = if args.is_empty() {
+                    0
+                } else if unsafe { pyre_object::is_int(args[0]) } {
+                    // Small-int fast path — `@jit.elidable` `_bit_count`.
+                    pyre_object::int_bit_count(unsafe { pyre_object::w_int_get_value(args[0]) })
+                } else if unsafe { pyre_object::pyobject::is_int_or_long(args[0]) } {
+                    // long/bigint: population count of the magnitude, so the
+                    // i64 fast path (which leaves out-of-range values at 0)
+                    // does not undercount.
+                    unsafe {
+                        crate::builtins::obj_to_bigint(args[0])
+                            .iter_u32_digits()
+                            .map(|d| d.count_ones() as i64)
+                            .sum()
+                    }
                 } else {
                     0
                 };
-                Ok(pyre_object::w_int_new(pyre_object::int_bit_count(val)))
+                Ok(pyre_object::w_int_new(count))
             },
             1,
         ),
@@ -8856,7 +8873,10 @@ fn init_float_type(ns: &mut DictStorage) {
                         pyre_object::w_long_new(b)
                     }
                 };
-                Ok(pyre_object::w_tuple_new(vec![to_pyint(numer), to_pyint(denom)]))
+                Ok(pyre_object::w_tuple_new(vec![
+                    to_pyint(numer),
+                    to_pyint(denom),
+                ]))
             },
             1,
         ),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -2132,6 +2132,17 @@ fn build_gc() -> Box<dyn majit_gc::GcAllocator> {
         &mut pytype_to_tid,
         <pyre_object::interp_array::W_Array as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // W_Chain (`itertools.chain`) — typed payload via `#[pyre_class]` in
+    // AUTO-ID mode.  Both the `w_iterables` source iterator and the current
+    // sub-iterator `w_it` are owned solely by the W_Chain (no external
+    // root), so the collector must trace both edges.  Tail of the
+    // register_pyre_class chain so no earlier slot shifts.
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_object::interp_itertools::W_Chain
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // W_MemoryView (`memoryview`) — typed payload via `#[pyre_class]` in
     // AUTO-ID mode.  Its geometry and backing live in an off-heap
     // `*const BufferView`, so the macro's empty `gc_ptr_offsets` reach

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -482,6 +482,50 @@ pub unsafe fn is_chain(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &CHAIN_TYPE) }
 }
 
+/// Read the `w_iterables` field of a `W_Chain`.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `W_Chain`.
+#[inline]
+pub unsafe fn w_chain_get_iterables(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_Chain)).w_iterables }
+}
+
+/// Read the `w_it` field of a `W_Chain`.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `W_Chain`.
+#[inline]
+pub unsafe fn w_chain_get_it(obj: PyObjectRef) -> PyObjectRef {
+    unsafe { (*(obj as *const W_Chain)).w_it }
+}
+
+/// Store the `w_iterables` field of a `W_Chain`.  Reassigning a pointer
+/// field can record an old→young edge, so the GC write barrier runs.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `W_Chain`.
+#[inline]
+pub unsafe fn w_chain_set_iterables(obj: PyObjectRef, w_value: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut W_Chain)).w_iterables = w_value;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
+}
+
+/// Store the `w_it` field of a `W_Chain`.  Reassigning a pointer field can
+/// record an old→young edge, so the GC write barrier runs.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `W_Chain`.
+#[inline]
+pub unsafe fn w_chain_set_it(obj: PyObjectRef, w_value: PyObjectRef) {
+    unsafe {
+        (*(obj as *mut W_Chain)).w_it = w_value;
+        crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -418,6 +418,70 @@ pub unsafe fn is_cycle(obj: PyObjectRef) -> bool {
     unsafe { py_type_check(obj, &CYCLE_TYPE) }
 }
 
+// ── W_Chain — pypy/module/itertools/interp_itertools.py:class W_Chain ──
+//
+// ```python
+// class W_Chain(W_Root):
+//     def __init__(self, space, w_iterables):
+//         self.space = space
+//         self.w_iterables = w_iterables
+//         self.w_it = None
+//
+//     def _advance(self):
+//         self.w_it = self.space.iter(self.space.next(self.w_iterables))
+//
+//     def next_w(self):
+//         if not self.w_it:
+//             self._advance()     # may raise StopIteration
+//         while True:
+//             try:
+//                 return self.space.next(self.w_it)
+//             except OperationError as e:
+//                 if e.match(self.space, self.space.w_StopIteration):
+//                     self.w_it = None
+//                     self._advance()
+//                 else:
+//                     raise
+// ```
+//
+// `w_iterables` is an iterator over the source iterables; `w_it` is the
+// current active sub-iterator (PY_NULL until the first `next_w`, and reset
+// to PY_NULL each time a sub-iterator is exhausted).  Both pointer fields
+// are owned solely by the W_Chain, so the GC must trace them — the type is
+// registered in the JIT GC driver (`pyre-jit/src/eval.rs`) via
+// `register_pyre_class` in AUTO-ID mode.
+#[pyre_class("itertools.chain", static_name = "CHAIN")]
+pub struct W_Chain {
+    pub w_iterables: PyObjectRef,
+    pub w_it: PyObjectRef,
+}
+
+/// `w_iterables` must already be an iterator over the source iterables
+/// (`chain` / `chain.from_iterable` apply `space.iter`).  `w_it` starts
+/// PY_NULL (no active sub-iterator yet).
+pub fn w_chain_new(w_iterables: PyObjectRef) -> PyObjectRef {
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
+    let _roots = crate::gc_roots::push_roots();
+    crate::gc_roots::pin_root(w_iterables);
+    W_Chain::allocate(W_Chain {
+        ob: PyObject {
+            ob_type: std::ptr::null(),
+            w_class: std::ptr::null_mut(),
+        },
+        w_iterables,
+        w_it: std::ptr::null_mut(),
+    })
+}
+
+/// Check if an object is a `W_Chain`.
+///
+/// # Safety
+/// `obj` must be a valid, non-null pointer to a `PyObject`.
+#[inline]
+pub unsafe fn is_chain(obj: PyObjectRef) -> bool {
+    unsafe { py_type_check(obj, &CHAIN_TYPE) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -519,6 +583,29 @@ mod tests {
         assert_eq!(
             <W_Cycle as crate::lltype::GcType>::SIZE,
             W_CYCLE_OBJECT_SIZE
+        );
+    }
+
+    // W_Chain is registered in AUTO-ID mode (no `type_id = N`), so the GC
+    // tid is stamped at JIT-driver init rather than asserted against a
+    // constant.  What must hold is that both traced edges — the source
+    // `w_iterables` iterator and the current sub-iterator `w_it` — are
+    // reported to the collector, and that the descriptor reflects the
+    // struct's size.
+    #[test]
+    fn w_chain_gc_descriptor_traces_both_pointer_fields() {
+        assert_eq!(W_CHAIN_GC_PTR_OFFSETS.len(), 2);
+        assert_eq!(
+            W_CHAIN_GC_PTR_OFFSETS[0],
+            std::mem::offset_of!(W_Chain, w_iterables)
+        );
+        assert_eq!(
+            W_CHAIN_GC_PTR_OFFSETS[1],
+            std::mem::offset_of!(W_Chain, w_it)
+        );
+        assert_eq!(
+            <W_Chain as crate::lltype::GcType>::SIZE,
+            W_CHAIN_OBJECT_SIZE
         );
     }
 }


### PR DESCRIPTION
Brings `test_math` to a full pass. `pyre -m test test_math` → `== Tests result: SUCCESS ==`, Ran 89 tests, OK (skipped=4: three CPython-impl-detail skips + `test_sumprod_stress` under the `cpu` resource).

### Commits
- **math — test_math parity**: comb/perm bigint paths (`pymath::math::comb_bigint`/`perm_bigint` + i64 fast paths); domain-error messages carrying the offending value (`sin`/`cos`/`tan`/`asin`/`acos`/`atanh`/`sqrt`/`gamma`, and `log`/`log2`/`log10`); `try_get_double` propagates raising `__float__`/`__index__` descriptors and raises `OverflowError` for over-range longs; `sumprod` int-`0` accumulator + exactly-2-args; `ceil`/`floor`/`trunc` via type-only `lookup_special` (trunc has no `__float__` fallback); `float()` constructor and float add/sub/mul/truediv/floordiv/mod raise `OverflowError` on over-range long operands; `as_integer_ratio` via `rustpython_common::int::float_to_ratio`; `_abc` seeds a per-class `_abc_registry`.
- **sys — displayhook**: implement `sys.displayhook`/`sys.__displayhook__` (repr → live `sys.stdout` + `builtins._`) and route `PRINT_EXPR` through the live hook, so the `mathdata/ieee754.txt` doctest's redirected stdout is captured.
- **itertools.chain / int.bit_count / float pow**:
  - `itertools.chain` is now a lazy `W_Chain` iterator (mirrors `W_Cycle`) instead of eagerly materializing every argument — an infinite argument such as `chain([3], repeat(3))` (reached via `_pydecimal` thousands-grouping in `format(Decimal(...), '')`) no longer hangs at construction.
  - `int.bit_count()` sums the population count over the bigint magnitude's `u32` digits, so values ≥ 2**63 no longer report `0`.
  - float pow raises `ZeroDivisionError("zero to a negative power")` for a zero base with a negative exponent; `int ** negative` delegates to float pow, so `0 ** -1` carries this message (matches `mathdata/ieee754.txt`).

The `ieee754.txt` doctest only began executing once `sys.displayhook` was wired, which then surfaced the pre-existing `int.bit_count` (via `test_isqrt_huge`) and float-pow-message gaps fixed here.

*Note: PR opened by Claude on behalf of the author.*