### PR TITLE
jit: FOR_ITER per-iteration getarrayitem_vable_r iterator reload (#152)

### DIFF
--- a/pyre/bench/synth/kept_stack_deep_var_shortcircuit_mutate.py
+++ b/pyre/bench/synth/kept_stack_deep_var_shortcircuit_mutate.py
@@ -1,0 +1,35 @@
+# Adversarial companion to kept_stack_deep_var_shortcircuit: the deep
+# operand-stack Variables g(i)/h(i) are held across a `p or q` short-circuit
+# guard EXACTLY as in that bench, but g and h each MUTATE a shared global list
+# (a non-journaled STORE_SUBSCR-class heap effect committed inside a user
+# frame).  A FOR_ITER trace that consumes the iterator, aborts on the deep
+# kept-stack guard, and then DELIVERS the in-flight item would re-run the body
+# and DOUBLE the mutation.  The `log` length must equal the iteration count
+# exactly (2 mutations per iteration): a doubled delivery over-counts, a
+# dropped iteration under-counts.
+log = []
+
+
+def g(i):
+    log.append(i)
+    return i * 2 + 1
+
+
+def h(i):
+    log.append(-i)
+    return i * 3 - 1
+
+
+def f(n):
+    s = 0
+    for i in range(n):
+        p = (i % 4) != 0
+        q = (i % 5) != 0
+        t = (g(i), h(i), (g(i) if (p or q) else h(i)))
+        s += t[0] - t[1] + t[2]
+    return s
+
+
+r = f(40000)
+print(r)
+print(len(log))

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9489,40 +9489,123 @@ impl CodeWriter {
                         // interpreter on side-exit; the trace only records the
                         // continuing iteration (the loop closes at the back-edge).
                         Instruction::ForIter { delta } => {
-                            // Source `next()`'s iterator argument from the
-                            // loop-carried operand Variable at TOS
-                            // (`current_state.stack.last()`, the merge-rebound
-                            // loop-input the runtime vstack mirror holds as an
-                            // InputArgRef), mirroring RPython `space.next(
-                            // peekvalue())`.  Feeding a real operand Variable
-                            // gives the loop-carried iterator a genuine SSA
-                            // reader, so the graph allocator assigns it a
-                            // DISTINCT live color and `compute_liveness` marks it
-                            // live at the FOR_ITER `-live-` marker; both cascades
-                            // let `build_pcdep_color_slots` keep the
-                            // `(iter_color -> nlocals+0)` operand entry at this
-                            // guard pc.  Without a reader (the prior portal-only
-                            // `getarrayitem_vable_r` reload was defined-and-
-                            // consumed inside the opcode) the loop-carried
-                            // iterator color is dropped from both `pcdep` and the
-                            // `-live-` R-bank, so a guard-pc resume (M3) cannot
-                            // reconstruct the kept iterator operand slot and
-                            // re-executes FOR_ITER on a non-iterator.  GET_ITER's
-                            // `setarrayitem_vable_r` still populates the vable
-                            // image (blackhole/interp read), so dropping the
-                            // reload is safe; DCE removes it.  TOS is the iterator
-                            // (`current_depth - 1`).
-                            let iter_slot_depth = current_depth.saturating_sub(1);
-                            let iter_value: super::flow::FlowValue = current_state
-                                .stack
-                                .last()
-                                .cloned()
-                                .unwrap_or_else(|| fresh_ref_value(&mut graph).into());
-                            if is_portal {
-                                if let super::flow::FlowValue::Variable(v) = &iter_value {
-                                    pin!(Some(*v), stack_base + iter_slot_depth);
+                            // Reload `next()`'s iterator argument from its
+                            // value-stack slot every iteration, porting RPython
+                            // `w_iterator = self.peekvalue()`
+                            // (pyopcode.py:1303-1304).  `peekvalue` reads
+                            // `locals_cells_stack_w[index]`, which
+                            // `jtransform.py:760-767 do_fixed_list_getitem`
+                            // lowers to `getarrayitem_vable_r` inside the loop
+                            // body.  GET_ITER's `pushvalue` populated the slot
+                            // via `setarrayitem_vable_r` (see above), so the
+                            // reload always finds the live iterator.
+                            //
+                            // The reload is required, not optional: pyre's
+                            // `jit_merge_point` reds are `[frame, ec]` only
+                            // (interp_jit.py:67), so the operand stack is NOT
+                            // loop-carried in registers — it lives in the
+                            // virtualizable image.  An iterator defined once in
+                            // the loop preamble cannot survive as an SSA
+                            // register across the compiled resident loop; a full-
+                            // body walk that resumes past the loop-header merge
+                            // point would then read an unbound register on the
+                            // `ForIterNext` residual (ResidualCallArgUnbound).
+                            // Re-materializing it from the vable each iteration
+                            // gives it a genuine in-loop reader, so
+                            // `compute_liveness` marks it live at the FOR_ITER
+                            // `-live-` marker and `build_pcdep_color_slots` keeps
+                            // its `(color -> slot)` entry for the M3 body-guard
+                            // resume.  TOS is the iterator (`current_depth - 1`).
+                            //
+                            // WITHHOLD the reload when the loop body holds a
+                            // CALL result across an in-body conditional branch
+                            // (a `CALL` opcode and a `POP_JUMP_IF_*` both inside
+                            // `[py_pc+1, exhaust_target)`).  That shape produces
+                            // a depth > 1 operand stack of call results kept
+                            // across a short-circuit / conditional guard whose
+                            // COMPILED interior-guard resume cannot yet
+                            // reconstruct the deep slots (the walk-level operand
+                            // mirror reports them present, but the blackhole
+                            // rebuilds them NULL — the #416/#420 deep-kept
+                            // interior-snapshot gap).  Enabling the reload lets
+                            // the walk enter and CONSUME the shared iterator, run
+                            // the body's residual calls concretely, then abort at
+                            // the deep guard — an irreversible half-executed
+                            // iteration that cannot be delivered (re-running the
+                            // body doubles a committed effect) nor cleanly
+                            // dropped (it loses the iteration).  Without the
+                            // reload the `ForIterNext` residual has no bound
+                            // iterator argument, so the walk aborts at the
+                            // FOR_ITER header BEFORE the consume
+                            // (`ResidualCallArgUnbound`) and the location
+                            // interprets permanently — bit-exact, the pre-reload
+                            // behaviour.  condexpr (branch, no call) and
+                            // nested_call (call, no in-body branch) do not match,
+                            // so both keep the reload.  Lifted when the deep-kept
+                            // interior-guard snapshot lands.
+                            let foriter_deep_kept_call_hazard = {
+                                let exhaust_target = jump_target_forward(
+                                    code,
+                                    num_instrs,
+                                    py_pc + 1,
+                                    delta.get(op_arg).as_usize(),
+                                );
+                                let mut scan_state = pyre_interpreter::OpArgState::default();
+                                let mut has_call = false;
+                                let mut has_branch = false;
+                                for scan_pc in 0..num_instrs {
+                                    let (scan_instr, _) =
+                                        scan_state.get(code.instructions[scan_pc]);
+                                    if scan_pc <= py_pc || scan_pc >= exhaust_target {
+                                        continue;
+                                    }
+                                    match scan_instr {
+                                        Instruction::Call { .. }
+                                        | Instruction::CallKw { .. }
+                                        | Instruction::CallFunctionEx
+                                        | Instruction::CallIntrinsic1 { .. }
+                                        | Instruction::CallIntrinsic2 { .. } => has_call = true,
+                                        Instruction::PopJumpIfTrue { .. }
+                                        | Instruction::PopJumpIfFalse { .. }
+                                        | Instruction::PopJumpIfNone { .. }
+                                        | Instruction::PopJumpIfNotNone { .. } => has_branch = true,
+                                        _ => {}
+                                    }
                                 }
-                            }
+                                has_call && has_branch
+                            };
+                            let iter_slot_depth = current_depth.saturating_sub(1);
+                            let iter_value: super::flow::FlowValue =
+                                if is_portal && !foriter_deep_kept_call_hazard {
+                                    let iter_abs_slot =
+                                        (stack_base_absolute + iter_slot_depth as usize) as i64;
+                                    let v_iter_idx: super::flow::FlowValue =
+                                        super::flow::Constant::signed(iter_abs_slot).into();
+                                    let v_iter = emit_graph_op_with_result(
+                                        &mut graph,
+                                        &current_block.block(),
+                                        "getarrayitem_vable_r",
+                                        vable_getarrayitem_ref_graph_args(
+                                            frame_var.into(),
+                                            v_iter_idx.into(),
+                                        ),
+                                        Kind::Ref,
+                                        py_pc as i64,
+                                    );
+                                    pin!(Some(v_iter), stack_base + iter_slot_depth);
+                                    v_iter.into()
+                                } else {
+                                    // Non-portal callee (no vable read; keep the
+                                    // loop-carried operand SSA Variable at TOS) OR
+                                    // the deep-kept-call hazard shape (withhold the
+                                    // reload so the walk aborts at the header before
+                                    // the irreversible consume).
+                                    current_state
+                                        .stack
+                                        .last()
+                                        .cloned()
+                                        .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                                };
                             let next_var = residual_call!(
                                 for_iter_next_fn_idx,
                                 CallFlavor::MayForce,


### PR DESCRIPTION
## Summary

Restores the per-iteration iterator reload in the `FOR_ITER` handler so the `kept_stack_deep_var_{condexpr,nested_call}` residency benches JIT-compile instead of aborting `ResidualCallArgUnbound{pc:230}` on the `ForIterNext` residual. This is a `/parity` fix — it ports RPython's `w_iterator = self.peekvalue()` (`pyopcode.py:1303-1304`, lowered by `jtransform.py:760-767 do_fixed_list_getitem` to `getarrayitem_vable_r` inside the loop body).

The `jit_merge_point` reds are `[frame, ec]` only (matching `interp_jit.py:67`), so the operand stack lives in the virtualizable image, not in loop-carried registers. An iterator defined once in the loop preamble cannot survive as an SSA register across the compiled resident loop; re-materializing it from the vable each iteration gives it a genuine in-loop reader, so `compute_liveness` keeps it live at the `-live-` marker and `build_pcdep_color_slots` retains its color→slot entry for the M3 body-guard resume.

## Withhold gate (deep-kept-call hazard)

The reload is **withheld** when the loop body holds a CALL result across an in-body conditional branch (both a CALL-family op and a `POP_JUMP_IF_*` inside `[py_pc+1, exhaust_target)`). That shape (e.g. `kept_stack_deep_var_shortcircuit`) reaches a depth>1 kept operand stack at an interior short-circuit guard whose *compiled* resume cannot yet reconstruct the deep slots (the #416/#420 deep-kept interior-snapshot gap). With the reload the walk would consume the shared iterator, run the body's residual calls concretely, then abort at the deep guard — an irreversible half-executed iteration that can neither be delivered (doubles a committed effect) nor cleanly dropped (loses the iteration). Withholding aborts at the `FOR_ITER` header *before* the consume, so the location interprets permanently — bit-exact with the pre-reload behaviour. Lifted once the deep-kept interior-guard snapshot lands.

## Results (true reference = `PYRE_NO_JIT=1`)

- `kept_stack_deep_var_condexpr` → `-266006670` — JIT-resident
- `kept_stack_deep_var_nested_call` → `818440000` — JIT-resident
- `kept_stack_deep_var_shortcircuit` → `840076000` — gated, interprets (its f-loop never JIT-compiled anyway)
- new `kept_stack_deep_var_shortcircuit_mutate.py` → `840076000 / 120000` — companion where `g`/`h` append to a global list, so a torn or doubled iteration is observable; proves no tear/double

## Verification

- `check.py` dynasm / cranelift / wasm — 184/184 each
- synth JIT-vs-NO_JIT sweep — 211/211 bit-exact
- `cargo test -p pyre-jit` 297/0, `-p pyre-jit-trace` 12/0
- `PYRE_PCDEP_VALIDATE=1` — 0 injection violations on the trio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop execution handling in the JIT to better preserve correct behavior when loops contain nested calls and branching.
  * Reduced the chance of incorrect iterator reuse in complex loop patterns.

* **Tests**
  * Added a new benchmark case that stresses this loop behavior under heavy iteration and mutation, helping validate the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->