### PR TITLE
majit: #344 Phase B review follow-ups (;state CI example, GFC hoist, single-pass scalar write-back)

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -286,7 +286,7 @@ jobs:
           -p majit-metainterp -p majit-backend-cranelift \
           -p pyre-jit -p pyre-jit-trace -p pyrex -p pyre-interpreter -p majit \
           -p tlr -p tl -p tla -p tiny2 -p tiny3 -p tinyframe \
-          -p braininterp -p dualtape -p tlc -p calc -p i64env
+          -p braininterp -p dualtape -p tlc -p calc -p i64env -p spcount
         exit "$status"
 
   cargo-test-macos:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spcount"
+version = "0.0.2"
+dependencies = [
+ "majit-ir",
+ "majit-macros",
+ "majit-metainterp",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "majit/examples/tlc",
     "majit/examples/calc",
     "majit/examples/i64env",
+    "majit/examples/spcount",
     # pyre
     "pyre/pyre-object",
     "pyre/pyre-macros",

--- a/majit/examples/spcount/Cargo.toml
+++ b/majit/examples/spcount/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spcount"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[features]
+default = ["cranelift"]
+cranelift = ["majit-metainterp/cranelift"]
+dynasm = ["majit-metainterp/dynasm"]
+
+[dependencies]
+majit-ir = { workspace = true }
+majit-metainterp = { workspace = true }
+majit-macros = { workspace = true }

--- a/majit/examples/spcount/src/main.rs
+++ b/majit/examples/spcount/src/main.rs
@@ -1,0 +1,394 @@
+//! Single-pass whole-circuit-close regression example.
+//!
+//! Every other `majit/examples` interpreter uses the plain
+//! `jit_merge_point!()` marker. This one uses the `; state` selector form
+//! (`jit_merge_point!(driver, program, pc; state)`) — the single-pass
+//! whole-circuit-close path. When the walk closes a loop, the merge-point hook
+//! writes the walk-final scalar state field(s) back into native `state`,
+//! re-derives storage-backed caches via `recover` (a no-op here — no
+//! storage-derived caches), then direct-enters the compiled loop rather than
+//! replaying the walked body. That path is the sole/default trace-close path
+//! after issue #344 Phase B, yet inside this repository only aheui — a separate
+//! git repo, outside CI — exercised it. This crate closes that coverage gap.
+//!
+//! The interpreter is a minimal stack machine, structurally the tl example's
+//! virtualizable-stack shape (`state_fields = { stackpos: int, stack: [int;
+//! virt] }`): a scalar `stackpos` the loop mutates plus a loop-carried virt
+//! array. That is the shape whose single-pass close is known to converge (a
+//! scalar-only interpreter with a residual adjacent to a tight back-edge
+//! collapses its per-opcode merge points and never reaches the loop header).
+//!
+//! ## Reds regime
+//!
+//! The loop-carried reds are recovered through the state-field side channel:
+//! `stackpos` is written back by `writeback_scalar_state_fields_from_sym` and
+//! the virt `stack` lives on the heap the compiled code mutates in place. This
+//! is the EMPTY-reds case the driver publishes at CloseLoop
+//! (`single_pass_outcome = Some((pc, Vec::new()))` in `jitdriver.rs`, where the
+//! empty reds vector is documented as INTENTIONALLY empty). The macro's
+//! non-empty-reds transfer branch (`if !__sp_reds.is_empty()` — a
+//! `restore_values` into native state) therefore stays UNEXERCISED: the driver
+//! hard-codes empty reds at the close, so no example crate can drive that
+//! branch without changing the driver/macro. A genuinely register-resident,
+//! non-storage-recoverable loop-carried red is not expressible through this
+//! macro surface — every loop-carried value must land in a declared state
+//! field, which the state-field write-back (not `__sp_reds`) transfers. Adding
+//! coverage for the non-empty-reds branch is a driver/macro change, out of
+//! scope for an example crate.
+
+/// Bytecode stream. Byte-wide opcodes/operands, same shape as the tl env.
+pub type Bytecode = [u8];
+
+// ── Opcodes ──
+const PUSH: u8 = 2; // [PUSH, imm]: push a signed-byte immediate
+const POP: u8 = 3; // pop top
+const SWAP: u8 = 4; // swap the top two
+const PICK: u8 = 6; // [PICK, i]: duplicate stack[stackpos - i - 1]
+const ADD: u8 = 8; // pop a, b; push b + a
+const SUB: u8 = 9; // pop a, b; push b - a
+const BR_COND: u8 = 18; // [BR_COND, off]: pop cond; if cond != 0 jump
+const RETURN: u8 = 21; // return top
+const PUSHARG: u8 = 22; // push the input argument
+const TOUCH: u8 = 30; // residual: side-effecting, result-neutral stack touch
+
+// ── Countable side-effecting residual ──
+
+/// Number of `touch` invocations, observed by the tests. A walk-vs-native
+/// double-execution of the residual during single-pass tracing would inflate
+/// this beyond the interpreter's count.
+#[cfg(test)]
+static TOUCH_CALLS: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+
+/// Side-effecting residual, `@dont_look_inside` — the JIT does not trace into
+/// it; it emits a residual CALL. `#[dont_look_inside]` is non-elidable and may
+/// raise, so the optimizer keeps the call. It reads and rewrites the live
+/// top-of-stack through the raw stack pointer: a genuine heap side effect that
+/// forces the virtualizable stack, yet leaves every value unchanged. The
+/// computed result is therefore independent of how many times `touch` runs, so
+/// the call count alone is the double-execution detector. Modelled on tl's
+/// `storage_roll`.
+#[majit_macros::dont_look_inside]
+extern "C" fn touch(stack_ptr: usize, stackpos: i64) {
+    #[cfg(test)]
+    TOUCH_CALLS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    if stackpos > 0 {
+        let stack =
+            unsafe { std::slice::from_raw_parts_mut(stack_ptr as *mut i64, stackpos as usize) };
+        let top = stack[(stackpos - 1) as usize];
+        stack[(stackpos - 1) as usize] = top;
+    }
+}
+
+// ── State ──
+
+/// Virtualizable stack: a scalar `stackpos` plus a loop-carried virt array.
+struct StackState {
+    stackpos: i64,
+    stack: Vec<i64>,
+}
+
+// ── JIT mainloop ──
+
+#[majit_macros::jit_interp(
+    state = StackState,
+    env = Bytecode,
+    auto_calls = true,
+    greens = [pc, program],
+    state_fields = {
+        stackpos: int,
+        stack: [int; virt],
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, inputarg: i64, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<StackState> =
+        majit_metainterp::JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let stacksize: i32 = 0;
+    let mut state = StackState {
+        stackpos: 0,
+        stack: vec![0i64; program.len()],
+    };
+
+    // warmspot.py:281-289 canonical-liveness install hook.
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        // `; state` selects the single-pass close: the walk's final state is
+        // transferred into `state` here (write-back + recover) instead of being
+        // replayed. Byte-identical to `jit_merge_point!()` until the walk closes
+        // a loop.
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            PUSH => {
+                let value = program[pc] as i8 as i64;
+                pc += 1;
+                state.stack[state.stackpos as usize] = value;
+                state.stackpos = state.stackpos + 1;
+            }
+            POP => {
+                state.stackpos = state.stackpos - 1;
+            }
+            SWAP => {
+                let a = state.stack[(state.stackpos - 1) as usize];
+                let b = state.stack[(state.stackpos - 2) as usize];
+                state.stack[(state.stackpos - 1) as usize] = b;
+                state.stack[(state.stackpos - 2) as usize] = a;
+            }
+            PICK => {
+                let i = program[pc] as usize;
+                pc += 1;
+                let v = state.stack[(state.stackpos as usize) - i - 1];
+                state.stack[state.stackpos as usize] = v;
+                state.stackpos = state.stackpos + 1;
+            }
+            ADD => {
+                let a = state.stack[(state.stackpos - 1) as usize];
+                let b = state.stack[(state.stackpos - 2) as usize];
+                state.stack[(state.stackpos - 2) as usize] = b + a;
+                state.stackpos = state.stackpos - 1;
+            }
+            SUB => {
+                let a = state.stack[(state.stackpos - 1) as usize];
+                let b = state.stack[(state.stackpos - 2) as usize];
+                state.stack[(state.stackpos - 2) as usize] = b - a;
+                state.stackpos = state.stackpos - 1;
+            }
+            // Residual @dont_look_inside touch of the live stack.
+            TOUCH => {
+                touch(state.stack.as_mut_ptr() as usize, state.stackpos);
+            }
+            BR_COND => {
+                let offset = program[pc] as i8 as i64;
+                let target = ((pc as i64) + offset + 1) as usize;
+                pc += 1;
+                state.stackpos = state.stackpos - 1;
+                let jump = state.stack[state.stackpos as usize] != 0;
+                if jump {
+                    if target <= pc {
+                        can_enter_jit!(driver, target, &mut state, program, || {});
+                    }
+                    pc = target;
+                    continue;
+                }
+            }
+            RETURN => break,
+            PUSHARG => {
+                state.stack[state.stackpos as usize] = inputarg;
+                state.stackpos = state.stackpos + 1;
+            }
+            _ => {}
+        }
+    }
+
+    state.stackpos = state.stackpos - 1;
+    state.stack[state.stackpos as usize]
+}
+
+// ── Plain reference interpreter ──
+
+/// The same bytecode executed with no JIT. `TOUCH` is a result-neutral no-op
+/// here (it does not call the counted residual), so the plain result equals the
+/// JIT result and the residual count stays a pure JIT-side signal — mirroring
+/// how tl's `interp` uses an uncounted `roll`.
+pub fn interp(program: &Bytecode, inputarg: i64) -> i64 {
+    let mut pc: usize = 0;
+    let mut stack: Vec<i64> = Vec::with_capacity(program.len());
+
+    while pc < program.len() {
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            PUSH => {
+                stack.push(program[pc] as i8 as i64);
+                pc += 1;
+            }
+            POP => {
+                stack.pop();
+            }
+            SWAP => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                stack.push(a);
+                stack.push(b);
+            }
+            PICK => {
+                let i = program[pc] as usize;
+                pc += 1;
+                let n = stack.len() - i - 1;
+                let v = stack[n];
+                stack.push(v);
+            }
+            ADD => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                stack.push(b + a);
+            }
+            SUB => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                stack.push(b - a);
+            }
+            TOUCH => {}
+            BR_COND => {
+                let offset = program[pc] as i8 as i64;
+                let cond = stack.pop().unwrap();
+                if cond != 0 {
+                    pc = (pc as i64 + offset + 1) as usize;
+                } else {
+                    pc += 1;
+                }
+            }
+            RETURN => break,
+            PUSHARG => {
+                stack.push(inputarg);
+            }
+            _ => {}
+        }
+    }
+    stack.pop().unwrap()
+}
+
+/// `sum(N) = N + (N-1) + ... + 1`, a hot loop with no residual — used by the
+/// output-match / smoke tests and `main`. The result is `N*(N+1)/2`. Identical
+/// to tl's sum loop; it carries no `TOUCH` so it never perturbs the residual
+/// counter (the tests run in parallel and share `TOUCH_CALLS`).
+///
+///   0: PUSH 0            [0]           acc = 0
+///   2: PUSHARG           [0, N]        counter = N
+///   loop header @ 3:
+///   3: PICK 0            [acc, c, c]   dup counter
+///   5: BR_COND 2         [acc, c]      if c != 0 -> body @9 (pops the dup)
+///   7: POP               [acc]         c == 0: drop counter
+///   8: RETURN                          return acc
+///   body @ 9:
+///   9: SWAP              [c, acc]
+///   10: PICK 1           [c, acc, c]
+///   12: ADD              [c, acc+c]
+///   13: SWAP             [acc+c, c]
+///   14: PUSH 1 SUB       [acc, c-1]    decrement counter
+///   17: PUSH 1           [acc, c-1, 1] unconditional back-jump cond
+///   19: BR_COND 238      -> jump to loop header @3
+fn sum_program() -> Vec<u8> {
+    vec![
+        PUSH, 0,       // 0
+        PUSHARG, // 2
+        PICK, 0, // 3  (loop header)
+        BR_COND, 2,      // 5  -> body @9
+        POP,    // 7
+        RETURN, // 8
+        SWAP,   // 9
+        PICK, 1,    // 10
+        ADD,  // 12
+        SWAP, // 13
+        PUSH, 1, SUB, // 14
+        PUSH, 1, // 17
+        BR_COND, 238, // 19 offset byte @20 -> target = 20 + (-18) + 1 = 3
+    ]
+}
+
+/// The sum loop with a leading `TOUCH` residual in the body — used only by the
+/// residual-count test. `touch` fires exactly once per iteration, so the loop
+/// runs it exactly N times. The result is still `N*(N+1)/2` because `touch` is
+/// result-neutral.
+///
+///   body @ 9:
+///   9: TOUCH             [acc, c]      residual (result-neutral)
+///   10: SWAP             [c, acc]
+///   11: PICK 1           [c, acc, c]
+///   13: ADD              [c, acc+c]
+///   14: SWAP             [acc+c, c]
+///   15: PUSH 1 SUB       [acc, c-1]    decrement counter
+///   18: PUSH 1           [acc, c-1, 1] unconditional back-jump cond
+///   20: BR_COND 237      -> jump to loop header @3
+#[cfg(test)]
+fn touch_loop_program() -> Vec<u8> {
+    vec![
+        PUSH, 0,       // 0
+        PUSHARG, // 2
+        PICK, 0, // 3  (loop header)
+        BR_COND, 2,      // 5  -> body @9
+        POP,    // 7
+        RETURN, // 8
+        TOUCH,  // 9  residual
+        SWAP,   // 10
+        PICK, 1,    // 11
+        ADD,  // 13
+        SWAP, // 14
+        PUSH, 1, SUB, // 15
+        PUSH, 1, // 18
+        BR_COND, 237, // 20 offset byte @21 -> target = 21 + (-19) + 1 = 3
+    ]
+}
+
+fn main() {
+    let n: i64 = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1_000_000);
+    let program = sum_program();
+    let result = mainloop(&program, n, 3);
+    println!("sum({n}) [single-pass JIT] = {result}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::Ordering;
+
+    /// The plain interpreter and the single-pass JIT mainloop must compute the
+    /// identical result across a range of inputs (each exercises the CloseLoop
+    /// single-pass close).
+    #[test]
+    fn jit_output_matches_interp() {
+        let program = sum_program();
+        for n in [1_i64, 2, 3, 5, 10, 20, 50, 100, 200] {
+            let expected = interp(&program, n);
+            let got = mainloop(&program, n, 3);
+            assert_eq!(got, n * (n + 1) / 2, "sum({n}) closed form");
+            assert_eq!(got, expected, "JIT diverged from interp for n={n}");
+        }
+    }
+
+    /// THE regression this crate exists to catch. The residual `touch` fires
+    /// exactly once per loop iteration, and the loop runs a known number of
+    /// times. Under single-pass tracing (the walk is the sole executor) the
+    /// residual must run exactly the interpreter's count — a walk-vs-native
+    /// double-execution during the trace-then-close would inflate it.
+    #[test]
+    fn jit_residual_not_double_executed() {
+        let program = touch_loop_program();
+        let n: i64 = 50;
+
+        let expected = interp(&program, n);
+        TOUCH_CALLS.store(0, Ordering::Relaxed);
+        let got = mainloop(&program, n, 3);
+        let jit_touches = TOUCH_CALLS.load(Ordering::Relaxed);
+
+        assert_eq!(got, expected, "JIT result diverged from interp");
+        // One TOUCH per iteration; N iterations before the counter hits 0.
+        let expected_touches = n as u32;
+        assert_eq!(
+            jit_touches, expected_touches,
+            "residual touch executed {jit_touches}× but the loop runs exactly \
+             {expected_touches} iterations — a walk-vs-native double-execution \
+             during single-pass tracing would inflate this count"
+        );
+    }
+
+    /// Smoke test: a program with no back-edge never enters the JIT.
+    #[test]
+    fn jit_no_loop() {
+        let program = vec![PUSH, 42, RETURN];
+        assert_eq!(mainloop(&program, 0, 3), 42);
+    }
+}

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -868,12 +868,26 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
-    // D2 per-opcode single-executor: write each scalar state field back into
-    // native state from the walk's persistent sym (`state_field_value`), the
-    // inverse of `initialize_sym_scalar_parts`. recover runs afterwards and
-    // overwrites the storage-derived caches, so only scalars recover cannot
-    // re-derive (e.g. aheui `selected`) meaningfully carry through.
-    let writeback_scalar_parts: Vec<TokenStream> = scalars
+    // D2 per-opcode single-executor: read each scalar state field's concrete
+    // value off the walk's persistent sym in scalar index order (mirrors
+    // `state_field_value` / the `<field>_value` slots). Captured at the
+    // CloseLoop point (while the sym is still live) into
+    // `MetaInterp::single_pass_scalar_values`.
+    let collect_scalar_values_parts: Vec<TokenStream> = scalars
+        .iter()
+        .map(|(_, f)| {
+            let value_name = quote::format_ident!("{}_value", f.name);
+            quote! { values.push(sym.#value_name); }
+        })
+        .collect();
+    // D2 per-opcode single-executor: write each captured scalar state-field
+    // value back into native state, the inverse of
+    // `initialize_sym_scalar_parts`. `values[idx]` is the scalar at
+    // state-field index `idx` (the order `collect_scalar_values_parts`
+    // produced). recover runs afterwards and overwrites the storage-derived
+    // caches, so only scalars recover cannot re-derive (e.g. aheui `selected`)
+    // meaningfully carry through.
+    let writeback_from_values_parts: Vec<TokenStream> = scalars
         .iter()
         .enumerate()
         .map(|(idx, (_, f))| {
@@ -881,11 +895,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             let rust_ty = scalar_rust_type(&f.kind);
             let idx_lit = idx;
             quote! {
-                if let Some(__v) =
-                    majit_metainterp::JitCodeSym::state_field_value(sym, #idx_lit)
-                {
-                    self.#fname = __v as #rust_ty;
-                }
+                self.#fname = values[#idx_lit] as #rust_ty;
             }
         })
         .collect();
@@ -2056,8 +2066,14 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 #recover_body
             }
 
-            fn writeback_scalar_state_fields_from_sym(&mut self, sym: &Self::Sym) {
-                #(#writeback_scalar_parts)*
+            fn collect_scalar_state_field_values(sym: &Self::Sym) -> Vec<i64> {
+                let mut values = Vec::new();
+                #(#collect_scalar_values_parts)*
+                values
+            }
+
+            fn writeback_scalar_state_fields_from_values(&mut self, values: &[i64]) {
+                #(#writeback_from_values_parts)*
             }
 
             fn state_field_layout(&self) -> majit_metainterp::blackhole::StateFieldLayout {

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1295,7 +1295,14 @@ fn generate_merge_wrapper(config: &JitInterpConfig, func: &ItemFn) -> TokenStrea
                 // production warmstate / backend.
                 let __result = __meta
                     .with_trace_ctx_and_token_resolver(
-                        |__ctx, __resolve, __rec_target, __rec_decision, __rec_exec| {
+                        |__ctx,
+                         __resolve,
+                         __rec_target,
+                         __rec_decision,
+                         __rec_exec,
+                         __rec_exec_ref,
+                         __rec_exec_float,
+                         __rec_exec_void| {
                             let __runtime =
                                 majit_metainterp::ClosureRuntimeWithResolver::new(
                                     |pc: usize| pc,
@@ -1303,6 +1310,9 @@ fn generate_merge_wrapper(config: &JitInterpConfig, func: &ItemFn) -> TokenStrea
                                     __rec_target,
                                     __rec_decision,
                                     __rec_exec,
+                                    __rec_exec_ref,
+                                    __rec_exec_float,
+                                    __rec_exec_void,
                                 );
                             #trace_fn_name(
                                 __ctx,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1998,21 +1998,25 @@ fn rewrite_body(
                                 if let Some((__sp_pc, __sp_reds)) = __mp_out
                                 {
                                     // Push the walk-mutated scalar state fields
-                                    // (e.g. a walk-advanced `selected`) from the
-                                    // still-live persistent sym into native
-                                    // `state`. The walk advances these on the sym
-                                    // via BC_STORE_STATE_FIELD only; native
-                                    // `state` is frozen at trace-start (S_k), so
-                                    // without this the scalars stay stale — and a
-                                    // `recover` that re-derives caches FROM a
-                                    // scalar (stacksize from selected) would then
-                                    // read the wrong index. Must precede both
+                                    // (e.g. a walk-advanced `selected`) into
+                                    // native `state`. The walk advances these on
+                                    // the sym via BC_STORE_STATE_FIELD only;
+                                    // native `state` is frozen at trace-start
+                                    // (S_k), so without this the scalars stay
+                                    // stale — and a `recover` that re-derives
+                                    // caches FROM a scalar (stacksize from
+                                    // selected) would then read the wrong index.
+                                    // The values were captured off the still-live
+                                    // sym inside the CloseLoop arm (the arm clears
+                                    // the sym before returning, so they cannot be
+                                    // re-read here) and stashed on the MetaInterp;
+                                    // this consumes the stash. Must precede both
                                     // `recover` (which refines storage-backed
                                     // caches from the current scalars) and
                                     // `try_resume_into_compiled_loop` (which reads
                                     // the native scalars to seed the compiled
                                     // loop). No-op with no scalar state fields
-                                    // or no live sym.
+                                    // or when no CloseLoop stashed values.
                                     #driver.writeback_scalar_state_fields(
                                         &mut #state,
                                     );

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -361,15 +361,30 @@ pub trait JitState: Sized {
 
     fn recover_after_compiled_run(&mut self) {}
 
+    /// Whole-circuit single-pass: read the walk's scalar state-field concrete
+    /// values off the still-live persistent sym, in scalar state-field index
+    /// order (idx `0..num_scalars`). Called from the CloseLoop arm of
+    /// `merge_point` while the sym is `Some`, before the arm clears it; the
+    /// captured values are stashed on the `MetaInterp` and applied to native
+    /// `state` after the walk closes (`writeback_scalar_state_fields_from_values`
+    /// via the `jit_merge_point!` hook). Empty when the state has no scalar
+    /// fields. Default empty; the `#[jit_interp]` macro overrides it for
+    /// state-field consumers.
+    fn collect_scalar_state_field_values(_sym: &Self::Sym) -> Vec<i64> {
+        Vec::new()
+    }
+
     /// Whole-circuit single-pass: write the walk's scalar state-field concrete
-    /// values from the persistent sym back into native state. A scalar the walk
+    /// values (captured at close time by `collect_scalar_state_field_values`)
+    /// into native state. `values[idx]` is the scalar at state-field index
+    /// `idx`, written in the same order the sym read them. A scalar the walk
     /// mutates but `recover` cannot re-derive from shared storage (e.g. aheui's
     /// `selected` storage index, set by SEL from a program operand) would
-    /// otherwise stay frozen at its trace-start value. Called before
+    /// otherwise stay frozen at its trace-start value. Applied before
     /// `recover_after_compiled_run` so recover then refines the storage-derived
     /// caches (stacksize / list refs) from the now-current scalars. Default
     /// no-op; the `#[jit_interp]` macro overrides it for state-field consumers.
-    fn writeback_scalar_state_fields_from_sym(&mut self, _sym: &Self::Sym) {}
+    fn writeback_scalar_state_fields_from_values(&mut self, _values: &[i64]) {}
 
     /// blackhole.py:1679 `_exit_frame_with_exception` → warmspot.py:998-1005.
     ///

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -2263,7 +2263,8 @@ impl JitCodeBuilder {
         for &(kind, src) in greens {
             match kind {
                 JitArgKind::Ref => self.touch_ref_reg(src),
-                JitArgKind::Int | JitArgKind::Float => self.touch_reg(src),
+                JitArgKind::Int => self.touch_reg(src),
+                JitArgKind::Float => self.touch_float_reg(src),
             }
         }
         for &(kind, caller_src, _callee_dst) in args {
@@ -2287,6 +2288,127 @@ impl JitCodeBuilder {
             self.push_u16(callee_dst);
         }
         self.record_resulttype('i');
+    }
+
+    /// Ref-result sibling of [`Self::recursive_call_int`]
+    /// (`opimpl_recursive_call_r`).  Same payload shape; the result lands in
+    /// the ref register `result_dst`.
+    pub fn recursive_call_ref(
+        &mut self,
+        jd_index: u16,
+        result_dst: u16,
+        greens: &[(JitArgKind, u16)],
+        args: &[(JitArgKind, u16, u16)],
+    ) {
+        self.touch_ref_reg(result_dst);
+        for &(kind, src) in greens {
+            match kind {
+                JitArgKind::Ref => self.touch_ref_reg(src),
+                JitArgKind::Int => self.touch_reg(src),
+                JitArgKind::Float => self.touch_float_reg(src),
+            }
+        }
+        for &(kind, caller_src, _callee_dst) in args {
+            self.touch_call_arg(JitCallArg {
+                kind,
+                reg: caller_src,
+            });
+        }
+        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_REF);
+        self.push_u16(jd_index);
+        self.push_u16(result_dst);
+        self.push_u16(greens.len() as u16);
+        for &(kind, src) in greens {
+            self.push_u8(kind.encode());
+            self.push_u16(src);
+        }
+        self.push_u16(args.len() as u16);
+        for &(kind, caller_src, callee_dst) in args {
+            self.push_u8(kind.encode());
+            self.push_u16(caller_src);
+            self.push_u16(callee_dst);
+        }
+        self.record_resulttype('r');
+    }
+
+    /// Float-result sibling of [`Self::recursive_call_int`]
+    /// (`opimpl_recursive_call_f`).  Same payload shape; the result lands in
+    /// the float register `result_dst`.
+    pub fn recursive_call_float(
+        &mut self,
+        jd_index: u16,
+        result_dst: u16,
+        greens: &[(JitArgKind, u16)],
+        args: &[(JitArgKind, u16, u16)],
+    ) {
+        self.touch_float_reg(result_dst);
+        for &(kind, src) in greens {
+            match kind {
+                JitArgKind::Ref => self.touch_ref_reg(src),
+                JitArgKind::Int => self.touch_reg(src),
+                JitArgKind::Float => self.touch_float_reg(src),
+            }
+        }
+        for &(kind, caller_src, _callee_dst) in args {
+            self.touch_call_arg(JitCallArg {
+                kind,
+                reg: caller_src,
+            });
+        }
+        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_FLOAT);
+        self.push_u16(jd_index);
+        self.push_u16(result_dst);
+        self.push_u16(greens.len() as u16);
+        for &(kind, src) in greens {
+            self.push_u8(kind.encode());
+            self.push_u16(src);
+        }
+        self.push_u16(args.len() as u16);
+        for &(kind, caller_src, callee_dst) in args {
+            self.push_u8(kind.encode());
+            self.push_u16(caller_src);
+            self.push_u16(callee_dst);
+        }
+        self.record_resulttype('f');
+    }
+
+    /// Void-result sibling of [`Self::recursive_call_int`]
+    /// (`opimpl_recursive_call_v`).  Carries no result register — the
+    /// `result_dst` slot is emitted as the `u16::MAX` "no result" sentinel the
+    /// dispatcher decodes to `None`.
+    pub fn recursive_call_void(
+        &mut self,
+        jd_index: u16,
+        greens: &[(JitArgKind, u16)],
+        args: &[(JitArgKind, u16, u16)],
+    ) {
+        for &(kind, src) in greens {
+            match kind {
+                JitArgKind::Ref => self.touch_ref_reg(src),
+                JitArgKind::Int => self.touch_reg(src),
+                JitArgKind::Float => self.touch_float_reg(src),
+            }
+        }
+        for &(kind, caller_src, _callee_dst) in args {
+            self.touch_call_arg(JitCallArg {
+                kind,
+                reg: caller_src,
+            });
+        }
+        self.start_instr(jitcode::insns::BC_RECURSIVE_CALL_VOID);
+        self.push_u16(jd_index);
+        self.push_u16(u16::MAX);
+        self.push_u16(greens.len() as u16);
+        for &(kind, src) in greens {
+            self.push_u8(kind.encode());
+            self.push_u16(src);
+        }
+        self.push_u16(args.len() as u16);
+        for &(kind, caller_src, callee_dst) in args {
+            self.push_u8(kind.encode());
+            self.push_u16(caller_src);
+            self.push_u16(callee_dst);
+        }
     }
 
     /// Constant-operand form of `ref_return`. `flatten.py:130-146

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1382,18 +1382,21 @@ impl<S: JitState> JitDriver<S> {
         self.meta.single_pass_outcome.take()
     }
 
-    /// Push the walk's scalar state fields from the still-live persistent sym
-    /// back into native `state`. The walk advances a scalar (notably a SEL's
-    /// new `selected`) on the sym only; native `state` stays at its trace-start
-    /// value until this write-back. No-op when no sym is live. Called from the
-    /// whole-circuit single-pass `jit_merge_point!` branch, before
-    /// `recover_after_compiled_run` so recover refines the storage-derived
-    /// caches (e.g. stacksize from the now-current selected) from the
-    /// written-back scalars.
+    /// Push the walk's scalar state fields into native `state`. The walk
+    /// advances a scalar (notably a SEL's new `selected`) on the sym only;
+    /// native `state` stays at its trace-start value until this write-back.
+    /// The values were captured off the still-live sym inside the CloseLoop
+    /// arm (`single_pass_scalar_values`, scalar index order) — the arm clears
+    /// the sym before returning, so they cannot be re-read here. Consumes
+    /// (`take`s) the stash. No-op when no CloseLoop stashed values (the hot
+    /// path) or the state has no scalar fields. Called from the whole-circuit
+    /// single-pass `jit_merge_point!` branch, before `recover_after_compiled_run`
+    /// so recover refines the storage-derived caches (e.g. stacksize from the
+    /// now-current selected) from the written-back scalars.
     #[inline]
-    pub fn writeback_scalar_state_fields(&self, state: &mut S) {
-        if let Some(sym) = self.sym.as_ref() {
-            state.writeback_scalar_state_fields_from_sym(sym);
+    pub fn writeback_scalar_state_fields(&mut self, state: &mut S) {
+        if let Some(values) = self.meta.single_pass_scalar_values.take() {
+            state.writeback_scalar_state_fields_from_values(&values);
         }
     }
 
@@ -1801,9 +1804,10 @@ impl<S: JitState> JitDriver<S> {
                 // (an interpreter program pc, NOT the JitCode op cursor). The
                 // reds vector published here is INTENTIONALLY empty. The
                 // merge-point hook transfers walk-final loop state without it:
-                // scalar state fields (e.g. selected) are written back from
-                // the live sym by `writeback_scalar_state_fields`, then
-                // `recover` re-derives the storage-backed cache fields
+                // scalar state fields (e.g. selected) are captured here from
+                // the still-live sym (`single_pass_scalar_values`) and written
+                // into native `state` by the macro hook after the walk closes,
+                // then `recover` re-derives the storage-backed cache fields
                 // (stacksize, storage refs) from the walk-advanced shared
                 // storage. `dispatch` does populate `ctx.walk_final_reds` from
                 // the merge point's red-operand slots, but that register-bank
@@ -1817,6 +1821,17 @@ impl<S: JitState> JitDriver<S> {
                 let pc = self.meta.trace_ctx().and_then(|ctx| ctx.walk_final_pc);
                 if let Some(p) = pc {
                     self.meta.single_pass_outcome = Some((p, Vec::new()));
+                }
+                // Capture the walk-final scalar state-field values off the
+                // still-live sym in scalar index order (idx `0..num_scalars`),
+                // BEFORE `self.sym = None` at the end of this arm drops them.
+                // native `state` is not in scope here (only in the
+                // `jit_merge_point!` macro expansion), so stash the values on
+                // the MetaInterp for the macro hook to apply after the close.
+                // Empty when the state has no scalar fields.
+                if let Some(sym) = self.sym.as_ref() {
+                    let scalars = S::collect_scalar_state_field_values(sym);
+                    self.meta.single_pass_scalar_values = Some(scalars);
                 }
                 // pyjitpl.py:2979-3036 reached_loop_header parity.
                 // Path 1: bridge — only if has_compiled_targets (line 2982).
@@ -5230,6 +5245,145 @@ mod tests {
         assert_eq!(stats.loops_compiled, 1);
         assert_eq!(stats.loops_aborted, 0);
         assert_eq!(stats.bridges_compiled, 0);
+    }
+
+    /// State whose walk advances a scalar state field the recover hook cannot
+    /// re-derive (an aheui `selected`-style storage index). The Sym carries the
+    /// scalar; `collect_scalar_state_field_values` reads it (at close time,
+    /// while the sym is live) and `writeback_scalar_state_fields_from_values`
+    /// pushes the captured value into native `state`.
+    #[derive(Default)]
+    struct ScalarWalkState {
+        // Native scalar; frozen at trace-start until the close-time write-back.
+        selected: i64,
+        // Set by the write-back so the test can observe the applied value.
+        writeback_applied: Option<Vec<i64>>,
+    }
+
+    #[derive(Default)]
+    struct ScalarWalkSym {
+        // The walk mutates this in the merge-point closure (a
+        // BC_STORE_STATE_FIELD analog); native `state.selected` stays frozen.
+        selected: i64,
+    }
+
+    impl JitState for ScalarWalkState {
+        type Meta = ();
+        type Sym = ScalarWalkSym;
+        type Env = ();
+
+        fn build_meta(&self, _header_pc: usize, _env: &Self::Env) -> Self::Meta {}
+
+        fn extract_live(&self, _meta: &Self::Meta) -> Vec<i64> {
+            // One inputarg so the trace records a valid input.
+            vec![self.selected]
+        }
+
+        fn create_sym(_meta: &Self::Meta, _header_pc: usize) -> Self::Sym {
+            ScalarWalkSym::default()
+        }
+
+        fn initialize_sym(&self, sym: &mut Self::Sym, _meta: &Self::Meta) {
+            // Seed the sym's scalar mirror from the trace-start native value.
+            sym.selected = self.selected;
+        }
+
+        fn is_compatible(&self, _meta: &Self::Meta) -> bool {
+            true
+        }
+
+        fn restore(&mut self, _meta: &Self::Meta, _values: &[i64]) {}
+
+        fn collect_jump_args(_sym: &Self::Sym) -> Vec<OpRef> {
+            Vec::new()
+        }
+
+        // The bug: this must observe the walk-final scalar captured while the
+        // sym was still live, NOT the trace-start value and NOT a no-op.
+        fn collect_scalar_state_field_values(sym: &Self::Sym) -> Vec<i64> {
+            vec![sym.selected]
+        }
+
+        fn writeback_scalar_state_fields_from_values(&mut self, values: &[i64]) {
+            self.selected = values[0];
+            self.writeback_applied = Some(values.to_vec());
+        }
+
+        // Force the abort branch of the CloseLoop arm — no backend compile is
+        // needed to exercise the capture-before-clear / apply-after-clear
+        // ordering, which is where the bug lived.
+        fn validate_close(_sym: &Self::Sym, _meta: &Self::Meta) -> bool {
+            false
+        }
+    }
+
+    /// Regression: the whole-circuit single-pass CloseLoop arm captures the
+    /// walk-final scalar state fields off the still-live sym (into
+    /// `single_pass_scalar_values`) BEFORE it clears `self.sym`, and
+    /// `writeback_scalar_state_fields` applies that stash to native `state`
+    /// afterward. Previously the write-back read `self.sym` directly, but the
+    /// CloseLoop arm had already set `self.sym = None`, so the write-back was
+    /// always a silent no-op — a program whose walk advanced a scalar (e.g. an
+    /// aheui SEL changing `selected`) would seed native state from the stale
+    /// trace-start value.
+    #[test]
+    fn single_pass_close_writes_back_walk_final_scalar() {
+        let mut driver = JitDriver::<ScalarWalkState>::new(1);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+
+        // Trace-start native state: selected == 3.
+        let mut state = ScalarWalkState {
+            selected: 3,
+            writeback_applied: None,
+        };
+        let target_pc = 7usize;
+        let key = target_pc as u64;
+
+        // Start a real trace: this seeds `driver.sym` via create_sym +
+        // initialize_sym (sym.selected == 3) and installs the trace session.
+        driver.force_start_tracing(key, target_pc, &mut state, &());
+        assert!(
+            driver.is_tracing(),
+            "force_start_tracing must start a trace"
+        );
+
+        // Drive the merge point to a CloseLoop. The closure stands in for the
+        // walk: it advances the scalar on the sym (selected 3 -> 9) and stamps
+        // the walk-final pc so the single-pass outcome is published, then
+        // closes the loop.
+        driver.merge_point(|meta, sym| {
+            sym.selected = 9;
+            if let Some(ctx) = meta.trace_ctx() {
+                ctx.walk_final_pc = Some(target_pc);
+            }
+            TraceAction::CloseLoop
+        });
+
+        // merge_point cleared the sym as part of CloseLoop handling.
+        assert!(
+            driver.sym.is_none(),
+            "CloseLoop handling must clear the sym before returning",
+        );
+
+        // Mimic the `jit_merge_point!(...; state)` macro hook: the walk-final
+        // outcome is published, then the write-back applies the captured
+        // walk-final scalar into native state.
+        let outcome = driver.take_single_pass_outcome();
+        assert!(
+            outcome.is_some(),
+            "CloseLoop must publish the single-pass outcome",
+        );
+        driver.writeback_scalar_state_fields(&mut state);
+
+        assert_eq!(
+            state.selected, 9,
+            "native state must receive the walk-final scalar (9), not stay frozen at the trace-start value (3)",
+        );
+        assert_eq!(
+            state.writeback_applied,
+            Some(vec![9]),
+            "write-back must run with the walk-final captured values, not be a no-op",
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1066,6 +1066,17 @@ pub struct MetaInterp<M: Clone> {
     /// after the trace closes. `take`n by the `__merge` wrapper. `None` when
     /// the walk did not populate the reds.
     pub(crate) single_pass_outcome: Option<(usize, Vec<Value>)>,
+    /// Single-pass tracing: the walk-final scalar state-field values captured
+    /// off the still-live sym at the CloseLoop point (scalar state-field index
+    /// order, idx `0..num_scalars`), BEFORE the CloseLoop arm clears the sym.
+    /// `merge_point`'s closure sees only `&mut MetaInterp` and `&mut sym`, and
+    /// the arm sets `self.sym = None` before returning, so native `state`
+    /// (available only in the `jit_merge_point!` macro expansion) cannot read
+    /// the sym after the close. Stash the values here while the sym is still
+    /// live; the macro hook `take`s them and applies them to native `state`
+    /// via `writeback_scalar_state_fields_from_values`. `None` outside
+    /// single-pass or when the state has no scalar fields.
+    pub(crate) single_pass_scalar_values: Option<Vec<i64>>,
     /// Single-pass tracing: the green key the CloseLoop arm compiled the
     /// (cross-loop-cut) inner loop under, captured after a `Compiled`
     /// outcome so the merge-point hook can DIRECTLY enter that freshly
@@ -2260,6 +2271,7 @@ impl<M: Clone> MetaInterp<M> {
             loop_header_pcs: indexmap::IndexMap::new(),
             tracing: None,
             single_pass_outcome: None,
+            single_pass_scalar_values: None,
             single_pass_compiled_key: None,
             next_trace_id: 1,
             hooks: JitHooks::default(),

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3932,6 +3932,9 @@ impl<M: Clone> MetaInterp<M> {
             &dyn Fn(usize, &[i64]) -> Option<(Arc<JitCellToken>, u64)>,
             &dyn Fn(usize, &[i64], usize, usize) -> InlineDecision,
             &dyn Fn(&JitCellToken, &[Value]) -> Option<i64>,
+            &dyn Fn(&JitCellToken, &[Value]) -> Option<i64>,
+            &dyn Fn(&JitCellToken, &[Value]) -> Option<i64>,
+            &dyn Fn(&JitCellToken, &[Value]) -> Option<()>,
         ) -> R,
     ) -> Option<R> {
         let tracing = self.tracing.as_mut()?;
@@ -4011,12 +4014,41 @@ impl<M: Clone> MetaInterp<M> {
                 None
             }
         };
+        // Ref / float siblings decode the single FINISH output in its raw
+        // packing (`execute_token_raw` stores a ref as its `GcRef` bits and a
+        // float as `f64::to_bits()`, both into `outputs`), so the int decode
+        // shape carries through unchanged.
+        let recursive_exec_ref = |token: &JitCellToken, reds: &[Value]| -> Option<i64> {
+            let result = backend.execute_token_raw(token, reds);
+            if result.is_finish {
+                result.outputs.first().copied()
+            } else {
+                None
+            }
+        };
+        let recursive_exec_float = |token: &JitCellToken, reds: &[Value]| -> Option<i64> {
+            let result = backend.execute_token_raw(token, reds);
+            if result.is_finish {
+                result.outputs.first().copied()
+            } else {
+                None
+            }
+        };
+        // Void runs the callee for its side effects; a finished loop yields
+        // `Some(())`, an unfinished one `None`.
+        let recursive_exec_void = |token: &JitCellToken, reds: &[Value]| -> Option<()> {
+            let result = backend.execute_token_raw(token, reds);
+            result.is_finish.then_some(())
+        };
         Some(f(
             tracing,
             &resolver,
             &recursive_target,
             &recursive_decision,
             &recursive_exec,
+            &recursive_exec_ref,
+            &recursive_exec_float,
+            &recursive_exec_void,
         ))
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -14069,7 +14069,13 @@ pub enum InlineDecision {
     Inline,
     /// Emit a CALL_ASSEMBLER: callee has compiled code.
     CallAssembler,
-    /// Emit a residual (opaque) call.
+    /// Callee not compiled and no on-demand token machinery.  pyjitpl.py:1417
+    /// (`inlining` true) would build the token via `compile_tmp_callback`
+    /// (warmstate.py:714-722) and still emit CALL_ASSEMBLER; lacking that here,
+    /// this variant means "no token yet" and the dispatcher aborts/retries
+    /// until the callee compiles.  It is not pyjitpl.py's `inlining`-false
+    /// residual call.  See `should_inline_core` for the same
+    /// `compile_tmp_callback` gap.
     ResidualCall,
 }
 
@@ -14092,9 +14098,18 @@ pub(crate) fn decide_recursive_inline(
     recursive_depth: usize,
     max_unroll: usize,
 ) -> (InlineDecision, bool) {
-    // pyjitpl.py:1417 — a non-inlined recursive call routes to
-    // CALL_ASSEMBLER when the callee has (or is converging on) compiled
-    // code, else to a residual call.
+    // pyjitpl.py:1417 — with `warmrunnerstate.inlining` true (pyjitpl.py:1381,
+    // always the case here) a non-inlined recursive call always takes
+    // `assembler_call = True`.  When the callee is (or is converging on)
+    // compiled it routes to CALL_ASSEMBLER against the resolvable token; when
+    // it is not compiled, pyjitpl.py:1417 still takes `assembler_call = True`
+    // and `get_assembler_token` synthesises the token on demand via
+    // `compile_tmp_callback` (warmstate.py:714-722).  There is no
+    // `compile_tmp_callback` here, so the not-compiled case is labelled
+    // `ResidualCall` — a stand-in meaning "no token yet, cannot emit
+    // CALL_ASSEMBLER" — which the dispatcher turns into abort/retry.  It is
+    // NOT pyjitpl.py's `inlining`-false residual (`assembler_call = False`)
+    // path.
     let non_inline = if callee_compiled {
         InlineDecision::CallAssembler
     } else {

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -2097,9 +2097,21 @@ where
             );
         }
         if decision != crate::pyjitpl::InlineDecision::Inline {
-            // `ResidualCall` is not wired in this epic; abort so the trace
-            // is retried rather than recording an unhandled call
-            // (pyjitpl.py falls to `do_residual_call`; pyre retries).
+            // `ResidualCall` here labels pyjitpl.py:1376's callee-not-compiled
+            // case.  Under `warmrunnerstate.inlining` (pyjitpl.py:1381, always
+            // true here — warmstate.rs:471) that case takes
+            // `assembler_call = True` (pyjitpl.py:1417) →
+            // `direct_assembler_call` → `get_assembler_token`, which
+            // synthesises the callee token on demand via `compile_tmp_callback`
+            // (warmstate.py:714-722); it is NOT a residual call.  There is no
+            // `compile_tmp_callback` here (pyjitpl.rs `should_inline_core`),
+            // so the on-demand token cannot be built at this point: abort and
+            // retry until the callee compiles on its own, after which a later
+            // attempt takes the wired `CallAssembler` leg
+            // (`exec_recursive_call_assembler`).  pyjitpl.py's true residual
+            // path (`assembler_call = False`, do_residual_call) is reachable
+            // only when `inlining` is false, which is never the case here, so
+            // it is intentionally unmodelled.
             return TraceAction::Abort;
         }
         // pc-aligned portal runtimes (dispatch.rs test fixtures) wire

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -616,6 +616,52 @@ pub trait JitCodeRuntime {
     ) -> Option<i64> {
         None
     }
+
+    /// Ref-result sibling of [`Self::execute_recursive_assembler_int`]
+    /// (`call_assembler_ref` / `do_residual_call` tp == 'r').  Drives the
+    /// callee loop's JITFRAME-ABI entry and decodes the single ref FINISH
+    /// output as its raw `GcRef` bits (the same `as_usize() as i64` packing
+    /// the `BC_CALL_ASSEMBLER_REF` arm stores through `set_ref_reg`).
+    /// Returns `None` when the loop did not finish with a ref result or when
+    /// the runtime has no backend (the default), in which case the caller
+    /// aborts.
+    fn execute_recursive_assembler_ref(
+        &self,
+        _token: &majit_backend::JitCellToken,
+        _reds: &[Value],
+    ) -> Option<i64> {
+        None
+    }
+
+    /// Float-result sibling of [`Self::execute_recursive_assembler_int`]
+    /// (`call_assembler_float` / `do_residual_call` tp == 'f').  Drives the
+    /// callee loop's JITFRAME-ABI entry and decodes the single float FINISH
+    /// output as its `f64::to_bits()` packing (the same `longlong.ZEROF`
+    /// packing the `BC_CALL_ASSEMBLER_FLOAT` arm stores through
+    /// `set_float_reg`).  Returns `None` when the loop did not finish with a
+    /// float result or when the runtime has no backend (the default), in
+    /// which case the caller aborts.
+    fn execute_recursive_assembler_float(
+        &self,
+        _token: &majit_backend::JitCellToken,
+        _reds: &[Value],
+    ) -> Option<i64> {
+        None
+    }
+
+    /// Void-result sibling of [`Self::execute_recursive_assembler_int`]
+    /// (`call_assembler_void` / `do_residual_call` tp == 'v').  Drives the
+    /// callee loop's JITFRAME-ABI entry for its side effects; there is no
+    /// result to decode.  Returns `Some(())` when the loop finished and
+    /// `None` when it did not finish or the runtime has no backend (the
+    /// default), in which case the caller aborts.
+    fn execute_recursive_assembler_void(
+        &self,
+        _token: &majit_backend::JitCellToken,
+        _reds: &[Value],
+    ) -> Option<()> {
+        None
+    }
 }
 
 /// [FR] WIP gate for the state-field recursive-portal Inline re-entry rework.
@@ -656,23 +702,39 @@ where
 /// through the production warmstate / backend.  All closures are built by
 /// `MetaInterp::with_trace_ctx_and_token_resolver`, which split-borrows the
 /// MetaInterp fields they read.
-pub struct ClosureRuntimeWithResolver<FLabel, FResolve, FTarget, FDecision, FExec> {
+pub struct ClosureRuntimeWithResolver<
+    FLabel,
+    FResolve,
+    FTarget,
+    FDecision,
+    FExec,
+    FExecR,
+    FExecF,
+    FExecV,
+> {
     label_at: FLabel,
     resolve_token: FResolve,
     recursive_target: FTarget,
     recursive_decision: FDecision,
     recursive_exec: FExec,
+    recursive_exec_ref: FExecR,
+    recursive_exec_float: FExecF,
+    recursive_exec_void: FExecV,
 }
 
-impl<FLabel, FResolve, FTarget, FDecision, FExec>
-    ClosureRuntimeWithResolver<FLabel, FResolve, FTarget, FDecision, FExec>
+impl<FLabel, FResolve, FTarget, FDecision, FExec, FExecR, FExecF, FExecV>
+    ClosureRuntimeWithResolver<FLabel, FResolve, FTarget, FDecision, FExec, FExecR, FExecF, FExecV>
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         label_at: FLabel,
         resolve_token: FResolve,
         recursive_target: FTarget,
         recursive_decision: FDecision,
         recursive_exec: FExec,
+        recursive_exec_ref: FExecR,
+        recursive_exec_float: FExecF,
+        recursive_exec_void: FExecV,
     ) -> Self {
         Self {
             label_at,
@@ -680,18 +742,33 @@ impl<FLabel, FResolve, FTarget, FDecision, FExec>
             recursive_target,
             recursive_decision,
             recursive_exec,
+            recursive_exec_ref,
+            recursive_exec_float,
+            recursive_exec_void,
         }
     }
 }
 
-impl<FLabel, FResolve, FTarget, FDecision, FExec> JitCodeRuntime
-    for ClosureRuntimeWithResolver<FLabel, FResolve, FTarget, FDecision, FExec>
+impl<FLabel, FResolve, FTarget, FDecision, FExec, FExecR, FExecF, FExecV> JitCodeRuntime
+    for ClosureRuntimeWithResolver<
+        FLabel,
+        FResolve,
+        FTarget,
+        FDecision,
+        FExec,
+        FExecR,
+        FExecF,
+        FExecV,
+    >
 where
     FLabel: Fn(usize) -> usize,
     FResolve: Fn(u64) -> Option<std::sync::Arc<majit_backend::JitCellToken>>,
     FTarget: Fn(usize, &[i64]) -> Option<(std::sync::Arc<majit_backend::JitCellToken>, u64)>,
     FDecision: Fn(usize, &[i64], usize, usize) -> crate::pyjitpl::InlineDecision,
     FExec: Fn(&majit_backend::JitCellToken, &[Value]) -> Option<i64>,
+    FExecR: Fn(&majit_backend::JitCellToken, &[Value]) -> Option<i64>,
+    FExecF: Fn(&majit_backend::JitCellToken, &[Value]) -> Option<i64>,
+    FExecV: Fn(&majit_backend::JitCellToken, &[Value]) -> Option<()>,
 {
     fn label_at(&self, pc: usize) -> usize {
         (self.label_at)(pc)
@@ -728,6 +805,30 @@ where
         reds: &[Value],
     ) -> Option<i64> {
         (self.recursive_exec)(token, reds)
+    }
+
+    fn execute_recursive_assembler_ref(
+        &self,
+        token: &majit_backend::JitCellToken,
+        reds: &[Value],
+    ) -> Option<i64> {
+        (self.recursive_exec_ref)(token, reds)
+    }
+
+    fn execute_recursive_assembler_float(
+        &self,
+        token: &majit_backend::JitCellToken,
+        reds: &[Value],
+    ) -> Option<i64> {
+        (self.recursive_exec_float)(token, reds)
+    }
+
+    fn execute_recursive_assembler_void(
+        &self,
+        token: &majit_backend::JitCellToken,
+        reds: &[Value],
+    ) -> Option<()> {
+        (self.recursive_exec_void)(token, reds)
     }
 }
 
@@ -1952,15 +2053,18 @@ where
 
         // Read each green from the register bank its `JitArgKind` names: a
         // ref green (e.g. tl's `program`) from the ref bank, an int green
-        // (e.g. `pc`) from the int bank.  The values are collected in green
-        // declaration order so they hash against `green_args_spec`.
-        // `green_pc` is the first green (the int portal entry pc), or 0 when
-        // the call carries no greens.
+        // (e.g. `pc`) from the int bank, a float green from the float bank
+        // (its raw i64 bits feed the green-key hash — `prepare_list_of_boxes`
+        // decodes `argcode == 'f'` from `registers_f`).  The values are
+        // collected in green declaration order so they hash against
+        // `green_args_spec`.  `green_pc` is the first green (the int portal
+        // entry pc), or 0 when the call carries no greens.
         let green_values: Vec<i64> = green_srcs
             .iter()
             .map(|&(kind, src)| match kind {
                 JitArgKind::Ref => self.read_ref_reg(src).1,
-                JitArgKind::Int | JitArgKind::Float => self.read_int_reg(src).1,
+                JitArgKind::Int => self.read_int_reg(src).1,
+                JitArgKind::Float => self.read_float_reg(src).1,
             })
             .collect();
         let green_pc = green_values.first().copied().unwrap_or(0) as usize;
@@ -2004,6 +2108,15 @@ where
             let mut portal_frame = MIFrame::setup(portal, green_pc, None, Some(ctx));
             portal_frame.code_cursor = green_pc;
             ctx.push_inline_frame((jd_index, green_pc), u32::MAX);
+            // pyjitpl.py:2465 newframe -> enter_portal_frame(jd_no, unique_id)
+            // for an inlined portal (greenkey present). `unique_id` has no
+            // warmstate source here; use `green_pc` as a stable per-entry id.
+            // Pairs with the deferred LEAVE_PORTAL_FRAME recorded by the
+            // recursive-portal merge-point cut (opimpl_jit_merge_point
+            // else-branch).
+            let jd_box = ctx.const_int(jd_index as i64);
+            let uid_box = ctx.const_int(green_pc as i64);
+            ctx.record_op(OpCode::EnterPortalFrame, &[jd_box, uid_box]);
             portal_frame.inline_frame = true;
             for (kind, caller_src, callee_dst) in arg_triples {
                 match kind {
@@ -2057,8 +2170,12 @@ where
     /// Because the callee runs as its own compiled loop with its caller's
     /// state forced to the heap, there is no shared-shadow aliasing and no
     /// caller-frame resume coupling — the callee's guards resume in its own
-    /// blackhole.  Wires the `Int` result kind only; `Ref` / `Float` /
-    /// `Void` recursive assembler calls are a follow-on slice.
+    /// blackhole.  Wires all four result kinds (`Int` / `Ref` / `Float` /
+    /// `Void`): each drives its kind-specific concrete executor
+    /// (`execute_recursive_assembler_{int,ref,float,void}`), records the
+    /// matching `CallAssembler{I,R,F,N}` descr via
+    /// `call_assembler_{int,ref,float,void}_arc_typed`, and writes the result
+    /// into the correct register bank (`Void` has no result).
     #[allow(clippy::too_many_arguments)]
     fn exec_recursive_call_assembler(
         &mut self,
@@ -2074,11 +2191,16 @@ where
         // fresh state supersedes it); kept for the opcode's decode shape.
         _arg_triples: &[(JitArgKind, usize, usize)],
     ) -> TraceAction {
-        // S1 supports only the `Int` result kind through CALL_ASSEMBLER.
-        let result_dst = match (result_kind, result_dst) {
-            (Some(JitArgKind::Int), Some(dst)) => dst,
+        // Validate the (result_kind, result_dst) pairing: the three typed
+        // kinds carry a destination register, `Void` carries none.  Any
+        // other shape is a malformed opcode — abort.
+        match (result_kind, result_dst) {
+            (Some(JitArgKind::Int), Some(_))
+            | (Some(JitArgKind::Ref), Some(_))
+            | (Some(JitArgKind::Float), Some(_))
+            | (None, None) => {}
             _ => return TraceAction::Abort,
-        };
+        }
 
         // The greens carry the portal green key (pyjitpl.py:3593-3599
         // `get_assembler_token(greenargs)`), already read from the correct
@@ -2186,14 +2308,70 @@ where
         // pyjitpl.py:2017 — vrefs walk + vinfo stamp before the call.
         ctx.vrefs_before_residual_call();
         let active_vable = self.prepare_standard_virtualizable_before_residual_call(ctx);
-        let concrete = match runtime.execute_recursive_assembler_int(&token_arc, &red_values) {
-            Some(value) => value,
-            None => return TraceAction::Abort,
-        };
-        // pyjitpl.py:2046-2049 vrefs_after_residual_call.
-        ctx.vrefs_after_residual_call();
-        let traced = ctx.call_assembler_int_arc_typed(token_arc, &args, &arg_types);
-        self.set_int_reg(result_dst, Some(traced), Some(concrete));
+        // Concrete leg + `CallAssembler{I,R,F,N}` record + result writeback,
+        // one arm per result kind.  The concrete executor decodes the FINISH
+        // output in the kind's raw packing (int as-is, ref as its `GcRef`
+        // bits, float as `f64::to_bits()`); the recorded descr is emitted by
+        // the matching `call_assembler_*_arc_typed`, and the traced result op
+        // is written into the result kind's register bank.  `Void` runs the
+        // callee for its side effects with no result to decode or write.
+        //
+        // `vrefs_after_residual_call` fires between the concrete run and the
+        // CALL_ASSEMBLER record in every arm (pyjitpl.py:2046-2049).
+        match result_kind {
+            Some(JitArgKind::Int) => {
+                let concrete =
+                    match runtime.execute_recursive_assembler_int(&token_arc, &red_values) {
+                        Some(value) => value,
+                        None => return TraceAction::Abort,
+                    };
+                ctx.vrefs_after_residual_call();
+                let traced = ctx.call_assembler_int_arc_typed(token_arc, &args, &arg_types);
+                self.set_int_reg(
+                    result_dst.expect("int result kind requires a destination"),
+                    Some(traced),
+                    Some(concrete),
+                );
+            }
+            Some(JitArgKind::Ref) => {
+                let concrete =
+                    match runtime.execute_recursive_assembler_ref(&token_arc, &red_values) {
+                        Some(value) => value,
+                        None => return TraceAction::Abort,
+                    };
+                ctx.vrefs_after_residual_call();
+                let traced = ctx.call_assembler_ref_arc_typed(token_arc, &args, &arg_types);
+                self.set_ref_reg(
+                    result_dst.expect("ref result kind requires a destination"),
+                    Some(traced),
+                    Some(concrete),
+                );
+            }
+            Some(JitArgKind::Float) => {
+                let concrete =
+                    match runtime.execute_recursive_assembler_float(&token_arc, &red_values) {
+                        Some(value) => value,
+                        None => return TraceAction::Abort,
+                    };
+                ctx.vrefs_after_residual_call();
+                let traced = ctx.call_assembler_float_arc_typed(token_arc, &args, &arg_types);
+                self.set_float_reg(
+                    result_dst.expect("float result kind requires a destination"),
+                    Some(traced),
+                    Some(concrete),
+                );
+            }
+            None => {
+                if runtime
+                    .execute_recursive_assembler_void(&token_arc, &red_values)
+                    .is_none()
+                {
+                    return TraceAction::Abort;
+                }
+                ctx.vrefs_after_residual_call();
+                ctx.call_assembler_void_arc_typed(token_arc, &args, &arg_types);
+            }
+        }
         // Free each fresh allocation after the call: the compiled loop's
         // residual `CallN`.  Recorded after CALL_ASSEMBLER so the callee has
         // the state for the duration of its run; the trace-time owner box is
@@ -3753,17 +3931,23 @@ where
                         }
                     }
                 }
-                // [FR] pyjitpl.py:1551 `if self.metainterp.portal_call_depth:
-                // return` — a jit_merge_point reached INSIDE an inline
-                // recursive-portal callee is NOT the traced loop's header, so
-                // it is a pure no-op: skip both the auto loop-header stamp and
-                // the close protocol below.  Without this, the callee's merge
-                // point (it shares the caller's dispatch jitcode, entered at
-                // offset 0) resets `seen_loop_header_for_jdindex` to -1, and the
-                // real outer header then falls through instead of closing.  The
-                // payload cursor was already advanced above, so the callee
-                // continues to its next opcode.  Gated to the FR experiment.
-                if portal_inline_experiment_enabled() && ctx.inline_depth() > 0 {
+                // pyjitpl.py:1547-1552 — a jit_merge_point reached INSIDE an
+                // inline recursive-portal callee, while no loop_header has been
+                // seen yet (`seen_loop_header_for_jdindex < 0`), is a pure
+                // no-op: the `if not jitdriver_sd.no_loop_header: if
+                // self.metainterp.portal_call_depth: return` early-out skips the
+                // auto loop-header stamp so the callee's merge point (it shares
+                // the caller's dispatch jitcode, entered at offset 0) does not
+                // corrupt the outer header.  The payload cursor was already
+                // advanced above, so the callee continues to its next opcode.
+                // A seen>=0 (or `no_loop_header` auto-stamped) depth>0 merge
+                // point falls through into the close protocol at the else-branch
+                // cut below (pyjitpl.py:1579-1602).
+                let no_loop_header = ctx.metainterp_sd().jitdrivers_sd[jdindex].no_loop_header;
+                if ctx.inline_depth() > 0
+                    && self.seen_loop_header_for_jdindex < 0
+                    && !no_loop_header
+                {
                     return TraceAction::Continue;
                 }
                 // MAJIT_PCSEQ (W4/D2 diagnostic): log the interpreter green pc
@@ -3805,7 +3989,7 @@ where
                 //     `MetaInterp.has_compiled_targets(green_key)` keyed
                 //     on the trace's green key.
                 if self.seen_loop_header_for_jdindex < 0 && ctx.num_ops() > 0 {
-                    let no_loop_header = ctx.metainterp_sd().jitdrivers_sd[jdindex].no_loop_header;
+                    // `no_loop_header` hoisted above (EDIT A) and reused here.
                     let should_auto_stamp = if no_loop_header {
                         // pyjitpl.py:1554 path through (skip the
                         // `if not jitdriver_sd.no_loop_header:` guard).
@@ -3863,6 +4047,84 @@ where
                         self.seen_loop_header_for_jdindex,
                     );
                     self.seen_loop_header_for_jdindex = -1;
+                    if ctx.inline_depth() > 0 {
+                        // pyjitpl.py:1579-1602 else-branch: a recursive-portal
+                        // merge point reached at portal_call_depth > 0 is NOT
+                        // the traced loop's own header. Instead of a close it
+                        // returns from the inlined callee frame
+                        // (`finishframe(leave_portal_frame=False)`), then
+                        // `do_recursive_call(assembler_call=True)` on the caller
+                        // frame so the recursion follows a CALL_ASSEMBLER into
+                        // the callee's own compiled loop, then
+                        // `leave_portal_frame`, then `raise ChangeFrame` to
+                        // resume the caller.
+                        //
+                        // (1) capture old_frame (the inlined portal callee, top
+                        //     of stack) before the pop (pyjitpl.py:1592) so its
+                        //     return-destination slot and jitdriver index are
+                        //     read from the callee, not the caller.
+                        let old_frame = self.frames.current_mut();
+                        let jd_no = old_frame.jitcode.jitdriver_sd().unwrap_or(jdindex);
+                        let (result_kind, result_dst) = if let Some(d) = old_frame.return_i {
+                            (Some(JitArgKind::Int), Some(d))
+                        } else if let Some(d) = old_frame.return_r {
+                            (Some(JitArgKind::Ref), Some(d))
+                        } else if let Some(d) = old_frame.return_f {
+                            (Some(JitArgKind::Float), Some(d))
+                        } else {
+                            (None, None)
+                        };
+                        // (2) finishframe(leave_portal_frame=False) analog
+                        //     (pyjitpl.py:1593-1596): pop the inline callee
+                        //     frame, mirror the ctx inline depth, and restore the
+                        //     caller sym scalar / vable state the push saved —
+                        //     but DO NOT wire the return (do_recursive_call's job)
+                        //     and DO NOT record LEAVE_PORTAL_FRAME yet
+                        //     (leave_portal_frame=False).
+                        let popped = self.frames.pop().expect("recursive-cut: framestack < 2");
+                        if popped.inline_frame {
+                            ctx.pop_inline_frame();
+                        }
+                        if let Some(snapshot) = popped.portal_scalar_state.clone() {
+                            sym.restore_inline_scalar_state(snapshot);
+                        }
+                        if popped.portal_vable_saved {
+                            ctx.restore_saved_virtualizable();
+                        }
+                        // (3) do_recursive_call(assembler_call=True) on the caller
+                        //     (now current): reuse the existing 8-step
+                        //     CALL_ASSEMBLER recorder. `set_int_reg(result_dst)`
+                        //     inside binds the result on the CALLER frame
+                        //     (make_result_of_lastop parity, pyjitpl.py:1584-1590).
+                        let green_values: Vec<i64> = mp_green_ints
+                            .iter()
+                            .chain(mp_green_refs.iter())
+                            .chain(mp_green_floats.iter())
+                            .copied()
+                            .collect();
+                        match self.exec_recursive_call_assembler(
+                            ctx,
+                            sym,
+                            _runtime,
+                            result_kind,
+                            jdindex,
+                            result_dst,
+                            &green_values,
+                            &[],
+                        ) {
+                            TraceAction::Continue => {}
+                            // Abort propagates (missing fresh-reds / target).
+                            other => return other,
+                        }
+                        // (4) deferred LEAVE_PORTAL_FRAME (pyjitpl.py:1600-1601),
+                        //     recorded AFTER the CALL_ASSEMBLER so the trace order
+                        //     is CALL_ASSEMBLER … then LEAVE.
+                        let jd_box = ctx.const_int(jd_no as i64);
+                        ctx.record_op(OpCode::LeavePortalFrame, &[jd_box]);
+                        // (5) raise ChangeFrame (pyjitpl.py:1602): resume the
+                        //     caller frame in the walker dispatch loop.
+                        return TraceAction::Continue;
+                    }
                     // pyjitpl.py:2991-2993 reached_loop_header: generate a dummy
                     // GUARD_FUTURE_CONDITION just before the implicit JUMP so
                     // unroll's `jump_to_existing_trace` has a `patchguardop`
@@ -7462,6 +7724,49 @@ mod tests {
             RECURSIVE_CALLEE_ARG.with(|c| c.set(arg));
             Some(arg + 100)
         }
+
+        fn execute_recursive_assembler_ref(
+            &self,
+            _token: &majit_backend::JitCellToken,
+            reds: &[Value],
+        ) -> Option<i64> {
+            let arg = match reds.first() {
+                Some(Value::Int(v)) => *v,
+                _ => return None,
+            };
+            RECURSIVE_CALLEE_ARG.with(|c| c.set(arg));
+            // A ref result is a raw `GcRef`-bits payload; return a distinct,
+            // recognizable non-zero value.
+            Some(arg + 200)
+        }
+
+        fn execute_recursive_assembler_float(
+            &self,
+            _token: &majit_backend::JitCellToken,
+            reds: &[Value],
+        ) -> Option<i64> {
+            let arg = match reds.first() {
+                Some(Value::Int(v)) => *v,
+                _ => return None,
+            };
+            RECURSIVE_CALLEE_ARG.with(|c| c.set(arg));
+            // A float result carries `f64::to_bits()`; return a recognizable
+            // float value packed the way `execute_token_raw` would.
+            Some(f64::to_bits(arg as f64 + 0.5) as i64)
+        }
+
+        fn execute_recursive_assembler_void(
+            &self,
+            _token: &majit_backend::JitCellToken,
+            reds: &[Value],
+        ) -> Option<()> {
+            let arg = match reds.first() {
+                Some(Value::Int(v)) => *v,
+                _ => return None,
+            };
+            RECURSIVE_CALLEE_ARG.with(|c| c.set(arg));
+            Some(())
+        }
     }
 
     /// Test `JitCodeSym` for the recursive CALL_ASSEMBLER fresh-frame path: a
@@ -7605,6 +7910,377 @@ mod tests {
             finish_args[0],
             call_op.pos.get(),
             "the recursive CALL_ASSEMBLER result must be wired into the caller's return register",
+        );
+    }
+
+    /// #19 Step 3 (Ref) — a `BC_RECURSIVE_CALL_REF` whose runtime decides
+    /// `CallAssembler` records a `CallAssemblerR` (+ GUARD_NOT_FORCED) carrying
+    /// the fresh reds, and the ref result flows into the caller's ref return
+    /// register.  The concrete leg still runs with the FRESH `stackpos = 0`.
+    #[test]
+    fn recursive_call_assembler_ref_records_and_returns_result() {
+        RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+
+        let mut caller_builder = JitCodeBuilder::new();
+        caller_builder.recursive_call_ref(0, 0, &[], &[]);
+        caller_builder.ref_return(0);
+        let caller = caller_builder.finish();
+
+        let runtime = RecursiveAssemblerRuntime {
+            token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
+        };
+        let mut ctx = TraceCtx::for_test(0);
+        let mut sym = RecursiveFreshSym;
+        let action =
+            trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
+
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                finish_arg_types,
+                exit_with_exception: false,
+            } => {
+                assert_eq!(finish_arg_types, vec![majit_ir::Type::Ref]);
+                finish_args
+            }
+            other => {
+                panic!("expected Finish[Ref] from recursive CALL_ASSEMBLER, got {other:?}")
+            }
+        };
+        assert_eq!(finish_args.len(), 1);
+        // The callee's concrete entry ran with the FRESH reds (zeroed stackpos).
+        assert_eq!(RECURSIVE_CALLEE_ARG.with(|c| c.get()), 0);
+
+        let recorder = ctx.into_recorder();
+        let ops = recorder.ops();
+        let call_ops: Vec<_> = ops
+            .iter()
+            .filter(|o| o.opcode == OpCode::CallAssemblerR)
+            .collect();
+        assert_eq!(
+            call_ops.len(),
+            1,
+            "recursive CALL_ASSEMBLER[Ref] must record exactly one CallAssemblerR op",
+        );
+        let call = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::CallAssemblerR)
+            .unwrap();
+        let gnf = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::GuardNotForced)
+            .expect("CALL_ASSEMBLER[Ref] must record a GUARD_NOT_FORCED");
+        assert!(call < gnf, "CALL_ASSEMBLER must precede GUARD_NOT_FORCED");
+        assert_eq!(
+            finish_args[0],
+            call_ops[0].pos.get(),
+            "the recursive CALL_ASSEMBLER[Ref] result must be wired into the caller's ref return register",
+        );
+    }
+
+    /// #19 Step 3 (Float) — a `BC_RECURSIVE_CALL_FLOAT` records a
+    /// `CallAssemblerF` (+ GUARD_NOT_FORCED) and wires the float result into
+    /// the caller's float return register.
+    #[test]
+    fn recursive_call_assembler_float_records_and_returns_result() {
+        RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+
+        let mut caller_builder = JitCodeBuilder::new();
+        caller_builder.recursive_call_float(0, 0, &[], &[]);
+        caller_builder.float_return(0);
+        let caller = caller_builder.finish();
+
+        let runtime = RecursiveAssemblerRuntime {
+            token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
+        };
+        let mut ctx = TraceCtx::for_test(0);
+        let mut sym = RecursiveFreshSym;
+        let action =
+            trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
+
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                finish_arg_types,
+                exit_with_exception: false,
+            } => {
+                assert_eq!(finish_arg_types, vec![majit_ir::Type::Float]);
+                finish_args
+            }
+            other => {
+                panic!("expected Finish[Float] from recursive CALL_ASSEMBLER, got {other:?}")
+            }
+        };
+        assert_eq!(finish_args.len(), 1);
+        assert_eq!(RECURSIVE_CALLEE_ARG.with(|c| c.get()), 0);
+
+        let recorder = ctx.into_recorder();
+        let ops = recorder.ops();
+        let call_ops: Vec<_> = ops
+            .iter()
+            .filter(|o| o.opcode == OpCode::CallAssemblerF)
+            .collect();
+        assert_eq!(
+            call_ops.len(),
+            1,
+            "recursive CALL_ASSEMBLER[Float] must record exactly one CallAssemblerF op",
+        );
+        let call = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::CallAssemblerF)
+            .unwrap();
+        let gnf = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::GuardNotForced)
+            .expect("CALL_ASSEMBLER[Float] must record a GUARD_NOT_FORCED");
+        assert!(call < gnf, "CALL_ASSEMBLER must precede GUARD_NOT_FORCED");
+        assert_eq!(
+            finish_args[0],
+            call_ops[0].pos.get(),
+            "the recursive CALL_ASSEMBLER[Float] result must be wired into the caller's float return register",
+        );
+    }
+
+    /// #19 Step 3 (Void) — a `BC_RECURSIVE_CALL_VOID` records a
+    /// `CallAssemblerN` (+ GUARD_NOT_FORCED) with no result destination; the
+    /// callee runs its concrete leg for side effects only (the fresh
+    /// `stackpos = 0` reaches the executor) and the caller finishes void.
+    #[test]
+    fn recursive_call_assembler_void_records_and_runs_side_effect() {
+        RECURSIVE_CALLEE_ARG.with(|c| c.set(-1));
+
+        let mut caller_builder = JitCodeBuilder::new();
+        caller_builder.recursive_call_void(0, &[], &[]);
+        caller_builder.void_return();
+        let caller = caller_builder.finish();
+
+        let runtime = RecursiveAssemblerRuntime {
+            token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
+        };
+        let mut ctx = TraceCtx::for_test(0);
+        let mut sym = RecursiveFreshSym;
+        let action =
+            trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
+
+        match action {
+            TraceAction::Finish {
+                finish_args,
+                finish_arg_types,
+                exit_with_exception: false,
+            } => {
+                assert!(finish_args.is_empty(), "void return has no finish args");
+                assert!(
+                    finish_arg_types.is_empty(),
+                    "void return has no finish arg types"
+                );
+            }
+            other => {
+                panic!("expected Finish[Void] from recursive CALL_ASSEMBLER, got {other:?}")
+            }
+        };
+        // The callee's concrete void leg ran with the FRESH reds (zeroed
+        // stackpos), proving the side effect fired.
+        assert_eq!(RECURSIVE_CALLEE_ARG.with(|c| c.get()), 0);
+
+        let recorder = ctx.into_recorder();
+        let ops = recorder.ops();
+        let call_ops: Vec<_> = ops
+            .iter()
+            .filter(|o| o.opcode == OpCode::CallAssemblerN)
+            .collect();
+        assert_eq!(
+            call_ops.len(),
+            1,
+            "recursive CALL_ASSEMBLER[Void] must record exactly one CallAssemblerN op",
+        );
+        let call = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::CallAssemblerN)
+            .unwrap();
+        let gnf = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::GuardNotForced)
+            .expect("CALL_ASSEMBLER[Void] must record a GUARD_NOT_FORCED");
+        assert!(call < gnf, "CALL_ASSEMBLER must precede GUARD_NOT_FORCED");
+    }
+
+    /// #19 Step 1 — a `jit_merge_point` reached INSIDE an inlined recursive
+    /// portal callee (portal_call_depth > 0) must NOT be traced through the
+    /// callee's return; it takes the `opimpl_jit_merge_point` else-branch
+    /// (pyjitpl.py:1579-1602): finishframe(leave_portal_frame=False) pops the
+    /// inline callee, do_recursive_call(assembler_call=True) records a
+    /// CALL_ASSEMBLER into the callee's own compiled loop on the caller frame,
+    /// then a deferred leave_portal_frame, then ChangeFrame resumes the caller.
+    ///
+    /// The fixture merges the two existing recursive-portal fixtures: it BOTH
+    /// inlines the portal (so `inline_depth() > 0` and the callee reaches a
+    /// merge point at depth > 0) AND resolves a CALL_ASSEMBLER target so the
+    /// cut can record the recursion.  The recorded op stream must be
+    /// `[ENTER_PORTAL_FRAME … CALL_ASSEMBLER, GUARD_NOT_FORCED,
+    /// LEAVE_PORTAL_FRAME]` in that order (LEAVE deferred past the call), and
+    /// the callee body after the merge point (its `int_return`) must NOT be
+    /// traced inline — the recursion is a single CALL_ASSEMBLER, not an
+    /// inlined tail.
+    struct RecursivePortalMergePointRuntime {
+        portal: std::sync::Arc<JitCode>,
+        token: std::sync::Arc<majit_backend::JitCellToken>,
+    }
+
+    impl JitCodeRuntime for RecursivePortalMergePointRuntime {
+        fn label_at(&self, _pc: usize) -> usize {
+            0
+        }
+
+        fn recursive_inline_decision(
+            &self,
+            _jd_index: usize,
+            _green_values: &[i64],
+            _inline_depth: usize,
+            _recursive_depth: usize,
+        ) -> crate::pyjitpl::InlineDecision {
+            // Inline the portal so `exec_recursive_call` takes the
+            // `portal_jitcode` branch and pushes the inline frame.
+            crate::pyjitpl::InlineDecision::Inline
+        }
+
+        fn portal_jitcode(&self, _jd_index: usize) -> Option<std::sync::Arc<JitCode>> {
+            Some(self.portal.clone())
+        }
+
+        fn recursive_call_assembler_target(
+            &self,
+            _jd_index: usize,
+            _green_values: &[i64],
+        ) -> Option<(std::sync::Arc<majit_backend::JitCellToken>, u64)> {
+            Some((self.token.clone(), 0))
+        }
+
+        fn execute_recursive_assembler_int(
+            &self,
+            _token: &majit_backend::JitCellToken,
+            reds: &[Value],
+        ) -> Option<i64> {
+            // Concrete leg: the fresh reds start with the zeroed scalar, so
+            // arg + 100 == 100 is distinguishable from any caller value.
+            let arg = match reds.first() {
+                Some(Value::Int(v)) => *v,
+                _ => return None,
+            };
+            Some(arg + 100)
+        }
+    }
+
+    #[test]
+    fn recursive_portal_merge_point_cuts_to_call_assembler() {
+        // Portal body: a merge point THEN a return.  The merge point is
+        // reached at portal_call_depth > 0 (inlined), triggering the
+        // else-branch cut; the trailing `int_return` must NOT be traced (the
+        // callee frame is popped by the cut before it can run).
+        let mut portal_builder = JitCodeBuilder::new();
+        portal_builder.jit_merge_point(0, &[], &[], &[], &[], &[], &[]);
+        portal_builder.int_return(0);
+        let portal = std::sync::Arc::new(portal_builder.finish());
+
+        // Caller: recurse into the portal (decision = Inline), result into
+        // reg 0, then return reg 0.
+        let mut caller_builder = JitCodeBuilder::new();
+        caller_builder.recursive_call_int(0, 0, &[], &[]);
+        caller_builder.int_return(0);
+        let caller = caller_builder.finish();
+
+        // Register a jitdriver with `no_loop_header = true` so the callee's
+        // merge point auto-stamps `seen_loop_header_for_jdindex` (>= 0),
+        // bypassing the EDIT-A seen<0 skip and flowing into the depth>0 cut.
+        let mut staticdata = crate::MetaInterpStaticData::new();
+        let mut jd = crate::jitdriver::JitDriverStaticData::new(vec![], vec![("frame", Type::Int)]);
+        jd.index = Some(0);
+        jd.result_type = Type::Int;
+        jd.no_loop_header = true;
+        staticdata.jitdrivers_sd.push(jd);
+
+        let recorder = crate::recorder::Trace::new();
+        let mut ctx = TraceCtx::new(recorder, 0, std::sync::Arc::new(staticdata));
+        let mut sym = RecursiveFreshSym;
+        let runtime = RecursivePortalMergePointRuntime {
+            portal: portal.clone(),
+            token: std::sync::Arc::new(majit_backend::JitCellToken::new(7)),
+        };
+
+        let action =
+            trace_jitcode_with_args_and_runtime(&mut ctx, &mut sym, &caller, 0, &runtime, &[]);
+
+        let finish_args = match action {
+            TraceAction::Finish {
+                finish_args,
+                finish_arg_types,
+                exit_with_exception: false,
+            } => {
+                assert_eq!(finish_arg_types, vec![majit_ir::Type::Int]);
+                finish_args
+            }
+            other => {
+                panic!("expected Finish[Int] from recursive-portal merge-point cut, got {other:?}")
+            }
+        };
+
+        let recorder = ctx.into_recorder();
+        let ops = recorder.ops();
+
+        let enter = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::EnterPortalFrame);
+        let call = ops.iter().position(|o| o.opcode == OpCode::CallAssemblerI);
+        let gnf = ops.iter().position(|o| o.opcode == OpCode::GuardNotForced);
+        let leave = ops
+            .iter()
+            .position(|o| o.opcode == OpCode::LeavePortalFrame);
+
+        let enter = enter.expect("must record ENTER_PORTAL_FRAME at the inline-portal push");
+        let call = call.expect("cut must record a CALL_ASSEMBLER for the recursion");
+        let gnf = gnf.expect("CALL_ASSEMBLER must record a GUARD_NOT_FORCED");
+        let leave = leave.expect("cut must record the deferred LEAVE_PORTAL_FRAME");
+
+        // Each of the paired ops is unique.
+        assert_eq!(
+            ops.iter()
+                .filter(|o| o.opcode == OpCode::EnterPortalFrame)
+                .count(),
+            1,
+            "exactly one ENTER_PORTAL_FRAME",
+        );
+        assert_eq!(
+            ops.iter()
+                .filter(|o| o.opcode == OpCode::CallAssemblerI)
+                .count(),
+            1,
+            "the recursion is a single CALL_ASSEMBLER — the callee was NOT traced inline",
+        );
+        assert_eq!(
+            ops.iter()
+                .filter(|o| o.opcode == OpCode::LeavePortalFrame)
+                .count(),
+            1,
+            "exactly one LEAVE_PORTAL_FRAME",
+        );
+
+        // Recorded order: [ENTER_PORTAL_FRAME … CALL_ASSEMBLER,
+        // GUARD_NOT_FORCED, LEAVE_PORTAL_FRAME] — the LEAVE is deferred past
+        // the CALL_ASSEMBLER (leave_portal_frame=False on the pop,
+        // re-emitted after the call).
+        assert!(
+            enter < call && call < gnf && gnf < leave,
+            "op order must be ENTER < CALL_ASSEMBLER < GUARD_NOT_FORCED < LEAVE, got \
+             enter={enter} call={call} gnf={gnf} leave={leave}",
+        );
+
+        // The portal tail after the merge point (`int_return`) produced no
+        // inline return-derived ops: the sole finish value is the recursion's
+        // CALL_ASSEMBLER result wired into the caller's return register.
+        assert_eq!(finish_args.len(), 1);
+        assert_eq!(
+            finish_args[0],
+            ops[call].pos.get(),
+            "the finish value must be the recursive CALL_ASSEMBLER result",
         );
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3863,6 +3863,30 @@ where
                         self.seen_loop_header_for_jdindex,
                     );
                     self.seen_loop_header_for_jdindex = -1;
+                    // pyjitpl.py:2991-2993 reached_loop_header: generate a dummy
+                    // GUARD_FUTURE_CONDITION just before the implicit JUMP so
+                    // unroll's `jump_to_existing_trace` has a `patchguardop`
+                    // whose `rd_resume_position` it copies onto every extra
+                    // virtual-state guard (unroll.py:333-337, resume.py:397).
+                    // The source-level tracer emits this in `close_loop_args_at`
+                    // (trace_opcode.rs:3397); the state-field dispatch model
+                    // reaches the loop header here instead.  Emitted
+                    // unconditionally at the top of the reached_loop_header
+                    // equivalent, BEFORE the header-match/close/append branching,
+                    // so it fires for EVERY outcome — including the inner-loop
+                    // first-visit append-and-continue path (pyjitpl.py:3058-3060)
+                    // — matching upstream's top-of-function `generate_guard`
+                    // emission.  `record_state_guard` captures the matching resume
+                    // snapshot at `mp_opcode_pc`, mirroring `generate_guard`'s
+                    // `capture_resumedata` (pyjitpl.py:2591-2602).
+                    self.record_state_guard(
+                        ctx,
+                        sym,
+                        OpCode::GuardFutureCondition,
+                        &[],
+                        mp_opcode_pc,
+                        false,
+                    );
                     // pyjitpl.py:2974-3060 reached_loop_header: close the loop
                     // ONLY when the current merge point's green key matches the
                     // trace-start (loop-header) key — `same_greenkey`
@@ -3950,26 +3974,8 @@ where
                             ctx.walk_final_pc = mp_green_pc.map(|p| p as usize);
                             ctx.walk_final_reds = std::mem::take(&mut walk_reds);
                         }
-                        // pyjitpl.py:2967-2969 reached_loop_header: emit a dummy
-                        // GUARD_FUTURE_CONDITION just before the implicit JUMP so
-                        // unroll's `jump_to_existing_trace` has a `patchguardop`
-                        // whose `rd_resume_position` it copies onto every extra
-                        // virtual-state guard (unroll.py:333-337, resume.py:397).
-                        // The source-level tracer emits this in
-                        // `close_loop_args_at` (trace_opcode.rs:3397); the
-                        // state-field dispatch model closes here instead, so the
-                        // GFC must be recorded here.  `record_state_guard`
-                        // captures the matching resume snapshot at
-                        // `mp_opcode_pc`, mirroring `generate_guard`'s
-                        // `capture_resumedata` (pyjitpl.py:2591-2602).
-                        self.record_state_guard(
-                            ctx,
-                            sym,
-                            OpCode::GuardFutureCondition,
-                            &[],
-                            mp_opcode_pc,
-                            false,
-                        );
+                        // GUARD_FUTURE_CONDITION already emitted unconditionally at
+                        // the reached_loop_header entry above (pyjitpl.py:2993).
                         return TraceAction::CloseLoop;
                     }
                     // No same_greenkey match — fall through and keep tracing
