### PR TITLE
majit: single-pass whole-circuit close as the sole trace-close path (#344 Phase B)

### DIFF
--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1936,41 +1936,14 @@ fn rewrite_body(
                     // add a second merge-point dispatch — `driver.merge_point` guards
                     // again internally, but the closure runs only once.
                     let new_tokens: TokenStream = if let Some(state) = &args.state {
-                        // Single-pass opt-in: after the walk, if the CloseLoop
+                        // Single-pass close: after the walk, if the CloseLoop
                         // populated a walk-final (pc, reds) snapshot, transfer
                         // it into native state and resume the native loop at the
                         // close pc, skipping the body re-run. `#merge_fn` returns
-                        // `None` (so this is inert) whenever `PYRE_SINGLE_PASS` is
-                        // off or the walk did not populate reds.
+                        // `None` whenever the walk did not populate reds.
                         quote! {
                             if #driver.is_tracing() {
                                 let __mp_out = #merge_fn(&mut #driver, #env, #pc);
-                                // D2 per-opcode single-executor
-                                // (PYRE_AUTHORITATIVE): the authoritative walker
-                                // executed exactly one opcode and returned its
-                                // boundary pc. Re-derive the native scalar caches
-                                // (stacksize / selected ref) from the
-                                // walk-advanced shared storage, jump the native
-                                // loop to the boundary pc, and skip native's own
-                                // dispatch of the walked opcode. Inert (the
-                                // channel stays `None`) unless authoritative.
-                                if let Some(__next_pc) =
-                                    #driver.take_authoritative_next_pc()
-                                {
-                                    // Propagate the walk's scalar state fields
-                                    // (e.g. SEL's new `selected`) from the live
-                                    // sym into native state BEFORE recover, so
-                                    // recover re-derives the storage-backed
-                                    // caches from the current scalars.
-                                    #driver.writeback_authoritative_state_fields(
-                                        &mut #state,
-                                    );
-                                    majit_metainterp::JitState::recover_after_compiled_run(
-                                        &mut #state,
-                                    );
-                                    #pc = __next_pc;
-                                    continue;
-                                }
                                 if let Some((__sp_pc, __sp_reds)) = __mp_out
                                 {
                                     // Push the walk-mutated scalar state fields
@@ -1987,8 +1960,7 @@ fn rewrite_body(
                                     // caches from the current scalars) and
                                     // `try_resume_into_compiled_loop` (which reads
                                     // the native scalars to seed the compiled
-                                    // loop). Mirrors the authoritative branch's
-                                    // ordering. No-op with no scalar state fields
+                                    // loop). No-op with no scalar state fields
                                     // or no live sym.
                                     #driver.writeback_authoritative_state_fields(
                                         &mut #state,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1962,7 +1962,7 @@ fn rewrite_body(
                                     // the native scalars to seed the compiled
                                     // loop). No-op with no scalar state fields
                                     // or no live sym.
-                                    #driver.writeback_authoritative_state_fields(
+                                    #driver.writeback_scalar_state_fields(
                                         &mut #state,
                                     );
                                     // Transfer any loop-carried reds the walk

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -361,16 +361,14 @@ pub trait JitState: Sized {
 
     fn recover_after_compiled_run(&mut self) {}
 
-    /// D2 per-opcode single-executor (`authoritative_executor_enabled()`):
-    /// write the walk's scalar state-field concrete values from the persistent
-    /// sym back into native state. Under per-opcode drive the native dispatch
-    /// arm is skipped, so a scalar the walk mutates but `recover` cannot
-    /// re-derive from shared storage (e.g. aheui's `selected` storage index,
-    /// set by SEL from a program operand) would otherwise stay frozen at its
-    /// trace-start value. Called before `recover_after_compiled_run` so recover
-    /// then refines the storage-derived caches (stacksize / list refs) from the
-    /// now-current scalars. Default no-op; the `#[jit_interp]` macro overrides
-    /// it for state-field consumers. Inert unless authoritative.
+    /// Whole-circuit single-pass: write the walk's scalar state-field concrete
+    /// values from the persistent sym back into native state. A scalar the walk
+    /// mutates but `recover` cannot re-derive from shared storage (e.g. aheui's
+    /// `selected` storage index, set by SEL from a program operand) would
+    /// otherwise stay frozen at its trace-start value. Called before
+    /// `recover_after_compiled_run` so recover then refines the storage-derived
+    /// caches (stacksize / list refs) from the now-current scalars. Default
+    /// no-op; the `#[jit_interp]` macro overrides it for state-field consumers.
     fn writeback_scalar_state_fields_from_sym(&mut self, _sym: &Self::Sym) {}
 
     /// blackhole.py:1679 `_exit_frame_with_exception` → warmspot.py:998-1005.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1391,7 +1391,7 @@ impl<S: JitState> JitDriver<S> {
     /// caches (e.g. stacksize from the now-current selected) from the
     /// written-back scalars.
     #[inline]
-    pub fn writeback_authoritative_state_fields(&self, state: &mut S) {
+    pub fn writeback_scalar_state_fields(&self, state: &mut S) {
         if let Some(sym) = self.sym.as_ref() {
             state.writeback_scalar_state_fields_from_sym(sym);
         }
@@ -1802,7 +1802,7 @@ impl<S: JitState> JitDriver<S> {
                 // reds vector published here is INTENTIONALLY empty. The
                 // merge-point hook transfers walk-final loop state without it:
                 // scalar state fields (e.g. selected) are written back from
-                // the live sym by `writeback_authoritative_state_fields`, then
+                // the live sym by `writeback_scalar_state_fields`, then
                 // `recover` re-derives the storage-backed cache fields
                 // (stacksize, storage refs) from the walk-advanced shared
                 // storage. `dispatch` does populate `ctx.walk_final_reds` from

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1382,23 +1382,14 @@ impl<S: JitState> JitDriver<S> {
         self.meta.single_pass_outcome.take()
     }
 
-    /// D2 per-opcode single-executor: take the boundary pc stashed by the
-    /// `OpcodeComplete` arm of `merge_point`. `Some(next_pc)` means the
-    /// authoritative walker executed one opcode; the native loop assigns it to
-    /// `pc` and skips its own dispatch of that opcode. `None` otherwise.
-    #[inline]
-    pub fn take_authoritative_next_pc(&mut self) -> Option<usize> {
-        self.meta.authoritative_next_pc.take()
-    }
-
     /// Push the walk's scalar state fields from the still-live persistent sym
     /// back into native `state`. The walk advances a scalar (notably a SEL's
     /// new `selected`) on the sym only; native `state` stays at its trace-start
-    /// value until this write-back. No-op when no sym is live. Called from both
-    /// single-executor `jit_merge_point!` branches (per-opcode authoritative and
-    /// whole-circuit single-pass), before `recover_after_compiled_run` so
-    /// recover refines the storage-derived caches (e.g. stacksize from the
-    /// now-current selected) from the written-back scalars.
+    /// value until this write-back. No-op when no sym is live. Called from the
+    /// whole-circuit single-pass `jit_merge_point!` branch, before
+    /// `recover_after_compiled_run` so recover refines the storage-derived
+    /// caches (e.g. stacksize from the now-current selected) from the
+    /// written-back scalars.
     #[inline]
     pub fn writeback_authoritative_state_fields(&self, state: &mut S) {
         if let Some(sym) = self.sym.as_ref() {
@@ -1507,13 +1498,11 @@ impl<S: JitState> JitDriver<S> {
                 if let Some(hp) = loop_header_pc {
                     self.meta.record_loop_header_pc(k, hp);
                 }
-                // Single-pass: stash the just-compiled loop's key so the
-                // merge-point hook can directly enter it with the walk-final
-                // state instead of re-interpreting the walked body
-                // (cross-loop-cut: this is cut_inner_green_key).
-                if crate::single_pass_enabled() {
-                    self.meta.single_pass_compiled_key = Some(k);
-                }
+                // Stash the just-compiled loop's key so the merge-point hook
+                // can directly enter it with the walk-final state instead of
+                // re-interpreting the walked body (cross-loop-cut: this is
+                // cut_inner_green_key).
+                self.meta.single_pass_compiled_key = Some(k);
             }
         }
         outcome
@@ -1802,33 +1791,32 @@ impl<S: JitState> JitDriver<S> {
                 return;
             }
             TraceAction::CloseLoop => {
-                // Single-pass tracing: snapshot the walk-final (pc, reds) off
-                // the active TraceCtx BEFORE `compile_loop` (below) drains it,
-                // stashing onto the MetaInterp so the `__merge` wrapper can
-                // read it after the trace closes. `None` outside single-pass
-                // and whenever the walk did not populate the reds.
-                if crate::single_pass_enabled() {
-                    // Resume pc is the walk-final green pc the dispatch stashed
-                    // (an interpreter program pc, NOT the JitCode op cursor). The
-                    // reds vector published here is INTENTIONALLY empty. The
-                    // merge-point hook transfers walk-final loop state without it:
-                    // scalar state fields (e.g. selected) are written back from
-                    // the live sym by `writeback_authoritative_state_fields`, then
-                    // `recover` re-derives the storage-backed cache fields
-                    // (stacksize, storage refs) from the walk-advanced shared
-                    // storage. `dispatch` does populate `ctx.walk_final_reds` from
-                    // the merge point's red-operand slots, but that register-bank
-                    // snapshot is NOT a valid `restore_values` source for the
-                    // state-field model — those slots are type-grouped operand
-                    // order, not `collect_jump_args` order, and include reds (e.g.
-                    // floats) with no state-field target, so restoring them would
-                    // write the wrong values. A JIT whose merge point carries real
-                    // red operands would instead source reds here, but none that
-                    // close exist today.
-                    let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
-                    if let Some(p) = pc {
-                        self.meta.single_pass_outcome = Some((p, Vec::new()));
-                    }
+                // Snapshot the walk-final (pc, reds) off the active TraceCtx
+                // BEFORE `compile_loop` (below) drains it, stashing onto the
+                // MetaInterp so the `__merge` wrapper can read it after the
+                // trace closes. `None` whenever the walk did not populate the
+                // reds.
+                //
+                // Resume pc is the walk-final green pc the dispatch stashed
+                // (an interpreter program pc, NOT the JitCode op cursor). The
+                // reds vector published here is INTENTIONALLY empty. The
+                // merge-point hook transfers walk-final loop state without it:
+                // scalar state fields (e.g. selected) are written back from
+                // the live sym by `writeback_authoritative_state_fields`, then
+                // `recover` re-derives the storage-backed cache fields
+                // (stacksize, storage refs) from the walk-advanced shared
+                // storage. `dispatch` does populate `ctx.walk_final_reds` from
+                // the merge point's red-operand slots, but that register-bank
+                // snapshot is NOT a valid `restore_values` source for the
+                // state-field model — those slots are type-grouped operand
+                // order, not `collect_jump_args` order, and include reds (e.g.
+                // floats) with no state-field target, so restoring them would
+                // write the wrong values. A JIT whose merge point carries real
+                // red operands would instead source reds here, but none that
+                // close exist today.
+                let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
+                if let Some(p) = pc {
+                    self.meta.single_pass_outcome = Some((p, Vec::new()));
                 }
                 // pyjitpl.py:2979-3036 reached_loop_header parity.
                 // Path 1: bridge — only if has_compiled_targets (line 2982).
@@ -2304,15 +2292,6 @@ impl<S: JitState> JitDriver<S> {
                 self.meta.abort_trace(true);
                 self.sym = None;
                 self.meta.clear_trace_session();
-            }
-            TraceAction::OpcodeComplete { next_pc } => {
-                // D2 per-opcode single-executor: the walker executed one opcode
-                // and returned its boundary pc. The trace session stays alive
-                // (NOT drained/compiled) — accumulation continues on the next
-                // merge_point call. Stash the boundary pc so the
-                // `jit_merge_point!` macro expansion advances the native loop
-                // there and skips its own dispatch of the walked opcode.
-                self.meta.authoritative_next_pc = Some(next_pc);
             }
         }
     }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -122,9 +122,9 @@ pub use pyjitpl::{
     CompileOutcome, CompiledExitLayout, CompiledTerminalExitLayout, CompiledTraceLayout,
     DeadFrameArtifacts, DetailedDriverRunOutcome, InlineDecision, JitCodeMachine, JitCodeRuntime,
     JitCodeSym, JitHooks, JitStats, MIFrame, MIFrameStack, MetaInterp, MetaInterpGlobalData,
-    MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, authoritative_executor_enabled,
-    build_state_field_snapshot, call_int_function, call_ref_function, call_void_function, counters,
-    single_pass_enabled, struct_field_write_effect_info, trace_jitcode, trace_jitcode_with_args,
+    MetaInterpStaticData, RawCompileResult, StandaloneFrameStack, build_state_field_snapshot,
+    call_int_function, call_ref_function, call_void_function, counters,
+    struct_field_write_effect_info, trace_jitcode, trace_jitcode_with_args,
     trace_jitcode_with_args_and_runtime,
 };
 pub use quasiimmut::QuasiImmut;
@@ -223,15 +223,6 @@ pub enum TraceAction {
     /// (do_recursive_call assembler_call=True), then continue tracing
     /// the parent (ChangeFrame).
     RecursiveCallAssembler { green_key: u64, target_pc: usize },
-    /// Per-opcode single-executor (D2 / `PYRE_AUTHORITATIVE`): the
-    /// authoritative walker executed exactly ONE interpreter opcode and
-    /// reached the next merge-point boundary. `next_pc` is the concrete
-    /// interpreter pc of that boundary merge point (the promoted-green slot-0
-    /// pc). The native loop assigns it to its program counter and skips its own
-    /// dispatch of the walked opcode. Unlike `CloseLoop`, the trace is NEITHER
-    /// drained NOR compiled — accumulation continues on the next merge_point
-    /// call. Produced only under `authoritative_executor_enabled()`.
-    OpcodeComplete { next_pc: usize },
 }
 
 /// Marker macro for the tracing merge point.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4,8 +4,7 @@ mod frame;
 pub use dispatch::build_state_field_snapshot;
 pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
-    StandaloneFrameStack, struct_field_write_effect_info, trace_jitcode,
-    trace_jitcode_with_args,
+    StandaloneFrameStack, struct_field_write_effect_info, trace_jitcode, trace_jitcode_with_args,
     trace_jitcode_with_args_and_runtime,
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4,8 +4,8 @@ mod frame;
 pub use dispatch::build_state_field_snapshot;
 pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
-    StandaloneFrameStack, authoritative_executor_enabled, single_pass_enabled,
-    struct_field_write_effect_info, trace_jitcode, trace_jitcode_with_args,
+    StandaloneFrameStack, struct_field_write_effect_info, trace_jitcode,
+    trace_jitcode_with_args,
     trace_jitcode_with_args_and_runtime,
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};
@@ -1061,11 +1061,11 @@ pub struct MetaInterp<M: Clone> {
     /// a loop compiles; queried at `start_bridge_tracing`.
     pub(crate) loop_header_pcs: indexmap::IndexMap<u64, usize>,
     pub(crate) tracing: Option<TraceCtx>,
-    /// Single-pass tracing (`PYRE_SINGLE_PASS`): the `(walk_final_pc,
-    /// walk_final_reds)` snapshot copied off the active `TraceCtx` at the
-    /// CloseLoop point BEFORE `compile_loop` drains the ctx, so the
-    /// merge-point hook can read it after the trace closes. `take`n by the
-    /// `__merge` wrapper. `None` outside single-pass.
+    /// Single-pass tracing: the `(walk_final_pc, walk_final_reds)` snapshot
+    /// copied off the active `TraceCtx` at the CloseLoop point BEFORE
+    /// `compile_loop` drains the ctx, so the merge-point hook can read it
+    /// after the trace closes. `take`n by the `__merge` wrapper. `None` when
+    /// the walk did not populate the reds.
     pub(crate) single_pass_outcome: Option<(usize, Vec<Value>)>,
     /// Single-pass tracing: the green key the CloseLoop arm compiled the
     /// (cross-loop-cut) inner loop under, captured after a `Compiled`
@@ -1075,14 +1075,6 @@ pub struct MetaInterp<M: Clone> {
     /// iteration N+1 onward (the walk's draw was the peeled preamble).
     /// `None` outside single-pass or when compilation did not succeed.
     pub(crate) single_pass_compiled_key: Option<u64>,
-    /// D2 per-opcode single-executor (`PYRE_AUTHORITATIVE`): the boundary pc
-    /// carried by a `TraceAction::OpcodeComplete` — the interpreter pc the
-    /// authoritative walker advanced to after executing exactly one opcode.
-    /// Set by `jitdriver::merge_point`'s OpcodeComplete arm, `take`n by the
-    /// `__merge` wrapper's caller so the native loop assigns it to `pc` and
-    /// skips its own dispatch of the walked opcode. `None` outside
-    /// authoritative mode.
-    pub(crate) authoritative_next_pc: Option<usize>,
     pub(crate) next_trace_id: u64,
     /// JIT hooks for profiling and debugging.
     pub(crate) hooks: JitHooks,
@@ -2270,7 +2262,6 @@ impl<M: Clone> MetaInterp<M> {
             tracing: None,
             single_pass_outcome: None,
             single_pass_compiled_key: None,
-            authoritative_next_pc: None,
             next_trace_id: 1,
             hooks: JitHooks::default(),
             pending_token: None,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -15,41 +15,6 @@ use crate::jitcode::insns::MAX_HOST_CALL_ARITY;
 use crate::jitcode::{self, JitArgKind, JitCallArg, JitCallTarget, JitCode, JitCodeRuntimeExt};
 use crate::{TraceAction, TraceCtx};
 
-/// Single-pass tracing: when set, on CloseLoop the walk's final state is
-/// transferred into native state at the merge-point hook and the native loop
-/// resumes into the compiled loop, skipping the walked span's re-run.
-/// Default-off: the native body re-runs the walked span after the walk closes.
-/// Read once.
-pub fn single_pass_enabled() -> bool {
-    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_SINGLE_PASS").is_some())
-}
-
-/// pyjitpl.py:3018-3060 reached_loop_header parity for a NESTED inner loop:
-/// when the JitCode dispatch walk re-reaches a non-header merge point whose
-/// green key it already visited, close the loop there (cross-loop cut) instead
-/// of spinning to the trace limit. Gated for incremental bring-up; single-pass
-/// (`single_pass_enabled`) implies it so the close + reds transfer move
-/// together.
-pub fn inner_close_enabled() -> bool {
-    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| single_pass_enabled() || std::env::var_os("PYRE_INNER_CLOSE").is_some())
-}
-
-/// Walker-as-tracer (`PYRE_AUTHORITATIVE`): when set, the `run_to_end` walk is
-/// the SOLE authoritative executor for a trace — residual calls execute exactly
-/// once during the walk and the outer mainloop must neither replay them nor
-/// re-run the walked span. Parity target: `pyre-jit-trace`
-/// `WalkContext::is_authoritative_executor` + `production_walker_handles`
-/// (the eval loop skips `execute_opcode_step` for walker-handled opcodes).
-/// Default-off. This is the incremental bring-up gate for the per-opcode seam
-/// rewrite; on its own the native-side walked-span skip must land before it is
-/// correct end-to-end.
-pub fn authoritative_executor_enabled() -> bool {
-    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FLAG.get_or_init(|| std::env::var_os("PYRE_AUTHORITATIVE").is_some())
-}
-
 /// Decode a virtualizable shadow Value (RPython Box concrete) back into the
 /// raw int/ref/float bit pattern that pyre stores in register shadows
 /// (`frame.int_values`, `frame.ref_values`, `frame.float_values`).
@@ -812,15 +777,6 @@ pub struct JitCodeMachine<'mi, S, R> {
     /// because the previous arm's `BC_LOOP_HEADER` handler stamped it.
     /// Pyre's typed `i32` mirrors RPython's `int` (sentinel `-1`).
     seen_loop_header_for_jdindex: i32,
-    /// D2 per-opcode single-executor: within one `run_to_end` call under
-    /// `authoritative_executor_enabled()`, the machine enters at the current
-    /// opcode's merge point (the ENTRY MP) and must stop at the NEXT
-    /// non-closing merge point (the BOUNDARY MP) after executing exactly one
-    /// opcode. This flag distinguishes them: `false` until the entry MP is
-    /// passed, then `true`; the boundary MP returns
-    /// `TraceAction::OpcodeComplete`. Reset at the top of every `run_to_end`.
-    /// Inert unless authoritative.
-    authoritative_seen_entry_mp: bool,
     marker: PhantomData<(S, R)>,
 }
 
@@ -1403,7 +1359,6 @@ where
             outer_program_pc: None,
             // pyjitpl.py:2882 / :2916 — sentinel "no loop_header seen yet".
             seen_loop_header_for_jdindex: -1,
-            authoritative_seen_entry_mp: false,
             marker: PhantomData,
         }
     }
@@ -1809,10 +1764,6 @@ where
             .outer_program_pc
             .unwrap_or_else(|| self.frames.current_mut().pc);
         sym.begin_portal_op(portal_pc);
-        // D2 per-opcode single-executor: each `run_to_end` call walks exactly
-        // one opcode under authoritative mode, so the entry-vs-boundary
-        // merge-point flag starts fresh every call.
-        self.authoritative_seen_entry_mp = false;
         // Safety backstop against a runaway trace-recording loop.  A
         // jitcode-level cycle that re-steps without growing the recorded op
         // list never trips `is_too_long` (which counts ops), so the
@@ -1893,11 +1844,7 @@ where
                     );
                 }
                 match action {
-                    // OpcodeComplete = a successful one-opcode boundary (D2), not
-                    // an abort: commit the portal op like a normal close.
-                    TraceAction::CloseLoop | TraceAction::OpcodeComplete { .. } => {
-                        sym.commit_portal_op()
-                    }
+                    TraceAction::CloseLoop => sym.commit_portal_op(),
                     _ => sym.abort_portal_op(),
                 }
                 return action;
@@ -3670,11 +3617,11 @@ where
                 let mut mp_green_refs: Vec<i64> = Vec::new();
                 let mut mp_green_floats: Vec<i64> = Vec::new();
                 // Single-pass tracing: the walk closes back to an interpreter
-                // program pc; capture it (below, gated) so the merge-point hook
-                // can resume the native loop there. Gated so the
-                // observer/replay path pays nothing.
-                let capture_walk_reds = single_pass_enabled();
-                let inner_close = inner_close_enabled();
+                // program pc; capture it (below) so the merge-point hook can
+                // resume the native loop there. The walk is the sole executor,
+                // so the close always transfers walk-final state.
+                let capture_walk_reds = true;
+                let inner_close = true;
                 // pyjitpl.py:3060 reached_loop_header `current_merge_points.append`:
                 // the live arg boxes (greens slots 0..3 + reds slots 3..6, in
                 // operand order) at this merge point. A NESTED inner-loop revisit
@@ -4056,9 +4003,7 @@ where
                             let header_pc = ctx.header_pc;
                             let inner_key =
                                 crate::green_key_from_code_ptr(ctx.green_key_raw.0, pc as usize);
-                            if ctx.has_merge_point_at(inner_key, header_pc)
-                                && std::env::var_os("PYRE_NO_INNER_CLOSE").is_none()
-                            {
+                            if ctx.has_merge_point_at(inner_key, header_pc) {
                                 if std::env::var_os("MAJIT_SPDIAG").is_some() {
                                     eprintln!(
                                         "@@@SPDIAG INNER-CUT-CLOSE pc={pc} header_pc={header_pc} inner_key={inner_key} walk_reds={walk_reds:?}"
@@ -4141,27 +4086,6 @@ where
                             }
                             ctx.add_merge_point(inner_key, original_boxes, header_pc);
                         }
-                    }
-                }
-                // D2 per-opcode single-executor (PYRE_AUTHORITATIVE): reaching
-                // here means every loop-close check above declined (a closing
-                // merge point already returned CloseLoop). A non-closing merge
-                // point is an interpreter-opcode boundary. The FIRST such point
-                // in this run_to_end call is the ENTRY (the opcode about to
-                // execute) — mark it and keep tracing the body. The NEXT is the
-                // BOUNDARY reached after exactly one opcode — return its
-                // interpreter green pc so the native loop advances pc there and
-                // skips re-dispatching the walked opcode. Inert (falls through
-                // to Continue) unless authoritative.
-                if authoritative_executor_enabled() {
-                    if self.authoritative_seen_entry_mp {
-                        if let Some(pc) = mp_green_pc {
-                            return TraceAction::OpcodeComplete {
-                                next_pc: pc as usize,
-                            };
-                        }
-                    } else {
-                        self.authoritative_seen_entry_mp = true;
                     }
                 }
             }

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -347,11 +347,11 @@ pub struct TraceCtx {
     /// `MetaInterp::walk_active_trace_refs`. Used by cut_trace_from to
     /// remap escaped original inputargs to their stable Const value.
     pub initial_inputarg_consts: Vec<OpRef>,
-    /// Single-pass tracing (`PYRE_SINGLE_PASS`): the resume-aligned bytecode
-    /// pc the walk closed back to, captured at the CloseLoop decision point
-    /// in the JitCode dispatch. `None` for every trace unless single-pass
-    /// populated it. Surfaced through `MetaInterp::single_pass_outcome` (set
-    /// before `compile_loop` drains the ctx) to the gated merge-point hook.
+    /// Single-pass tracing: the resume-aligned bytecode pc the walk closed
+    /// back to, captured at the CloseLoop decision point in the JitCode
+    /// dispatch. `None` until the walk populates it. Surfaced through
+    /// `MetaInterp::single_pass_outcome` (set before `compile_loop` drains the
+    /// ctx) to the merge-point hook.
     pub walk_final_pc: Option<usize>,
     /// Single-pass tracing: the walk-final concrete RED values captured from
     /// the closing merge point's red operands (their live `int_values` /

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -600,7 +600,12 @@ class Check:
                 # producer instead.
                 print(red("LLBC artefacts are missing under build/llbc/."))
                 print("Run the extractor first, then re-run this script:")
-                print("    scripts/extract-llbc.py pyre-object pyre-interpreter")
+                # No crate arguments: extract the full DEFAULT_CRATES set
+                # (pyre-object, pyre-interpreter, pyre-jit). Naming only the
+                # mandatory pair would omit pyre-jit.ullbc, leaving check.py to
+                # validate the degraded 2-crate frontend without the
+                # eval_loop_jit portal.
+                print("    scripts/extract-llbc.py")
             else:
                 self._print_cargo_diagnostics(cargo_path)
             sys.exit(1)


### PR DESCRIPTION
## #344 Phase B — single-pass whole-circuit close is the sole trace-close path

Slices 1–3 (merged) removed the observer/replay queue. Phase B completes #344
by retiring the last piece of the two-executor shape: the per-opcode
`PYRE_AUTHORITATIVE` path.

### Finding that drove the change

Reading the PyPy source (`rpython/jit/metainterp/pyjitpl.py`) settled the open
design point: PyPy has **no** per-opcode "return a boundary pc to the outer
loop" step. `MetaInterp.run_one_step` runs many opcodes until close, and
`reached_loop_header` signals close by raising
`ContinueRunningNormally` / `EnterJitAssembler`; compiled-code entry is
decoupled (`warmstate.maybe_compile_and_run`). pyre's own `trace_bytecode`
likewise walks a whole region and flushes walk-final state to the live frame.

So majit's `TraceAction::OpcodeComplete { next_pc }` per-opcode-return channel
was a non-parity invention with no PyPy/pyre analog. Empirically it also
over-ran: `PYRE_AUTHORITATIVE=1` drove aheui `logo --jit` to a non-terminating
5 MB+ output (the side-effecting output opcode re-executed), versus the correct
bit-exact `996310` on the default single-pass path. The PyPy-orthodox
per-opcode model *is* majit's single-pass whole-circuit close.

### Changes

1. The single-pass whole-circuit close is now the unconditional default — the
   only trace-close path.
2. Deleted the `OpcodeComplete` variant, `authoritative_next_pc`,
   `authoritative_seen_entry_mp`, `take_authoritative_next_pc`, the macro
   authoritative branch, and the `run_to_end` / `merge_point` `OpcodeComplete`
   sites.
3. Retired the `PYRE_SINGLE_PASS` / `PYRE_INNER_CLOSE` / `PYRE_AUTHORITATIVE`
   env gates and the `PYRE_NO_INNER_CLOSE` debug hatch (zero references remain).
4. Renamed the now-accurately-scoped `writeback_authoritative_state_fields` →
   `writeback_scalar_state_fields`.

The pre-existing `check.py` commit on this branch extracts the full default
crate set in the LLBC-missing hint (unrelated tidy-up carried along).

### Cross-repo companion (separate repo, not in this diff)

aheui is the sole `; state` consumer and lives in its own repo. Its
`PYRE_SINGLE_PASS=1` self-set is removed and its `build.rs` now sets
`PipelineConfig.register_trait_families` (#408 drift) so it builds against this
majit.

### Verification

- aheui `logo --jit` == `996310` (bit-exact vs `--no-jit`, terminates);
  hello-world / factorial / fibonacci / 99bottles also match `--no-jit`.
- All 11 `majit/examples` green.
- `majit-metainterp` test suite green (1384).
- `python ./pyre/check.py --backend dynasm` 183/183.
- Codex parity review (diff base = pre-Phase-B): the deletion moves **toward**
  parity. Follow-ups tracked separately (non-blocking): a `; state`
  micro-example for CI coverage of the single-pass close; two pre-existing
  trace-engine debts this patch did not touch (`GUARD_FUTURE_CONDITION` emitted
  only on the close path vs every `reached_loop_header`; inline-portal
  merge-point handling gated on `portal_inline_experiment_enabled` vs the
  recursive-call-assembler protocol).

Closes #344.

— *authored by Claude*
