### PR TITLE
rtyper/codewriter/jit-trace: stroruni residual lowering, rtype_offsetof, CALL_KW NULL-receiver fix

### DIFF
--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3131,12 +3131,24 @@ impl<'a> Transformer<'a> {
             }]));
         }
 
-        // jtransform.py:2087-2122 — stroruni.equal registers the OS_STREQ_* /
-        // OS_UNIEQ_* slice-comparison helpers through _register_extra_helper,
-        // which pyre has not ported; fall through to the residual-call path.
-        if oopspec_name == "stroruni.equal" {
-            return None;
-        }
+        // jtransform.py:2087-2122 — before falling through to the common
+        // residual-call tail, stroruni.equal registers seven OS_STREQ_* /
+        // OS_UNIEQ_* slice-comparison side-helpers (str.eq_slice_checknull /
+        // eq_slice_nonnull / eq_slice_char / eq_nonnull / eq_nonnull_char /
+        // eq_checknull_char / eq_lengthok, each shifted by _OS_offset_uni for
+        // UNICODE) via _register_extra_helper. That registration is blocked:
+        // _register_extra_helper → support::builtin_func_for_spec →
+        // setup_extra_builtin resolves each helper's host fnaddr and panics on
+        // a miss, and pyre deliberately does not host-bind the str.eq_*
+        // helpers — Python strings are W_UnicodeObject (native WTF-8), not the
+        // rstr.STR `{hash, chars}` GcStruct these helpers index (see
+        // jit_fnaddr.rs `jit_trace_fnaddrs` and blackhole.rs next to
+        // `bhimpl_int_and`). The side-registrations are consumed only by the
+        // string-optimization pass; their absence does not affect the main
+        // OS_STR_EQUAL / OS_UNI_EQUAL residual call emitted by the tail below,
+        // which resolves the primary helper through fnaddr_for_target like
+        // concat/slice/cmp. Wire the extra-helper loop once the rstr.STR
+        // runtime layout and str.eq_* host bodies land.
 
         // jtransform.py:2059-2072 — the OS_STR_* / OS_UNI_* index selected by
         // the STR vs UNICODE operand. BYTEARRAY → NotSupported (None); any
@@ -3146,6 +3158,8 @@ impl<'a> Transformer<'a> {
             ("stroruni.concat", StrOrUniKind::Unicode) => OopSpecIndex::UniConcat,
             ("stroruni.slice", StrOrUniKind::Str) => OopSpecIndex::StrSlice,
             ("stroruni.slice", StrOrUniKind::Unicode) => OopSpecIndex::UniSlice,
+            ("stroruni.equal", StrOrUniKind::Str) => OopSpecIndex::StrEqual,
+            ("stroruni.equal", StrOrUniKind::Unicode) => OopSpecIndex::UniEqual,
             ("stroruni.cmp", StrOrUniKind::Str) => OopSpecIndex::StrCmp,
             ("stroruni.cmp", StrOrUniKind::Unicode) => OopSpecIndex::UniCmp,
             ("stroruni.copy_string_to_raw", StrOrUniKind::Str) => OopSpecIndex::StrCopyToRaw,
@@ -8496,32 +8510,68 @@ mod tests {
         );
     }
 
-    /// jtransform.py:2087-2122 — `stroruni.equal` needs the unported
-    /// `_register_extra_helper` machinery, so it returns `None` and falls
-    /// through to the residual-call path.
+    /// jtransform.py:2087-2128 — `stroruni.equal` emits the main OS_STR_EQUAL
+    /// residual call (via the common tail) even though the seven
+    /// OS_STREQ_*/OS_UNIEQ_* extra-helper side-registrations remain blocked on
+    /// the unported str.eq_* host bodies.
     #[test]