@@ -4031,14 +4037,9 @@ where
                                     ctx.walk_final_pc = Some(pc as usize);
                                     ctx.walk_final_reds = std::mem::take(&mut walk_reds);
                                 }
-                                self.record_state_guard(
-                                    ctx,
-                                    sym,
-                                    OpCode::GuardFutureCondition,
-                                    &[],
-                                    mp_opcode_pc,
-                                    false,
-                                );
+                                // GUARD_FUTURE_CONDITION already emitted
+                                // unconditionally at the reached_loop_header entry
+                                // above (pyjitpl.py:2993).
                                 return TraceAction::CloseLoop;
                             }
                             // first visit → append and keep tracing


### PR DESCRIPTION
## #344 Phase B review follow-ups

Follow-ups on top of the merged #344 Phase B (PR #427), addressing the two
Codex P1 review comments and closing the CI-coverage gap. One combined commit.

### 1. `; state` single-pass CI example (`majit/examples/spcount`)

Before this, the `jit_merge_point!(...; state)` single-pass whole-circuit-close
path — now the sole/default trace-close path — had **no** coverage in this
repo's CI. Its only other consumer, aheui, lives in a separate repo outside CI.
`spcount` is a tl-shaped stack machine (scalar `stackpos` + virtualizable
`stack`) with a countable `@dont_look_inside` residual. Its
`jit_residual_not_double_executed` test asserts the residual runs exactly once
per iteration (a walk-vs-native double-execution during single-pass tracing
would inflate the count). Registered in the workspace members and the CI
cranelift `-p` list (the dynasm leg uses `--all`).

