### PR TITLE
rtyper: is_null on List/Dict + fail-closed on lift-errored registry entry

### DIFF
--- a/majit/majit-translate/src/annotator/unaryop.rs
+++ b/majit/majit-translate/src/annotator/unaryop.rs
@@ -2659,6 +2659,11 @@ pub(crate) fn find_method(s_self: &SomeValue, name: &str) -> Option<SomeBuiltinM
             "remove" => "list_method_remove",
             "pop" => "list_method_pop",
             "index" => "list_method_index",
+            // Raw-pointer `p.is_null()` on a `SomeList` receiver (the list
+            // backing carries a `Ptr` concretetype); the getattr annotator
+            // answers the same probe with `ptr_method_is_null`, so mirror it
+            // here for the rtyper's method-existence check.
+            "is_null" => "ptr_method_is_null",
             _ => return None,
         },
         SomeValue::Dict(_) => match name {
@@ -2683,6 +2688,13 @@ pub(crate) fn find_method(s_self: &SomeValue, name: &str) -> Option<SomeBuiltinM
             "delitem_with_hash" => "dict_method_delitem_with_hash",
             "delitem_if_value_is" => "dict_method_delitem_if_value_is",
             "move_to_end" => "dict_method_move_to_end",
+            // A raw-pointer `p.is_null()` whose receiver Charon erases to
+            // a `SomeDict` (the dict-typed field carries a `Ptr(dicttable)`
+            // concretetype).  The getattr annotator answers the same probe
+            // with `ptr_method_is_null`; mirror it here so the rtyper's
+            // `rtype_getattr` method-existence check finds it and forwards
+            // the receiver to `OrderedDictRepr::rtype_method("is_null")`.
+            "is_null" => "ptr_method_is_null",
             _ => return None,
         },
         SomeValue::String(_) => match name {

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1809,6 +1809,29 @@ pub fn translate_op(
                     // 3c. Unknown prefix — `TyperError` (caller must
                     //     register the path or import the prefix).
                     let callable_host = if let Some(entry) = call_registry.lookup(&key) {
+                        // Fail-closed: an entry whose pyre-side body failed to
+                        // lift (recorded by
+                        // `populate_call_registry_from_call_graphs` Pass 2 via
+                        // `record_lift_error`) is NOT a resolved callable.
+                        // Binding its `host_object` would let a graph
+                        // referencing an unbuildable foreign callee false-Match
+                        // through the dual gate and partial-codewrite with the
+                        // callee's pre-real residual kind. Treat it as
+                        // unresolved so the referencing graph deterministically
+                        // Skips to the legacy walker (unbuildable callee →
+                        // caller Skips).
+                        if let Some(lift_err) = entry.pyre_lift_error() {
+                            return Err(TyperError::message(format!(
+                                "translate_op: OpKind::Call::FunctionPath \
+                                 {{ segments: {:?} }} resolves to a \
+                                 PyreCallRegistry entry whose pyre-side lift \
+                                 failed ({lift_err}); the referencing graph \
+                                 falls back to the legacy walker. \
+                                 Result slot = {}",
+                                segments,
+                                fmt_op_result(op),
+                            )));
+                        }
                         entry.host_object.clone()
                     } else if segments.len() == 1
                         && let Some(builtin) = HOST_ENV.lookup_builtin(&segments[0])
@@ -1875,6 +1898,22 @@ pub fn translate_op(
                         // same-leaf matches converge on a single `host_object`
                         // identity, otherwise `None` falls through to the hard
                         // error below.
+                        //
+                        // Same fail-closed rule as the exact-lookup branch: a
+                        // lift-errored entry is unresolved, so the referencing
+                        // graph Skips to the legacy walker.
+                        if let Some(lift_err) = entry.pyre_lift_error() {
+                            return Err(TyperError::message(format!(
+                                "translate_op: OpKind::Call::FunctionPath \
+                                 {{ segments: {:?} }} leaf-matches a \
+                                 PyreCallRegistry entry whose pyre-side lift \
+                                 failed ({lift_err}); the referencing graph \
+                                 falls back to the legacy walker. \
+                                 Result slot = {}",
+                                segments,
+                                fmt_op_result(op),
+                            )));
+                        }
                         entry.host_object.clone()
                     } else {
                         return Err(TyperError::message(format!(

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rordereddict.rs
@@ -1229,6 +1229,15 @@ impl Repr for OrderedDictRepr {
     /// (`rordereddict.py:285-301`).
     fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
         match method_name {
+            // `is_null` is the lltype `_ptr` nullity probe on the dict
+            // pointer — lower it as `ptr_iszero` (opimpl.py:134-136
+            // `op_ptr_iszero`), the same lowering `InstanceRepr` uses for
+            // the `ptr_method_is_null` bound method the annotator seats on
+            // pointer-carrying receivers.
+            "is_null" => {
+                let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+                Ok(hop.genop("ptr_iszero", vlist, GenopResult::LLType(LowLevelType::Bool)))
+            }
             "get" => {
                 let args = if hop.nb_args() == 3 {
                     hop.inputargs(vec![

--- a/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
+++ b/majit/majit-translate/src/translator/rtyper/pyre_call_registry.rs
@@ -147,6 +147,16 @@ impl PyreFunctionEntry {
     pub fn record_lift_error(&self, message: String) {
         self.function_desc.borrow().record_pyre_lift_error(message);
     }
+
+    /// Read-side twin of [`record_lift_error`]: the recorded pyre-side
+    /// lift failure message, or `None` when the entry's body lifted
+    /// cleanly.  `translate_op` consults this to fail-closed on a callee
+    /// whose graph could not be built (unbuildable callee → caller Skips
+    /// to the legacy walker), instead of binding a `host_object` that
+    /// would partial-codewrite with a pre-real residual kind.
+    pub fn pyre_lift_error(&self) -> Option<String> {
+        self.function_desc.borrow().pyre_lift_error_message()
+    }
 }
 
 /// Per-subject result of the two-phase rtyper drive (`PYRE_TWO_PHASE_RTYPE`).

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -30,8 +30,8 @@ use crate::translator::rtyper::lltypesystem::lltype::{
 use crate::translator::rtyper::lltypesystem::rstr::sub_helper_funcptr_constant;
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
-    ConvertedTo, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype, exception_args,
-    helper_pygraph_from_graph, variable_with_lltype, void_field_const,
+    ConvertedTo, GenopResult, HighLevelOp, LowLevelFunction, RPythonTyper, constant_with_lltype,
+    exception_args, helper_pygraph_from_graph, variable_with_lltype, void_field_const,
 };
 
 /// RPython `class FixedSizeListRepr(AbstractFixedSizeListRepr,
@@ -272,6 +272,14 @@ impl Repr for FixedSizeListRepr {
     /// [`build_ll_reverse_helper_graph`]. `reverse` returns `None` (void).
     fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
         match method_name {
+            // `is_null` is the lltype `_ptr` nullity probe on the list
+            // backing pointer — lower it as `ptr_iszero` (opimpl.py:134-136
+            // `op_ptr_iszero`), matching the `ptr_method_is_null` bound
+            // method the annotator seats on pointer-carrying receivers.
+            "is_null" => {
+                let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+                Ok(hop.genop("ptr_iszero", vlist, GenopResult::LLType(LowLevelType::Bool)))
+            }
             "reverse" => {
                 let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
                 hop.exception_cannot_occur()?;
@@ -860,6 +868,14 @@ impl Repr for ListRepr {
     /// / bare `getarrayitem` on a `Ptr(GcArray)`.
     fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
         match method_name {
+            // `is_null` is the lltype `_ptr` nullity probe on the list
+            // header pointer — lower it as `ptr_iszero` (opimpl.py:134-136
+            // `op_ptr_iszero`), matching the `ptr_method_is_null` bound
+            // method the annotator seats on pointer-carrying receivers.
+            "is_null" => {
+                let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+                Ok(hop.genop("ptr_iszero", vlist, GenopResult::LLType(LowLevelType::Bool)))
+            }
             "reverse" => {
                 let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
                 hop.exception_cannot_occur()?;

--- a/majit/majit-translate/src/translator/rtyper/rmodel.rs
+++ b/majit/majit-translate/src/translator/rtyper/rmodel.rs
@@ -1985,8 +1985,20 @@ impl Repr for PtrRepr {
     fn rtype_getattr(&self, hop: &HighLevelOp) -> RTypeResult {
         let attr = hop_arg_const_string(hop, 1)?;
         let r_result = hop_r_result(hop)?;
+        // rptr.py:44-46: `if isinstance(hop.s_result, SomeLLADTMeth):
+        // return hop.inputarg(hop.r_result, arg=0)`.
         if matches!(&*hop.s_result.borrow(), Some(SomeValue::LLADTMeth(_))) {
             return hop.inputarg(&r_result, 0).map(Some);
+        }
+        // `is_null` on a bare pointer reaches here as a `SomeBuiltinMethod`
+        // (`unaryop.rs ptr_method_is_null`) rather than a `SomeLLADTMeth`.
+        // The bound method is represented as its receiver
+        // (`BuiltinMethodRepr.lowleveltype == self_repr.lowleveltype`), so
+        // forward the pointer value in self's repr and let
+        // `BuiltinMethodRepr.rtype_simple_call` dispatch back through
+        // `rtype_method`.
+        if matches!(&*hop.s_result.borrow(), Some(SomeValue::BuiltinMethod(_))) {
+            return hop.inputarg(self, 0).map(Some);
         }
         if self.ptrtype()._example()._lookup_adtmeth(&attr).is_ok() {
             let value = hop
@@ -2029,6 +2041,20 @@ impl Repr for PtrRepr {
             vlist,
             GenopResult::LLType(r_result.lowleveltype().clone()),
         ))
+    }
+
+    /// `BuiltinMethodRepr.rtype_simple_call` dispatch target for the ptr
+    /// bound method seated by the `SomeBuiltinMethod` pass-through in
+    /// `rtype_getattr`. `is_null` is the lltype `_ptr` nullity probe —
+    /// lower it as `ptr_iszero` (opimpl.py:134-136 `op_ptr_iszero`).
+    fn rtype_method(&self, method_name: &str, hop: &HighLevelOp) -> RTypeResult {
+        if method_name == "is_null" {
+            let vlist = hop.inputargs(vec![ConvertedTo::Repr(self)])?;
+            return Ok(hop.genop("ptr_iszero", vlist, GenopResult::LLType(LowLevelType::Bool)));
+        }
+        Err(TyperError::message(format!(
+            "missing PtrRepr.rtype_method_{method_name}"
+        )))
     }
 
     fn rtype_setattr(&self, hop: &HighLevelOp) -> RTypeResult {


### PR DESCRIPTION
Three rtyper census-driven slices on top of `origin/main`.

## 1. Lower `is_null` on List/Dict reprs via `ptr_iszero`
Five prepass graphs Skipped with "no method `is_null` on List/Dict"
(`w_module_dict_is_object_strategy`, `w_module_dict_object_storage{,_mut}`,
`baseobjspace::isinstance_w`, `call::issubtype_ptr`). The getattr annotator
already answered `p.is_null()` with `ptr_method_is_null`, but
`unaryop::find_method` (the table consulted by `rtype_getattr`'s
`find_method().is_none()` gate) had no `is_null` arm for List/Dict.

- Add `is_null` arms to `find_method` (List + Dict).
- Lower `is_null` → `ptr_iszero` in `FixedSizeListRepr`, `ListRepr`,
  `OrderedDictRepr`, mirroring `InstanceRepr::rtype_method`.

## 2. Fail-closed on a lift-errored `PyreCallRegistry` entry
`translate_op`'s FunctionPath resolution bound `entry.host_object` from a
registry entry even when `populate_call_registry_from_call_graphs` had
recorded a pyre-side lift failure for that callee, letting a graph referencing
an unbuildable foreign callee false-Match through the dual gate and
partial-codewrite with the callee's pre-real (Int) residual kind — tripping the
`encode_regorconst_source` Int≠Ref assert (an order-dependent codewriter panic
during the trace prepass).

- Add `PyreFunctionEntry::pyre_lift_error()` (read-side twin of
  `record_lift_error`).
- Consult it in both the exact-lookup and leaf-match resolution branches: a
  lift-errored entry is treated as unresolved and returns a `TyperError`, so
  the referencing graph deterministically Skips to the legacy walker. Lift
  errors now propagate transitively up the call tree.

`w_module_dict_setitem_str_internal` now deterministically phaseA-Skips,
eliminating the order-dependence by construction.

## 3. Lower `is_null` on bare `Ptr TO Opaque(GCREF)` reprs
`PtrRepr::rtype_getattr` fell through to a field lookup for `is_null` on a bare
GCREF pointer receiver (the annotator seats it as a `SomeBuiltinMethod`
`ptr_method_is_null`, not a `SomeLLADTMeth`), tripping the `_nofield` error and
Skipping `w_int_new` / `w_float_new` to the legacy walker.

- Pass a `SomeBuiltinMethod` result through `rtype_getattr` the same way as
  `SomeLLADTMeth`, forwarding the pointer value in self's repr (the bound
  method shares the receiver's lowleveltype).
- Add `PtrRepr::rtype_method` lowering `is_null` → `ptr_iszero`, mirroring
  `InstanceRepr`.

## Verification
- `cargo check` green; 2971 majit-translate unit tests pass.
- Census: `is_null` gaps closed; `w_module_dict_setitem_str_internal`
  deterministically Skips; prepass phaseB frontier reduced (the residual is a
  separate PyType `issubtype`/`isinstance` → `object_vtable` cluster).
- `pyre/check.py`: **dynasm 183/183 + cranelift 183/183 green**. wasm 4-fail is
  the pre-existing baseline (3 `decode_ref` TAGINT-in-REF resume panics +
  1 `sre_pattern_methods`), unchanged by this PR.