### PR TITLE
jit: poll the async-action ticker at loop back-edges (GuardEvalBreaker)

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -9808,6 +9808,54 @@ impl CraneliftBackend {
                     }
                 }
 
+                OpCode::GuardEvalBreaker => {
+                    // Back-edge eval-breaker poll: load the async-action ticker
+                    // cell (baked address) and side-exit when it is negative (a
+                    // pending signal / async action). `0` = no ticker published
+                    // (signal handling not installed) → inert guard.
+                    let info = &guard_infos[guard_idx];
+                    guard_idx += 1;
+
+                    let ticker_addr = majit_ir::eval_breaker::ticker_addr();
+                    if ticker_addr != 0 {
+                        let addr_val = builder.ins().iconst(cl_types::I64, ticker_addr as i64);
+                        let ticker =
+                            builder
+                                .ins()
+                                .load(cl_types::I64, MemFlags::trusted(), addr_val, 0);
+                        let zero = builder.ins().iconst(cl_types::I64, 0);
+                        let is_pending = builder.ins().icmp(IntCC::SignedLessThan, ticker, zero);
+
+                        let exit_block = builder.create_block();
+                        builder.set_cold_block(exit_block);
+                        let cont_block = builder.create_block();
+                        if preamble_phase {
+                            builder.set_cold_block(cont_block);
+                        }
+                        builder
+                            .ins()
+                            .brif(is_pending, exit_block, &[], cont_block, &[]);
+
+                        builder.switch_to_block(exit_block);
+                        builder.seal_block(exit_block);
+                        let cur_jf = builder.ins().get_pinned_reg(ptr_type);
+                        emit_guard_exit(
+                            &mut builder,
+                            &constants,
+                            cur_jf,
+                            info,
+                            &ref_root_slots,
+                            &stale_ref_vars,
+                            ref_root_base_ofs,
+                            ptr_type,
+                            call_conv,
+                        );
+
+                        builder.switch_to_block(cont_block);
+                        builder.seal_block(cont_block);
+                    }
+                }
+
                 OpCode::GuardFutureCondition => {
                     // Future condition: the guard condition is computed lazily.
                     // For now, behave like GuardTrue on args[0].

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -9819,10 +9819,8 @@ impl CraneliftBackend {
                     let ticker_addr = majit_ir::eval_breaker::ticker_addr();
                     if ticker_addr != 0 {
                         let addr_val = builder.ins().iconst(cl_types::I64, ticker_addr as i64);
-                        let ticker =
-                            builder
-                                .ins()
-                                .load(cl_types::I64, MemFlags::trusted(), addr_val, 0);
+                        let flags = MemFlags::trusted();
+                        let ticker = builder.ins().load(cl_types::I64, flags, addr_val, 0);
                         let zero = builder.ins().iconst(cl_types::I64, 0);
                         let is_pending = builder.ins().icmp(IntCC::SignedLessThan, ticker, zero);
 

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3413,6 +3413,21 @@ impl<'a> AssemblerARM64<'a> {
             OpCode::GuardNotInvalidated => {
                 self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
             }
+            OpCode::GuardEvalBreaker => {
+                // Back-edge eval-breaker poll: load the async-action ticker
+                // cell and deopt when it is negative (a pending signal /
+                // async action). `0` = no ticker published (signal handling
+                // not installed) → inert guard, no runtime check.
+                let ticker_addr = majit_ir::eval_breaker::ticker_addr();
+                if ticker_addr == 0 {
+                    self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
+                } else {
+                    self.emit_mov_imm64(16, ticker_addr as i64);
+                    dynasm!(self.mc ; .arch aarch64 ; ldr X(16), [x16] ; cmp X(16), xzr);
+                    self.guard_success_cc = Some(CC_GE);
+                    self.implement_guard_with_faillocs(op, op_index, fail_index, faillocs);
+                }
+            }
             OpCode::GuardAlwaysFails => {
                 self.implement_guard_always_fails_with_faillocs(op, op_index, fail_index, faillocs);
             }

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4468,6 +4468,23 @@ impl<'a> Assembler386<'a> {
             OpCode::GuardNotInvalidated => {
                 self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
             }
+            OpCode::GuardEvalBreaker => {
+                // Back-edge eval-breaker poll: load the async-action ticker
+                // cell and deopt when it is negative (a pending signal /
+                // async action). `0` = no ticker published (signal handling
+                // not installed) → inert guard, no runtime check.
+                let ticker_addr = majit_ir::eval_breaker::ticker_addr();
+                if ticker_addr == 0 {
+                    self.implement_guard_nojump_with_faillocs(op, op_index, fail_index, faillocs);
+                } else {
+                    let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+                    dynasm!(self.mc ; .arch x64
+                        ; mov Rq(scratch), QWORD ticker_addr as i64
+                        ; cmp QWORD [Rq(scratch)], 0);
+                    self.guard_success_cc = Some(CC_GE);
+                    self.implement_guard_with_faillocs(op, op_index, fail_index, faillocs);
+                }
+            }
             OpCode::GuardAlwaysFails => {
                 self.implement_guard_always_fails_with_faillocs(op, op_index, fail_index, faillocs);
             }

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1415,8 +1415,13 @@ fn build_function(
                 guard_idx += 1;
             }
             // Guards that always pass in wasm MVP (no force-token /
-            // invalidation tracking yet).
-            OpCode::GuardNotInvalidated | OpCode::GuardNotForced | OpCode::GuardNotForced2 => {
+            // invalidation tracking yet). GuardEvalBreaker is inert here too:
+            // wasm32-unknown-unknown has no OS signals, so the ticker never
+            // goes negative.
+            OpCode::GuardNotInvalidated
+            | OpCode::GuardNotForced
+            | OpCode::GuardNotForced2
+            | OpCode::GuardEvalBreaker => {
                 guard_idx += 1;
             }
             OpCode::GuardNoException => {

--- a/majit/majit-ir/src/eval_breaker.rs
+++ b/majit/majit-ir/src/eval_breaker.rs
@@ -1,0 +1,30 @@
+//! Address of the interpreter's async-action ticker cell, published by the
+//! host (pyre) so the JIT backends can bake a `GuardEvalBreaker` that polls it
+//! at loop back-edges.
+//!
+//! The cell is `ExecutionContext.actionflag._ticker`; the OS signal handler
+//! forces it negative and the interpreter runs `action_dispatcher` when it
+//! goes below zero. Compiled loops mirror the `CHECK_EVAL_BREAKER()` back-edge
+//! ticker poll by loading this cell and deopting to the interpreter when it is
+//! negative, so async signals/actions are delivered without waiting for the
+//! loop to exit naturally.
+//!
+//! The address is a single process-global registered once at startup
+//! (`register_ticker` ← `install_signal_handling`) and stable for the process
+//! lifetime (the `ExecutionContext` is held behind an `Rc` and never moves).
+//! `0` means no cell has been published yet — backends treat `GuardEvalBreaker`
+//! as inert in that case.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static TICKER_ADDR: AtomicUsize = AtomicUsize::new(0);
+
+/// Publish the ticker cell address. Called once at startup by the host.
+pub fn set_ticker_addr(addr: usize) {
+    TICKER_ADDR.store(addr, Ordering::Relaxed);
+}
+
+/// Address of the ticker cell, or `0` if none has been published.
+pub fn ticker_addr() -> usize {
+    TICKER_ADDR.load(Ordering::Relaxed)
+}

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -3,6 +3,7 @@ pub mod debug;
 pub mod descr;
 pub mod descr_registry;
 pub mod effectinfo;
+pub mod eval_breaker;
 pub mod field_entry;
 pub mod forwarding;
 pub mod indexmap_ext;

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1831,6 +1831,7 @@ pub enum OpCode {
     GuardNotForced,
     GuardNotForced2,
     GuardNotInvalidated,
+    GuardEvalBreaker,
     GuardFutureCondition,
     GuardAlwaysFails,
 
@@ -2870,6 +2871,7 @@ static OPARITY: [Option<u8>; OPCODE_COUNT] = {
     set!(GuardNotForced, 0);
     set!(GuardNotForced2, 0);
     set!(GuardNotInvalidated, 0);
+    set!(GuardEvalBreaker, 0);
     set!(GuardFutureCondition, 0);
     set!(GuardAlwaysFails, 0);
     // Arithmetic (binary)
@@ -3107,6 +3109,7 @@ static OPWITHDESCR: [bool; OPCODE_COUNT] = {
         GuardNotForced,
         GuardNotForced2,
         GuardNotInvalidated,
+        GuardEvalBreaker,
         GuardFutureCondition,
         GuardAlwaysFails,
         // Array/field access
@@ -3465,6 +3468,7 @@ static OPNAME: [&str; OPCODE_COUNT] = {
         GuardNotForced,
         GuardNotForced2,
         GuardNotInvalidated,
+        GuardEvalBreaker,
         GuardFutureCondition,
         GuardAlwaysFails,
         IntAdd,
@@ -3792,6 +3796,7 @@ mod tests {
             OpCode::GuardNotForced,
             OpCode::GuardNotForced2,
             OpCode::GuardNotInvalidated,
+            OpCode::GuardEvalBreaker,
             OpCode::GuardFutureCondition,
             OpCode::GuardAlwaysFails,
             OpCode::VecI,
@@ -4223,6 +4228,7 @@ mod tests {
             OpCode::GuardNotForced,
             OpCode::GuardNotForced2,
             OpCode::GuardNotInvalidated,
+            OpCode::GuardEvalBreaker,
             OpCode::GuardFutureCondition,
             OpCode::GuardAlwaysFails,
         ];
@@ -4259,6 +4265,7 @@ mod tests {
             OpCode::GuardNoException,
             OpCode::GuardNotForced,
             OpCode::GuardNotInvalidated,
+            OpCode::GuardEvalBreaker,
             OpCode::GuardAlwaysFails,
         ];
         for op in &non_foldable {

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -402,7 +402,13 @@ pub fn install_signal_handling(ec: &mut ExecutionContext) {
 
     // Hand the ticker cell address to the OS handler so it can force the
     // ticker negative (rsignal.py:31-32 `pypysig_getaddr_occurred`).
-    signalstate::register_ticker(ec.actionflag.ticker_addr());
+    let ticker_addr = ec.actionflag.ticker_addr();
+    signalstate::register_ticker(ticker_addr);
+    // Publish the same cell to the JIT backends so a compiled loop's
+    // `GuardEvalBreaker` polls it at the back-edge and deopts when it goes
+    // negative, delivering async actions to JIT-compiled loops
+    // (`CHECK_EVAL_BREAKER`).
+    majit_ir::eval_breaker::set_ticker_addr(ticker_addr as usize);
 
     // app_main.py:926 — `signal.signal(SIGINT, default_int_handler)`.
     #[cfg(unix)]

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -3154,6 +3154,15 @@ impl MIFrame {
         ctx: &mut TraceCtx,
         target_pc: Option<usize>,
     ) -> Vec<OpRef> {
+        // `JUMP_BACKWARD` eval-breaker poll (`CHECK_EVAL_BREAKER`): emit
+        // a `GuardEvalBreaker` in the loop body before the closing JUMP so the
+        // compiled loop polls the async-action ticker at the back-edge and
+        // deopts when a signal / async action is pending, instead of running
+        // uninterruptibly until natural loop exit. Nullary guard: no data
+        // operands, so its resume snapshot is the ordinary loop-body liveness
+        // (like GuardNotInvalidated). Captured before the flush/materialize
+        // below so the snapshot reflects the pre-close loop-body state.
+        self.generate_guard(ctx, OpCode::GuardEvalBreaker, &[]);
         // pyjitpl.py:2954-2965 reached_loop_header: virtualizable_boxes
         // (read from locals_cells_stack_w[*] by virtualizable.py:86-98
         // read_boxes) are carried into the JUMP unchanged, including


### PR DESCRIPTION
## What

JIT-compiled hot loops previously ran their back-edge with no eval-breaker
poll, so once a loop was compiled it ran uninterruptibly until it exited
naturally — pending async signals/actions (Ctrl-C `KeyboardInterrupt`,
GIL/thread switch, pending calls) were not delivered mid-loop. The
interpreter's eval-breaker check lives only in the warm-up per-bytecode gate,
which is not traced into compiled loops. This mirrors `JUMP_BACKWARD` →
`CHECK_EVAL_BREAKER()`.

This adds a nullary guard `OpCode::GuardEvalBreaker`, emitted at the start of
`MIFrame::close_loop_args_at`, so every compiled loop polls the interpreter's
async-action ticker (`ExecutionContext.actionflag._ticker`, the cell the OS
signal handler forces negative) at its back-edge and deopts to the interpreter
when the ticker goes negative.

## How

- **majit-ir**: `GuardEvalBreaker` added to the non-foldable guard block so the
  `is_guard` / `is_foldable_guard` range checks pick it up automatically (arity
  0, plus `OPWITHDESCR` / `OPNAME` / test tables). New `majit_ir::eval_breaker`
  process-global carries the ticker cell address (`set_ticker_addr` /
  `ticker_addr`).
- **interp_signal**: `install_signal_handling` publishes the ticker address to
  `majit_ir::eval_breaker` right after `register_ticker` (same cell the OS
  handler writes).
- **dynasm**: load ticker address, `cmp qword [addr],0`, `guard_success_cc =
  CC_GE` (deopt when `< 0`). Address `0` leaves the guard inert.
- **cranelift**: load ticker, `icmp SignedLessThan 0`, `brif` to the guard exit.
  Address `0` leaves the guard inert.
- **wasm**: inert (no OS signals in wasm32), folded into the
  `GuardNotInvalidated` arm.

The guard is nullary, so its resume snapshot is the ordinary loop-body liveness
(same contract as `GuardNotInvalidated`); regalloc needs no change.

## Testing

- `check.py --synthetic-only` on **dynasm 145/145** and **cranelift 145/145**.
- `MAJIT_LOG=1` confirms `GuardEvalBreaker()` is emitted in the compiled
  `float_loop` body with a correct 4-value resume snapshot; the baked ticker
  address equals the registered ticker cell.
- Perf: NEW/OLD ≈ 0.98–1.02 on float_loop / fib_loop / int_arithmetic / nbody —
  no measurable overhead (poll is off the loop-carried critical path and is a
  perfectly-predicted never-taken branch).

## Notes

End-to-end OS-signal delivery is not exercised by the synthetic suite (it sends
no signals); the deopt/resume machinery is shared with `GuardNotInvalidated`. A
dedicated forced-ticker regression test and the adjacent Windows
`signal.SIGINT` exposure gap are possible follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loops now check for pending async actions at back edges, allowing long-running code to respond sooner.
  * JIT compilation now supports a new guard type used for this runtime polling behavior.
  * Signal ticker information is now shared with the JIT so compiled code can observe it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->