### PR TITLE
str: CPython 3.14 parity — case mapping, argument validation, and formatting

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1276,7 +1276,7 @@ unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             if let Some(v) = w_list_getitem(obj, i) {
                 items.push(v);
             }
-            i += step;
+            i = i.saturating_add(step);
         }
         return Ok(w_list_new(items));
     }
@@ -1305,7 +1305,7 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             if let Some(v) = w_tuple_getitem(obj, i) {
                 items.push(v);
             }
-            i += step;
+            i = i.saturating_add(step);
         }
         return Ok(w_tuple_new(items));
     }
@@ -1341,7 +1341,7 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             if i >= 0 && (i as usize) < cps.len() {
                 result.push(cps[i as usize]);
             }
-            i += step;
+            i = i.saturating_add(step);
         }
         return Ok(w_str_from_wtf8(result));
     }
@@ -1389,14 +1389,14 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
                 result.push(pyre_object::bytesobject::bytes_like_getitem(
                     obj, i as usize,
                 ));
-                i += step;
+                i = i.saturating_add(step);
             }
         } else {
             while i > stop {
                 result.push(pyre_object::bytesobject::bytes_like_getitem(
                     obj, i as usize,
                 ));
-                i += step;
+                i = i.saturating_add(step);
             }
         }
         return Ok(if is_bytes {
@@ -2140,7 +2140,7 @@ unsafe fn getitem_range_iter(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         let mut i = start;
         while (step > 0 && i < stop) || (step < 0 && i > stop) {
             items.push(w_int_new(r.current + i * r.step));
-            i += step;
+            i = i.saturating_add(step);
         }
         return Ok(w_list_new(items));
     }
@@ -2294,7 +2294,7 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
         if i >= 0 && i < len {
             indices.push(i);
         }
-        i += step;
+        i = i.saturating_add(step);
     }
     let other_len = pyre_object::w_list_len(w_other);
     if other_len != indices.len() {
@@ -2530,7 +2530,7 @@ unsafe fn setitem_bytearray_slice(
         if i >= 0 && i < len {
             indices.push(i as usize);
         }
-        i += step;
+        i = i.saturating_add(step);
     }
     if sequence2.len() != indices.len() {
         return Err(PyError::new(
@@ -11441,7 +11441,15 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
             }
             return Ok(false);
         }
-        if is_str(haystack) && is_str(needle) {
+        if is_str(haystack) {
+            // `x in s` requires a str left operand; any other type is a
+            // TypeError rather than an elementwise scan.
+            if !is_str(needle) {
+                return Err(PyError::type_error(format!(
+                    "'in <string>' requires string as left operand, not {}",
+                    crate::type_methods::arg_type_name(needle)
+                )));
+            }
             // Substring test over the WTF-8 bytes: the encoding is
             // self-synchronizing, so a byte-level match coincides with a
             // codepoint-level match and lone surrogates compare correctly.
@@ -11712,12 +11720,12 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 if step > 0 {
                     while i < stop {
                         indices.push(i);
-                        i += step;
+                        i = i.saturating_add(step);
                     }
                 } else {
                     while i > stop {
                         indices.push(i);
-                        i += step;
+                        i = i.saturating_add(step);
                     }
                 }
                 indices.sort_unstable_by(|a, b| b.cmp(a));
@@ -11760,12 +11768,12 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 if step > 0 {
                     while i < stop {
                         indices.push(i);
-                        i += step;
+                        i = i.saturating_add(step);
                     }
                 } else {
                     while i > stop {
                         indices.push(i);
-                        i += step;
+                        i = i.saturating_add(step);
                     }
                 }
                 indices.sort_unstable_by(|a, b| b.cmp(a));

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1358,7 +1358,10 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             "string index out of range",
         ));
     }
-    Err(index_type_error("string", index))
+    Err(PyError::type_error(format!(
+        "string indices must be integers, not '{}'",
+        crate::type_methods::arg_type_name(index)
+    )))
 }
 
 #[inline(never)]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7,7 +7,7 @@ use crate::{
     make_module_builtin_function_with_arity,
 };
 use pyre_object::*;
-use rustpython_wtf8::{CodePoint, Wtf8Buf};
+use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
 /// `buffer_w` — select the byte-storage `Buffer` variant for a memoryview
 /// backing by concrete kind, so a bytes / bytearray / array *subclass* backing
@@ -4724,6 +4724,27 @@ pub fn get_build_class_func() -> PyObjectRef {
 pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (pos, kwargs) = split_builtin_kwargs(args);
     kwarg_reject_unknown(kwargs, &["object", "encoding", "errors"], "str")?;
+    let kw_count = kwargs
+        .map(|dict| unsafe {
+            pyre_object::w_dict_str_entries_wtf8(dict)
+                .iter()
+                .filter(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
+                .count()
+        })
+        .unwrap_or(0);
+    let arg_count = pos.len() + kw_count;
+    if pos.len() > 3 {
+        return Err(crate::PyError::type_error(format!(
+            "str expected at most 3 arguments, got {}",
+            pos.len()
+        )));
+    }
+    if arg_count > 3 {
+        return Err(crate::PyError::type_error(format!(
+            "str() takes at most 3 arguments ({} given)",
+            arg_count
+        )));
+    }
     // `str(object='', encoding='utf-8', errors='strict')` — every parameter
     // is positional-or-keyword (unicodeobject.py:descr_new).  An absent
     // `object` yields the empty string; an encoding/errors of None counts as
@@ -4780,9 +4801,7 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             // WTF-8-preserving so a `__str__` override returning a lone
             // surrogate yields that str rather than panicking.
             if let Some(r) = crate::display::builtin_subclass_dunder_obj(obj, tp, "__str__")? {
-                return Ok(pyre_object::w_str_from_wtf8(
-                    pyre_object::w_str_get_wtf8(r).to_owned(),
-                ));
+                return Ok(r);
             }
             // `str(s) is s` only for an exact `str`; a subclass with no
             // `__str__` override is copied to a fresh base `str`.
@@ -4794,8 +4813,45 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             ));
         }
     }
+    unsafe {
+        let obj = crate::baseobjspace::unwrap_cell(obj);
+        if !obj.is_null() && std::ptr::eq((*obj).ob_type, &INSTANCE_TYPE as *const PyType) {
+            if let Some(r) = crate::display::try_call_dunder_obj_above_object(obj, "__str__")? {
+                return Ok(r);
+            }
+            if let Some(r) = crate::display::try_call_dunder_obj(obj, "__repr__")? {
+                return Ok(r);
+            }
+        }
+    }
     let w = unsafe { crate::py_str_wtf8(obj)? };
     Ok(pyre_object::w_str_from_wtf8(w))
+}
+
+unsafe fn py_repr_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    unsafe {
+        if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+            return Ok(w_str_new(&format!(
+                "{}",
+                pyre_object::tagged_int::untag_int(obj)
+            )));
+        }
+        let obj = crate::baseobjspace::unwrap_cell(obj);
+        if !obj.is_null() {
+            let tp = (*obj).ob_type;
+            if let Some(r) = crate::display::builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
+                return Ok(r);
+            }
+            if std::ptr::eq(tp, &INSTANCE_TYPE as *const PyType) {
+                if let Some(r) = crate::display::try_call_dunder_obj(obj, "__repr__")? {
+                    return Ok(r);
+                }
+            }
+        }
+        Ok(pyre_object::w_str_from_wtf8(crate::display::py_repr_wtf8(
+            obj,
+        )?))
+    }
 }
 
 /// `repr(obj)` → string representation
@@ -4808,21 +4864,19 @@ fn builtin_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     // WTF-8-preserving so a `__repr__` override returning a lone surrogate
     // yields that str rather than panicking in the `String` path.
-    let w = unsafe { crate::py_repr_wtf8(args[0])? };
-    Ok(pyre_object::w_str_from_wtf8(w))
+    unsafe { py_repr_obj(args[0]) }
 }
 
 /// `unicodeobject.c:unicode_repr` post-pass — take the repr of `obj`
 /// and escape every non-ASCII code point as `\xXX` / `\uXXXX` /
 /// `\UXXXXXXXX`.  Shared by the `ascii()` builtin and the `!a`
 /// `str.format` conversion.
