### PR TITLE
rtyper: lower issubtype/isinstance on PyType InstanceRepr

### DIFF
--- a/majit/majit-translate/src/translator/rtyper/rclass.rs
+++ b/majit/majit-translate/src/translator/rtyper/rclass.rs
@@ -3682,6 +3682,49 @@ impl Repr for InstanceRepr {
     fn rtype_isinstance(&self, hop: &HighLevelOp) -> RTypeResult {
         use crate::translator::rtyper::rtyper::{ConvertedTo, make_ll_isinstance};
 
+        // pyre models type objects as `PyType` GcStruct instances that
+        // carry `subclassrange_{min,max}` directly (the OBJECT_VTABLE
+        // layout is unified into the runtime `PyType`). When the class arg
+        // is such a PyType instance the upstream `class_repr` path cannot
+        // apply — there is no InstanceRepr->RootClassRepr conversion
+        // (`castable` rejects the GcStruct->Struct gc-status change).
+        // Detect the PyType-shaped class arg structurally and lower to a
+        // getfield+int_between helper that reads the ranges off the PyType
+        // ptr, mirroring `ll_isinstance` (rclass.py:1143-1147) on the pyre
+        // `PyObject`/`PyType` structs. The class arg (`&EXCEPTION_TYPE`) is
+        // an opaque host-address `_ptr` whose ranges are re-stamped at
+        // runtime under a seqlock, so it is read at runtime rather than
+        // const-folded through `make_ll_isinstance`.
+        let r_cls = hop.args_r.borrow().get(1).cloned().flatten();
+        if let Some(r_cls) = &r_cls {
+            let cls_is_pytype = (r_cls.as_ref() as &dyn std::any::Any)
+                .downcast_ref::<InstanceRepr>()
+                .is_some_and(|inst| {
+                    let f = inst.allinstancefields();
+                    f.contains_key("subclassrange_min") && f.contains_key("subclassrange_max")
+                });
+            if cls_is_pytype && self.allinstancefields().contains_key("ob_type") {
+                let rtyper = self.rtyper.upgrade().ok_or_else(|| {
+                    TyperError::message("InstanceRepr.rtype_isinstance: rtyper weak ref expired")
+                })?;
+                // Keep `obj` in its own PyObject repr (not `common_repr`):
+                // `ob_type` lives on `PyObject`, and coercing to `OBJECTPTR`
+                // would retarget the getfield owner to `object`. Pass `cls`
+                // in its own repr so both coercions are identity — no
+                // `convert_const` on the `&EXCEPTION_TYPE` Constant.
+                let v = hop.inputargs(vec![
+                    ConvertedTo::Repr(self as &dyn Repr),
+                    ConvertedTo::Repr(r_cls.as_ref()),
+                ])?;
+                let helper = rtyper.lowlevel_helper_function(
+                    "ll_isinstance_pytype",
+                    vec![self.lowleveltype().clone(), r_cls.lowleveltype().clone()],
+                    LowLevelType::Bool,
+                )?;
+                return hop.gendirectcall(&helper, vec![v[0].clone(), v[1].clone()]);
+            }
+        }
+
         // upstream: `class_repr = get_type_repr(hop.rtyper)`.
         let rtyper = self.rtyper.upgrade().ok_or_else(|| {
             TyperError::message("InstanceRepr.rtype_isinstance: rtyper weak ref expired")
@@ -3751,6 +3794,48 @@ impl Repr for InstanceRepr {
             LowLevelType::Bool,
         )?;
         hop.gendirectcall(&helper, vec![v_obj, v_cls])
+    }
+
+    /// pyre-specific `issubtype` lowering for a `PyType` InstanceRepr.
+    ///
+    /// Upstream `issubtype` only reaches `AbstractClassRepr`
+    /// (rclass.py:403-414) because `type(x)` yields a class-repr
+    /// (`CLASSTYPE`) value. pyre's type objects are `PyType` GcStruct
+    /// *instances* carrying `subclassrange_{min,max}` directly, and
+    /// `flowspace_adapter` rewrites `ll_issubclass(subcls, cls)` to an
+    /// `issubtype` op whose operands are `PyType` InstanceReprs. Lower it
+    /// like `ClassRepr.rtype_issubtype`'s variable case — a
+    /// getfield+int_between helper (rclass.py:1133-1137 `ll_issubclass`) —
+    /// but reading the ranges off the PyType ptrs (no object_vtable, no
+    /// InstanceRepr->RootClassRepr cast, which `castable` rejects on the
+    /// gc-status change). Gate structurally on the two range fields so
+    /// only PyType-shaped InstanceReprs take this path; every other
+    /// InstanceRepr keeps the rmodel `missing_rtype_operation` default.
+    fn rtype_issubtype(&self, hop: &crate::translator::rtyper::rtyper::HighLevelOp) -> RTypeResult {
+        use crate::translator::rtyper::rtyper::ConvertedTo;
+        let is_pytype = {
+            let f = self.allinstancefields();
+            f.contains_key("subclassrange_min") && f.contains_key("subclassrange_max")
+        };
+        if !is_pytype {
+            return Err(self.missing_rtype_operation("issubtype"));
+        }
+        let rtyper = self.rtyper.upgrade().ok_or_else(|| {
+            TyperError::message("InstanceRepr.rtype_issubtype: rtyper weak ref expired")
+        })?;
+        // Both operands are the same PyType InstanceRepr; coerce each to
+        // `self` (identity) so no conversion is emitted. subcls = arg0,
+        // cls = arg1, matching `ll_issubclass(subcls, cls)`.
+        let v = hop.inputargs(vec![
+            ConvertedTo::Repr(self as &dyn Repr),
+            ConvertedTo::Repr(self as &dyn Repr),
+        ])?;
+        let helper = rtyper.lowlevel_helper_function(
+            "ll_issubclass_pytype",
+            vec![self.lowleveltype().clone(), self.lowleveltype().clone()],
+            LowLevelType::Bool,
+        )?;
+        hop.gendirectcall(&helper, vec![v[0].clone(), v[1].clone()])
     }
 
     /// RPython `InstanceRepr.convert_const(self, value)` (rclass.py:772-792):

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -3044,6 +3044,10 @@ fn lowlevel_helper_graph(
         "ll_both_none" => lowlevel_both_none_helper_graph(name, args, result),
         "ll_issubclass" => lowlevel_issubclass_helper_graph(name, args, result),
         "ll_isinstance" => lowlevel_isinstance_helper_graph(rtyper, name, args, result),
+        "ll_issubclass_pytype" => lowlevel_issubclass_pytype_helper_graph(name, args, result),
+        "ll_isinstance_pytype" => {
+            lowlevel_isinstance_pytype_helper_graph(rtyper, name, args, result)
+        }
         "ll_type" => lowlevel_type_helper_graph(name, args, result),
         _ => Ok(synthetic_lowlevel_helper_graph(name, args, result)),
     }
@@ -3161,6 +3165,101 @@ fn lowlevel_issubclass_helper_graph(
     let argnames = vec!["arg0".to_string(), "arg1".to_string()];
     let subcls = variable_with_lltype("arg0", CLASSTYPE.clone());
     let cls = variable_with_lltype("arg1", CLASSTYPE.clone());
+    let cls_min = variable_with_lltype("cls_min", LowLevelType::Signed);
+    let subcls_min = variable_with_lltype("subcls_min", LowLevelType::Signed);
+    let cls_max = variable_with_lltype("cls_max", LowLevelType::Signed);
+    let is_subclass = variable_with_lltype("result", LowLevelType::Bool);
+    let return_var = variable_with_lltype("result", LowLevelType::Bool);
+
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(subcls.clone()),
+        Hlvalue::Variable(cls.clone()),
+    ]);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(cls.clone()),
+            void_field_const("subclassrange_min"),
+        ],
+        Hlvalue::Variable(cls_min.clone()),
+    ));
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(subcls.clone()),
+            void_field_const("subclassrange_min"),
+        ],
+        Hlvalue::Variable(subcls_min.clone()),
+    ));
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![
+            Hlvalue::Variable(cls),
+            void_field_const("subclassrange_max"),
+        ],
+        Hlvalue::Variable(cls_max.clone()),
+    ));
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_between",
+        vec![
+            Hlvalue::Variable(cls_min),
+            Hlvalue::Variable(subcls_min),
+            Hlvalue::Variable(cls_max),
+        ],
+        Hlvalue::Variable(is_subclass.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(is_subclass)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, argnames, func))
+}
+
+/// `ll_issubclass_pytype(subcls, cls)` — pyre variant of
+/// [`lowlevel_issubclass_helper_graph`] operating directly on
+/// `Ptr(GcStruct pyobject::PyType)` instead of `CLASSTYPE`.
+///
+/// pyre unifies the OBJECT_VTABLE layout into the runtime `PyType`
+/// GcStruct, so `subclassrange_{min,max}` are the PyType's own fields
+/// and the subclass check reads them straight off the PyType ptrs, the
+/// same `int_between` shape as `ll_issubclass` (rclass.py:1133-1137).
+/// The class operand is never a materialised object_vtable `_ptr`
+/// (a `&PyType` static lowers to an opaque host-address `_ptr`), so both
+/// operands' ranges are read at runtime — no const-fold. Validation is
+/// tolerant (matching-Ptr operands) rather than pinned to `CLASSTYPE`.
+fn lowlevel_issubclass_pytype_helper_graph(
+    name: &str,
+    args: &[LowLevelType],
+    result: &LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    if !(args.len() == 2 && matches!(args[0], LowLevelType::Ptr(_)) && args[0] == args[1])
+        || result != &LowLevelType::Bool
+    {
+        return Err(TyperError::message(format!(
+            "{name} expects (PyTypePtr, PyTypePtr) -> Bool with matching ptrs, \
+             got ({args:?}) -> {result:?}"
+        )));
+    }
+    let pytype_lltype = args[0].clone();
+
+    let argnames = vec!["arg0".to_string(), "arg1".to_string()];
+    let subcls = variable_with_lltype("arg0", pytype_lltype.clone());
+    let cls = variable_with_lltype("arg1", pytype_lltype.clone());
     let cls_min = variable_with_lltype("cls_min", LowLevelType::Signed);
     let subcls_min = variable_with_lltype("subcls_min", LowLevelType::Signed);
     let cls_max = variable_with_lltype("cls_max", LowLevelType::Signed);
@@ -3380,6 +3479,128 @@ fn lowlevel_isinstance_helper_graph(
     let callee = rtyper.lowlevel_helper_function(
         "ll_issubclass",
         vec![CLASSTYPE.clone(), CLASSTYPE.clone()],
+        LowLevelType::Bool,
+    )?;
+    callblock
+        .borrow_mut()
+        .operations
+        .push(direct_call_operation(
+            rtyper,
+            &callee,
+            vec![Hlvalue::Variable(obj_cls), Hlvalue::Variable(cls1)],
+            call_result.clone(),
+        )?);
+    callblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(call_result)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(graph, argnames, func))
+}
+
+/// `ll_isinstance_pytype(obj, cls)` — pyre variant of
+/// [`lowlevel_isinstance_helper_graph`]. `obj` is a
+/// `Ptr(GcStruct pyobject::PyObject)` whose `ob_type` field holds the
+/// runtime `PyType` (the OBJECT `typeptr` role, rclass.py:1143-1147).
+/// Reads `obj.ob_type` and tail-calls `ll_issubclass_pytype`; the
+/// null-check is unconditional, matching pyre-object `ll_isinstance`'s
+/// `if obj.is_null() return false` (covering both can_be_none variants).
+fn lowlevel_isinstance_pytype_helper_graph(
+    rtyper: &RPythonTyper,
+    name: &str,
+    args: &[LowLevelType],
+    result: &LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    if !(args.len() == 2
+        && matches!(args[0], LowLevelType::Ptr(_))
+        && matches!(args[1], LowLevelType::Ptr(_)))
+        || result != &LowLevelType::Bool
+    {
+        return Err(TyperError::message(format!(
+            "{name} expects (PyObjectPtr, PyTypePtr) -> Bool, got ({args:?}) -> {result:?}"
+        )));
+    }
+    let obj_lltype = args[0].clone();
+    let cls_lltype = args[1].clone();
+
+    let argnames = vec!["arg0".to_string(), "arg1".to_string()];
+    let obj0 = variable_with_lltype("arg0", obj_lltype.clone());
+    let cls0 = variable_with_lltype("arg1", cls_lltype.clone());
+    let is_nonnull = variable_with_lltype("is_nonnull", LowLevelType::Bool);
+    let obj1 = variable_with_lltype("obj", obj_lltype.clone());
+    let cls1 = variable_with_lltype("cls", cls_lltype.clone());
+    let obj_cls = variable_with_lltype("obj_cls", cls_lltype.clone());
+    let call_result = variable_with_lltype("result", LowLevelType::Bool);
+    let return_var = variable_with_lltype("result", LowLevelType::Bool);
+
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(obj0.clone()),
+        Hlvalue::Variable(cls0.clone()),
+    ]);
+    let callblock = Block::shared(vec![
+        Hlvalue::Variable(obj1.clone()),
+        Hlvalue::Variable(cls1.clone()),
+    ]);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // upstream `if not obj:` — `ptr_nonzero(obj)`: true link reads the
+    // typeptr, false link returns False.
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "ptr_nonzero",
+        vec![Hlvalue::Variable(obj0.clone())],
+        Hlvalue::Variable(is_nonnull.clone()),
+    ));
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_nonnull));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(obj0.clone()),
+                Hlvalue::Variable(cls0.clone()),
+            ],
+            Some(callblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )],
+            Some(graph.returnblock.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+
+    // upstream `obj_cls = obj.typeptr` — pyre reads the `ob_type` field.
+    callblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getfield",
+        vec![Hlvalue::Variable(obj1), void_field_const("ob_type")],
+        Hlvalue::Variable(obj_cls.clone()),
+    ));
+    // upstream `return ll_issubclass(obj_cls, cls)`.
+    let callee = rtyper.lowlevel_helper_function(
+        "ll_issubclass_pytype",
+        vec![cls_lltype.clone(), cls_lltype.clone()],
         LowLevelType::Bool,
     )?;
     callblock
