### PR TITLE
#346: per-instantiation Option/Result classdefs + compute_mro residualization

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2167,6 +2167,25 @@ impl Bookkeeper {
                         return Some(parent.to_string());
                     }
                 }
+                // A generic enum instantiation (`Option<X>`, `Result<T,E>`) and
+                // a collapsed non-suffixed spelling of the same enum
+                // (`core.option.Option`, from a ctor whose ADT head lost its
+                // type argument) both denote ONE class — RPython has no
+                // generics, so every spelling of an enum is the same class.
+                // Subclass each under the bare enum leaf (`Option` / `Result`)
+                // so two sibling instantiations, and a collapsed value, share a
+                // base and `commonbase` to it at a phi merge instead of failing
+                // `mergeinputargs` with "no common base class".  The bare leaf
+                // is the discriminant-only root (its only row is
+                // `__discriminant`), so it carries no payload attr the
+                // per-instantiation `__pos_N` writes could conflict on.
+                if reg.is_enum_base(&lookup) {
+                    let stripped = majit_ir::descr::strip_generic_args(&lookup);
+                    let bare_leaf = stripped.rsplit("::").next().unwrap_or(&stripped);
+                    if bare_leaf != lookup.as_str() && !seen.contains(bare_leaf) {
+                        return Some(bare_leaf.to_string());
+                    }
+                }
                 let (first_name, first_ty) = reg.fields.get(&lookup)?.first()?;
                 // Only header-conventional first fields mark subclassing
                 // (`ob_header: PyObject` / `base: FrameBlock`).  A

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7791,7 +7791,14 @@ impl<'a> Lowering<'a> {
         // Destination `Option`: enum root + `Some` variant owners + payload.
         let def_id = self.tyref_adt_def_id(dest_ty)?;
         let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
+        // Suffix the enum root with the destination `Option<X>`'s `<X>` so a
+        // `bool::then` construction mints the same per-instantiation root a
+        // static `Some(..)` mints; `some_owner` then derives `Option<X>::Some`.
+        let option_owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(dest_ty)?;
         // Closure env ADT → its `name_path` is the `call_once` inherent
@@ -7957,7 +7964,14 @@ impl<'a> Lowering<'a> {
         }
         let def_id = self.tyref_adt_def_id(recv_ty)?;
         let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
+        // Suffix the enum root with the receiver `Option<X>`'s `<X>` so the
+        // per-instantiation root a static `Some(..)` mints is reused here;
+        // `some_owner` then derives `Option<X>::Some`.
+        let option_owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(recv_ty, self.llbc)
+        );
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
         // Closure env ADT → its `name_path` is the `call_once` inherent method
@@ -7967,6 +7981,10 @@ impl<'a> Lowering<'a> {
         let env_td = self.llbc.type_by_id(env_def_id)?;
         let call_once_owner = env_td.item_meta.name_path();
         let result_ty = tyref_to_value_type(dest_ty, self.llbc);
+        // The single-element closure-`Args` tuple `(payload,)` the extracted
+        // `call_once` reads its `.0` from, keyed to the same `Tuple<X>` leaf
+        // the read side derives at `resolve_place`.
+        let args_tuple_suffix = option_payload_tuple_suffix(recv_ty, self.llbc);
         Some(crate::front::option_map_or::MapOrSite {
             result_var: result_var.clone(),
             option_owner,
@@ -7974,6 +7992,7 @@ impl<'a> Lowering<'a> {
             call_once_owner,
             payload_ty,
             result_ty,
+            args_tuple_suffix,
         })
     }
 
@@ -8001,12 +8020,23 @@ impl<'a> Lowering<'a> {
         }
         let def_id = self.tyref_adt_def_id(recv_ty)?;
         let td = self.llbc.type_by_id(def_id)?;
-        let option_owner = td.item_meta.name_path();
+        // Suffix the enum root with the receiver `Option<X>`'s `<X>` so the
+        // per-instantiation root a static `Some(..)` mints is reused here;
+        // `some_owner` then derives `Option<X>::Some`.
+        let option_owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(recv_ty, self.llbc)
+        );
         let some_owner = Self::tagged_pair_payload_owner(td, &option_owner, 1)?;
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
         let env_def_id = self.tyref_ref_adt_def_id(env_ty?)?;
         let env_td = self.llbc.type_by_id(env_def_id)?;
         let call_once_owner = env_td.item_meta.name_path();