-pub(crate) fn py_ascii(obj: PyObjectRef) -> Result<String, crate::PyError> {
-    let s = unsafe { crate::py_repr(obj)? };
+fn ascii_escape_wtf8(s: &Wtf8) -> String {
     let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        let cp = ch as u32;
+    for ch in s.code_points() {
+        let cp = ch.to_u32();
         if cp < 0x80 {
-            out.push(ch);
+            out.push(char::from_u32(cp).unwrap());
         } else if cp <= 0xFF {
             out.push_str(&format!("\\x{cp:02x}"));
         } else if cp <= 0xFFFF {
@@ -4831,7 +4885,29 @@ pub(crate) fn py_ascii(obj: PyObjectRef) -> Result<String, crate::PyError> {
             out.push_str(&format!("\\U{cp:08x}"));
         }
     }
-    Ok(out)
+    out
+}
+
+pub(crate) fn py_ascii(obj: PyObjectRef) -> Result<String, crate::PyError> {
+    let s = unsafe { crate::display::py_repr_wtf8(obj)? };
+    Ok(ascii_escape_wtf8(&s))
+}
+
+fn py_ascii_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let r = unsafe { py_repr_obj(obj)? };
+    let r_wtf8 = unsafe { pyre_object::w_str_get_wtf8(r) };
+    let out = ascii_escape_wtf8(r_wtf8);
+    let changed = r_wtf8.as_str().map(|s| s != out).unwrap_or(true);
+    if unsafe { is_exact_type(r, &STR_TYPE) } || changed {
+        return Ok(w_str_new(&out));
+    }
+    let Some(tp) = (unsafe { crate::typedef::r#type(r) }) else {
+        return Ok(w_str_new(&out));
+    };
+    let Some(new_fn) = (unsafe { crate::baseobjspace::lookup_in_type(tp, "__new__") }) else {
+        return Ok(w_str_new(&out));
+    };
+    crate::builtins::call_and_check(new_fn, &[tp, w_str_new(&out)])
 }
 
 /// `bltinmodule.c:builtin_ascii` — like `repr`, but escape every
@@ -4843,7 +4919,7 @@ fn builtin_ascii(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    Ok(w_str_new(&py_ascii(args[0])?))
+    py_ascii_obj(args[0])
 }
 
 /// `int(obj)` → convert to int

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4780,13 +4780,13 @@ pub(crate) fn builtin_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         if unsafe { is_str(obj) } {
             return Err(crate::PyError::type_error("decoding str is not supported"));
         }
-        if !unsafe { pyre_object::bytesobject::is_bytes_like(obj) } {
+        let Some(src) = crate::typedef::buffer_as_bytes_like(obj)? else {
             let tn = unsafe { (*(*obj).ob_type).name };
             return Err(crate::PyError::type_error(format!(
                 "decoding to str: need a bytes-like object, {tn} found"
             )));
-        }
-        let mut decode_args = vec![obj, w_encoding.unwrap_or_else(w_none)];
+        };
+        let mut decode_args = vec![src, w_encoding.unwrap_or_else(w_none)];
         if let Some(e) = w_errors {
             decode_args.push(e);
         }

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -17,6 +17,18 @@ use crate::{
 /// Uses the unified `call_function` instead of a dedicated callback.
 fn try_call_dunder(obj: PyObjectRef, name: &str) -> Result<Option<String>, crate::PyError> {
     unsafe {
+        Ok(try_call_dunder_obj(obj, name)?
+            .map(|result| pyre_object::w_str_get_value(result).to_string()))
+    }
+}
+
+/// Try to call a dunder method (__repr__, __str__, etc.) on an instance,
+/// returning the raw result object when it is a `str`.
+pub(crate) unsafe fn try_call_dunder_obj(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    unsafe {
         if !pyre_object::is_instance(obj) {
             return Ok(None);
         }
@@ -30,7 +42,32 @@ fn try_call_dunder(obj: PyObjectRef, name: &str) -> Result<Option<String>, crate
         // TypeError (`object.c slot_tp_repr` / `slot_tp_str`).
         let result = crate::builtins::call_and_check(method, &[obj])?;
         if pyre_object::is_str(result) {
-            return Ok(Some(pyre_object::w_str_get_value(result).to_string()));
+            return Ok(Some(result));
+        }
+        Err(dunder_returned_non_string(name, result))
+    }
+}
+
+pub(crate) unsafe fn try_call_dunder_obj_above_object(
+    obj: PyObjectRef,
+    name: &str,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    unsafe {
+        if !pyre_object::is_instance(obj) {
+            return Ok(None);
+        }
+        let Some(w_type) = crate::typedef::r#type(obj) else {
+            return Ok(None);
+        };
+        let Some((src, method)) = crate::baseobjspace::lookup_where(w_type, name) else {
+            return Ok(None);
+        };
+        if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
+            return Ok(None);
+        }
+        let result = crate::builtins::call_and_check(method, &[obj])?;
+        if pyre_object::is_str(result) {
+            return Ok(Some(result));
         }
         Err(dunder_returned_non_string(name, result))
     }
@@ -44,20 +81,8 @@ unsafe fn try_call_dunder_wtf8(
     name: &str,
 ) -> Result<Option<Wtf8Buf>, crate::PyError> {
     unsafe {
-        if !pyre_object::is_instance(obj) {
-            return Ok(None);
-        }
-        let Some(method) = crate::baseobjspace::lookup(obj, name) else {
-            return Ok(None);
-        };
-        if method.is_null() {
-            return Ok(None);
-        }
-        let result = crate::builtins::call_and_check(method, &[obj])?;
-        if pyre_object::is_str(result) {
-            return Ok(Some(pyre_object::w_str_get_wtf8(result).to_wtf8_buf()));
-        }
-        Err(dunder_returned_non_string(name, result))
+        Ok(try_call_dunder_obj(obj, name)?
+            .map(|result| pyre_object::w_str_get_wtf8(result).to_wtf8_buf()))
     }
 }
 

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -718,6 +718,10 @@ fn walk_pyframe_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
                 // reaches — code objects are Box-immortal — so forward those
                 // the same way.
                 crate::pycode::walk_mapdict_method_cache_gc(&mut forward);
+                // _codecs.CodecState is a space-cache object in PyPy; pyre
+                // keeps the same list/dict state in module-local storage, so
+                // its Python objects must be forwarded explicitly.
+                crate::module::_codecs::walk_codec_state_gc(&mut forward);
             }
             // The minor walk above promoted every young value reachable
             // from the prebuilt family; re-arm the write-tracking bit

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 use crate::{CodeObject, Mode, compile_source_with_filename};
 use crate::{DictStorage, PyExecutionContext, dict_storage_store};
 use pyre_object::*;
+use rustpython_wtf8::Wtf8Buf;
 
 /// Module-local re-export of the host-OS surface.  Routes through
 /// `rustpython_host_env` when the `host_env` feature is enabled; when
@@ -560,7 +561,6 @@ pub fn install_builtin_modules() {
     // pure-Python fallback take over: `_datetime` -> `_pydatetime`,
     // `_decimal` -> `_pydecimal`, `_asyncio` -> pure-Python asyncio.
     for name in &[
-        "_string",
         "_warnings",
         "_heapq",
         "_tokenize",
@@ -576,8 +576,110 @@ pub fn install_builtin_modules() {
     register_builtin_module("array", crate::module::array::init_array_module);
     register_builtin_module("_csv", crate::module::_csv::init);
     register_builtin_module("_scproxy", init_scproxy);
+    register_builtin_module("_string", init_string_module);
     register_builtin_module("_tracemalloc", init_tracemalloc);
     register_builtin_module("_sysconfig", init_sysconfig_stub);
+}
+
+fn require_string_module_str(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(&arg) = args.first() else {
+        return Err(crate::PyError::type_error("expected str, got object"));
+    };
+    if !unsafe { pyre_object::is_str(arg) } {
+        return Err(crate::PyError::type_error(format!(
+            "expected str, got {}",
+            crate::type_methods::arg_type_name(arg)
+        )));
+    }
+    Ok(arg)
+}
+
+fn init_string_module(ns: &mut DictStorage) {
+    crate::dict_storage_store(
+        ns,
+        "formatter_parser",
+        crate::make_builtin_function("formatter_parser", |args| {
+            use rustpython_common::format::{FormatPart, FormatString, FromTemplate};
+
+            let arg = require_string_module_str(args)?;
+            let body = unsafe { pyre_object::w_str_get_wtf8(arg) };
+            let parsed = FormatString::from_str(body)
+                .map_err(|_| crate::PyError::value_error("bad format string"))?;
+
+            let mut tuples = Vec::new();
+            let mut pending: Option<Wtf8Buf> = None;
+            for part in parsed.format_parts {
+                match part {
+                    FormatPart::Literal(text) => pending = Some(text),
+                    FormatPart::Field {
+                        field_name,
+                        conversion_spec,
+                        format_spec,
+                    } => {
+                        let literal = pending.take().unwrap_or_default();
+                        let conversion = match conversion_spec {
+                            Some(c) => pyre_object::w_str_new(&c.to_char_lossy().to_string()),
+                            None => pyre_object::w_none(),
+                        };
+                        tuples.push(pyre_object::w_tuple_new(vec![
+                            pyre_object::w_str_from_wtf8(literal),
+                            pyre_object::w_str_from_wtf8(field_name),
+                            pyre_object::w_str_from_wtf8(format_spec),
+                            conversion,
+                        ]));
+                    }
+                }
+            }
+            if let Some(text) = pending {
+                tuples.push(pyre_object::w_tuple_new(vec![
+                    pyre_object::w_str_from_wtf8(text),
+                    pyre_object::w_none(),
+                    pyre_object::w_none(),
+                    pyre_object::w_none(),
+                ]));
+            }
+            Ok(pyre_object::w_list_new(tuples))
+        }),
+    );
+    crate::dict_storage_store(
+        ns,
+        "formatter_field_name_split",
+        crate::make_builtin_function("formatter_field_name_split", |args| {
+            use rustpython_common::format::{FieldName, FieldNamePart, FieldType};
+
+            let arg = require_string_module_str(args)?;
+            let body = unsafe { pyre_object::w_str_get_wtf8(arg) };
+            let FieldName { field_type, parts } = FieldName::parse(body)
+                .map_err(|_| crate::PyError::value_error("bad field name"))?;
+
+            let first = match field_type {
+                FieldType::Auto => pyre_object::w_str_new(""),
+                FieldType::Index(n) => pyre_object::w_int_new(n as i64),
+                FieldType::Keyword(s) => pyre_object::w_str_from_wtf8(s),
+            };
+            let rest = parts
+                .into_iter()
+                .map(|part| match part {
+                    FieldNamePart::Attribute(s) => pyre_object::w_tuple_new(vec![
+                        pyre_object::w_bool_from(true),
+                        pyre_object::w_str_from_wtf8(s),
+                    ]),
+                    FieldNamePart::Index(n) => pyre_object::w_tuple_new(vec![
+                        pyre_object::w_bool_from(false),
+                        pyre_object::w_int_new(n as i64),
+                    ]),
+                    FieldNamePart::StringIndex(s) => pyre_object::w_tuple_new(vec![
+                        pyre_object::w_bool_from(false),
+                        pyre_object::w_str_from_wtf8(s),
+                    ]),
+                })
+                .collect();
+            Ok(pyre_object::w_tuple_new(vec![
+                first,
+                pyre_object::w_list_new(rest),
+            ]))
+        }),
+    );
 }
 
 /// `_sysconfig` stub — exposes `config_vars()` returning an empty dict. On

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -5,7 +5,96 @@
 //! text path. The codec registry (`register` / `lookup`) and error
 //! handlers remain stubs; binary transform codecs are not modelled.
 
+use std::cell::Cell;
+
 use pyre_object::*;
+
+struct CodecState {
+    codec_search_path: PyObjectRef,
+    codec_search_cache: PyObjectRef,
+    codec_error_registry: PyObjectRef,
+    codec_need_encodings: bool,
+}
+
+impl CodecState {
+    fn new() -> Self {
+        Self {
+            codec_search_path: w_list_new(Vec::new()),
+            codec_search_cache: w_dict_new(),
+            codec_error_registry: w_dict_new(),
+            codec_need_encodings: true,
+        }
+    }
+}
+
+thread_local! {
+    static CODEC_STATE: Cell<*mut CodecState> = const { Cell::new(std::ptr::null_mut()) };
+}
+
+fn with_codec_state<R>(f: impl FnOnce(&mut CodecState) -> R) -> R {
+    CODEC_STATE.with(|slot| {
+        let mut ptr = slot.get();
+        if ptr.is_null() {
+            ptr = Box::into_raw(Box::new(CodecState::new()));
+            slot.set(ptr);
+        }
+        f(unsafe { &mut *ptr })
+    })
+}
+
+pub(crate) unsafe fn walk_codec_state_gc(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
+    CODEC_STATE.with(|slot| {
+        let ptr = slot.get();
+        if ptr.is_null() {
+            return;
+        }
+        let state = unsafe { &mut *ptr };
+        visitor(&mut state.codec_search_path);
+        visitor(&mut state.codec_search_cache);
+        visitor(&mut state.codec_error_registry);
+    });
+}
+
+// PyPy `interp_codecs.py:166-190 normalize`.
+fn normalize(encoding: &str) -> String {
+    let mut chars = String::new();
+    let mut punct = false;
+    for c in encoding.chars() {
+        if c.is_alphanumeric() || c == '.' {
+            if punct && !chars.is_empty() {
+                chars.push('_');
+            }
+            if c.is_ascii() {
+                chars.push(c.to_ascii_lowercase());
+            }
+            punct = false;
+        } else {
+            punct = true;
+        }
+    }
+    chars
+}
+
+fn is_callable(obj: PyObjectRef) -> bool {
+    if obj.is_null() {
+        return false;
+    }
+    unsafe {
+        if crate::is_function(obj)
+            || pyre_object::is_method(obj)
+            || pyre_object::is_type(obj)
+            || pyre_object::is_staticmethod(obj)
+            || pyre_object::is_classmethod(obj)
+        {
+            return true;
+        }
+        if pyre_object::is_instance(obj) {
+            let w_type = pyre_object::w_instance_get_type(obj);
+            return crate::baseobjspace::lookup_in_type(w_type, "__call__").is_some();
+        }
+    }
+    false
+}
 
 // `lookup_error(name)` returns a pass-through handler that never fires
 // because the pure-Python stdlib paths pyre exercises do not encounter
@@ -18,9 +107,1113 @@ fn lookup_error(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     ))
 }
 
+fn register_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_search_function) = args.first().copied() else {
+        return Err(crate::PyError::type_error("register() missing argument"));
+    };
+    if !is_callable(w_search_function) {
+        return Err(crate::PyError::type_error("argument must be callable"));
+    }
+    // PyPy `interp_codecs.py:143-155 register_codec`.
+    with_codec_state(|state| unsafe {
+        pyre_object::listobject::w_list_append(state.codec_search_path, w_search_function);
+    });
+    Ok(w_none())
+}
+
+fn unregister(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_search_function) = args.first().copied() else {
+        return Err(crate::PyError::type_error("unregister() missing argument"));
+    };
+    // PyPy `interp_codecs.py:157-164 unregister`: remove and clear cache;
+    // return -1 when the search function was not present.
+    with_codec_state(|state| {
+        match crate::listobject::w_list_remove(state.codec_search_path, w_search_function) {
+            Ok(()) => {
+                unsafe { pyre_object::dictmultiobject::w_dict_clear(state.codec_search_cache) };
+                Ok(w_int_new(0))
+            }
+            Err(_) => Ok(w_int_new(-1)),
+        }
+    })
+}
+
+fn ensure_encodings_imported(state: &mut CodecState) -> Result<(), crate::PyError> {
+    if !state.codec_need_encodings {
+        return Ok(());
+    }
+    // PyPy `_lookup_codec_loop`: import encodings once so it can register
+    // `encodings.search_function` through this module's register().
+    let ec = crate::call::getexecutioncontext();
+    crate::importing::importhook("encodings", w_none(), w_none(), 0, ec)?;
+    let _ = crate::importing::importhook("encodings.utf_8", w_none(), w_none(), 0, ec);
+    state.codec_need_encodings = false;
+    if unsafe { pyre_object::w_list_len(state.codec_search_path) } == 0 {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::LookupError,
+            "no codec search functions registered: can't find encoding",
+        ));
+    }
+    Ok(())
+}
+
+fn lookup_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_encoding) = args.first().copied() else {
+        return Err(crate::PyError::type_error("lookup() missing encoding"));
+    };
+    if !unsafe { is_str(w_encoding) } {
+        return Err(crate::PyError::type_error("lookup() argument must be str"));
+    }
+    let encoding = unsafe { w_str_get_value(w_encoding) }.to_string();
+    let normalized_encoding = normalize(&encoding);
+
+    with_codec_state(|state| {
+        if let Some(w_result) = unsafe {
+            pyre_object::dictmultiobject::w_dict_getitem_str(
+                state.codec_search_cache,
+                &normalized_encoding,
+            )
+        } {
+            return Ok(w_result);
+        }
+
+        ensure_encodings_imported(state)?;
+        let w_v = w_str_new(&normalized_encoding);
+        let n = unsafe { pyre_object::w_list_len(state.codec_search_path) };
+        for i in 0..n {
+            let Some(w_search) =
+                (unsafe { pyre_object::w_list_getitem(state.codec_search_path, i as i64) })
+            else {
+                continue;
+            };
+            let w_result = crate::call::call_function_impl_result(w_search, &[w_v])?;
+            if unsafe { pyre_object::is_none(w_result) } {
+                continue;
+            }
+            if !unsafe { pyre_object::is_tuple(w_result) }
+                || unsafe { pyre_object::w_tuple_len(w_result) } != 4
+            {
+                return Err(crate::PyError::type_error(
+                    "codec search functions must return 4-tuples",
+                ));
+            }
+            unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str(
+                    state.codec_search_cache,
+                    &normalized_encoding,
+                    w_result,
+                );
+            }
+            return Ok(w_result);
+        }
+        Err(crate::PyError::new(
+            crate::PyErrorKind::LookupError,
+            format!("unknown encoding: {encoding}"),
+        ))
+    })
+}
+
+pub(crate) fn lookup_text_codec(
+    action: &str,
+    encoding: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    let w_codec_info = lookup_codec(&[w_str_new(encoding)])?;
+    match crate::baseobjspace::getattr_str(w_codec_info, "_is_text_encoding") {
+        Ok(w_flag) if !crate::baseobjspace::is_true(w_flag)? => {
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::LookupError,
+                format!(
+                    "'{encoding}' is not a text encoding; use codecs.{action}() to handle arbitrary codecs"
+                ),
+            ));
+        }
+        Ok(_) => {}
+        Err(e) if e.kind == crate::PyErrorKind::AttributeError => {}
+        Err(e) => return Err(e),
+    }
+    Ok(w_codec_info)
+}
+
+fn call_codec(
+    w_coder: PyObjectRef,
+    w_obj: PyObjectRef,
+    action: &str,
+    errors: Option<&str>,
+) -> Result<PyObjectRef, crate::PyError> {
+    // PyPy `interp_codecs.py:577-595 _call_codec`.
+    let w_res = if let Some(errors) = errors {
+        crate::call::call_function_impl_result(w_coder, &[w_obj, w_str_new(errors)])?
+    } else {
+        crate::call::call_function_impl_result(w_coder, &[w_obj])?
+    };
+    if !unsafe { pyre_object::is_tuple(w_res) } || unsafe { pyre_object::w_tuple_len(w_res) } != 2 {
+        let msg = if action.starts_with("en") {
+            "encoder must return a tuple (object, integer)".to_string()
+        } else if action.starts_with("de") {
+            "decoder must return a tuple (object, integer)".to_string()
+        } else {
+            format!("{action} must return a tuple (object, integer)")
+        };
+        return Err(crate::PyError::type_error(msg));
+    }
+    Ok(unsafe { pyre_object::w_tuple_getitem(w_res, 0).unwrap_or_else(w_none) })
+}
+
+pub(crate) fn encode_text_codec(
+    w_obj: PyObjectRef,
+    encoding: &str,
+    errors: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    let w_codec_info = lookup_text_codec("encode", encoding)?;
+    let w_encfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 0).unwrap_or_else(w_none) };
+    let w_retval = call_codec(w_encfunc, w_obj, "encoding", Some(errors))?;
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(w_retval) } {
+        let tname = unsafe { (*(*w_retval).ob_type).name };
+        return Err(crate::PyError::type_error(format!(
+            "'{encoding}' encoder returned '{tname}' instead of 'bytes'; use codecs.encode() to encode to arbitrary types"
+        )));
+    }
+    Ok(w_retval)
+}
+
+pub(crate) fn decode_text_codec(
+    w_obj: PyObjectRef,
+    encoding: &str,
+    errors: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    let w_codec_info = lookup_text_codec("decode", encoding)?;
+    let w_decfunc = unsafe { pyre_object::w_tuple_getitem(w_codec_info, 1).unwrap_or_else(w_none) };
+    let w_retval = call_codec(w_decfunc, w_obj, "decoding", Some(errors))?;
+    if !unsafe { pyre_object::is_str(w_retval) } {
+        let tname = unsafe { (*(*w_retval).ob_type).name };
+        return Err(crate::PyError::type_error(format!(
+            "'{encoding}' decoder returned '{tname}' instead of 'str'; use codecs.decode() to decode to arbitrary types"
+        )));
+    }
+    Ok(w_retval)
+}
+
+fn forget_codec(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(w_encoding) = args.first().copied() else {
+        return Ok(w_none());
+    };
+    if !unsafe { is_str(w_encoding) } {
+        return Ok(w_none());
+    }
+    let normalized_encoding = normalize(unsafe { w_str_get_value(w_encoding) });
+    with_codec_state(|state| {
+        let w_cache = state.codec_search_cache;
+        let w_key = w_str_new(&normalized_encoding);
+        if unsafe { pyre_object::dictmultiobject::w_dict_lookup(w_cache, w_key).is_some() } {
+            let _ = crate::baseobjspace::delitem(w_cache, w_key);
+        }
+    });
+    Ok(w_none())
+}
+
+fn encode_with_name(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+    encoding: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_str(w_obj) } {
+        return Err(crate::PyError::type_error("encoder argument must be str"));
+    }
+    // PyPy `make_encoder_wrapper`: convert to unicode, call unicodehelper
+    // encoder, return `(bytes, unicode_length)`.
+    let encode_method = crate::baseobjspace::getattr_str(w_obj, "encode")?;
+    let encoded =
+        crate::call::call_function_impl_result(encode_method, &[w_str_new(encoding), errors])?;
+    Ok(w_tuple_new(vec![
+        encoded,
+        w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
+    ]))
+}
+
+fn decode_with_name(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+    encoding: &str,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
+        return Err(crate::PyError::type_error(
+            "decoder argument must be bytes-like",
+        ));
+    }
+    // PyPy `make_decoder_wrapper`: decode a bytes buffer and return
+    // `(unicode, bytes_consumed)`.
+    let consumed = unsafe { pyre_object::bytesobject::bytes_like_data(w_obj).len() };
+    let decode_method = crate::baseobjspace::getattr_str(w_obj, "decode")?;
+    let decoded =
+        crate::call::call_function_impl_result(decode_method, &[w_str_new(encoding), errors])?;
+    Ok(w_tuple_new(vec![decoded, w_int_new(consumed as i64)]))
+}
+
+fn charmap_encode_impl(
+    w_unicode: PyObjectRef,
+    errors: PyObjectRef,
+    w_mapping: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if unsafe { pyre_object::is_none(w_mapping) } {
+        return encode_with_name(w_unicode, errors, "latin-1");
+    }
+    if !unsafe { is_str(w_unicode) } {
+        return Err(crate::PyError::type_error(
+            "charmap_encode() argument must be str",
+        ));
+    }
+    let errors_s = if unsafe { is_str(errors) } {
+        unsafe { w_str_get_value(errors) }
+    } else {
+        "strict"
+    };
+    let mut out = Vec::new();
+    for cp in unsafe { w_str_get_wtf8(w_unicode) }.code_points() {
+        let w_ch = match crate::baseobjspace::getitem(w_mapping, w_int_new(cp.to_u32() as i64)) {
+            Ok(w_ch) => w_ch,
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::PyErrorKind::LookupError | crate::PyErrorKind::KeyError
+                ) =>
+            {
+                match errors_s {
+                    "ignore" => continue,
+                    "replace" => {
+                        out.push(b'?');
+                        continue;
+                    }
+                    _ => {
+                        return Err(crate::PyError::new(
+                            crate::PyErrorKind::UnicodeEncodeError,
+                            "character maps to <undefined>",
+                        ));
+                    }
+                }
+            }
+            Err(e) => return Err(e),
+        };
+        if unsafe { pyre_object::bytesobject::is_bytes_like(w_ch) } {
+            out.extend_from_slice(unsafe { pyre_object::bytesobject::bytes_like_data(w_ch) });
+        } else if unsafe { pyre_object::is_int(w_ch) } {
+            let x = unsafe { pyre_object::w_int_get_value(w_ch) };
+            if !(0..256).contains(&x) {
+                return Err(crate::PyError::type_error(
+                    "character mapping must be in range(256)",
+                ));
+            }
+            out.push(x as u8);
+        } else if unsafe { pyre_object::is_none(w_ch) } {
+            match errors_s {
+                "ignore" => {}
+                "replace" => out.push(b'?'),
+                _ => {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::UnicodeEncodeError,
+                        "character maps to <undefined>",
+                    ));
+                }
+            }
+        } else {
+            return Err(crate::PyError::type_error(
+                "character mapping must return integer, bytes or None, not str",
+            ));
+        }
+    }
+    Ok(w_tuple_new(vec![
+        w_bytes_from_bytes(&out),
+        w_int_new(unsafe { pyre_object::w_str_len(w_unicode) } as i64),
+    ]))
+}
+
+fn charmap_decode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+    w_mapping: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if unsafe { pyre_object::is_none(w_mapping) } {
+        return decode_with_name(w_obj, errors, "latin-1");
+    }
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
+        return Err(crate::PyError::type_error(
+            "charmap_decode() argument must be bytes-like",
+        ));
+    }
+    let errors_s = if unsafe { is_str(errors) } {
+        unsafe { w_str_get_value(errors) }
+    } else {
+        "strict"
+    };
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) };
+    let mapping_chars: Option<Vec<_>> = if unsafe { is_str(w_mapping) } {
+        Some(
+            unsafe { w_str_get_wtf8(w_mapping) }
+                .code_points()
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        None
+    };
+    let mut out = rustpython_wtf8::Wtf8Buf::new();
+    for &b in data {
+        let mapped = if let Some(chars) = mapping_chars.as_ref() {
+            chars.get(b as usize).copied().map(|cp| {
+                let mut one = rustpython_wtf8::Wtf8Buf::new();
+                one.push(cp);
+                w_str_from_wtf8(one)
+            })
+        } else {
+            match crate::baseobjspace::getitem(w_mapping, w_int_new(b as i64)) {
+                Ok(w_ch) => Some(w_ch),
+                Err(e)
+                    if matches!(
+                        e.kind,
+                        crate::PyErrorKind::LookupError | crate::PyErrorKind::KeyError
+                    ) =>
+                {
+                    None
+                }
+                Err(e) => return Err(e),
+            }
+        };
+        let Some(w_ch) = mapped else {
+            match errors_s {
+                "ignore" => continue,
+                "replace" => {
+                    out.push_char('\u{FFFD}');
+                    continue;
+                }
+                _ => {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::UnicodeDecodeError,
+                        "character maps to <undefined>",
+                    ));
+                }
+            }
+        };
+        if unsafe { is_str(w_ch) } {
+            let s = unsafe { w_str_get_wtf8(w_ch) };
+            if s.as_bytes() == "\u{FFFE}".as_bytes() {
+                match errors_s {
+                    "ignore" => continue,
+                    "replace" => {
+                        out.push_char('\u{FFFD}');
+                        continue;
+                    }
+                    _ => {
+                        return Err(crate::PyError::new(
+                            crate::PyErrorKind::UnicodeDecodeError,
+                            "character maps to <undefined>",
+                        ));
+                    }
+                }
+            }
+            out.push_wtf8(s);
+        } else if unsafe { pyre_object::is_int(w_ch) } {
+            let x = unsafe { pyre_object::w_int_get_value(w_ch) };
+            if !(0..=0x10FFFF).contains(&x) {
+                return Err(crate::PyError::type_error(
+                    "character mapping must be in range(0x110000)",
+                ));
+            }
+            out.push(rustpython_wtf8::CodePoint::from_u32(x as u32).unwrap());
+        } else if unsafe { pyre_object::is_none(w_ch) } {
+            match errors_s {
+                "ignore" => {}
+                "replace" => out.push_char('\u{FFFD}'),
+                _ => {
+                    return Err(crate::PyError::new(
+                        crate::PyErrorKind::UnicodeDecodeError,
+                        "character maps to <undefined>",
+                    ));
+                }
+            }
+        } else {
+            return Err(crate::PyError::type_error(
+                "character mapping must return integer, None or str",
+            ));
+        }
+    }
+    Ok(w_tuple_new(vec![
+        w_str_from_wtf8(out),
+        w_int_new(data.len() as i64),
+    ]))
+}
+
+fn utf7_is_base64(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'+' || b == b'/'
+}
+
+fn utf7_to_base64(n: u32) -> u8 {
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[(n & 0x3f) as usize]
+}
+
+fn utf7_from_base64(b: u8) -> u32 {
+    match b {
+        b'a'..=b'z' => (b - 71) as u32,
+        b'A'..=b'Z' => (b - 65) as u32,
+        b'0'..=b'9' => (b + 4) as u32,
+        b'+' => 62,
+        _ => 63,
+    }
+}
+
+fn utf7_decode_direct(b: u8) -> bool {
+    b <= 127 && b != b'+'
+}
+
+fn utf7_category(oc: u32) -> u8 {
+    if oc > 127 {
+        return 3;
+    }
+    let b = oc as u8;
+    if matches!(b, b'\t' | b'\n' | b'\r' | b' ') {
+        2
+    } else if b.is_ascii_alphanumeric() || b"'(),-./:?".contains(&b) {
+        0
+    } else if b"!\"#$%&*;<=>@[]^_`{|}".contains(&b) {
+        1
+    } else {
+        3
+    }
+}
+
+fn utf7_encode_direct(oc: u32) -> bool {
+    oc < 128 && oc > 0 && utf7_category(oc) != 3
+}
+
+fn utf7_encode_unit(out: &mut Vec<u8>, unit: u32, base64bits: &mut u32, base64buffer: &mut u32) {
+    *base64bits += 16;
+    *base64buffer = (*base64buffer << 16) | unit;
+    while *base64bits >= 6 {
+        out.push(utf7_to_base64(*base64buffer >> (*base64bits - 6)));
+        *base64bits -= 6;
+    }
+    *base64buffer &= (1 << *base64bits) - 1;
+}
+
+fn utf7_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_str(w_obj) } {
+        return Err(crate::PyError::type_error(
+            "utf_7_encode() argument must be str",
+        ));
+    }
+    // PyPy `unicodehelper.py:utf8_encode_utf_7`.
+    let mut out = Vec::new();
+    let mut in_shift = false;
+    let mut base64bits = 0;
+    let mut base64buffer = 0;
+    for cp in unsafe { w_str_get_wtf8(w_obj) }.code_points() {
+        let oc = cp.to_u32();
+        if !in_shift {
+            if oc == b'+' as u32 {
+                out.extend_from_slice(b"+-");
+            } else if utf7_encode_direct(oc) {
+                out.push(oc as u8);
+            } else {
+                out.push(b'+');
+                in_shift = true;
+                if oc >= 0x10000 {
+                    utf7_encode_unit(
+                        &mut out,
+                        0xd800 | ((oc - 0x10000) >> 10),
+                        &mut base64bits,
+                        &mut base64buffer,
+                    );
+                    utf7_encode_unit(
+                        &mut out,
+                        0xdc00 | ((oc - 0x10000) & 0x3ff),
+                        &mut base64bits,
+                        &mut base64buffer,
+                    );
+                } else {
+                    utf7_encode_unit(&mut out, oc, &mut base64bits, &mut base64buffer);
+                }
+            }
+        } else if utf7_encode_direct(oc) {
+            if base64bits != 0 {
+                out.push(utf7_to_base64(base64buffer << (6 - base64bits)));
+                base64buffer = 0;
+                base64bits = 0;
+            }
+            in_shift = false;
+            if utf7_is_base64(oc as u8) || oc == b'-' as u32 {
+                out.push(b'-');
+            }
+            out.push(oc as u8);
+        } else if oc >= 0x10000 {
+            utf7_encode_unit(
+                &mut out,
+                0xd800 | ((oc - 0x10000) >> 10),
+                &mut base64bits,
+                &mut base64buffer,
+            );
+            utf7_encode_unit(
+                &mut out,
+                0xdc00 | ((oc - 0x10000) & 0x3ff),
+                &mut base64bits,
+                &mut base64buffer,
+            );
+        } else {
+            utf7_encode_unit(&mut out, oc, &mut base64bits, &mut base64buffer);
+        }
+    }
+    if base64bits != 0 {
+        out.push(utf7_to_base64(base64buffer << (6 - base64bits)));
+    }
+    if in_shift {
+        out.push(b'-');
+    }
+    Ok(w_tuple_new(vec![
+        w_bytes_from_bytes(&out),
+        w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
+    ]))
+}
+
+fn utf7_decode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
+        return Err(crate::PyError::type_error(
+            "utf_7_decode() argument must be bytes-like",
+        ));
+    }
+    // PyPy `unicodehelper.py:str_decode_utf_7`.
+    let errors_s = if unsafe { is_str(errors) } {
+        unsafe { w_str_get_value(errors) }
+    } else {
+        "strict"
+    };
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) };
+    let mut out = rustpython_wtf8::Wtf8Buf::new();
+    let mut pos = 0usize;
+    let mut in_shift = false;
+    let mut base64bits = 0u32;
+    let mut base64buffer = 0u32;
+    let mut surrogate = 0u32;
+    let mut shift_out_start = 0usize;
+    while pos < data.len() {
+        let ch = data[pos];
+        if in_shift {
+            if utf7_is_base64(ch) {
+                base64buffer = (base64buffer << 6) | utf7_from_base64(ch);
+                base64bits += 6;
+                pos += 1;
+                if base64bits >= 16 {
+                    let out_ch = base64buffer >> (base64bits - 16);
+                    base64bits -= 16;
+                    base64buffer &= (1 << base64bits) - 1;
+                    if surrogate != 0 {
+                        if (0xdc00..=0xdfff).contains(&out_ch) {
+                            let code = (((surrogate & 0x3ff) << 10) | (out_ch & 0x3ff)) + 0x10000;
+                            out.push(rustpython_wtf8::CodePoint::from_u32(code).unwrap());
+                            surrogate = 0;
+                            continue;
+                        }
+                        out.push(rustpython_wtf8::CodePoint::from_u32(surrogate).unwrap());
+                        surrogate = 0;
+                    }
+                    if (0xd800..=0xdbff).contains(&out_ch) {
+                        surrogate = out_ch;
+                    } else {
+                        out.push(rustpython_wtf8::CodePoint::from_u32(out_ch).unwrap());
+                    }
+                }
+            } else {
+                in_shift = false;
+                if base64bits > 0 {
+                    let bad = base64bits >= 6 || base64buffer != 0;
+                    if bad {
+                        if errors_s == "ignore" {
+                            pos += 1;
+                            continue;
+                        }
+                        return Err(crate::typedef::unicode_decode_error(
+                            "utf7",
+                            data,
+                            pos.saturating_sub(1),
+                            pos,
+                            "partial character in shift sequence",
+                        ));
+                    }
+                }
+                if surrogate != 0 && utf7_decode_direct(ch) {
+                    out.push(rustpython_wtf8::CodePoint::from_u32(surrogate).unwrap());
+                }
+                surrogate = 0;
+                if ch == b'-' {
+                    pos += 1;
+                }
+            }
+        } else if ch == b'+' {
+            pos += 1;
+            if pos < data.len() && data[pos] == b'-' {
+                pos += 1;
+                out.push_char('+');
+            } else if pos < data.len() && !utf7_is_base64(data[pos]) {
+                if errors_s == "ignore" {
+                    pos += 1;
+                    continue;
+                }
+                return Err(crate::typedef::unicode_decode_error(
+                    "utf7",
+                    data,
+                    pos.saturating_sub(1),
+                    (pos + 1).min(data.len()),
+                    "ill-formed sequence",
+                ));
+            } else {
+                in_shift = true;
+                surrogate = 0;
+                shift_out_start = pos - 1;
+                base64bits = 0;
+                base64buffer = 0;
+            }
+        } else if utf7_decode_direct(ch) {
+            out.push_char(ch as char);
+            pos += 1;
+        } else {
+            if errors_s == "ignore" {
+                pos += 1;
+                continue;
+            }
+            return Err(crate::typedef::unicode_decode_error(
+                "utf7",
+                data,
+                pos,
+                (pos + 1).min(data.len()),
+                "unexpected special character",
+            ));
+        }
+    }
+    if in_shift && (surrogate != 0 || base64bits >= 6 || (base64bits > 0 && base64buffer != 0)) {
+        if errors_s != "ignore" {
+            return Err(crate::typedef::unicode_decode_error(
+                "utf7",
+                data,
+                shift_out_start,
+                pos,
+                "unterminated shift sequence",
+            ));
+        }
+        pos = shift_out_start;
+    }
+    Ok(w_tuple_new(vec![
+        w_str_from_wtf8(out),
+        w_int_new(pos as i64),
+    ]))
+}
+
+fn push_ascii_hex_escape(out: &mut Vec<u8>, prefix: u8, cp: u32, digits: usize) {
+    out.push(b'\\');
+    out.push(prefix);
+    for shift in (0..digits).rev() {
+        out.push(b"0123456789abcdef"[((cp >> (shift * 4)) & 0xf) as usize]);
+    }
+}
+
+fn unicode_escape_encode_impl(w_obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_str(w_obj) } {
+        return Err(crate::PyError::type_error(
+            "unicode_escape_encode() argument must be str",
+        ));
+    }
+    // PyPy `unicodehelper.py:utf8_encode_unicode_escape`.
+    let mut out = Vec::new();
+    for cp in unsafe { w_str_get_wtf8(w_obj) }.code_points() {
+        match cp.to_u32() {
+            0x5c => out.extend_from_slice(br"\\"),
+            0x09 => out.extend_from_slice(br"\t"),
+            0x0a => out.extend_from_slice(br"\n"),
+            0x0d => out.extend_from_slice(br"\r"),
+            0x20..=0x7e => out.push(cp.to_u32() as u8),
+            c @ 0x00..=0xff => push_ascii_hex_escape(&mut out, b'x', c, 2),
+            c @ 0x100..=0xffff => push_ascii_hex_escape(&mut out, b'u', c, 4),
+            c => push_ascii_hex_escape(&mut out, b'U', c, 8),
+        }
+    }
+    Ok(w_tuple_new(vec![
+        w_bytes_from_bytes(&out),
+        w_int_new(unsafe { pyre_object::w_str_len(w_obj) } as i64),
+    ]))
+}
+
+fn hex_value(b: u8) -> Option<u32> {
+    match b {
+        b'0'..=b'9' => Some((b - b'0') as u32),
+        b'a'..=b'f' => Some((b - b'a' + 10) as u32),
+        b'A'..=b'F' => Some((b - b'A' + 10) as u32),
+        _ => None,
+    }
+}
+
+fn unicode_escape_error(
+    errors: &str,
+    original: &[u8],
+    start: usize,
+    end: usize,
+    reason: &str,
+    out: &mut rustpython_wtf8::Wtf8Buf,
+) -> Result<(), crate::PyError> {
+    match errors {
+        "ignore" => Ok(()),
+        "replace" => {
+            out.push_char('\u{FFFD}');
+            Ok(())
+        }
+        "backslashreplace" => {
+            for &b in &original[start..end.min(original.len())] {
+                out.push_str(&format!("\\x{b:02x}"));
+            }
+            Ok(())
+        }
+        _ => Err(crate::PyError::new(
+            crate::PyErrorKind::UnicodeDecodeError,
+            reason,
+        )),
+    }
+}
+
+fn unicode_escape_decode_impl(
+    w_obj: PyObjectRef,
+    errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let data: Vec<u8> = if unsafe { pyre_object::bytesobject::is_bytes_like(w_obj) } {
+        unsafe { pyre_object::bytesobject::bytes_like_data(w_obj) }.to_vec()
+    } else if unsafe { is_str(w_obj) } {
+        unsafe { w_str_get_wtf8(w_obj) }.as_bytes().to_vec()
+    } else {
+        return Err(crate::PyError::type_error(
+            "unicode_escape_decode() argument must be bytes-like or str",
+        ));
+    };
+    // PyPy `unicodehelper.py:str_decode_unicode_escape`.
+    let errors_s = if unsafe { is_str(errors) } {
+        unsafe { w_str_get_value(errors) }
+    } else {
+        "strict"
+    };
+    let mut out = rustpython_wtf8::Wtf8Buf::new();
+    let mut pos = 0usize;
+    while pos < data.len() {
+        let ch = data[pos];
+        if ch != b'\\' {
+            out.push(rustpython_wtf8::CodePoint::from_u32(ch as u32).unwrap());
+            pos += 1;
+            continue;
+        }
+        let escape_start = pos;
+        pos += 1;
+        if pos >= data.len() {
+            unicode_escape_error(
+                errors_s,
+                &data,
+                escape_start,
+                data.len(),
+                "\\ at end of string",
+                &mut out,
+            )?;
+            break;
+        }
+        let ch = data[pos];
+        pos += 1;
+        match ch {
+            b'\n' => {}
+            b'\\' => out.push_char('\\'),
+            b'\'' => out.push_char('\''),
+            b'"' => out.push_char('"'),
+            b'b' => out.push_char('\x08'),
+            b'f' => out.push_char('\x0c'),
+            b't' => out.push_char('\t'),
+            b'n' => out.push_char('\n'),
+            b'r' => out.push_char('\r'),
+            b'v' => out.push_char('\x0b'),
+            b'a' => out.push_char('\x07'),
+            b'0'..=b'7' => {
+                let mut value = (ch - b'0') as u32;
+                for _ in 0..2 {
+                    if pos < data.len() && matches!(data[pos], b'0'..=b'7') {
+                        value = (value << 3) + (data[pos] - b'0') as u32;
+                        pos += 1;
+                    }
+                }
+                out.push(rustpython_wtf8::CodePoint::from_u32(value).unwrap());
+            }
+            b'x' | b'u' | b'U' => {
+                let digits = match ch {
+                    b'x' => 2,
+                    b'u' => 4,
+                    _ => 8,
+                };
+                let msg = match ch {
+                    b'x' => "truncated \\xXX escape",
+                    b'u' => "truncated \\uXXXX escape",
+                    _ => "truncated \\UXXXXXXXX escape",
+                };
+                if pos + digits > data.len() {
+                    unicode_escape_error(errors_s, &data, escape_start, data.len(), msg, &mut out)?;
+                    pos = data.len();
+                    continue;
+                }
+                let mut value = 0u32;
+                let mut ok = true;
+                for &b in &data[pos..pos + digits] {
+                    if let Some(v) = hex_value(b) {
+                        value = (value << 4) | v;
+                    } else {
+                        ok = false;
+                        break;
+                    }
+                }
+                let end = pos + digits;
+                pos = end;
+                if !ok || value > 0x10ffff {
+                    unicode_escape_error(
+                        errors_s,
+                        &data,
+                        escape_start,
+                        end,
+                        "illegal Unicode character",
+                        &mut out,
+                    )?;
+                    continue;
+                }
+                out.push(rustpython_wtf8::CodePoint::from_u32(value).unwrap());
+            }
+            b'N' => {
+                let mut end = pos;
+                if pos < data.len() && data[pos] == b'{' {
+                    end += 1;
+                    while end < data.len() && data[end] != b'}' {
+                        end += 1;
+                    }
+                    if end < data.len() && data[end] == b'}' {
+                        end += 1;
+                    }
+                }
+                unicode_escape_error(
+                    errors_s,
+                    &data,
+                    escape_start,
+                    end,
+                    "unknown Unicode character name",
+                    &mut out,
+                )?;
+                pos = end;
+            }
+            _ => {
+                out.push_char('\\');
+                out.push(rustpython_wtf8::CodePoint::from_u32(ch as u32).unwrap());
+            }
+        }
+    }
+    Ok(w_tuple_new(vec![
+        w_str_from_wtf8(out),
+        w_int_new(data.len() as i64),
+    ]))
+}
+
+fn charmap_build(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let Some(chars) = args.first().copied() else {
+        return Err(crate::PyError::type_error(
+            "charmap_build() missing argument",
+        ));
+    };
+    if !unsafe { is_str(chars) } {
+        return Err(crate::PyError::type_error(
+            "charmap_build() argument must be str",
+        ));
+    }
+
+    // PyPy `interp_codecs.py:1006-1016 charmap_build`: build a dict mapping
+    // each Unicode codepoint in `chars` to its ordinal position.
+    let w_charmap = w_dict_new();
+    for (num, cp) in unsafe { w_str_get_wtf8(chars) }.code_points().enumerate() {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_store(
+                w_charmap,
+                w_int_new(cp.to_u32() as i64),
+                w_int_new(num as i64),
+            );
+        }
+    }
+    Ok(w_charmap)
+}
+
 crate::py_module! {
     "_codecs",
     inline_functions: {
+        fn ascii_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "ascii")
+        }
+        fn ascii_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "ascii")
+        }
+        fn latin_1_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "latin-1")
+        }
+        fn latin_1_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "latin-1")
+        }
+        fn utf_8_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-8")
+        }
+        fn utf_8_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-8")
+        }
+        fn utf_16_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-16")
+        }
+        fn utf_16_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-16")
+        }
+        fn utf_16_be_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-16-be")
+        }
+        fn utf_16_be_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-16-be")
+        }
+        fn utf_16_le_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-16-le")
+        }
+        fn utf_16_le_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-16-le")
+        }
+        fn utf_32_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-32")
+        }
+        fn utf_32_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-32")
+        }
+        fn utf_32_be_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-32-be")
+        }
+        fn utf_32_be_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-32-be")
+        }
+        fn utf_32_le_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "utf-32-le")
+        }
+        fn utf_32_le_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "utf-32-le")
+        }
+        fn raw_unicode_escape_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            encode_with_name(obj, errors, "raw-unicode-escape")
+        }
+        fn raw_unicode_escape_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            decode_with_name(obj, errors, "raw-unicode-escape")
+        }
+        fn utf_7_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] _errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            utf7_encode_impl(obj)
+        }
+        fn utf_7_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            utf7_decode_impl(obj, errors)
+        }
+        fn unicode_escape_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] _errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            unicode_escape_encode_impl(obj)
+        }
+        fn unicode_escape_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_bool_from(false))] _final: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            unicode_escape_decode_impl(obj, errors)
+        }
+        fn charmap_encode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_none())] mapping: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            charmap_encode_impl(obj, errors, mapping)
+        }
+        fn charmap_decode(
+            obj: PyObjectRef,
+            #[default(w_str_new("strict"))] errors: PyObjectRef,
+            #[default(w_none())] mapping: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            charmap_decode_impl(obj, errors, mapping)
+        }
         // `encode(obj, encoding='utf-8', errors='strict')` — text path of
         // `PyCodec_Encode`: a str is encoded via `str.encode`; anything
         // else passes through unchanged.
