### PR TITLE
jit: close gh#152 deep-kept operand-stack resume gap (RPython register/liveness channel)

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1783,7 +1783,14 @@ impl<S: JitState> JitDriver<S> {
         match action {
             TraceAction::Continue => {}
             TraceAction::CompileTrace => {
-                self.meta.abort_trace(false);
+                // Successful compile-into-existing-target: raise_if_successful()
+                // raises ContinueRunningNormally (pyjitpl.py:3095-3123), which
+                // bypasses the `except SwitchToBlackhole` handler, so only the
+                // live history teardown runs — `aborted_tracing` accounting is
+                // NOT reached on success (the loop/bridge counter was already
+                // bumped at backend-compile time). Call the live-teardown half
+                // only, not the accounting half.
+                self.meta.abort_trace_live(false);
                 self.sym = None;
                 self.meta.clear_trace_session();
                 self.compile_trace_success = true;
@@ -1906,7 +1913,10 @@ impl<S: JitState> JitDriver<S> {
                                         continue_running_normally_values,
                                         None,
                                     );
-                                    self.meta.abort_trace(false);
+                                    // Success edge: live teardown only, no
+                                    // aborted_tracing accounting (see the
+                                    // CompileTrace arm above).
+                                    self.meta.abort_trace_live(false);
                                     return;
                                 }
                                 // pyjitpl.py:2993-3007: after retrace_needed(),
@@ -2060,7 +2070,10 @@ impl<S: JitState> JitDriver<S> {
                                     continue_running_normally_values,
                                     loop_header_pc,
                                 );
-                                self.meta.abort_trace(false);
+                                // Success edge: live teardown only, no
+                                // aborted_tracing accounting (see the
+                                // CompileTrace arm above).
+                                self.meta.abort_trace_live(false);
                                 return;
                             }
                             // pyjitpl.py:2993-3007: after retrace_needed(),
@@ -2440,7 +2453,11 @@ impl<S: JitState> JitDriver<S> {
                 let (continue_running_normally_values, continue_running_normally_pc) = self
                     .take_continue_running_normally_payload()
                     .map_or((None, None), |(values, pc)| (Some(values), pc));
-                self.meta.abort_trace(false);
+                // Re-observing a success the CompileTrace arm already tore down
+                // (compile_trace_success flag). Live teardown only — the
+                // accounting must not fire (it would double-count a single
+                // successful compile as two aborts).
+                self.meta.abort_trace_live(false);
                 self.sym = None;
                 self.meta.clear_trace_session();
                 return Some(DetailedDriverRunOutcome::Jump {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1791,6 +1791,10 @@ impl<S: JitState> JitDriver<S> {
                 // bumped at backend-compile time). Call the live-teardown half
                 // only, not the accounting half.
                 self.meta.abort_trace_live(false);
+                // No aborted_tracing follows on success, so drop the
+                // pending_abort_* payload abort_trace_live staged (else it
+                // attaches this key to a later, unrelated abort's hook).
+                self.meta.clear_pending_abort();
                 self.sym = None;
                 self.meta.clear_trace_session();
                 self.compile_trace_success = true;
@@ -1917,6 +1921,7 @@ impl<S: JitState> JitDriver<S> {
                                     // aborted_tracing accounting (see the
                                     // CompileTrace arm above).
                                     self.meta.abort_trace_live(false);
+                                    self.meta.clear_pending_abort();
                                     return;
                                 }
                                 // pyjitpl.py:2993-3007: after retrace_needed(),
@@ -2074,6 +2079,7 @@ impl<S: JitState> JitDriver<S> {
                                 // aborted_tracing accounting (see the
                                 // CompileTrace arm above).
                                 self.meta.abort_trace_live(false);
+                                self.meta.clear_pending_abort();
                                 return;
                             }
                             // pyjitpl.py:2993-3007: after retrace_needed(),
@@ -2458,6 +2464,7 @@ impl<S: JitState> JitDriver<S> {
                 // accounting must not fire (it would double-count a single
                 // successful compile as two aborts).
                 self.meta.abort_trace_live(false);
+                self.meta.clear_pending_abort();
                 self.sym = None;
                 self.meta.clear_trace_session();
                 return Some(DetailedDriverRunOutcome::Jump {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6972,6 +6972,20 @@ impl<M: Clone> MetaInterp<M> {
         self.clear_trace_session();
     }
 
+    /// Drop the `pending_abort_*` payload staged by `abort_trace_live`.
+    ///
+    /// `abort_trace_live` always stages `(green_key, permanent)` for the
+    /// `aborted_tracing` call that normally follows on the `SwitchToBlackhole`
+    /// unwind. A *successful* compile teardown runs `abort_trace_live` for its
+    /// live cleanup but fires no `aborted_tracing` (raise_if_successful raises
+    /// `ContinueRunningNormally`, pyjitpl.py:3095-3123), so the staged key must
+    /// be dropped here — leaving it would attach this successfully-compiled
+    /// key to a later, unrelated abort's `on_trace_abort` hook.
+    pub fn clear_pending_abort(&mut self) {
+        self.pending_abort_green_key = None;
+        self.pending_abort_permanent = false;
+    }
+
     /// Finish the current trace with a terminal `FINISH`, then optimize and compile it.
     ///
     /// `exit_with_exception` selects the FINISH descr per `pyjitpl.py`:
@@ -12565,8 +12579,7 @@ impl<M: Clone> MetaInterp<M> {
                     // fires, so letting stale greenkey linger would
                     // attach this successfully-compiled bridge's key
                     // to a later, unrelated abort.
-                    self.pending_abort_green_key = None;
-                    self.pending_abort_permanent = false;
+                    self.clear_pending_abort();
                     Ok(())
                 }
                 // pyjitpl.py:3220/:3245 `compile.giveup()` per

--- a/pyre/bench/synth/kept_stack_deep_var_shortcircuit_mutate.py
+++ b/pyre/bench/synth/kept_stack_deep_var_shortcircuit_mutate.py
@@ -4,9 +4,9 @@
 # (a non-journaled STORE_SUBSCR-class heap effect committed inside a user
 # frame).  A FOR_ITER trace that consumes the iterator, aborts on the deep
 # kept-stack guard, and then DELIVERS the in-flight item would re-run the body
-# and DOUBLE the mutation.  The `log` length must equal the iteration count
-# exactly (2 mutations per iteration): a doubled delivery over-counts, a
-# dropped iteration under-counts.
+# and DOUBLE the mutation.  The `log` length must equal 3x the iteration count
+# exactly (g, h, and one conditional g/h append per iteration): a doubled
+# delivery over-counts, a dropped iteration under-counts.
 log = []
 
 

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2041,20 +2041,20 @@ pub fn call_with_kwargs(
         let instance_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(instance);
         // Step 2: __init__(self, *args, **kwargs) with full kwargs support.
-        if let Some(w_insttype) = type_call_init_type(instance, callable) {
-            if let Some(init_fn) =
+        if let Some(w_insttype) = type_call_init_type(instance, callable)
+            && !type_call_type_x_shortcut(callable, pos_args.len(), kwargs.is_empty())
+            && let Some(init_fn) =
                 unsafe { crate::baseobjspace::lookup_in_type(w_insttype, "__init__") }
-            {
-                let mut init_args = Vec::with_capacity(1 + pos_args.len());
-                init_args.push(instance);
-                init_args.extend_from_slice(pos_args);
-                let init_result = if unsafe { crate::is_function(init_fn) } && !kwargs.is_empty() {
-                    call_with_kwargs(frame, init_fn, &init_args, kwargs)?
-                } else {
-                    call_callable(frame, init_fn, &init_args)?
-                };
-                check_init_returned_none(init_result)?;
-            }
+        {
+            let mut init_args = Vec::with_capacity(1 + pos_args.len());
+            init_args.push(instance);
+            init_args.extend_from_slice(pos_args);
+            let init_result = if unsafe { crate::is_function(init_fn) } && !kwargs.is_empty() {
+                call_with_kwargs(frame, init_fn, &init_args, kwargs)?
+            } else {
+                call_callable(frame, init_fn, &init_args)?
+            };
+            check_init_returned_none(init_result)?;
         }
         return Ok(pyre_object::gc_roots::shadow_stack_get(instance_slot));
     }
@@ -2363,7 +2363,9 @@ fn type_descr_call_impl(w_type: PyObjectRef, args: &[PyObjectRef]) -> PyObjectRe
     // Step 2: __init__ — only if __new__ returned an instance of w_type.
     // PyPy checks the Python-level type(instance), so builtin-layout subtypes
     // like set subclasses still run __init__.
-    if let Some(w_insttype) = type_call_init_type(instance, w_type) {
+    if let Some(w_insttype) = type_call_init_type(instance, w_type)
+        && !type_call_type_x_shortcut(w_type, args.len(), true)
+    {
         if let Some(init_fn) =
             unsafe { crate::baseobjspace::lookup_in_type(w_insttype, "__init__") }
         {
@@ -2413,6 +2415,14 @@ fn type_call_init_type(instance: PyObjectRef, w_type: PyObjectRef) -> Option<PyO
     } else {
         None
     }
+}
+
+/// typeobject.py:735-736 — the `type(x)` shortcut: `type.__call__` skips
+/// __init__ when self is the `type` builtin, there are no keyword
+/// arguments, and exactly one positional argument (`type(x)` returns the
+/// class of x, already produced by __new__).
+fn type_call_type_x_shortcut(w_type: PyObjectRef, nargs: usize, no_kwargs: bool) -> bool {
+    no_kwargs && nargs == 1 && std::ptr::eq(w_type, crate::typedef::w_type())
 }
 
 /// Pointer-based subtype check for descr_call __init__ guard — the MRO
@@ -3627,7 +3637,9 @@ fn type_descr_call_with_mode(
 
     // Step 2: __init__ — only if __new__ returned an instance of w_type.
     // PyPy: descr_call — skips __init__ when __new__ returns a foreign type.
-    if let Some(w_insttype) = type_call_init_type(instance, w_type) {
+    if let Some(w_insttype) = type_call_init_type(instance, w_type)
+        && !type_call_type_x_shortcut(w_type, args.len(), true)
+    {
         if let Some(init_fn) =
             unsafe { crate::baseobjspace::lookup_in_type(w_insttype, "__init__") }
         {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7329,6 +7329,28 @@ pub(crate) fn fbw_vable_scalar_ca_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_DEEPKEPT_INT` (default OFF) — extend the deep-kept operand-stack
+/// recovery in [`walker_capture_snapshot_for_last_guard_impl`] to fill an
+/// UNBOXED-INT hole from the Int register bank. A Ref-typed stack slot
+/// semantically holding an Int (e.g. condexpr's `a+i` `IntAdd` result) is left
+/// a hole by the Ref-only fill; when on, the capture reads `registers_i[color]`
+/// (the color named by `semantic_slot_color_for_int_slot`) and boxes the raw
+/// int into a `W_IntObject` (`wrapint`) so the vable array carries a Ref.
+/// Ports the `if length_i:` i-bank section of `get_list_of_active_boxes`
+/// (`pyjitpl.py:206-210`). Default OFF: flag-off is byte-identical to the
+/// int-as-hole behavior (resume re-materializes the int from its defining IR),
+/// mirroring how the S1 mirror extension staged behind `PYRE_FBW_DEEPKEPT_MIRROR`.
+pub(crate) fn deepkept_int_recovery_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_DEEPKEPT_INT") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => false,
+    })
+}
+
 /// `PYRE_FBW_RAISE` (default ON) — the FBW walker owns the Python raise/except
 /// loop.  The twin NULL-ref guards exempt the trailing `cause` sentinel of a
 /// [`PyreHelperKind::RaiseVarargs`] residual so the walker records the raise.
@@ -10225,7 +10247,9 @@ fn walker_capture_snapshot_for_last_guard_impl(
                     if covered.contains(&vidx) {
                         continue;
                     }
-                    // Guard-PC color that owns operand-stack slot `nlocals + s`.
+                    // Guard-PC Ref color that owns operand-stack slot
+                    // `nlocals + s` (`get_list_of_active_boxes` `if length_r:`
+                    // section, `pyjitpl.py:211-215`).
                     if let Some(color) =
                         crate::state::semantic_slot_color_for_ref_slot(&pcdep, nlocals + s)
                     {
@@ -10237,15 +10261,64 @@ fn walker_capture_snapshot_for_last_guard_impl(
                             // bank color holding an `IntAdd` result, e.g.
                             // condexpr's `a+i`) is Int-typed and would decode as
                             // `Box type Int != expected Ref`; it needs a
-                            // `NEW_W_INT` box the capture cannot synthesize, so
-                            // leave it a hole (the mirror already sourced every
-                            // restorable slot).
+                            // `NEW_W_INT` box the capture cannot synthesize
+                            // (boxing here emits into a settled trace →
+                            // `store_final_boxes_in_guard` panic), so leave it a
+                            // hole (the mirror already sourced every restorable
+                            // slot). The int-bank recovery below handles the
+                            // bank-0 channel where a raw int lives in the Int
+                            // register file instead.
                             if box_op != OpRef::NONE
                                 && !opref_is_null_const_ptr(box_op)
                                 && box_op.ty() == Some(majit_ir::Type::Ref)
                             {
                                 augmented.push((vidx, box_op));
                                 covered.insert(vidx);
+                            }
+                        }
+                    }
+                    // Int-bank fill (`get_list_of_active_boxes` `if length_i:`
+                    // section, `pyjitpl.py:206-210` —
+                    // `add_box_to_storage(self.registers_i[index])`), gated
+                    // `PYRE_FBW_DEEPKEPT_INT` (default OFF). Ref precedence:
+                    // only fill a slot the Ref bank left a hole. A bank-0 (Int)
+                    // pcdep entry names the Int-bank color owning slot
+                    // `nlocals + s`, and `registers_i[color]` holds the raw
+                    // unboxed int; box it into a `W_IntObject` (`wrapint`, the
+                    // `NewWithVtable` + `SetfieldGc(intval)` pair
+                    // `materialize_loop_carried_value` emits for a Ref-typed
+                    // loop-carried slot) so the uniformly Ref-typed vable array
+                    // carries a Ref, not a raw Int the resume decode would
+                    // reject as `Box type Int != expected Ref`. Default OFF:
+                    // flag-off leaves the int a hole, byte-identical to today
+                    // (resume re-materializes it from its defining IR).
+                    //
+                    // Scaffolding on the current frontend: pyre's operand stack
+                    // is uniformly Ref-banked in the pcdep map
+                    // (`locals_cells_stack_w` is a `W_Root[]` array), so no
+                    // bank-0 stack entry exists yet and this fires nowhere. The
+                    // real int-hole source — a Ref-bank color whose
+                    // `registers_r[color]` OpRef is itself Int-typed — CANNOT be
+                    // boxed here: `wrapint` emits `NewWithVtable` + `SetfieldGc`
+                    // into an already-settled trace at capture time, which trips
+                    // `store_final_boxes_in_guard` (`resume.py:397`
+                    // `resume_position >= 0`). The box must be synthesized at
+                    // operand-stack PUSH time, not lazily at snapshot capture —
+                    // that is a frontend change beyond this capture hook (a
+                    // bank-0 channel, e.g. the tagged-int epic, or a push-time
+                    // NEW_W_INT), tracked as a follow-up. This literal i-bank
+                    // read stays as the RPython-parity channel for when bank-0
+                    // stack entries do exist.
+                    if deepkept_int_recovery_enabled() && !covered.contains(&vidx) {
+                        if let Some(color) =
+                            crate::state::semantic_slot_color_for_int_slot(&pcdep, nlocals + s)
+                        {
+                            if let Some(&raw) = ctx.registers_i.get(color) {
+                                if raw != OpRef::NONE && raw.ty() == Some(majit_ir::Type::Int) {
+                                    let boxed = crate::state::wrapint(ctx.trace_ctx, raw);
+                                    augmented.push((vidx, boxed));
+                                    covered.insert(vidx);
+                                }
                             }
                         }
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -10166,6 +10166,94 @@ fn walker_capture_snapshot_for_last_guard_impl(
             } else {
                 Vec::new()
             };
+            // Recover a kept operand-stack slot the walk mirror lost across a
+            // not-taken branch merge.  At a branch guard whose not-taken arm
+            // keeps a CALL result deep on the operand stack
+            // (`t=(g(i),h(i),(g(i) if p or q else h(i)))`), the walk took the
+            // OTHER arm, so `ctx.vstack_boxes[s]` is a `PY_NULL` hole for the
+            // deep slot and the `stack_sync` overlay above omits it — the
+            // resumed vable array then reads that slot NULL and the interpreted
+            // body dereferences it (SIGSEGV).  The trampoline edge-move recovery
+            // (`resolved_recovered`) is empty for this shape, so the mirror is
+            // the only kept-stack source and it has a hole.
+            // Fill the hole from the guard-PC register file: the per-PC
+            // `pcdep_color_slots` map at `guard_py_pc` names the Ref-bank color
+            // that holds operand-stack slot `nlocals + s` at THIS guard PC (the
+            // same authoritative inversion `collect_outer_active_boxes` reads),
+            // and `ctx.registers_r[color]` holds the live guard-state box.  This
+            // is the guard-PC color read (as `resolved_recovered` does for
+            // `registers_r[src]`), NOT the retired stale merge-color read.
+            // This ports `get_list_of_active_boxes`
+            // (rpython/jit/metainterp/pyjitpl.py:177-234), which captures guard
+            // resume boxes from `registers_r[index]` via the per-PC `-live-`
+            // set.
+            // Capture-only: writes the transient snapshot overlay, never the live
+            // shadow (the trace_opcode.rs:2218 bridge-NULL constraint holds).
+            let stack_sync: Vec<(usize, OpRef)> = if guard_py_pc.is_some()
+                && sym.owns_virtualizable_shadow()
+                && !sym.jitcode.is_null()
+            {
+                let gpc = guard_py_pc.unwrap() as usize;
+                let nlocals = sym.nlocals;
+                let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
+                let depth = unsafe {
+                    let jc = &*sym.jitcode;
+                    if jc.payload.code_ptr.is_null() {
+                        0usize
+                    } else {
+                        crate::liveness::liveness_for(jc.payload.code_ptr)
+                            .depth_at_py_pc()
+                            .get(gpc)
+                            .copied()
+                            .unwrap_or(0) as usize
+                    }
+                };
+                let pcdep: Vec<(u8, u16, u16)> = unsafe {
+                    let jc = &*sym.jitcode;
+                    jc.payload
+                        .metadata
+                        .pcdep_color_slots
+                        .get(gpc)
+                        .cloned()
+                        .unwrap_or_default()
+                };
+                let mut covered: std::collections::HashSet<usize> =
+                    stack_sync.iter().map(|&(idx, _)| idx).collect();
+                let mut augmented = stack_sync;
+                for s in 0..depth {
+                    let vidx = nvs + nlocals + s;
+                    if covered.contains(&vidx) {
+                        continue;
+                    }
+                    // Guard-PC color that owns operand-stack slot `nlocals + s`.
+                    if let Some(color) =
+                        crate::state::semantic_slot_color_for_ref_slot(&pcdep, nlocals + s)
+                    {
+                        if let Some(&box_op) = ctx.registers_r.get(color) {
+                            // Only a genuine Ref box may fill an operand-stack
+                            // slot: the vable array is uniformly Ref-typed, and
+                            // `build_vable_snapshot_boxes` reads each entry's
+                            // `OpRef::ty()`.  An unboxed-int kept temp (a `Ref`-
+                            // bank color holding an `IntAdd` result, e.g.
+                            // condexpr's `a+i`) is Int-typed and would decode as
+                            // `Box type Int != expected Ref`; it needs a
+                            // `NEW_W_INT` box the capture cannot synthesize, so
+                            // leave it a hole (the mirror already sourced every
+                            // restorable slot).
+                            if box_op != OpRef::NONE
+                                && !opref_is_null_const_ptr(box_op)
+                                && box_op.ty() == Some(majit_ir::Type::Ref)
+                            {
+                                augmented.push((vidx, box_op));
+                                covered.insert(vidx);
+                            }
+                        }
+                    }
+                }
+                augmented
+            } else {
+                stack_sync
+            };
             let saved_shadow: Vec<(usize, Option<OpRef>)> = stack_sync
                 .iter()
                 .map(|&(idx, _)| (idx, ctx.trace_ctx.virtualizable_box_at(idx)))

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1788,6 +1788,28 @@ pub(crate) fn semantic_slot_for_reg_color(
     stack_match.or(local_match)
 }
 
+/// Inverse of [`semantic_slot_for_reg_color`] for the Ref bank: given a
+/// semantic `locals_cells_stack_w` slot, return the Ref-bank color that owns
+/// it at this PC per the `(bank, color, slot)` map. Used by the deep-kept
+/// operand-stack recovery in `walker_capture_snapshot_for_last_guard_impl` to
+/// name the guard-PC register (`registers_r[color]`) holding a kept operand-
+/// stack slot the walk mirror lost. Returns the smallest matching color;
+/// `None` when no live Ref color owns the slot at this PC.
+pub(crate) fn semantic_slot_color_for_ref_slot(
+    pcdep_entries: &[(u8, u16, u16)],
+    slot: usize,
+) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    for &(b, color, s) in pcdep_entries {
+        if b != 1 || s as usize != slot {
+            continue;
+        }
+        let c = color as usize;
+        best = Some(best.map_or(c, |cur: usize| cur.min(c)));
+    }
+    best
+}
+
 // Sentinel null JitCode for uninitialized PyreSym.
 //
 // Cannot be `static` because `Arc::new` is not const; use a thread_local

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1788,6 +1788,27 @@ pub(crate) fn semantic_slot_for_reg_color(
     stack_match.or(local_match)
 }
 
+/// Bank-generic inverse of [`semantic_slot_for_reg_color`]: given a semantic
+/// `locals_cells_stack_w` slot and a bank tag (`pyjitcode.rs:198-204`:
+/// 0=Int, 1=Ref, 2=Float), return the color of that bank owning the slot at
+/// this PC per the `(bank, color, slot)` map. Returns the smallest matching
+/// color; `None` when no live color of that bank owns the slot at this PC.
+fn semantic_slot_color_for_slot(
+    pcdep_entries: &[(u8, u16, u16)],
+    slot: usize,
+    bank: u8,
+) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    for &(b, color, s) in pcdep_entries {
+        if b != bank || s as usize != slot {
+            continue;
+        }
+        let c = color as usize;
+        best = Some(best.map_or(c, |cur: usize| cur.min(c)));
+    }
+    best
+}
+
 /// Inverse of [`semantic_slot_for_reg_color`] for the Ref bank: given a
 /// semantic `locals_cells_stack_w` slot, return the Ref-bank color that owns
 /// it at this PC per the `(bank, color, slot)` map. Used by the deep-kept
@@ -1799,15 +1820,28 @@ pub(crate) fn semantic_slot_color_for_ref_slot(
     pcdep_entries: &[(u8, u16, u16)],
     slot: usize,
 ) -> Option<usize> {
-    let mut best: Option<usize> = None;
-    for &(b, color, s) in pcdep_entries {
-        if b != 1 || s as usize != slot {
-            continue;
-        }
-        let c = color as usize;
-        best = Some(best.map_or(c, |cur: usize| cur.min(c)));
-    }
-    best
+    semantic_slot_color_for_slot(pcdep_entries, slot, 1)
+}
+
+/// Int-bank inverse of [`semantic_slot_for_reg_color`]: given a semantic
+/// `locals_cells_stack_w` slot, return the Int-bank color (`registers_i`) that
+/// owns it at this PC per the `(bank, color, slot)` map. The Int-bank sibling
+/// of [`semantic_slot_color_for_ref_slot`], feeding the deep-kept UNBOXED-INT
+/// operand-stack recovery in `walker_capture_snapshot_for_last_guard_impl`: a
+/// bank-0 (Int) stack slot names the guard-PC `registers_i[color]` holding the
+/// raw int, which the capture then boxes into a `W_IntObject`.
+/// `get_list_of_active_boxes` (`pyjitpl.py:206-210`) captures the i-bank via a
+/// separate `if length_i:` section
+/// (`add_box_to_storage(self.registers_i[index])`). Returns the smallest
+/// matching color; `None` when no live Int color owns the slot — which is
+/// every current-frontend stack slot, since pyre banks `locals_cells_stack_w`
+/// uniformly as Ref (bank-1). See the caller for why the Ref-bank Int-typed
+/// hole is NOT recovered by boxing at capture time.
+pub(crate) fn semantic_slot_color_for_int_slot(
+    pcdep_entries: &[(u8, u16, u16)],
+    slot: usize,
+) -> Option<usize> {
+    semantic_slot_color_for_slot(pcdep_entries, slot, 0)
 }
 
 // Sentinel null JitCode for uninitialized PyreSym.

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9557,66 +9557,17 @@ impl CodeWriter {
                             // its `(color -> slot)` entry for the M3 body-guard
                             // resume.  TOS is the iterator (`current_depth - 1`).
                             //
-                            // WITHHOLD the reload when the loop body holds a
-                            // CALL result across an in-body conditional branch
-                            // (a `CALL` opcode and a `POP_JUMP_IF_*` both inside
-                            // `[py_pc+1, exhaust_target)`).  That shape produces
-                            // a depth > 1 operand stack of call results kept
-                            // across a short-circuit / conditional guard whose
-                            // COMPILED interior-guard resume cannot yet
-                            // reconstruct the deep slots (the walk-level operand
-                            // mirror reports them present, but the blackhole
-                            // rebuilds them NULL — the #416/#420 deep-kept
-                            // interior-snapshot gap).  Enabling the reload lets
-                            // the walk enter and CONSUME the shared iterator, run
-                            // the body's residual calls concretely, then abort at
-                            // the deep guard — an irreversible half-executed
-                            // iteration that cannot be delivered (re-running the
-                            // body doubles a committed effect) nor cleanly
-                            // dropped (it loses the iteration).  Without the
-                            // reload the `ForIterNext` residual has no bound
-                            // iterator argument, so the walk aborts at the
-                            // FOR_ITER header BEFORE the consume
-                            // (`ResidualCallArgUnbound`) and the location
-                            // interprets permanently — bit-exact, the pre-reload
-                            // behaviour.  condexpr (branch, no call) and
-                            // nested_call (call, no in-body branch) do not match,
-                            // so both keep the reload.  Lifted when the deep-kept
-                            // interior-guard snapshot lands.
-                            let foriter_deep_kept_call_hazard = {
-                                let exhaust_target = jump_target_forward(
-                                    code,
-                                    num_instrs,
-                                    py_pc + 1,
-                                    delta.get(op_arg).as_usize(),
-                                );
-                                let mut scan_state = pyre_interpreter::OpArgState::default();
-                                let mut has_call = false;
-                                let mut has_branch = false;
-                                for scan_pc in 0..num_instrs {
-                                    let (scan_instr, _) =
-                                        scan_state.get(code.instructions[scan_pc]);
-                                    if scan_pc <= py_pc || scan_pc >= exhaust_target {
-                                        continue;
-                                    }
-                                    match scan_instr {
-                                        Instruction::Call { .. }
-                                        | Instruction::CallKw { .. }
-                                        | Instruction::CallFunctionEx
-                                        | Instruction::CallIntrinsic1 { .. }
-                                        | Instruction::CallIntrinsic2 { .. } => has_call = true,
-                                        Instruction::PopJumpIfTrue { .. }
-                                        | Instruction::PopJumpIfFalse { .. }
-                                        | Instruction::PopJumpIfNone { .. }
-                                        | Instruction::PopJumpIfNotNone { .. } => has_branch = true,
-                                        _ => {}
-                                    }
-                                }
-                                has_call && has_branch
-                            };
+                            // The per-iteration reload is unconditional for
+                            // portals.  Deep operand-stack kept temps that an
+                            // in-body branch-guard resume needs (a CALL result
+                            // held across a short-circuit / conditional guard)
+                            // are recovered via the register/liveness channel in
+                            // `walker_capture_snapshot_for_last_guard_impl`
+                            // (jitcode_dispatch.rs), porting
+                            // `get_list_of_active_boxes` (pyjitpl.py:177-234).
                             let iter_slot_depth = current_depth.saturating_sub(1);
                             let iter_value: super::flow::FlowValue =
-                                if is_portal && !foriter_deep_kept_call_hazard {
+                                if is_portal {
                                     let iter_abs_slot =
                                         (stack_base_absolute + iter_slot_depth as usize) as i64;
                                     let v_iter_idx: super::flow::FlowValue =
@@ -9635,11 +9586,8 @@ impl CodeWriter {
                                     pin!(Some(v_iter), stack_base + iter_slot_depth);
                                     v_iter.into()
                                 } else {
-                                    // Non-portal callee (no vable read; keep the
-                                    // loop-carried operand SSA Variable at TOS) OR
-                                    // the deep-kept-call hazard shape (withhold the
-                                    // reload so the walk aborts at the header before
-                                    // the irreversible consume).
+                                    // Non-portal callee: no vable read; keep the
+                                    // loop-carried operand SSA Variable at TOS.
                                     current_state
                                         .stack
                                         .last()

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -9566,34 +9566,33 @@ impl CodeWriter {
                             // (jitcode_dispatch.rs), porting
                             // `get_list_of_active_boxes` (pyjitpl.py:177-234).
                             let iter_slot_depth = current_depth.saturating_sub(1);
-                            let iter_value: super::flow::FlowValue =
-                                if is_portal {
-                                    let iter_abs_slot =
-                                        (stack_base_absolute + iter_slot_depth as usize) as i64;
-                                    let v_iter_idx: super::flow::FlowValue =
-                                        super::flow::Constant::signed(iter_abs_slot).into();
-                                    let v_iter = emit_graph_op_with_result(
-                                        &mut graph,
-                                        &current_block.block(),
-                                        "getarrayitem_vable_r",
-                                        vable_getarrayitem_ref_graph_args(
-                                            frame_var.into(),
-                                            v_iter_idx.into(),
-                                        ),
-                                        Kind::Ref,
-                                        py_pc as i64,
-                                    );
-                                    pin!(Some(v_iter), stack_base + iter_slot_depth);
-                                    v_iter.into()
-                                } else {
-                                    // Non-portal callee: no vable read; keep the
-                                    // loop-carried operand SSA Variable at TOS.
-                                    current_state
-                                        .stack
-                                        .last()
-                                        .cloned()
-                                        .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
-                                };
+                            let iter_value: super::flow::FlowValue = if is_portal {
+                                let iter_abs_slot =
+                                    (stack_base_absolute + iter_slot_depth as usize) as i64;
+                                let v_iter_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(iter_abs_slot).into();
+                                let v_iter = emit_graph_op_with_result(
+                                    &mut graph,
+                                    &current_block.block(),
+                                    "getarrayitem_vable_r",
+                                    vable_getarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        v_iter_idx.into(),
+                                    ),
+                                    Kind::Ref,
+                                    py_pc as i64,
+                                );
+                                pin!(Some(v_iter), stack_base + iter_slot_depth);
+                                v_iter.into()
+                            } else {
+                                // Non-portal callee: no vable read; keep the
+                                // loop-carried operand SSA Variable at TOS.
+                                current_state
+                                    .stack
+                                    .last()
+                                    .cloned()
+                                    .unwrap_or_else(|| fresh_ref_value(&mut graph).into())
+                            };
                             let next_var = residual_call!(
                                 for_iter_next_fn_idx,
                                 CallFlavor::MayForce,

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -706,9 +706,51 @@ pub unsafe fn w_type_get_mro(obj: PyObjectRef) -> *mut Vec<PyObjectRef> {
 pub unsafe fn w_type_issubtype(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
     let mro_ptr = w_type_get_mro(w_type);
     if mro_ptr.is_null() {
+        // typeobject.py:1646 _issubtype_slow_and_wrong — a partially
+        // initialised type (custom metaclass mro()) has no mro yet; walk
+        // find_best_base up the base chain (single inheritance, deliberately
+        // wrong for multiple inheritance).
+        let mut w_cls = w_type;
+        while !w_cls.is_null() {
+            if std::ptr::eq(w_cls, cls) {
+                return true;
+            }
+            w_cls = find_best_base(w_cls);
+        }
         return false;
     }
     (*mro_ptr).iter().any(|&t| std::ptr::eq(t, cls))
+}
+
+/// typeobject.py:1335-1354 find_best_base — the type base whose instance
+/// layout a subtype extends (most-derived layout among the type bases).
+/// Non-raising variant for the null-mro subtype fallback.
+unsafe fn find_best_base(w_type: PyObjectRef) -> PyObjectRef {
+    let bases = w_type_get_bases(w_type);
+    if bases.is_null() {
+        return PY_NULL;
+    }
+    let mut w_bestbase = PY_NULL;
+    let mut best_layout: *const Layout = std::ptr::null();
+    for w_cand in crate::tupleobject::w_tuple_items_copy_as_vec(bases) {
+        if !is_type(w_cand) {
+            continue;
+        }
+        let cand_layout = w_type_get_layout_ptr(w_cand);
+        if w_bestbase.is_null() {
+            w_bestbase = w_cand;
+            best_layout = cand_layout;
+            continue;
+        }
+        if cand_layout != best_layout
+            && !cand_layout.is_null()
+            && (*cand_layout).issublayout(best_layout)
+        {
+            w_bestbase = w_cand;
+            best_layout = cand_layout;
+        }
+    }
+    w_bestbase
 }
 
 /// Set the cached MRO.


### PR DESCRIPTION
Closes the deep-kept operand-stack resume gap in the FOR_ITER residency path
(gh#152 layer-2 census: the `kept_stack_deep_var_*` trio + `short_circuit_side_effects`).

## What

Three commits, all gh#152:

1. **`majit: route successful-compile trace teardown to abort_trace_live`** — fix the
   `loops_aborted` success-teardown double-count. `abort_trace(false)` was overloaded as
   generic trace-session teardown and bumped `stats.loops_aborted` even on a *successful*
   compile (a NEW-DEVIATION vs RPython's `aborted_tracing`, which is reached only on the
   `SwitchToBlackhole` unwind). The four success edges now route to `abort_trace_live(false)`
   (live teardown, no accounting); `loops_aborted` reads 0 on all loop-nest benches with
   `loops_compiled`/`bridges_compiled`/`guard_failures` unchanged.

2. **`synth: correct mutation-count comment`** — the `kept_stack_deep_var_shortcircuit_mutate`
   canary appends 3× per iteration (g, h, conditional g/h); comment corrected to match.

3. **`jit: deep-kept operand-stack resume via register/liveness channel; delete FOR_ITER
   hazard gate`** — the core fix. A depth>1 kept operand stack could not be reconstructed at
   a compiled interior branch guard, causing an `ResidualCallArgUnbound` abort (walk declined,
   permanent interpreter fallback) or a SIGSEGV when the reload was forced on.

   Root cause (RPython parity): pyre restored the deep operand stack through the vable
   positional channel (a shadow that `pop_value` NULL-clears), whereas RPython's
   `get_list_of_active_boxes` (`rpython/jit/metainterp/pyjitpl.py:177-234`) captures guard
   resume boxes from the **register file** `registers_r[index]` via the per-PC `-live-` set.

   The fix:
   - **Delete the `foriter_deep_kept_call_hazard` gate** (a #342 NEW-DEVIATION with no RPython
     backing) that withheld the FOR_ITER per-iteration `getarrayitem_vable_r` reload for loop
     bodies with a CALL across an in-body conditional branch. The reload is now unconditional
     for portals, matching `w_iterator = self.peekvalue()` (`pypy/interpreter/pyopcode.py:1303`).
   - **Recover deep kept operand slots from the register/liveness channel**: in
     `walker_capture_snapshot_for_last_guard_impl`, a slot the walk mirror leaves NULL across a
     not-taken branch merge is filled from `ctx.registers_r[color]`, where `color` is the
     `pcdep_color_slots[guard_py_pc]` inverse (new `state::semantic_slot_color_for_ref_slot`).
     Capture-only (transient snapshot overlay, never the live shadow). Fills `Type::Ref` slots;
     an unboxed-int kept temp stays a hole (follow-up: int-bank `NEW_W_INT` capture).

   Arm-independence is correct by construction: the recovery is keyed to the guard's resume PC
   liveness, matching RPython's per-PC `-live-` set.

## Results

The census 4 benches, previously 1.10×–1.21× *slower* than the interpreter (pure residency
loss), now all beat it after the fix:

| bench | census (before) | post-fix |
|---|---|---|
| kept_stack_deep_var_condexpr | 1.10× slower | 2.50× faster |
| kept_stack_deep_var_nested_call | 1.15× slower | 1.40× faster |
| kept_stack_deep_var_shortcircuit | 1.21× slower | 1.35× faster |
| short_circuit_side_effects | 0.50× (partial) | 1.77× faster |

The deep_var trio's shared `ResidualCallArgUnbound` abort is gone; the `built_as_portal=false`
structural-decline log still fires on the short-circuit pair but is now benign (the trait-tracer
fallback is a net win). That structural decline is a separate architectural item (pyre's
one-artifact-per-`CodeObject` model vs RPython's independent per-greenkey portal/callee tokens),
not a residency defect on any current bench.

## Verification

- `pyre/check.py` **155/155 on dynasm and cranelift** (flagless, no env gates).
- `kept_stack_deep_var_{condexpr,nested_call,shortcircuit}` + the `shortcircuit_mutate` canary
  bit-exact (`len(log)=120000`, no double-delivery / dropped iteration).
- `cargo test -p pyre-jit-trace` 297/0, `-p pyre-jit` 260/0.
- Loop-nest steady-state stats (`nbody`/`fannkuch`/`spectral_norm`/`nested_loop`) unchanged
  except `loops_aborted` → 0.
- Codex parity review: 0 regressions introduced by this patch.

Issue body refreshed at the corresponding commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved trace recovery and stack resumption, including better handling of deep-kept values during JIT execution.
  * Updated `type(x)` behavior so it more closely matches Python/PyPy expectations.

* **Bug Fixes**
  * Prevented successful trace compilation paths from being counted as aborts.
  * Fixed cases where pending abort state could leak into unrelated trace events.
  * Improved subtype checks for partially initialized types.
  * Simplified iterator reload behavior in portal execution for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->