### 2. Hoist `GUARD_FUTURE_CONDITION` (Codex §3 parity)

`rpython/jit/metainterp/pyjitpl.py:2993` emits the dummy
`GUARD_FUTURE_CONDITION` unconditionally at the **top** of `reached_loop_header`,
before the compile/close/append branching, so it fires on every outcome —
including the "append and continue tracing" path. majit's `BC_JIT_MERGE_POINT`
emitted it only in the two close branches, missing the inner-loop first-visit
append path. Moved the single emission above the header-match branch and dropped
the two per-branch copies (GFC now recorded exactly once per
`reached_loop_header`).

### 3. Fix `writeback_scalar_state_fields` no-op (Codex P1 #2)

`merge_point` set `self.sym = None` at the end of the `CloseLoop` arm before
returning, so the macro's post-return `writeback_scalar_state_fields` read a
`None` sym and never wrote the walk-final scalars into native `state`. A walk
that advanced a scalar (e.g. an aheui SEL-advanced `selected`) across a
single-pass close left native state frozen at the trace-start value, and
`recover` then re-derived storage caches from a stale scalar. Confirmed by
runtime instrumentation (writeback fired twice on `logo.aheui`, both with the
sym already cleared).

Fix: capture the scalar values off the still-live sym inside the `CloseLoop`
arm (new `JitState::collect_scalar_state_field_values` static method, mirroring
`collect_jump_args` — `JitDriver`'s `S::Sym` has no `JitCodeSym` bound so the
driver cannot read `state_field_value` directly), stash them on `MetaInterp`,
and have `writeback_scalar_state_fields` consume the stash via a new
`writeback_scalar_state_fields_from_values` method. The macro call order
(`writeback` → `recover` → `try_resume`) is unchanged. Adds a regression test
that drives a scalar advance across a `CloseLoop` and asserts native state
receives it; verified it fails when the capture is disabled.

Codex P1 #1 ("`capture_walk_reds` unconditional → default plain-form callers
double-execute the residual") was **not** actioned: it is overturned by the tl
`jit_residual_not_double_executed` canary (green). `capture_walk_reds` only
records `walk_final_pc`; its consumption (`try_resume` + `continue`) happens
only in the `; state` form, and plain-form callers discard the returned outcome,
so no double-execution occurs.

### Verification

- `majit-metainterp` 1385, `spcount` 3, `tl` 28 — 0 failed.
- aheui `logo --jit` == `--no-jit` == `996310` bytes, byte-identical.
- `cargo fmt --check` clean; no new clippy warnings.

— *authored by Claude*

---

### Additional commits since this PR was opened

The following commits were pushed onto `single-walker` after this PR was opened
and are now part of it:

- **`c0db89dbf94`** — `port recursive-portal merge-point cut ... (#19)`: recursive-portal
  merge-point cut plus the 4-kind recursive `CALL_ASSEMBLER` handling.
- **`41954edcdb9`** — `majit: correct ResidualCall/abort parity comments in
  exec_recursive_call`: corrects the `ResidualCall`/abort parity comments in
  `exec_recursive_call` (comment-only change).

— *authored by Claude*
