### PR TITLE
jit(wasm): fix #420 wasm-only failures + inline_helper strict-MF regression

### DIFF
--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1873,7 +1873,13 @@ static W_OBJECT_OBJECT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::n
             (
                 "W_ObjectObject.map",
                 core::mem::offset_of!(pyre_object::W_ObjectObject, map),
-                8,
+                // `map` is a `*const MapNode` erased to an opaque Int word, so
+                // its width is one machine word — 4 bytes on wasm32, 8 on
+                // 64-bit. Hardcoding 8 would read/write past the field on
+                // wasm32, folding the adjacent `storage` pointer into the high
+                // half of a `guard_value(map)` load (and clobbering it on a
+                // `setfield_gc(map)` store).
+                core::mem::size_of::<usize>(),
                 Type::Int,
                 false,
                 false,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12836,6 +12836,7 @@ fn try_walker_inline_user_call(
         }
     } else if strict_inlinable
         && fbw_strict_multiframe_enabled()
+        && inline_depth < FBW_MAX_MULTIFRAME_DEPTH
         && strict_callee_collapse_unsound(body.code)
     {
         // gh#420: a strict straight-line callee's in-callee guard collapses to
@@ -12854,6 +12855,13 @@ fn try_walker_inline_user_call(
         // `a + b` / `a * b`) has an idempotent collapse, so it is left on that
         // collapse — a strict callee seeds no frame red, so pushing it through
         // the always-declining MF snapshot would abort a working inline.
+        //
+        // Bounded by `inline_depth < FBW_MAX_MULTIFRAME_DEPTH` (mirror of
+        // `try_multiframe`): pushing a paused caller frame while already one
+        // inline level deep yields two `InlineParentFrame`s (n_parents ==
+        // n_callees == 2), a 3-frame snapshot the resume path is sound for only
+        // one paused caller frame.  A nested side-effecting strict callee then
+        // falls back to the single-frame collapse (its pre-strict-MF behavior).
         compute_inline_caller_frame(ctx, op.pc)
     } else {
         None
@@ -12878,51 +12886,76 @@ fn try_walker_inline_user_call(
     // same defect class as the LOAD_ATTR fold empty-boxes bug.  Mirror
     // `try_walker_list_append_inline`: read the caller's live register
     // banks from `FULL_BODY_SNAPSHOT_SYM` at the CALL-site py_pc.
-    let inline_outer_active_boxes = if ctx.is_full_body_walk && ctx.outer_active_boxes.is_empty() {
-        let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
-        if sym_ptr.is_null() {
-            ctx.outer_active_boxes.clone()
-        } else {
-            let sym = unsafe { &*sym_ptr };
-            if sym.jitcode.is_null() {
-                ctx.outer_active_boxes.clone()
-            } else {
-                // Liveness coordinate is the CALL op's own (jitcode index,
-                // py_pc) — NOT the `ctx` sentinels.  `dispatch_via_miframe`
-                // initializes `ctx.outer_jitcode_index` to 0 and
-                // `ctx.entry_py_pc` to the walk-entry py_pc, so for a CALL in a
-                // non-root jitcode, or a CALL not at the walk-entry pc, those
-                // select the wrong liveness window and the callee guard snapshot
-                // encodes the wrong frame boxes.  Derive the coordinate from the
-                // snapshot sym's jitcode at the CALL op's pc, matching
-                // `orthodox_list_append_commit`.
-                let (call_site_py_pc, call_site_jc_index) = unsafe {
-                    let jc = &*sym.jitcode;
-                    let jc_index = jc.index as u32;
-                    let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
-                    if !jc.payload.code_ptr.is_null() {
-                        let codeobj = &*jc.payload.code_ptr;
-                        py = skip_python_trivia_forward(codeobj, py as usize) as u32;
-                    }
-                    (py, jc_index)
-                };
-                collect_outer_active_boxes(
-                    sym,
-                    ctx.trace_ctx,
-                    ctx.registers_i,
-                    ctx.registers_r,
-                    ctx.registers_f,
-                    call_site_jc_index,
-                    call_site_py_pc,
-                    None,
-                    majit_ir::resumedata::NO_JITCODE_PC,
-                    None,
+    //
+    // The snapshot header coordinate (`sub_wc.entry_py_pc` /
+    // `sub_wc.outer_jitcode_index`, stamped below) MUST be the SAME coordinate
+    // these boxes are collected at.  A callee guard that collapses to the
+    // caller boundary stamps that coordinate as its resume `SnapshotFrame`
+    // header, and the decoder (`setup_bridge_sym`) reads the liveness window at
+    // that header to size and place the stored boxes
+    // (`reg_indices.total_len() == frame.values.len()`).  Collecting boxes at
+    // the CALL site but stamping the walk-entry header desyncs the two windows
+    // (count-mismatch assert / wrong slot layout), so carry the box coordinate
+    // to the header alongside the boxes.
+    let (inline_outer_active_boxes, inline_outer_py_pc, inline_outer_jc_index) =
+        if ctx.is_full_body_walk && ctx.outer_active_boxes.is_empty() {
+            let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+            if sym_ptr.is_null() {
+                (
+                    ctx.outer_active_boxes.clone(),
+                    ctx.entry_py_pc,
+                    ctx.outer_jitcode_index,
                 )
+            } else {
+                let sym = unsafe { &*sym_ptr };
+                if sym.jitcode.is_null() {
+                    (
+                        ctx.outer_active_boxes.clone(),
+                        ctx.entry_py_pc,
+                        ctx.outer_jitcode_index,
+                    )
+                } else {
+                    // Liveness coordinate is the CALL op's own (jitcode index,
+                    // py_pc) — NOT the `ctx` sentinels.  `dispatch_via_miframe`
+                    // initializes `ctx.outer_jitcode_index` to 0 and
+                    // `ctx.entry_py_pc` to the walk-entry py_pc, so for a CALL in
+                    // a non-root jitcode, or a CALL not at the walk-entry pc,
+                    // those select the wrong liveness window and the callee guard
+                    // snapshot encodes the wrong frame boxes.  Derive the
+                    // coordinate from the snapshot sym's jitcode at the CALL op's
+                    // pc, matching `orthodox_list_append_commit`.
+                    let (call_site_py_pc, call_site_jc_index) = unsafe {
+                        let jc = &*sym.jitcode;
+                        let jc_index = jc.index as u32;
+                        let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+                        if !jc.payload.code_ptr.is_null() {
+                            let codeobj = &*jc.payload.code_ptr;
+                            py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+                        }
+                        (py, jc_index)
+                    };
+                    let boxes = collect_outer_active_boxes(
+                        sym,
+                        ctx.trace_ctx,
+                        ctx.registers_i,
+                        ctx.registers_r,
+                        ctx.registers_f,
+                        call_site_jc_index,
+                        call_site_py_pc,
+                        None,
+                        majit_ir::resumedata::NO_JITCODE_PC,
+                        None,
+                    );
+                    (boxes, call_site_py_pc, call_site_jc_index)
+                }
             }
-        }
-    } else {
-        ctx.outer_active_boxes.clone()
-    };
+        } else {
+            (
+                ctx.outer_active_boxes.clone(),
+                ctx.entry_py_pc,
+                ctx.outer_jitcode_index,
+            )
+        };
     let callee_outcome = {
         let mut sub_wc = WalkContext {
             registers_r: &mut callee_regs_r,
@@ -12951,16 +12984,16 @@ fn try_walker_inline_user_call(
             sub_jitcode_lookup: callee_lookup,
             last_exc_value: None,
             last_exc_value_concrete: ConcreteValue::Null,
-            entry_py_pc: ctx.entry_py_pc,
-            outer_jitcode_index: ctx.outer_jitcode_index,
+            entry_py_pc: inline_outer_py_pc,
+            outer_jitcode_index: inline_outer_jc_index,
             outer_active_boxes: inline_outer_active_boxes,
         };
         // Guards emitted inside the callee body — both the walker's own
         // and the `_nonstandard_virtualizable` PTR_EQ promote that
         // `vable_getfield_*` records internally — resume at this CALL
-        // boundary (`sub_wc.entry_py_pc` / `outer_active_boxes`, inherited
-        // from the caller), not at a callee `op_pc` that has no meaning in
-        // the outer jitcode's py_pc→jitcode tables.  See
+        // boundary (`sub_wc.entry_py_pc` / `outer_active_boxes`, both stamped
+        // at the CALL-site coordinate above), not at a callee `op_pc` that has
+        // no meaning in the outer jitcode's py_pc→jitcode tables.  See
         // `INLINE_SUBWALK_CAPTURE_BOUNDARY`.
         let _inline_boundary = InlineSubwalkCaptureGuard::enter();
         // Track this callee on the FBW inline stack for the lifetime of the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12769,6 +12769,38 @@ fn try_walker_inline_user_call(
     // side-effecting prologue must decline the CA inline (see the arm).
     let prologue_journal_before = fbw_store_journal_len();
     let prologue_effect_before = fbw_has_unjournaled_effect();
+    // Compute fresh outer_active_boxes for the inline sub-walk when the
+    // parent FBW walk carries an empty set (`dispatch_via_miframe`
+    // initializes `outer_active_boxes: Vec::new()`; it is computed
+    // dynamically per guard by the FBW path).  A callee guard falls
+    // through to the per-opcode arm path which reads `ctx.outer_active_boxes`,
+    // so an empty inherited set produces a resume snapshot with zero frame
+    // boxes while the decoder expects the full liveness-derived set — the
+    // same defect class as the LOAD_ATTR fold empty-boxes bug.  Mirror
+    // `try_walker_list_append_inline`: read the caller's live register
+    // banks from `FULL_BODY_SNAPSHOT_SYM` at the CALL-site py_pc.
+    let inline_outer_active_boxes = if ctx.is_full_body_walk && ctx.outer_active_boxes.is_empty() {
+        let sym_ptr = FULL_BODY_SNAPSHOT_SYM.with(|c| c.get());
+        if sym_ptr.is_null() {
+            ctx.outer_active_boxes.clone()
+        } else {
+            let sym = unsafe { &*sym_ptr };
+            collect_outer_active_boxes(
+                sym,
+                ctx.trace_ctx,
+                ctx.registers_i,
+                ctx.registers_r,
+                ctx.registers_f,
+                ctx.outer_jitcode_index,
+                ctx.entry_py_pc,
+                None,
+                majit_ir::resumedata::NO_JITCODE_PC,
+                None,
+            )
+        }
+    } else {
+        ctx.outer_active_boxes.clone()
+    };
     let callee_outcome = {
         let mut sub_wc = WalkContext {
             registers_r: &mut callee_regs_r,
@@ -12799,7 +12831,7 @@ fn try_walker_inline_user_call(
             last_exc_value_concrete: ConcreteValue::Null,
             entry_py_pc: ctx.entry_py_pc,
             outer_jitcode_index: ctx.outer_jitcode_index,
-            outer_active_boxes: ctx.outer_active_boxes.clone(),
+            outer_active_boxes: inline_outer_active_boxes,
         };
         // Guards emitted inside the callee body — both the walker's own
         // and the `_nonstandard_virtualizable` PTR_EQ promote that

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -7238,6 +7238,35 @@ pub(crate) fn fbw_inline_multiframe_enabled() -> bool {
     })
 }
 
+/// `PYRE_FBW_STRICT_MULTIFRAME` (gh#420): give a STRICT straight-line inlined
+/// callee the same multi-frame guard snapshot the branch-bearing multiframe
+/// path uses, so an in-callee guard resumes at the callee's OWN coordinate
+/// (with the caller paused at the CALL return point) instead of collapsing to
+/// the caller boundary.  The single-frame collapse re-executes the whole call
+/// on deopt, which re-materializes it at a stale `valuestackdepth` (a resume
+/// `LOAD_FAST` push overflows the frame, an `rd_numb` decode overruns) and
+/// re-applies a committed heap side effect — visible on the wasm resume path,
+/// where a guard-failure deopt is not absorbed by a compiled bridge.
+///
+/// The caller (paused) frame is pushed whenever it is snapshot-able
+/// ([`compute_inline_caller_frame`] returns `Some`; `None` keeps the collapse).
+/// When the CALLEE frame is then not snapshot-able either — a kept operand-stack
+/// temp the callee sub-walk does not mirror (a `LOAD_METHOD` receiver, a
+/// residual-call result live across the guard) —
+/// [`walker_capture_multi_frame_inline_snapshot`] returns `Unsupported`, and the
+/// inline declines to an ordinary residual call rather than falling back to the
+/// corrupt collapse.  Default-on; `=0`/`false` opts out.
+pub(crate) fn fbw_strict_multiframe_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var_os("PYRE_FBW_STRICT_MULTIFRAME") {
+        Some(v) => {
+            let v = v.to_string_lossy();
+            v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        None => true,
+    })
+}
+
 /// `PYRE_FBW_LOOP_CALLEE_CA` (gap-10, general loop-bearing-callee →
 /// CALL_ASSEMBLER): when a multi-frame inlined callee sub-walk reaches the
 /// callee's own `jit_merge_point` and a compiled loop token already exists
@@ -9964,6 +9993,13 @@ fn walker_capture_snapshot_for_last_guard_impl(
         let n_callees = FBW_INLINE_CODE_STACK.with(|s| s.borrow().len());
         if n_parents > 0 && n_parents == n_callees {
             let parent_frames = FBW_INLINE_PARENT_FRAMES.with(|s| s.borrow().clone());
+            // A STRICT straight-line callee (gh#420) whose own frame is not
+            // MF-snapshot-able (a kept operand-stack temp the sub-walk does not
+            // mirror) propagates the `Unsupported` error the same as the branch
+            // path: the enclosing inline declines to a residual call rather than
+            // resuming through the single-frame collapse, whose caller-boundary
+            // re-execute both mis-sizes the resumed frame (a decode/`LOAD_FAST`
+            // out-of-bounds) and re-applies the callee's committed side effect.
             return walker_capture_multi_frame_inline_snapshot(
                 ctx,
                 op_pc,
@@ -12756,6 +12792,16 @@ fn try_walker_inline_user_call(
             Some(pf) => Some(pf),
             None => return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc }),
         }
+    } else if strict_inlinable && fbw_strict_multiframe_enabled() {
+        // gh#420: a strict straight-line callee's in-callee guard collapses to
+        // the caller boundary and re-executes the whole call on deopt, doubling
+        // a committed heap side effect and resuming at a stale valuestackdepth.
+        // Give it the same paused-caller frame the branch multiframe path uses
+        // so the guard resumes at the callee's own coordinate.  Best effort:
+        // when the caller frame is not snapshot-able keep the single-frame
+        // collapse (do NOT decline the inline — that shape is otherwise served
+        // correctly today), so this never removes a working inline.
+        compute_inline_caller_frame(ctx, op.pc)
     } else {
         None
     };

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11648,6 +11648,48 @@ fn callee_fast_path_inlinable(
     true
 }
 
+/// True when a STRICT straight-line callee commits a heap side effect that its
+/// single-frame collapse would re-apply on a deopt / abort re-execute — the
+/// gh#420 unsoundness.  The collapse resumes at the caller CALL boundary and
+/// re-runs the WHOLE call, so a committed store or construction is doubled
+/// (`inline_callee_constructs_object`'s `P(n)` construct;
+/// `inlined_mutation_before_abort`'s `c.n = c.n + 1` store, whose recorded
+/// value persists past the trace abort).  Such a callee routes through the
+/// multi-frame decline (a paused caller frame) so the enclosing inline declines
+/// to a residual instead of collapsing.
+///
+/// A PURE value-returning leaf — only typed helper residual calls (an int/float
+/// binop `residual_call_ir_r`, an idempotent field read) plus ref moves and a
+/// return, e.g. `inline_helper`'s `a + b` / `a * b` — re-executes identically
+/// on deopt, so its collapse is sound and it must NOT be pushed through the
+/// always-declining MF snapshot (a strict callee seeds no frame red, so that
+/// snapshot can only decline, aborting a working inline).
+///
+/// Conservative: a general ref-first-arg residual call (`residual_call_r_*`, an
+/// arbitrary Python call / constructor that may raise or mutate), a VOID
+/// residual call (`..._v`, a statement run for its effect — a store / append),
+/// or an explicit vable/gc field or array write all count as a side effect.
+fn strict_callee_collapse_unsound(body_code: &[u8]) -> bool {
+    let mut pc = 0usize;
+    while pc < body_code.len() {
+        let Some(d) = crate::jitcode_runtime::decode_op_at(body_code, pc) else {
+            // Undecodable tail: be conservative — take the decline, not the
+            // collapse.
+            return true;
+        };
+        let op = d.opname;
+        if op.starts_with("residual_call_r")
+            || (op.starts_with("residual_call") && op.ends_with("_v"))
+            || op.contains("setfield")
+            || op.contains("setarrayitem")
+        {
+            return true;
+        }
+        pc = d.next_pc;
+    }
+    false
+}
+
 /// True iff `d` is a scalar `getfield_vable_r` whose field is a Ref-typed
 /// compile-time constant (`pycode` / `w_globals`) — the only vable op
 /// [`try_resolve_inline_callee_static_field`] can satisfy without a seeded
@@ -12792,7 +12834,10 @@ fn try_walker_inline_user_call(
             Some(pf) => Some(pf),
             None => return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc }),
         }
-    } else if strict_inlinable && fbw_strict_multiframe_enabled() {
+    } else if strict_inlinable
+        && fbw_strict_multiframe_enabled()
+        && strict_callee_collapse_unsound(body.code)
+    {
         // gh#420: a strict straight-line callee's in-callee guard collapses to
         // the caller boundary and re-executes the whole call on deopt, doubling
         // a committed heap side effect and resuming at a stale valuestackdepth.
@@ -12801,6 +12846,14 @@ fn try_walker_inline_user_call(
         // when the caller frame is not snapshot-able keep the single-frame
         // collapse (do NOT decline the inline — that shape is otherwise served
         // correctly today), so this never removes a working inline.
+        //
+        // Gated on the callee committing a heap side effect
+        // ([`strict_callee_collapse_unsound`]): only then is the collapse
+        // re-execute unsound and the paused-caller frame (→ MF snapshot decline
+        // → residual) warranted.  A PURE value-returning leaf (`inline_helper`'s
+        // `a + b` / `a * b`) has an idempotent collapse, so it is left on that
+        // collapse — a strict callee seeds no frame red, so pushing it through
+        // the always-declining MF snapshot would abort a working inline.
         compute_inline_caller_frame(ctx, op.pc)
     } else {
         None

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -12831,18 +12831,41 @@ fn try_walker_inline_user_call(
             ctx.outer_active_boxes.clone()
         } else {
             let sym = unsafe { &*sym_ptr };
-            collect_outer_active_boxes(
-                sym,
-                ctx.trace_ctx,
-                ctx.registers_i,
-                ctx.registers_r,
-                ctx.registers_f,
-                ctx.outer_jitcode_index,
-                ctx.entry_py_pc,
-                None,
-                majit_ir::resumedata::NO_JITCODE_PC,
-                None,
-            )
+            if sym.jitcode.is_null() {
+                ctx.outer_active_boxes.clone()
+            } else {
+                // Liveness coordinate is the CALL op's own (jitcode index,
+                // py_pc) — NOT the `ctx` sentinels.  `dispatch_via_miframe`
+                // initializes `ctx.outer_jitcode_index` to 0 and
+                // `ctx.entry_py_pc` to the walk-entry py_pc, so for a CALL in a
+                // non-root jitcode, or a CALL not at the walk-entry pc, those
+                // select the wrong liveness window and the callee guard snapshot
+                // encodes the wrong frame boxes.  Derive the coordinate from the
+                // snapshot sym's jitcode at the CALL op's pc, matching
+                // `orthodox_list_append_commit`.
+                let (call_site_py_pc, call_site_jc_index) = unsafe {
+                    let jc = &*sym.jitcode;
+                    let jc_index = jc.index as u32;
+                    let mut py = python_pc_for_jitcode_pc(&jc.payload.metadata, op.pc);
+                    if !jc.payload.code_ptr.is_null() {
+                        let codeobj = &*jc.payload.code_ptr;
+                        py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+                    }
+                    (py, jc_index)
+                };
+                collect_outer_active_boxes(
+                    sym,
+                    ctx.trace_ctx,
+                    ctx.registers_i,
+                    ctx.registers_r,
+                    ctx.registers_f,
+                    call_site_jc_index,
+                    call_site_py_pc,
+                    None,
+                    majit_ir::resumedata::NO_JITCODE_PC,
+                    None,
+                )
+            }
         }
     } else {
         ctx.outer_active_boxes.clone()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -11668,7 +11668,10 @@ fn callee_fast_path_inlinable(
 /// Conservative: a general ref-first-arg residual call (`residual_call_r_*`, an
 /// arbitrary Python call / constructor that may raise or mutate), a VOID
 /// residual call (`..._v`, a statement run for its effect — a store / append),
-/// or an explicit vable/gc field or array write all count as a side effect.
+/// or an explicit vable/gc field, array, or interior-field write all count as a
+/// side effect (`setinteriorfield_gc_*` — an array-of-struct / dict-storage
+/// write — is caught by the `setinteriorfield` substring; note the plain
+/// `setfield` substring does not span it).
 fn strict_callee_collapse_unsound(body_code: &[u8]) -> bool {
     let mut pc = 0usize;
     while pc < body_code.len() {
@@ -11682,6 +11685,7 @@ fn strict_callee_collapse_unsound(body_code: &[u8]) -> bool {
             || (op.starts_with("residual_call") && op.ends_with("_v"))
             || op.contains("setfield")
             || op.contains("setarrayitem")
+            || op.contains("setinteriorfield")
         {
             return true;
         }


### PR DESCRIPTION
Closes #420 — the four wasm-only synthetic failures pass, plus a fix for an `inline_helper` regression the #420 work itself introduced (caught by CI on all three backends). Rebased onto current `main`; the tagged-int groundwork this branch previously carried is now upstream via #417, so the branch is purely the #420 fixes.

## #420: four wasm-only failures

The four benches failed only on wasm (dynasm + cranelift were green). Three distinct roots:

### Inline-callee guard snapshot (`inlined_mutation_before_abort`, `inline_callee_constructs_object`)

A guard emitted inside an inlined callee sub-walk built its resume snapshot at the outer CALL boundary (single-frame collapse), corrupting the wasm resume two ways:

- `jit: fill inline sub-walk guard snapshot from live register banks` — the full-body walk initializes `outer_active_boxes` empty and recomputes per-guard on the FBW path, so a callee guard read an empty set (zero frame boxes while the decoder expected the full liveness set). Recompute it fresh via `collect_outer_active_boxes` at the CALL-site py_pc when the parent walk carries an empty set.
- `jit: route strict straight-line inline-callee guards through the multi-frame snapshot` — a strict straight-line callee pushed no paused caller frame, so its in-callee guards resumed at the caller CALL boundary, re-executing the call and mis-sizing the resumed frame (`LOAD_FAST` push past the frame array / `rd_numb` decode overrun → `inline_callee_constructs_object` `pyframe.rs` index-out-of-bounds panic). Under `PYRE_FBW_STRICT_MULTIFRAME` (default on) the strict path computes a paused caller frame via `compute_inline_caller_frame`, and declines to a residual call when the callee frame is not snapshot-able.

### `W_ObjectObject.map` field width on wasm32 (`inlined_helper_mutation`, `sre_pattern_methods`)

`jit(wasm): size W_ObjectObject.map at word width, not fixed 8 bytes` — the `map` field descr hardcoded `field_size: 8`. `map` is a `*const` pointer erased to an opaque `Type::Int` word; on wasm32 a pointer is 4 bytes, and map's neighbor at `offset+4` is the `storage` pointer. The `guard_value(map)` loaded 8 bytes — folding `storage` into the high half — so the garbage-high value never matched the clean 4-byte map constant and the guard failed every iteration, deopting after the loop body had already committed its side effect and then re-executing it. Fix: `field_size` → `core::mem::size_of::<usize>()` (4 on wasm32, 8 on 64-bit; native descr byte-identical, so dynasm/cranelift unaffected).

### Fresh-collect liveness coordinate

`jit: derive inline sub-walk fresh-collect liveness coordinate from the CALL op` — the fresh `collect_outer_active_boxes` path passed the `ctx` sentinels (`outer_jitcode_index` 0, walk-entry py_pc) instead of the CALL op's own coordinate, so a CALL in a non-root jitcode selected the wrong liveness window. Derive `(jitcode index, CALL-site py_pc)` from the snapshot sym's jitcode at `op.pc`, matching `orthodox_list_append_commit`.

## `inline_helper` strict-MF regression (all three backends)

The strict-multiframe fix above pushed a paused caller frame for **every** strict straight-line inlined callee. A strict callee seeds no callee frame red, so its in-callee guard snapshot always returns `Unsupported` and the inline declines. For a **pure value-returning leaf** (`inline_helper`'s `a + b` / `a * b`) whose declining guard is an arithmetic-overflow guard, that `Unsupported` propagates out of the sub-walk and aborts the whole loop trace — so `inline_helper`, which compiled fine on `main` via the single-frame collapse, stopped compiling (`loops_compiled=0 loops_aborted=25`) and timed out in the interpreter on all three backends.

`jit: gate strict-MF caller-frame push on a side-effecting callee` — a new `strict_callee_collapse_unsound` predicate gates the push: route through the MF decline only when the callee body commits a heap side effect the collapse re-execute would double (a general ref-arg residual call / constructor `residual_call_r_*`, a void side-effect residual call `residual_call_*_v`, or a `setfield` / `setarrayitem` write). `inline_callee_constructs_object` (`P(n)` construct) and `inlined_mutation_before_abort` (`c.n = c.n + 1` store) still take the decline; a pure leaf keeps its sound single-frame collapse.

## Results (full `pyre/check.py`, all three backends)

| backend | result | `inline_helper` |
|---|---|---|
| dynasm | 159/159 | 0.16s (1.1x) |
| cranelift | 159/159 | 0.16s (1.1x) |
| wasm | 159/159 | 0.34s (2.3x) |

All four #420 benches (`inlined_mutation_before_abort`, `inline_callee_constructs_object`, `inlined_helper_mutation`, `sre_pattern_methods`) pass on wasm; `inline_helper` compiles again on all three; no synth regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JIT trace handling for strict inlining, making guard and snapshot behavior more reliable in deeper call paths.
  * Added support for an environment toggle to control stricter multi-frame handling.

* **Bug Fixes**
  * Fixed a target-specific field size issue so object layout works correctly on 32-bit platforms.
  * Prevented incorrect guard collapse that could re-execute side effects or resume from the wrong location during deoptimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->