@@ -8117,5 +8338,104 @@ mod tests {
             err.to_string().contains("expects (T, T) -> T"),
             "mixed arg lltypes must be rejected: {err}"
         );
+    }
+
+    /// `ll_issubclass_pytype` reads `subclassrange_{min,max}` off the two
+    /// PyType ptrs and folds to `int_between` — the same shape as
+    /// `ll_issubclass` but on the pyre `PyType` GcStruct. The field names
+    /// must be RAW (not `inst_`-mangled): the codewriter's Charon
+    /// struct-layout offset registry is keyed by the bare field name.
+    #[test]
+    fn issubclass_pytype_helper_graph_reads_raw_subclassrange_fields() {
+        use crate::flowspace::model::{Hlvalue, SpaceOperation};
+        // A `Ptr(...)` stands in for the PyType ptr; the builder pins only
+        // the emitted op shape + field names, not the pointee struct.
+        let ptr = OBJECTPTR.clone();
+        let pygraph = lowlevel_issubclass_pytype_helper_graph(
+            "ll_issubclass_pytype",
+            &[ptr.clone(), ptr.clone()],
+            &LowLevelType::Bool,
+        )
+        .expect("ll_issubclass_pytype must build");
+        let graph = pygraph.graph.borrow();
+        let start = graph.startblock.borrow();
+        assert_eq!(start.operations.len(), 4, "op count");
+        assert_eq!(start.operations[0].opname, "getfield");
+        assert_eq!(start.operations[1].opname, "getfield");
+        assert_eq!(start.operations[2].opname, "getfield");
+        assert_eq!(start.operations[3].opname, "int_between");
+        let field = |op: &SpaceOperation| -> String {
+            match &op.args[1] {
+                Hlvalue::Constant(c) => match &c.value {
+                    ConstValue::ByteStr(b) => String::from_utf8_lossy(b).into_owned(),
+                    other => panic!("field-name const not ByteStr: {other:?}"),
+                },
+                other => panic!("getfield arg1 not a Constant: {other:?}"),
+            }
+        };
+        assert_eq!(field(&start.operations[0]), "subclassrange_min");
+        assert_eq!(field(&start.operations[1]), "subclassrange_min");
+        assert_eq!(field(&start.operations[2]), "subclassrange_max");
+    }
+
+    #[test]
+    fn issubclass_pytype_helper_graph_rejects_mismatched_ptrs() {
+        let err = lowlevel_issubclass_pytype_helper_graph(
+            "ll_issubclass_pytype",
+            &[OBJECTPTR.clone(), CLASSTYPE.clone()],
+            &LowLevelType::Bool,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("matching ptrs"),
+            "mismatched ptr operands must be rejected: {err}"
+        );
+    }
+
+    /// `ll_isinstance_pytype` guards on `ptr_nonzero(obj)`, reads
+    /// `obj.ob_type` (RAW name), and tail-calls `ll_issubclass_pytype`,
+    /// mirroring pyre-object `ll_isinstance` on the `PyObject`/`PyType`
+    /// structs.
+    #[test]
+    fn isinstance_pytype_helper_graph_reads_ob_type_and_calls_issubclass() {
+        use crate::annotator::annrpython::RPythonAnnotator;
+        use crate::flowspace::model::Hlvalue;
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata");
+        let pygraph = lowlevel_isinstance_pytype_helper_graph(
+            &rtyper,
+            "ll_isinstance_pytype",
+            &[OBJECTPTR.clone(), OBJECTPTR.clone()],
+            &LowLevelType::Bool,
+        )
+        .expect("ll_isinstance_pytype must build");
+        let graph = pygraph.graph.borrow();
+        let start = graph.startblock.borrow();
+        // upstream `if not obj:` — the null-check gate.
+        assert_eq!(start.operations.len(), 1);
+        assert_eq!(start.operations[0].opname, "ptr_nonzero");
+        assert!(start.exitswitch.is_some(), "null-check exitswitch present");
+        // The true link's callblock reads `ob_type` then direct_calls
+        // ll_issubclass_pytype.
+        let callblock = start.exits[0]
+            .borrow()
+            .target
+            .clone()
+            .expect("true link has a callblock target");
+        let cb = callblock.borrow();
+        assert_eq!(cb.operations.len(), 2);
+        assert_eq!(cb.operations[0].opname, "getfield");
+        let field = match &cb.operations[0].args[1] {
+            Hlvalue::Constant(c) => match &c.value {
+                ConstValue::ByteStr(b) => String::from_utf8_lossy(b).into_owned(),
+                other => panic!("field-name const not ByteStr: {other:?}"),
+            },
+            other => panic!("getfield arg1 not a Constant: {other:?}"),
+        };
+        assert_eq!(field, "ob_type");
+        assert_eq!(cb.operations[1].opname, "direct_call");
     }
 }