+        // The single-element closure-`Args` tuple `(payload,)` the extracted
+        // `call_once` reads its `.0` from, keyed to the same `Tuple<X>` leaf
+        // the read side derives at `resolve_place`.
+        let args_tuple_suffix = option_payload_tuple_suffix(recv_ty, self.llbc);
         // The type the closure's `call_once` returns: `map`'s dest is
         // `Option<U>` and its closure returns `U` (the dest payload);
         // `and_then`'s dest is `Option<U>` returned directly; `unwrap_or_else`'s
@@ -8025,6 +8055,7 @@ impl<'a> Lowering<'a> {
             call_once_owner,
             payload_ty,
             call_result_ty,
+            args_tuple_suffix,
         })
     }
 
@@ -8193,7 +8224,16 @@ impl<'a> Lowering<'a> {
         // Same owner-path / ctor-leaf split `resolve_aggregate_adt`
         // performs, so the ctor target and FieldWrite owner carry the
         // spellings the rest of the aggregate machinery expects.
-        let owner = td.item_meta.name_path();
+        // Route the runtime-discriminant tagged-pair ctor to the SAME
+        // per-instantiation enum root a static `Some(..)`/`Ok(..)` mints,
+        // by suffixing the bare template name with the `<X>` the
+        // destination `Option<X>`/`Result<X, E>` local carries.
+        // Fail-closed: no splitting generic yields "" → bare owner.
+        let owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
         let arg = arg.clone();
         let bb_id = self.block_id[mir_bb];
 
@@ -8295,7 +8335,16 @@ impl<'a> Lowering<'a> {
         let Some(td) = self.llbc.type_by_id(def_id) else {
             return Ok(false);
         };
-        let owner = td.item_meta.name_path();
+        // Route the runtime-discriminant tagged-pair ctor to the SAME
+        // per-instantiation enum root a static `Some(..)`/`Ok(..)` mints,
+        // by suffixing the bare template name with the `<X>` the
+        // destination `Option<X>`/`Result<X, E>` local carries.
+        // Fail-closed: no splitting generic yields "" → bare owner.
+        let owner = format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        );
         let arg = arg.clone();
         if self.multi_assigned_locals.contains(&dest_local) {
             // A re-bindable local may later carry a runtime `Result`,
@@ -11869,6 +11918,81 @@ fn tyref_tuple_suffix(ty: &TyRef, llbc: &Llbc) -> String {
         .and_then(serde_json::Value::as_object)
         .map(|adt| tuple_shape_suffix(adt, llbc))
         .unwrap_or_default()
+}
+
+/// The `<X>` enum-instantiation suffix for a destination `Option<X>` /
+/// `Result<X, E>` local `ty`.  A runtime-discriminant decomposition
+/// (`checked_neg`, `usize::try_from`) constructs the enum ROOT — no static
+/// variant annotates the destination — so it cannot route through
+/// `resolve_aggregate_adt`'s enum arm; without a suffix it mints the bare
+/// template (`core.option.Option`), whose `__pos_0` then unions every
+/// caller's payload (`int ∪ FrameDebugData ∪ …`) onto one classdef.
+/// Suffixing the root with the `<X>` the `place.ty` carries mints one root
+/// per instantiation instead, so each `__pos_0` sees a single concrete
+/// payload — the spelling a static `Some(..)`/`Ok(..)` construction already
+/// mints.  Extracts `ty`'s `{"Adt": …}` node (as [`tyref_tuple_suffix`]
+/// does) and defers to [`adt_head_instantiation_suffix`], already RC2-gated
+/// (an `f32`/`f64`/`()`/`""` argument yields `None`).  Fail-closed: a
+/// missing `Adt` node, a non-enum type, or a deferred argument yields `""` —
+/// the bare owner, unchanged.
+fn tyref_enum_instantiation_suffix(ty: &TyRef, llbc: &Llbc) -> String {
+    let value = match ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return String::new(),
+        },
+    };
+    value
+        .as_object()
+        .and_then(|m| m.get("Adt"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|adt| adt_head_instantiation_suffix(adt, llbc))
+        .unwrap_or_default()
+}
+
+/// The `<X>` suffix for the single-element closure-`Args` tuple `(payload,)` a
+/// unary `map_or`/`and_then`/`map` closure receives, where `payload` is the
+/// receiver `Option<X>`'s Some payload.  The extracted `call_once` body reads
+/// this tuple's `.0` via a real Charon `Tuple<X>` container (owner derived at
+/// [`Lowering::resolve_place`] mir.rs:4269 through [`tyref_tuple_suffix`]); the
+/// synthesized WRITE must derive the identical leaf so the `__pos_0` write and
+/// read key under one classdef.  Both terminate in `render_adt_type_args` →
+/// `charon_type_value_to_ast_string` (which strips `&T → T`) on the SAME
+/// payload node, so the strings are equal by construction.  Sourced from
+/// `recv_ty` (`Option<X>`, un-erased) — NOT `site.payload_ty`, which is
+/// `Ref(None)` erased.  Fail-closed: a non-Option recv, a missing payload node,
+/// or a deferred arg yields "" (bare `Tuple`, unchanged).
+fn option_payload_tuple_suffix(recv_ty: &TyRef, llbc: &Llbc) -> String {
+    // 1. pull recv_ty.Adt.generics.types[0] exactly as
+    //    tyref_option_payload_value_type does (mir.rs:7743).
+    let body = match recv_ty {
+        TyRef::Inline { value: (_, v) } => v,
+        TyRef::Other(v) => v,
+        TyRef::Dedup { id } => match llbc.dedup_body(*id) {
+            Some(v) => v,
+            None => return String::new(),
+        },
+    };
+    let Some(node) = body
+        .get("Adt")
+        .and_then(|a| a.get("generics"))
+        .and_then(|g| g.get("types"))
+        .and_then(|t| t.get(0))
+    else {
+        return String::new();
+    };
+    // 2. synthesize wrapper {"Adt":{"id":"Tuple","generics":{"types":[node]}}}.
+    let wrapper = serde_json::json!({
+        "Adt": {
+            "id": "Tuple",
+            "generics": { "types": [node.clone()] }
+        }
+    });
+    // 3. return tyref_tuple_suffix of the wrapper — the same renderer the read
+    //    side routes through, so the `&`-stripped leaf matches by construction.
+    tyref_tuple_suffix(&TyRef::Other(wrapper), llbc)
 }
 
 /// A type-argument drives a per-instantiation variant-class split unless

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -76,6 +76,12 @@ pub(crate) struct ClosureSelectSite {
     /// [`ValueType`]: `U` for `map`, `Option<U>` for `and_then`, `T` for
     /// `unwrap_or_else`.
     pub call_result_ty: ValueType,
+    /// The `<X>` suffix for the closure `Args` tuple `(payload,)` — the same
+    /// `Tuple<X>` leaf the extracted `call_once` reads its `.0` under, derived
+    /// from the receiver `Option<X>`'s payload node so the synthesized write
+    /// and the `resolve_place` read key under one classdef.  "" (bare `Tuple`)
+    /// for a unit payload.
+    pub args_tuple_suffix: String,
 }
 
 /// Rewrite every recorded closure-select call site into the discriminant
@@ -231,6 +237,7 @@ fn rewire_one_closure_select_site(
                 Some((payload, site.payload_ty.clone())),
                 &site.call_once_owner,
                 site.call_result_ty.clone(),
+                &site.args_tuple_suffix,
             );
             match site.kind {
                 // `map` wraps the closure result back into `Some(U)`.
@@ -274,6 +281,7 @@ fn rewire_one_closure_select_site(
                 None,
                 &site.call_once_owner,
                 site.call_result_ty.clone(),
+                &site.args_tuple_suffix,
             )
         }
     };
