### PR TITLE
aheui JIT: native_int_binops, ConcreteOnlyVoid policy, LLBC census, diagnostics

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -37,6 +37,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.pool_arrays,
         &config.ref_fields,
         &config.call_returns,
+        &config.native_int_binops,
         config.split_dispatch,
         config.switch_dispatch,
     );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1610,6 +1610,10 @@ impl<'c> Lowerer<'c> {
                         },
                     );
                 }
+                crate::jit_interp::CallPolicyKind::ConcreteOnlyVoid => {
+                    // No IR ops emitted on the JIT path. The concrete
+                    // RefFieldRewriter path calls the function normally.
+                }
                 _ => return None,
             },
             CallPolicySpec::Infer => {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -941,6 +941,7 @@ impl<'c> Lowerer<'c> {
                             vec![Register::new(result_kind, reg)],
                         ),
                         quote! {
+                            use majit_metainterp::jitcode::JitCodeRuntimeExt as _;
                             let __sub_jitcode = __majit_pipeline_jitcode(#pipeline_name);
                             let (__sub_return_kind, _) = __sub_jitcode
                                 .trailing_return_info()

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -153,6 +153,12 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_pool_array_get_call(call) {
                     return Some(binding);
                 }
+                // jtransform.py:2030 _handle_int_special — pure int binop
+                // aliases bypass the call-policy machinery and emit a native
+                // IR op (IntAdd, IntSub, etc.) directly.
+                if let Some(binding) = self.lower_native_int_binop_call(call) {
+                    return Some(binding);
+                }
                 self.lower_call_value(call)
             }
             Expr::MethodCall(call) => self.lower_method_call_value(call),
@@ -1454,6 +1460,51 @@ impl<'c> Lowerer<'c> {
             }
             _ => None,
         }
+    }
+
+    /// Recognize a function call registered as a native int binop alias.
+    /// Emits the corresponding IR op (IntAdd, IntSub, etc.) directly,
+    /// bypassing the call-policy machinery.  The concrete path calls the
+    /// original function normally — no observer replay needed (pure op).
+    ///
+    /// jtransform.py:2030 `_handle_int_special()` parity.
+    fn lower_native_int_binop_call(&mut self, call: &ExprCall) -> Option<Binding> {
+        let config = self.config?;
+        let func_segments = canonical_expr_segments(&call.func)?;
+        let opcode_name = config
+            .native_int_binops
+            .iter()
+            .find(|(path, _)| *path == func_segments)
+            .map(|(_, op)| op.clone())?;
+
+        if call.args.len() != 2 {
+            return None;
+        }
+
+        let lhs = self.lower_value_expr(&call.args[0])?;
+        let rhs = self.lower_value_expr(&call.args[1])?;
+        if !matches!(lhs.kind, BindingKind::Int) || !matches!(rhs.kind, BindingKind::Int) {
+            return None;
+        }
+
+        let reg = self.alloc_reg();
+        let lhs_reg = lhs.reg;
+        let rhs_reg = rhs.reg;
+        let opcode = Ident::new(&opcode_name, proc_macro2::Span::call_site());
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::BinopI,
+                Register::ints(&[lhs_reg, rhs_reg]),
+                vec![Register::int(reg)],
+            ),
+            binop_i_emit_tokens(reg, &opcode, lhs_reg, rhs_reg),
+        );
+        Some(Binding {
+            reg,
+            kind: BindingKind::Int,
+            depends_on_stack: lhs.depends_on_stack || rhs.depends_on_stack,
+            struct_type: None,
+        })
     }
 
     fn lower_binary(&mut self, expr: &ExprBinary) -> Option<Binding> {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -478,7 +478,8 @@ pub(super) fn call_policy_effect_slot(
         | K::InlineFloat
         | K::InlinePipelineInt
         | K::InlinePipelineRef
-        | K::InlinePipelineFloat => None,
+        | K::InlinePipelineFloat
+        | K::ConcreteOnlyVoid => None,
     }
 }
 