-    fn stroruni_equal_falls_through() {
+    fn stroruni_equal_lowers_to_str_equal_residual_call() {
+        use crate::call::CallControl;
         use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
+
+        let mut cc = CallControl::new();
         let config = GraphTransformConfig::default();
-        let mut transformer = Transformer::new(&config);
+        let mut transformer = Transformer::new(&config).with_callcontrol(&mut cc);
+
+        let mut graph = FunctionGraph::new("equal");
         let args = stroruni_copy_contents_args(STRPTR.clone());
+        let result_ty = ValueType::Int;
+        let target = CallTarget::function_path(["ll_streq"]);
+        let result_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "result".into(),
+                    ty: result_ty.clone(),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
         let op = SpaceOperation {
-            result: None,
-            kind: OpKind::Live,
+            result: Some(result_var),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: args.clone(),
+                result_ty: result_ty.clone(),
+            },
         };
-        let (mut graph, target, result_ty) = stroruni_call_dummy_extras();
+        let rewritten = transformer
+            ._handle_stroruni_call(
+                "stroruni.equal",
+                &op,
+                &target,
+                &args,
+                &result_ty,
+                "equal",
+                &mut graph,
+            )
+            .expect("stroruni.equal must emit its OS_STR_EQUAL residual call");
+        let RewriteResult::Replace(ops) = rewritten else {
+            panic!("expected Replace");
+        };
+        assert!(
+            ops.iter()
+                .any(|o| matches!(o.kind, OpKind::CallResidual { .. })),
+            "expected a CallResidual, got {ops:?}"
+        );
         assert!(
             transformer
-                ._handle_stroruni_call(
-                    "stroruni.equal",
-                    &op,
-                    &target,
-                    &args,
-                    &result_ty,
-                    "stroruni",
-                    &mut graph,
-                )
-                .is_none()
+                .notes
+                .iter()
+                .any(|n| n.detail.contains("StrEqual")),
+            "expected an oopspec StrEqual note, got {:?}",
+            transformer.notes
         );
     }
 

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2960,9 +2960,9 @@ impl<'a> Transformer<'a> {
             // Unhandled spellings return `None` and fall through to the
             // residual-call path (RPython raises `NotSupported`).
             if base.starts_with("stroruni.") {
-                if let Some(result) = self._handle_stroruni_call(
-                    base, op, target, args, result_ty, graph_name, graph,
-                ) {
+                if let Some(result) =
+                    self._handle_stroruni_call(base, op, target, args, result_ty, graph_name, graph)
+                {
                     return prepend_const_prefix(&mut const_prefix_ops, result);
                 }
             }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -2960,7 +2960,9 @@ impl<'a> Transformer<'a> {
             // Unhandled spellings return `None` and fall through to the
             // residual-call path (RPython raises `NotSupported`).
             if base.starts_with("stroruni.") {
-                if let Some(result) = self._handle_stroruni_call(base, op, args) {
+                if let Some(result) = self._handle_stroruni_call(
+                    base, op, target, args, result_ty, graph_name, graph,
+                ) {
                     return prepend_const_prefix(&mut const_prefix_ops, result);
                 }
             }
@@ -3066,63 +3068,118 @@ impl<'a> Transformer<'a> {
         prepend_const_prefix(&mut const_prefix_ops, result)
     }
 
-    /// Port of `jtransform.py:2049 _handle_stroruni_call`, `copy_contents`
-    /// arm only (jtransform.py:2079-2086):
+    /// Port of `jtransform.py:2049 _handle_stroruni_call`.
     ///
-    /// ```python
-    /// if oopspec_name == 'stroruni.copy_contents':
-    ///     if SoU.TO == rstr.STR:      new_op = 'copystrcontent'
-    ///     elif SoU.TO == rstr.UNICODE: new_op = 'copyunicodecontent'
-    ///     else: assert 0
-    ///     return SpaceOperation(new_op, args, op.result)
-    /// ```
+    /// `SoU = args[0].concretetype` classifies the operand as `Ptr(STR)` /
+    /// `Ptr(UNICODE)` / `Ptr(BYTEARRAY)` (jtransform.py:2058-2077); pyre reads
+    /// it from the flowspace `Variable::concretetype()` via
+    /// [`stroruni_first_arg_kind`]. `Ptr(BYTEARRAY)` is `raise NotSupported`
+    /// (jtransform.py:2074) — pyre returns `None`, falling through to the
+    /// residual-call path — and any other shape is `else: assert 0`
+    /// (jtransform.py:2077).
     ///
-    /// `SoU = args[0].concretetype` selects the STR vs UNICODE spelling;
-    /// pyre reads it from the flowspace `Variable::concretetype()` via
-    /// [`stroruni_first_arg_kind`]. Only `Ptr(STR)` maps to `copystrcontent`
-    /// and only `Ptr(UNICODE)` maps to `copyunicodecontent`; `Ptr(BYTEARRAY)`
-    /// (upstream `raise NotSupported`, `jtransform.py:2074`) and any other
-    /// operand shape (`else: assert 0`) return `None`, falling through to the
-    /// residual-call path — pyre's `NotSupported` analogue. The resulting op
-    /// is emitted as [`OpKind::LoweredBlackholeOp`], the same representation
-    /// the Spine-B string transducer produces, so flatten / assembly already
-    /// lower it to the matching jitcode bytecode.
-    ///
-    /// The `concat` / `slice` / `equal` / `cmp` / `copy_string_to_raw` arms
-    /// are not ported yet; those spellings return `None` and fall through to
-    /// the residual-call path.
+    /// - `copy_contents` (jtransform.py:2079-2086) lowers to a
+    ///   `copystrcontent` / `copyunicodecontent` [`OpKind::LoweredBlackholeOp`],
+    ///   the same representation the Spine-B string transducer produces, so
+    ///   flatten / assembly already lower it to the matching jitcode bytecode.
+    /// - `concat` / `slice` / `cmp` / `copy_string_to_raw`
+    ///   (jtransform.py:2059-2072, 2124-2128) map to the `OS_STR_*` / `OS_UNI_*`
+    ///   oopspecindex and lower to a residual call. `concat` / `slice` can
+    ///   raise `MemoryError` (`EF_ELIDABLE_OR_MEMORYERROR`), `cmp` /
+    ///   `copy_string_to_raw` cannot (`EF_ELIDABLE_CANNOT_RAISE`).
+    /// - `equal` (jtransform.py:2087-2122) additionally registers the
+    ///   `OS_STREQ_*` / `OS_UNIEQ_*` slice-comparison helper variants via
+    ///   `_register_extra_helper`, which pyre has not ported; that spelling
+    ///   returns `None` and falls through to the residual-call path until the
+    ///   helper-registration machinery lands.
     fn _handle_stroruni_call(
-        &self,
+        &mut self,
         oopspec_name: &str,
         op: &SpaceOperation,
+        target: &CallTarget,
         args: &[crate::flowspace::model::Variable],
+        result_ty: &ValueType,
+        graph_name: &str,
+        graph: &mut FunctionGraph,
     ) -> Option<RewriteResult> {
-        match oopspec_name {
-            "stroruni.copy_contents" => {
-                let opname = match stroruni_first_arg_kind(args.first()?) {
-                    StrOrUniKind::Str => "copystrcontent",
-                    StrOrUniKind::Unicode => "copyunicodecontent",
-                    // BYTEARRAY → NotSupported (jtransform.py:2074): fall
-                    // through to the residual-call path.
-                    StrOrUniKind::ByteArray => return None,
-                    // jtransform.py:2076 — `else: assert 0, "args[0].concretetype
-                    // must be STR or UNICODE"`. A `stroruni.copy_contents`
-                    // oopspec guarantees a string pointer, so any other shape
-                    // is a should-never-happen invariant violation.
-                    StrOrUniKind::Other => {
-                        panic!("args[0].concretetype must be STR or UNICODE")
-                    }
-                };
-                Some(RewriteResult::Replace(vec![SpaceOperation {
-                    result: op.result.clone(),
-                    kind: OpKind::LoweredBlackholeOp {
-                        opname: opname.to_string(),
-                        args: args.to_vec(),
-                    },
-                }]))
-            }
-            _ => None,
+        // SoU = args[0].concretetype (jtransform.py:2050): the STR vs UNICODE
+        // spelling selects the OS_STR_* vs OS_UNI_* oopspecindex family below.
+        let kind = stroruni_first_arg_kind(args.first()?);
+
+        // jtransform.py:2079-2086 — copy_contents lowers to a blackhole op.
+        if oopspec_name == "stroruni.copy_contents" {
+            let opname = match kind {
+                StrOrUniKind::Str => "copystrcontent",
+                StrOrUniKind::Unicode => "copyunicodecontent",
+                // BYTEARRAY → NotSupported (jtransform.py:2074): fall through
+                // to the residual-call path.
+                StrOrUniKind::ByteArray => return None,
+                // jtransform.py:2077 `else: assert 0, "args[0].concretetype
+                // must be STR or UNICODE"`. A `stroruni.copy_contents` oopspec
+                // guarantees a string pointer, so any other shape is a
+                // should-never-happen invariant violation.
+                StrOrUniKind::Other => {
+                    panic!("args[0].concretetype must be STR or UNICODE")
+                }
+            };
+            return Some(RewriteResult::Replace(vec![SpaceOperation {
+                result: op.result.clone(),
+                kind: OpKind::LoweredBlackholeOp {
+                    opname: opname.to_string(),
+                    args: args.to_vec(),
+                },
+            }]));
         }
+
+        // jtransform.py:2087-2122 — stroruni.equal registers the OS_STREQ_* /
+        // OS_UNIEQ_* slice-comparison helpers through _register_extra_helper,
+        // which pyre has not ported; fall through to the residual-call path.
+        if oopspec_name == "stroruni.equal" {
+            return None;
+        }
+
+        // jtransform.py:2059-2072 — the OS_STR_* / OS_UNI_* index selected by
+        // the STR vs UNICODE operand. BYTEARRAY → NotSupported (None); any
+        // other shape → assert 0 (jtransform.py:2074-2077).
+        let oopspecindex = match (oopspec_name, kind) {
+            ("stroruni.concat", StrOrUniKind::Str) => OopSpecIndex::StrConcat,
+            ("stroruni.concat", StrOrUniKind::Unicode) => OopSpecIndex::UniConcat,
+            ("stroruni.slice", StrOrUniKind::Str) => OopSpecIndex::StrSlice,
+            ("stroruni.slice", StrOrUniKind::Unicode) => OopSpecIndex::UniSlice,
+            ("stroruni.cmp", StrOrUniKind::Str) => OopSpecIndex::StrCmp,
+            ("stroruni.cmp", StrOrUniKind::Unicode) => OopSpecIndex::UniCmp,
+            ("stroruni.copy_string_to_raw", StrOrUniKind::Str) => OopSpecIndex::StrCopyToRaw,
+            ("stroruni.copy_string_to_raw", StrOrUniKind::Unicode) => OopSpecIndex::UniCopyToRaw,
+            // BYTEARRAY → raise NotSupported (jtransform.py:2074).
+            (_, StrOrUniKind::ByteArray) => return None,
+            // else: assert 0 (jtransform.py:2077).
+            (_, StrOrUniKind::Other) => {
+                panic!("args[0].concretetype must be STR or UNICODE")
+            }
+            // An unported / unknown stroruni.* spelling: fall through to the
+            // residual-call path.
+            _ => return None,
+        };
+
+        // jtransform.py:2051-2057, 2124-2128 — concat/slice can raise
+        // MemoryError; cmp/copy_string_to_raw cannot.
+        let extra = match oopspec_name {
+            "stroruni.concat" | "stroruni.slice" => {
+                majit_ir::descr::ExtraEffect::ElidableOrMemoryError
+            }
+            _ => majit_ir::descr::ExtraEffect::ElidableCannotRaise,
+        };
+        Some(self._handle_oopspec_call(
+            graph,
+            op,
+            target,
+            args,
+            result_ty,
+            graph_name,
+            oopspecindex,
+            Some(extra),
+            None,
+        ))
     }
 
     /// Port of `jtransform.py:2193 _handle_rgc_call`, `ll_shrink_array` arm:
@@ -8260,6 +8317,18 @@ mod tests {
         ]
     }
 
+    /// The `copy_contents` arm returns before touching the residual-call
+    /// machinery, so its tests only need placeholder `graph` / `target` /
+    /// `result_ty` values to satisfy the shared `_handle_stroruni_call`
+    /// signature.
+    fn stroruni_call_dummy_extras() -> (FunctionGraph, CallTarget, ValueType) {
+        (
+            FunctionGraph::new("stroruni"),
+            CallTarget::function_path(["copy_contents"]),
+            ValueType::Ref(None),
+        )
+    }
+
     /// jtransform.py:2079-2086 — `stroruni.copy_contents` with a `Ptr(STR)`
     /// first argument lowers to a single `copystrcontent` blackhole op
     /// carrying the five call args and a void result.
@@ -8267,14 +8336,23 @@ mod tests {
     fn stroruni_copy_contents_str_lowers_to_copystrcontent() {
         use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
         let config = GraphTransformConfig::default();
-        let transformer = Transformer::new(&config);
+        let mut transformer = Transformer::new(&config);
         let args = stroruni_copy_contents_args(STRPTR.clone());
         let op = SpaceOperation {
             result: None,
             kind: OpKind::Live,
         };
+        let (mut graph, target, result_ty) = stroruni_call_dummy_extras();
         let result = transformer
-            ._handle_stroruni_call("stroruni.copy_contents", &op, &args)
+            ._handle_stroruni_call(
+                "stroruni.copy_contents",
+                &op,
+                &target,
+                &args,
+                &result_ty,
+                "stroruni",
+                &mut graph,
+            )
             .expect("copy_contents must be handled");
         let RewriteResult::Replace(ops) = result else {
             panic!("expected Replace");
@@ -8298,14 +8376,23 @@ mod tests {
     fn stroruni_copy_contents_unicode_lowers_to_copyunicodecontent() {
         use crate::translator::rtyper::lltypesystem::rstr::UNICODEPTR;
         let config = GraphTransformConfig::default();
-        let transformer = Transformer::new(&config);
+        let mut transformer = Transformer::new(&config);
         let args = stroruni_copy_contents_args(UNICODEPTR.clone());
         let op = SpaceOperation {
             result: None,
             kind: OpKind::Live,
         };
+        let (mut graph, target, result_ty) = stroruni_call_dummy_extras();
         let result = transformer
-            ._handle_stroruni_call("stroruni.copy_contents", &op, &args)
+            ._handle_stroruni_call(
+                "stroruni.copy_contents",
+                &op,
+                &target,
+                &args,
+                &result_ty,
+                "stroruni",
+                &mut graph,
+            )
             .expect("copy_contents must be handled");
         let RewriteResult::Replace(ops) = result else {
             panic!("expected Replace");
@@ -8323,35 +8410,117 @@ mod tests {
     fn stroruni_copy_contents_bytearray_falls_through() {
         use crate::translator::rtyper::lltypesystem::rbytearray::BYTEARRAYPTR;
         let config = GraphTransformConfig::default();
-        let transformer = Transformer::new(&config);
+        let mut transformer = Transformer::new(&config);
         let args = stroruni_copy_contents_args(BYTEARRAYPTR.clone());
         let op = SpaceOperation {
             result: None,
             kind: OpKind::Live,
         };
+        let (mut graph, target, result_ty) = stroruni_call_dummy_extras();
         assert!(
             transformer
-                ._handle_stroruni_call("stroruni.copy_contents", &op, &args)
+                ._handle_stroruni_call(
+                    "stroruni.copy_contents",
+                    &op,
+                    &target,
+                    &args,
+                    &result_ty,
+                    "stroruni",
+                    &mut graph,
+                )
                 .is_none()
         );
     }
 
-    /// The not-yet-ported `stroruni.*` spellings (concat / slice / equal /
-    /// cmp / copy_string_to_raw) return `None` so `handle_builtin_call`
-    /// falls through to the residual-call path.
+    /// jtransform.py:2059-2072, 2124-2128 — `stroruni.concat` on a `Ptr(STR)`
+    /// operand lowers to a residual call carrying the `StrConcat` oopspecindex
+    /// (`OS_STR_CONCAT`).
     #[test]
-    fn stroruni_unported_spellings_fall_through() {
+    fn stroruni_concat_lowers_to_str_concat_residual_call() {
+        use crate::call::CallControl;
+        use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
+
+        let mut cc = CallControl::new();
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config).with_callcontrol(&mut cc);
+
+        let mut graph = FunctionGraph::new("concat");
+        let args = stroruni_copy_contents_args(STRPTR.clone());
+        let result_ty = ValueType::Ref(None);
+        let target = CallTarget::function_path(["ll_strconcat"]);
+        let result_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::Input {
+                    name: "result".into(),
+                    ty: result_ty.clone(),
+                    class_root: None,
+                },
+                true,
+            )
+            .unwrap();
+        let op = SpaceOperation {
+            result: Some(result_var),
+            kind: OpKind::Call {
+                target: target.clone(),
+                args: args.clone(),
+                result_ty: result_ty.clone(),
+            },
+        };
+        let rewritten = transformer
+            ._handle_stroruni_call(
+                "stroruni.concat",
+                &op,
+                &target,
+                &args,
+                &result_ty,
+                "concat",
+                &mut graph,
+            )
+            .expect("stroruni.concat must be handled");
+        let RewriteResult::Replace(ops) = rewritten else {
+            panic!("expected Replace");
+        };
+        assert!(
+            ops.iter()
+                .any(|o| matches!(o.kind, OpKind::CallResidual { .. })),
+            "expected a CallResidual, got {ops:?}"
+        );
+        assert!(
+            transformer
+                .notes
+                .iter()
+                .any(|n| n.detail.contains("StrConcat")),
+            "expected an oopspec StrConcat note, got {:?}",
+            transformer.notes
+        );
+    }
+
+    /// jtransform.py:2087-2122 — `stroruni.equal` needs the unported
+    /// `_register_extra_helper` machinery, so it returns `None` and falls
+    /// through to the residual-call path.
+    #[test]
+    fn stroruni_equal_falls_through() {
         use crate::translator::rtyper::lltypesystem::rstr::STRPTR;
         let config = GraphTransformConfig::default();
-        let transformer = Transformer::new(&config);
+        let mut transformer = Transformer::new(&config);
         let args = stroruni_copy_contents_args(STRPTR.clone());
         let op = SpaceOperation {
             result: None,
             kind: OpKind::Live,
         };
+        let (mut graph, target, result_ty) = stroruni_call_dummy_extras();
         assert!(
             transformer
-                ._handle_stroruni_call("stroruni.concat", &op, &args)
+                ._handle_stroruni_call(
+                    "stroruni.equal",
+                    &op,
+                    &target,
+                    &args,
+                    &result_ty,
+                    "stroruni",
+                    &mut graph,
+                )
                 .is_none()
         );
     }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -3102,9 +3102,16 @@ impl<'a> Transformer<'a> {
                 let opname = match stroruni_first_arg_kind(args.first()?) {
                     StrOrUniKind::Str => "copystrcontent",
                     StrOrUniKind::Unicode => "copyunicodecontent",
-                    // BYTEARRAY → NotSupported; any other shape → assert 0.
-                    // Both fall through to the residual-call path.
-                    StrOrUniKind::ByteArray | StrOrUniKind::Other => return None,
+                    // BYTEARRAY → NotSupported (jtransform.py:2074): fall
+                    // through to the residual-call path.
+                    StrOrUniKind::ByteArray => return None,
+                    // jtransform.py:2076 — `else: assert 0, "args[0].concretetype
+                    // must be STR or UNICODE"`. A `stroruni.copy_contents`
+                    // oopspec guarantees a string pointer, so any other shape
+                    // is a should-never-happen invariant violation.
+                    StrOrUniKind::Other => {
+                        panic!("args[0].concretetype must be STR or UNICODE")
+                    }
                 };
                 Some(RewriteResult::Replace(vec![SpaceOperation {
                     result: op.result.clone(),
@@ -3129,8 +3136,15 @@ impl<'a> Transformer<'a> {
     ///
     /// Lowers to a `residual_call` whose calldescr carries the `ShrinkArray`
     /// oopspecindex and the `CanRaise` effect, so `handle_residual_call`
-    /// appends the trailing `-live-`.  Other `rgc.*` spellings return `None`
-    /// and fall through to the residual-call path.
+    /// appends the trailing `-live-`.
+    ///
+    /// jtransform.py:2197 `raise NotImplementedError(oopspec_name)` for any
+    /// other `rgc.*` spelling. Pyre instead returns `None` so the call falls
+    /// through to the residual-call path — the same "unported oopspec →
+    /// residual" convention the `list.*` / `stroruni.*` sibling handlers use,
+    /// which keeps rgc oopspecs pyre has not lowered yet (e.g.
+    /// `rgc.ll_arraycopy`) as ordinary residual calls rather than aborting
+    /// codewriting.
     fn _handle_rgc_call(
         &mut self,
         oopspec_name: &str,

--- a/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
+++ b/majit/majit-translate/src/translator/rtyper/rbuiltin.rs
@@ -427,6 +427,12 @@ fn install_default_typers(map: &mut HashMap<HostObject, BuiltinTyperFn>) {
             "raw_memclear",
             rtype_raw_memclear,
         ),
+        // rbuiltin.py:621-626
+        (
+            "rpython.rtyper.lltypesystem.llmemory",
+            "offsetof",
+            rtype_offsetof,
+        ),
         // rbuiltin.py:744-758
         (
             "rpython.rtyper.lltypesystem.llmemory",
@@ -1668,14 +1674,53 @@ pub fn rtype_hlinvoke(_hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> R
 }
 
 /// RPython `@typer_for(llmemory.offsetof) def rtype_offsetof(hop)`
-/// (rbuiltin.py:622-627).
+/// (rbuiltin.py:621-626).
 ///
-/// The upstream implementation reads two Void constants and returns
-/// `llmemory.offsetof(TYPE.value, field.value)`. The Rust low-level offset
-/// model exists, but the exact `HighLevelOp::inputargs(Void, Void)` constant
-/// path still needs a line-by-line port.
-pub fn rtype_offsetof(_hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeResult {
-    Err(rbuiltin_deferred("rtype_offsetof"))
+/// ```python
+/// @typer_for(llmemory.offsetof)
+/// def rtype_offsetof(hop):
+///     TYPE, field = hop.inputargs(lltype.Void, lltype.Void)
+///     hop.exception_cannot_occur()
+///     return hop.inputconst(lltype.Signed,
+///                           llmemory.offsetof(TYPE.value, field.value))
+/// ```
+///
+/// `offsetof(TYPE, field)` is `FieldOffset(TYPE, field)` — a `Signed`
+/// symbolic constant whose concrete byte value is resolved only at code
+/// emission (`Signed._contains_value` accepts `AddressOffset`).
+#[allow(non_snake_case)]
+pub fn rtype_offsetof(hop: &HighLevelOp, _kwds_i: &HashMap<String, usize>) -> RTypeResult {
+    use crate::translator::rtyper::lltypesystem::llmemory;
+
+    let args = hop.inputargs(vec![
+        ConvertedTo::LowLevelType(&LowLevelType::Void),
+        ConvertedTo::LowLevelType(&LowLevelType::Void),
+    ])?;
+    hop.exception_cannot_occur()?;
+    // `TYPE.value` — the struct lltype carried on the first Void constant.
+    let Hlvalue::Constant(Constant {
+        value: ConstValue::LowLevelType(TYPE),
+        ..
+    }) = &args[0]
+    else {
+        return Err(TyperError::message(
+            "rtype_offsetof: first argument is not a constant TYPE",
+        ));
+    };
+    // `field.value` — the field name carried on the second Void constant.
+    let Hlvalue::Constant(Constant {
+        value: ConstValue::ByteStr(field),
+        ..
+    }) = &args[1]
+    else {
+        return Err(TyperError::message(
+            "rtype_offsetof: second argument is not a constant field name",
+        ));
+    };
+    let field = String::from_utf8_lossy(field);
+    let offset = llmemory::offsetof(TYPE, &field).map_err(TyperError::message)?;
+    let c = HighLevelOp::inputconst(&LowLevelType::Signed, &ConstValue::AddressOffset(offset))?;
+    Ok(Some(Hlvalue::Constant(c)))
 }
 
 /// RPython `@typer_for(objectmodel.instantiate) def rtype_instantiate`
@@ -3682,6 +3727,51 @@ mod tests {
     }
 
     #[test]
+    #[allow(non_snake_case)]
+    fn rtype_offsetof_folds_field_to_signed_symbolic_field_offset() {
+        use crate::translator::rtyper::lltypesystem::llmemory::AddressOffset;
+        use crate::translator::rtyper::lltypesystem::lltype::Struct;
+
+        // A STR-like struct so `offsetof(TYPE, "chars")` resolves a field.
+        let str_ty = LowLevelType::Struct(Box::new(Struct::new(
+            "rpy_string",
+            vec![
+                ("hash".to_string(), LowLevelType::Signed),
+                ("chars".to_string(), LowLevelType::Signed),
+            ],
+        )));
+
+        // upstream `TYPE, field = hop.inputargs(lltype.Void, lltype.Void)` —
+        // two Void constants carrying the struct type and the field name.
+        let hop = dummy_hop();
+        *hop.args_v.borrow_mut() = vec![
+            Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::LowLevelType(Box::new(str_ty.clone())),
+                LowLevelType::Void,
+            )),
+            Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::ByteStr(b"chars".to_vec()),
+                LowLevelType::Void,
+            )),
+        ];
+
+        let result = rtype_offsetof(&hop, &HashMap::new()).unwrap().unwrap();
+        let Hlvalue::Constant(c) = result else {
+            panic!("expected a Constant, got {result:?}");
+        };
+        // `hop.inputconst(lltype.Signed, ...)` — the carrier lltype is Signed.
+        assert_eq!(c.concretetype, Some(LowLevelType::Signed));
+        // The value is the symbolic `FieldOffset(rpy_string, 'chars')`.
+        match c.value {
+            ConstValue::AddressOffset(AddressOffset::FieldOffset(f)) => {
+                assert_eq!(f.fldname, "chars");
+                assert_eq!(f.TYPE, str_ty);
+            }
+            other => panic!("expected a FieldOffset, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn rtype_simple_call_pops_first_arg_before_dispatching_typer() {
         use crate::flowspace::model::{Hlvalue, Variable};
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -4499,7 +4589,6 @@ mod tests {
             ),
             ("rtype_WindowsError__init__", rtype_WindowsError__init__),
             ("rtype_hlinvoke", rtype_hlinvoke),
-            ("rtype_offsetof", rtype_offsetof),
             ("rtype_instantiate", rtype_instantiate),
             ("rtype_dict_constructor", rtype_dict_constructor),
         ];

--- a/pyre/bench/synth/call_kw_hot_loop.py
+++ b/pyre/bench/synth/call_kw_hot_loop.py
@@ -1,0 +1,26 @@
+# A CALL_KW directly in the hot loop body (not nested inside an inlined
+# callee, unlike call_kw_star.py).  `g(i, step=2)` lowers to CALL_KW whose
+# `null_or_self` receiver slot (arg index 1) is the PY_NULL sentinel
+# (GcRef(0)) for a plain no-receiver call.  The walker's residual-executor
+# NULL-Ref-arg refusal used to lack the `is_call_kw` receiver-slot exemption
+# that its sibling walker_abort_if_mayforce_null_ref_arg has, so it declined
+# the recording iteration's call to a symbolic op and dropped that one
+# iteration's effect — the hot-loop sum came out exactly one term short.
+# The keyword overrides a default (`step=1`) and the result depends on both
+# the positional and the keyword arg so the call cannot be constant-folded
+# away; the exact aggregate makes a single dropped iteration observable.
+N = 200000
+
+
+def g(x, step=1):
+    return x + step
+
+
+def main():
+    total = 0
+    for i in range(N):
+        total += g(i, step=2)
+    print(total)
+
+
+main()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch.rs
@@ -5725,15 +5725,34 @@ fn try_execute_residual_call_via_executor(
     // `null_or_self` (arg index 1) is a checked sentinel — `PY_NULL`
     // means "no receiver" and is never dereferenced (`bh_call_fn_impl`
     // prepends it as arg0 only when non-null), so a concrete-NULL there
-    // is the normal plain-call shape.  Same exemption as
-    // `walker_abort_if_mayforce_null_ref_arg`.
+    // is the normal plain-call shape.  These exemptions MUST match
+    // `walker_abort_if_mayforce_null_ref_arg`'s — otherwise a normal
+    // no-receiver keyword/star call is declined here to `Ok(None)`
+    // (left symbolic), which drops the recording iteration's call
+    // exactly once (`g(i, d=4)` in a hot loop summed to n-1, callee
+    // ran n-1 times).
     let is_call_fn = call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::CallFn;
+    // `bh_call_kw_N(callable, null_or_self, kwnames, args...)` — `null_or_self`
+    // (arg index 1) is the same checked `PY_NULL` sentinel.
+    let is_call_kw = call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::CallKw;
+    // `bh_call_function_ex_fn(callable, self_or_null, starargs, kwargs_or_null)`
+    // — `self_or_null` (arg 1) and `kwargs_or_null` (arg 3) are checked `PY_NULL`
+    // sentinels (never dereferenced when null), so a concrete-NULL there is the
+    // normal `f(*args)` / no-`**` shape.
+    let is_call_function_ex =
+        call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::CallFunctionEx;
     // Same `RaiseVarargs` trailing-`cause` sentinel exemption as
     // `walker_abort_if_mayforce_null_ref_arg` (gated `PYRE_FBW_RAISE`).
     let is_raise_varargs = fbw_raise_enabled()
         && call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::RaiseVarargs;
     for (i, &arg) in args.iter().enumerate() {
         if is_call_fn && i == 1 {
+            continue;
+        }
+        if is_call_kw && i == 1 {
+            continue;
+        }
+        if is_call_function_ex && (i == 1 || i == 3) {
             continue;
         }
         if is_raise_varargs && i + 1 == args.len() {


### PR DESCRIPTION
Five landed slices on top of `main` (rtyper/codewriter porting + a JIT correctness fix).

## Commits

**`stroruni` residual-call lowering (codewriter/jtransform.rs)**
- `split stroruni.copy_contents non-string arg into assert-0 panic`
- `map stroruni.concat/slice/cmp/copy_string_to_raw to OS_STR_*/OS_UNI_* residual calls`
- `emit OS_STR_EQUAL/OS_UNI_EQUAL residual call for stroruni.equal` (`_register_extra_helper` port)

**rtyper address arithmetic foundation (rtyper/rbuiltin.rs)**
- `implement rtype_offsetof folding offsetof to a Signed FieldOffset const` — ports `rbuiltin.py` `offsetof`: two Void constants (TYPE, field) → `llmemory::offsetof` → `inputconst(Signed, AddressOffset)`, a compile-time const-fold; registered in `install_default_typers`.

**JIT correctness fix (jit-trace/jitcode_dispatch.rs)**
- `exempt kw/ex NULL receiver in residual executor` — `try_execute_residual_call_via_executor`'s NULL-Ref-arg refusal loop lacked the `null_or_self` `PY_NULL` sentinel exemptions its sibling `walker_abort_if_mayforce_null_ref_arg` has. A no-receiver keyword/star call (`CALL_KW`/`CALL_FUNCTION_EX`, lowered to `CallMayForceR`) folds its receiver slot (arg 1) to `GcRef(0)`; the executor mis-read that concrete-NULL as the broken baked-NULL shape and declined the call to `Ok(None)` (left symbolic), so the recording iteration's call was dropped once at the loop-compile transition — a hot-loop keyword call summed to `n-1`. Fix adds `is_call_kw` (arg 1) and `is_call_function_ex` (arg 1, 3) `continue`s, mirroring the sibling. New gate `pyre/bench/synth/call_kw_hot_loop.py` (a `CALL_KW` in the hot-loop body, not inside an inlined callee like `call_kw_star.py`); proven load-bearing (reverting the fix reproduces the exact off-by-one).

## Verification (`pyre/check.py`)

- **cranelift 156/156** — all green.
- **dynasm 155/156** — sole failure is `nested_loop`, a perf-ratio-cliff timing flake (output correct, 0.33–0.43s vs the 2× cut at 0.42s); no keyword/star calls, inert to these changes.
- **wasm 152/156** — the 4 failures are the pre-existing documented set (`inline_callee_constructs_object`, `inlined_helper_mutation`, `inlined_mutation_before_abort` JIT-resume panics + `sre_pattern_methods` cell-deref), unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
