### PR TITLE
interp: PickleBuffer/pickle/bytearray parity + frame underflow guard

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2349,39 +2349,59 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     if is_slice(index) {
         return setitem_bytearray_slice(obj, index, value);
     }
-    // `descr_setitem`: getindex_w(index) → _fixindex(idx) → coerce value.  The
-    // index gate and byte coercion are inlined (not routed through the shared
-    // `bytearray_index`/`byte_w`) and the coercion is kept inside the in-bounds
-    // block: a shared-function result fails to bind a concrete Int repr in the
-    // rtyper (concretetype None), which the codewriter then mis-colors Ref
-    // against its Int provenance.  `__index__` index support and coercing before
-    // the bounds check (so `ba[oob] = bad` reports the value error ahead of
-    // IndexError) are deferred on that same kind-provenance gap.
-    if !is_int(index) {
-        return Err(PyError::type_error("bytearray indices must be integers"));
+    // `descr_setitem`: getindex_w(index) → byte_w(value) → _fixindex(idx) store.
+    // Both coercions are inlined rather than routed through the shared
+    // `bytearray_index`/`byte_w`, whose `Result<int>` payload fails to bind a
+    // concrete Int repr in the rtyper (concretetype None) so the codewriter
+    // mis-colors it Ref against its Int provenance; the inline `space_index`
+    // pattern keeps the Int repr concrete.  The value is coerced before the
+    // bounds check so `ba[oob] = bad` reports the value error ahead of the
+    // IndexError, and `len` is read after value coercion.
+    let idx = if is_int(index) {
+        w_int_get_value(index)
+    } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
+        let indexed = space_index(index)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(i) => i,
+                // `getindex_w` overflow reports the source type, not the coerced int.
+                Err(_) => {
+                    return Err(PyError::new(
+                        PyErrorKind::IndexError,
+                        format!(
+                            "cannot fit '{}' into an index-sized integer",
+                            object_functionstr_type_name(index)
+                        ),
+                    ));
+                }
+            }
+        }
+    } else {
+        return Err(index_type_error("bytearray", index));
+    };
+    let v = if is_int(value) {
+        w_int_get_value(value)
+    } else {
+        let indexed = space_index(value)?;
+        if is_int(indexed) {
+            w_int_get_value(indexed)
+        } else {
+            match i64::try_from(w_long_get_value(indexed)) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(PyError::value_error("byte must be in range(0, 256)"));
+                }
+            }
+        }
+    };
+    if !(0..=255).contains(&v) {
+        return Err(PyError::value_error("byte must be in range(0, 256)"));
     }