@@ -54,10 +1247,10 @@ crate::py_module! {
         "lookup_error"     / 1 = lookup_error,
         "register_error"   / 2 = |_| Ok(w_none()),
         "_unregister_error" / 1 = |_| Ok(w_bool_from(false)),
-        "register"       / 1 = |_| Ok(w_none()),
-        "unregister"     / 1 = |_| Ok(w_none()),
-        "lookup"         / 1 = |_| Ok(w_none()),
-        "_forget_codec"  / 1 = |args| Ok(args.first().copied().unwrap_or(w_none())),
-        "charmap_build"  / 1 = |_| Ok(w_dict_new()),
+        "register"       / 1 = register_codec,
+        "unregister"     / 1 = unregister,
+        "lookup"         / 1 = lookup_codec,
+        "_forget_codec"  / 1 = forget_codec,
+        "charmap_build"  / 1 = charmap_build,
     },
 }

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -55,6 +55,7 @@ crate::py_module! {
         "register_error"   / 2 = |_| Ok(w_none()),
         "_unregister_error" / 1 = |_| Ok(w_bool_from(false)),
         "register"       / 1 = |_| Ok(w_none()),
+        "unregister"     / 1 = |_| Ok(w_none()),
         "lookup"         / 1 = |_| Ok(w_none()),
         "_forget_codec"  / 1 = |args| Ok(args.first().copied().unwrap_or(w_none())),
         "charmap_build"  / 1 = |_| Ok(w_dict_new()),

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -1053,6 +1053,9 @@ pub(crate) unsafe fn str_repeat(s: PyObjectRef, n: PyObjectRef) -> PyResult {
     // `w_str_get_value`.
     let bytes = w_str_get_wtf8(s).as_bytes();
     let count = repeat_count(n, "new string is too long")?;
+    if count == 1 {
+        return Ok(crate::type_methods::str_result_unchanged(s));
+    }
     let total = bytes
         .len()
         .checked_mul(count)

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2039,8 +2039,24 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         if is_float_pair(a, b) {
             return float_mod(a, b);
         }
-        // str % args — PyPy: unicodeobject.py mod__String_ANY
+        // str % args — reflected-subclass priority: a str subclass on the
+        // right overriding __rmod__ is tried before the built-in formatter.
         if is_str(a) {
+            if let Some((method, w_type)) =
+                crate::baseobjspace::subclass_special_override(b, "__rmod__")
+            {
+                let priority = match (crate::typedef::r#type(a), crate::typedef::r#type(b)) {
+                    (Some(at), Some(bt)) => !std::ptr::eq(at, bt) && issubtype_cached(bt, at),
+                    _ => false,
+                };
+                if priority {
+                    match crate::baseobjspace::get_and_call_function(method, b, w_type, &[a]) {
+                        Ok(result) if !is_not_implemented(result) => return Ok(result),
+                        Ok(_) => {}
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
             return crate::objspace::std::formatting::str_format_percent(a, b);
         }
         if let Some(result) = try_dispatch_binary_special(a, b, "__mod__", "__rmod__")? {

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -182,16 +182,16 @@ unsafe fn number_arg_decimal(spec: &CFormatSpec, obj: PyObjectRef) -> Result<Big
         )?;
         return Ok(arg_to_bigint(pyint));
     }
-    if has_dunder(obj, "__index__") {
-        return Ok(crate::builtins::obj_to_bigint(
-            crate::baseobjspace::space_index(obj)?,
-        ));
-    }
     if let Some(method) = crate::baseobjspace::lookup(obj, "__int__") {
         let r = crate::builtins::call_and_check(method, &[obj])?;
         if is_int_like(r) || is_long(r) {
             return Ok(arg_to_bigint(r));
         }
+    }
+    if has_dunder(obj, "__index__") {
+        return Ok(crate::builtins::obj_to_bigint(
+            crate::baseobjspace::space_index(obj)?,
+        ));
     }
     Err(number_type_error(spec, obj, "a real number is required"))
 }
@@ -240,9 +240,12 @@ unsafe fn char_arg(obj: PyObjectRef) -> Result<CodePoint, PyError> {
     } else if has_dunder(obj, "__index__") {
         crate::builtins::obj_to_bigint(crate::baseobjspace::space_index(obj)?)
     } else {
+        let tn = match crate::typedef::r#type(obj) {
+            Some(w_type) => crate::baseobjspace::type_repr_qualified_name(w_type),
+            None => crate::baseobjspace::object_functionstr_type_name(obj),
+        };
         return Err(PyError::type_error(format!(
-            "%c requires an int or a unicode character, not {}",
-            crate::baseobjspace::object_functionstr_type_name(obj),
+            "%c requires an int or a unicode character, not {tn}"
         )));
     };
     let overflow = || {
@@ -273,7 +276,7 @@ unsafe fn update_quantity_from_tuple(
     if !matches!(quantity, Some(CFormatQuantity::FromValuesTuple)) {
         return Ok(());
     }
-    let v = star_int(pos.next())?;
+    let v = star_int(pos.next(), StarField::Width)?;
     if v < 0 {
         flags.insert(CConversionFlags::LEFT_ADJUST);
     }
@@ -293,22 +296,37 @@ unsafe fn update_precision_from_tuple(
     ) {
         return Ok(());
     }
-    let v = star_int(pos.next())?;
+    let v = star_int(pos.next(), StarField::Precision)?;
     *precision = Some(CFormatPrecision::Quantity(CFormatQuantity::Amount(
         v.max(0) as usize,
     )));
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum StarField {
+    Width,
+    Precision,
+}
+
 /// The `*` argument must be an int; consume it, matching `nextinputvalue`.
-unsafe fn star_int(arg: Option<PyObjectRef>) -> Result<i64, PyError> {
+unsafe fn star_int(arg: Option<PyObjectRef>, field: StarField) -> Result<i64, PyError> {
     let Some(arg) = arg else {
         return Err(PyError::type_error(
             "not enough arguments for format string",
         ));
     };
-    if !is_int_like(arg) {
+    if !pyre_object::pyobject::is_int_or_long(arg) {
         return Err(PyError::type_error("* wants int"));
     }
-    Ok(int_value(arg))
+    let big = crate::builtins::obj_to_bigint(arg);
+    use num_traits::ToPrimitive;
+    match field {
+        StarField::Width => big.to_i64().ok_or_else(|| {
+            PyError::overflow_error("Python int too large to convert to C ssize_t")
+        }),
+        StarField::Precision => big.to_i32().map(|v| v as i64).ok_or_else(|| {
+            PyError::overflow_error("Python int too large to convert to C int")
+        }),
+    }
 }

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -322,11 +322,12 @@ unsafe fn star_int(arg: Option<PyObjectRef>, field: StarField) -> Result<i64, Py
     let big = crate::builtins::obj_to_bigint(arg);
     use num_traits::ToPrimitive;
     match field {
-        StarField::Width => big.to_i64().ok_or_else(|| {
-            PyError::overflow_error("Python int too large to convert to C ssize_t")
-        }),
-        StarField::Precision => big.to_i32().map(|v| v as i64).ok_or_else(|| {
-            PyError::overflow_error("Python int too large to convert to C int")
-        }),
+        StarField::Width => big
+            .to_i64()
+            .ok_or_else(|| PyError::overflow_error("Python int too large to convert to C ssize_t")),
+        StarField::Precision => big
+            .to_i32()
+            .map(|v| v as i64)
+            .ok_or_else(|| PyError::overflow_error("Python int too large to convert to C int")),
     }
 }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1550,9 +1550,9 @@ pub fn builtin_value_format(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     if spec.is_empty() {
         // `str(self)` — a str self passes through as WTF-8.
         if unsafe { pyre_object::is_str(args[0]) } {
-            return Ok(pyre_object::w_str_from_wtf8(
-                unsafe { pyre_object::w_str_get_wtf8(args[0]) }.to_wtf8_buf(),
-            ));
+            return Ok(pyre_object::w_str_from_wtf8(unsafe {
+                crate::display::py_str_wtf8(args[0])?
+            }));
         }
         return Ok(pyre_object::w_str_new(&unsafe { crate::py_str(args[0])? }));
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -363,12 +363,25 @@ pub fn str_method_join(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     // element must be a str; otherwise TypeError("sequence item N:
     // expected str instance, <T> found"). Silently dropping non-str
     // items lost the error and produced an empty join.
+    //
+    // A single-element join returns that element (unicode_result_unchanged):
+    // an exact str unchanged, a str subclass copied to a base str.
+    if items.len() == 1 {
+        let item = items[0];
+        if unsafe { !is_str(item) } {
+            return Err(crate::PyError::type_error(format!(
+                "sequence item 0: expected str instance, {} found",
+                arg_type_name(item)
+            )));
+        }
+        return Ok(str_result_unchanged(item));
+    }
     let mut out = rustpython_wtf8::Wtf8Buf::new();
     for (i, item) in items.iter().enumerate() {
         if unsafe { !is_str(*item) } {
             return Err(crate::PyError::type_error(format!(
                 "sequence item {i}: expected str instance, {} found",
-                unsafe { (*(*(*item)).ob_type).name }
+                arg_type_name(*item)
             )));
         }
         if i > 0 {
@@ -725,25 +738,35 @@ pub fn str_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 pub fn str_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "startswith", 1)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-    let slice = str_slice_args(s, args);
+    let Some(slice) = str_slice_args(s, args) else {
+        return validate_prefix_arg(args[1], "startswith").map(|()| w_bool_from(false));
+    };
     str_prefix_match(slice, args[1], "startswith", true).map(w_bool_from)
 }
 
 pub fn str_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "endswith", 1)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-    let slice = str_slice_args(s, args);
+    let Some(slice) = str_slice_args(s, args) else {
+        return validate_prefix_arg(args[1], "endswith").map(|()| w_bool_from(false));
+    };
     str_prefix_match(slice, args[1], "endswith", false).map(w_bool_from)
 }
 
-fn str_slice_args<'a>(s: &'a Wtf8, args: &[pyre_object::PyObjectRef]) -> &'a Wtf8 {
+/// Apply `startswith`/`endswith`'s optional `start`/`end` bounds to `s`,
+/// returning the code-point window as WTF-8. `None` signals an empty,
+/// out-of-range window (`start` past the end, or `start > end`), for which
+/// the tail match is always `False` — even for an empty needle. A positive
+/// `start` is not upper-clamped so `''.endswith('', 1, 0)` stays `start >
+/// end` rather than collapsing to a valid empty slice.
+fn str_slice_args<'a>(s: &'a Wtf8, args: &[pyre_object::PyObjectRef]) -> Option<&'a Wtf8> {
     let char_len = s.code_points().count() as i64;
     let start = if args.len() >= 3 {
         let v = unsafe { pyre_object::w_int_get_value(args[2]) };
         if v < 0 {
             (char_len + v).max(0) as usize
         } else {
-            (v as usize).min(char_len as usize)
+            v as usize
         }
     } else {
         0
@@ -758,9 +781,8 @@ fn str_slice_args<'a>(s: &'a Wtf8, args: &[pyre_object::PyObjectRef]) -> &'a Wtf
     } else {
         char_len as usize
     };
-    let empty = unsafe { Wtf8::from_bytes_unchecked(&[]) };
     if start > end {
-        return empty;
+        return None;
     }
     let bytes = s.as_bytes();
     let byte_start = s
@@ -771,7 +793,7 @@ fn str_slice_args<'a>(s: &'a Wtf8, args: &[pyre_object::PyObjectRef]) -> &'a Wtf
         .code_point_indices()
         .nth(end)
         .map_or(bytes.len(), |(i, _)| i);
-    unsafe { Wtf8::from_bytes_unchecked(&bytes[byte_start..byte_end]) }
+    Some(unsafe { Wtf8::from_bytes_unchecked(&bytes[byte_start..byte_end]) })
 }
 
 fn str_prefix_match(
@@ -803,7 +825,7 @@ fn str_prefix_match(
             if !unsafe { pyre_object::is_str(item) } {
                 return Err(crate::PyError::type_error(format!(
                     "tuple for {method} must only contain str, not {}",
-                    unsafe { (*(*item).ob_type).name }
+                    arg_type_name(item)
                 )));
             }
             let p = unsafe { pyre_object::w_str_get_wtf8(item) };
@@ -815,38 +837,76 @@ fn str_prefix_match(
     }
     Err(crate::PyError::type_error(format!(
         "{method} first arg must be str or a tuple of str, not {}",
-        unsafe { (*(*needle).ob_type).name }
+        arg_type_name(needle)
+    )))
+}
+
+/// Type-check a `startswith`/`endswith` argument (a str, or a tuple whose
+/// items are all str) without running the match. Used on the out-of-range
+/// window path, where the result is `False` but a bad argument type still
+/// raises the same `TypeError` as the in-range path.
+fn validate_prefix_arg(needle: PyObjectRef, method: &str) -> Result<(), crate::PyError> {
+    if unsafe { pyre_object::is_str(needle) } {
+        return Ok(());
+    }
+    if unsafe { pyre_object::is_tuple(needle) } {
+        let n = unsafe { pyre_object::w_tuple_len(needle) };
+        for i in 0..n as i64 {
+            let item =
+                unsafe { pyre_object::w_tuple_getitem(needle, i) }.expect("index is in range");
+            if !unsafe { pyre_object::is_str(item) } {
+                return Err(crate::PyError::type_error(format!(
+                    "tuple for {method} must only contain str, not {}",
+                    arg_type_name(item)
+                )));
+            }
+        }
+        return Ok(());
+    }
+    Err(crate::PyError::type_error(format!(
+        "{method} first arg must be str or a tuple of str, not {}",
+        arg_type_name(needle)
     )))
 }
 
 pub fn str_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    arity_at_least_positional(args, "replace", 2)?;
+    // `old` / `new` are positional-only; `count` is positional-or-keyword.
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if pos.len() < 3 {
+        return Err(crate::PyError::type_error(format!(
+            "replace() takes at least 2 positional arguments ({} given)",
+            pos.len().saturating_sub(1)
+        )));
+    }
+    crate::builtins::kwarg_reject_unknown(kwargs, &["count"], "replace")?;
+    crate::builtins::kwarg_reject_duplicate(kwargs, "replace", "count", pos.get(3).is_some())?;
     // pypy/objspace/std/unicodeobject.py:1132-1148 descr_replace —
     // both `old` and `new` must be str / W_UnicodeObject; otherwise
     // TypeError("replace() argument N must be str, not ...").
-    if !unsafe { pyre_object::is_str(args[1]) } {
+    if !unsafe { pyre_object::is_str(pos[1]) } {
         return Err(crate::PyError::type_error(format!(
             "replace() argument 1 must be str, not {}",
-            unsafe { (*(*args[1]).ob_type).name }
+            arg_type_name(pos[1])
         )));
     }
-    if !unsafe { pyre_object::is_str(args[2]) } {
+    if !unsafe { pyre_object::is_str(pos[2]) } {
         return Err(crate::PyError::type_error(format!(
             "replace() argument 2 must be str, not {}",
-            unsafe { (*(*args[2]).ob_type).name }
+            arg_type_name(pos[2])
         )));
     }
-    let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-    let old = unsafe { pyre_object::w_str_get_wtf8(args[1]) };
-    let new = unsafe { pyre_object::w_str_get_wtf8(args[2]) };
-    // `unicodeobject.py descr_replace` — optional count argument; a
-    // negative count means "no limit" (matches CPython); 0 leaves the
-    // string untouched.
-    let maxcount = match args.get(3) {
-        Some(&w_count) if unsafe { pyre_object::is_int(w_count) } => unsafe {
-            pyre_object::w_int_get_value(w_count)
-        },
-        _ => -1,
+    let s = unsafe { pyre_object::w_str_get_wtf8(pos[0]) };
+    let old = unsafe { pyre_object::w_str_get_wtf8(pos[1]) };
+    let new = unsafe { pyre_object::w_str_get_wtf8(pos[2]) };
+    // Optional `count`: a negative count means "no limit"; 0 leaves the
+    // string untouched. Resolved through `__index__`.
+    let maxcount = match pos
+        .get(3)
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs, "count"))
+    {
+        Some(w_count) => crate::builtins::space_index_w(w_count)?,
+        None => -1,
     };
     Ok(w_str_from_wtf8(wtf8_replace(s, old, new, maxcount)))
 }
@@ -2682,7 +2742,7 @@ pub fn str_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let width = unsafe { w_int_get_value(args[1]) }.max(0) as usize;
     let len = s.code_points().count();
     if len >= width {
-        return Ok(args[0]);
+        return Ok(str_result_unchanged(args[0]));
     }
     let need = width - len;
     let mut cps = s.code_points();
@@ -2899,6 +2959,18 @@ fn push_cp_repeated(out: &mut Wtf8Buf, cp: CodePoint, n: usize) {
     }
 }
 
+/// `unicode_result_unchanged`: a str method whose result equals the
+/// receiver returns the receiver itself only when it is an exact `str`; a
+/// `str` subclass is copied to a fresh base `str`, since str methods never
+/// return a subclass instance.
+fn str_result_unchanged(obj: PyObjectRef) -> PyObjectRef {
+    if unsafe { is_exact_type(obj, &STR_TYPE) } {
+        obj
+    } else {
+        w_str_from_wtf8(unsafe { w_str_get_wtf8(obj) }.to_owned())
+    }
+}
+
 pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "center", 1)?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