### PR DESCRIPTION
## What

pyre models type objects as `PyType` GcStruct instances that carry
`subclassrange_{min,max}` directly (the `OBJECT_VTABLE` layout is unified into
the runtime `PyType`). `flowspace_adapter` rewrites the recognised
`ll_issubclass` / `ll_isinstance` calls into `issubtype` / `isinstance` ops
whose class operand is such a `PyType` **InstanceRepr**, but the class-repr
machinery expected a `RootClassRepr` (`Ptr(OBJECT_VTABLE)`):

- the `issubtype` op fell through to the rmodel `missing_rtype_operation` default;
- `rtype_isinstance` demanded an `InstanceRepr -> RootClassRepr` conversion that
  has no pairtype arm — and cannot have one, because `castable` rejects the
  `GcStruct -> Struct` gc-status change.

These were the last 3 phaseB census failures (`is_exception` ×2, `ll_isinstance` ×1).

## How

Treat the `PyType` InstanceRepr as its **own** class-repr and read the
`subclassrange_{min,max}` ranges off the `PyType` ptrs directly — no
`object_vtable`, no `cast_pointer`:

- `InstanceRepr::rtype_issubtype` (new) and a `PyType` branch in
  `InstanceRepr::rtype_isinstance`, both gated structurally on the presence of
  `subclassrange_{min,max}` (and `ob_type` on the object side) so only
  PyType-shaped InstanceReprs take the path; every other InstanceRepr keeps the
  rmodel default byte-for-byte.
