### PR TITLE
#346: retire the rtyper legacy walker — dyn-Indirect dispatch + residual/analyser cat2 slices

### DIFF
--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -491,8 +491,10 @@ static CA_GCMAP_ZERO_RUNS: GuestCell<Vec<(usize, &'static [(usize, usize)])>> =
 /// static once and steady-state recursion performs no allocator calls at
 /// all. Entries stay registered as libc jitframes and are never freed
 /// (bounded by peak recursion depth).
-static CA_FRAMES: GuestCell<CaFrames> =
-    GuestCell::new(CaFrames { entries: Vec::new(), live: 0 });
+static CA_FRAMES: GuestCell<CaFrames> = GuestCell::new(CaFrames {
+    entries: Vec::new(),
+    live: 0,
+});
 
 /// Backing store for [`CA_FRAMES`]: `entries[..live]` live, `entries[live..]`
 /// pooled (top at `entries[live]`).

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -621,6 +621,28 @@ impl Bookkeeper {
             .any(|path| path.rsplit("::").next().unwrap_or(path) == leaf)
     }
 
+    /// Resolve a bare trait `leaf` to the unique registered dispatch-family
+    /// base spelling ([`Self::pyre_trait_family_bases`] key = the trait's
+    /// full `name_path()`).  The inline-Field `CallTarget::Indirect` carries
+    /// the trait by leaf (`dyn_indirect_target` strips the vtable path to its
+    /// leaf, matching `register_trait_method`), but the receiver-narrowing
+    /// cast (`__pyre_cast_instance`) and the family base mint both key on the
+    /// qualified spelling — so the leaf must map back to it.  Returns `None`
+    /// when the leaf matches no family or matches more than one qualified
+    /// path (ambiguous — the caller then keeps the classdef-less receiver
+    /// rather than casting to an arbitrary base).
+    pub fn registered_trait_family_base_root(&self, leaf: &str) -> Option<String> {
+        let bases = self.pyre_trait_family_bases.borrow();
+        let mut matches = bases
+            .keys()
+            .filter(|path| path.rsplit("::").next().unwrap_or(path) == leaf);
+        let first = matches.next()?.clone();
+        match matches.next() {
+            Some(_) => None,
+            None => Some(first),
+        }
+    }
+
     /// No upstream equivalent — forced by pyre's numbering order, not a
     /// casual workaround.  Upstream runs `assign_inheritance_ids` ONCE
     /// inside `RPythonTyper.specialize`, AFTER `annotator.complete()`

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2016,17 +2016,52 @@ impl Bookkeeper {
         // Strip the `<…>` argument span so the lookup resolves under the
         // template key — matching `StructFieldRegistry::lookup_fields`,
         // which the bare-`reg.fields.get` here bypasses.
-        let fields: Option<Vec<(String, String)>> = {
+        let mut fields: Vec<(String, String)> = {
             let guard = self.pyre_struct_fields.borrow();
-            guard.as_ref().and_then(|r| {
+            match guard.as_ref().and_then(|r| {
                 r.fields
                     .get(majit_ir::descr::strip_generic_args(n).as_ref())
                     .cloned()
-            })
+            }) {
+                Some(f) => f,
+                None => return Ok(()),
+            }
         };
-        let Some(fields) = fields else {
-            return Ok(());
-        };
+        // A per-instantiation variant carries concrete payload rows keyed
+        // under its full `<…>`-suffixed spelling
+        // (`Option<*mut PyObject>::Some` → `__pos_0: *mut PyObject`,
+        // registered by `register_ref_enum_instantiation_rows`), while the
+        // stripped template row is the generic `??TypeVar` that projects to
+        // `Impossible`.  Substitute a template field's type with the exact
+        // key's concrete type ONLY for a RAW-POINTER payload: a pointer
+        // resolves to its pointee struct root (`PyObject`) independent of
+        // spelling, so projecting it here needs no constructor to flow the
+        // value and cannot collide with a differently-spelled named-ADT
+        // payload at `generalize_attr`.  A named heap-ADT payload
+        // (`Result<_, DictKeyError>::Err`) keeps the template `Impossible`
+        // and is filled by the constructor's `setattr` under its own
+        // qualname spelling, unchanged.  Without this, a residual-return
+        // `Option<*mut PyObject>` narrowed to `SomeInstance(Some)` re-blocks
+        // its `__pos_0` payload read on an `Impossible` attr.
+        // Gated with the residual-Option narrow (mir.rs
+        // `option_residual_narrow_enabled`): the narrowed
+        // `Option<*mut PyObject>` residual result is the only consumer of the
+        // per-instantiation raw-pointer payload row today, so the two land
+        // and lift as one slice (`PYRE_OPTION_RESIDUAL_NARROW=0` restores the
+        // template-only projection).
+        if crate::front::mir::option_residual_narrow_enabled() {
+            let guard = self.pyre_struct_fields.borrow();
+            if let Some(exact) = guard.as_ref().and_then(|r| r.fields.get(n)) {
+                for (fname, fty) in &mut fields {
+                    if let Some((_, exact_ty)) = exact.iter().find(|(en, _)| en == fname) {
+                        let t = exact_ty.trim();
+                        if t.starts_with("*mut ") || t.starts_with("*const ") {
+                            *fty = exact_ty.clone();
+                        }
+                    }
+                }
+            }
+        }
         // Bare and qualified spellings of one struct intern to the
         // same canonical class — project its rows once.
         let canonical = majit_ir::descr::canonical_struct_name(n);

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -363,6 +363,19 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     // `BigInt::from(i64)` — boxes a machine int into the foreign opaque
     // `BigInt` (Python `long`); returns the classdef-less GcRef shell.
     analyzer_for(&mut reg, "BigInt.from", bigint_from);
+    // Foreign Rust container constructors — `Vec::new` /
+    // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new`.
+    // Each returns the classdef-less opaque `SomeInstance` shell (twin
+    // `bigint_from`), retiring the "no analyser registered" wall the
+    // two-phase prepass hits when residualizing bodies that build these
+    // containers (`OpcodeStepExecutor.build_*`, `NamespaceOpcodeHandler.
+    // store_*`, `coerce_to_list_for_args`, `FrameBox::new_boxed`,
+    // `malloc_raw`).  Keyed by the qualnames `HOST_ENV` bootstrap assigns
+    // — note the mixed bare/dotted spellings the census demands.
+    analyzer_for(&mut reg, "Vec.new", foreign_container_ctor);
+    analyzer_for(&mut reg, "vec.Vec.with_capacity", foreign_container_ctor);
+    analyzer_for(&mut reg, "indexmap.IndexMap.new", foreign_container_ctor);
+    analyzer_for(&mut reg, "Box.new", foreign_container_ctor);
     // `rarithmetic.r_uint` is routed via
     // `ExtRegistryEntry::ForType` (rarithmetic.py:572-582 `ForTypeEntry`):
     // bookkeeper's BUILTIN_ANALYZERS miss falls through to
@@ -1398,6 +1411,36 @@ fn string_constructor(
 /// Residualizing those foreign-method calls on an opaque instance is a
 /// separate port.
 fn bigint_from(
+    _bk: &Rc<Bookkeeper>,
+    _args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(SomeValue::Instance(SomeInstance::new(
+        None,
+        false,
+        std::collections::BTreeMap::new(),
+    )))
+}
+
+/// Analyzer for foreign Rust container constructors that box their
+/// contents behind an opaque handle the JIT never rtypes: `Vec::new`,
+/// `Vec::with_capacity`, `indexmap::IndexMap::new`, and `Box::new`.
+/// Each returns a freshly-built owned container/box whose element
+/// internals stay foreign — the same wall `BigInt::from` draws around
+/// the boxed arbitrary-precision integer.  Model the result as a
+/// classdef-less `SomeInstance` (the foreign-opaque GcRef shell
+/// `annotation_state::ref_fallback_instance` gives an unregistered
+/// host-struct pointee); it projects to `ValueType::Ref(None)`
+/// (`somevalue_to_valuetype`).
+///
+/// Registering these retires the `SomeBuiltin.call(): no analyser
+/// registered for <ctor>` wall the two-phase prepass hits when it
+/// residualizes a body that builds one of these containers.  A
+/// subsequent method/accessor call on the opaque handle (`Vec::index`,
+/// `IndexMap::get`, `Box::into_raw`, …) is a separate leaf resolved on
+/// its own path (`translate_op` / `PyreCallRegistry`, not the analyser
+/// table); this analyser only types the constructor's result.
+fn foreign_container_ctor(
     _bk: &Rc<Bookkeeper>,
     _args_s: &[Option<SomeValue>],
     _kwds: &HashMap<String, Option<SomeValue>>,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -706,12 +706,23 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     // `_jit_look_inside_` source as `merge_hints_from_llbcs`) so the
     // per-fn push can stamp the matching `return_type` token, keyed by
     // the identical `{module_path}::{name}` path the merge uses.
-    let dont_look_inside: std::collections::HashSet<String> =
-        crate::front::llbc_hints::harvest_hints_from_llbcs(std::slice::from_ref(llbc))
-            .into_iter()
-            .filter(|(_, hints)| hints.iter().any(|h| h == "dont_look_inside"))
-            .map(|(path, _)| path)
-            .collect();
+    let harvested = crate::front::llbc_hints::harvest_hints_from_llbcs(std::slice::from_ref(llbc));
+    let dont_look_inside: std::collections::HashSet<String> = harvested
+        .iter()
+        .filter(|(_, hints)| hints.iter().any(|h| h == "dont_look_inside"))
+        .map(|(path, _)| path.clone())
+        .collect();
+    // `#[majit_macros::elidable]` callees (`llbc_hints.rs:31` maps the
+    // `_elidable_function_` marker → `"elidable"`): the codewriter's
+    // elidable effect already lowers the callsite to CALL_PURE and never
+    // looks inside the body.  Harvest the elidable set from the same
+    // vector so `stamp_return_token` can stamp the matching FUNC.RESULT
+    // token, gated on `PYRE_ELIDABLE_RESIDUALIZE`.
+    let elidable_residual: std::collections::HashSet<String> = harvested
+        .iter()
+        .filter(|(_, hints)| hints.iter().any(|h| h == "elidable"))
+        .map(|(path, _)| path.clone())
+        .collect();
     let mut functions = Vec::new();
     let mut skipped: Vec<(String, String)> = Vec::new();
     for fd in llbc.iter_local_fns() {
@@ -822,6 +833,7 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         // (`lib.rs`) keeps its `None`→`Void` default when the routing is off
         // — off-path byte-identity holds.
         let stamp_return_token = dont_look_inside.contains(&fn_path)
+            || (elidable_residualize_enabled() && elidable_residual.contains(&fn_path))
             || (dyn_indirect_enabled() && trait_root.is_some() && self_ty_root.is_none());
         let return_type = if stamp_return_token {
             dont_look_inside_return_token(&fd.signature.output, llbc)
@@ -12028,6 +12040,20 @@ fn tuple_per_shape_enabled() -> bool {
 pub(crate) fn dyn_indirect_enabled() -> bool {
     matches!(
         std::env::var("PYRE_DYN_INDIRECT").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Residualize a `#[majit_macros::elidable]` graph — stamp its return-kind
+/// FUNC.RESULT token and prefill a signature-only stub instead of lifting
+/// the body — mirroring `@elidable` + `look_inside_graph=False` (the
+/// callsite already lowers to CALL_PURE via the codewriter's elidable
+/// effect; the body is never looked inside).  Default-OFF —
+/// `PYRE_ELIDABLE_RESIDUALIZE=1` opts in; every other value (unset
+/// included) keeps the elidable body lifted as today.
+pub(crate) fn elidable_residualize_enabled() -> bool {
+    matches!(
+        std::env::var("PYRE_ELIDABLE_RESIDUALIZE").as_deref(),
         Ok("1") | Ok("true")
     )
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12025,7 +12025,7 @@ fn tuple_per_shape_enabled() -> bool {
 /// `__dyn_call` residual (see the `(CallClass::Dynamic, ..)` arm).
 /// Default-OFF — `PYRE_DYN_INDIRECT=1` opts in; every other value (unset
 /// included) keeps the inert `__dyn_call` emit.
-fn dyn_indirect_enabled() -> bool {
+pub(crate) fn dyn_indirect_enabled() -> bool {
     matches!(
         std::env::var("PYRE_DYN_INDIRECT").as_deref(),
         Ok("1") | Ok("true")

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -812,7 +812,18 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
         } else {
             format!("{module_path}::{name}")
         };
-        let return_type = if dont_look_inside.contains(&fn_path) {
+        // A trait default body is registered as the `<default methods of
+        // Trait>` family sentinel and picked as the Indirect-dispatch
+        // witness (`getcalldescr`'s indirect arm reads its `return_type` as
+        // `FUNC.RESULT`).  Left `None` it maps to `Void` and mismatches the
+        // caller's `Ref`/`Int` `result_ty`; stamp the same token an opaque
+        // callee gets so the witness reports its real return kind.  Gated on
+        // `PYRE_DYN_INDIRECT` so the direct `[Trait, method]` registration
+        // (`lib.rs`) keeps its `None`→`Void` default when the routing is off
+        // — off-path byte-identity holds.
+        let stamp_return_token = dont_look_inside.contains(&fn_path)
+            || (dyn_indirect_enabled() && trait_root.is_some() && self_ty_root.is_none());
+        let return_type = if stamp_return_token {
             dont_look_inside_return_token(&fd.signature.output, llbc)
         } else {
             None

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -5185,6 +5185,22 @@ impl<'a> Lowering<'a> {
             tyref_node(&call.dest.ty, self.llbc)
                 .and_then(|n| strip_ty_wrappers(n, self.llbc))
                 .and_then(|n| raw_ptr_pointee_class_root(n, self.llbc))
+                // A `dont_look_inside` residual returning `Option<*mut PyObject>`
+                // erases the same way — `dont_look_inside_return_token` maps it to
+                // the `ref` GCREF token, so `result_ty` is `Ref(None)` too — but its
+                // `call.dest.ty` is the `Option<…>` ADT, not a bare raw pointer, so
+                // the `raw_ptr_pointee_class_root` above misses.  Narrow it to the
+                // per-instantiation `Option` enum root a constructed
+                // `Some(..)`/`None` of the same instantiation mints, so the caller's
+                // `if let Some(x) = ..` (`Discriminant` → `__discriminant` read, then
+                // the Some-arm `__pos_0` payload) resolves against the Option classdef
+                // instead of blocking on a classdef-less GCREF.  Gated so the
+                // bare-GCREF residual result can be restored.
+                .or_else(|| {
+                    option_residual_narrow_enabled()
+                        .then(|| self.option_residual_narrow_root(&call.dest.ty))
+                        .flatten()
+                })
         } else {
             None
         };
@@ -7742,6 +7758,52 @@ impl<'a> Lowering<'a> {
         };
         let inner = body.get("Adt")?.get("generics")?.get("types")?.get(0)?;
         Some(self.type_node_to_value_type(inner))
+    }
+
+    /// The per-instantiation `Option` enum root for a residual-call
+    /// destination `dest_ty` that is an `Option<*mut RegisteredStruct>`
+    /// (`Option<PyObjectRef>`), or `None` when `dest_ty` is not an Option
+    /// whose payload is a raw pointer to a registered struct root.
+    ///
+    /// A `dont_look_inside` residual returning `Option<*mut PyObject>` has
+    /// its result kind erased to the `ref` GCREF token, so the call result
+    /// arrives classdef-less; the caller's `if let Some(x) = ..` then reads
+    /// `__discriminant` off a bare pointer and panics.  Minting the SAME
+    /// root a constructed `Some(..)`/`None` of this instantiation mints
+    /// (`Option`'s `name_path` + the destination `<X>` suffix, exactly as
+    /// [`Self::recognize_bool_then_site`] / the tagged-pair ctor derive it)
+    /// lets the narrowed result share the constructed Option's ClassDef, so
+    /// the residual and constructed Options unify at a phi merge and the
+    /// discriminant / payload reads resolve.
+    ///
+    /// The payload distinguisher is [`raw_ptr_pointee_class_root`] on the
+    /// Option's first type argument: `Some` for `Option<*mut PyObject>`,
+    /// `None` for `Option<u64>` (no raw pointer) and `Option<*mut u8>` (a
+    /// primitive pointee with no registered struct root) — both of which
+    /// stay classdef-less GCREF, unchanged.
+    fn option_residual_narrow_root(&self, dest_ty: &TyRef) -> Option<String> {
+        if !crate::front::result_exc::tyref_is_option(dest_ty, self.llbc) {
+            return None;
+        }
+        // Distinguisher: the Option's payload must be a raw pointer whose
+        // pointee resolves to a registered struct root.
+        let payload = tyref_node(dest_ty, self.llbc)?
+            .as_object()?
+            .get("Adt")?
+            .get("generics")?
+            .get("types")?
+            .get(0)?;
+        strip_ty_wrappers(payload, self.llbc)
+            .and_then(|n| raw_ptr_pointee_class_root(n, self.llbc))?;
+        // The narrow root is the Option enum instantiation itself — the same
+        // spelling a static `Some(..)` construction of this instantiation mints.
+        let def_id = self.tyref_adt_def_id(dest_ty)?;
+        let td = self.llbc.type_by_id(def_id)?;
+        Some(format!(
+            "{}{}",
+            td.item_meta.name_path(),
+            tyref_enum_instantiation_suffix(dest_ty, self.llbc)
+        ))
     }
 
     /// Project a raw Charon type node (a `generics.types` entry) to a
@@ -11870,6 +11932,21 @@ fn render_adt_type_args(
 fn tuple_per_shape_enabled() -> bool {
     !matches!(
         std::env::var("PYRE_TUPLE_PER_SHAPE_CLASSDEF").as_deref(),
+        Ok("0") | Ok("false")
+    )
+}
+
+/// Narrow a `dont_look_inside` residual call whose destination is
+/// `Option<*mut PyObject>` from the classdef-less `ref` GCREF token to the
+/// per-instantiation `Option` enum root, so the caller's `if let Some(x) =
+/// ..` (`__discriminant` read + Some-arm `__pos_0` payload) resolves against
+/// the Option classdef instead of panicking with `Ptr{Opaque(GCREF)}
+/// instance has no field "__discriminant"`.  On by default;
+/// `PYRE_OPTION_RESIDUAL_NARROW=0` is the kill switch that restores the
+/// bare-GCREF residual result.
+pub(crate) fn option_residual_narrow_enabled() -> bool {
+    !matches!(
+        std::env::var("PYRE_OPTION_RESIDUAL_NARROW").as_deref(),
         Ok("0") | Ok("false")
     )
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4633,6 +4633,57 @@ impl<'a> Lowering<'a> {
         }
     }
 
+    /// Decode an inline-Field `dyn Trait` call operand into the
+    /// `(trait_root, method_name)` pair the `CallTarget::Indirect`
+    /// vtable-dispatch pipeline keys on.
+    ///
+    /// The inline dispatch reads the method fn-ptr straight out of the
+    /// receiver's vtable — the operand's terminal projection is
+    /// `Field[Adt(vtable_id), slot]` off `(*recv).vtable`, where the
+    /// vtable type is the `<Trait>::{vtable}` struct and the slot field
+    /// is named `method_<name>`.  Returns `None` for any other operand
+    /// shape (the one-hop `Option<fn-ptr>` deref and `call_once` closure
+    /// shims are bare locals / non-`Field[Adt]` projections), which keeps
+    /// those on the synthetic `__dyn_call` path.
+    fn dyn_indirect_target(&self, dyn_operand: &Operand) -> Option<(String, String)> {
+        let place = match dyn_operand {
+            Operand::Copy(p) | Operand::Move(p) => p,
+            Operand::Const(_) => return None,
+        };
+        let PlaceKind::Projection(_, elem) = &place.kind else {
+            return None;
+        };
+        let ProjectionElem::Tagged(v) = elem else {
+            return None;
+        };
+        let field_payload = v.as_object()?.get("Field")?;
+        // The terminal container must be an `Adt` (the vtable struct);
+        // decode its type id the same two ways `resolve_adt_field` does
+        // (bare u64 or `{id:{Adt}}` head), never hardcoding a value.
+        let arr = field_payload.as_array()?;
+        let container = arr.first()?.as_object()?;
+        let adt = container.get("Adt")?.as_array()?;
+        let head = adt.first()?;
+        let vtable_id = match head.as_u64() {
+            Some(id) => id,
+            None => head.get("id")?.get("Adt")?.as_u64()?,
+        };
+        // `resolve_adt_field` names the slot `method_<name>`; strip the
+        // prefix for the trait method leaf.
+        let (_owner, field_name, _ty, _id) = self.resolve_adt_field(field_payload)?;
+        let method_name = field_name.strip_prefix("method_")?.to_string();
+        // The vtable type is spelled `<path>::<Trait>::{vtable}`; the
+        // trait_root the family lookup keys on is the bare trait leaf
+        // (matching `register_trait_method`, which registers under
+        // `SemanticFunction.trait_root` = the trait's leaf name).
+        let vtable_path = self.llbc.type_by_id(vtable_id)?.item_meta.name_path();
+        let trait_path = vtable_path
+            .strip_suffix("::{vtable}")
+            .unwrap_or(vtable_path.as_str());
+        let trait_root = trait_path.rsplit("::").next()?.to_string();
+        Some((trait_root, method_name))
+    }
+
     /// Resolve a global `def_id` to its fully-qualified path segments
     /// via the reader's `global_decls` table.
     fn global_segments(&self, mir_bb: usize, def_id: u64) -> Result<Vec<String>, LowerError> {
@@ -6079,23 +6130,45 @@ impl<'a> Lowering<'a> {
                 }
             }
             (CallClass::Dynamic, CallFunc::Dynamic(dyn_operand)) => {
-                // `dyn Trait` virtual call. The fat-pointer receiver
-                // is carried in `dyn_operand`; thread it into `args[0]`
-                // and emit a synthetic `__dyn_call` path so the
-                // codewriter sees a uniform `Call` shape.  A faithful
-                // lowering would emit `VtableMethodPtr` + `IndirectCall`;
-                // that needs the trait_root/method_name pair Charon does
-                // not yet surface.
-                let recv = self.resolve_operand(mir_bb, dyn_operand)?;
-                let mut full_args = Vec::with_capacity(args.len() + 1);
-                full_args.push(recv);
-                full_args.extend(args);
-                OpKind::Call {
-                    target: CallTarget::FunctionPath {
-                        segments: vec!["__dyn_call".to_string()],
-                    },
-                    args: full_args,
-                    result_ty,
+                // `dyn Trait` virtual call.  The inline-dispatch form reads
+                // the method fn-ptr straight out of the receiver's vtable
+                // (`(*recv).vtable.method_<name>`), so the operand's
+                // terminal projection is `Field[Adt(vtable_id), slot]`.
+                // Route those through the faithful `CallTarget::Indirect`
+                // vtable pipeline (`rpbc::lower_indirect_calls` →
+                // `VtableMethodPtr` + `IndirectCall`, carrying the full
+                // impl family) instead of the synthetic `__dyn_call`.  The
+                // call args already carry the receiver in `args[0]` (the
+                // operand projection's base local), which is exactly the
+                // receiver slot `IndirectCall` expects, so the arg list
+                // passes through unchanged.
+                //
+                // Any other operand shape — the one-hop `Option<fn-ptr>`
+                // deref and `call_once` closure shims — is a stored
+                // fn-ptr / `FnOnce`, not a vtable slot; it keeps the
+                // synthetic `__dyn_call` path (the fat-pointer receiver
+                // threaded into `args[0]`).
+                let indirect = dyn_indirect_enabled()
+                    .then(|| self.dyn_indirect_target(&dyn_operand))
+                    .flatten();
+                if let Some((trait_root, method_name)) = indirect {
+                    OpKind::Call {
+                        target: CallTarget::indirect(trait_root, method_name),
+                        args,
+                        result_ty,
+                    }
+                } else {
+                    let recv = self.resolve_operand(mir_bb, dyn_operand)?;
+                    let mut full_args = Vec::with_capacity(args.len() + 1);
+                    full_args.push(recv);
+                    full_args.extend(args);
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath {
+                            segments: vec!["__dyn_call".to_string()],
+                        },
+                        args: full_args,
+                        result_ty,
+                    }
                 }
             }
             (CallClass::Ptr, _) => {
@@ -11933,6 +12006,18 @@ fn tuple_per_shape_enabled() -> bool {
     !matches!(
         std::env::var("PYRE_TUPLE_PER_SHAPE_CLASSDEF").as_deref(),
         Ok("0") | Ok("false")
+    )
+}
+
+/// Route inline-Field `dyn Trait` virtual calls through the faithful
+/// `CallTarget::Indirect` vtable pipeline instead of the synthetic
+/// `__dyn_call` residual (see the `(CallClass::Dynamic, ..)` arm).
+/// Default-OFF — `PYRE_DYN_INDIRECT=1` opts in; every other value (unset
+/// included) keeps the inert `__dyn_call` emit.
+fn dyn_indirect_enabled() -> bool {
+    matches!(
+        std::env::var("PYRE_DYN_INDIRECT").as_deref(),
+        Ok("1") | Ok("true")
     )
 }
 

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1226,26 +1226,28 @@ fn analyze_pipeline_from_module_paths(
         .pipeline
         .register_trait_families
         .iter()
-        .filter_map(|trait_qualified| match trait_impl_owners.get(trait_qualified) {
-            Some(owners) => make_registration(trait_qualified, owners),
-            None => {
-                // Config validation: a named family that matches no
-                // harvested trait is almost always a spelling mismatch
-                // (the key is the trait's full `name_path()`).  List the
-                // available multi-impl trait paths so the consumer can
-                // correct it.
-                let candidates: Vec<&String> = trait_impl_owners
-                    .iter()
-                    .filter(|(_, owners)| owners.len() >= 2)
-                    .map(|(path, _)| path)
-                    .collect();
-                eprintln!(
-                    "register_trait_families: no harvested trait matches {trait_qualified:?}; \
+        .filter_map(
+            |trait_qualified| match trait_impl_owners.get(trait_qualified) {
+                Some(owners) => make_registration(trait_qualified, owners),
+                None => {
+                    // Config validation: a named family that matches no
+                    // harvested trait is almost always a spelling mismatch
+                    // (the key is the trait's full `name_path()`).  List the
+                    // available multi-impl trait paths so the consumer can
+                    // correct it.
+                    let candidates: Vec<&String> = trait_impl_owners
+                        .iter()
+                        .filter(|(_, owners)| owners.len() >= 2)
+                        .map(|(path, _)| path)
+                        .collect();
+                    eprintln!(
+                        "register_trait_families: no harvested trait matches {trait_qualified:?}; \
                  known multi-impl trait paths: {candidates:?}"
-                );
-                None
-            }
-        })
+                    );
+                    None
+                }
+            },
+        )
         .collect();
     // Gated auto-population (issue #346, S2.3): with `PYRE_DYN_INDIRECT`
     // on, register EVERY `>=2`-impl trait so its inline `dyn Trait`
@@ -1264,31 +1266,30 @@ fn analyze_pipeline_from_module_paths(
             .iter()
             .map(|r| r.base_root.as_str())
             .collect();
-        let mut auto: Vec<call::TraitFamilyRegistration> = trait_impl_owners
-            .iter()
-            .filter(|(trait_qualified, owners)| {
-                owners.len() >= 2 && !already.contains(trait_qualified.as_str())
-            })
-            .filter_map(|(trait_qualified, owners)| {
-                let reg = make_registration(trait_qualified, owners)?;
-                // Cross-registry leaf collision: an impl leaf shared by
-                // another qualified struct in the field registry would
-                // collapse the subclass onto that struct's classdef.
-                if let Some(dup) = reg
-                    .impl_roots
-                    .iter()
-                    .find(|leaf| struct_leaf_counts.get(leaf.as_str()).copied().unwrap_or(0) > 1)
-                {
-                    eprintln!(
-                        "register_trait_families: auto {trait_qualified:?} impl leaf {dup:?} \
+        let mut auto: Vec<call::TraitFamilyRegistration> =
+            trait_impl_owners
+                .iter()
+                .filter(|(trait_qualified, owners)| {
+                    owners.len() >= 2 && !already.contains(trait_qualified.as_str())
+                })
+                .filter_map(|(trait_qualified, owners)| {
+                    let reg = make_registration(trait_qualified, owners)?;
+                    // Cross-registry leaf collision: an impl leaf shared by
+                    // another qualified struct in the field registry would
+                    // collapse the subclass onto that struct's classdef.
+                    if let Some(dup) = reg.impl_roots.iter().find(|leaf| {
+                        struct_leaf_counts.get(leaf.as_str()).copied().unwrap_or(0) > 1
+                    }) {
+                        eprintln!(
+                            "register_trait_families: auto {trait_qualified:?} impl leaf {dup:?} \
                          collides with another registered struct; skipping — leaf-keyed \
                          seeding cannot disambiguate them"
-                    );
-                    return None;
-                }
-                Some(reg)
-            })
-            .collect();
+                        );
+                        return None;
+                    }
+                    Some(reg)
+                })
+                .collect();
         // Deterministic mint order (BTreeMap iteration on `trait_impl_owners`
         // is already sorted, but sort defensively since a HashMap seeded it).
         auto.sort_by(|a, b| a.base_root.cmp(&b.base_root));

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1186,70 +1186,114 @@ fn analyze_pipeline_from_module_paths(
     // (e.g. the aheui census) names `>=2`-impl trait qualified paths
     // whose `dyn Trait` receivers should annotate to a base ClassDef
     // linking the impl subclasses, so a method getattr on the receiver
-    // resolves the impl MethodDesc family.  Pyre production names none,
-    // so its multi-impl traits keep their classdef-less / fail-loud
-    // disposition unchanged.  Built from `trait_impl_owners` (before it
-    // is consumed below) and forwarded through `CallControl` to
-    // `dual_gate_registry`, which mints each family before the
+    // resolves the impl MethodDesc family.  Built from `trait_impl_owners`
+    // (before it is consumed below) and forwarded through `CallControl`
+    // to `dual_gate_registry`, which mints each family before the
     // class-method seeding.
-    let trait_family_registrations: Vec<call::TraitFamilyRegistration> = config
+    //
+    // Per-family builder shared by the config and the gated auto-population
+    // paths.  Skips a family whose impl owners collapse to one leaf under
+    // the leaf-keyed (`canonical_struct_name`) family interning + method
+    // seeding — that would silently drop a member; leaving the trait's
+    // classdef-less / fail-loud disposition is the fail-safe.  Mirrors the
+    // `struct_leaf_counts` bail on the single-impl path below.
+    let make_registration = |trait_qualified: &str,
+                             owners: &std::collections::BTreeSet<String>|
+     -> Option<call::TraitFamilyRegistration> {
+        let impl_roots: Vec<String> = owners
+            .iter()
+            .map(|owner| owner.rsplit("::").next().unwrap_or(owner).to_string())
+            .collect();
+        // Within-family leaf collision: two impls of THIS trait whose
+        // qualified owners share a leaf across modules.
+        let mut seen = std::collections::HashSet::new();
+        if let Some(dup) = impl_roots.iter().find(|leaf| !seen.insert(leaf.as_str())) {
+            eprintln!(
+                "register_trait_families: {trait_qualified:?} has impls sharing \
+                 leaf {dup:?} across modules ({owners:?}); skipping — leaf-keyed \
+                 seeding cannot disambiguate them"
+            );
+            return None;
+        }
+        Some(call::TraitFamilyRegistration {
+            base_root: trait_qualified.to_string(),
+            impl_roots,
+        })
+    };
+    // Config-named families first (empty in pyre production).  Preserves
+    // the prior spelling-mismatch diagnostic on the `None` arm.
+    let mut trait_family_registrations: Vec<call::TraitFamilyRegistration> = config
         .pipeline
         .register_trait_families
         .iter()
-        .filter_map(
-            |trait_qualified| match trait_impl_owners.get(trait_qualified) {
-                Some(owners) => {
-                    let impl_roots: Vec<String> = owners
-                        .iter()
-                        .map(|owner| owner.rsplit("::").next().unwrap_or(owner).to_string())
-                        .collect();
-                    // The family interning + method seeding key impl
-                    // subclasses by leaf (`canonical_struct_name`), so two
-                    // impls whose qualified owners share a leaf across
-                    // modules would collapse to one classdef and silently
-                    // drop a member. Skip such a family — leaving the
-                    // trait's classdef-less / fail-loud disposition — rather
-                    // than mis-seed it; a same-leaf consumer needs
-                    // qualified-root interning end-to-end (the leaf-keyed
-                    // struct registry and receiver match are pre-existing).
-                    // Mirrors the `struct_leaf_counts` bail on the
-                    // single-impl path below.
-                    let mut seen = std::collections::HashSet::new();
-                    let dup_leaf = impl_roots.iter().find(|leaf| !seen.insert(leaf.as_str()));
-                    if let Some(dup) = dup_leaf {
-                        eprintln!(
-                            "register_trait_families: {trait_qualified:?} has impls sharing \
-                             leaf {dup:?} across modules ({owners:?}); skipping — leaf-keyed \
-                             seeding cannot disambiguate them"
-                        );
-                        None
-                    } else {
-                        Some(call::TraitFamilyRegistration {
-                            base_root: trait_qualified.clone(),
-                            impl_roots,
-                        })
-                    }
-                }
-                None => {
-                    // Config validation: a named family that matches no
-                    // harvested trait is almost always a spelling mismatch
-                    // (the key is the trait's full `name_path()`).  List the
-                    // available multi-impl trait paths so the consumer can
-                    // correct it.
-                    let candidates: Vec<&String> = trait_impl_owners
-                        .iter()
-                        .filter(|(_, owners)| owners.len() >= 2)
-                        .map(|(path, _)| path)
-                        .collect();
-                    eprintln!(
-                        "register_trait_families: no harvested trait matches {trait_qualified:?}; \
-                     known multi-impl trait paths: {candidates:?}"
-                    );
-                    None
-                }
-            },
-        )
+        .filter_map(|trait_qualified| match trait_impl_owners.get(trait_qualified) {
+            Some(owners) => make_registration(trait_qualified, owners),
+            None => {
+                // Config validation: a named family that matches no
+                // harvested trait is almost always a spelling mismatch
+                // (the key is the trait's full `name_path()`).  List the
+                // available multi-impl trait paths so the consumer can
+                // correct it.
+                let candidates: Vec<&String> = trait_impl_owners
+                    .iter()
+                    .filter(|(_, owners)| owners.len() >= 2)
+                    .map(|(path, _)| path)
+                    .collect();
+                eprintln!(
+                    "register_trait_families: no harvested trait matches {trait_qualified:?}; \
+                 known multi-impl trait paths: {candidates:?}"
+                );
+                None
+            }
+        })
         .collect();
+    // Gated auto-population (issue #346, S2.3): with `PYRE_DYN_INDIRECT`
+    // on, register EVERY `>=2`-impl trait so its inline `dyn Trait`
+    // receiver (lowered to `CallTarget::Indirect`) narrows to the family
+    // base ClassDef.  Union with the config list (dedup by base_root),
+    // never replacing it, to stay forward-safe with the aheui census.
+    // MUST stay behind the gate: minting base/impl subclass classdefs
+    // perturbs `pyre_struct_root_names` → `ensure_session` inheritance-id
+    // numbering even off-path, so gate-OFF keeps the config-only (empty in
+    // prod) set byte-identical.  Applies the same within-family `dup_leaf`
+    // guard as the config path plus the cross-registry `struct_leaf_counts`
+    // bail: an impl leaf that also names a DIFFERENT registered struct
+    // would mis-seed the family, so skip it (fail-safe classdef-less).
+    if front::mir::dyn_indirect_enabled() {
+        let already: std::collections::HashSet<&str> = trait_family_registrations
+            .iter()
+            .map(|r| r.base_root.as_str())
+            .collect();
+        let mut auto: Vec<call::TraitFamilyRegistration> = trait_impl_owners
+            .iter()
+            .filter(|(trait_qualified, owners)| {
+                owners.len() >= 2 && !already.contains(trait_qualified.as_str())
+            })
+            .filter_map(|(trait_qualified, owners)| {
+                let reg = make_registration(trait_qualified, owners)?;
+                // Cross-registry leaf collision: an impl leaf shared by
+                // another qualified struct in the field registry would
+                // collapse the subclass onto that struct's classdef.
+                if let Some(dup) = reg
+                    .impl_roots
+                    .iter()
+                    .find(|leaf| struct_leaf_counts.get(leaf.as_str()).copied().unwrap_or(0) > 1)
+                {
+                    eprintln!(
+                        "register_trait_families: auto {trait_qualified:?} impl leaf {dup:?} \
+                         collides with another registered struct; skipping — leaf-keyed \
+                         seeding cannot disambiguate them"
+                    );
+                    return None;
+                }
+                Some(reg)
+            })
+            .collect();
+        // Deterministic mint order (BTreeMap iteration on `trait_impl_owners`
+        // is already sorted, but sort defensively since a HashMap seeded it).
+        auto.sort_by(|a, b| a.base_root.cmp(&b.base_root));
+        trait_family_registrations.extend(auto);
+    }
     call_control.set_trait_family_registrations(trait_family_registrations);
     let trait_unique_impls: std::collections::HashMap<String, String> = trait_impl_owners
         .into_iter()

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -1713,7 +1713,10 @@ pub(crate) fn populate_call_registry_from_call_graphs(
         // `default_someshell_for_lltype` → `lltype_to_annotation` path
         // already covers `Ptr(_)`.  An unrecognized token (none
         // currently emitted) falls through to the normal lift.
-        if graph.hints.iter().any(|h| h == "dont_look_inside") {
+        let residualize = graph.hints.iter().any(|h| h == "dont_look_inside")
+            || (crate::front::mir::elidable_residualize_enabled()
+                && graph.hints.iter().any(|h| h == "elidable"));
+        if residualize {
             let return_lltype = match graph.return_type.as_deref() {
                 None | Some("()") => Some(LowLevelType::Void),
                 Some("bool") => Some(LowLevelType::Bool),

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2143,19 +2143,39 @@ pub fn translate_op(
                 // Instead lower to the same `getattr(receiver,
                 // method_name)` + `simple_call(bound_method, args[1..])`
                 // shape as `CallTarget::Method`.  The receiver `args[0]` is
-                // seeded as the trait-family base `ClassDef`
-                // (`derive_subject_inputcells`, this file ~:2741 via
-                // `pyre_trait_family_bases`, the #346 receiver-driven
-                // dispatch machinery), whose impl subclasses carry the
-                // methods through attrfamily merge — so the method getattr
-                // resolves the impl `MethodDesc` family and the trailing
-                // `simple_call` rtypes through the ordinary bound-method
-                // path (`rpbc.py:199 FunctionRepr.call`).  `trait_root` is
-                // not needed at this stage: the family the getattr resolves
-                // is keyed on the receiver's classdef, which the seeding
-                // already pinned to the same trait family
-                // `(trait_root, method_name)` names.
-                CallTarget::Indirect { method_name, .. } => {
+                // a `dyn Trait` call-result / deref TEMP annotated
+                // `SomeInstance(classdef=None)` — `dyn Trait` has no
+                // `class_root`, and `derive_subject_inputcells` (this file
+                // ~:2784, the #346 receiver seeder) only touches startblock
+                // inputargs, not temps — so the method getattr would block
+                // on the classdef-less shell.  Narrow the receiver first to
+                // the trait-family base `ClassDef` via the
+                // `__pyre_cast_instance` mechanism (same as slice A /
+                // `mir.rs:3725`, lowered at ~:1467 in this file): emit
+                // `simple_call(__pyre_cast_instance, receiver,
+                // Constant(byte_str(base_root)))` producing a narrowed
+                // receiver, then `getattr(narrowed, method_name)`.  The
+                // family base's impl subclasses carry the methods through
+                // attrfamily merge, so the getattr resolves the impl
+                // `MethodDesc` family and the trailing `simple_call` rtypes
+                // through the ordinary bound-method path
+                // (`rpbc.py:199 FunctionRepr.call`); dispatch stays virtual.
+                //
+                // The cast root must resolve through `pyre_struct_root_classes`
+                // to the base classdef `register_trait_family` minted under
+                // `canonical_struct_name(base_root)`.  `trait_root` here is
+                // the bare trait leaf (`dyn_indirect_target`), but the family
+                // base is keyed by the trait's full `name_path()`, so map the
+                // leaf back through `registered_trait_family_base_root`.  When
+                // no base is registered (unregistered / foreign trait, or an
+                // ambiguous same-leaf collision) the lookup returns `None`
+                // and the plain getattr is emitted — the receiver stays
+                // classdef-less and fails loud exactly as before, no cast to
+                // a non-existent root.
+                CallTarget::Indirect {
+                    method_name,
+                    trait_root,
+                } => {
                     let mut iter = arg_hls.into_iter();
                     let receiver = iter.next().ok_or_else(|| {
                         TyperError::message(
@@ -2163,21 +2183,50 @@ pub fn translate_op(
                                 .to_string(),
                         )
                     })?;
+                    let base_root = call_registry
+                        .bookkeeper()
+                        .registered_trait_family_base_root(&trait_root);
+                    let mut ops = Vec::with_capacity(3);
+                    // Narrow the receiver to the family base classdef when the
+                    // trait is a registered dispatch family.
+                    let getattr_receiver = if let Some(base_root) = base_root {
+                        let callable_host =
+                            HOST_ENV.lookup_builtin("__pyre_cast_instance").ok_or_else(|| {
+                                TyperError::message(
+                                    "__pyre_cast_instance missing from HOST_ENV bootstrap"
+                                        .to_string(),
+                                )
+                            })?;
+                        let narrowed = Hlvalue::Variable(Variable::new());
+                        ops.push(FlowspaceOp::new(
+                            "simple_call",
+                            vec![
+                                Hlvalue::Constant(Constant::new(ConstValue::HostObject(
+                                    callable_host,
+                                ))),
+                                receiver,
+                                Hlvalue::Constant(Constant::new(ConstValue::byte_str(&base_root))),
+                            ],
+                            narrowed.clone(),
+                        ));
+                        narrowed
+                    } else {
+                        receiver
+                    };
                     let bound_method = Hlvalue::Variable(Variable::new());
                     let mut call_args = Vec::with_capacity(iter.size_hint().0 + 1);
                     call_args.push(bound_method.clone());
                     call_args.extend(iter);
-                    Ok(vec![
-                        FlowspaceOp::new(
-                            "getattr",
-                            vec![
-                                receiver,
-                                Hlvalue::Constant(Constant::new(ConstValue::byte_str(method_name))),
-                            ],
-                            bound_method,
-                        ),
-                        FlowspaceOp::new("simple_call", call_args, result),
-                    ])
+                    ops.push(FlowspaceOp::new(
+                        "getattr",
+                        vec![
+                            getattr_receiver,
+                            Hlvalue::Constant(Constant::new(ConstValue::byte_str(method_name))),
+                        ],
+                        bound_method,
+                    ));
+                    ops.push(FlowspaceOp::new("simple_call", call_args, result));
+                    Ok(ops)
                 }
                 CallTarget::UnsupportedExpr => Err(TyperError::message(format!(
                     "translate_op: Call with CallTarget::UnsupportedExpr at \

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2129,13 +2129,56 @@ pub fn translate_op(
                         FlowspaceOp::new("simple_call", call_args, result),
                     ])
                 }
-                CallTarget::Indirect { .. } => Err(TyperError::message(format!(
-                    "translate_op: Call with CallTarget::Indirect at result={} \
-                     must be lowered to VtableMethodPtr + IndirectCall by \
-                     rclass.rs before reaching the flowspace adapter; \
-                     reaching here means the rclass rewrite didn't run",
-                    fmt_op_result(op),
-                ))),
+                // A `dyn Trait` virtual call. `front::mir` routes the
+                // inline-Field vtable-slot dispatch here (gated behind
+                // `PYRE_DYN_INDIRECT`) with the receiver already in
+                // `args[0]`.  The production codewriter lowers it through
+                // `rpbc::lower_indirect_calls` (`VtableMethodPtr` +
+                // `IndirectCall`), but pyre has no IR vtable struct, so the
+                // funcptr projection cannot carry a `Ptr(Func)` lltype that
+                // `PtrRepr::rtype_simple_call` (rmodel.rs:2202) needs —
+                // synthesising a `SomePtr(Func)` symbolically is not
+                // available in the two-phase annotate/rtype prepass.
+                //
+                // Instead lower to the same `getattr(receiver,
+                // method_name)` + `simple_call(bound_method, args[1..])`
+                // shape as `CallTarget::Method`.  The receiver `args[0]` is
+                // seeded as the trait-family base `ClassDef`
+                // (`derive_subject_inputcells`, this file ~:2741 via
+                // `pyre_trait_family_bases`, the #346 receiver-driven
+                // dispatch machinery), whose impl subclasses carry the
+                // methods through attrfamily merge — so the method getattr
+                // resolves the impl `MethodDesc` family and the trailing
+                // `simple_call` rtypes through the ordinary bound-method
+                // path (`rpbc.py:199 FunctionRepr.call`).  `trait_root` is
+                // not needed at this stage: the family the getattr resolves
+                // is keyed on the receiver's classdef, which the seeding
+                // already pinned to the same trait family
+                // `(trait_root, method_name)` names.
+                CallTarget::Indirect { method_name, .. } => {
+                    let mut iter = arg_hls.into_iter();
+                    let receiver = iter.next().ok_or_else(|| {
+                        TyperError::message(
+                            "Call::Indirect has empty args: dyn-Trait receiver must be args[0]"
+                                .to_string(),
+                        )
+                    })?;
+                    let bound_method = Hlvalue::Variable(Variable::new());
+                    let mut call_args = Vec::with_capacity(iter.size_hint().0 + 1);
+                    call_args.push(bound_method.clone());
+                    call_args.extend(iter);
+                    Ok(vec![
+                        FlowspaceOp::new(
+                            "getattr",
+                            vec![
+                                receiver,
+                                Hlvalue::Constant(Constant::new(ConstValue::byte_str(method_name))),
+                            ],
+                            bound_method,
+                        ),
+                        FlowspaceOp::new("simple_call", call_args, result),
+                    ])
+                }
                 CallTarget::UnsupportedExpr => Err(TyperError::message(format!(
                     "translate_op: Call with CallTarget::UnsupportedExpr at \
                      result={} — frontend coverage gap; the `front::mir` \
@@ -4538,34 +4581,59 @@ mod tests {
     }
 
     #[test]
-    fn translate_op_call_indirect_surfaces_rclass_invariant() {
-        // Call::Indirect must be lowered to VtableMethodPtr +
-        // IndirectCall by `rclass.rs` before reaching the flowspace
-        // adapter. Reaching here means the rclass rewrite didn't run;
-        // surface the structural invariant break.
+    fn translate_op_call_indirect_chains_getattr_simple_call() {
+        // Call::Indirect (`dyn Trait` virtual call) lowers to the same
+        // `[getattr(receiver, method_name) -> meth, simple_call(meth,
+        // args[1..])]` chain as `CallTarget::Method`.  The receiver
+        // `args[0]` is seeded (by `derive_subject_inputcells`) as the
+        // trait-family base ClassDef, so the method getattr resolves the
+        // impl `MethodDesc` family in the two-phase prepass instead of
+        // failing loud.
         let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
         let mut graph = LegacyGraph::new("translate_op_fixture");
         let vars = mint_vars(&mut graph, 11); // vars[0..11]
-        value_map.insert(vars[1].clone(), Hlvalue::Variable(Variable::new()));
-        value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new()));
+        value_map.insert(vars[1].clone(), Hlvalue::Variable(Variable::new())); // receiver
+        value_map.insert(vars[2].clone(), Hlvalue::Variable(Variable::new())); // arg
+        value_map.insert(vars[3].clone(), Hlvalue::Variable(Variable::new())); // result
         let op = SpaceOperation {
-            result: Some(vars[2].clone()),
+            result: Some(vars[3].clone()),
             kind: OpKind::Call {
                 target: crate::model::CallTarget::Indirect {
                     trait_root: "MyTrait".into(),
                     method_name: "do_it".into(),
                 },
-                args: vec![vars[1].clone()],
+                args: vec![vars[1].clone(), vars[2].clone()],
                 result_ty: ValueType::Int,
             },
         };
-        let err = translate_op(&op, &value_map, &empty_call_registry())
-            .expect_err("Call::Indirect must surface rclass invariant break");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("Indirect") && msg.contains("rclass"),
-            "fail-loud must cite Indirect + rclass.rs, got: {msg}"
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("Call::Indirect must lower to getattr + simple_call");
+        assert_eq!(translated.len(), 2);
+        assert_eq!(translated[0].opname, "getattr");
+        assert_eq!(translated[1].opname, "simple_call");
+        // getattr's name arg is the method name as a byte string.
+        let Hlvalue::Constant(ref name_const) = translated[0].args[1] else {
+            panic!("getattr method-name arg must be a Constant");
+        };
+        assert!(matches!(
+            name_const.value,
+            ConstValue::ByteStr(ref bytes) if bytes == b"do_it"
+        ));
+        // Bound-method Variable identity threads from getattr.result into
+        // simple_call.args[0].
+        let Hlvalue::Variable(ref m1) = translated[0].result else {
+            panic!("getattr result must be Variable");
+        };
+        let Hlvalue::Variable(ref m2) = translated[1].args[0] else {
+            panic!("simple_call's first arg must be Variable (bound method)");
+        };
+        assert_eq!(
+            m1.id(),
+            m2.id(),
+            "bound method Variable identity must thread"
         );
+        // simple_call args = [bound_method, args[1..]]
+        assert_eq!(translated[1].args.len(), 2);
     }
 
     #[test]
@@ -5182,11 +5250,11 @@ mod tests {
 
     #[test]
     fn function_graph_to_flowspace_unported_opkind_surfaces_failloud() {
-        // A graph carrying a still-fail-loud OpKind (Call::Indirect —
-        // requires rclass.rs lowering to VtableMethodPtr + IndirectCall
-        // before reaching the adapter) must surface that op's
-        // translate_op error from inside Pass 2, not silently emit a
-        // partial graph.
+        // A graph carrying a still-fail-loud OpKind
+        // (Call::UnsupportedExpr — a frontend coverage gap that
+        // `front::mir` must classify before the rtyper sees it) must
+        // surface that op's translate_op error from inside Pass 2, not
+        // silently emit a partial graph.
         let mut graph = LegacyGraph::new("unported_op");
         let vars = mint_vars(&mut graph, 4); // vars[0..4]
         let inputargs = block_inputargs(&vars, &[1]);
@@ -5197,10 +5265,7 @@ mod tests {
             operations: vec![SpaceOperation {
                 result: Some(vars[2].clone()),
                 kind: OpKind::Call {
-                    target: crate::model::CallTarget::Indirect {
-                        trait_root: "MyTrait".into(),
-                        method_name: "do_it".into(),
-                    },
+                    target: crate::model::CallTarget::UnsupportedExpr,
                     args: vec![arg_var],
                     result_ty: ValueType::Int,
                 },
@@ -5228,7 +5293,7 @@ mod tests {
             .expect_err("unported OpKind must surface as TyperError");
         let msg = format!("{err}");
         assert!(
-            msg.contains("Indirect") && msg.contains("rclass"),
+            msg.contains("UnsupportedExpr") && msg.contains("front::mir"),
             "unported-op error must propagate translate_op's fail-loud message, got: {msg}"
         );
     }

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2190,8 +2190,9 @@ pub fn translate_op(
                     // Narrow the receiver to the family base classdef when the
                     // trait is a registered dispatch family.
                     let getattr_receiver = if let Some(base_root) = base_root {
-                        let callable_host =
-                            HOST_ENV.lookup_builtin("__pyre_cast_instance").ok_or_else(|| {
+                        let callable_host = HOST_ENV
+                            .lookup_builtin("__pyre_cast_instance")
+                            .ok_or_else(|| {
                                 TyperError::message(
                                     "__pyre_cast_instance missing from HOST_ENV bootstrap"
                                         .to_string(),

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4422,7 +4422,7 @@ fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bool) -> PyRe
             for w_metaclass in w_metaclasses.iter().flatten() {
                 let w_metaclass = *w_metaclass;
                 if is_type(w_metaclass) {
-                    if let Some((src, descr)) = lookup_where(w_metaclass, name) {
+                    if let Some((src, descr)) = lookup_where_pair(w_metaclass, name) {
                         if !std::ptr::eq(src, w_type_type)
                             && !std::ptr::eq(src, w_object)
                             && is_data_descr(descr)
@@ -5932,6 +5932,46 @@ pub(crate) unsafe fn lookup_in_type_where_uncached(
     lookup_where(w_type, name).map(|(_src, value)| value)
 }
 
+/// `lookup_where` *defining-class* projection — the `dont_look_inside`
+/// companion of [`lookup_in_type_where_uncached`] returning the `w_class`
+/// half (`(w_class, w_value).0`) of the same MRO walk, for the callers that
+/// need the class that defines the descriptor (a `src`-guard against `type`
+/// / `object` / a builtin base).
+///
+/// `dont_look_inside` for the same reason as the value projection: the
+/// `mro` binding in [`lookup_where`] phi-merges the cached `&*mro` slice
+/// against the freshly computed opaque [`compute_mro`] `Vec` borrow, a
+/// union the annotator cannot model (`<other> ∪ _ptr`).  [`lookup_where`]'s
+/// 2-tuple return exceeds the single-register residual ABI, so the two
+/// halves are exposed as two single-`Option` residuals over the same
+/// deterministic, side-effect-free lookup; a caller that needs both rebuilds
+/// the pair via [`lookup_where_pair`].  Marker `_jit_look_inside_ = False`
+/// (rlib/jit.py:139).
+#[majit_macros::dont_look_inside]
+pub(crate) unsafe fn lookup_where_class_uncached(
+    w_type: PyObjectRef,
+    name: &str,
+) -> Option<PyObjectRef> {
+    lookup_where(w_type, name).map(|(src, _value)| src)
+}
+
+/// Rebuild the `(w_class, w_value)` pair of [`lookup_where`] from its two
+/// single-register `dont_look_inside` projections
+/// ([`lookup_where_class_uncached`] and [`lookup_in_type_where_uncached`]),
+/// for the callers that need both halves.  The projections run over the same
+/// deterministic MRO walk, so the reconstructed pair is identical to the raw
+/// `lookup_where` result; the value half decides presence (`None` when the
+/// name is absent), so the class half is only fetched on a hit.  Keeping the
+/// raw walk behind the two residuals contains its `<other> ∪ _ptr` phi-merge.
+pub(crate) unsafe fn lookup_where_pair(
+    w_type: PyObjectRef,
+    name: &str,
+) -> Option<(PyObjectRef, PyObjectRef)> {
+    let value = lookup_in_type_where_uncached(w_type, name)?;
+    let class = lookup_where_class_uncached(w_type, name)?;
+    Some((class, value))
+}
+
 /// WTF-8 keyed MRO attribute lookup — surrogate-safe sibling of
 /// `lookup_in_type` / `lookup_in_type_where`.  A lone-surrogate name
 /// can only live in a class namespace's `DictStorage` (never as a
@@ -6133,7 +6173,8 @@ unsafe fn _cached_lookup_where(
     if let Some(tup) = hit {
         return tup;
     }
-    let tup = lookup_where(w_type, name).unwrap_or((std::ptr::null_mut(), std::ptr::null_mut()));
+    let tup =
+        lookup_where_pair(w_type, name).unwrap_or((std::ptr::null_mut(), std::ptr::null_mut()));
     // Prebuilt-family store: the cache slot is reached only by
     // `walk_method_cache_gc`, skipped on clean minor collections.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
@@ -6187,7 +6228,7 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
     name: &str,
 ) -> Option<(PyObjectRef, PyObjectRef)> {
     if w_type.is_null() || !is_type(w_type) {
-        return lookup_where(w_type, name);
+        return lookup_where_pair(w_type, name);
     }
     // typeobject.py:505 — `promote(self)`.
     let _ = majit_metainterp::jit::promote(w_type);
@@ -6197,7 +6238,7 @@ pub(crate) unsafe fn lookup_where_with_method_cache(
     let version_tag = w_type_version_tag(w_type);
     if version_tag == 0 {
         // typeobject.py:507-509 — no version tag: uncacheable.
-        return lookup_where(w_type, name);
+        return lookup_where_pair(w_type, name);
     }
     // typeobject.py:510-511 — `w_class, w_value =
     // self._pure_lookup_where_with_method_cache(name, version_tag)`.  The
@@ -9361,7 +9402,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         // storage iterator to avoid an infinite recursion.
         if is_list(obj) {
             if !pyre_object::is_exact_list(obj) {
-                if let Some((src, method)) = lookup_where((*obj).w_class, "__iter__") {
+                if let Some((src, method)) = lookup_where_pair((*obj).w_class, "__iter__") {
                     if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::LIST_TYPE)) {
                         // descroperation.py:339-341 — an explicit
                         // `__iter__ = None` override marks the subclass
@@ -9381,7 +9422,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
         }
         if is_tuple(obj) {
             if !pyre_object::is_exact_tuple(obj) {
-                if let Some((src, method)) = lookup_where((*obj).w_class, "__iter__") {
+                if let Some((src, method)) = lookup_where_pair((*obj).w_class, "__iter__") {
                     if !std::ptr::eq(src, pyre_object::get_instantiate(&pyre_object::TUPLE_TYPE)) {
                         // descroperation.py:339-341 — an explicit
                         // `__iter__ = None` override marks the subclass

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -882,14 +882,18 @@ fn metaclass_call_override(callable: PyObjectRef) -> Option<PyObjectRef> {
     if std::ptr::eq(metaclass, crate::typedef::w_type()) {
         return None;
     }
-    // Resolve __call__ AND where it is defined; the default `type.__call__`
+    // Resolve WHERE `__call__` is defined first; the default `type.__call__`
     // (the implicit instantiation path) is not an override, so a metaclass
-    // that merely inherits it — e.g. ABCMeta — keeps the fast path.
-    let (where_defined, call_descr) =
-        unsafe { crate::baseobjspace::lookup_where(metaclass, "__call__") }?;
+    // that merely inherits it — e.g. ABCMeta — keeps the fast path.  The
+    // defining-class half is the cheap guard, so it runs before the value
+    // half's second residual walk (avoided on the common fast path).
+    let where_defined =
+        unsafe { crate::baseobjspace::lookup_where_class_uncached(metaclass, "__call__") }?;
     if std::ptr::eq(where_defined, crate::typedef::w_type()) {
         return None;
     }
+    let call_descr =
+        unsafe { crate::baseobjspace::lookup_in_type_where_uncached(metaclass, "__call__") }?;
     let bound = unsafe { crate::baseobjspace::get(call_descr, callable, metaclass) }
         .ok()
         .flatten()

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -234,6 +234,12 @@ pub fn set_last_exec_ctx(ctx: *const crate::PyExecutionContext) {
 /// that need to temporarily pin a different context (blackhole's
 /// `bh_call_fn_impl` cold path, for example) pair this with
 /// `set_last_exec_ctx` to restore the prior value on return.
+///
+/// `dont_look_inside`: the `LAST_EXEC_CTX` thread-local `.with` read has no
+/// extractable graph (front::mir const-folds the `ThreadLocal` global to
+/// None), so the call stays a residual read via the registered fnaddr
+/// (`@dont_look_inside`, `rlib/jit.py:139`), the `take_call_error` twin.
+#[majit_macros::dont_look_inside]
 pub fn take_last_exec_ctx() -> *const crate::PyExecutionContext {
     LAST_EXEC_CTX.with(|c| c.get())
 }
@@ -2441,9 +2447,9 @@ fn call_user_function_with_args(func: PyObjectRef, args: &[PyObjectRef]) -> PyOb
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
     };
-    let exec_ctx = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+    let exec_ctx = build_class_exec_ctx();
     let exec_ctx = if exec_ctx.is_null() {
-        LAST_EXEC_CTX.with(|c| c.get())
+        take_last_exec_ctx()
     } else {
         exec_ctx
     };
@@ -2525,9 +2531,9 @@ fn call_user_function_resolved_frameless(func: PyObjectRef, args: &[PyObjectRef]
     let func_code = unsafe {
         crate::w_code_get_ptr(w_code as pyre_object::PyObjectRef) as *const crate::CodeObject
     };
-    let exec_ctx = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+    let exec_ctx = build_class_exec_ctx();
     let exec_ctx = if exec_ctx.is_null() {
-        LAST_EXEC_CTX.with(|c| c.get())
+        take_last_exec_ctx()
     } else {
         exec_ctx
     };
@@ -2589,7 +2595,7 @@ fn call_metaclass_with_kwargs(
             Vec::new()
         };
         let frame = {
-            let stored = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+            let stored = build_class_exec_ctx();
             if stored.is_null() {
                 std::ptr::null_mut()
             } else {
@@ -2957,7 +2963,7 @@ fn build_class_inner(
                     _ => Vec::new(),
                 };
                 let prepare_frame = {
-                    let stored = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+                    let stored = build_class_exec_ctx();
                     if stored.is_null() {
                         std::ptr::null_mut()
                     } else {
@@ -3058,7 +3064,7 @@ fn build_class_inner(
     // class body stores into it after execution. This lets EnumDict etc.
     // track member definitions via __setitem__.
 
-    let stored = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+    let stored = build_class_exec_ctx();
     let exec_ctx = if stored.is_null() {
         std::ptr::null::<crate::PyExecutionContext>()
     } else {
@@ -3555,9 +3561,9 @@ pub(crate) fn call_init_subclass_on_bases(
         .map(|(k, v)| (unsafe { pyre_object::w_str_get_wtf8(*k) }.to_owned(), *v))
         .collect();
     let frame = {
-        let stored = BUILD_CLASS_EXEC_CTX.with(|c| c.get());
+        let stored = build_class_exec_ctx();
         let stored = if stored.is_null() {
-            LAST_EXEC_CTX.with(|c| c.get())
+            take_last_exec_ctx()
         } else {
             stored
         };
@@ -3597,6 +3603,17 @@ thread_local! {
 /// Set the execution context for __build_class__ to use.
 pub fn set_build_class_exec_ctx(ctx: *const crate::PyExecutionContext) {
     BUILD_CLASS_EXEC_CTX.with(|c| c.set(ctx));
+}
+
+/// Read the __build_class__ execution context.
+///
+/// `dont_look_inside`: the `BUILD_CLASS_EXEC_CTX` thread-local `.with` read
+/// has no extractable graph (front::mir const-folds the `ThreadLocal` global
+/// to None), so the call stays a residual read via the registered fnaddr
+/// (`@dont_look_inside`, `rlib/jit.py:139`), the `take_last_exec_ctx` twin.
+#[majit_macros::dont_look_inside]
+pub fn build_class_exec_ctx() -> *const crate::PyExecutionContext {
+    BUILD_CLASS_EXEC_CTX.with(|c| c.get())
 }
 
 // ── Type calling (instance creation) ─────────────────────────────────

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -59,7 +59,7 @@ pub(crate) unsafe fn try_call_dunder_obj_above_object(
         let Some(w_type) = crate::typedef::r#type(obj) else {
             return Ok(None);
         };
-        let Some((src, method)) = crate::baseobjspace::lookup_where(w_type, name) else {
+        let Some((src, method)) = crate::baseobjspace::lookup_where_pair(w_type, name) else {
             return Ok(None);
         };
         if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
@@ -385,7 +385,7 @@ unsafe fn exc_user_dunder_obj(obj: PyObjectRef, name: &str) -> Option<PyObjectRe
         if w_class.is_null() || !pyre_object::is_type(w_class) {
             return None;
         }
-        let (src, method) = crate::baseobjspace::lookup_where(w_class, name)?;
+        let (src, method) = crate::baseobjspace::lookup_where_pair(w_class, name)?;
         if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
             return None;
         }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1138,6 +1138,25 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::call::clear_call_error",
         clear_call_error as *const (),
     );
+    // `#[dont_look_inside]` execution-context thread-local reads
+    // (`BUILD_CLASS_EXEC_CTX` / `LAST_EXEC_CTX`), twins of the call-error
+    // slot accessors above; front::mir const-folds the `ThreadLocal` global
+    // to None, so their bodies have no extractable graph and the call stays
+    // a residual read via the registered fnaddr.
+    let build_class_exec_ctx: fn() -> *const crate::PyExecutionContext =
+        crate::call::build_class_exec_ctx;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::build_class_exec_ctx",
+        build_class_exec_ctx as *const (),
+    );
+    let take_last_exec_ctx: fn() -> *const crate::PyExecutionContext =
+        crate::call::take_last_exec_ctx;
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::call::take_last_exec_ctx",
+        take_last_exec_ctx as *const (),
+    );
     let take_pending_hash_error: fn() -> crate::PyError =
         crate::baseobjspace::take_pending_hash_error;
     push_fnaddr(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -528,6 +528,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::dictmultiobject::w_dict_len",
+        "pyre_object::w_dict_len",
+        pyre_object::dictmultiobject::w_dict_len as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_setitem_str",
+        "pyre_object::w_dict_setitem_str",
+        pyre_object::dictmultiobject::w_dict_setitem_str as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::dictmultiobject::w_module_dict_new_with_storage_proxy",
         "pyre_object::w_module_dict_new_with_storage_proxy",
         pyre_object::dictmultiobject::w_module_dict_new_with_storage_proxy as *const (),

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -2597,6 +2597,11 @@ pub unsafe fn w_dict_getitem_str_proxy_first(obj: PyObjectRef, key: &str) -> Opt
 /// Dispatches through the polymorphic strategy slot so module dicts
 /// fan out via `ModuleDictStrategy::setitem_str` and regular dicts
 /// via `ObjectDictStrategy::setitem_str`.
+///
+/// Residualise the setitem_str leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`): the strategy dispatch it wraps mutates
+/// runtime-mutable dict storage the tracer cannot model.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_setitem_str(obj: PyObjectRef, key: &str, value: PyObjectRef) {
     w_dict_get_strategy(obj).setitem_str(obj, key, value)
 }
@@ -3120,6 +3125,11 @@ pub unsafe fn w_module_dict_clear_inner(obj: PyObjectRef) {
 /// `pypy/objspace/std/dictmultiobject.py:107-109 W_DictMultiObject.length`
 /// — `return self.get_strategy().length(self)`.  Dispatches through
 /// the polymorphic strategy slot.
+///
+/// Residualise the length leaf (`@dont_look_inside`,
+/// `rlib/jit.py:139`): the strategy dispatch it wraps reads
+/// runtime-mutable dict storage the tracer cannot model.
+#[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_len(obj: PyObjectRef) -> usize {
     w_dict_get_strategy(obj).length(obj)
 }


### PR DESCRIPTION
A stack of #346 slices toward retiring the rtyper legacy walker. #346 closes when every graph the JIT prepass touches lifts through the two-phase (annotate → rtype) CodeWriter path — or is removed from legacy routing because the legacy walker adds nothing — so `cutover::is_known_unported` matches nothing and `legacy_annotator.rs` + `legacy_resolve.rs` delete.

All slices are default-OFF gated or convergent-with-legacy, and gate-OFF is byte-identical: `pyre/check.py` dynasm 160/160 + cranelift 160/160 + wasm 160/160, 3/3 backends.

## Slices (bottom to top)

### Residual narrowing (slice A/B)
- **narrow `Option<*mut PyObject>` dont_look_inside residual to per-instantiation SomeInstance** — a `#[dont_look_inside]` callee returning `Option<*mut PyObject>` arrives as a classdef-less GCREF; the traced caller's `if let Some(x) = ..` `Discriminant`/payload read blocked the annotator. `result_narrow_root` (gated `PYRE_OPTION_RESIDUAL_NARROW`) narrows the result to the per-instantiation `Option` enum root via `__pyre_cast_instance`.
- **residualize `w_dict_len` / `w_dict_setitem_str` via dont_look_inside** — dict-strategy dispatch the two-phase prepass could not model.

### S1–S2.3: dyn-Trait indirect dispatch into the two-phase path (gated `PYRE_DYN_INDIRECT`, default-OFF)
- **route inline-Field dyn-Trait calls through `CallTarget::Indirect`** (S1 keystone).
- **stamp trait default-body return token for the Indirect-dispatch witness** (S2.1) — clears the `getcalldescr` Void-vs-Ref family-witness panic.
- **lower dyn-Trait `CallTarget::Indirect` to getattr+simple_call in the rtyper prepass** (S2.2) — removes the flowspace-adapter fail-loud arm.
- **auto-register ≥2-impl trait families + narrow the Indirect receiver to the family base classdef** (S2.3) — clears the classdef-less receiver wall.

Together S1–S2.3 enter dyn-Trait indirect dispatch fully into the normal two-phase rtype path, removing three dispatch-specific walls; gate-OFF byte-identical.

### cat2 (`compute_at_fixpoint`) convergence
- **residualize `BUILD_CLASS_EXEC_CTX` / `LAST_EXEC_CTX` reads via dont_look_inside** — the two value-returning thread-local reads are wrapped behind `#[dont_look_inside]` accessors (twin of `shadow_stack_len`), so callers annotate a typed `*const PyExecutionContext` residual instead of the const-folded-None FunctionPath the annotator could not resolve. Clears 14 unregistered TL-read chains.
- **residualize `#[elidable]` callee bodies in the two-phase prepass** (gated `PYRE_ELIDABLE_RESIDUALIZE`, default-OFF) — an `elidable`-hinted graph gets a return-kind-typed signature stub instead of having its body looked into, matching `@elidable` + `look_inside_graph=False` (CALL_PURE residualize). Drains the `METHOD_CACHE` thread-local root that blocked the opcode-dispatch family. The callsite CALL_PURE token is preserved (`mark_elidable` is orthogonal to body lift).
- **register foreign container ctors `Vec`/`IndexMap`/`Box::new` as builtin analysers** — the twin of `malloc_raw_alloc` / `bigint_from`; these foreign constructors are residualized-by-return-kind by the legacy walker, so registering an opaque-instance analyser is convergence, not regression. Drains the constructor wall under the shared descriptor-protocol hub (`compute_at_fixpoint` distinct 89 → 68).

## Notes
- The remaining cat2 wall is the `lookup_where` `<other> ∪ _ptr` phi-merge (the `compute_mro` opaque-Vec union) plus `getattr_str_impl` deep-interp — separate follow-up slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)