@@ -492,6 +493,9 @@ pub(super) fn call_policy_effect_slot(
 /// conditional-call slot but force / may raise, so they keep the marker.
 pub(super) fn explicit_call_emits_post_live(kind: crate::jit_interp::CallPolicyKind) -> bool {
     if binding_kind_for_inline_policy(kind).is_some() {
+        return false;
+    }
+    if matches!(kind, crate::jit_interp::CallPolicyKind::ConcreteOnlyVoid) {
         return false;
     }
     call_policy_effect_slot(kind)
@@ -513,7 +517,8 @@ pub(super) fn call_policy_result_kind(
         | K::ReleaseGilVoid
         | K::ReleaseGilVoidWrapped
         | K::LoopInvariantVoid
-        | K::LoopInvariantVoidWrapped => Some(CallResultKind::Void),
+        | K::LoopInvariantVoidWrapped
+        | K::ConcreteOnlyVoid => Some(CallResultKind::Void),
 
         K::ResidualInt
         | K::ResidualIntWrapped

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -196,6 +196,12 @@ pub struct LowererConfig {
     /// result is bound, the lowerer sets `Binding.struct_type` from this map
     /// so subsequent `result.field` accesses resolve through `ref_fields`.
     pub(super) call_returns: HashMap<Vec<String>, syn::Path>,
+    /// Pure function → native IR integer binop aliases.  Key = canonical func
+    /// path segments, value = IR opcode name (e.g. "IntAdd").  When
+    /// `lower_native_int_binop_call` encounters a call whose path matches a
+    /// key, it emits the named IR opcode directly — bypassing the call-policy
+    /// machinery.  jtransform.py:2030 `_handle_int_special()` parity.
+    pub(super) native_int_binops: Vec<(Vec<String>, String)>,
     /// Source: `JitInterpConfig.split_dispatch`.  When set, the dispatch lowerer
     /// routes pure forward-advancing green-pc arms through the per-arm
     /// sub-JitCode path with a pc-returning `inline_call_<types>_i` instead of
@@ -812,6 +818,7 @@ impl LowererConfig {
         pool_arrays: &[crate::jit_interp::PoolArrayEntry],
         ref_fields: &[crate::jit_interp::RefFieldEntry],
         call_returns: &[(Path, Path)],
+        native_int_binops: &[(Path, Ident)],
         split_dispatch: bool,
         switch_dispatch: bool,
     ) -> Self {
@@ -1005,6 +1012,10 @@ impl LowererConfig {
                         canonical_path_segments(&entry.getter),
                     )
                 })
+                .collect(),
+            native_int_binops: native_int_binops
+                .iter()
+                .map(|(path, op)| (canonical_path_segments(path), op.to_string()))
                 .collect(),
             split_dispatch,
             switch_dispatch,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -658,6 +658,24 @@ impl Parse for JitInterpConfig {
     }
 }
 
+impl JitInterpConfig {
+    /// Whether any registered call uses an `InlinePipeline*` policy, which
+    /// requires the host to supply `__majit_pipeline_jitcode` in the dispatch
+    /// jitcode builder's scope.
+    pub fn uses_inline_pipeline(&self) -> bool {
+        self.calls.iter().any(|c| {
+            matches!(
+                c.policy,
+                Some(
+                    CallPolicyKind::InlinePipelineInt
+                        | CallPolicyKind::InlinePipelineRef
+                        | CallPolicyKind::InlinePipelineFloat
+                )
+            )
+        })
+    }
+}
+
 /// Parse `residual_writes = { <ref_scalar>.<field> => [helper, ...], ... }`.
 /// Each map key is a `state` ref-scalar field path (`selected_ref.size`) and
 /// the value is a bracketed list of residual helper function paths that mutate

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -148,6 +148,14 @@ pub struct JitInterpConfig {
     /// `allocator_func(v0, v1)`.  The JIT path already handles struct
     /// literals natively via `lower_struct_value` (New + SetfieldGc).
     pub struct_allocs: Vec<(Path, Path)>,
+    /// Pure function → native IR integer binop aliases.
+    /// `native_int_binops = { val_add => IntAdd, ... }`.  When the JIT-path
+    /// lowerer encounters a call whose path matches a key, it emits the named
+    /// IR opcode (e.g. `IntAdd`) directly instead of routing through the
+    /// call-policy machinery.  The concrete path calls the function normally.
+    /// jtransform.py:2030-2047 `_handle_int_special()` parity — oopspec
+    /// `int.add`/`int.sub`/`int.mul` codewriter-time rewrite.
+    pub native_int_binops: Vec<(Path, Ident)>,
     /// Opt-in: route pure forward-advancing dispatch arms (those whose body
     /// only does work then `pc += N`, with no back-edge / `can_enter_jit!` /
     /// early return) through the per-arm sub-JitCode path with a pc-returning
@@ -522,6 +530,7 @@ impl Parse for JitInterpConfig {
         let mut ref_fields: Vec<RefFieldEntry> = Vec::new();
         let mut call_returns: Vec<(Path, Path)> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
+        let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut split_dispatch = false;
         let mut switch_dispatch = false;
 
@@ -585,6 +594,9 @@ impl Parse for JitInterpConfig {
                 "struct_allocs" => {
                     struct_allocs = parse_call_returns_map(input)?;
                 }
+                "native_int_binops" => {
+                    native_int_binops = parse_native_int_binops_map(input)?;
+                }
                 "split_dispatch" => {
                     split_dispatch = input.parse::<LitBool>()?.value;
                 }
@@ -639,6 +651,7 @@ impl Parse for JitInterpConfig {
             ref_fields,
             call_returns,
             struct_allocs,
+            native_int_binops,
             split_dispatch,
             switch_dispatch,
         })
@@ -703,6 +716,20 @@ fn parse_call_returns_map(input: ParseStream) -> syn::Result<Vec<(Path, Path)>> 
         content.parse::<Token![=>]>()?;
         let return_type: Path = content.parse()?;
         entries.push((func_path, return_type));
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
+}
+
+fn parse_native_int_binops_map(input: ParseStream) -> syn::Result<Vec<(Path, Ident)>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        let func_path: Path = content.parse()?;
+        content.parse::<Token![=>]>()?;
+        let opcode: Ident = content.parse()?;
+        entries.push((func_path, opcode));
         let _ = content.parse::<Token![,]>();
     }
     Ok(entries)

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -450,6 +450,11 @@ pub(crate) enum CallPolicyKind {
     InlinePipelineInt,
     InlinePipelineRef,
     InlinePipelineFloat,
+    /// Calls the function on the concrete path only; the JIT-path lowerer
+    /// emits no IR ops at all. Use for operations that have no JIT-visible
+    /// side effects (e.g. returning a node to a free-list -- RPython's `del`
+    /// generates zero IR ops).
+    ConcreteOnlyVoid,
 }
 
 pub(crate) fn parse_call_policy_kind(kind: &Ident) -> Option<CallPolicyKind> {
@@ -508,6 +513,7 @@ pub(crate) fn parse_call_policy_kind(kind: &Ident) -> Option<CallPolicyKind> {
         "inline_pipeline_int" => CallPolicyKind::InlinePipelineInt,
         "inline_pipeline_ref" => CallPolicyKind::InlinePipelineRef,
         "inline_pipeline_float" => CallPolicyKind::InlinePipelineFloat,
+        "concrete_only_void" => CallPolicyKind::ConcreteOnlyVoid,
         _ => return None,
     })
 }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -961,7 +961,7 @@ impl BlackholeInterpreter {
         let mut values = Vec::with_capacity(length);
         for _ in 0..length {
             let index = self.next_u8() as usize;
-            if std::env::var_os("MAJIT_BH_DEBUG").is_some() {
+            if crate::bh_debug_enabled() {
                 eprintln!(
                     "[bh-getlist] i{index} -> {}",
                     self.registers_i.get(index).copied().unwrap_or(0)
@@ -1006,7 +1006,7 @@ impl BlackholeInterpreter {
     /// reads it as a raw signed byte (`'c'` argcode, assembler.py:312
     /// `USE_C_FORM`).
     pub(crate) fn bhimpl_jit_merge_point(&mut self, opcode: u8) -> Result<(), DispatchError> {
-        let nbody_debug = std::env::var_os("PYRE_NBODY_DEBUG").is_some();
+        let nbody_debug = crate::nbody_debug_enabled();
         let jdindex_byte = self.next_u8();
         let jdindex = if opcode == jitcode::insns::BC_JIT_MERGE_POINT_C {
             (jdindex_byte as i8) as usize
@@ -5256,7 +5256,7 @@ fn handler_goto_if_not_int_eq(
     let b = bh.registers_i[code[position + 1] as usize];
     let target = (code[position + 2] as usize) | ((code[position + 3] as usize) << 8);
     let pc = position + 4;
-    if std::env::var_os("MAJIT_BH_DEBUG").is_some() {
+    if crate::bh_debug_enabled() {
         eprintln!(
             "[bh-brcond] pos={} int_eq i{}={} i{}={} target={} fallthrough={}",
             position - 1,
@@ -5545,7 +5545,7 @@ fn handler_goto_if_not(
     let a = bh.registers_i[code[position] as usize];
     let target = (code[position + 1] as usize) | ((code[position + 2] as usize) << 8);
     let pc = position + 3;
-    if std::env::var_os("MAJIT_BH_DEBUG").is_some() {
+    if crate::bh_debug_enabled() {
         eprintln!(
             "[bh-brcond] pos={} cond_reg=i{} cond={} target={} fallthrough={}",
             position - 1,
@@ -8378,7 +8378,7 @@ fn handler_getarrayitem_vable_r(
     code: &[u8],
     p: usize,
 ) -> Result<usize, DispatchError> {
-    let nbody_debug = std::env::var_os("PYRE_NBODY_DEBUG").is_some();
+    let nbody_debug = crate::nbody_debug_enabled();
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize] as usize;
     let vinfo = vable_clear_token_and_get_vinfo(bh, vable);
@@ -8420,7 +8420,7 @@ fn handler_setarrayitem_vable_r(
     code: &[u8],
     p: usize,
 ) -> Result<usize, DispatchError> {
-    let nbody_debug = std::env::var_os("PYRE_NBODY_DEBUG").is_some();
+    let nbody_debug = crate::nbody_debug_enabled();
     let vable = bh.registers_r[code[p] as usize];
     let index = bh.registers_i[code[p + 1] as usize] as usize;
     let value = bh.registers_r[code[p + 2] as usize];

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -89,7 +89,7 @@ impl Drop for TraceContinuationSuspendGuard {
 /// Diagnostic env gates read once and cached — these are checked on the hot
 /// back-edge / guard-failure paths that run every loop iteration, so re-reading
 /// the environment per call would add a syscall to each iteration.
-fn spdiag_enabled() -> bool {
+pub(crate) fn spdiag_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_SPDIAG").is_some())
 }
@@ -1415,7 +1415,7 @@ impl<S: JitState> JitDriver<S> {
         state: &mut S,
         env: &S::Env,
     ) -> Option<usize> {
-        let dbg = std::env::var_os("MAJIT_CLOSEDBG").is_some();
+        let dbg = crate::closedbg_enabled();
         let key = match self.meta.single_pass_compiled_key.take() {
             Some(k) => k,
             None => {
@@ -1471,7 +1471,7 @@ impl<S: JitState> JitDriver<S> {
     ) -> crate::CompileOutcome {
         let loop_header_pc = self.meta.trace_ctx().map(|c| c.header_pc);
         let loop_green_key = self.current_trace_green_key();
-        if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+        if crate::closedbg_enabled() {
             eprintln!(
                 "@@@CLOSE LOOP-COMPILE green_key={} header_pc={} jump_args={}",
                 loop_green_key.map(|k| k as i64).unwrap_or(-1),
@@ -1480,7 +1480,7 @@ impl<S: JitState> JitDriver<S> {
             );
         }
         let outcome = self.meta.compile_loop(jump_args, meta);
-        if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+        if crate::closedbg_enabled() {
             eprintln!(
                 "@@@CLOSE LOOP-COMPILE outcome={:?}",
                 match &outcome {
@@ -1835,7 +1835,7 @@ impl<S: JitState> JitDriver<S> {
                     // retargeted by `reached_loop_header`.
                     let target_key = self.current_trace_green_key().unwrap_or(bridge_key);
                     let has_targets = self.meta.has_compiled_targets(target_key);
-                    if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                    if crate::closedbg_enabled() {
                         let hp = self
                             .meta
                             .trace_ctx()

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -166,6 +166,109 @@ pub fn jit_strict_mode() -> bool {
     *STRICT
 }
 
+// ── Cached diagnostic env-var helpers ────────────────────────────────
+//
+// Each env var is read once and cached via OnceLock so hot paths
+// (back-edge, guard-failure, optimizer) never re-acquire the global
+// env lock.
+
+pub fn closedbg_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_CLOSEDBG").is_some())
+}
+
+pub fn bh_debug_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_BH_DEBUG").is_some())
+}
+
+pub fn nbody_debug_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("PYRE_NBODY_DEBUG").is_some())
+}
+
+pub fn mptrace_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_MPTRACE").is_some())
+}
+
+pub fn pcseq_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_PCSEQ").is_some())
+}
+
+pub fn tldbg_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_TLDBG").is_some())
+}
+
+pub fn heapdbg_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_HEAPDBG").is_some())
+}
+
+pub fn diag_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_DIAG").is_some())
+}
+
+pub fn log_jtet_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_LOG_JTET").is_some())
+}
+
+pub fn smallir_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_SMALLIR").is_some())
+}
+
+pub fn log_opt_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_LOG_OPT").is_some())
+}
+
+pub fn bridge_debug_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("MAJIT_BRIDGE_DEBUG").is_some())
+}
+
+pub fn no_unroll_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("PYRE_NO_UNROLL").is_some())
+}
+
+/// `PYRE_ORIGINAL_BOXES`: default true, only disabled by `0` or `false`.
+pub fn original_boxes_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| match std::env::var_os("PYRE_ORIGINAL_BOXES") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
+pub fn stall_window() -> u64 {
+    static VAL: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
+        std::env::var("MAJIT_STALL_WINDOW")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1_000_000)
+    });
+    *VAL
+}
+
+pub fn step_limit() -> u64 {
+    static VAL: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| {
+        std::env::var("MAJIT_STEP_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8_000_000)
+    });
+    *VAL
+}
+
 /// Result of tracing a single instruction.
 ///
 /// Returned by the interpreter's `trace_instruction()` function

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -70,9 +70,7 @@ pub(crate) fn next_snapshot_pos<T>(store: &[Option<T>]) -> i32 {
     store.len() as i32
 }
 
-pub(crate) fn majit_log_enabled() -> bool {
-    std::env::var_os("MAJIT_LOG").is_some()
-}
+pub(crate) use crate::majit_log_enabled;
 
 /// info.py:865-894 `getrawptrinfo` / `getptrinfo` return shape, with
 /// RPython `_forwarded` object identity preserved.

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1078,7 +1078,7 @@ impl Optimizer {
                 }
                 installed_heads.insert(head_key);
             }
-            if std::env::var_os("MAJIT_LOG").is_some() {
+            if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] install_imported_virtual head={:?} fields={:?}",
                     entry.head, entry.fields
@@ -1346,7 +1346,7 @@ impl Optimizer {
                     .get(*label_slot)
                     .copied()
                     .unwrap_or_else(|| {
-                        if std::env::var_os("MAJIT_LOG").is_some() {
+                        if crate::majit_log_enabled() {
                             eprintln!(
                                 "[jit] MISS: label_slot={} len={}",
                                 *label_slot,
@@ -2038,7 +2038,7 @@ impl Optimizer {
     /// optimizer.py: log_loop(ops)
     /// Log the optimized trace for debugging/profiling.
     pub fn log_optimized_trace(ctx: &OptContext) {
-        if std::env::var("MAJIT_LOG_OPT").is_ok() {
+        if crate::log_opt_enabled() {
             eprintln!(
                 "[MAJIT] optimized trace: {} ops, {} guards",
                 ctx.new_operations.len(),
@@ -3327,7 +3327,7 @@ impl Optimizer {
                         })
                     })
                     .collect();
-                if std::env::var_os("MAJIT_LOG").is_some() {
+                if crate::majit_log_enabled() {
                     for entry in &ctx.exported_short_boxes {
                         eprintln!(
                             "[jit] exported_short_box: kind={:?} pos={:?} opcode={:?} args={:?} descr_idx={:?} invented={} same_as_source={:?}",
@@ -3815,7 +3815,7 @@ impl Optimizer {
                 }
             }
         }
-        if ops.len() < 120 && std::env::var_os("MAJIT_SMALLIR").is_some() {
+        if ops.len() < 120 && crate::smallir_enabled() {
             eprintln!("@@@SMALLIR LOOP total={}", ops.len());
             for (i, op) in ops.iter().enumerate() {
                 eprintln!("@@@SMALLIR   [{i}] {:?}", op);
@@ -3956,7 +3956,7 @@ impl Optimizer {
             .as_ref()
             .map_or(false, |op| op.opcode == OpCode::Jump);
 
-        if optimized_ops.len() < 120 && std::env::var_os("MAJIT_SMALLIR").is_some() {
+        if optimized_ops.len() < 120 && crate::smallir_enabled() {
             eprintln!(
                 "@@@SMALLIR BRIDGE total={} has_jump={} front_targets={}",
                 optimized_ops.len(),
@@ -4626,7 +4626,7 @@ impl Optimizer {
                 {
                     let target_pos = replacement.pos.get().raw() as usize;
                     if target_pos < ctx.new_operations.len() {
-                        if std::env::var_os("MAJIT_LOG").is_some() {
+                        if crate::majit_log_enabled() {
                             eprintln!(
                                 "[opt] guard replacement op={:?} pos={:?} target_index={} len={}",
                                 op.opcode,
@@ -4750,7 +4750,7 @@ impl Optimizer {
                 }
             }
         }
-        if std::env::var_os("MAJIT_LOG").is_some()
+        if crate::majit_log_enabled()
             && matches!(
                 op.opcode,
                 OpCode::CallMayForceI

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -777,7 +777,7 @@ impl UnrollOptimizer {
         // ── Phase 2: optimize_peeled_loop (compile.py:291-292) ──
         let body_num_inputs = num_inputs;
 
-        if std::env::var_os("MAJIT_LOG").is_some() {
+        if crate::majit_log_enabled() {
             eprintln!(
                 "[jit] preamble peeling: {} virtual(s), phase1 end_args={} p1_patchguardop={}",
                 exported_state
@@ -866,7 +866,7 @@ impl UnrollOptimizer {
         // RPython parity: Phase 2 imports heap cache via short preamble
         // RPython: Phase 2 heap cache is populated by inline_short_preamble
         // replaying HeapOps through send_extra_operation.
-        if std::env::var_os("MAJIT_LOG").is_some() {
+        if crate::majit_log_enabled() {
             let gc_before = ops.iter().filter(|o| o.opcode.is_guard()).count();
             eprintln!(
                 "[jit] phase 2 input: {} ops, {} guards, body_ni={}",
@@ -1071,7 +1071,7 @@ impl UnrollOptimizer {
             .clone()
             .expect("phase 2 missing import_state label_args");
 
-        if std::env::var_os("MAJIT_LOG").is_some() {
+        if crate::majit_log_enabled() {
             for op in &p2_ops {
                 if op.opcode.is_guard() {
                     let rd_numb_len = op.resolved_rd_numb().map(|s| s.len()).unwrap_or(0);
@@ -1397,7 +1397,7 @@ impl UnrollOptimizer {
         // unroll.py:176-177: disable_retracing_if_max_retrace_guards
         if Self::disable_retracing_if_max_retrace_guards(&p2_ops, self.max_retrace_guards) {
             self.retraced_count = u32::MAX;
-            if std::env::var_os("MAJIT_LOG").is_some() {
+            if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] too many guards (>{}), disabling retracing",
                     self.max_retrace_guards
@@ -1405,7 +1405,7 @@ impl UnrollOptimizer {
             }
         }
 
-        if std::env::var_os("MAJIT_LOG").is_some() {
+        if crate::majit_log_enabled() {
             eprintln!(
                 "[jit] finalize_short_preamble: target_tokens={}",
                 self.target_tokens.len()
@@ -1421,7 +1421,7 @@ impl UnrollOptimizer {
         // jump_to_existing_trace regardless of body size.
         let p2_guard_count = p2_ops.iter().filter(|o| o.opcode.is_guard()).count();
         let skip_jump_to_existing = false;
-        if std::env::var_os("MAJIT_LOG").is_some() {
+        if crate::majit_log_enabled() {
             eprintln!(
                 "[jit] post-finalize: entering jump_to_existing_trace section (p2_guards={}, skip={})",
                 p2_guard_count, skip_jump_to_existing
@@ -1564,7 +1564,7 @@ impl UnrollOptimizer {
                     )
                     .is_none();
                 if let Some(reason) = jump_ctx.take_invalid_loop() {
-                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                    if crate::log_jtet_enabled() {
                         eprintln!(
                             "[jit][jte] InvalidLoop during force_boxes=false: {}",
                             reason.0
@@ -1578,7 +1578,7 @@ impl UnrollOptimizer {
                     did_jump
                 }
             };
-            if std::env::var_os("MAJIT_LOG").is_some() {
+            if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] jump_to_existing_trace(force_boxes=false) result: jumped={}, invalid_loop={}",
                     jumped, invalid_loop
@@ -1590,7 +1590,7 @@ impl UnrollOptimizer {
                 // unroll.py:161-174: virtual state not matched, retry
                 if self.retraced_count < self.retrace_limit {
                     self.retraced_count += 1;
-                    if std::env::var_os("MAJIT_LOG").is_some() {
+                    if crate::majit_log_enabled() {
                         eprintln!(
                             "[jit] Retracing ({}/{})",
                             self.retraced_count, self.retrace_limit
@@ -1609,7 +1609,7 @@ impl UnrollOptimizer {
                         )
                         .is_none();
                     jumped = if let Some(reason) = jump_ctx.take_invalid_loop() {
-                        if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                        if crate::log_jtet_enabled() {
                             eprintln!(
                                 "[jit][jte] InvalidLoop during force_boxes=true retrace: {}",
                                 reason.0
@@ -1633,7 +1633,7 @@ impl UnrollOptimizer {
                         )
                         .is_none();
                     jumped = if let Some(reason) = jump_ctx.take_invalid_loop() {
-                        if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                        if crate::log_jtet_enabled() {
                             eprintln!(
                                 "[jit][jte] InvalidLoop during force_boxes=true limit: {}",
                                 reason.0
@@ -1677,7 +1677,7 @@ impl UnrollOptimizer {
                     // code from a previous compilation (separate function).
                     // Fall back to jump_to_preamble, matching RPython's
                     // behavior when the target isn't reachable (unroll.py:228).
-                    if std::env::var_os("MAJIT_LOG").is_some() {
+                    if crate::majit_log_enabled() {
                         eprintln!(
                             "[jit] jump_to_existing_trace: external target {:?} != body {:?}, falling back to preamble",
                             redirected_jump_descr_idx, current_body_descr_idx
@@ -1699,7 +1699,7 @@ impl UnrollOptimizer {
         if !sp.is_empty() {
             self.short_preamble = Some(sp.clone());
         }
-        if std::env::var_os("MAJIT_LOG").is_some() {
+        if crate::majit_log_enabled() {
             eprintln!(
                 "[jit] assembly_contract: label_args={:?} used_boxes={:?} jump_args={:?}",
                 label_args, sp.used_boxes, sp.jump_args
@@ -1724,7 +1724,7 @@ impl UnrollOptimizer {
                 .expect("preamble target token must exist before jump_to_preamble")
                 .clone();
             let preamble_arity = exported_renamed_inputargs.len();
-            if std::env::var_os("MAJIT_LOG").is_some() {
+            if crate::majit_log_enabled() {
                 let body_jump_arity = body_terminal_op.as_ref().map(|j| j.num_args()).unwrap_or(0);
                 eprintln!(
                     "[jit] jump_to_preamble: body_jump_args={} preamble_arity={} start_label_args={:?}",
@@ -3260,7 +3260,7 @@ impl OptUnroll {
             ) {
                 Ok(guards) => guards,
                 Err(()) => {
-                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                    if crate::log_jtet_enabled() {
                         eprintln!(
                             "[jit][jte] target_token #{tt_idx} generate_guards failed (force_boxes={force_boxes})",
                         );
@@ -3300,7 +3300,7 @@ impl OptUnroll {
                 });
                 let rd_resume_position = patch.rd_resume_position.get();
                 for mut guard_op in emitted {
-                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                    if crate::log_jtet_enabled() {
                         let arg_values: Vec<_> = guard_op
                             .getarglist()
                             .iter()
@@ -3357,7 +3357,7 @@ impl OptUnroll {
             ) {
                 Ok(result) => result,
                 Err(()) => {
-                    if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                    if crate::log_jtet_enabled() {
                         eprintln!(
                             "[jit][jte] target_token #{tt_idx} make_inputargs failed (force_boxes={force_boxes})",
                         );
@@ -3701,7 +3701,7 @@ impl OptUnroll {
         loop {
             fixpoint_iter += 1;
             if fixpoint_iter > 20 {
-                if std::env::var_os("MAJIT_LOG").is_some() {
+                if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit][inline_short_preamble] fixpoint loop exceeded 20 iterations, breaking"
                     );
@@ -5085,7 +5085,7 @@ fn assemble_peeled_trace_with_jump_args(
             } else {
                 label_args.len()
             };
-            if std::env::var_os("MAJIT_LOG").is_some() {
+            if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit] assemble_jump: inner_label={:?} original_args={:?} mapped_base_args={:?} label_args={:?} filtered_extra_jump_args={:?}",
                     current_inner_label_index,

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -1053,7 +1053,7 @@ impl VirtualState {
                     (node.info.info_type(), ctx.opref_type(resolved_for_store))
                 {
                     if expected != actual {
-                        if std::env::var_os("MAJIT_LOG").is_some() {
+                        if crate::majit_log_enabled() {
                             eprintln!(
                                 "[label-type-mismatch] slot={} expected={:?} actual={:?} \
                                  source={:?} resolved={:?}",
@@ -1237,7 +1237,7 @@ impl VirtualState {
                 runtime_box,
                 &mut state,
             ) {
-                if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                if crate::log_jtet_enabled() {
                     let runtime_value = runtime_box.and_then(|rb| {
                         state
                             .ctx
@@ -1333,7 +1333,7 @@ impl VirtualState {
             Some(prev) if prev != inc_pos => {
                 state.bad.insert(expected as *const _);
                 state.bad.insert(incoming as *const _);
-                if std::env::var_os("MAJIT_LOG_JTET").is_some() {
+                if crate::log_jtet_enabled() {
                     eprintln!(
                         "[jit][jte] renum alias mismatch arg_idx={arg_idx} expected.position={exp_pos} \
                          prior_incoming={prev} current_incoming={inc_pos}"

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5189,7 +5189,10 @@ impl<M: Clone> MetaInterp<M> {
         let num_ops_before = trace.ops.len();
         let num_trace_inputargs = trace.inputargs.len();
         if crate::majit_log_enabled() {
-            eprintln!("[jit-diag] entering optimizer: {} ops, {} inputargs", num_ops_before, num_trace_inputargs);
+            eprintln!(
+                "[jit-diag] entering optimizer: {} ops, {} inputargs",
+                num_ops_before, num_trace_inputargs
+            );
         }
 
         // Save trace_ops + constants snapshot for potential unroll-free retry

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -771,7 +771,7 @@ fn normalize_root_loop_entry_contract(
         return Err((0, jump_arg_count));
     }
     if jump_targets_current_loop && label_arg_count != jump_arg_count {
-        if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+        if crate::closedbg_enabled() {
             eprintln!(
                 "@@@CONTRACT label({label_arg_count})={:?}",
                 label_op.map(|op| op.getarglist())
@@ -2802,14 +2802,7 @@ impl<M: Clone> MetaInterp<M> {
             .driver_descriptor()
             .map(|driver| driver.num_greens())
             .unwrap_or(0);
-        let use_original_boxes = descriptor_num_greens > 0
-            && match std::env::var_os("PYRE_ORIGINAL_BOXES") {
-                Some(v) => {
-                    let v = v.to_string_lossy();
-                    v != "0" && !v.eq_ignore_ascii_case("false")
-                }
-                None => true,
-            };
+        let use_original_boxes = descriptor_num_greens > 0 && crate::original_boxes_enabled();
         let num_green_args = if use_original_boxes {
             descriptor_num_greens
         } else {
@@ -5064,7 +5057,7 @@ impl<M: Clone> MetaInterp<M> {
                 );
             }
             self.warm_state.abort_tracing(green_key, true);
-            if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+            if crate::closedbg_enabled() {
                 eprintln!("@@@CANCEL-SITE line={}", line!());
             }
             return CompileOutcome::Cancelled;
@@ -5205,7 +5198,7 @@ impl<M: Clone> MetaInterp<M> {
         // simple-loop compilation path (compile.py:251 compile_simple_loop)
         // without preamble peeling, useful for diagnostics and to isolate
         // unroller-related regressions.
-        let no_unroll = std::env::var_os("PYRE_NO_UNROLL").is_some();
+        let no_unroll = crate::no_unroll_enabled();
 
         // Use UnrollOptimizer for preamble peeling when available.
         // compile.py: compile_loop → PreambleCompileData + LoopCompileData.
@@ -5347,7 +5340,7 @@ impl<M: Clone> MetaInterp<M> {
                         // abort_tracing — TRACING flag must stay active.
                         if !self.cancelled_too_many_times() {
                             self.exported_state = None;
-                            if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                            if crate::closedbg_enabled() {
                                 eprintln!("@@@CANCEL-SITE line={}", line!());
                             }
                             return CompileOutcome::Cancelled;
@@ -5545,7 +5538,7 @@ impl<M: Clone> MetaInterp<M> {
                         );
                     }
                     self.cancel_count += 1;
-                    if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                    if crate::closedbg_enabled() {
                         eprintln!("@@@CANCEL-SITE line={}", line!());
                     }
                     return CompileOutcome::Cancelled;
@@ -5588,7 +5581,7 @@ impl<M: Clone> MetaInterp<M> {
                     );
                 }
                 self.cancel_count += 1;
-                if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
                 return CompileOutcome::Cancelled;
@@ -5636,14 +5629,14 @@ impl<M: Clone> MetaInterp<M> {
         }
         let mut compiled_ops =
             compile::normalize_closing_jump_args(optimized_ops, &constants, final_num_inputs);
-        if crate::majit_log_enabled() || std::env::var_os("MAJIT_DIAG").is_some() {
+        if crate::majit_log_enabled() || crate::diag_enabled() {
             eprintln!(
                 "[jit] compiled loop: {} ops before opt -> {} ops after opt ({:.1}% reduction)",
                 num_ops_before,
                 compiled_ops.len(),
                 (1.0 - compiled_ops.len() as f64 / num_ops_before as f64) * 100.0
             );
-            if std::env::var_os("MAJIT_DIAG").is_some() {
+            if crate::diag_enabled() {
                 let mut counts: std::collections::HashMap<majit_ir::OpCode, usize> =
                     std::collections::HashMap::new();
                 for op in &compiled_ops {
@@ -5860,7 +5853,7 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 self.warm_state.abort_tracing(green_key, !is_invalid_loop);
                 self.cancel_count += 1;
-                if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
                 return CompileOutcome::Cancelled;
@@ -5966,7 +5959,7 @@ impl<M: Clone> MetaInterp<M> {
                         &format!("compiled_loops.insert green_key={green_key}"),
                     );
                 }
-                if std::env::var_os("MAJIT_SPDIAG").is_some() {
+                if crate::jitdriver::spdiag_enabled() {
                     eprintln!("@@@SPDIAG compiled_loops.insert green_key={green_key}");
                 }
                 token.set_retraced_count(final_retraced_count);
@@ -6029,7 +6022,7 @@ impl<M: Clone> MetaInterp<M> {
                 self.cancel_count += 1;
                 // pyjitpl.py:3025: self.exported_state = None
                 self.exported_state = None;
-                if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
                 return CompileOutcome::Cancelled;
@@ -6213,7 +6206,7 @@ impl<M: Clone> MetaInterp<M> {
                         green_key, bridge_origin
                     );
                 }
-                if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                if crate::closedbg_enabled() {
                     eprintln!("@@@CANCEL-SITE line={}", line!());
                 }
                 return CompileOutcome::Cancelled;
@@ -6323,7 +6316,7 @@ impl<M: Clone> MetaInterp<M> {
                 // (populated by `start_retrace_from_guard`).  No
                 // `(trace_id, fail_index)` reverse lookup.
                 if !self.compiled_loops.contains_key(&origin_key) {
-                    if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                    if crate::closedbg_enabled() {
                         eprintln!("@@@CANCEL-SITE line={}", line!());
                     }
                     return CompileOutcome::Cancelled;
@@ -6363,7 +6356,7 @@ impl<M: Clone> MetaInterp<M> {
                 // compile a fresh entry bridge and attach it to the
                 // original interpreter green key.
                 let Some((original_green_key, entry_meta)) = entry_bridge else {
-                    if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                    if crate::closedbg_enabled() {
                         eprintln!("@@@CANCEL-SITE line={}", line!());
                     }
                     return CompileOutcome::Cancelled;
@@ -6866,7 +6859,7 @@ impl<M: Clone> MetaInterp<M> {
                         &format!("compiled_loops.insert green_key={green_key}"),
                     );
                 }
-                if std::env::var_os("MAJIT_SPDIAG").is_some() {
+                if crate::jitdriver::spdiag_enabled() {
                     eprintln!(
                         "@@@SPDIAG FINISH-compile compiled_loops.insert green_key={green_key}"
                     );

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5168,17 +5168,41 @@ impl<M: Clone> MetaInterp<M> {
             .map(|rc| (**rc).clone())
             .collect();
         if crate::majit_log_enabled() {
-            eprintln!("--- trace (before opt) ---");
-            eprint!("{}", majit_ir::format_trace(&trace_ops, &constants));
+            eprintln!("--- trace (before opt) --- [{} ops]", trace_ops.len());
+            if trace_ops.len() <= 10000 {
+                eprint!("{}", majit_ir::format_trace(&trace_ops, &constants));
+            } else {
+                eprintln!("  [trace too large for full dump, showing op counts]");
+                let mut counts: std::collections::HashMap<majit_ir::OpCode, usize> =
+                    std::collections::HashMap::new();
+                for op in &trace_ops {
+                    *counts.entry(op.opcode).or_insert(0) += 1;
+                }
+                let mut sorted: Vec<_> = counts.into_iter().collect();
+                sorted.sort_by(|a, b| b.1.cmp(&a.1));
+                for (opcode, count) in sorted.iter().take(15) {
+                    eprintln!("  {:?}: {}", opcode, count);
+                }
+            }
         }
 
         let num_ops_before = trace.ops.len();
         let num_trace_inputargs = trace.inputargs.len();
+        if crate::majit_log_enabled() {
+            eprintln!("[jit-diag] entering optimizer: {} ops, {} inputargs", num_ops_before, num_trace_inputargs);
+        }
 
         // Save trace_ops + constants snapshot for potential unroll-free retry
         // (pyjitpl.py:3016-3021).
         let trace_ops_snapshot = trace_ops.clone();
         let constants_snapshot = constants.clone();
+
+        // PyPy: pyjitpl.py:3016-3017 `can_use_unroll = cpu.supports_guard_gc_type
+        // and 'unroll' in warmstate.enable_opts`. PYRE_NO_UNROLL forces the
+        // simple-loop compilation path (compile.py:251 compile_simple_loop)
+        // without preamble peeling, useful for diagnostics and to isolate
+        // unroller-related regressions.
+        let no_unroll = std::env::var_os("PYRE_NO_UNROLL").is_some();
 
         // Use UnrollOptimizer for preamble peeling when available.
         // compile.py: compile_loop → PreambleCompileData + LoopCompileData.
@@ -5275,13 +5299,23 @@ impl<M: Clone> MetaInterp<M> {
             Vec<majit_ir::OpRc>,
             crate::optimizeopt::unroll::ExportedState,
         )> = None;
-        let optimize_result = unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
-            &trace_ops,
-            &mut constants,
-            num_trace_inputargs,
-            vable_config.clone(),
-            Some(&mut phase1_out),
-        );
+        let optimize_result = if no_unroll {
+            if crate::majit_log_enabled() {
+                eprintln!(
+                    "[jit] PYRE_NO_UNROLL: skipping unroll optimizer at key={}",
+                    green_key,
+                );
+            }
+            Err(crate::optimize::InvalidLoop("PYRE_NO_UNROLL"))
+        } else {
+            unroll_opt.optimize_trace_with_constants_and_inputs_vable_out(
+                &trace_ops,
+                &mut constants,
+                num_trace_inputargs,
+                vable_config.clone(),
+                Some(&mut phase1_out),
+            )
+        };
         let mut retried_without_unroll = false;
         let (optimized_ops, final_num_inputs) = match optimize_result {
             Ok(result) => result,
@@ -5299,17 +5333,22 @@ impl<M: Clone> MetaInterp<M> {
                             green_key, reason,
                         );
                     }
-                    self.cancel_count += 1;
-                    // pyjitpl.py:3018-3029: RPython increments cancel_count
-                    // and falls through (tracing continues). compile_loop is
-                    // re-invoked on the next reached_loop_header. Do NOT call
-                    // abort_tracing — TRACING flag must stay active.
-                    if !self.cancelled_too_many_times() {
-                        self.exported_state = None;
-                        if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
-                            eprintln!("@@@CANCEL-SITE line={}", line!());
+                    // When PYRE_NO_UNROLL is set, the InvalidLoop is synthetic
+                    // — skip the cancel_count gate and go straight to the
+                    // simple-loop retry path.
+                    if !no_unroll {
+                        self.cancel_count += 1;
+                        // pyjitpl.py:3018-3029: RPython increments cancel_count
+                        // and falls through (tracing continues). compile_loop is
+                        // re-invoked on the next reached_loop_header. Do NOT call
+                        // abort_tracing — TRACING flag must stay active.
+                        if !self.cancelled_too_many_times() {
+                            self.exported_state = None;
+                            if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                                eprintln!("@@@CANCEL-SITE line={}", line!());
+                            }
+                            return CompileOutcome::Cancelled;
                         }
-                        return CompileOutcome::Cancelled;
                     }
                     {
                         // The retry MOVES the original snapshot maps into
@@ -5594,18 +5633,40 @@ impl<M: Clone> MetaInterp<M> {
         }
         let mut compiled_ops =
             compile::normalize_closing_jump_args(optimized_ops, &constants, final_num_inputs);
-        if crate::majit_log_enabled() {
+        if crate::majit_log_enabled() || std::env::var_os("MAJIT_DIAG").is_some() {
             eprintln!(
-                "[jit] normalize_closing_jump_args done, {} ops",
-                compiled_ops.len()
+                "[jit] compiled loop: {} ops before opt -> {} ops after opt ({:.1}% reduction)",
+                num_ops_before,
+                compiled_ops.len(),
+                (1.0 - compiled_ops.len() as f64 / num_ops_before as f64) * 100.0
             );
+            if std::env::var_os("MAJIT_DIAG").is_some() {
+                let mut counts: std::collections::HashMap<majit_ir::OpCode, usize> =
+                    std::collections::HashMap::new();
+                for op in &compiled_ops {
+                    *counts.entry(op.opcode).or_insert(0) += 1;
+                }
+                let mut sorted: Vec<_> = counts.into_iter().collect();
+                sorted.sort_by(|a, b| b.1.cmp(&a.1));
+                eprintln!("[jit] after-opt op breakdown:");
+                for (opcode, count) in &sorted {
+                    eprintln!("  {:?}: {}", opcode, count);
+                }
+            }
         }
 
         if crate::debug::have_debug_prints() {
             let _s = crate::debug::scope("jit-log-opt-loop");
-            crate::debug::debug_print("--- trace (after opt) ---");
-            for line in majit_ir::format_trace(&compiled_ops, &constants).lines() {
-                crate::debug::debug_print(line);
+            crate::debug::debug_print(&format!(
+                "--- trace (after opt) --- [{} ops]",
+                compiled_ops.len()
+            ));
+            if compiled_ops.len() <= 10000 {
+                for line in majit_ir::format_trace(&compiled_ops, &constants).lines() {
+                    crate::debug::debug_print(line);
+                }
+            } else {
+                crate::debug::debug_print("[trace too large for full dump]");
             }
             for op in &compiled_ops {
                 if op.opcode == majit_ir::OpCode::GuardNotInvalidated {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -966,7 +966,7 @@ where
             // inline callee frame.  State-field JIT still needs to
             // materialize `__JitSym` scalars into an MIFrame register bank,
             // but the only orthodox destination is the root/portal frame.
-            if std::env::var_os("MAJIT_BH_DEBUG").is_some() {
+            if crate::bh_debug_enabled() {
                 eprintln!(
                     "[rec-guard] resume_pc={} frames={} root_i0_reg={:?} root_i0_val={:?}",
                     resume_pc,
@@ -1773,14 +1773,8 @@ where
         //     a non-productive spin never does).  Catches the cycle early.
         //   * `step_limit` — absolute cap for any other runaway.
         // `MAJIT_STALL_WINDOW` / `MAJIT_STEP_LIMIT` override for diagnosis.
-        let stall_window: u64 = std::env::var("MAJIT_STALL_WINDOW")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(1_000_000);
-        let step_limit: u64 = std::env::var("MAJIT_STEP_LIMIT")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(8_000_000);
+        let stall_window: u64 = crate::stall_window();
+        let step_limit: u64 = crate::step_limit();
         let mut step_count: u64 = 0;
         let mut last_num_ops = ctx.num_recorded_ops();
         let mut steps_since_growth: u64 = 0;
@@ -1834,7 +1828,7 @@ where
                 }
             };
             if !matches!(action, TraceAction::Continue) {
-                if std::env::var_os("MAJIT_TLDBG").is_some() {
+                if crate::tldbg_enabled() {
                     eprintln!(
                         "@@@TLDBG run_to_end end action={:?} step_count={} num_recorded_ops={} trace_limit={}",
                         action,
@@ -2547,7 +2541,7 @@ where
                 } else {
                     0
                 };
-                if !is_ref && ctx.is_bridge_trace && std::env::var_os("MAJIT_HEAPDBG").is_some() {
+                if !is_ref && ctx.is_bridge_trace && crate::heapdbg_enabled() {
                     use std::sync::atomic::{AtomicU64, Ordering};
                     static N: AtomicU64 = AtomicU64::new(0);
                     let n = N.fetch_add(1, Ordering::Relaxed);
@@ -3777,7 +3771,7 @@ where
                 // seen_loop_header like MAJIT_MPTRACE). Confirms the walk holds a
                 // concrete per-opcode next-pc = mp_green_pc, the walker-drives-pc
                 // data source for the per-opcode single-executor.
-                if std::env::var_os("MAJIT_PCSEQ").is_some() {
+                if crate::pcseq_enabled() {
                     let sf: Vec<Option<i64>> = (0..3).map(|i| sym.state_field_value(i)).collect();
                     eprintln!(
                         "@@@PCSEQ mp pc={mp_green_pc:?} greens={mp_green_ints:?} refs={mp_green_refs:?} floats={mp_green_floats:?} hdr={:?} sf={sf:?} num_ops={} seen_lh={}",
@@ -3932,7 +3926,7 @@ where
                         true
                     };
                     let header_matches = pc_matches && same_greenkey;
-                    if std::env::var_os("MAJIT_MPTRACE").is_some() {
+                    if crate::mptrace_enabled() {
                         eprintln!(
                             "@@@MPTRACE visit pc={mp_green_pc:?} header_pc={} close_target={close_target_pc} matches={header_matches} num_ops={}",
                             ctx.header_pc,
@@ -3940,7 +3934,7 @@ where
                         );
                     }
                     if header_matches {
-                        if std::env::var_os("MAJIT_SPDIAG").is_some() {
+                        if crate::jitdriver::spdiag_enabled() {
                             eprintln!(
                                 "@@@SPDIAG HEADER-CLOSE close_target_pc={close_target_pc} mp_green_pc={mp_green_pc:?} walk_reds={walk_reds:?}"
                             );
@@ -4004,12 +3998,12 @@ where
                             let inner_key =
                                 crate::green_key_from_code_ptr(ctx.green_key_raw.0, pc as usize);
                             if ctx.has_merge_point_at(inner_key, header_pc) {
-                                if std::env::var_os("MAJIT_SPDIAG").is_some() {
+                                if crate::jitdriver::spdiag_enabled() {
                                     eprintln!(
                                         "@@@SPDIAG INNER-CUT-CLOSE pc={pc} header_pc={header_pc} inner_key={inner_key} walk_reds={walk_reds:?}"
                                     );
                                 }
-                                if std::env::var_os("MAJIT_CLOSEDBG").is_some() {
+                                if crate::closedbg_enabled() {
                                     let mut i = 0;
                                     while let Some(o) = sym.state_field_ref(i) {
                                         eprintln!("@@@RED int[{i}]={o:?}");
@@ -4078,7 +4072,7 @@ where
                             } else {
                                 red_boxes
                             };
-                            if std::env::var_os("MAJIT_MPTRACE").is_some() {
+                            if crate::mptrace_enabled() {
                                 eprintln!(
                                     "@@@MPTRACE add-mp pc={pc} header_pc={header_pc} inner_key={inner_key} num_ops={}",
                                     ctx.num_ops(),

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -6658,7 +6658,7 @@ impl<'a> ResumeDataDirectReader<'a> {
         // jitcode.py:152
         let mut offset = info + 3;
 
-        let bh_debug = std::env::var_os("MAJIT_BH_DEBUG").is_some();
+        let bh_debug = crate::bh_debug_enabled();
         if bh_debug {
             eprintln!(
                 "[bh-section] info={info} length_i={length_i} length_r={length_r} length_f={length_f} \
@@ -7176,7 +7176,7 @@ pub fn read_frame_liveness_reg_indices(
 ) -> FrameLivenessRegIndices {
     use majit_translate::liveness::LivenessIterator;
     if !jitcode.can_decode_live_vars(pc, op_live) {
-        if std::env::var_os("MAJIT_BRIDGE_DEBUG").is_some() {
+        if crate::bridge_debug_enabled() {
             eprintln!(
                 "[bridgeB] read_frame_liveness_reg_indices: no liveness startpoint at pc={pc} op_live={op_live} — declining (empty banks)"
             );
@@ -7185,7 +7185,7 @@ pub fn read_frame_liveness_reg_indices(
     }
     let info = jitcode.get_live_vars_info(pc, op_live);
     if info + 2 >= all_liveness.len() {
-        if std::env::var_os("MAJIT_BRIDGE_DEBUG").is_some() {
+        if crate::bridge_debug_enabled() {
             eprintln!(
                 "[bridgeB] read_frame_liveness_reg_indices: liveness info {info} out of range (len={}) at pc={pc} — declining (empty banks)",
                 all_liveness.len()
@@ -7340,7 +7340,7 @@ pub fn blackhole_from_resumedata<'a>(
         // `#124`: pass the carried direct JitCode pc so the resolver can
         // prefer it over the lossy `pc_map` translation.
         let resolved = resolve_jitcode(jitcode_pos, pc, jitcode_pc)?;
-        if std::env::var_os("MAJIT_BH_DEBUG").is_some() {
+        if crate::bh_debug_enabled() {
             eprintln!(
                 "[bh-frame] jitcode_pos={jitcode_pos} encoded_pc={pc} resolved_pc={}",
                 resolved.pc

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -37,6 +37,7 @@ mod local_crates;
 pub mod model;
 pub mod model_ssa;
 pub mod opcode_dispatch;
+mod local_crates;
 mod parse;
 pub mod pipeline;
 #[cfg(test)]
@@ -154,7 +155,7 @@ fn build_semantic_program_via_active_frontend(
             // Seed the local-crate alias roots from the loaded set so
             // `free_function_alias_paths` and the registry's canonical
             // dedup treat every extracted crate name as an alias root
-            // (`local_crates.rs`); non-pyre consumer crates resolve
+            // (`local_crates.rs`); non-pyre consumers (aheui) resolve
             // their crate-qualified cross-crate callsites through this.
             crate::local_crates::register_local_crate_roots(
                 llbcs.iter().map(|l| l.crate_name().to_string()),

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -37,7 +37,6 @@ mod local_crates;
 pub mod model;
 pub mod model_ssa;
 pub mod opcode_dispatch;
-mod local_crates;
 mod parse;
 pub mod pipeline;
 #[cfg(test)]

--- a/majit/majit-translate/src/local_crates.rs
+++ b/majit/majit-translate/src/local_crates.rs
@@ -5,7 +5,7 @@
 //! identity, so a callable has one identity regardless of the import
 //! spelling. pyre resolves symbolic paths extracted from LLBC, where a
 //! cross-crate callsite spells the callee with its crate name
-//! (`myinterp::io::output_flush`) while the graph registers under
+//! (`aheui_runtime::io::output_flush`) while the graph registers under
 //! module-relative spellings — so every *local* (LLBC-extracted) crate
 //! name must be an alias root on both the registration side
 //! (`free_function_alias_paths`) and the canonical-dedup side
@@ -16,43 +16,25 @@
 //! included so fixtures that build programs without the active frontend
 //! (and the pyre production set itself) keep their spellings unchanged.
 
-use std::cell::RefCell;
+use std::sync::RwLock;
 
 const DEFAULT_ROOTS: [&str; 3] = ["pyre_interpreter", "pyre_object", "pyre_jit"];
 
-thread_local! {
-    /// Per-pipeline-invocation local-crate alias roots, seeded once at the
-    /// top of `build_semantic_program_via_active_frontend` and read back at
-    /// the alias / dedup / tie-break sites during the SAME invocation.
-    ///
-    /// Thread-local, not a process-global `RwLock`: a translate pipeline
-    /// runs start-to-finish on one thread (there is no `par_iter` inside it),
-    /// and `generated::all_jitcodes` already scopes the whole per-thread
-    /// pipeline registry with a `thread_local!` `OnceCell` to preserve
-    /// RPython's single-thread annotator invariant. A shared `RwLock` let a
-    /// second pipeline on another thread (parallel `cargo test`, or any
-    /// future parallel translate) overwrite this run's roots between its own
-    /// seed and read, flaking alias resolution. The roots belong to one
-    /// invocation, so scoping them to the invocation's thread is exact — the
-    /// same TLS adaptation of a PyPy GIL-singleton as
-    /// `jitdriver.rs::BACK_EDGE_BH_BUILDER`. (The translate pipeline is a
-    /// build-time / test-fixture code generator, not a runtime path — the
-    /// pyre VM never touches these roots — so no cross-thread reader exists.)
-    static REGISTERED: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
-}
+static REGISTERED: RwLock<Vec<String>> = RwLock::new(Vec::new());
 
-/// Replace this thread's registered local-crate set with one pipeline
-/// invocation's LLBC crate names. A later invocation on the same thread
-/// overwrites (per-invocation semantics, like the `STRUCT_ORIGIN_REGISTRY`
-/// re-seed).
+/// Replace the registered local-crate set with one pipeline
+/// invocation's LLBC crate names. A later invocation in the same
+/// process overwrites (per-invocation semantics, like the
+/// `STRUCT_ORIGIN_REGISTRY` re-seed).
 pub(crate) fn register_local_crate_roots(names: impl IntoIterator<Item = String>) {
-    REGISTERED.with(|registered| *registered.borrow_mut() = names.into_iter().collect());
+    let mut registered = REGISTERED.write().unwrap();
+    *registered = names.into_iter().collect();
 }
 
 /// Registered local crate names plus the always-included pyre trio,
 /// registered names first.
 pub(crate) fn local_crate_roots() -> Vec<String> {
-    let mut roots: Vec<String> = REGISTERED.with(|registered| registered.borrow().clone());
+    let mut roots: Vec<String> = REGISTERED.read().unwrap().clone();
     for default in DEFAULT_ROOTS {
         if !roots.iter().any(|r| r == default) {
             roots.push(default.to_string());
@@ -62,6 +44,5 @@ pub(crate) fn local_crate_roots() -> Vec<String> {
 }
 
 pub(crate) fn is_local_crate_root(seg: &str) -> bool {
-    DEFAULT_ROOTS.contains(&seg)
-        || REGISTERED.with(|registered| registered.borrow().iter().any(|r| r == seg))
+    DEFAULT_ROOTS.contains(&seg) || REGISTERED.read().unwrap().iter().any(|r| r == seg)
 }

--- a/majit/majit-translate/src/local_crates.rs
+++ b/majit/majit-translate/src/local_crates.rs
@@ -16,25 +16,41 @@
 //! included so fixtures that build programs without the active frontend
 //! (and the pyre production set itself) keep their spellings unchanged.
 
-use std::sync::RwLock;
+use std::cell::RefCell;
 
 const DEFAULT_ROOTS: [&str; 3] = ["pyre_interpreter", "pyre_object", "pyre_jit"];
 
-static REGISTERED: RwLock<Vec<String>> = RwLock::new(Vec::new());
+thread_local! {
+    /// Per-pipeline-invocation local-crate alias roots, seeded once at the
+    /// top of `build_semantic_program_via_active_frontend` and read back at
+    /// the alias / dedup / tie-break sites during the SAME invocation.
+    ///
+    /// Thread-local, not a process-global `RwLock`: a translate pipeline
+    /// runs start-to-finish on one thread (there is no `par_iter` inside it),
+    /// and `generated::all_jitcodes` already scopes the whole per-thread
+    /// pipeline registry with a `thread_local!` `OnceCell` to preserve
+    /// RPython's single-thread annotator invariant. A shared `RwLock` let a
+    /// second pipeline on another thread (parallel `cargo test`, or any
+    /// future parallel translate) overwrite this run's roots between its own
+    /// seed and read, flaking alias resolution. The roots belong to one
+    /// invocation, so scoping them to the invocation's thread is exact — the
+    /// same TLS adaptation of a PyPy GIL-singleton as
+    /// `jitdriver.rs::BACK_EDGE_BH_BUILDER`.
+    static REGISTERED: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
 
-/// Replace the registered local-crate set with one pipeline
-/// invocation's LLBC crate names. A later invocation in the same
-/// process overwrites (per-invocation semantics, like the
-/// `STRUCT_ORIGIN_REGISTRY` re-seed).
+/// Replace this thread's registered local-crate set with one pipeline
+/// invocation's LLBC crate names. A later invocation on the same thread
+/// overwrites (per-invocation semantics, like the `STRUCT_ORIGIN_REGISTRY`
+/// re-seed).
 pub(crate) fn register_local_crate_roots(names: impl IntoIterator<Item = String>) {
-    let mut registered = REGISTERED.write().unwrap();
-    *registered = names.into_iter().collect();
+    REGISTERED.with(|registered| *registered.borrow_mut() = names.into_iter().collect());
 }
 
 /// Registered local crate names plus the always-included pyre trio,
 /// registered names first.
 pub(crate) fn local_crate_roots() -> Vec<String> {
-    let mut roots: Vec<String> = REGISTERED.read().unwrap().clone();
+    let mut roots: Vec<String> = REGISTERED.with(|registered| registered.borrow().clone());
     for default in DEFAULT_ROOTS {
         if !roots.iter().any(|r| r == default) {
             roots.push(default.to_string());
@@ -44,5 +60,6 @@ pub(crate) fn local_crate_roots() -> Vec<String> {
 }
 
 pub(crate) fn is_local_crate_root(seg: &str) -> bool {
-    DEFAULT_ROOTS.contains(&seg) || REGISTERED.read().unwrap().iter().any(|r| r == seg)
+    DEFAULT_ROOTS.contains(&seg)
+        || REGISTERED.with(|registered| registered.borrow().iter().any(|r| r == seg))
 }

--- a/majit/majit-translate/tests/test_aheui_census.rs
+++ b/majit/majit-translate/tests/test_aheui_census.rs
@@ -1,0 +1,211 @@
+//! M0 instrumentation for the aheui rtyper-penetration epic.
+//!
+//! Runs the production analyze pipeline (`analyze_multiple_pipeline_with_modules`)
+//! over the Charon-extracted aheui LLBC set (`build/llbc/aheui-runtime.ullbc`
+//! + `build/llbc/aheuinterpreter.ullbc`, produced by
+//! `scripts/extract-llbc.py aheui-runtime aheuinterpreter`) with the portal
+//! bound to `aheuinterpreter::interp::mainloop`, and surfaces the two-phase
+//! prepass census dispositions for the mainloop closure (`val_*`,
+//! `Storage`, …).
+//!
+//! This is a measurement, not an acceptance gate: it prints what the
+//! pipeline can and cannot digest today. Run as
+//!
+//! ```sh
+//! PYRE_RTYPER_VERBOSE=1 cargo test --release -p majit-translate \
+//!     --test test_aheui_census -- --ignored --nocapture
+//! ```
+
+use majit_translate::{AnalyzeConfig, HostStaticAddrs, PipelineConfig, PortalSpec};
+
+/// Resolve the named aheui LLBC artefacts and export `PYRE_MIR_FRONTEND_LLBC`.
+/// Returns `false` (skip cleanly) when any is absent. Tests sharing this
+/// process each re-export the var for their own artefact set; run with
+/// `--test-threads=1`.
+fn ensure_aheui_llbc_env(required: &[&str]) -> bool {
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..");
+    let llbc_dir = workspace_root.join("build").join("llbc");
+    let mut paths = Vec::with_capacity(required.len());
+    for name in required {
+        let p = llbc_dir.join(name);
+        if !p.exists() {
+            return false;
+        }
+        paths.push(p.to_string_lossy().into_owned());
+    }
+    let joined = std::env::join_paths(&paths).expect("join llbc paths");
+    // SAFETY: serialized test binary; set before any worker spawns.
+    unsafe { std::env::set_var("PYRE_MIR_FRONTEND_LLBC", joined) };
+    true
+}
+
+/// Census the `val_*` helper subtree directly. The `mainloop` BFS closure
+/// (`aheui_census_m0`) is currently truncated before reaching `val_add`
+/// (call-target resolution fails at `dispatch_mut`/`LinkedList` level), so
+/// this second probe seeds the BFS from `val_add` itself to measure the
+/// arithmetic helpers' own phaseA/phaseB disposition.
+///
+/// Process-global registries (`STRUCT_ORIGIN_REGISTRY`, …) are re-seeded by
+/// each pipeline invocation; run serialized (`--test-threads=1`) to keep the
+/// two probes from racing on them.
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "release-only: runs full LLBC translation; use `cargo test --release --test test_aheui_census`"
+)]
+fn aheui_census_m0_val_helpers() {
+    if !ensure_aheui_llbc_env(&["aheui-runtime.ullbc", "aheuinterpreter.ullbc"]) {
+        eprintln!(
+            "skipping: build/llbc/{{aheui-runtime,aheuinterpreter}}.ullbc missing — \
+             run `scripts/extract-llbc.py aheui-runtime aheuinterpreter`"
+        );
+        return;
+    }
+    run_census_with_portal(val_add_portal());
+}
+
+/// Same probe against the smallint build (`Val = i64`,
+/// `val_add = wrapping_add`) — the rpaheui-smallint-parity mode M1 targets.
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "release-only: runs full LLBC translation; use `cargo test --release --test test_aheui_census`"
+)]
+fn aheui_census_m0_val_helpers_smallint() {
+    if !ensure_aheui_llbc_env(&["aheui-runtime-smallint.ullbc"]) {
+        eprintln!(
+            "skipping: build/llbc/aheui-runtime-smallint.ullbc missing — \
+             run `scripts/extract-llbc.py aheui-runtime-smallint`"
+        );
+        return;
+    }
+    run_census_with_portal(val_add_portal());
+}
+
+fn val_add_portal() -> PortalSpec {
+    PortalSpec {
+        name: "val_add".to_string(),
+        greens: Vec::new(),
+        reds: Vec::new(),
+        virtualizables: Vec::new(),
+        red_types: Vec::new(),
+    }
+}
+
+fn run_census_with_portal(portal: PortalSpec) {
+    let config = AnalyzeConfig {
+        pipeline: PipelineConfig {
+            portal: Some(portal),
+            ..Default::default()
+        },
+    };
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        majit_translate::analyze_multiple_pipeline_with_modules(
+            &[],
+            &config,
+            None,
+            &|_, _| None,
+            &[],
+            HostStaticAddrs::default(),
+        )
+    }));
+    match outcome {
+        Ok(result) => {
+            eprintln!("=== aheui census: pipeline completed ===");
+            eprintln!("jitcodes emitted: {}", result.jitcodes.len());
+            let mut names: Vec<String> = result
+                .jitcodes_by_path
+                .keys()
+                .map(|k| k.canonical_key())
+                .collect();
+            names.sort_unstable();
+            eprintln!("jitcode paths: {names:#?}");
+            let mut insns: Vec<&String> = result.insns.keys().collect();
+            insns.sort_unstable();
+            eprintln!("insn vocabulary: {insns:?}");
+        }
+        Err(err) => {
+            let msg = err
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| err.downcast_ref::<&str>().copied())
+                .unwrap_or("<non-string panic>");
+            eprintln!("=== aheui census: pipeline panicked after census ===");
+            eprintln!("panic: {msg}");
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "release-only: runs full LLBC translation; use `cargo test --release --test test_aheui_census`"
+)]
+fn aheui_census_m0() {
+    if !ensure_aheui_llbc_env(&["aheui-runtime.ullbc", "aheuinterpreter.ullbc"]) {
+        eprintln!(
+            "skipping: build/llbc/{{aheui-runtime,aheuinterpreter}}.ullbc missing — \
+             run `scripts/extract-llbc.py aheui-runtime aheuinterpreter`"
+        );
+        return;
+    }
+
+    let config = AnalyzeConfig {
+        pipeline: PipelineConfig {
+            // Portal + green/red layout documented in
+            // `aheui/aheuinterpreter/src/interp.rs` (mirrors
+            // rpaheui/aheui/aheui.py greens/reds).
+            portal: Some(PortalSpec {
+                name: "mainloop".to_string(),
+                greens: ["pc", "stackok", "is_queue", "program"]
+                    .map(String::from)
+                    .to_vec(),
+                reds: ["stacksize", "storage", "selected"]
+                    .map(String::from)
+                    .to_vec(),
+                virtualizables: Vec::new(),
+                red_types: Vec::new(),
+            }),
+            ..Default::default()
+        },
+    };
+
+    // The drain / jitcode-emission tail may well panic on aheui shapes the
+    // pipeline has never seen; the census histograms are printed before
+    // that point, so capture the panic and report it instead of dying.
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        majit_translate::analyze_multiple_pipeline_with_modules(
+            &[],
+            &config,
+            None,
+            &|_, _| None,
+            &[],
+            HostStaticAddrs::default(),
+        )
+    }));
+
+    match outcome {
+        Ok(result) => {
+            eprintln!("=== aheui census M0: pipeline completed ===");
+            eprintln!("jitcodes emitted: {}", result.jitcodes.len());
+            let mut names: Vec<&str> = result
+                .jitcodes_by_path
+                .keys()
+                .map(|k| k.segments.last().map(|s| s.as_str()).unwrap_or(""))
+                .collect();
+            names.sort_unstable();
+            eprintln!("jitcode leaves: {names:?}");
+        }
+        Err(err) => {
+            let msg = err
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| err.downcast_ref::<&str>().copied())
+                .unwrap_or("<non-string panic>");
+            eprintln!("=== aheui census M0: pipeline panicked after census ===");
+            eprintln!("panic: {msg}");
+        }
+    }
+}


### PR DESCRIPTION
## Changes

### majit-macros
- **`native_int_binops` config**: Pure function → native IR integer binop aliases. When the JIT-path lowerer encounters a call matching a key (e.g. `val_add`), it emits `IntAdd` directly instead of `CALL_PURE_I`. The concrete path calls the function normally. (`jtransform.py:2030 _handle_int_special()` parity)
- **`ConcreteOnlyVoid` call policy**: Calls the function on the concrete path only; the JIT-path lowerer emits no IR ops at all. For operations with no JIT-visible side effects (RPython `del` generates zero IR ops).
- **`uses_inline_pipeline()` helper + `JitCodeRuntimeExt` import** fix for InlinePipeline codegen

### majit-metainterp  
- `PYRE_NO_UNROLL` diagnostic gate
- Large-trace dump guards + `MAJIT_DIAG` env

### majit-translate
- Derive crate alias roots from loaded LLBC set
- Aheui LLBC extraction and census probes

### Status
- `native_int_binops` mechanism is complete but **blocked** by optimizer stack overflow on large traces (gh#430 — `autogenintrules` rewrite chain causes deep recursion on 70K-op traces)
- `ConcreteOnlyVoid` mechanism is complete but not usable for `jit_free_node` on aheui (aheui-rust#5 — nursery free-list requires active maintenance in compiled code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration-driven lowering for native integer binop aliases, plus a new call policy option for void-only concrete calls.
  * Extended loop-optimizer diagnostics (including before/after trace summaries) when logging is enabled.

* **Bug Fixes**
  * Improved void-call handling on the JIT path to avoid unnecessary IR generation and extra markers.
  * Refined internal debug/diagnostic gating so logging behavior is consistent and centralized.

* **Tests**
  * Added AHEUI translation census/instrumentation integration tests with safe skipping and richer output reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->