@@ -2906,7 +2978,7 @@ pub fn str_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let fillchar = pad_fillchar(args, "center")?;
     let s_len = s.code_points().count();
     if s_len >= width {
-        return Ok(args[0]);
+        return Ok(str_result_unchanged(args[0]));
     }
     // unicodeobject.py:1098 d = (width - len) ; lpad = d//2 + (d & width & 1)
     let d = width - s_len;
@@ -2927,7 +2999,7 @@ pub fn str_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let fillchar = pad_fillchar(args, "ljust")?;
     let s_len = s.code_points().count();
     if s_len >= width {
-        return Ok(args[0]);
+        return Ok(str_result_unchanged(args[0]));
     }
     let mut out = Wtf8Buf::with_capacity(s.len() + (width - s_len) * 4);
     out.push_wtf8(s);
@@ -2943,7 +3015,7 @@ pub fn str_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     let fillchar = pad_fillchar(args, "rjust")?;
     let s_len = s.code_points().count();
     if s_len >= width {
-        return Ok(args[0]);
+        return Ok(str_result_unchanged(args[0]));
     }
     let mut out = Wtf8Buf::with_capacity(s.len() + (width - s_len) * 4);
     push_cp_repeated(&mut out, fillchar, width - s_len);
@@ -3207,17 +3279,54 @@ pub fn str_method_removesuffix(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
 
 /// PyPy: unicodeobject.py descr_expandtabs
 pub fn str_method_expandtabs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "expandtabs")?;