@@ -323,14 +331,24 @@ fn emit_call_once(
     arg: Option<(Variable, ValueType)>,
     call_once_owner: &str,
     result_ty: ValueType,
+    args_tuple_suffix: &str,
 ) -> Variable {
+    // The `(payload,)` Args tuple keys under the per-shape `Tuple<X>` leaf the
+    // extracted `call_once` reads `.0` from at `resolve_place`; a niladic
+    // closure's `()` tuple has no `.0` and stays bare `Tuple` (empty types →
+    // "" on both sides), so the suffix applies only when an argument is written.
+    let tuple_owner = if arg.is_some() {
+        format!("Tuple{args_tuple_suffix}")
+    } else {
+        "Tuple".to_string()
+    };
     let args_tuple = graph.alloc_value_var();
     graph.block_mut(block).operations.push(SpaceOperation {
         result: Some(args_tuple.clone()),
         kind: OpKind::Call {
-            target: CallTarget::synthetic_transparent_ctor("Tuple"),
+            target: CallTarget::synthetic_transparent_ctor(&tuple_owner),
             args: Vec::new(),
-            result_ty: ValueType::Ref(Some("Tuple".to_string())),
+            result_ty: ValueType::Ref(Some(tuple_owner.clone())),
         },
     });
     if let Some((value, _value_ty)) = arg {
@@ -340,7 +358,7 @@ fn emit_call_once(
                 base: args_tuple.clone(),
                 field: FieldDescriptor {
                     name: "__pos_0".to_string(),
-                    owner_root: Some("Tuple".to_string()),
+                    owner_root: Some(tuple_owner.clone()),
                     owner_id: None,
                 },
                 value: LinkArg::Value(value),
@@ -373,6 +391,7 @@ mod tests {
             call_once_owner: "test::closure".into(),
             payload_ty: ValueType::Int,
             call_result_ty: ValueType::Int,
+            args_tuple_suffix: String::new(),
         }
     }
 

--- a/majit/majit-translate/src/front/option_map_or.rs
+++ b/majit/majit-translate/src/front/option_map_or.rs
@@ -85,6 +85,12 @@ pub(crate) struct MapOrSite {
     /// The `map_or` result `U` projected to a [`ValueType`] — the `call_once`
     /// result kind and the select result kind.
     pub result_ty: ValueType,
+    /// The `<X>` suffix for the closure `Args` tuple `(payload,)` — the same
+    /// `Tuple<X>` leaf the extracted `call_once` reads its `.0` under, derived
+    /// from the receiver `Option<X>`'s payload node so the synthesized write
+    /// and the `resolve_place` read key under one classdef.  "" (bare `Tuple`)
+    /// for a unit payload.
+    pub args_tuple_suffix: String,
 }
 
 /// Rewrite every recorded `Option::map_or` call site into the discriminant
@@ -247,14 +253,17 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
     });
     // The closure's `Args` tuple `(payload,)` — the transparent-ctor + a
     // single `__pos_0` FieldWrite, the same shape `Rvalue::Aggregate` emits for