-    let idx = w_int_get_value(index);
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let actual = if idx < 0 { len + idx } else { idx };
     if actual >= 0 && actual < len {
-        let v = if is_int(value) {
-            w_int_get_value(value)
-        } else {
-            let indexed = space_index(value)?;
-            if is_int(indexed) {
-                w_int_get_value(indexed)
-            } else {
-                match i64::try_from(w_long_get_value(indexed)) {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Err(PyError::value_error("byte must be in range(0, 256)"));
-                    }
-                }
-            }
-        };
-        if !(0..=255).contains(&v) {
-            return Err(PyError::value_error("byte must be in range(0, 256)"));
-        }
         pyre_object::bytearrayobject::w_bytearray_setitem(obj, actual as usize, v as u8);
         return Ok(w_none());
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -191,6 +191,9 @@ unsafe fn memoryview_buffer_params(obj: PyObjectRef) -> Option<(String, i64, boo
 /// reports the original exporter as `.obj`); a non-buffer raises TypeError.
 pub(crate) fn w_memoryview_new(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     use pyre_object::memoryview::*;
+    if let Some(target) = crate::module::__pypy__::interp_buffer::forwarded_exporter(w_obj) {
+        return w_memoryview_new(target?);
+    }
     unsafe {
         if is_w_memoryview(w_obj) {
             memoryview_check_released(w_obj)?;

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1378,19 +1378,22 @@ impl SharedOpcodeHandler for PyFrame {
     }
 
     fn pop_value(&mut self) -> Result<Self::Value, PyError> {
-        if self.valuestackdepth <= self.nlocals() {
+        if self.valuestackdepth <= self.stack_base() {
             return Err(stack_underflow_error("interpreter opcode"));
         }
         Ok(self.pop())
     }
 
     fn peek_at(&mut self, depth: usize) -> Result<Self::Value, PyError> {
+        // The operand stack starts at `stack_base()` (`co_nlocals` + cell +
+        // free slots), matching `_stack_start()`; guarding against `nlocals()`
+        // alone would let an underflow slip into the cell/free region.
         // `valuestackdepth` is a `usize` field (seeded unsigned) whereas
-        // `nlocals() + depth` seeds signed; cast both to `i64` (lowered as
+        // `stack_base() + depth` seeds signed; cast both to `i64` (lowered as
         // `intmask`, identity on non-negative counts) so the guard compares
         // within one signedness instead of tripping the rtyper's
         // signed-vs-unsigned refusal.
-        if (self.valuestackdepth as i64) <= (self.nlocals() + depth) as i64 {
+        if (self.valuestackdepth as i64) <= (self.stack_base() + depth) as i64 {
             return Err(stack_underflow_error("interpreter peek"));
         }
         Ok(PyFrame::peek_at(self, depth))

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -80,6 +80,22 @@ impl W_PickleBuffer {
     }
 }
 
+/// If `obj` is a `PickleBuffer`, the wrapped exporter its buffer protocol
+/// forwards to — `buffer_w` delegates to the underlying object, so `bytes(pb)`
+/// / `memoryview(pb)` operate on the wrapped `bytes`/`bytearray`/`array`/
+/// `memoryview`. `Some(Err(..))` once the buffer was released; `None` when
+/// `obj` is not a `PickleBuffer`.
+pub(crate) fn forwarded_exporter(obj: PyObjectRef) -> Option<Result<PyObjectRef, PyError>> {
+    W_PickleBuffer::from_obj(obj).map(|pb| {
+        let w = pb.wrapped();
+        if unsafe { pyre_object::is_none(w) } {
+            Err(released_error())
+        } else {
+            Ok(w)
+        }
+    })
+}
+
 fn released_error() -> PyError {
     PyError::value_error("operation forbidden on released PickleBuffer object")
 }

--- a/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
+++ b/pyre/pyre-interpreter/src/module/__pypy__/interp_buffer.rs
@@ -155,6 +155,18 @@ pub(crate) fn buffer_view(obj: PyObjectRef) -> Result<(Vec<u8>, bool), PyError> 
     )))
 }
 
+/// Whether the wrapped exporter's buffer is C-contiguous, matching the
+/// `_pickle` save path's `iscontiguous(buf)` guard. `bytes`/`bytearray`/`array`
+/// are one-dimensional and always contiguous; a `memoryview` reports through
+/// its `c_contiguous` flag.
+pub(crate) fn is_contiguous(obj: PyObjectRef) -> Result<bool, PyError> {
+    if is_memoryview(obj) {
+        let w = crate::baseobjspace::getattr_str(obj, "c_contiguous")?;
+        return crate::baseobjspace::is_true(w);
+    }
+    Ok(true)
+}
+
 /// The `memoryview` builtin type via the live execution context.
 fn memoryview_type() -> Option<PyObjectRef> {
     let frame = crate::eval::CURRENT_FRAME.with(|f| f.get());

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -1594,6 +1594,11 @@ fn save_picklebuffer(
             "PickleBuffer can not be pickled after release",
         ));
     }
+    if !crate::module::__pypy__::interp_buffer::is_contiguous(wrapped)? {
+        return Err(pickling_error(
+            "PickleBuffer can not be pickled when pointing to a non-contiguous buffer",
+        ));
+    }
     let (data, readonly) = crate::module::__pypy__::interp_buffer::buffer_view(wrapped)?;
     let mut in_band = true;
     if !unsafe { pyre_object::is_none(ctx.buffer_callback) } {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -10289,6 +10289,9 @@ fn bytes_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 pub(crate) fn buffer_as_bytes_like(
     obj: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, crate::PyError> {
+    if let Some(target) = crate::module::__pypy__::interp_buffer::forwarded_exporter(obj) {
+        return buffer_as_bytes_like(target?);
+    }
     if unsafe { pyre_object::interp_array::is_array(obj) } {
         return Ok(Some(pyre_object::bytesobject::w_bytes_from_bytes(unsafe {
             pyre_object::interp_array::w_array_bytes(obj)


### PR DESCRIPTION
Four self-contained interpreter parity fixes on top of `main`.

### `interp: pop/peek underflow guards use stack_base()`
The `SharedOpcodeHandler` `pop_value`/`peek_at` underflow guards compared `valuestackdepth` against `nlocals()` (co_nlocals only), but the operand stack starts at `stack_base()` = `nlocals() + ncells()` (matching `_stack_start()` = co_nlocals + cell + free slots). Guarding at `nlocals()` let an underflow into the cell/free region slip past the graceful error — `pop_value` would then reach `pop()`'s hard `assert!(valuestackdepth > stack_base())`, and `peek_at` would read a cell/free slot as a stack value.

### `interp: PickleBuffer forwards buffer protocol to wrapped exporter`
`W_PickleBuffer` now participates in the buffer protocol by delegating to its wrapped object (`buffer_w`). A new `forwarded_exporter(obj)` returns the wrapped `bytes`/`bytearray`/`array`/`memoryview` (or an error once released) and is consulted at the top of `buffer_as_bytes_like` and `w_memoryview_new`, so `bytes(pb)`, `bytearray(pb)`, and `memoryview(pb)` operate on the wrapped exporter instead of raising `TypeError`.

### `_pickle: reject non-contiguous PickleBuffer with PicklingError`
`save_picklebuffer` now checks `is_contiguous(wrapped)` unconditionally, before the `buffer_callback` branch, and raises `PicklingError` "PickleBuffer can not be pickled when pointing to a non-contiguous buffer" — matching `save_picklebuffer`'s `iscontiguous` guard. `is_contiguous` reports true for `bytes`/`bytearray`/`array` and reads `c_contiguous` for a `memoryview`.

### `interp: bytearray setitem __index__ index + value-before-bounds`
`setitem_bytearray` coerces the index through `__index__` and coerces the value before the bounds check, matching `descr_setitem` order (`getindex_w` → `byte_w` → `_fixindex`): `ba[obj_with__index__] = v` works, and `ba[oob] = bad` reports the value error ahead of `IndexError`; `len` is read after value coercion. Both coercions are inlined via `space_index` rather than the shared `bytearray_index`/`byte_w` helpers, whose `Result<int>` payload takes `concretetype` None in the rtyper so the codewriter mis-colors it `Ref` against its `Int` provenance; the inline form keeps the `Int` repr concrete.

### Verification
- `pyre/check.py --backend dynasm,cranelift` → dynasm 183/183 + cranelift 183/183.
- `pyre-jit-trace` codewriter prepass build succeeds with no `Register kind Int does not match` miscolor (the decisive check for the bytearray change; `check.py` does not build `pyre-jit-trace`).
- Behavioural repros for PickleBuffer export, non-contiguous pickle rejection, and bytearray setitem match CPython on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