-    let s = unsafe { w_str_get_wtf8(args[0]) };
-    let tabsize = if args.len() > 1 {
-        unsafe { w_int_get_value(args[1]) }
-    } else {
-        8
+    // `tabsize` is positional-or-keyword (default 8).
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if pos.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "expandtabs() takes at most 1 argument ({} given)",
+            pos.len().saturating_sub(1)
+        )));
+    }
+    crate::builtins::kwarg_reject_unknown(kwargs, &["tabsize"], "expandtabs")?;
+    crate::builtins::kwarg_reject_duplicate(kwargs, "expandtabs", "tabsize", pos.get(1).is_some())?;
+    let s = unsafe { w_str_get_wtf8(pos[0]) };
+    let tabsize = match pos
+        .get(1)
+        .copied()
+        .or_else(|| crate::builtins::kwarg_get(kwargs, "tabsize"))
+    {
+        Some(t) => crate::builtins::space_index_w(t)?,
+        None => 8,
     };
     // Tabs advance to the next multiple of `tabsize` measured from the
     // start of the current line (the column resets on `\n` / `\r`); a
-    // non-positive `tabsize` drops tabs entirely.
-    let mut result = Wtf8Buf::with_capacity(s.len());
+    // non-positive `tabsize` drops tabs entirely. The expanded length is
+    // tracked with checked arithmetic so a pathological `tabsize` raises
+    // OverflowError instead of attempting an unbounded allocation.
+    let overflow = || crate::PyError::overflow_error("result is too long");
+    let mut total: i64 = 0;
+    let mut col: i64 = 0;
+    for cp in s.code_points() {
+        match cp.to_char() {
+            Some('\t') => {
+                if tabsize > 0 {
+                    let incr = tabsize - (col % tabsize);
+                    col = col.checked_add(incr).ok_or_else(overflow)?;
+                    total = total.checked_add(incr).ok_or_else(overflow)?;
+                }
+            }
+            Some('\n') | Some('\r') => {
+                total = total.checked_add(1).ok_or_else(overflow)?;
+                col = 0;
+            }
+            _ => {
+                total = total.checked_add(1).ok_or_else(overflow)?;
+                col += 1;
+            }
+        }
+    }
+    let cap = usize::try_from(total).map_err(|_| overflow())?;
+    let mut result = Wtf8Buf::with_capacity(cap);
     let mut col: i64 = 0;
     for cp in s.code_points() {
         match cp.to_char() {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1032,7 +1032,8 @@ fn format_render(
     depth: u32,
 ) -> Result<Wtf8Buf, crate::PyError> {
     use rustpython_common::format::{
-        FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
+        FieldName, FieldNamePart, FieldType, FormatParseError, FormatPart, FormatString,
+        FromTemplate,
     };
     let lookup_kwarg = |name: &str| -> Result<Option<PyObjectRef>, crate::PyError> {
         if let Some(m) = mapping {
@@ -1072,9 +1073,16 @@ fn format_render(
         // threading the auto-/manual-numbering state (`None` = uncommitted,
         // `Some(true)` = automatic `{}`, `Some(false)` = manual `{0}`).
         //
-        // Classify only the head (up to the first `.`/`[`) here, so a
-        // missing/out-of-range base raises IndexError/KeyError before a
+        // A missing `]` terminates the field, so it precedes base-argument
+        // resolution; every other chain error (empty attribute, empty/`!`
+        // item, stray char after `]`) is a resolution error that follows the
+        // base lookup. Classify only the head (up to the first `.`/`[`) here,
+        // so a missing/out-of-range base raises IndexError/KeyError before a
         // malformed attribute or item chain raises ValueError.
+        let full = FieldName::parse(field_name);
+        if matches!(full, Err(FormatParseError::MissingRightBracket)) {
+            return Err(format_parse_err(FormatParseError::MissingRightBracket, fmt));
+        }
         let mut head = Wtf8Buf::new();
         for ch in field_name.code_points() {
             if ch == '.' || ch == '[' {
@@ -1125,10 +1133,9 @@ fn format_render(
             }
         };
 
-        // Parse the full field name for the attribute/item chain; chain parse
-        // errors now surface after the base argument has been resolved.
-        let FieldName { parts, .. } =
-            FieldName::parse(field_name).map_err(|e| format_parse_err(e, fmt))?;
+        // Surface any remaining chain parse error now that the base argument
+        // has been resolved, then walk the attribute/item chain.
+        let FieldName { parts, .. } = full.map_err(|e| format_parse_err(e, fmt))?;
 
         // `_resolve_lookups` — walk the `.attr` / `[element]` chain; a
         // bracketed all-digit element is an integer index, anything else a
@@ -1142,6 +1149,18 @@ fn format_render(
                     crate::baseobjspace::getitem(val, pyre_object::w_int_new(*idx as i64))?
                 }
                 FieldNamePart::StringIndex(key) => {
+                    // An all-digit bracket element that reached here overflowed
+                    // the integer index — a value that fits is already
+                    // classified as `Index` — so reject it like the head does.
+                    if key
+                        .as_str()
+                        .ok()
+                        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
+                    {
+                        return Err(crate::PyError::value_error(
+                            "Too many decimal digits in format string",
+                        ));
+                    }
                     crate::baseobjspace::getitem(val, pyre_object::w_str_from_wtf8(key.clone()))?
                 }
             };

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -737,6 +737,7 @@ pub fn str_method_rstrip(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// unicodeobject.py:848 descr_startswith(self, prefix, start=0, end=sys.maxsize)
 pub fn str_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "startswith", 1)?;
+    arity_at_most(args, "startswith", 3)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
     let Some(slice) = str_slice_args(s, args) else {
         return validate_prefix_arg(args[1], "startswith").map(|()| w_bool_from(false));
@@ -746,6 +747,7 @@ pub fn str_method_startswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 
 pub fn str_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "endswith", 1)?;
+    arity_at_most(args, "endswith", 3)?;
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
     let Some(slice) = str_slice_args(s, args) else {
         return validate_prefix_arg(args[1], "endswith").map(|()| w_bool_from(false));
@@ -761,7 +763,8 @@ pub fn str_method_endswith(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
 /// end` rather than collapsing to a valid empty slice.
 fn str_slice_args<'a>(s: &'a Wtf8, args: &[pyre_object::PyObjectRef]) -> Option<&'a Wtf8> {
     let char_len = s.code_points().count() as i64;
-    let start = if args.len() >= 3 {
+    // `None` bounds mean "not provided" (start -> 0, end -> len).
+    let start = if args.len() >= 3 && !unsafe { pyre_object::is_none(args[2]) } {
         let v = unsafe { pyre_object::w_int_get_value(args[2]) };
         if v < 0 {
             (char_len + v).max(0) as usize
@@ -771,7 +774,7 @@ fn str_slice_args<'a>(s: &'a Wtf8, args: &[pyre_object::PyObjectRef]) -> Option<
     } else {
         0
     };
-    let end = if args.len() >= 4 {
+    let end = if args.len() >= 4 && !unsafe { pyre_object::is_none(args[3]) } {
         let v = unsafe { pyre_object::w_int_get_value(args[3]) };
         if v < 0 {
             (char_len + v).max(0) as usize
@@ -945,12 +948,14 @@ fn wtf8_idx_window(
 
 pub fn str_method_find(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "find", 1)?;
+    arity_at_most(args, "find", 3)?;
     require_str_sub(args, "find")?;
     Ok(w_int_new(str_unwrap_and_search(args, true)?.unwrap_or(-1)))
 }
 
 pub fn str_method_rfind(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "rfind", 1)?;
+    arity_at_most(args, "rfind", 3)?;
     require_str_sub(args, "rfind")?;
     Ok(w_int_new(str_unwrap_and_search(args, false)?.unwrap_or(-1)))
 }
@@ -2869,6 +2874,7 @@ fn str_unwrap_and_search(
 /// PyPy: unicodeobject.py descr_count
 pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "count", 1)?;
+    arity_at_most(args, "count", 3)?;
     require_str_sub(args, "count")?;
     // Operands read as WTF-8 so lone surrogates do not panic; the optional
     // start / end arguments bound the count window over the code points.
@@ -2887,6 +2893,7 @@ pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// "substring not found" (ValueError).
 pub fn str_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "index", 1)?;
+    arity_at_most(args, "index", 3)?;
     require_str_sub(args, "index")?;
     match str_unwrap_and_search(args, true)? {
         Some(i) => Ok(w_int_new(i)),
@@ -2899,6 +2906,7 @@ pub fn str_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// unicodeobject.py:572 descr_rindex
 pub fn str_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "rindex", 1)?;
+    arity_at_most(args, "rindex", 3)?;
     require_str_sub(args, "rindex")?;
     match str_unwrap_and_search(args, false)? {
         Some(i) => Ok(w_int_new(i)),
@@ -3252,11 +3260,17 @@ pub fn str_method_removeprefix(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             pos.len().saturating_sub(1)
         )));
     }
+    if !unsafe { pyre_object::is_str(pos[1]) } {
+        return Err(crate::PyError::type_error(format!(
+            "removeprefix() argument must be str, not {}",
+            arg_type_name(pos[1])
+        )));
+    }
     let s = unsafe { w_str_get_wtf8(pos[0]) };
     let prefix = unsafe { w_str_get_wtf8(pos[1]) };
     match s.strip_prefix(prefix) {
         Some(rest) => Ok(w_str_from_wtf8(rest.to_wtf8_buf())),
-        None => Ok(pos[0]),
+        None => Ok(str_result_unchanged(pos[0])),
     }
 }
 
@@ -3269,11 +3283,17 @@ pub fn str_method_removesuffix(args: &[PyObjectRef]) -> Result<PyObjectRef, crat
             pos.len().saturating_sub(1)
         )));
     }
+    if !unsafe { pyre_object::is_str(pos[1]) } {
+        return Err(crate::PyError::type_error(format!(
+            "removesuffix() argument must be str, not {}",
+            arg_type_name(pos[1])
+        )));
+    }
     let s = unsafe { w_str_get_wtf8(pos[0]) };
     let suffix = unsafe { w_str_get_wtf8(pos[1]) };
     match s.strip_suffix(suffix) {
         Some(rest) => Ok(w_str_from_wtf8(rest.to_wtf8_buf())),
-        None => Ok(pos[0]),
+        None => Ok(str_result_unchanged(pos[0])),
     }
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -881,23 +881,13 @@ pub fn str_method_rfind(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 pub fn str_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_no_args(args, "upper")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let out = wtf8_map_chars(s, |c, out| {
-        for u in c.to_uppercase() {
-            out.push_char(u);
-        }
-    });
-    Ok(w_str_from_wtf8(out))
+    Ok(w_str_from_wtf8(wtf8_map_str_runs(s, str::to_uppercase)))
 }
 
 pub fn str_method_lower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_no_args(args, "lower")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let out = wtf8_map_chars(s, |c, out| {
-        for l in c.to_lowercase() {
-            out.push_char(l);
-        }
-    });
-    Ok(w_str_from_wtf8(out))
+    Ok(w_str_from_wtf8(wtf8_map_str_runs(s, str::to_lowercase)))
 }
 
 /// PyPy: unicodeobject.py descr_format
@@ -2550,6 +2540,32 @@ fn wtf8_map_chars(s: &Wtf8, f: impl Fn(char, &mut Wtf8Buf)) -> Wtf8Buf {
             Some(c) => f(c, &mut out),
             None => out.push(cp),
         }
+    }
+    out
+}
+
+/// Apply a whole-string case transform (`str::to_lowercase` / `to_uppercase`)
+/// to each maximal valid-UTF-8 run of `s`, passing lone surrogates through
+/// unchanged.  Operating on the run rather than each scalar preserves the
+/// context rules those transforms encode — notably the Greek Final_Sigma
+/// (`Σ` → `ς` word-finally, `σ` elsewhere).
+fn wtf8_map_str_runs(s: &Wtf8, f: impl Fn(&str) -> String) -> Wtf8Buf {
+    let mut out = Wtf8Buf::with_capacity(s.len());
+    let mut run = String::new();
+    for cp in s.code_points() {
+        match cp.to_char() {
+            Some(c) => run.push(c),
+            None => {
+                if !run.is_empty() {
+                    out.push_str(&f(&run));
+                    run.clear();
+                }
+                out.push(cp);
+            }
+        }
+    }
+    if !run.is_empty() {
+        out.push_str(&f(&run));
     }
     out
 }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1073,6 +1073,11 @@ fn format_render(
         // `Some(true)` = automatic `{}`, `Some(false)` = manual `{0}`).
         let FieldName { field_type, parts } =
             FieldName::parse(field_name).map_err(|e| format_parse_err(e, fmt))?;
+        if mapping.is_some() && matches!(field_type, FieldType::Auto | FieldType::Index(_)) {
+            return Err(crate::PyError::value_error(
+                "Format string contains positional fields",
+            ));
+        }
         let mut val = match field_type {
             FieldType::Auto => {
                 if let Some(false) = *numbering {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2147,10 +2147,11 @@ pub fn encode_object(
         "raw-unicode-escape" => Ok(encode_raw_unicode_escape(s)),
         _ => match encode_utf16_32(s, &enc_lower, w_object, errors) {
             Some(out) => out,
-            None => Err(crate::PyError::new(
-                crate::PyErrorKind::LookupError,
-                format!("unknown encoding: {encoding}"),
-            )),
+            None => {
+                let encoded =
+                    crate::module::_codecs::encode_text_codec(w_object, encoding, errors)?;
+                Ok(unsafe { pyre_object::bytesobject::bytes_like_data(encoded) }.to_vec())
+            }
         },
     }
 }
@@ -2868,54 +2869,581 @@ pub fn str_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     Ok(w_str_from_wtf8(out))
 }
 
-/// Number of non-overlapping occurrences of `needle` in `haystack`,
-/// scanning over the WTF-8 bytes. The encoding is self-synchronizing,
-/// so a byte-window match starts on a code-point boundary and the count
-/// equals the code-point-level count. An empty needle matches at every
-/// code-point boundary (len+1 positions), as in `str.count`.
-fn wtf8_count(haystack: &Wtf8, needle: &Wtf8) -> usize {
-    let h = haystack.as_bytes();
-    let n = needle.as_bytes();
-    if n.is_empty() {
-        return haystack.code_points().count() + 1;
-    }
-    let mut count = 0;
-    let mut i = 0;
-    while i + n.len() <= h.len() {
-        if &h[i..i + n.len()] == n {
-            count += 1;
-            i += n.len();
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SearchMode {
+    Count,
+    Find,
+    RFind,
+}
+
+const TWOWAY_MAX_SHIFT: usize = 255;
+const TWOWAY_TABLE_SIZE: usize = 64;
+const TWOWAY_TABLE_MASK: usize = TWOWAY_TABLE_SIZE - 1;
+
+#[inline]
+fn rstring_bloom_add(mask: u64, c: u8) -> u64 {
+    // RPython `rstring.py:bloom_add`, with LONG_BIT = 64 on this target.
+    mask | (1u64 << (c & 63))
+}
+
+#[inline]
+fn rstring_bloom(mask: u64, c: u8) -> bool {
+    // RPython `rstring.py:bloom`.
+    (mask & (1u64 << (c & 63))) != 0
+}
+
+fn rstring_lex_search(needle: &[u8], len_needle: usize, invert_alphabet: bool) -> (usize, usize) {
+    // RPython `rstring.py:_lex_search`.
+    let mut max_suffix = 0usize;
+    let mut candidate = 1usize;
+    let mut k = 0usize;
+    let mut period = 1usize;
+    while candidate + k < len_needle {
+        let a = needle[candidate + k];
+        let b = needle[max_suffix + k];
+        if if invert_alphabet { b < a } else { a < b } {
+            candidate += k + 1;
+            k = 0;
+            period = candidate - max_suffix;
+        } else if a == b {
+            if k + 1 != period {
+                k += 1;
+            } else {
+                candidate += period;
+                k = 0;
+            }
         } else {
-            i += 1;
+            max_suffix = candidate;
+            candidate += 1;
+            k = 0;
+            period = 1;
         }
     }
-    count
+    (max_suffix, period)
+}
+
+fn rstring_factorize(needle: &[u8], len_needle: usize) -> (usize, usize) {
+    // RPython `rstring.py:_factorize`.
+    let (cut1, period1) = rstring_lex_search(needle, len_needle, false);
+    let (cut2, period2) = rstring_lex_search(needle, len_needle, true);
+    if cut1 > cut2 {
+        (cut1, period1)
+    } else {
+        (cut2, period2)
+    }
+}
+
+fn rstring_twoway_preprocess(
+    needle: &[u8],
+    len_needle: usize,
+) -> (usize, usize, usize, bool, [u8; TWOWAY_TABLE_SIZE]) {
+    // RPython `rstring.py:_twoway_preprocess`.
+    let (cut, mut period) = rstring_factorize(needle, len_needle);
+    let mut is_periodic = true;
+    let mut i = 0usize;
+    while i < cut {
+        if needle[i] != needle[period + i] {
+            is_periodic = false;
+            break;
+        }
+        i += 1;
+    }
+    let gap = if is_periodic {
+        0
+    } else {
+        period = cut.max(len_needle - cut) + 1;
+        let mut gap = len_needle;
+        let last = (needle[len_needle - 1] as usize) & TWOWAY_TABLE_MASK;
+        let mut i = len_needle - 1;
+        while i > 0 {
+            i -= 1;
+            if ((needle[i] as usize) & TWOWAY_TABLE_MASK) == last {
+                gap = len_needle - 1 - i;
+                break;
+            }
+        }
+        gap
+    };
+    let not_found_shift = len_needle.min(TWOWAY_MAX_SHIFT) as u8;
+    let mut table = [not_found_shift; TWOWAY_TABLE_SIZE];
+    let mut i = len_needle - not_found_shift as usize;
+    while i < len_needle {
+        table[(needle[i] as usize) & TWOWAY_TABLE_MASK] = (len_needle - 1 - i) as u8;
+        i += 1;
+    }
+    (cut, period, gap, is_periodic, table)
+}
+
+fn rstring_two_way(
+    value: &[u8],
+    base: usize,
+    n: usize,
+    needle: &[u8],
+    m: usize,
+    cut: usize,
+    mut period: usize,
+    gap: usize,
+    is_periodic: bool,
+    table: &[u8; TWOWAY_TABLE_SIZE],
+) -> isize {
+    // RPython `rstring.py:_two_way`.
+    let haystack_end = base + n;
+    let mut window_last = base + m - 1;
+    if is_periodic {
+        let mut memory = 0usize;
+        let mut skip_horspool = false;
+        while window_last < haystack_end {
+            if !skip_horspool {
+                loop {
+                    let shift = table[(value[window_last] as usize) & TWOWAY_TABLE_MASK] as usize;
+                    window_last += shift;
+                    if shift == 0 {
+                        break;
+                    }
+                    if window_last >= haystack_end {
+                        return -1;
+                    }
+                }
+            }
+            skip_horspool = false;
+            let window = window_last + 1 - m;
+            let mut i = cut.max(memory);
+            let mut mismatch = false;
+            while i < m {
+                if needle[i] != value[window + i] {
+                    window_last += i - cut + 1;
+                    memory = 0;
+                    mismatch = true;
+                    break;
+                }
+                i += 1;
+            }
+            if mismatch {
+                continue;
+            }
+            i = memory;
+            while i < cut {
+                if needle[i] != value[window + i] {
+                    window_last += period;
+                    memory = m - period;
+                    if window_last >= haystack_end {
+                        return -1;
+                    }
+                    let shift = table[(value[window_last] as usize) & TWOWAY_TABLE_MASK] as usize;
+                    if shift != 0 {
+                        let mem_jump = cut.max(memory) - cut + 1;
+                        memory = 0;
+                        window_last += shift.max(mem_jump);
+                    } else {
+                        skip_horspool = true;
+                    }
+                    mismatch = true;
+                    break;
+                }
+                i += 1;
+            }
+            if mismatch {
+                continue;
+            }
+            return (window - base) as isize;
+        }
+        -1
+    } else {
+        if period < gap {
+            period = gap;
+        }
+        let gap_jump_end = (cut + gap).min(m);
+        while window_last < haystack_end {
+            loop {
+                let shift = table[(value[window_last] as usize) & TWOWAY_TABLE_MASK] as usize;
+                window_last += shift;
+                if shift == 0 {
+                    break;
+                }
+                if window_last >= haystack_end {
+                    return -1;
+                }
+            }
+            let window = window_last + 1 - m;
+            let mut mismatch = false;
+            let mut i = cut;
+            while i < gap_jump_end {
+                if needle[i] != value[window + i] {
+                    window_last += gap;
+                    mismatch = true;
+                    break;
+                }
+                i += 1;
+            }
+            if mismatch {
+                continue;
+            }
+            i = gap_jump_end;
+            while i < m {
+                if needle[i] != value[window + i] {
+                    window_last += i - cut + 1;
+                    mismatch = true;
+                    break;
+                }
+                i += 1;
+            }
+            if mismatch {
+                continue;
+            }
+            i = 0;
+            while i < cut {
+                if needle[i] != value[window + i] {
+                    window_last += period;
+                    mismatch = true;
+                    break;
+                }
+                i += 1;
+            }
+            if mismatch {
+                continue;
+            }
+            return (window - base) as isize;
+        }
+        -1
+    }
+}
+
+fn rstring_two_way_count(
+    value: &[u8],
+    base: usize,
+    n: usize,
+    needle: &[u8],
+    m: usize,
+    cut: usize,
+    period: usize,
+    gap: usize,
+    is_periodic: bool,
+    table: &[u8; TWOWAY_TABLE_SIZE],
+) -> usize {
+    // RPython `rstring.py:_two_way_count`.
+    let mut index = 0usize;
+    let mut count = 0usize;
+    loop {
+        let result = rstring_two_way(
+            value,
+            base + index,
+            n - index,
+            needle,
+            m,
+            cut,
+            period,
+            gap,
+            is_periodic,
+            table,
+        );
+        if result == -1 {
+            return count;
+        }
+        count += 1;
+        index += result as usize + m;
+    }
+}
+
+fn rstring_default_find(
+    value: &[u8],
+    base: usize,
+    n: usize,
+    needle: &[u8],
+    m: usize,
+    mode: SearchMode,
+) -> isize {
+    // RPython `rstring.py:_default_find`.
+    let w = n - m;
+    let mlast = m - 1;
+    let mut count = 0usize;
+    let mut gap = mlast;
+    let last = needle[mlast];
+    let mut mask = 0u64;
+    let mut j = 0usize;
+    while j < mlast {
+        mask = rstring_bloom_add(mask, needle[j]);
+        if needle[j] == last {
+            gap = mlast - j - 1;
+        }
+        j += 1;
+    }
+    mask = rstring_bloom_add(mask, last);
+    let mut i = 0usize;
+    while i <= w {
+        if value[base + mlast + i] == last {
+            j = 0;
+            while j < mlast {
+                if value[base + i + j] != needle[j] {
+                    break;
+                }
+                j += 1;
+            }
+            if j == mlast {
+                if mode != SearchMode::Count {
+                    return i as isize;
+                }
+                count += 1;
+                i += mlast;
+            } else {
+                let la = base + mlast + i + 1;
+                let c = if la < value.len() { value[la] } else { 0 };
+                if !rstring_bloom(mask, c) {
+                    i += m;
+                } else {
+                    i += gap;
+                }
+            }
+        } else {
+            let la = base + mlast + i + 1;
+            let c = if la < value.len() { value[la] } else { 0 };
+            if !rstring_bloom(mask, c) {
+                i += m;
+            }
+        }
+        i += 1;
+    }
+    if mode != SearchMode::Count {
+        -1
+    } else {
+        count as isize
+    }
+}
+
+fn rstring_adaptive_find(
+    value: &[u8],
+    base: usize,
+    n: usize,
+    needle: &[u8],
+    m: usize,
+    mode: SearchMode,
+) -> isize {
+    // RPython `rstring.py:_adaptive_find`.
+    let w = n - m;
+    let mlast = m - 1;
+    let mut count = 0usize;
+    let mut gap = mlast;
+    let mut hits = 0usize;
+    let last = needle[mlast];
+    let mut mask = 0u64;
+    let mut j = 0usize;
+    while j < mlast {
+        mask = rstring_bloom_add(mask, needle[j]);
+        if needle[j] == last {
+            gap = mlast - j - 1;
+        }
+        j += 1;
+    }
+    mask = rstring_bloom_add(mask, last);
+    let mut i = 0usize;
+    while i <= w {
+        if value[base + mlast + i] == last {
+            j = 0;
+            while j < mlast {
+                if value[base + i + j] != needle[j] {
+                    break;
+                }
+                j += 1;
+            }
+            if j == mlast {
+                if mode != SearchMode::Count {
+                    return i as isize;
+                }
+                count += 1;
+                i += mlast;
+            } else {
+                hits += j + 1;
+                if hits > m / 4 && w - i > 2000 {
+                    let (cut, period, gap, is_periodic, table) =
+                        rstring_twoway_preprocess(needle, m);
+                    if mode != SearchMode::Count {
+                        let res = rstring_two_way(
+                            value,
+                            base + i,
+                            n - i,
+                            needle,
+                            m,
+                            cut,
+                            period,
+                            gap,
+                            is_periodic,
+                            &table,
+                        );
+                        return if res == -1 { -1 } else { res + i as isize };
+                    }
+                    let res = rstring_two_way_count(
+                        value,
+                        base + i,
+                        n - i,
+                        needle,
+                        m,
+                        cut,
+                        period,
+                        gap,
+                        is_periodic,
+                        &table,
+                    );
+                    return (res + count) as isize;
+                }
+                let la = base + mlast + i + 1;
+                let c = if la < value.len() { value[la] } else { 0 };
+                if !rstring_bloom(mask, c) {
+                    i += m;
+                } else {
+                    i += gap;
+                }
+            }
+        } else {
+            let la = base + mlast + i + 1;
+            let c = if la < value.len() { value[la] } else { 0 };
+            if !rstring_bloom(mask, c) {
+                i += m;
+            }
+        }
+        i += 1;
+    }
+    if mode != SearchMode::Count {
+        -1
+    } else {
+        count as isize
+    }
+}
+
+fn rstring_search_normal(
+    value: &[u8],
+    other: &[u8],
+    mut start: usize,
+    mut end: usize,
+    mode: SearchMode,
+) -> isize {
+    // RPython `rstring.py:_search_normal`, specialized to byte-backed
+    // PyPy unicode `_utf8` / pyre WTF-8 storage.
+    end = end.min(value.len());
+    start = start.min(end);
+    let n = end - start;
+    let m = other.len();
+    if m == 0 {
+        return match mode {
+            SearchMode::Count => (end - start + 1) as isize,
+            SearchMode::RFind => end as isize,
+            SearchMode::Find => start as isize,
+        };
+    }
+    let Some(w) = n.checked_sub(m) else {
+        return if mode == SearchMode::Count { 0 } else { -1 };
+    };
+    if mode != SearchMode::RFind {
+        let res = if n < 2500 || (m < 100 && n < 30000) || m < 6 {
+            rstring_default_find(value, start, n, other, m, mode)
+        } else if (m >> 2) * 3 < (n >> 2) {
+            let (cut, period, gap, is_periodic, table) = rstring_twoway_preprocess(other, m);
+            if mode == SearchMode::Count {
+                return rstring_two_way_count(
+                    value,
+                    start,
+                    n,
+                    other,
+                    m,
+                    cut,
+                    period,
+                    gap,
+                    is_periodic,
+                    &table,
+                ) as isize;
+            }
+            rstring_two_way(
+                value,
+                start,
+                n,
+                other,
+                m,
+                cut,
+                period,
+                gap,
+                is_periodic,
+                &table,
+            )
+        } else {
+            rstring_adaptive_find(value, start, n, other, m, mode)
+        };
+        if mode == SearchMode::Count {
+            res
+        } else if res == -1 {
+            -1
+        } else {
+            start as isize + res
+        }
+    } else {
+        // RPython `rstring.py:_search_normal` reverse-find branch.
+        let mlast = m - 1;
+        let mut skip = mlast;
+        let mut mask = rstring_bloom_add(0, other[0]);
+        let mut i = mlast;
+        while i > 0 {
+            mask = rstring_bloom_add(mask, other[i]);
+            if other[i] == other[0] {
+                skip = i - 1;
+            }
+            i -= 1;
+        }
+        let mut i = start + w + 1;
+        while i > start {
+            i -= 1;
+            if value[i] == other[0] {
+                let mut matched = true;
+                let mut j = mlast;
+                while j > 0 {
+                    if value[i + j] != other[j] {
+                        matched = false;
+                        break;
+                    }
+                    j -= 1;
+                }
+                if matched {
+                    return i as isize;
+                }
+                if i > 0 && !rstring_bloom(mask, value[i - 1]) {
+                    i = i.saturating_sub(m);
+                } else {
+                    i = i.saturating_sub(skip);
+                }
+            } else if i > 0 && !rstring_bloom(mask, value[i - 1]) {
+                i = i.saturating_sub(m);
+            }
+        }
+        -1
+    }
+}
+
+/// Number of non-overlapping occurrences of `needle` in `haystack`,
+/// scanning over the WTF-8 bytes. PyPy's `unicodeobject.py:1116` delegates
+/// to `_utf8.count`; the RPython translation path for non-host strings is
+/// `rstring.py:_search_normal(..., SEARCH_COUNT)`.
+fn wtf8_count(haystack: &Wtf8, needle: &Wtf8) -> usize {
+    if needle.is_empty() {
+        return haystack.code_points().count() + 1;
+    }
+    rstring_search_normal(
+        haystack.as_bytes(),
+        needle.as_bytes(),
+        0,
+        haystack.len(),
+        SearchMode::Count,
+    ) as usize
 }
 
 /// First byte offset of `needle` fully within `haystack[lo..hi]`, over
-/// WTF-8 bytes. An empty needle matches at `lo`.
+/// WTF-8 bytes. PyPy `unicodeobject.py:_unwrap_and_search` searches the
+/// `_utf8` storage after converting codepoint bounds to byte bounds.
 fn wtf8_find_bounded(haystack: &[u8], needle: &[u8], lo: usize, hi: usize) -> Option<usize> {
-    if needle.is_empty() {
-        return Some(lo);
-    }
-    if needle.len() > hi {
-        return None;
-    }
-    (lo..=hi - needle.len()).find(|&i| &haystack[i..i + needle.len()] == needle)
+    let res = rstring_search_normal(haystack, needle, lo, hi, SearchMode::Find);
+    if res == -1 { None } else { Some(res as usize) }
 }
 
 /// Last byte offset of `needle` fully within `haystack[lo..hi]`, over
-/// WTF-8 bytes. An empty needle matches at `hi`.
+/// WTF-8 bytes. Mirrors `rstring.py:_search_normal(..., SEARCH_RFIND)`.
 fn wtf8_rfind_bounded(haystack: &[u8], needle: &[u8], lo: usize, hi: usize) -> Option<usize> {
-    if needle.is_empty() {
-        return Some(hi);
-    }
-    if needle.len() > hi {
-        return None;
-    }
-    (lo..=hi - needle.len())
-        .rev()
-        .find(|&i| &haystack[i..i + needle.len()] == needle)
+    let res = rstring_search_normal(haystack, needle, lo, hi, SearchMode::RFind);
+    if res == -1 { None } else { Some(res as usize) }
 }
 
 /// PyPy `_unwrap_and_search` (unicodeobject.py:1288-1317) — the shared

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -3403,9 +3403,7 @@ pub fn str_method_expandtabs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     Ok(w_str_from_wtf8(result))
 }
 
-/// PyPy: unicodeobject.py descr_translate
-///
-/// str.translate(table) — table is a dict mapping ordinals (int) to
+/// str.translate(table) — table is a mapping from ordinals (int) to
 /// ordinals (int), strings (str), or None (delete).
 pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_exact(args, "str.translate", 1)?;
@@ -3415,20 +3413,27 @@ pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
     unsafe {
         for cp in s.code_points() {
             let key = w_int_new(cp.to_u32() as i64);
-            if let Some(val) = w_dict_lookup(table, key) {
-                if is_none(val) {
-                    // None → delete character
-                } else if is_int(val) {
-                    if let Some(c) = CodePoint::from_u32(w_int_get_value(val) as u32) {
+            match crate::baseobjspace::finditem(table, key)? {
+                None => result.push(cp),
+                Some(val) if is_none(val) => {}
+                Some(val) if is_int(val) => {
+                    let code = w_int_get_value(val);
+                    if let Some(c) = u32::try_from(code).ok().and_then(CodePoint::from_u32) {
                         result.push(c);
+                    } else {
+                        return Err(crate::PyError::value_error(
+                            "character mapping must be in range(0x110000)",
+                        ));
                     }
-                } else if is_str(val) {
-                    result.push_wtf8(w_str_get_wtf8(val));
-                } else {
-                    result.push(cp);
                 }
-            } else {
-                result.push(cp);
+                Some(val) if is_str(val) => {
+                    result.push_wtf8(w_str_get_wtf8(val));
+                }
+                Some(_) => {
+                    return Err(crate::PyError::type_error(
+                        "character mapping must return integer, None or str",
+                    ));
+                }
             }
         }
     }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1730,10 +1730,11 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
     }
 }
 
-/// Reject a sign flag or `=` alignment in a string format spec — both are
-/// disallowed for `str` values but accepted by the shared formatter.  Only
-/// the *explicit* alignment is inspected: a leading `0` flag (which the
-/// shared parser normalises to `=`) is a zero fill and stays legal for text.
+/// Reject a sign flag, `=` alignment, or `#` alternate form in a string
+/// format spec — all disallowed for `str` values but accepted by the shared
+/// formatter.  Only the *explicit* alignment is inspected: a leading `0` flag
+/// (which the shared parser normalises to `=`) is a zero fill and stays legal
+/// for text, and a `#` used as a fill character precedes the alignment.
 fn reject_string_sign_align(spec: &str) -> Result<(), crate::PyError> {
     let chars: Vec<char> = spec.chars().collect();
     let n = chars.len();
@@ -1757,6 +1758,11 @@ fn reject_string_sign_align(spec: &str) -> Result<(), crate::PyError> {
         } else {
             "Sign not allowed in string format specifier"
         }));
+    }
+    if i < n && chars[i] == '#' {
+        return Err(crate::PyError::value_error(
+            "Alternate form (#) not allowed in string format specifier",
+        ));
     }
     Ok(())
 }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2971,7 +2971,7 @@ fn push_cp_repeated(out: &mut Wtf8Buf, cp: CodePoint, n: usize) {
 /// receiver returns the receiver itself only when it is an exact `str`; a
 /// `str` subclass is copied to a fresh base `str`, since str methods never
 /// return a subclass instance.
-fn str_result_unchanged(obj: PyObjectRef) -> PyObjectRef {
+pub(crate) fn str_result_unchanged(obj: PyObjectRef) -> PyObjectRef {
     if unsafe { is_exact_type(obj, &STR_TYPE) } {
         obj
     } else {
@@ -3183,8 +3183,17 @@ fn wtf8_replace(input: &Wtf8, sub: &Wtf8, by: &Wtf8, maxcount: i64) -> Wtf8Buf {
 /// PyPy: unicodeobject.py descr_partition
 pub fn str_method_partition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_exact(args, "str.partition", 1)?;
+    if !unsafe { pyre_object::is_str(args[1]) } {
+        return Err(crate::PyError::type_error(format!(
+            "must be str, not {}",
+            arg_type_name(args[1])
+        )));
+    }
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) }.as_bytes();
     let sep = unsafe { pyre_object::w_str_get_wtf8(args[1]) }.as_bytes();
+    if sep.is_empty() {
+        return Err(crate::PyError::value_error("empty separator"));
+    }
     match wtf8_find_bounded(s, sep, 0, s.len()) {
         Some(i) => Ok(w_tuple_new(vec![
             wtf8_slice_str(&s[..i]),
@@ -3198,8 +3207,17 @@ pub fn str_method_partition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 /// PyPy: unicodeobject.py descr_rpartition
 pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_exact(args, "str.rpartition", 1)?;
+    if !unsafe { pyre_object::is_str(args[1]) } {
+        return Err(crate::PyError::type_error(format!(
+            "must be str, not {}",
+            arg_type_name(args[1])
+        )));
+    }
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) }.as_bytes();
     let sep = unsafe { pyre_object::w_str_get_wtf8(args[1]) }.as_bytes();
+    if sep.is_empty() {
+        return Err(crate::PyError::value_error("empty separator"));
+    }
     match wtf8_rfind_bounded(s, sep, 0, s.len()) {
         Some(i) => Ok(w_tuple_new(vec![
             wtf8_slice_str(&s[..i]),
@@ -3218,6 +3236,19 @@ pub fn str_method_rpartition(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 pub fn str_method_splitlines(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_receiver(args, "splitlines")?;
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if pos.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "splitlines() takes at most 1 argument ({} given)",
+            pos.len().saturating_sub(1)
+        )));
+    }
+    crate::builtins::kwarg_reject_unknown(kwargs, &["keepends"], "splitlines")?;
+    crate::builtins::kwarg_reject_duplicate(
+        kwargs,
+        "splitlines",
+        "keepends",
+        pos.get(1).is_some(),
+    )?;
     // `\n` / `\r` are single bytes that cannot occur inside a multi-byte
     // WTF-8 sequence, so the line boundaries are found by walking bytes;
     // each emitted slice cuts on a code-point boundary.

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -117,6 +117,24 @@ pub(crate) fn require_receiver(args: &[PyObjectRef], name: &str) -> Result<(), c
     Ok(())
 }
 
+/// Receiver-only arity for `str` methods that take no arguments (`isspace`,
+/// `lower`, …).  Rejects a missing receiver and any extra positional argument,
+/// matching `str.{name}() takes no arguments (N given)`.
+pub(crate) fn require_no_args(args: &[PyObjectRef], name: &str) -> Result<(), crate::PyError> {
+    if args.is_empty() {
+        return Err(crate::PyError::type_error(format!(
+            "descriptor '{name}' of 'str' object needs an argument"
+        )));
+    }
+    if args.len() > 1 {
+        return Err(crate::PyError::type_error(format!(
+            "str.{name}() takes no arguments ({} given)",
+            args.len() - 1
+        )));
+    }
+    Ok(())
+}
+
 // ── List methods ─────────────────────────────────────────────────────
 // All take self (list) as first arg.
 
@@ -572,7 +590,7 @@ pub fn str_method_rsplit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 /// `CaseFolding.txt` status-C+F mapping to each scalar code point and
 /// passes lone surrogates through unchanged.
 pub fn str_method_casefold(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "casefold")?;
+    require_no_args(args, "casefold")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     Ok(w_str_from_wtf8(case::casefold_wtf8(s)))
 }
@@ -861,7 +879,7 @@ pub fn str_method_rfind(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 }
 
 pub fn str_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "upper")?;
+    require_no_args(args, "upper")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let out = wtf8_map_chars(s, |c, out| {
         for u in c.to_uppercase() {
@@ -872,7 +890,7 @@ pub fn str_method_upper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 }
 
 pub fn str_method_lower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "lower")?;
+    require_no_args(args, "lower")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let out = wtf8_map_chars(s, |c, out| {
         for l in c.to_lowercase() {
@@ -2537,7 +2555,7 @@ fn wtf8_map_chars(s: &Wtf8, f: impl Fn(char, &mut Wtf8Buf)) -> Wtf8Buf {
 }
 
 pub fn str_method_isdigit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isdigit")?;
+    require_no_args(args, "isdigit")?;
     // A lone surrogate satisfies no character class, so a non-UTF-8
     // backing is never all-digit (and the empty string is false too).
     let s = unsafe { w_str_get_wtf8(args[0]) };
@@ -2549,7 +2567,7 @@ pub fn str_method_isdigit(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 pub fn str_method_isdecimal(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isdecimal")?;
+    require_no_args(args, "isdecimal")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(classify::is_decimal),
@@ -2559,7 +2577,7 @@ pub fn str_method_isdecimal(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 pub fn str_method_isnumeric(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isnumeric")?;
+    require_no_args(args, "isnumeric")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(classify::is_numeric),
@@ -2569,7 +2587,7 @@ pub fn str_method_isnumeric(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 }
 
 pub fn str_method_istitle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "istitle")?;
+    require_no_args(args, "istitle")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let mut cased = false;
     let mut prev_cased = false;
@@ -2601,7 +2619,7 @@ pub fn str_method_istitle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 }
 
 pub fn str_method_isalpha(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isalpha")?;
+    require_no_args(args, "isalpha")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(classify::is_alpha),
@@ -2612,7 +2630,7 @@ pub fn str_method_isalpha(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: unicodeobject.py descr_isidentifier
 pub fn str_method_isidentifier(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isidentifier")?;
+    require_no_args(args, "isidentifier")?;
     // An identifier cannot contain a lone surrogate, so a non-UTF-8
     // backing is never an identifier.
     let s = unsafe { w_str_get_wtf8(args[0]) };
@@ -2805,7 +2823,7 @@ pub fn str_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 
 /// PyPy: unicodeobject.py descr_title
 pub fn str_method_title(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "title")?;
+    require_no_args(args, "title")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let mut result = Wtf8Buf::with_capacity(s.len());
     let mut prev_is_sep = true;
@@ -2835,7 +2853,7 @@ pub fn str_method_title(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 
 /// PyPy: unicodeobject.py descr_capitalize
 pub fn str_method_capitalize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "capitalize")?;
+    require_no_args(args, "capitalize")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let mut result = Wtf8Buf::with_capacity(s.len());
     let mut cps = s.code_points();
@@ -2864,7 +2882,7 @@ pub fn str_method_capitalize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
 
 /// PyPy: unicodeobject.py descr_swapcase
 pub fn str_method_swapcase(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "swapcase")?;
+    require_no_args(args, "swapcase")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let out = wtf8_map_chars(s, |c, out| {
         if c.is_uppercase() {
@@ -2977,7 +2995,7 @@ pub fn str_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// Empty string returns True per CPython.  Delegates the per-character
 /// category check to `classify::is_printable`.
 pub fn str_method_isprintable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isprintable")?;
+    require_no_args(args, "isprintable")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     // Empty returns True (vacuous); a lone surrogate is not printable.
     let result = match s.as_str() {
@@ -2989,7 +3007,7 @@ pub fn str_method_isprintable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
 
 /// PyPy: unicodeobject.py descr_isspace
 pub fn str_method_isspace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isspace")?;
+    require_no_args(args, "isspace")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(classify::is_space),
@@ -3026,21 +3044,21 @@ fn wtf8_cased_all(s: &Wtf8, want_upper: bool) -> bool {
 
 /// PyPy: unicodeobject.py descr_isupper
 pub fn str_method_isupper(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isupper")?;
+    require_no_args(args, "isupper")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     Ok(w_bool_from(wtf8_cased_all(s, true)))
 }
 
 /// PyPy: unicodeobject.py descr_islower
 pub fn str_method_islower(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "islower")?;
+    require_no_args(args, "islower")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     Ok(w_bool_from(wtf8_cased_all(s, false)))
 }
 
 /// PyPy: unicodeobject.py descr_isalnum
 pub fn str_method_isalnum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isalnum")?;
+    require_no_args(args, "isalnum")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => !v.is_empty() && v.chars().all(classify::is_alnum),
@@ -3051,7 +3069,7 @@ pub fn str_method_isalnum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 /// PyPy: unicodeobject.py descr_isascii
 pub fn str_method_isascii(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    require_receiver(args, "isascii")?;
+    require_no_args(args, "isascii")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
     let result = match s.as_str() {
         Ok(v) => v.is_ascii(),

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1610,6 +1610,41 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
             }
             return format_finite_float(v, spec);
         }
+        if let Some((re, im)) = crate::objspace::descroperation::complex_val(val) {
+            let p = parse_spec(spec);
+            if p.fill == '0' {
+                return Err(crate::PyError::value_error(
+                    "Zero padding is not allowed in complex format specifier",
+                ));
+            }
+            if p.align == Some('=') {
+                return Err(crate::PyError::value_error(
+                    "'=' alignment flag is not allowed in complex format specifier",
+                ));
+            }
+            let align = p.align.unwrap_or('>');
+            // No presentation type and no precision: pad str(self), which
+            // already carries the parentheses / bare-imaginary form.
+            if p.ty == '\0' && p.precision.is_none() {
+                let body = Wtf8Buf::from_string(crate::py_str(val)?);
+                return Ok(pad_wtf8(&body, p.fill, align, p.width));
+            }
+            // A presentation type or precision formats the real and imaginary
+            // parts as floats and joins them; the imaginary part always
+            // carries an explicit sign and the whole ends in `j`.
+            let prec = p
+                .precision
+                .map(|precision| format!(".{precision}"))
+                .unwrap_or_default();
+            let ty = if p.ty == '\0' { 'f' } else { p.ty };
+            let re_spec = format!("{prec}{ty}");
+            let im_spec = format!("+{prec}{ty}");
+            let mut body = format_finite_float(re, &re_spec)?;
+            let im_str = format_finite_float(im, &im_spec)?;
+            body.push_wtf8(&im_str);
+            body.push_char('j');
+            return Ok(pad_wtf8(&body, p.fill, align, p.width));
+        }
         if pyre_object::is_str(val) {
             let full = pyre_object::w_str_get_wtf8(val);
             // The shared string formatter rejects grouping and numeric types
@@ -1622,7 +1657,10 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
             let sc: Vec<char> = spec.chars().collect();
             let zero_fill = if sc.len() >= 2 && matches!(sc[1], '<' | '>' | '=' | '^') {
                 sc.get(2) == Some(&'0')
-            } else if sc.first().is_some_and(|c| matches!(c, '<' | '>' | '=' | '^')) {
+            } else if sc
+                .first()
+                .is_some_and(|c| matches!(c, '<' | '>' | '=' | '^'))
+            {
                 sc.get(1) == Some(&'0')
             } else {
                 sc.first() == Some(&'0')

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1616,6 +1616,20 @@ fn format_with_spec(val: PyObjectRef, spec: &str) -> Result<Wtf8Buf, crate::PyEr
             // but not a sign or `=` alignment, which are also disallowed for
             // strings.
             reject_string_sign_align(spec)?;
+            // A `0` fill flag at the start of the width pads text with the
+            // default-left alignment; the shared formatter treats it as a
+            // numeric alignment, so handle it here.
+            let sc: Vec<char> = spec.chars().collect();
+            let zero_fill = if sc.len() >= 2 && matches!(sc[1], '<' | '>' | '=' | '^') {
+                sc.get(2) == Some(&'0')
+            } else if sc.first().is_some_and(|c| matches!(c, '<' | '>' | '=' | '^')) {
+                sc.get(1) == Some(&'0')
+            } else {
+                sc.first() == Some(&'0')
+            };
+            if zero_fill {
+                return format_surrogate_str(full, spec);
+            }
             // A valid-UTF-8 body goes through the shared string formatter,
             // which pads by code point.
             if let Ok(valid) = full.as_str() {
@@ -1693,6 +1707,10 @@ fn format_surrogate_str(body: &Wtf8, spec: &str) -> Result<Wtf8Buf, crate::PyErr
     } else if n >= 1 && matches!(chars[0], '<' | '>' | '=' | '^') {
         align = chars[0];
         i = 1;
+    }
+    if i < n && chars[i] == '0' {
+        fill = '0';
+        i += 1;
     }
     let mut width = 0usize;
     while i < n && chars[i].is_ascii_digit() {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -2533,17 +2533,6 @@ fn decode_utf32_impl(
 /// Map each scalar code point of `s` through `f`, appending to a
 /// `Wtf8Buf`; a lone surrogate passes through unchanged.  Used by the
 /// case-mapping methods, which leave surrogates untouched.
-fn wtf8_map_chars(s: &Wtf8, f: impl Fn(char, &mut Wtf8Buf)) -> Wtf8Buf {
-    let mut out = Wtf8Buf::with_capacity(s.len());
-    for cp in s.code_points() {
-        match cp.to_char() {
-            Some(c) => f(c, &mut out),
-            None => out.push(cp),
-        }
-    }
-    out
-}
-
 /// Apply a whole-string case transform (`str::to_lowercase` / `to_uppercase`)
 /// to each maximal valid-UTF-8 run of `s`, passing lone surrogates through
 /// unchanged.  Operating on the run rather than each scalar preserves the
@@ -2612,7 +2601,7 @@ pub fn str_method_istitle(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
         // any other non-cased code point (the `None` arm / `else`).
         match cp.to_char() {
             Some(c) => {
-                if c.is_uppercase() {
+                if c.is_uppercase() || case::is_titlecase(c) {
                     if prev_cased {
                         return Ok(w_bool_from(false));
                     }
@@ -2841,77 +2830,21 @@ pub fn str_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
 pub fn str_method_title(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_no_args(args, "title")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let mut result = Wtf8Buf::with_capacity(s.len());
-    let mut prev_is_sep = true;
-    for cp in s.code_points() {
-        match cp.to_char() {
-            Some(c) => {
-                if prev_is_sep {
-                    for u in c.to_uppercase() {
-                        result.push_char(u);
-                    }
-                } else {
-                    for l in c.to_lowercase() {
-                        result.push_char(l);
-                    }
-                }
-                prev_is_sep = !c.is_alphanumeric();
-            }
-            // A lone surrogate is not alphanumeric — it starts a new word.
-            None => {
-                result.push(cp);
-                prev_is_sep = true;
-            }
-        }
-    }
-    Ok(w_str_from_wtf8(result))
+    Ok(w_str_from_wtf8(case::title_wtf8(s)))
 }
 
 /// PyPy: unicodeobject.py descr_capitalize
 pub fn str_method_capitalize(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_no_args(args, "capitalize")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let mut result = Wtf8Buf::with_capacity(s.len());
-    let mut cps = s.code_points();
-    if let Some(first) = cps.next() {
-        match first.to_char() {
-            Some(c) => {
-                for u in c.to_uppercase() {
-                    result.push_char(u);
-                }
-            }
-            None => result.push(first),
-        }
-        for cp in cps {
-            match cp.to_char() {
-                Some(c) => {
-                    for l in c.to_lowercase() {
-                        result.push_char(l);
-                    }
-                }
-                None => result.push(cp),
-            }
-        }
-    }
-    Ok(w_str_from_wtf8(result))
+    Ok(w_str_from_wtf8(case::capitalize_wtf8(s)))
 }
 
 /// PyPy: unicodeobject.py descr_swapcase
 pub fn str_method_swapcase(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     require_no_args(args, "swapcase")?;
     let s = unsafe { w_str_get_wtf8(args[0]) };
-    let out = wtf8_map_chars(s, |c, out| {
-        if c.is_uppercase() {
-            for l in c.to_lowercase() {
-                out.push_char(l);
-            }
-        } else {
-            for u in c.to_uppercase() {
-                out.push_char(u);
-            }
-        }
-    });
-    Ok(w_str_from_wtf8(out))
+    Ok(w_str_from_wtf8(case::swapcase_wtf8(s)))
 }
 
 /// PyPy: unicodeobject.py descr_center

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -88,6 +88,21 @@ pub(crate) fn arity_at_least_positional(
     Ok(())
 }
 
+/// Validate that a str search method's substring (`args[1]`) is a `str`,
+/// else raise `TypeError("{method}() argument 1 must be str, not {type}")`.
+/// The search path reads `args[1]` as a `W_UnicodeObject`; a non-str would
+/// be dereferenced as one. `args[1]` is guaranteed present by the caller's
+/// preceding `arity_at_least(_, _, 1)`.
+pub(crate) fn require_str_sub(args: &[PyObjectRef], method: &str) -> Result<(), crate::PyError> {
+    if !unsafe { pyre_object::is_str(args[1]) } {
+        return Err(crate::PyError::type_error(format!(
+            "{method}() argument 1 must be str, not {}",
+            arg_type_name(args[1])
+        )));
+    }
+    Ok(())
+}
+
 /// TypeError for a method accepting at most `max` positional arguments after
 /// the receiver, called with more — the METH_VARARGS "X expected at most N
 /// arguments, got M" form (`list.index`, `dict.pop`).
@@ -870,11 +885,13 @@ fn wtf8_idx_window(
 
 pub fn str_method_find(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "find", 1)?;
+    require_str_sub(args, "find")?;
     Ok(w_int_new(str_unwrap_and_search(args, true)?.unwrap_or(-1)))
 }
 
 pub fn str_method_rfind(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "rfind", 1)?;
+    require_str_sub(args, "rfind")?;
     Ok(w_int_new(str_unwrap_and_search(args, false)?.unwrap_or(-1)))
 }
 
@@ -2792,6 +2809,7 @@ fn str_unwrap_and_search(
 /// PyPy: unicodeobject.py descr_count
 pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "count", 1)?;
+    require_str_sub(args, "count")?;
     // Operands read as WTF-8 so lone surrogates do not panic; the optional
     // start / end arguments bound the count window over the code points.
     let s = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
@@ -2809,6 +2827,7 @@ pub fn str_method_count(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// "substring not found" (ValueError).
 pub fn str_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "index", 1)?;
+    require_str_sub(args, "index")?;
     match str_unwrap_and_search(args, true)? {
         Some(i) => Ok(w_int_new(i)),
         None => Err(crate::PyError::value_error("substring not found")),
@@ -2820,6 +2839,7 @@ pub fn str_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
 /// unicodeobject.py:572 descr_rindex
 pub fn str_method_rindex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     arity_at_least(args, "rindex", 1)?;
+    require_str_sub(args, "rindex")?;
     match str_unwrap_and_search(args, false)? {
         Some(i) => Ok(w_int_new(i)),
         None => Err(crate::PyError::value_error("substring not found")),

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1071,8 +1071,19 @@ fn format_render(
         // `_get_argument` — resolve the base argument named by the field,
         // threading the auto-/manual-numbering state (`None` = uncommitted,
         // `Some(true)` = automatic `{}`, `Some(false)` = manual `{0}`).
-        let FieldName { field_type, parts } =
-            FieldName::parse(field_name).map_err(|e| format_parse_err(e, fmt))?;
+        //
+        // Classify only the head (up to the first `.`/`[`) here, so a
+        // missing/out-of-range base raises IndexError/KeyError before a
+        // malformed attribute or item chain raises ValueError.
+        let mut head = Wtf8Buf::new();
+        for ch in field_name.code_points() {
+            if ch == '.' || ch == '[' {
+                break;
+            }
+            head.push(ch);
+        }
+        let FieldName { field_type, .. } =
+            FieldName::parse(&head).map_err(|e| format_parse_err(e, fmt))?;
         if mapping.is_some() && matches!(field_type, FieldType::Auto | FieldType::Index(_)) {
             return Err(crate::PyError::value_error(
                 "Format string contains positional fields",
@@ -1113,6 +1124,11 @@ fn format_render(
                 }
             }
         };
+
+        // Parse the full field name for the attribute/item chain; chain parse
+        // errors now surface after the base argument has been resolved.
+        let FieldName { parts, .. } =
+            FieldName::parse(field_name).map_err(|e| format_parse_err(e, fmt))?;
 
         // `_resolve_lookups` — walk the `.attr` / `[element]` chain; a
         // bracketed all-digit element is an integer index, anything else a

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2747,7 +2747,10 @@ fn init_str_type(ns: &mut DictStorage) {
                 if unsafe { pyre_object::pyobject::is_int_or_long(args[1]) } {
                     unsafe { crate::objspace::descroperation::str_repeat(args[0], args[1]) }
                 } else {
-                    Ok(pyre_object::w_not_implemented())
+                    let count = crate::builtins::space_index_w(args[1])?;
+                    unsafe {
+                        crate::objspace::descroperation::str_repeat(args[0], w_int_new(count))
+                    }
                 }
             },
             2,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -740,9 +740,13 @@ pub fn init_typeobjects() {
             &pyre_object::memoryview::MEMORYVIEW_TYPE as *const PyType as usize,
             memoryview_type as usize,
         );
+        let seq_iterator_type = new_typeobject_with_base("iterator", |_| {}, object_type);
+        // `Py_TPFLAGS_DISALLOW_INSTANTIATION` — an iterator is produced only by
+        // `iter(obj)`, never by `iterator()`, so `tp_new` is NULL.
+        unsafe { pyre_object::w_type_set_disallow_instantiation(seq_iterator_type) };
         reg.insert(
             &pyre_object::iterobject::SEQ_ITER_TYPE as *const PyType as usize,
-            new_typeobject_with_base("iterator", |_| {}, object_type) as usize,
+            seq_iterator_type as usize,
         );
         reg.insert(
             &pyre_object::functional::LONG_RANGE_ITER_TYPE as *const PyType as usize,

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2775,15 +2775,45 @@ fn init_str_type(ns: &mut DictStorage) {
         ns,
         "maketrans",
         make_maketrans_descr(|args| {
-            // maketrans(x[, y[, z]]) → translation dict
+            if args.is_empty() {
+                return Err(crate::PyError::type_error(
+                    "maketrans expected at least 1 argument, got 0",
+                ));
+            }
+            if args.len() > 3 {
+                return Err(crate::PyError::type_error(format!(
+                    "maketrans expected at most 3 arguments, got {}",
+                    args.len()
+                )));
+            }
+
             let d = pyre_object::w_dict_new();
-            if args.len() >= 3 {
-                // maketrans(x, y, z) — z is chars to delete (map to None).
-                // Keys/values are code-point ordinals, read through the
-                // WTF-8 view so a surrogate character does not panic.
+            if args.len() >= 2 {
+                if !unsafe { pyre_object::is_str(args[0]) } {
+                    return Err(crate::PyError::type_error(
+                        "first maketrans argument must be a string if there is a second argument",
+                    ));
+                }
+                if !unsafe { pyre_object::is_str(args[1]) } {
+                    return Err(crate::PyError::type_error(format!(
+                        "maketrans() argument 2 must be str, not {}",
+                        crate::type_methods::arg_type_name(args[1])
+                    )));
+                }
+                if args.len() == 3 && !unsafe { pyre_object::is_str(args[2]) } {
+                    return Err(crate::PyError::type_error(format!(
+                        "maketrans() argument 3 must be str, not {}",
+                        crate::type_methods::arg_type_name(args[2])
+                    )));
+                }
+
                 let x = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
                 let y = unsafe { pyre_object::w_str_get_wtf8(args[1]) };
-                let z = unsafe { pyre_object::w_str_get_wtf8(args[2]) };
+                if x.code_points().count() != y.code_points().count() {
+                    return Err(crate::PyError::value_error(
+                        "the first two maketrans arguments must have equal length",
+                    ));
+                }
                 for (xc, yc) in x.code_points().zip(y.code_points()) {
                     unsafe {
                         pyre_object::w_dict_store(
@@ -2793,29 +2823,24 @@ fn init_str_type(ns: &mut DictStorage) {
                         );
                     }
                 }
-                for zc in z.code_points() {
-                    unsafe {
-                        pyre_object::w_dict_store(
-                            d,
-                            pyre_object::w_int_new(zc.to_u32() as i64),
-                            pyre_object::w_none(),
-                        );
+                if args.len() == 3 {
+                    let z = unsafe { pyre_object::w_str_get_wtf8(args[2]) };
+                    for zc in z.code_points() {
+                        unsafe {
+                            pyre_object::w_dict_store(
+                                d,
+                                pyre_object::w_int_new(zc.to_u32() as i64),
+                                pyre_object::w_none(),
+                            );
+                        }
                     }
                 }
-            } else if args.len() >= 2 {
-                let x = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
-                let y = unsafe { pyre_object::w_str_get_wtf8(args[1]) };
-                for (xc, yc) in x.code_points().zip(y.code_points()) {
-                    unsafe {
-                        pyre_object::w_dict_store(
-                            d,
-                            pyre_object::w_int_new(xc.to_u32() as i64),
-                            pyre_object::w_int_new(yc.to_u32() as i64),
-                        );
-                    }
+            } else {
+                if !unsafe { pyre_object::is_dict(args[0]) } {
+                    return Err(crate::PyError::type_error(
+                        "if you give only one argument to maketrans it must be a dict",
+                    ));
                 }
-            } else if args.len() == 1 && unsafe { pyre_object::is_dict(args[0]) } {
-                // 1-arg dict form: maketrans({ord_or_char: replacement, ...})
                 let src = args[0];
                 unsafe {
                     // `w_dict_items` dispatches through `is_module_dict`
@@ -2826,12 +2851,18 @@ fn init_str_type(ns: &mut DictStorage) {
                             k
                         } else if pyre_object::is_str(k) {
                             let s = pyre_object::w_str_get_wtf8(k);
-                            match s.code_points().next() {
-                                Some(cp) => pyre_object::w_int_new(cp.to_u32() as i64),
-                                None => pyre_object::w_int_new(0),
+                            let mut cps = s.code_points();
+                            let cp = cps.next();
+                            if cp.is_none() || cps.next().is_some() {
+                                return Err(crate::PyError::value_error(
+                                    "string keys in translate table must be of length 1",
+                                ));
                             }
+                            pyre_object::w_int_new(cp.unwrap().to_u32() as i64)
                         } else {
-                            k
+                            return Err(crate::PyError::type_error(
+                                "keys in translate table must be strings or integers",
+                            ));
                         };
                         pyre_object::w_dict_store(d, ord_key, v);
                     }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2657,12 +2657,15 @@ fn init_str_type(ns: &mut DictStorage) {
         make_builtin_function_with_arity(
             "__contains__",
             |args| {
-                if args.len() < 2 {
-                    return Ok(pyre_object::w_bool_from(false));
+                if args.len() != 2 {
+                    return Err(crate::PyError::type_error(format!(
+                        "expected 1 argument, got {}",
+                        args.len().saturating_sub(1)
+                    )));
                 }
-                Ok(pyre_object::w_bool_from(
-                    crate::baseobjspace::contains_slot(args[0], args[1]).unwrap_or(false),
-                ))
+                Ok(pyre_object::w_bool_from(crate::baseobjspace::contains_slot(
+                    args[0], args[1],
+                )?))
             },
             2,
         ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2667,9 +2667,9 @@ fn init_str_type(ns: &mut DictStorage) {
                         args.len().saturating_sub(1)
                     )));
                 }
-                Ok(pyre_object::w_bool_from(crate::baseobjspace::contains_slot(
-                    args[0], args[1],
-                )?))
+                Ok(pyre_object::w_bool_from(
+                    crate::baseobjspace::contains_slot(args[0], args[1])?,
+                ))
             },
             2,
         ),
@@ -12158,10 +12158,9 @@ pub(crate) fn decode_bytes_to_wtf8(
             if let Some(result) = crate::type_methods::decode_utf16_32(data, &enc_lower, err_mode) {
                 result?
             } else {
-                return Err(crate::PyError::new(
-                    crate::PyErrorKind::LookupError,
-                    format!("unknown encoding: {encoding}"),
-                ));
+                let w_data = pyre_object::bytesobject::w_bytes_from_bytes(data);
+                let w_text = crate::module::_codecs::decode_text_codec(w_data, encoding, err_mode)?;
+                unsafe { pyre_object::w_str_get_wtf8(w_text) }.to_wtf8_buf()
             }
         }
     };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -8603,6 +8603,15 @@ fn init_complex_type(ns: &mut DictStorage) {
     );
     dict_storage_store(
         ns,
+        "__format__",
+        make_builtin_function_with_arity(
+            "__format__",
+            crate::type_methods::builtin_value_format,
+            2,
+        ),
+    );
+    dict_storage_store(
+        ns,
         "__hash__",
         make_builtin_function_with_arity(
             "__hash__",


### PR DESCRIPTION
Expands `str` parity with CPython 3.14, driven by `-m test test_str`: adopts the `rustpython-unicode` crate for case mapping, then fixes crashes and argument/format-string parity gaps across the `str` methods, constructor, `%`-formatting, and `__format__`.

## Unicode case mapping
- **_codecs: add `unregister` stub** — unblocks the `StrTest.setUp` cascade.
- **str: reject extra positional args on zero-argument methods** — `require_no_args` on 18 methods (`'x'.isspace(42)` → TypeError).
- **str: whole-string lower/upper to honor Final_Sigma** — `str.lower`/`upper` map over valid-UTF-8 runs so `'…Σ'.lower()` → `ς`.
- **str: route title/capitalize/swapcase/istitle through `rustpython-unicode::case`** — full context-sensitive, WTF-8-safe mappings.
- **repin rustpython-\* 6a118b33 → 5c36d5c3** — picks up RustPython #8241 (titlecase first-of-word with `LeadingAdjustment::None`; U+0345 → U+0399).

## Argument validation & parity
- **str: type-check substring arg of find/rfind/index/rindex/count** — these read `args[1]` as `W_UnicodeObject` without a type check, so `'x'.count(42)` dereferenced a foreign object and aborted. Now raises `"<method>() argument 1 must be str, not <type>"`.
- **seq: saturate slice-step iteration; str `__contains__` arity + non-str TypeError** — an extreme slice step no longer overflows; `x in s` requires a str left operand.
- **str: endswith bounds, padding/join identity, replace/expandtabs keywords** and **search-arg arity, None bounds, remove\*/subscript parity** — bound/None handling and `str`-subclass identity results across the search, padding, join, replace and expandtabs methods.
- **str: mul/partition/rpartition/splitlines argument parity** — `str.__mul__` coerces a non-int via `__index__`; partition/rpartition/splitlines validate arity, separator type, and keywords.
- **str.translate / maketrans: argument validation and error parity** — `translate` looks up code points through the mapping protocol, raises `ValueError`/`TypeError` for out-of-range or wrong-typed values, and takes exactly one argument; `maketrans` enforces 1..3 arity, str-type and equal-length checks, and dict-key validation.
- **str: decode any bytes-like object in the `str(obj, encoding)` constructor** — the decoding branch reads the source through the buffer protocol, so a `memoryview`/`array`/`bytearray` decodes like `bytes`.

## `str()`/`repr()`/`ascii()` and formatting
- **str/repr/ascii: preserve subclass result from `__str__`/`__repr__` and enforce `str()` arity** — `str()`/`repr()` return the dunder result object as-is when it is a str (exact or subclass); `ascii()` reconstructs the subclass for the no-escape case; `str()` rejects more than 3 positional arguments.
- **str formatting: honor subclass `__str__` in `__format__` and `__rmod__` priority** — an empty format spec collapses to `str(self)`; `str % rhs` gives a str subclass on the right that overrides `__rmod__` reflected-subclass priority.
- **str.format_map: reject positional replacement fields** — `{}`/`{0}` under `format_map` raise `ValueError("Format string contains positional fields")`.
- **str %-formatting: width/precision overflow, `%c` type name, `%d` `__int__` order** — a `*` width/precision accepts an int of any magnitude and raises `OverflowError` past the C limit; the `%c` "not an int/char" error names the fully-qualified type; `%d`/`%i`/`%u` coerce through `__int__` before `__index__`, while `%x`/`%X`/`%o` keep `__index__`.
- **str.__format__: zero-fill flag uses default-left text alignment** — `format('res', '08s')` → `'res00000'`.

## `__format__`, `str.format`, and `_string`
- **complex.__format__** — `format(complex, spec)` supports fill/align/width; an empty type with no precision pads `str(self)` (the `(3+2j)` form), a presentation type or precision formats the real/imaginary parts as floats joined with an explicit imaginary sign and trailing `j`; rejects `=` alignment and zero padding.
- **str.format: base argument resolved before the attribute/item chain** — `"{0.}".format()` raises `IndexError` (missing base) while `"{0.}".format(0)` raises `ValueError` (empty attribute); a missing `]` still terminates the field (`"{0[}".format()` → `ValueError`), and an all-digit `[index]` that overflows raises `ValueError`.
- **str.__format__: reject `#` alternate form** — `format('', '#')` raises `ValueError("Alternate form (#) not allowed in string format specifier")`.
- **_string: `formatter_parser` / `formatter_field_name_split`** — the `_string` module exposes the two format-introspection functions built on the shared template parser.
- **iterator: disallow direct instantiation** — `type(iter('abc'))()` raises `TypeError`.

Residual title/case sweep diffs are Unicode-version skew (crate ships Unicode 17, CPython 3.14 is 16), inherent.

## Still failing in test_str (follow-ups, larger — all infra)
`test_str`: run=138, failures=4 (10 methods remaining, all large infra):
- codecs registry (`test_codecs{,_charmap,_errors,_idna,_utf7}`, `test_ucs4`): utf-7/cp037/idna/raw-unicode-escape.
- `test_format`: an upstream `rustpython_common` `parse_spec` gap — a literal `{`/`}`/`!` inside a `[...]` bracket key (`{[{]}`) misparses; needs a crate fix + repin.
- `test_formatting_with_enum`: `class StrEnum(str, Enum)` instance layout (not a str-format bug).
- `test_raiseMemError` (getsizeof layout), `test_free_after_iterating` (GC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
