### PR TITLE
majit-blackhole: root the whole pending nextblackholeinterp chain across run()

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1224,8 +1224,30 @@ impl BlackholeInterpreter {
     /// Returns `Some(args)` for `ContinueRunningNormally` (RPython: raise
     /// jitexc.ContinueRunningNormally propagates through run→_run_forever).
     pub fn run(&mut self) -> Option<MergePointArgs> {
+        // Root this frame's register bank AND every pending caller frame
+        // reachable through `nextblackholeinterp`.  RPython keeps the whole
+        // blackhole interpreter chain transitively GC-traced from the head for
+        // the lifetime of `_run_forever`: each interp is a GC object and its
+        // `registers_r` array plus the `nextblackholeinterp` link are traced
+        // fields.  pyre's `push_bh_regs` roots one frame's `Vec` copy at a
+        // time, so a caller frame that is not yet running is invisible to the
+        // collector.  A minor collection triggered inside this frame's
+        // `run_inner` (nursery allocation) would then fail to forward a young
+        // object held only by a pending caller's register — most importantly
+        // that caller's own materialized `PyFrame` self-pointer — and
+        // `nursery.reset()` zeroes the reclaimed slot.  When control unwinds to
+        // that caller it reads a stale/zeroed frame (its `locals_cells_stack_w`
+        // slot NULL) and a vable opcode dereferences it.  Rooting the full
+        // pending chain here mirrors the RPython invariant.
         let bh_depth = unsafe {
-            majit_gc::shadow_stack::push_bh_regs(&mut self.registers_r, &mut self.tmpreg_r)
+            let depth =
+                majit_gc::shadow_stack::push_bh_regs(&mut self.registers_r, &mut self.tmpreg_r);
+            let mut caller = self.nextblackholeinterp.as_deref_mut();
+            while let Some(frame) = caller {
+                majit_gc::shadow_stack::push_bh_regs(&mut frame.registers_r, &mut frame.tmpreg_r);
+                caller = frame.nextblackholeinterp.as_deref_mut();
+            }
+            depth
         };
         let result = self.run_inner();
         majit_gc::shadow_stack::pop_bh_regs_to(bh_depth);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7019,19 +7019,21 @@ impl Drop for CarrierResumeGuard {
 const FBW_MAX_INLINE_RECURSION: usize = 7;
 
 /// Maximum inline depth the multiframe guard-snapshot path
-/// (`walker_capture_multi_frame_inline_snapshot`) SOUNDLY supports.  Only a
-/// single paused caller frame (depth-1, one parent) resumes correctly: on
-/// guard-failure blackhole resume the one caller frame's virtualizable is
-/// rematerialized and its `portal_frame_reg` decodes to a live vable.  A
-/// depth-≥2 snapshot has a MIDDLE inlined-callee frame whose `NewWithVtable`
-/// virtual `PyFrame` (`emit_new_pyframe_inline_with_params`) is NOT
-/// rematerialized by the resume decoder — its `portal_frame_reg` decodes to a
-/// raw `TAGVIRTUAL` value and `handler_setarrayitem_vable_r` dereferences it
-/// (`EXC_BAD_ACCESS`).  Bounded to 1 so `try_multiframe` (`inline_depth <
-/// FBW_MAX_MULTIFRAME_DEPTH`) only fires at the top inline level; deeper
-/// recursion folds to the `CALL_ASSEMBLER` tail.  Restoring deeper unroll
-/// needs middle-frame virtual rematerialization in the optimizer
-/// `store_final_boxes_in_guard` / resume decoder (the walker-arch rework).
+/// (`walker_capture_multi_frame_inline_snapshot`) unrolls before folding to
+/// the `CALL_ASSEMBLER` tail.  Bounded to 1: a depth-≥2 unroll of a tree
+/// recursion (e.g. `fib`, whose `n < 2` base-case guard fails per call) does
+/// not stay in compiled code — the unrolled trace guard-fails and deopts to
+/// the blackhole on essentially every recursive call (measured: two orders of
+/// magnitude more blackhole resumes than the folded path, ~20-30× slower).
+/// This mirrors `max_unroll_recursion` bounding the same runaway: past the
+/// bound the recursive call folds straight to `CALL_ASSEMBLER`
+/// (`_opimpl_recursive_call` → `do_recursive_call`, `pyjitpl.py:1404-1416`)
+/// rather than continuing to unroll the call tree.  `try_multiframe`
+/// (`inline_depth < FBW_MAX_MULTIFRAME_DEPTH`) therefore only fires at the top
+/// inline level.  (The depth-≥2 blackhole-resume crash that previously blocked
+/// this path was a GC-rooting gap in the nested `run()` chain, fixed by rooting
+/// the whole pending `nextblackholeinterp` chain across `run()`; raising the
+/// bound is now a performance, not a soundness, question.)
 const FBW_MAX_MULTIFRAME_DEPTH: usize = 1;
 
 /// Recursion depth of `w_code` on the FBW inline stack.


### PR DESCRIPTION
part of #343

## Summary

`BlackholeInterpreter::run()` pushed only the currently-running frame's `registers_r` onto the GC root stack. Pending caller frames reachable through `nextblackholeinterp` were not rooted, so a minor collection triggered inside `run_inner` (nursery allocation) failed to forward a young object held only by a caller's register — including that caller's materialized `PyFrame` self-pointer. `nursery.reset()` then zeroed the reclaimed slot, and on unwind to the caller a vable opcode dereferenced the stale/zeroed frame (`locals_cells_stack_w` NULL).

The fix walks the `nextblackholeinterp` chain and pushes every frame's register bank for the whole `run()` lifetime, popping back to the entry depth on return.

This closes the depth-2 multiframe-inline `CALL_ASSEMBLER` guard-failure resume crash (#126 investigation): the crash was a GC-rooting gap in the nested `run()` chain, not the previously-theorized object-kind divergence. Verified via nursery-size sweep (crash was collection-triggered; disappears with the rooting fix at all nursery sizes).

Also corrects the now-stale `FBW_MAX_MULTIFRAME_DEPTH` doc comment: it claimed depth-≥2 crashes with `EXC_BAD_ACCESS` (fixed here); the bound now reflects the real reason it stays at 1 — a depth-≥2 unroll of a tree recursion (e.g. `fib`) deopts to the blackhole on essentially every recursive call (~20-30× slower), matching how `max_unroll_recursion` bounds the same runaway before folding to `CALL_ASSEMBLER`.

## Verification

- Depth-2 multiframe path: EXIT 0, `fib32=2178309`, 40/40 clean at default nursery, nursery sweep 1MB–512MB all clean.
- Shipping fib path unchanged (`sum_fib_0_32=5702886`, `fib32=2178309`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)