-    // a tuple (owner_root `"Tuple"`, write ty `Ref(None)`).
+    // a tuple (write ty `Ref(None)`).  The owner carries the per-shape `<X>`
+    // suffix (`Tuple<FrameDebugData>`) so it keys under the same classdef the
+    // extracted `call_once` reads `.0` from at `resolve_place`.
+    let tuple_owner = format!("Tuple{}", site.args_tuple_suffix);
     let args_tuple = graph.alloc_value_var();
     graph.block_mut(then_bb).operations.push(SpaceOperation {
         result: Some(args_tuple.clone()),
         kind: OpKind::Call {
-            target: CallTarget::synthetic_transparent_ctor("Tuple"),
+            target: CallTarget::synthetic_transparent_ctor(&tuple_owner),
             args: Vec::new(),
-            result_ty: ValueType::Ref(Some("Tuple".to_string())),
+            result_ty: ValueType::Ref(Some(tuple_owner.clone())),
         },
     });
     graph.block_mut(then_bb).operations.push(SpaceOperation {
@@ -263,7 +272,7 @@ fn rewire_one_map_or_site(graph: &mut FunctionGraph, site: &MapOrSite) -> Result
             base: args_tuple.clone(),
             field: FieldDescriptor {
                 name: "__pos_0".to_string(),
-                owner_root: Some("Tuple".to_string()),
+                owner_root: Some(tuple_owner.clone()),
                 owner_id: None,
             },
             value: LinkArg::Value(payload),
@@ -377,6 +386,7 @@ mod tests {
             call_once_owner: "test::closure".into(),
             payload_ty: ValueType::Int,
             result_ty: ValueType::Int,
+            args_tuple_suffix: String::new(),
         }
     }
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1279,13 +1279,15 @@ pub(crate) fn is_known_unported(msg: &str) -> bool {
         // skips to the legacy walker until per-instantiation classdef
         // specialization lands.
         || msg.contains("cannot unify instances with no common base class")
-        // `model.rs:3061` subset-gap marker — the union pair has no
-        // ported `pair(s1, s2).union()` handler.  Upstream degenerates
-        // such pairs to `SomeObject` (`annmodel` pair(SomeObject,
-        // SomeObject).union, binaryop.py:64-72) instead of erroring,
-        // so any hit here is by construction an unported handler, not
-        // a divergence.  Skip to the legacy walker until the pair is
-        // ported.
+        // The union fallback marker — no arm handles this pair.  Upstream
+        // RAISES for the pairs that reach here: `pair(SomeObject, SomeObject)
+        // .union()` raises (binaryop.py:90-93), `pair(SomePtr, SomeObject)`
+        // raises (llannotation.py:118-120).  So a hit is a pyre PRODUCER
+        // divergence — a boxed `*mut PyObject` lifted as `SomePtr` where
+        // RPython carries `SomeInstance`, making a `SomeInstance ∪ SomePtr`
+        // phi RPython never constructs — not a missing union handler.  Skip
+        // to the legacy walker until the pointer values lift as instances
+        // (typed-Ref ClassDef projection).
         || msg.contains("no upstream pair(s1, s2).union() handler in current subset")
         // `InstanceRepr.getfield` walking the `rbase` chain before the
         // repr's deferred `setup()` ran (upstream drains pending

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5892,9 +5892,24 @@ pub(crate) unsafe fn lookup_where(
 
 /// `lookup_in_type` / `lookup_in_type_where` descriptor-only projection of
 /// [`lookup_where`], for the callers that do not need the defining class.
-/// The raw walk underneath the method cache; also the JIT path (no
-/// thread-local state) so the trace can lower it directly.
-unsafe fn lookup_in_type_where_uncached(w_type: PyObjectRef, name: &str) -> Option<PyObjectRef> {
+/// The raw walk underneath the method cache.
+///
+/// `dont_look_inside` — the scalar-`Option` residual boundary over the cold
+/// uncached MRO walk. [`compute_mro`] is opaque, so [`lookup_where`]'s `mro`
+/// binding phi-merges the cached `&*mro` slice against the freshly computed
+/// opaque `Vec` borrow, a union the annotator cannot model (`<other> ∪ _ptr`).
+/// Residualizing at this `-> Option<PyObjectRef>` projection keeps the phi-merge
+/// out of the traced numeric/unary and lookup-family callers while
+/// [`lookup_where`] itself stays traced (`_lookup_where` typeobject.py:480
+/// `@unroll_safe`). Marker `_jit_look_inside_ = False` (rlib/jit.py:139).
+///
+/// Mirror: the scalar-`Option` residuals in `objspace/std/mapdict.rs`
+/// (`instance_get_dict_slot` -> `Option<PyObjectRef>`).
+#[majit_macros::dont_look_inside]
+pub(crate) unsafe fn lookup_in_type_where_uncached(
+    w_type: PyObjectRef,
+    name: &str,
+) -> Option<PyObjectRef> {
     lookup_where(w_type, name).map(|(_src, value)| value)
 }
 
@@ -6486,6 +6501,24 @@ pub unsafe fn compute_default_mro(w_type: PyObjectRef) -> Vec<PyObjectRef> {
     compute_mro(w_type)
 }
 
+/// C3 linearization core (typeobject.py:1687 `compute_C3_mro`).
+///
+/// `dont_look_inside` — MRO computation is opaque, MRO iteration stays traced.
+/// C3 runs behind `@dont_look_inside` `__init__` (typeobject.py:199); the hot
+/// walk iterates the prebuilt `mro_w` (`_lookup_where` typeobject.py:480
+/// `@unroll_safe`, cache hit `_pure_lookup_where_with_method_cache`
+/// typeobject.py:516-517 `@elidable`, mirrored at
+/// [`_pure_lookup_where_with_method_cache`]). The first statement
+/// `vec![w_type]` lowers to the foreign, non-scalar
+/// `box_assume_init_into_vec_unsafe` alloc intrinsic, which has no annotator
+/// graph, so the entire self-recursive C3 walk residualizes here instead of
+/// blocking every numeric/unary and lookup-family graph that funnels through
+/// the cold uncached [`lookup_where`] branch. Marker `_jit_look_inside_ =
+/// False` (rlib/jit.py:139).
+///
+/// Mirror: the Vec-returning residuals in `objspace/std/mapdict.rs`
+/// (`instance_node_dict_keys` -> `Vec<PyObjectRef>`).
+#[majit_macros::dont_look_inside]
 pub(crate) unsafe fn compute_mro(w_type: PyObjectRef) -> Vec<PyObjectRef> {
     let mut result = vec![w_type];
     let bases = w_type_get_bases(w_type);

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -617,8 +617,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     let lookup_in_type_where_uncached: unsafe fn(
         pyre_object::PyObjectRef,
         &str,
-    ) -> Option<pyre_object::PyObjectRef> =
-        crate::baseobjspace::lookup_in_type_where_uncached;
+    ) -> Option<pyre_object::PyObjectRef> = crate::baseobjspace::lookup_in_type_where_uncached;
     push_alias_pair(
         &mut entries,
         "pyre_interpreter::baseobjspace::lookup_in_type_where_uncached",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -586,6 +586,45 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::objspace::std::mapdict::_obj_getdict",
         crate::objspace::std::mapdict::_obj_getdict as *const (),
     );
+    // #346: the C3 linearization core `compute_mro` carries `#[dont_look_inside]`
+    // — MRO computation is opaque, MRO iteration stays traced. The self-recursive
+    // C3 walk bottoms out in the `vec![w_type]` foreign alloc intrinsic, so it
+    // residualizes; its public wrapper `compute_default_mro` residualizes with
+    // it. Both are Vec-returning residuals with no build-time constant, so bind
+    // their `fn` directly by qualified path.
+    let compute_mro: unsafe fn(pyre_object::PyObjectRef) -> Vec<pyre_object::PyObjectRef> =
+        crate::baseobjspace::compute_mro;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::baseobjspace::compute_mro",
+        "pyre_interpreter::compute_mro",
+        compute_mro as *const (),
+    );
+    let compute_default_mro: unsafe fn(pyre_object::PyObjectRef) -> Vec<pyre_object::PyObjectRef> =
+        crate::baseobjspace::compute_default_mro;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::baseobjspace::compute_default_mro",
+        "pyre_interpreter::compute_default_mro",
+        compute_default_mro as *const (),
+    );
+    // #346: `lookup_in_type_where_uncached` is the scalar-`Option` residual
+    // boundary over the cold uncached MRO walk. With `compute_mro` opaque,
+    // `lookup_where`'s `mro` phi-merges the cached slice against the opaque
+    // `Vec` borrow (`<other> ∪ _ptr`), a union the annotator cannot model, so
+    // this projection carries `#[dont_look_inside]`. No build-time constant, so
+    // bind its `fn` directly by qualified path.
+    let lookup_in_type_where_uncached: unsafe fn(
+        pyre_object::PyObjectRef,
+        &str,
+    ) -> Option<pyre_object::PyObjectRef> =
+        crate::baseobjspace::lookup_in_type_where_uncached;
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::baseobjspace::lookup_in_type_where_uncached",
+        "pyre_interpreter::lookup_in_type_where_uncached",
+        lookup_in_type_where_uncached as *const (),
+    );
     // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic and
     // `longobject::bigint_gc_type_id` reads the init-assigned `BIGINT_GC_TYPE_ID`
     // atomic — neither is a build-time constant, so both carry


### PR DESCRIPTION
Two follow-on #346 slices toward retiring the rtyper legacy walker: per-instantiation classdef specialization for the `Option`/`Result` combinator front passes, and residualizing the `compute_mro` C3 walk so the numeric/unary and lookup families stop failing the two-phase prepass on the foreign `vec!` alloc intrinsic.

## Commits

### per-instantiation enum root + closure-Args Tuple suffix for Option combinators
A generic enum instantiation (`Option<X>`, `Result<T,E>`) and a collapsed non-suffixed spelling of the same enum (`core.option.Option`) were interned as distinct classdefs with no shared base, so `commonbase` returned `None` at a phi merge. Separately, the `bool::then` / `map_or` / `map` / `and_then` / `unwrap_or_else` front passes minted a bare `Tuple` for the closure `Args`, whose `__pos_0` unioned every closure payload in the program onto one classdef (`PyObject ∪ FrameDebugData`).

- Subclass a generic enum instantiation and a collapsed spelling of the same enum under the bare enum leaf in `intern_class_by_qualname` (discriminant-only root, no payload attr to conflict on).
- Suffix the tagged-pair enum root (`emit_tagged_pair_aggregate`, the `checked_neg` / `usize::try_from` runtime-discriminant lowering) with the destination `Option<X>`/`Result<X,E>`'s `<X>`.
- Suffix the enum root in `recognize_bool_then_site` / `recognize_map_or_site` / `recognize_closure_select_site` from the site's dest/recv `Option<X>`; suffix the synthesized closure-`Args` tuple in `option_map_or` / `option_closure_select` via `option_payload_tuple_suffix`, which routes the receiver Option's payload node through `tyref_tuple_suffix` — the same renderer the extracted `call_once` reads `.0` under at `resolve_place` — so the `__pos_0` write and read key under one classdef. A niladic closure's `()` tuple stays bare `Tuple`.

Effect: `cannot unify instances with no common base class` 52→10 (the `Option<…> ∪ core.option.Option` family and `PyObject ∪ FrameDebugData` go to zero).

### residualize compute_mro / lookup_in_type_where_uncached via dont_look_inside
`compute_mro` (C3 linearization) starts with `vec![w_type]`, which lowers to the foreign non-scalar `box_assume_init_into_vec_unsafe` alloc intrinsic that has no annotator graph; the self-recursive C3 walk blocked every numeric/unary and lookup-family graph funneling through the cold uncached `lookup_where` branch.

- Annotate `compute_mro` and the scalar-Option boundary `lookup_in_type_where_uncached` `#[dont_look_inside]` so the walk residualizes — MRO computation opaque, MRO iteration traced (`compute_C3_mro` behind `__init__` dont_look_inside, typeobject.py:199/1687).
- Bind the residual fnaddrs for `compute_mro`, its wrapper `compute_default_mro`, and `lookup_in_type_where_uncached` (siblings of the `note_alloc` / `try_gc_charge` residuals).
- Correct the union-fallback skip comment in `cutover.rs`: upstream RAISES for the pairs reaching it (`pair(SomeObject,SomeObject).union` binaryop.py:90-93, `pair(SomePtr,SomeObject)` llannotation.py:118-120), so the skip marks a pyre producer divergence (a boxed pointer lifted as `SomePtr` where RPython carries `SomeInstance`), not a missing union handler.

Effect: `compute_at_fixpoint` prepass failures 165→138.

## Verification
`check.py` dynasm 183/183 + cranelift 183/183 (the JIT paths that consume the new classdef owners / residual fnaddrs). The four wasm-backend `check.py` failures (`inline_callee_constructs_object`, `inlined_helper_mutation`, `inlined_mutation_before_abort`, `sre_pattern_methods`) reproduce identically on the base commit — pre-existing, independent of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of optional values and closure-based rewrites, including better support for generic cases and empty-argument closures.

* **Bug Fixes**
  * Fixed cases where different generic forms could be treated as separate enum identities.
  * Improved consistency in type resolution and method lookup during tracing, reducing mismatches and unexpected fallbacks.
  * Strengthened tracing behavior so internal lookup and MRO processing stay more stable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->