- New `ll_issubclass_pytype` / `ll_isinstance_pytype` helper graphs read the
  ranges with **raw** field names and fold to `int_between`, mirroring
  `ll_issubclass` (`rclass.py:1133-1137`) / `ll_isinstance` (`rclass.py:1143-1147`).
- The class operand (`&EXCEPTION_TYPE`) is an opaque host-address `_ptr`
  re-stamped at runtime under a seqlock, so it is read at runtime rather than
  const-folded through `make_ll_isinstance`.

## Parity note

`InstanceRepr::rtype_issubtype` has no upstream analog — upstream only
`ClassRepr` / `RootClassRepr` carry it. It is a faithful adaptation of pyre's
"type objects are `GcStruct` instances" model, not a deviation to be removed.

## Verification

- census **phaseB 3 -> 0** (phaseA unchanged / pre-existing buckets);
- `pyre/check.py`: **dynasm 155/155 + cranelift 155/155**;
- wasm 4-fail is the pre-existing baseline (decode_ref tag1 + 2× index-OOB + sre),
  disjoint from this rtyper-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `isinstance` and `issubtype` handling for class/type checks, including support for Pyre-style `PyType` inputs.
  * Added more reliable low-level evaluation for these checks, helping type-related behavior work correctly in more cases.

* **Bug Fixes**
  * Fixed failures when class arguments use `PyType`-shaped values.
  * Added validation for incompatible pointer shapes to avoid incorrect lowering during type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->